### PR TITLE
ref(assistant): Move experiment check to frontend

### DIFF
--- a/src/sentry/static/sentry/app/components/assistant/supportDrawer.jsx
+++ b/src/sentry/static/sentry/app/components/assistant/supportDrawer.jsx
@@ -7,6 +7,7 @@ import {t} from 'app/locale';
 import analytics from 'app/utils/analytics';
 import ExternalLink from 'app/components/externalLink';
 import HookStore from 'app/stores/hookStore';
+import ConfigStore from 'app/stores/configStore';
 import {
   AssistantContainer,
   CloseIcon,
@@ -96,6 +97,10 @@ const SupportDrawer = createReactClass({
   },
 
   render() {
+    if (!(ConfigStore.get('features') || new Set()).has('assistant')) {
+      return null;
+    }
+
     let docsResults = this.renderDocsResults();
     let helpcenterResults = this.renderHelpCenterResults();
     let results = helpcenterResults.concat(docsResults);

--- a/src/sentry/static/sentry/app/stores/guideStore.jsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.jsx
@@ -180,9 +180,10 @@ const GuideStore = Reflux.createStore({
     // Logic to determine if a guide is shown:
     // 1. If any required target is missing, don't show the guide.
     // 2. If the URL ends with #assistant, show the guide.
-    // 3. If the user has seen the guide, don't show it.
-    // 4. If the guide doesn't pass custom checks, don't show it.
-    // 5. Otherwise show the guide.
+    // 3. If the user isn't in the A/B test, don't show the guide.
+    // 4. If the user has seen the guide, don't show it.
+    // 5. If the guide doesn't pass custom checks, don't show it.
+    // 6. Otherwise show the guide.
 
     let availableTargets = [...this.state.anchors].map(a => a.props.target);
     // sort() so that we pick a guide deterministically every time this function is called.
@@ -195,7 +196,12 @@ const GuideStore = Reflux.createStore({
       });
 
     if (!this.state.forceShow) {
-      guideKeys = guideKeys.filter(key => !this.state.guides[key].seen);
+      let features = ConfigStore.get('features');
+      if (features && features.has('assistant')) {
+        guideKeys = guideKeys.filter(key => !this.state.guides[key].seen);
+      } else {
+        guideKeys = [];
+      }
     }
 
     // Pick the first guide that satisfies conditions.

--- a/src/sentry/static/sentry/app/views/app.jsx
+++ b/src/sentry/static/sentry/app/views/app.jsx
@@ -202,7 +202,7 @@ const App = createReactClass({
           <Alerts className="messages-container" />
           <Indicators className="indicators-container" />
           <ErrorBoundary>{this.renderBody()}</ErrorBoundary>
-          {ConfigStore.get('features').has('assistant') && <AssistantHelper />}
+          <AssistantHelper />
         </div>
       </ThemeProvider>
     );

--- a/tests/js/spec/components/assistant/supportDrawer.spec.jsx
+++ b/tests/js/spec/components/assistant/supportDrawer.spec.jsx
@@ -1,8 +1,15 @@
 import React from 'react';
 import {shallow, mount} from 'enzyme';
 import SupportDrawer from 'app/components/assistant/supportDrawer';
+import ConfigStore from 'app/stores/configStore';
 
 describe('SupportDrawer', function() {
+  beforeEach(function() {
+    ConfigStore.config = {
+      features: new Set(['assistant']),
+    };
+  });
+
   it('renders cue', function() {
     let wrapper = shallow(<SupportDrawer />, TestStubs.routerContext());
     expect(wrapper).toMatchSnapshot();

--- a/tests/js/spec/stores/guideStore.spec.jsx
+++ b/tests/js/spec/stores/guideStore.spec.jsx
@@ -8,13 +8,14 @@ describe('GuideStore', function() {
   let anchor1 = <GuideAnchor target="target 1" type="text" />;
   let anchor2 = <GuideAnchor target="target 2" type="text" />;
   let data;
-  ConfigStore.config = {
-    user: {
-      isSuperuser: true,
-    },
-  };
 
   beforeEach(function() {
+    ConfigStore.config = {
+      user: {
+        isSuperuser: true,
+      },
+      features: new Set(['assistant']),
+    };
     GuideStore.init();
     sandbox = sinon.sandbox.create();
     data = {
@@ -75,6 +76,12 @@ describe('GuideStore', function() {
     guide = GuideStore.state.currentGuide;
     // We don't have the alert reminder guide's data yet, so we can't show it.
     expect(guide).toEqual(null);
+  });
+
+  it('should not show a guide if the user is not in the experiment', function() {
+    ConfigStore.get('features').delete('assistant');
+    GuideStore.onFetchSucceeded(data);
+    expect(GuideStore.state.currentGuide).toEqual(null);
   });
 
   it('should force show a guide', function() {

--- a/tests/js/spec/views/settings/organizationMembers/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/index.spec.jsx
@@ -29,13 +29,17 @@ describe('OrganizationMembers', function() {
   let organization = TestStubs.Organization({
     access: ['member:admin', 'org:admin'],
   });
+  let getStub;
 
   beforeAll(function() {
-    sinon.stub(ConfigStore, 'get', () => currentUser);
+    getStub = sinon
+      .stub(ConfigStore, 'get')
+      .withArgs('user')
+      .returns(currentUser);
   });
 
   afterAll(function() {
-    ConfigStore.get.restore();
+    getStub.restore();
   });
 
   beforeEach(function() {


### PR DESCRIPTION
We want assistant to be triggerable for everyone if they put #assistant on the URL. Previously we were not setting up assistant if the user wasn't gated into the experiment, not we're setting it up and checking for the experiment after checking for the hashtag.