### PR TITLE
feat(discover): Add example queries

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -47,6 +47,12 @@ export default class OrganizationDiscover extends React.Component {
     this.forceUpdate();
   };
 
+  updateFields = query => {
+    Object.entries(query).forEach(([field, value]) => {
+      this.updateField(field, value);
+    });
+  };
+
   runQuery = () => {
     const {queryBuilder, organization} = this.props;
     // Strip any invalid conditions and aggregations
@@ -275,7 +281,7 @@ export default class OrganizationDiscover extends React.Component {
             {result && (
               <Result data={result} chartData={chartData} chartQuery={chartQuery} />
             )}
-            {!result && <Intro />}
+            {!result && <Intro updateQuery={this.updateFields} />}
           </Box>
         </Flex>
       </Discover>

--- a/src/sentry/static/sentry/app/views/organizationDiscover/intro.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/intro.jsx
@@ -1,12 +1,53 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'react-emotion';
 import {Box, Flex} from 'grid-emotion';
 
-import {tct} from 'app/locale';
+import {tct, t} from 'app/locale';
 
 import ExternalLink from 'app/components/externalLink';
+import Link from 'app/components/link';
 
 export default class Intro extends React.Component {
+  static propTypes = {
+    updateQuery: PropTypes.func.isRequired,
+  };
+
+  getExampleQueries() {
+    return [
+      {
+        description: t('Last 10 event IDs'),
+        query: {
+          fields: ['event_id'],
+          aggregations: [],
+          conditions: [],
+          limit: 10,
+          orderby: '-timestamp',
+        },
+      },
+      {
+        description: t('Events by project ID'),
+        query: {
+          fields: ['project_id'],
+          aggregations: [['count()', null, 'count']],
+          conditions: [],
+          limit: 1000,
+          orderby: '-count',
+        },
+      },
+      {
+        description: t('Top exception types'),
+        query: {
+          fields: ['exception_stacks.type'],
+          aggregations: [['count()', null, 'count']],
+          conditions: [['exception_stacks.type', 'IS NOT NULL', null]],
+          limit: 1000,
+          orderby: '-count',
+        },
+      },
+    ];
+  }
+
   render() {
     return (
       <IntroContainer
@@ -15,7 +56,7 @@ export default class Intro extends React.Component {
         justify="center"
       >
         <Box w={500}>
-          <p>
+          <TextBlock>
             {tct(
               `Welcome to [discover:Discover]. Discover lets you query raw
               event data in Sentry.`,
@@ -23,25 +64,27 @@ export default class Intro extends React.Component {
                 discover: <strong />,
               }
             )}
-          </p>
-          <p>
-            {tct(
-              `Getting started? Try selecting [projectId:projectId] under
-              Summarize, and [count:count] under Aggregations. Click "Run Query"
-              to get the total count of events by project over the last 2 weeks.`,
-              {
-                projectId: <code />,
-                count: <code />,
-              }
+          </TextBlock>
+          <TextBlock>
+            {t(
+              `Getting started? Try running one of the example queries below.
+              Select the query you want to make, then click "Run Query".`
             )}
-          </p>
-          <p>
+            <ul>
+              {this.getExampleQueries().map(({query, description}, idx) => (
+                <li key={idx}>
+                  <Link onClick={() => this.props.updateQuery(query)}>{description}</Link>
+                </li>
+              ))}
+            </ul>
+          </TextBlock>
+          <TextBlock>
             {tct(
               `To learn more about how to use the query builder, see the
               [docs:docs].`,
               {docs: <ExternalLink href="" />}
             )}
-          </p>
+          </TextBlock>
         </Box>
       </IntroContainer>
     );
@@ -51,4 +94,8 @@ export default class Intro extends React.Component {
 const IntroContainer = styled(Flex)`
   font-size: ${p => p.theme.fontSizeMedium};
   color: ${p => p.theme.gray5};
+`;
+
+const TextBlock = styled('div')`
+  margin: 0 0 20px;
 `;


### PR DESCRIPTION
This won't work exactly as it's supposed to yet since it depends on a bug in controlled SelectFields being fixed. (For multi select fields the value doesn't get updated properly when a new value prop is received).