### PR TITLE
fix(ui): remove incorrect class from base/modal

### DIFF
--- a/src/sentry/templates/sentry/integrations/vsts-config.html
+++ b/src/sentry/templates/sentry/integrations/vsts-config.html
@@ -3,7 +3,6 @@
 {% load sentry_assets %}
 {% load i18n %}
 
-{% block wrapperclass %}narrow auth{% endblock %}
 {% block modal_header_signout %}{% endblock %}
 
 {% block title %}{% trans "Visual Studio Team Services Setup" %} | {{ block.super }}{% endblock %}

--- a/src/sentry/templates/sentry/pipeline-error.html
+++ b/src/sentry/templates/sentry/pipeline-error.html
@@ -2,7 +2,6 @@
 
 {% load i18n %}
 
-{% block wrapperclass %}narrow auth{% endblock %}
 {% block title %}{% trans "Setup Error" %} | {{ block.super }}{% endblock %}
 
 {% block main %}

--- a/src/sentry/templates/sentry/slack-linked.html
+++ b/src/sentry/templates/sentry/slack-linked.html
@@ -3,7 +3,6 @@
 {% load i18n %}
 
 {% block title %}{% trans "Slack Linked" %} | {{ block.super }}{% endblock %}
-{% block wrapperclass %}narrow auth{% endblock %}
 
 {% block main %}
   <div class="align-center">


### PR DESCRIPTION
Non-auth models shouldn't have the `.auth` class as we use this class as a hook to display new auth modal styles.