### PR TITLE
fix(ui): Remove double header from fine tune by organization

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/account/accountNotificationFineTuning.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountNotificationFineTuning.jsx
@@ -170,7 +170,6 @@ class AccountNotificationsByOrganization extends React.Component {
 
     return (
       <React.Fragment>
-        <PanelHeader>{t('Organizations')}</PanelHeader>
         {orgFields.map(field => {
           return (
             <PanelBodyLineItem key={field.name}>
@@ -269,7 +268,7 @@ export default class AccountNotificationFineTuning extends AsyncView {
         >
           <Panel>
             <PanelBody>
-              <PanelHeader hasButtons>
+              <PanelHeader hasButtons={isProject}>
                 <Box flex="1">{isProject ? t('Projects') : t('Organizations')}</Box>
                 <Box>
                   {isProject &&


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/79684/44599847-75e4f780-a78c-11e8-987c-109b5e705cd6.png)
