### PR TITLE
feat(discover): Add basic line and bar charts

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -36,7 +36,8 @@ export default class OrganizationDiscover extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      result: null,
+      data: null,
+      query: null,
       chartData: null,
       chartQuery: null,
       isFetchingQuery: false,
@@ -77,9 +78,10 @@ export default class OrganizationDiscover extends React.Component {
     this.setState({isFetchingQuery: true});
 
     queryBuilder.fetch().then(
-      result => {
+      data => {
         const query = queryBuilder.getInternal();
-        this.setState({result, isFetchingQuery: false});
+        const queryCopy = {...query};
+        this.setState({data, query: queryCopy, isFetchingQuery: false});
 
         browserHistory.push({
           pathname: `/organizations/${organization.slug}/discover/${getQueryStringFromQuery(
@@ -89,7 +91,7 @@ export default class OrganizationDiscover extends React.Component {
       },
       err => {
         addErrorMessage(err.message);
-        this.setState({result: null, isFetchingQuery: false});
+        this.setState({data: null, query: null, isFetchingQuery: false});
       }
     );
 
@@ -173,7 +175,7 @@ export default class OrganizationDiscover extends React.Component {
 
     queryBuilder.reset();
     this.setState({
-      result: null,
+      data: null,
       chartData: null,
       chartQuery: null,
     });
@@ -182,10 +184,10 @@ export default class OrganizationDiscover extends React.Component {
     });
   };
   render() {
-    const {result, chartData, chartQuery, isFetchingQuery} = this.state;
+    const {data, query, chartData, chartQuery, isFetchingQuery} = this.state;
     const {queryBuilder} = this.props;
 
-    const query = queryBuilder.getInternal();
+    const currentQuery = queryBuilder.getInternal();
     const columns = queryBuilder.getColumns();
     // Do not allow conditions on projectID field
     const columnsForConditions = columns.filter(({name}) => name !== 'project_id');
@@ -208,15 +210,15 @@ export default class OrganizationDiscover extends React.Component {
           <strong>{t('Discover')}</strong>
           <Flex>
             <MultipleProjectSelector
-              value={query.projects}
+              value={currentQuery.projects}
               projects={this.props.organization.projects}
               onChange={val => this.updateField('projects', val)}
               onUpdate={this.runQuery}
             />
             <HeaderSeparator />
             <TimeRangeSelector
-              start={query.start}
-              end={query.end}
+              start={currentQuery.start}
+              end={currentQuery.end}
               onChange={(name, val) => this.updateField(name, val)}
               onUpdate={this.runQuery}
             />
@@ -233,20 +235,20 @@ export default class OrganizationDiscover extends React.Component {
                 multiple={true}
                 placeholder={this.getSummarizePlaceholder()}
                 options={fieldOptions}
-                value={query.fields}
+                value={currentQuery.fields}
                 onChange={val => this.updateField('fields', val.map(({value}) => value))}
               />
             </Fieldset>
             <Fieldset>
               <Aggregations
-                value={query.aggregations}
+                value={currentQuery.aggregations}
                 columns={columns}
                 onChange={val => this.updateField('aggregations', val)}
               />
             </Fieldset>
             <Fieldset>
               <Conditions
-                value={query.conditions}
+                value={currentQuery.conditions}
                 columns={columnsForConditions}
                 onChange={val => this.updateField('conditions', val)}
               />
@@ -257,7 +259,7 @@ export default class OrganizationDiscover extends React.Component {
                 label={t('Order By')}
                 placeholder={<PlaceholderText>{t('Order by...')}</PlaceholderText>}
                 options={this.getOrderbyOptions()}
-                value={query.orderby}
+                value={currentQuery.orderby}
                 onChange={val => this.updateField('orderby', val)}
               />
             </Fieldset>
@@ -266,7 +268,7 @@ export default class OrganizationDiscover extends React.Component {
                 name="limit"
                 label={t('Limit')}
                 placeholder="#"
-                value={query.limit}
+                value={currentQuery.limit}
                 onChange={val =>
                   this.updateField('limit', typeof val === 'number' ? val : null)}
               />
@@ -283,10 +285,15 @@ export default class OrganizationDiscover extends React.Component {
             </Flex>
           </Box>
           <Box w={[2 / 3, 2 / 3, 2 / 3, 3 / 4]} pl={2}>
-            {result && (
-              <Result data={result} chartData={chartData} chartQuery={chartQuery} />
+            {data && (
+              <Result
+                data={data}
+                query={query}
+                chartData={chartData}
+                chartQuery={chartQuery}
+              />
             )}
-            {!result && <Intro updateQuery={this.updateFields} />}
+            {!data && <Intro updateQuery={this.updateFields} />}
           </Box>
         </Flex>
       </Discover>

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
@@ -3,17 +3,18 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import styled from 'react-emotion';
 import {Box, Flex} from 'grid-emotion';
-import moment from 'moment';
 
 import {t} from 'app/locale';
 import BarChart from 'app/components/charts/barChart';
 import LineChart from 'app/components/charts/lineChart';
 
 import Table from './table';
+import {getChartData, getChartDataByDay} from './utils';
 
 export default class Result extends React.Component {
   static propTypes = {
     data: PropTypes.object,
+    query: PropTypes.object,
     chartData: PropTypes.object,
     chartQuery: PropTypes.object,
   };
@@ -26,76 +27,34 @@ export default class Result extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (!nextProps.chartData && this.state.view !== 'table') {
+    if (!nextProps.chartData && ['line-by-day', 'bar-by-day'].includes(this.state.view)) {
+      this.setState({
+        view: 'table',
+      });
+    }
+
+    if (
+      !nextProps.query.aggregations.length &&
+      ['line', 'bar'].includes(this.state.view)
+    ) {
       this.setState({
         view: 'table',
       });
     }
   }
 
-  // Converts a value to a string for the chart label. This could
-  // potentially cause incorrect grouping, e.g. if the value null and string
-  // 'null' are both present in the same series they will be merged into 1 value
-  getLabel(value) {
-    if (typeof value === 'object') {
-      try {
-        value = JSON.stringify(value);
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error(err);
-      }
-    }
-
-    return value;
-  }
-
-  getChartData(queryData, groupbyFields) {
-    const {aggregations} = this.props.chartQuery;
-    // We only chart the first aggregation for now
-    const aggregate = aggregations[0][2];
-    const dates = [
-      ...new Set(queryData.map(entry => moment.utc(entry.time * 1000).format('MMM Do'))),
-    ];
-    const output = {};
-    queryData.forEach(data => {
-      const key = groupbyFields.length
-        ? groupbyFields.map(field => this.getLabel(data[field])).join(',')
-        : aggregate;
-      if (key in output) {
-        output[key].data.push({
-          value: data[aggregate],
-          name: moment.utc(data.time * 1000).format('MMM Do'),
-        });
-      } else {
-        output[key] = {
-          data: [
-            {value: data[aggregate], name: moment.utc(data.time * 1000).format('MMM Do')},
-          ],
-        };
-      }
-    });
-    const result = [];
-    for (let key in output) {
-      const addDates = dates.filter(
-        date => !output[key].data.map(entry => entry.name).includes(date)
-      );
-      for (let i = 0; i < addDates.length; i++) {
-        output[key].data.push({
-          value: null,
-          name: addDates[i],
-        });
-      }
-
-      result.push({seriesName: key, data: output[key].data});
-    }
-    return result;
-  }
-
   renderToggle() {
     const options = [{id: 'table', name: t('Table')}];
 
-    if (this.props.chartData) {
+    if (this.props.query.aggregations.length) {
       options.push({id: 'line', name: t('Line')}, {id: 'bar', name: t('Bar')});
+    }
+
+    if (this.props.chartData) {
+      options.push(
+        {id: 'line-by-day', name: t('Line by Day')},
+        {id: 'bar-by-day', name: t('Bar by Day')}
+      );
     }
 
     return (
@@ -122,7 +81,8 @@ export default class Result extends React.Component {
 
   renderSummary() {
     const {data, chartData} = this.props;
-    const summaryData = this.state.view === 'table' ? data : chartData;
+    const baseViews = ['table', 'line', 'bar'];
+    const summaryData = baseViews.includes(this.state.view) ? data : chartData;
 
     return (
       <Summary>
@@ -132,23 +92,27 @@ export default class Result extends React.Component {
   }
 
   render() {
-    const {data, chartQuery, chartData} = this.props;
+    const {data, query, chartQuery, chartData} = this.props;
     const {view} = this.state;
+
+    const basicChartData = getChartData(data.data, query);
 
     return (
       <div>
         {this.renderToggle()}
 
         {view === 'table' && <Table data={data} />}
-        {view === 'line' && (
+        {view === 'line' && <LineChart series={basicChartData} height={300} />}
+        {view === 'bar' && <BarChart series={basicChartData} height={300} />}
+        {view === 'line-by-day' && (
           <LineChart
-            series={this.getChartData(chartData.data, chartQuery.fields)}
+            series={getChartDataByDay(chartData.data, chartQuery)}
             height={300}
           />
         )}
-        {view === 'bar' && (
+        {view === 'bar-by-day' && (
           <BarChart
-            series={this.getChartData(chartData.data, chartQuery.fields)}
+            series={getChartDataByDay(chartData.data, chartQuery)}
             stacked={true}
             height={300}
           />

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
@@ -1,12 +1,105 @@
+/*eslint no-use-before-define: ["error", { "functions": false }]*/
+
 import React from 'react';
 import styled from 'react-emotion';
+import moment from 'moment';
+
+/**
+ * Returns data formatted for basic line and bar charts, with each aggregation
+ * representing a series.
+ *
+ * @param {Array} data Data returned from Snuba
+ * @param {Object} query Query state corresponding to data
+ * @returns {Array}
+ */
+export function getChartData(data, query) {
+  const {fields} = query;
+
+  return query.aggregations.map(aggregation => {
+    return {
+      seriesName: aggregation[2],
+      data: data.map(res => {
+        return {
+          value: res[aggregation[2]],
+          name: fields.map(field => `${field} ${res[field]}`).join(' '),
+        };
+      }),
+    };
+  });
+}
+
+/**
+ * Returns time series data formatted for line and bar charts, with each day
+ * along the x-axis
+ *
+ * @param {Array} data Data returned from Snuba
+ * @param {Object} query Query state corresponding to data
+ * @returns {Array}
+ */
+export function getChartDataByDay(data, query) {
+  const {aggregations, fields} = query;
+  // We only chart the first aggregation for now
+  const aggregate = aggregations[0][2];
+  const dates = [
+    ...new Set(data.map(entry => moment.utc(entry.time * 1000).format('MMM Do'))),
+  ];
+  const output = {};
+  data.forEach(res => {
+    const key = fields.length
+      ? fields.map(field => getLabel(res[field])).join(',')
+      : aggregate;
+    if (key in output) {
+      output[key].data.push({
+        value: res[aggregate],
+        name: moment.utc(res.time * 1000).format('MMM Do'),
+      });
+    } else {
+      output[key] = {
+        data: [
+          {value: res[aggregate], name: moment.utc(res.time * 1000).format('MMM Do')},
+        ],
+      };
+    }
+  });
+  const result = [];
+  for (let key in output) {
+    const addDates = dates.filter(
+      date => !output[key].data.map(entry => entry.name).includes(date)
+    );
+    for (let i = 0; i < addDates.length; i++) {
+      output[key].data.push({
+        value: null,
+        name: addDates[i],
+      });
+    }
+
+    result.push({seriesName: key, data: output[key].data});
+  }
+  return result;
+}
+
+// Converts a value to a string for the chart label. This could
+// potentially cause incorrect grouping, e.g. if the value null and string
+// 'null' are both present in the same series they will be merged into 1 value
+function getLabel(value) {
+  if (typeof value === 'object') {
+    try {
+      value = JSON.stringify(value);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
+    }
+  }
+
+  return value;
+}
 
 /**
  * Takes any value and returns a display version of that value for
  * rendering in the "discover" result table. Handles only the 3 types
  * that we would expect to be present in Snuba data - string, null and array
  */
-function getDisplayValue(val, idx) {
+export function getDisplayValue(val, idx) {
   if (typeof val === 'string') {
     return <DarkGray key={idx}>{`"${val}"`}</DarkGray>;
   }
@@ -33,7 +126,7 @@ function getDisplayValue(val, idx) {
   return val;
 }
 
-function getDisplayText(val) {
+export function getDisplayText(val) {
   if (typeof val === 'string') {
     return `"${val}"`;
   }
@@ -63,5 +156,3 @@ const LightGray = styled.span`
 const DarkGray = styled.span`
   color: ${p => p.theme.gray5};
 `;
-
-export {getDisplayValue, getDisplayText};

--- a/tests/js/spec/views/organizationDiscover/discover.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/discover.spec.jsx
@@ -66,7 +66,7 @@ describe('Discover', function() {
       await tick();
       expect(queryBuilder.fetch).toHaveBeenCalledTimes(1);
       expect(queryBuilder.fetch).toHaveBeenCalledWith();
-      expect(wrapper.state().result).toEqual(mockResponse);
+      expect(wrapper.state().data).toEqual(mockResponse);
     });
 
     it('removes incomplete conditions', async function() {

--- a/tests/js/spec/views/organizationDiscover/result/utils.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/result/utils.spec.jsx
@@ -1,11 +1,48 @@
-import React from 'react';
-import {shallow} from 'enzyme';
+import {
+  getChartData,
+  getChartDataByDay,
+} from 'app/views/organizationDiscover/result/utils';
 
-import Result from 'app/views/organizationDiscover/result';
+describe('Utils', function() {
+  it('getChartData()', function() {
+    const raw = [
+      {count: 2, uniq_event_id: 1, project_id: 5, 'tags[environment]': null},
+      {count: 2, uniq_event_id: 3, project_id: 5, 'tags[environment]': 'staging'},
+      {count: 2, uniq_event_id: 4, project_id: 5, 'tags[environment]': 'alpha'},
+      {count: 6, uniq_event_id: 10, project_id: 5, 'tags[environment]': 'production'},
+    ];
 
-describe('Result', function() {
-  const data = {
-    data: [
+    const query = {
+      aggregations: [['count()', null, 'count'], ['uniq', 'event_id', 'uniq_event_id']],
+      fields: ['project_id', 'tags[environment]'],
+    };
+
+    const expected = [
+      {
+        seriesName: 'count',
+        data: [
+          {value: 2, name: 'project_id 5 tags[environment] null'},
+          {value: 2, name: 'project_id 5 tags[environment] staging'},
+          {value: 2, name: 'project_id 5 tags[environment] alpha'},
+          {value: 6, name: 'project_id 5 tags[environment] production'},
+        ],
+      },
+      {
+        seriesName: 'uniq_event_id',
+        data: [
+          {value: 1, name: 'project_id 5 tags[environment] null'},
+          {value: 3, name: 'project_id 5 tags[environment] staging'},
+          {value: 4, name: 'project_id 5 tags[environment] alpha'},
+          {value: 10, name: 'project_id 5 tags[environment] production'},
+        ],
+      },
+    ];
+
+    expect(getChartData(raw, query)).toEqual(expected);
+  });
+
+  it('getChartDataByDay()', function() {
+    const raw = [
       {
         'exception_stacks.type': 'ZeroDivisionError',
         platform: 'python',
@@ -54,20 +91,14 @@ describe('Result', function() {
         count: 30,
         time: 1532070000,
       },
-    ],
-    timing: {
-      duration_ms: 5,
-    },
-  };
-  const query = {
-    aggregations: [['count()', null, 'count']],
-    fields: ['platform', 'exception_stacks.type'],
-  };
+    ];
 
-  const wrapper = shallow(<Result data={data} chartData={data} chartQuery={query} />);
+    const query = {
+      aggregations: [['count()', null, 'count']],
+      fields: ['platform', 'exception_stacks.type'],
+    };
 
-  describe('getChartData()', function() {
-    const expectedData = [
+    const expected = [
       {
         data: [
           {name: 'Jul 9th', value: 6},
@@ -102,10 +133,6 @@ describe('Result', function() {
       },
     ];
 
-    it('Gets line chart data correctly', function() {
-      expect(wrapper.instance().getChartData(data.data, query.fields)).toEqual(
-        expectedData
-      );
-    });
+    expect(getChartDataByDay(raw, query)).toEqual(expected);
   });
 });


### PR DESCRIPTION
Show basic line and bar charts in addition to the time-series line and bar charts we already display.
Only show these when aggregations are present, in other cases this isn't particularly useful.