### PR TITLE
tests(acceptance): Fix iOS device name loading

### DIFF
--- a/src/sentry/static/sentry/app/components/deviceName.jsx
+++ b/src/sentry/static/sentry/app/components/deviceName.jsx
@@ -58,6 +58,10 @@ export default class DeviceName extends React.Component {
     // If library has not loaded yet, then just render the raw model string, better than empty
     if (!iOSDeviceList) return children;
 
-    return deviceNameMapper(children, iOSDeviceList);
+    return (
+      <span data-test-id="loaded-device-name">
+        {deviceNameMapper(children, iOSDeviceList)}
+      </span>
+    );
   }
 }

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -54,6 +54,7 @@ class IssueDetailsTest(AcceptanceTestCase):
             '/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
         self.browser.wait_until('.entries')
+        self.browser.wait_until('[data-test-id="loaded-device-name"]')
         self.browser.snapshot('issue details cocoa')
 
     def test_javascript_specific_event(self):
@@ -62,7 +63,8 @@ class IssueDetailsTest(AcceptanceTestCase):
         )
 
         self.browser.get(
-            '/{}/{}/issues/{}/events/{}/'.format(self.org.slug, self.project.slug, event.group.id, event.id)
+            '/{}/{}/issues/{}/events/{}/'.format(self.org.slug,
+                                                 self.project.slug, event.group.id, event.id)
         )
         self.browser.wait_until('.event-details-container')
         self.browser.wait_until_not('.loading-indicator')


### PR DESCRIPTION
Sometimes percy snapshots before the iOS device name library is loaded

e.g. https://percy.io/getsentry/sentry/builds/957233/view/57287059/1280?browser=firefox&mode=head