### PR TITLE
fix(theme): Prevent getChartPalette returning undefined

### DIFF
--- a/src/sentry/static/sentry/app/utils/theme.jsx
+++ b/src/sentry/static/sentry/app/utils/theme.jsx
@@ -222,7 +222,8 @@ theme.charts = {
   colors: CHART_PALETTE[CHART_PALETTE.length - 1],
 
   // We have an array that maps `number + 1` --> list of `number` colors
-  getColorPalette: length => CHART_PALETTE[length + 1],
+  getColorPalette: length =>
+    CHART_PALETTE[Math.min(CHART_PALETTE.length - 1, length + 1)],
 
   previousPeriod: theme.gray1,
 };


### PR DESCRIPTION
Fixes a bug where series with length > 16 did not render since
getChartPalette() was returning undefined in that case