### PR TITLE
feat(settings): Force slugify transform on slug inputs

### DIFF
--- a/src/sentry/static/sentry/app/components/createTeam/createTeamForm.jsx
+++ b/src/sentry/static/sentry/app/components/createTeam/createTeamForm.jsx
@@ -6,6 +6,7 @@ import {t, tct} from 'app/locale';
 import Form from 'app/views/settings/components/forms/form';
 import SentryTypes from 'app/sentryTypes';
 import TextField from 'app/views/settings/components/forms/textField';
+import slugify from 'app/utils/slugify';
 
 export default class CreateTeamForm extends React.Component {
   static propTypes = {
@@ -49,6 +50,7 @@ export default class CreateTeamForm extends React.Component {
             stacked
             flexibleControlStateSize
             inline={false}
+            transformInput={slugify}
           />
         </Form>
       </React.Fragment>

--- a/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {extractMultilineFields} from 'app/utils';
 import {t, tct} from 'app/locale';
+import slugify from 'app/utils/slugify';
 
 // Export route to make these forms searchable by label/help
 export const route = '/settings/:orgId/';
@@ -17,6 +18,7 @@ const formGroups = [
         required: true,
         label: t('Name'),
         help: t('A unique ID used to identify this organization'),
+        transformInput: slugify,
 
         saveOnBlur: false,
         saveMessageAlertType: 'info',

--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
+
 import {extractMultilineFields} from 'app/utils';
 import {t, tct, tn} from 'app/locale';
 import getDynamicText from 'app/utils/getDynamicText';
+import slugify from 'app/utils/slugify';
 
 // Export route to make these forms searchable by label/help
 export const route = '/settings/:orgId/:projectId/';
@@ -58,6 +60,7 @@ export const fields = {
     label: t('Name'),
     placeholder: t('my-service-name'),
     help: t('A unique ID used to identify this project'),
+    transformInput: slugify,
 
     saveOnBlur: false,
     saveMessageAlertType: 'info',

--- a/src/sentry/static/sentry/app/data/forms/teamSettingsFields.jsx
+++ b/src/sentry/static/sentry/app/data/forms/teamSettingsFields.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {t, tct} from 'app/locale';
+import slugify from 'app/utils/slugify';
 
 // Export route to make these forms searchable by label/help
 export const route = '/settings/:orgId/teams/:teamId/settings/';
@@ -18,6 +19,7 @@ const formGroups = [
         placeholder: 'e.g. api-team',
         help: t('A unique ID used to identify the team'),
         disabled: ({access}) => !access.has('team:write'),
+        transformInput: slugify,
 
         saveOnBlur: false,
         saveMessageAlertType: 'info',

--- a/src/sentry/static/sentry/app/utils/slugify.jsx
+++ b/src/sentry/static/sentry/app/utils/slugify.jsx
@@ -1,0 +1,5 @@
+// XXX: This is NOT an exhaustive slugify function
+// Only forces lowercase and replaces spaces with hyphens
+export default function slugify(str) {
+  return typeof str === 'string' ? str.toLowerCase().replace(' ', '-') : '';
+}

--- a/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
@@ -247,15 +247,22 @@ class FormModel {
 
   @action
   setValue(id, value) {
-    this.fields.set(id, value);
+    let fieldDescriptor = this.fieldDescriptor.get(id);
+    let finalValue = value;
+
+    if (fieldDescriptor && typeof fieldDescriptor.transformInput === 'function') {
+      finalValue = fieldDescriptor.transformInput(value);
+    }
+
+    this.fields.set(id, finalValue);
 
     if (this.options.onFieldChange) {
-      this.options.onFieldChange(id, value);
+      this.options.onFieldChange(id, finalValue);
     }
 
     this.validateField(id);
-    this.updateShowSaveState(id, value);
-    this.updateShowReturnButtonState(id, value);
+    this.updateShowSaveState(id, finalValue);
+    this.updateShowReturnButtonState(id, finalValue);
   }
 
   @action

--- a/tests/js/spec/utils/slugify.spec.jsx
+++ b/tests/js/spec/utils/slugify.spec.jsx
@@ -1,0 +1,19 @@
+import slugify from 'app/utils/slugify';
+
+describe('slugify', function() {
+  it('forces to lowercase', function() {
+    expect(slugify('STOPYELLING')).toBe('stopyelling');
+  });
+
+  it('replaces spaces with a hyphen', function() {
+    expect(slugify('STOP YELLING')).toBe('stop-yelling');
+  });
+
+  it('does not replace other special characters', function() {
+    expect(slugify('STOP YELLING!@#')).toBe('stop-yelling!@#');
+  });
+
+  it('returns an empty string if passed undefined', function() {
+    expect(slugify()).toBe('');
+  });
+});

--- a/tests/js/spec/views/projectGeneralSettings.spec.jsx
+++ b/tests/js/spec/views/projectGeneralSettings.spec.jsx
@@ -212,7 +212,7 @@ describe('projectGeneralSettings', function() {
     // Change slug to new-slug
     wrapper
       .find('input[name="slug"]')
-      .simulate('change', {target: {value: 'new-project'}})
+      .simulate('change', {target: {value: 'NEW PROJECT'}})
       .simulate('blur');
 
     // Slug does not save on blur

--- a/tests/js/spec/views/settings/organizationSettingsForm.spec.jsx
+++ b/tests/js/spec/views/settings/organizationSettingsForm.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-
 import {mount} from 'enzyme';
+
 import {saveOnBlurUndoMessage} from 'app/actionCreators/indicator';
 import OrganizationSettingsForm from 'app/views/settings/organizationGeneralSettings/organizationSettingsForm';
 
@@ -83,5 +83,41 @@ describe('OrganizationSettingsForm', function() {
         done(err);
       }
     });
+  });
+
+  it('can change slug', function() {
+    putMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/',
+      method: 'PUT',
+    });
+
+    let wrapper = mount(
+      <OrganizationSettingsForm
+        location={TestStubs.location()}
+        orgId={organization.slug}
+        access={new Set('org:admin')}
+        initialData={TestStubs.Organization()}
+        onSave={onSave}
+      />,
+      TestStubs.routerContext()
+    );
+
+    wrapper
+      .find('input[name="slug"]')
+      .simulate('change', {target: {value: 'NEW SLUG'}})
+      .simulate('blur');
+
+    expect(putMock).not.toHaveBeenCalled();
+
+    wrapper.find('SaveButton').simulate('click');
+
+    expect(putMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/',
+      expect.objectContaining({
+        data: {
+          slug: 'new-slug',
+        },
+      })
+    );
   });
 });

--- a/tests/js/spec/views/teamSettings.spec.jsx
+++ b/tests/js/spec/views/teamSettings.spec.jsx
@@ -50,7 +50,7 @@ describe('TeamSettings', function() {
 
     wrapper
       .find('input[name="slug"]')
-      .simulate('change', {target: {value: 'new-slug'}})
+      .simulate('change', {target: {value: 'NEW SLUG'}})
       .simulate('blur');
 
     wrapper.find('SaveButton').simulate('click');


### PR DESCRIPTION
This makes it so that our slug inputs force lower case and replaces spaces
with a hyphen.

Fixes JAVASCRIPT-3C0 (mostly)