### PR TITLE
feat(integrations): VSTS Extension installation

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -69,6 +69,10 @@ class IntegrationProvider(PipelineProvider):
     # a human readable name (e.g. 'Slack')
     name = None
 
+    # Whether the Integration should show up in the list of Providers on the
+    # Organization Integration settings page
+    visible = True
+
     # an IntegrationMetadata object, used to provide extra details in the
     # configuration interface of the integration.
     metadata = None

--- a/src/sentry/integrations/vsts_extension/integration.py
+++ b/src/sentry/integrations/vsts_extension/integration.py
@@ -25,10 +25,6 @@ class VstsExtensionIntegrationProvider(VstsIntegrationProvider):
         return views
 
     def build_integration(self, state):
-        # Normally this is saved into the ``identity`` state, but for some
-        # reason it gets wiped out in the NestedPipeline. Instead, we'll store
-        # it in it's own key (``vsts``) to be used down the line in
-        # ``VSTSOrganizationSelectionView``.
         state['account'] = {
             'AccountId': state['vsts']['AccountId'],
             'AccountName': state['vsts']['AccountName'],
@@ -50,7 +46,6 @@ class VstsExtensionFinishedView(PipelineView):
 
         messages.add_message(request, messages.SUCCESS, 'VSTS Extension installed.')
 
-        # TODO: replace with whatever we decide the finish step is.
         return HttpResponseRedirect(
             absolute_uri('/settings/{}/integrations/vsts-extension/{}/'.format(
                 pipeline.organization.slug,

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -584,6 +584,14 @@ function routes() {
         component={errorHandler(LazyLoad)}
       />
 
+      <Route
+        path="/extensions/vsts/link/"
+        getComponent={(loc, cb) =>
+          import(/*webpackChunkName: "VSTSOrganizationLink" */ './views/vstsOrganizationLink').then(
+            lazyLoad(cb)
+          )}
+      />
+
       <Route newnew path="/settings/" name="Settings" component={SettingsWrapper}>
         <IndexRoute
           getComponent={(loc, cb) =>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
@@ -78,8 +78,6 @@ export default class OrganizationIntegrations extends AsyncComponent {
       i => i.name
     );
     this.setState({integrations});
-
-    // TODO: Find unmigratable repos and display warning
   };
 
   onRemove = integration => {

--- a/src/sentry/static/sentry/app/views/vstsOrganizationLink.jsx
+++ b/src/sentry/static/sentry/app/views/vstsOrganizationLink.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+
+import {t} from 'app/locale';
+import {CSRF_COOKIE_NAME} from 'app/constants';
+import AsyncView from 'app/views/asyncView';
+import NarrowLayout from 'app/components/narrowLayout';
+import {Form, SelectField} from 'app/components/forms';
+import getCookie from 'app/utils/getCookie';
+
+export default class VSTSOrganizationLink extends AsyncView {
+  getEndpoints() {
+    return [['organizations', '/organizations/']];
+  }
+
+  getTitle() {
+    return 'Link Organization to VSTS';
+  }
+
+  getDefaultState() {
+    return {
+      organizations: [],
+    };
+  }
+
+  get targetId() {
+    return this.props.location.query.targetId;
+  }
+
+  get targetName() {
+    return this.props.location.query.targetName;
+  }
+
+  get organizations() {
+    return this.state.organizations.map(o => [o.slug, o.name]);
+  }
+
+  get defaultChoice() {
+    return !!this.organizations[0] ? this.organizations[0][0] : '';
+  }
+
+  onSubmit() {
+    // Because Form can't also just be a normal form.
+    const form = $('.link-org-form');
+    form.attr('method', 'POST');
+    form.attr('action', '/extensions/vsts/configure/');
+    form.submit();
+  }
+
+  render() {
+    return (
+      <NarrowLayout>
+        <Form
+          className="link-org-form"
+          submitLabel={t('Continue')}
+          onSubmit={this.onSubmit}
+        >
+          <input
+            type="hidden"
+            name="csrfmiddlewaretoken"
+            value={getCookie(CSRF_COOKIE_NAME)}
+          />
+
+          <input type="hidden" name="vsts_id" value={this.targetId} />
+          <input type="hidden" name="vsts_name" value={this.targetName} />
+
+          <SelectField
+            choices={this.organizations}
+            clearable={false}
+            value={this.defaultChoice}
+            name="organization"
+            label={t('Organization to use with VSTS')}
+          />
+        </Form>
+      </NarrowLayout>
+    );
+  }
+}

--- a/src/sentry/web/frontend/vsts_extension_configuration.py
+++ b/src/sentry/web/frontend/vsts_extension_configuration.py
@@ -1,0 +1,78 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+from django.utils.http import urlencode
+
+from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.models import Organization
+from sentry.web.frontend.base import BaseView
+
+
+class VstsExtensionConfigurationView(BaseView):
+    auth_required = False
+
+    def get(self, request, *args, **kwargs):
+        if not request.user.is_authenticated():
+            configure_uri = '{}?{}'.format(
+                reverse('vsts-extension-configuration'),
+                urlencode({
+                    'targetId': request.GET['targetId'],
+                    'targetName': request.GET['targetName'],
+                }),
+            )
+
+            redirect_uri = '{}?{}'.format(
+                reverse('sentry-login'),
+                urlencode({'next': configure_uri}),
+            )
+
+            return self.redirect(redirect_uri)
+
+        if request.user.get_orgs().count() == 1:
+            org = request.user.get_orgs()[0]
+
+            pipeline = self.init_pipeline(
+                request,
+                org,
+                request.GET['targetId'],
+                request.GET['targetName'],
+            )
+
+            return pipeline.current_step()
+        else:
+            return self.redirect('/extensions/vsts/link/?{}'.format(
+                urlencode({
+                    'targetId': request.GET['targetId'],
+                    'targetName': request.GET['targetName'],
+                })
+            ))
+
+    def post(self, request, *args, **kwargs):
+        # Update Integration with Organization chosen
+        org = Organization.objects.get(
+            slug=request.POST['organization'],
+        )
+
+        pipeline = self.init_pipeline(
+            request,
+            org,
+            request.POST['vsts_id'],
+            request.POST['vsts_name'],
+        )
+
+        return pipeline.current_step()
+
+    def init_pipeline(self, request, organization, id, name):
+        pipeline = IntegrationPipeline(
+            request=request,
+            organization=organization,
+            provider_key='vsts-extension',
+        )
+
+        pipeline.initialize()
+        pipeline.bind_state('vsts', {
+            'AccountId': id,
+            'AccountName': name,
+        })
+
+        return pipeline

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -55,6 +55,8 @@ from sentry.web.frontend.unsubscribe_issue_notifications import \
     UnsubscribeIssueNotificationsView
 from sentry.web.frontend.user_avatar import UserAvatarPhotoView
 from sentry.web.frontend.setup_wizard import SetupWizardView
+from sentry.web.frontend.vsts_extension_configuration import \
+    VstsExtensionConfigurationView
 from sentry.web.frontend.js_sdk_loader import JavaScriptSdkLoader
 
 
@@ -198,8 +200,10 @@ urlpatterns += patterns(
         name='sentry-account-confirm-email-send'
     ),
     url(r'^account/authorizations/$',
-        RedirectView.as_view(pattern_name="sentry-account-settings-authorizations", permanent=False),
-    ),
+        RedirectView.as_view(
+            pattern_name="sentry-account-settings-authorizations",
+            permanent=False),
+        ),
     url(
         r'^account/confirm-email/(?P<user_id>[\d]+)/(?P<hash>[0-9a-zA-Z]+)/$',
         accounts.confirm_email,
@@ -218,7 +222,7 @@ urlpatterns += patterns(
     ),
     url(r'^account/settings/$',
         RedirectView.as_view(pattern_name="sentry-account-settings", permanent=False),
-    ),
+        ),
     url(
         r'^account/settings/2fa/$',
         RedirectView.as_view(pattern_name="sentry-account-settings-security", permanent=False),
@@ -255,7 +259,7 @@ urlpatterns += patterns(
     ),
     url(r'^account/settings/emails/$',
         RedirectView.as_view(pattern_name="sentry-account-settings-emails", permanent=False),
-    ),
+        ),
 
     # Project Wizard
     url(
@@ -334,14 +338,14 @@ urlpatterns += patterns(
     ),
     url(r'^api/$',
         RedirectView.as_view(pattern_name="sentry-api", permanent=False),
-    ),
+        ),
     url(r'^api/applications/$',
         RedirectView.as_view(pattern_name="sentry-api-applications", permanent=False)),
     url(r'^api/new-token/$',
         RedirectView.as_view(pattern_name="sentry-api-new-auth-token", permanent=False)),
     url(r'^api/[^0]+/',
         RedirectView.as_view(pattern_name="sentry-api-details", permanent=False),
-    ),
+        ),
     url(r'^out/$', OutView.as_view()),
 
     url(r'^accept-transfer/$', react_page_view, name='sentry-accept-project-transfer'),
@@ -349,16 +353,23 @@ urlpatterns += patterns(
     # acting on behalf of an organization should use react_page_view
     url(r'^settings/account/$', generic_react_page_view, name="sentry-account-settings"),
     url(r'^settings/account/$', generic_react_page_view, name="sentry-account-settings-appearance"),
-    url(r'^settings/account/authorizations/$', generic_react_page_view, name="sentry-account-settings-authorizations"),
-    url(r'^settings/account/security/', generic_react_page_view, name='sentry-account-settings-security'),
+    url(r'^settings/account/authorizations/$', generic_react_page_view,
+        name="sentry-account-settings-authorizations"),
+    url(r'^settings/account/security/', generic_react_page_view,
+        name='sentry-account-settings-security'),
     url(r'^settings/account/avatar/$', generic_react_page_view, name='sentry-account-settings-avatar'),
-    url(r'^settings/account/identities/$', generic_react_page_view, name='sentry-account-settings-identities'),
-    url(r'^settings/account/subscriptions/$', generic_react_page_view, name='sentry-account-settings-subscriptions'),
-    url(r'^settings/account/notifications/', generic_react_page_view, name='sentry-account-settings-notifications'),
+    url(r'^settings/account/identities/$', generic_react_page_view,
+        name='sentry-account-settings-identities'),
+    url(r'^settings/account/subscriptions/$', generic_react_page_view,
+        name='sentry-account-settings-subscriptions'),
+    url(r'^settings/account/notifications/', generic_react_page_view,
+        name='sentry-account-settings-notifications'),
     url(r'^settings/account/emails/$', generic_react_page_view, name='sentry-account-settings-emails'),
     url(r'^settings/account/api/$', generic_react_page_view, name='sentry-api'),
-    url(r'^settings/account/api/applications/$', generic_react_page_view, name='sentry-api-applications'),
-    url(r'^settings/account/api/auth-tokens/new-token/$', generic_react_page_view, name='sentry-api-new-auth-token'),
+    url(r'^settings/account/api/applications/$',
+        generic_react_page_view, name='sentry-api-applications'),
+    url(r'^settings/account/api/auth-tokens/new-token/$',
+        generic_react_page_view, name='sentry-api-new-auth-token'),
     url(r'^settings/account/api/[^0]+/$', generic_react_page_view, name='sentry-api-details'),
     url(r'^settings/account/close-account/$', generic_react_page_view, name='sentry-remove-account'),
     url(r'^settings/account/', generic_react_page_view),
@@ -490,6 +501,13 @@ urlpatterns += patterns(
         r'^team-avatar/(?P<avatar_id>[^\/]+)/$',
         TeamAvatarPhotoView.as_view(),
         name='sentry-team-avatar-url'
+    ),
+
+    # VSTS Marketplace extension install flow
+    url(
+        r'^extensions/vsts/configure/$',
+        VstsExtensionConfigurationView.as_view(),
+        name='vsts-extension-configuration',
     ),
 
     # Generic

--- a/tests/sentry/web/frontend/test_vsts_extension_configuration.py
+++ b/tests/sentry/web/frontend/test_vsts_extension_configuration.py
@@ -1,0 +1,75 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from sentry.testutils import TestCase
+from sentry.models import OrganizationMember
+
+
+class VstsExtensionConfigurationTest(TestCase):
+    @property
+    def path(self):
+        return reverse('vsts-extension-configuration')
+
+    def setUp(self):
+        self.user = self.create_user()
+        self.org = self.create_organization()
+
+        OrganizationMember.objects.create(
+            user=self.user,
+            organization=self.org,
+        )
+
+    def test_logged_in_one_org(self):
+        self.login_as(self.user)
+
+        resp = self.client.get(self.path, {
+            'targetId': '1',
+            'targetName': 'foo',
+        })
+
+        # Goes straight to VSTS OAuth
+        assert resp.status_code == 302
+        assert resp.url.startswith(
+            'https://app.vssps.visualstudio.com/oauth2/authorize')
+
+    def test_logged_in_many_orgs(self):
+        self.login_as(self.user)
+
+        org = self.create_organization()
+        OrganizationMember.objects.create(
+            user=self.user,
+            organization=org,
+        )
+
+        resp = self.client.get(self.path, {
+            'targetId': '1',
+            'targetName': 'foo',
+        })
+
+        assert resp.status_code == 302
+        assert '/extensions/vsts/link/' in resp.url
+
+    def test_choose_org(self):
+        self.login_as(self.user)
+
+        resp = self.client.post(self.path, {
+            'vsts_id': '1',
+            'vsts_name': 'foo',
+            'organization': self.org.slug,
+        })
+
+        assert resp.status_code == 302
+        assert resp.url.startswith(
+            'https://app.vssps.visualstudio.com/oauth2/authorize')
+
+    def test_logged_out(self):
+        resp = self.client.get(self.path, {
+            'targetId': '1',
+            'targetName': 'foo',
+        })
+
+        assert resp.status_code == 302
+        assert '/auth/login/' in resp.url
+        # URL encoded post-login redirect URL
+        assert 'next=%2Fextensions%2Fvsts%2Fconfigure%2F%3FtargetName%3Dfoo%26targetId%3D1' in resp.url


### PR DESCRIPTION
Introduces the UI necessary to integrate with VSTS' marketplace. After the person clicks "Install" on their marketplace, they will be presented with a "Configure Sentry" button. That will kick off the process of choosing their Sentry Org to associate, as well as OAuth'ing to VSTS.

### Potato GIFs (of test extension):

**One Sentry Org**
![vsts-extension](https://user-images.githubusercontent.com/36059/44686200-58b95e80-aa02-11e8-97e9-2cfc6a207d19.gif)

**Many Sentry Orgs**
![vsts-extension-many-orgs](https://user-images.githubusercontent.com/36059/44686238-6a026b00-aa02-11e8-82e2-648f7589b300.gif)