### PR TITLE
perf: Get key info and top values info in 1 snuba query

### DIFF
--- a/src/sentry/api/endpoints/group_tagkey_details.py
+++ b/src/sentry/api/endpoints/group_tagkey_details.py
@@ -56,8 +56,12 @@ class GroupTagKeyDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                 group.project_id, group.id, environment_id, lookup_key)
         else:
             total_values = group_tag_key.count
-        top_values = tagstore.get_top_group_tag_values(
-            group.project_id, group.id, environment_id, lookup_key, limit=9)
+
+        if group_tag_key.top_values is None:
+            top_values = tagstore.get_top_group_tag_values(
+                group.project_id, group.id, environment_id, lookup_key, limit=9)
+        else:
+            top_values = group_tag_key.top_values
 
         data = {
             'key': key,

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -297,7 +297,8 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def get_tag_value_paginator(self, project_id, environment_id, key, query=None, order_by='-last_seen'):
+    def get_tag_value_paginator(self, project_id, environment_id, key,
+                                query=None, order_by='-last_seen'):
         """
         >>> get_tag_value_paginator(1, 2, 'environment', query='prod')
         """
@@ -309,7 +310,8 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def get_group_tag_value_paginator(self, project_id, group_id, environment_id, key, order_by='-id'):
+    def get_group_tag_value_paginator(self, project_id, group_id,
+                                      environment_id, key, order_by='-id'):
         """
         >>> get_group_tag_value_paginator(1, 2, 3, 'environment')
         """
@@ -400,8 +402,9 @@ class TagStorage(Service):
         tag_keys = self.get_group_tag_keys(project_id, group_id, environment_id)
 
         return [dict(
-            totalValues=self.get_group_tag_value_count(
-                project_id, group_id, environment_id, tk.key),
+            totalValues=(self.get_group_tag_value_count(
+                project_id, group_id, environment_id, tk.key)
+                if tk.count is None else tk.count),
             topValues=serialize(self.get_top_group_tag_values(
                 project_id, group_id, environment_id, tk.key, limit=10)),
             **serialize([tk])[0]

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -209,7 +209,7 @@ class SnubaTagStorage(TagStorage):
     def get_tag_values(self, project_id, environment_id, key):
         key = self.__get_tag_key_and_top_values(project_id, None, environment_id, key,
                                                 limit=None, raise_on_empty=False)
-        return key.top_values
+        return set(key.top_values)
 
     def get_group_tag_key(self, project_id, group_id, environment_id, key):
         return self.__get_tag_key_and_top_values(project_id, group_id, environment_id, key)
@@ -223,7 +223,7 @@ class SnubaTagStorage(TagStorage):
     def get_group_tag_values(self, project_id, group_id, environment_id, key):
         key = self.__get_tag_key_and_top_values(project_id, group_id, environment_id, key,
                                                 limit=None, raise_on_empty=False)
-        return key.top_values
+        return set(key.top_values)
 
     def get_group_list_tag_value(self, project_id, group_id_list, environment_id, key, value):
         start, end = self.get_time_range()

--- a/src/sentry/tagstore/types.py
+++ b/src/sentry/tagstore/types.py
@@ -30,10 +30,12 @@ class TagType(object):
 class TagKey(TagType):
     __slots__ = ['key', 'values_seen', 'status']
 
-    def __init__(self, key, values_seen, status=TagKeyStatus.VISIBLE):
+    def __init__(self, key, values_seen, status=TagKeyStatus.VISIBLE, count=None, top_values=None):
         self.key = key
         self.values_seen = values_seen
         self.status = status
+        self.count = count
+        self.top_values = top_values
 
 
 class TagValue(TagType):
@@ -50,11 +52,12 @@ class TagValue(TagType):
 class GroupTagKey(TagType):
     __slots__ = ['group_id', 'key', 'values_seen']
 
-    def __init__(self, group_id, key, values_seen, count=None):
+    def __init__(self, group_id, key, values_seen, count=None, top_values=None):
         self.group_id = group_id
         self.key = key
         self.values_seen = values_seen
         self.count = count
+        self.top_values = top_values
 
 
 class GroupTagValue(TagType):


### PR DESCRIPTION
Using `WITH TOTALS` we can get the overall counts for the
key, as well as those for the top values in a single query.