### PR TITLE
ref(integrations): Validate GitHub repo

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -42,6 +42,9 @@ class GitHubClientMixin(ApiClient):
             num
         ))
 
+    def repo_hooks(self, repo):
+        return self.get('/repos/{}/hooks'.format(repo))
+
     def get_commits(self, repo):
         return self.get('/repos/{}/commits'.format(repo))
 

--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -25,7 +25,7 @@ class GitHubRepositoryProvider(providers.IntegrationRepositoryProvider):
             # make sure installation has access to this specific repo
             client.repo_hooks(repo)
         except ApiError as e:
-            raise IntegrationError('Ensure you\'ve granted Sentry access to {}'.format(repo))
+            raise IntegrationError('You must grant Sentry access to {}'.format(repo))
 
         return repo_data
 

--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import logging
 import six
 
+from sentry.integrations.exceptions import ApiError, IntegrationError
 from sentry.models import Integration
 from sentry.plugins import providers
 
@@ -22,9 +23,9 @@ class GitHubRepositoryProvider(providers.IntegrationRepositoryProvider):
 
         try:
             # make sure installation has access to this specific repo
-            client.get_commits(repo)
-        except Exception as e:
-            installation.raise_error(e)
+            client.repo_hooks(repo)
+        except ApiError as e:
+            raise IntegrationError('Ensure you\'ve granted Sentry access to {}'.format(repo))
 
         return repo_data
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
@@ -117,7 +117,12 @@ export default class IntegrationRepos extends AsyncComponent {
           })
         );
       },
-      error: () => IndicatorStore.addError(t('Unable to add repository.')),
+      error: data => {
+        let text = data.responseJSON.errors
+          ? data.responseJSON.errors.__all__
+          : t('Unable to add repository.');
+        IndicatorStore.addError(text);
+      },
       complete: () => {
         IndicatorStore.remove(saveIndicator);
         this.setState({adding: false});


### PR DESCRIPTION
 * Uses a different endpoint to make sure we actually have access to the repo they've selected. 
* Adds more specific messaging when validation fails
![screen shot 2018-08-27 at 4 20 08 pm](https://user-images.githubusercontent.com/15368179/44691842-18afa700-aa15-11e8-8d5a-aa94a9350889.png)

