### PR TITLE
fix(ui): Fix invalid response in AsyncComponent error rendering

### DIFF
--- a/src/sentry/static/sentry/app/components/asyncComponent.jsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.jsx
@@ -264,7 +264,8 @@ class AsyncComponent extends React.Component {
     // If all error responses have status code === 0, then show erorr message but don't
     // log it to sentry
     let shouldLogSentry =
-      !!Object.values(this.state.errors).find(resp => resp.status !== 0) || disableLog;
+      !!Object.values(this.state.errors).find(resp => resp && resp.status !== 0) ||
+      disableLog;
 
     if (unauthorizedErrors) {
       return (


### PR DESCRIPTION
`resp` is not guaranteed to have a value. This can happen if XHR unexpectedly resets.
This was causing an infinite loop because this would trigger `errorHandler` which updates state.

Fixes JAVASCRIPT-471
Fixes JAVASCRIPT-472