### PR TITLE
fix(form): Remove setError side effect from isValidField

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
@@ -253,13 +253,13 @@ class FormModel {
       this.options.onFieldChange(id, value);
     }
 
-    this.updateErrorState(id);
+    this.validateField(id);
     this.updateShowSaveState(id, value);
     this.updateShowReturnButtonState(id, value);
   }
 
   @action
-  updateErrorState(id) {
+  validateField(id) {
     let validate = this.getDescriptor(id, 'validate');
     let errors = [];
 
@@ -324,7 +324,7 @@ class FormModel {
    */
   @action
   saveForm() {
-    Array.from(this.fieldDescriptor.keys()).forEach(id => !this.updateErrorState(id));
+    this.validateForm();
 
     if (this.isError) return null;
 
@@ -418,7 +418,7 @@ class FormModel {
       return null;
 
     // Check for error first
-    this.updateErrorState(id);
+    this.validateField(id);
     if (!this.isValidField(id)) return null;
 
     // shallow clone fields
@@ -579,7 +579,9 @@ class FormModel {
 
   // TODO: More validations
   @action
-  validate() {}
+  validateForm() {
+    Array.from(this.fieldDescriptor.keys()).forEach(id => !this.validateField(id));
+  }
 
   @action
   handleErrorResponse({responseJSON: resp} = {}) {

--- a/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
@@ -577,7 +577,6 @@ class FormModel {
     this.setFieldState(id, FormState.SAVING, false);
   }
 
-  // TODO: More validations
   @action
   validateForm() {
     Array.from(this.fieldDescriptor.keys()).forEach(id => !this.validateField(id));


### PR DESCRIPTION
Corrects the form model to validate and save field errors *only* in the updateErrorState action, and *not* when calling isValidField. Previously isValidField also did not save the required field error, which would only be saved if updateErrorState was called.