### PR TITLE
fix(ui): Fix 401s on stream requests

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -421,8 +421,12 @@ const Stream = createReactClass({
         });
       },
       error: err => {
-        let error = err.responseJSON || true;
-        error = error.detail || true;
+        let {detail} = (err && err.responseJSON) || {};
+        let error =
+          typeof detail === 'string'
+            ? detail
+            : (detail && detail.message) || 'Unknown HTTP error';
+
         this.setState({
           error,
           dataLoading: false,


### PR DESCRIPTION
Stream fails to render error message if `error.responseJSON.detail` is an object.

Fixes [JAVASCRIPT-3JM](https://sentry.io/sentry/javascript/issues/512408727/)