### PR TITLE
feat(discover): Hide scrollbars on table cells

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/table.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/table.jsx
@@ -137,4 +137,14 @@ const Cell = styled('div')`
   font-size: 14px;
   line-height: 30px;
   padding: 0 4px;
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
+
+  @-moz-document url-prefix() {
+    overflow: hidden;
+  }
+
+  -ms-overflow-style: -ms-autohiding-scrollbar;
 `;


### PR DESCRIPTION
Hide scrollbars on table cells in Chrome and IE/Edge.

Remove scrolling on Firefox since we can't hide scrollbars.