### PR TITLE
fix(security): Don't expose SETTINGS on Django error page

### DIFF
--- a/src/sentry/monkey.py
+++ b/src/sentry/monkey.py
@@ -70,5 +70,19 @@ def patch_parse_cookie():
     http.parse_cookie = safe_parse_cookie
 
 
-for patch in patch_parse_cookie, patch_httprequest_repr:
+def patch_django_views_debug():
+    # Prevent exposing any Django SETTINGS on our debug error page
+    # This information is not useful for Sentry development
+    # and poses a significant security risk if this is exposed by accident
+    # in any production system if, by change, it were deployed
+    # with DEBUG=True.
+    try:
+        from django.views import debug
+    except ImportError:
+        return
+
+    debug.get_safe_settings = lambda: {}
+
+
+for patch in patch_parse_cookie, patch_httprequest_repr, patch_django_views_debug:
     patch()


### PR DESCRIPTION
In the event that a production instance is deployed in DEBUG mode, let's
not expose any SETTINGS at all.

We don't have any real value in these for local development, so it's not
really useful and risky to expose.

This isn't really a fix to make DEBUG mode secure, it's just obfuscating
some potentially known secure fields.

DEBUG mode is still considered not safe for production use, and should
never be used on an instance exposed to the public internet. There will
always be information leakage available through this page, due to the
nature of what it is and it's purpose.

Refs: https://blog.scrt.ch/2018/08/24/remote-code-execution-on-a-facebook-server/