### PR TITLE
fix(ui): Fix Project Breadcrumbs in Settings

### DIFF
--- a/src/sentry/static/sentry/app/utils/recreateRoute.jsx
+++ b/src/sentry/static/sentry/app/utils/recreateRoute.jsx
@@ -19,7 +19,9 @@ export default function recreateRoute(to, {routes, params, location, stepBack}) 
 
   let baseRoute = paths.slice(lastRootIndex, routeIndex);
 
-  if (typeof stepBack !== 'undefined') {
+  if (stepBack >= 0) {
+    throw new Error('`stepBack` needs to be < 0');
+  } else if (typeof stepBack !== 'undefined') {
     baseRoute = baseRoute.slice(0, stepBack);
   }
 

--- a/tests/js/spec/utils/recreateRoute.spec.jsx
+++ b/tests/js/spec/utils/recreateRoute.spec.jsx
@@ -50,6 +50,10 @@ describe('recreateRoute', function() {
     );
   });
 
+  it('stepBack needs to be less than 0', function() {
+    expect(() => recreateRoute('', {routes, location, params, stepBack: 0})).toThrow();
+  });
+
   it('switches to new org but keeps current route', function() {
     expect(recreateRoute(routes[4], {routes, location, params: {orgId: 'new-org'}})).toBe(
       '/settings/new-org/api-keys/'


### PR DESCRIPTION
This specifically fixes JAVASCRIPT-46Y where a user is on Client Key Details page and switches to a new project using breadcrumb. Previously would keep the key id in route, now will switch to index view.