### PR TITLE
feat(health): Change Health Requester to handle more data transforms

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/health.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/health.jsx
@@ -38,7 +38,7 @@ export const doHealthRequest = (
     timeseries,
     includePrevious,
     topk,
-    filters,
+    specifiers,
     limit,
   }
 ) => {
@@ -55,7 +55,7 @@ export const doHealthRequest = (
     statsPeriod: totalPeriod,
     project: projects,
     environment: environments,
-    q: filters,
+    q: specifiers,
     limit,
     ...(topk ? {topk} : {}),
   };

--- a/src/sentry/static/sentry/app/actionCreators/health.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/health.jsx
@@ -16,13 +16,14 @@ const getPeriod = (originalPeriod, shouldDoublePeriod) => {
  * @param {Object} api API client instance
  * @param {Object} options Request parameters
  * @param {Object} options.organization Organization object
- * @param {Number[]} options.projects List of proejct ids
+ * @param {Number[]} options.projects List of project ids
  * @param {String} options.tag The "tag" to query for
  * @param {Boolean} options.timeseries Should we group results by time period
  * @param {String[]} options.environments List of environments to query for
  * @param {String} options.period Time period to query for, in the format: <integer><units> where units are "d" or "h"
  * @param {String} options.interval Time interval to group results in, in the format: <integer><units> where units are "d", "h", "m", "s"
  * @param {Boolean} options.includePrevious Should request also return reqsults for previous period?
+ * @param {Number} options.limit The number of rows to return
  * @param {Number} options.topk Include topk results
  */
 export const doHealthRequest = (
@@ -37,6 +38,8 @@ export const doHealthRequest = (
     timeseries,
     includePrevious,
     topk,
+    filters,
+    limit,
   }
 ) => {
   if (!api) return Promise.reject(new Error('API client not available'));
@@ -52,6 +55,8 @@ export const doHealthRequest = (
     statsPeriod: totalPeriod,
     project: projects,
     environment: environments,
+    q: filters,
+    limit,
     ...(topk ? {topk} : {}),
   };
 

--- a/src/sentry/static/sentry/app/views/organizationHealth/util/healthRequest.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/util/healthRequest.jsx
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {doHealthRequest} from 'app/actionCreators/health';
+import LoadingIndicator from 'app/components/loadingIndicator';
 import SentryTypes from 'app/sentryTypes';
 import withApi from 'app/utils/withApi';
 import withLatestContext from 'app/utils/withLatestContext';
 
 import HealthContext from './healthContext';
-import LoadingIndicator from '../../../components/loadingIndicator';
 
 class HealthRequestWithParams extends React.Component {
   static propTypes = {

--- a/src/sentry/static/sentry/app/views/organizationHealth/util/healthRequest.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/util/healthRequest.jsx
@@ -123,7 +123,7 @@ class HealthRequestWithParams extends React.Component {
   }
 
   fetchData = async () => {
-    let {tag} = this.props;
+    const {tag} = this.props;
 
     // If this is defined and > 0, we need to fetch the top tags ordered by count
     // And then if we need timeseries, we'll
@@ -151,7 +151,7 @@ class HealthRequestWithParams extends React.Component {
   };
 
   fetchTopTag = otherProps => {
-    let {api, includeTop, ...props} = this.props;
+    const {api, includeTop, ...props} = this.props;
 
     if (!includeTop) return Promise.resolve({});
 
@@ -159,7 +159,7 @@ class HealthRequestWithParams extends React.Component {
   };
 
   fetchTimeseriesData = otherProps => {
-    let {api, includeTimeseries, ...props} = this.props;
+    const {api, includeTimeseries, ...props} = this.props;
     if (!includeTimeseries) return Promise.resolve({});
     return doHealthRequest(api, {...props, ...otherProps, timeseries: true});
   };

--- a/src/sentry/static/sentry/app/views/organizationHealth/util/healthRequest.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/util/healthRequest.jsx
@@ -192,7 +192,8 @@ class HealthRequestWithParams extends React.Component {
     }
 
     const hasPreviousPeriod = isTimeseries && includePrevious;
-    const dataMiddleIndex = data.length / 2;
+    // Take the floor just in case, but data should always be divisible by 2
+    const dataMiddleIndex = Math.floor(data.length / 2);
 
     return {
       previous: hasPreviousPeriod ? data.slice(0, dataMiddleIndex) : null,

--- a/src/sentry/static/sentry/app/views/organizationHealth/util/healthRequest.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/util/healthRequest.jsx
@@ -125,8 +125,9 @@ class HealthRequestWithParams extends React.Component {
   fetchData = async () => {
     const {tag} = this.props;
 
-    // If this is defined and > 0, we need to fetch the top tags ordered by count
-    // And then if we need timeseries, we'll
+    // If `includeTop` is defined and > 0, we need to fetch the top tags ordered by count
+    // And then if we need timeseries, we'll pass the specific tag values into the timeseries query
+    // to fetch only the counts for those tag values.
     const tagData = await this.fetchTopTag();
     const tagSpecifiers =
       (tagData &&

--- a/src/sentry/static/sentry/app/views/organizationHealth/util/healthRequest.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/util/healthRequest.jsx
@@ -75,9 +75,14 @@ class HealthRequestWithParams extends React.Component {
 
     /**
      * Include a dataset transform that will aggregate count values for each timestamp.
-     * Note this expects a string for the series name to be used for the aggregated series.
+     * Be sure to supply a name to `timeAggregationSeriesName`
      */
-    includeTimeAggregation: PropTypes.string,
+    includeTimeAggregation: PropTypes.bool,
+
+    /**
+     * Name of series of aggregated timeseries
+     */
+    timeAggregationSeriesName: PropTypes.string,
 
     /**
      * Include a map of series name -> percentage integers
@@ -232,11 +237,11 @@ class HealthRequestWithParams extends React.Component {
   /**
    * Aggregate all counts for each time stamp
    */
-  transformAggregatedTimeseries = (data, name) => {
+  transformAggregatedTimeseries = (data, seriesName) => {
     if (!data) return null;
 
     return {
-      seriesName: name,
+      seriesName,
       data: this.calculateTotalsPerTimestamp(data),
     };
   };
@@ -290,6 +295,7 @@ class HealthRequestWithParams extends React.Component {
       includePercentages,
       includeTimeAggregation,
       includeTop,
+      timeAggregationSeriesName,
     } = this.props;
     const shouldIncludePercentages = includePercentages && includeTop && !isTimeseries;
     const {current, previous} = this.getData(data, isTimeseries);
@@ -324,7 +330,7 @@ class HealthRequestWithParams extends React.Component {
 
     const timeAggregatedData =
       isTimeseries && includeTimeAggregation
-        ? this.transformAggregatedTimeseries(current, includeTimeAggregation)
+        ? this.transformAggregatedTimeseries(current, timeAggregationSeriesName)
         : null;
 
     return {

--- a/src/sentry/static/sentry/app/views/organizationHealth/util/healthRequest.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/util/healthRequest.jsx
@@ -131,7 +131,9 @@ class HealthRequestWithParams extends React.Component {
     const tagSpecifiers =
       (tagData &&
         tagData.data &&
-        tagData.data.map(({[tag]: tagObject}) => tagObject && tagObject._health_id)) ||
+        tagData.data
+          .map(({[tag]: tagObject}) => tagObject && tagObject._health_id)
+          .filter(id => !!id)) ||
       null;
 
     const timeseriesData = await this.fetchTimeseriesData({

--- a/tests/js/spec/actionCreators/health.spec.jsx
+++ b/tests/js/spec/actionCreators/health.spec.jsx
@@ -17,7 +17,7 @@ describe('Health ActionCreator', function() {
       projects: [project.id],
       environments: [],
       topk: 5,
-      includePrevious: true,
+      includePrevious: false,
       period: '7d',
     });
 
@@ -30,7 +30,7 @@ describe('Health ActionCreator', function() {
           project: [project.id],
           environment: [],
           topk: 5,
-          includePrevious: true,
+          includePrevious: false,
           statsPeriod: '7d',
         }),
       })
@@ -48,7 +48,7 @@ describe('Health ActionCreator', function() {
       environments: [],
       tag: 'release',
       topk: 5,
-      includePrevious: true,
+      includePrevious: false,
       period: '7d',
     });
 
@@ -62,7 +62,7 @@ describe('Health ActionCreator', function() {
           environment: [],
           tag: 'release',
           topk: 5,
-          includePrevious: true,
+          includePrevious: false,
           statsPeriod: '7d',
         }),
       })
@@ -92,6 +92,60 @@ describe('Health ActionCreator', function() {
           environment: [],
           tag: 'release',
           includePrevious: false,
+          statsPeriod: '7d',
+        }),
+      })
+    );
+  });
+
+  it('requests timeseries w/ tag and previous period', function() {
+    mock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/health/graph/',
+    });
+    doHealthRequest(api, {
+      timeseries: true,
+      organization,
+      projects: [project.id],
+      environments: [],
+      tag: 'release',
+      topk: 5,
+      includePrevious: true,
+      period: '7d',
+    });
+
+    expect(mock).toHaveBeenCalled();
+
+    expect(mock).toHaveBeenLastCalledWith(
+      '/organizations/org-slug/health/graph/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          statsPeriod: '14d',
+        }),
+      })
+    );
+  });
+
+  it('requests non-timeseries and previous period', function() {
+    mock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/health/top/',
+    });
+    doHealthRequest(api, {
+      timeseries: false,
+      organization,
+      projects: [project.id],
+      environments: [],
+      tag: 'release',
+      topk: 5,
+      includePrevious: true,
+      period: '7d',
+    });
+
+    expect(mock).toHaveBeenCalled();
+
+    expect(mock).toHaveBeenLastCalledWith(
+      '/organizations/org-slug/health/top/',
+      expect.objectContaining({
+        query: expect.objectContaining({
           statsPeriod: '7d',
         }),
       })

--- a/tests/js/spec/views/organizationHealth/util/healthRequest.spec.jsx
+++ b/tests/js/spec/views/organizationHealth/util/healthRequest.spec.jsx
@@ -135,253 +135,322 @@ describe('HealthRequest', function() {
     });
   });
 
-  it('defines a category name getter', async function() {
-    doHealthRequest.mockImplementation(() =>
-      Promise.resolve({
-        data: [[new Date(), [COUNT_OBJ]]],
-      })
-    );
-    wrapper = mount(
-      <HealthRequestWithParams
-        {...DEFAULTS}
-        getCategory={release => release && release.slug}
-      >
-        {mock}
-      </HealthRequestWithParams>
-    );
-    await tick();
-    wrapper.update();
-    expect(mock).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        loading: false,
-        timeseriesData: [
-          {
-            seriesName: 'release-slug',
-            data: [
-              expect.objectContaining({
-                name: expect.anything(),
-                value: 123,
-              }),
-            ],
-          },
-        ],
-        originalTimeseriesData: [[expect.anything(), expect.anything()]],
-      })
-    );
-  });
+  describe('transforms', function() {
+    beforeEach(function() {
+      doHealthRequest.mockClear();
+    });
 
-  it('expands period in query if `includePrevious` and `timeseries`', async function() {
-    // doHealthRequest.mockClear();
-    doHealthRequest.mockImplementation(() =>
-      Promise.resolve({
-        data: [
-          [new Date(), [{...COUNT_OBJ, count: 321}, {...COUNT_OBJ, count: 79}]],
-          [new Date(), [COUNT_OBJ]],
-        ],
-      })
-    );
-    wrapper = mount(
-      <HealthRequestWithParams
-        {...DEFAULTS}
-        includeTimeseries={true}
-        includePrevious={true}
-        getCategory={({slug} = {}) => slug}
-      >
-        {mock}
-      </HealthRequestWithParams>
-    );
-
-    // actionCreator handles expanding the period when calling the API
-    expect(doHealthRequest).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        period: '24h',
-      })
-    );
-
-    await tick();
-    wrapper.update();
-
-    expect(mock).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        loading: false,
-        allTimeseriesData: [
-          [
-            expect.anything(),
-            [expect.objectContaining({count: 321}), expect.objectContaining({count: 79})],
+    it('defines a category name getter', async function() {
+      doHealthRequest.mockImplementation(() =>
+        Promise.resolve({
+          data: [[new Date(), [COUNT_OBJ]]],
+        })
+      );
+      wrapper = mount(
+        <HealthRequestWithParams
+          {...DEFAULTS}
+          getCategory={release => release && release.slug}
+        >
+          {mock}
+        </HealthRequestWithParams>
+      );
+      await tick();
+      wrapper.update();
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          loading: false,
+          timeseriesData: [
+            {
+              seriesName: 'release-slug',
+              data: [
+                expect.objectContaining({
+                  name: expect.anything(),
+                  value: 123,
+                }),
+              ],
+            },
           ],
-          [expect.anything(), [expect.objectContaining({count: 123})]],
-        ],
-        timeseriesData: [
-          {
-            seriesName: expect.anything(),
-            data: [
-              expect.objectContaining({
-                name: expect.anything(),
-                value: 123,
-              }),
-            ],
-          },
-        ],
-        previousTimeseriesData: {
-          seriesName: 'Previous Period',
+          originalTimeseriesData: [[expect.anything(), expect.anything()]],
+        })
+      );
+    });
+
+    it('expands period in query if `includePrevious` and `timeseries`', async function() {
+      doHealthRequest.mockImplementation(() =>
+        Promise.resolve({
           data: [
-            expect.objectContaining({
-              name: expect.anything(),
-              value: 400,
-            }),
+            [new Date(), [{...COUNT_OBJ, count: 321}, {...COUNT_OBJ, count: 79}]],
+            [new Date(), [COUNT_OBJ]],
           ],
-        },
+        })
+      );
+      wrapper = mount(
+        <HealthRequestWithParams
+          {...DEFAULTS}
+          includeTimeseries={true}
+          includePrevious={true}
+          getCategory={({slug} = {}) => slug}
+        >
+          {mock}
+        </HealthRequestWithParams>
+      );
 
-        originalTimeseriesData: [
-          [expect.anything(), [expect.objectContaining({count: 123})]],
-        ],
+      await tick();
+      wrapper.update();
 
-        originalPreviousTimeseriesData: [
-          [
-            expect.anything(),
-            [expect.objectContaining({count: 321}), expect.objectContaining({count: 79})],
+      // actionCreator handles expanding the period when calling the API
+      expect(doHealthRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          period: '24h',
+        })
+      );
+
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          loading: false,
+          allTimeseriesData: [
+            [
+              expect.anything(),
+              [
+                expect.objectContaining({count: 321}),
+                expect.objectContaining({count: 79}),
+              ],
+            ],
+            [expect.anything(), [expect.objectContaining({count: 123})]],
           ],
-        ],
-      })
-    );
-  });
-
-  it('transforms data for non-timeseries response', async function() {
-    doHealthRequest.mockImplementation(() =>
-      Promise.resolve({
-        data: [COUNT_OBJ],
-      })
-    );
-    wrapper = mount(
-      <HealthRequestWithParams
-        {...DEFAULTS}
-        includeTimeseries={false}
-        includeTop={true}
-        getCategory={({slug} = {}) => slug}
-      >
-        {mock}
-      </HealthRequestWithParams>
-    );
-
-    await tick();
-    wrapper.update();
-
-    expect(mock).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        loading: false,
-        tagData: [['release-slug', 123]],
-        originalTagData: [
-          {
-            count: 123,
-            release: {value: {slug: 'release-slug'}, _health_id: 'release:release-slug'},
+          timeseriesData: [
+            {
+              seriesName: expect.anything(),
+              data: [
+                expect.objectContaining({
+                  name: expect.anything(),
+                  value: 123,
+                }),
+              ],
+            },
+          ],
+          previousTimeseriesData: {
+            seriesName: 'Previous Period',
+            data: [
+              expect.objectContaining({
+                name: expect.anything(),
+                value: 400,
+              }),
+            ],
           },
-        ],
-      })
-    );
-  });
 
-  it('transforms data with percentages only when `includPercentages` prop is true', async function() {
-    doHealthRequest.mockImplementation(() =>
-      Promise.resolve({
-        data: [
-          {...COUNT_OBJ, count: 100, lastCount: 50},
-          {
-            count: 80,
-            lastCount: 100,
-            release: {
-              value: {
-                slug: 'new-release',
+          originalTimeseriesData: [
+            [expect.anything(), [expect.objectContaining({count: 123})]],
+          ],
+
+          originalPreviousTimeseriesData: [
+            [
+              expect.anything(),
+              [
+                expect.objectContaining({count: 321}),
+                expect.objectContaining({count: 79}),
+              ],
+            ],
+          ],
+        })
+      );
+    });
+
+    it('transforms data for non-timeseries response', async function() {
+      doHealthRequest.mockImplementation(() =>
+        Promise.resolve({
+          data: [COUNT_OBJ],
+        })
+      );
+      wrapper = mount(
+        <HealthRequestWithParams
+          {...DEFAULTS}
+          includeTimeseries={false}
+          includeTop={true}
+          getCategory={({slug} = {}) => slug}
+        >
+          {mock}
+        </HealthRequestWithParams>
+      );
+
+      await tick();
+      wrapper.update();
+
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          loading: false,
+          tagData: [['release-slug', 123]],
+          originalTagData: [
+            {
+              count: 123,
+              release: {
+                value: {slug: 'release-slug'},
+                _health_id: 'release:release-slug',
               },
             },
+          ],
+        })
+      );
+    });
+
+    it('transforms data with percentages only when `includPercentages` prop is true', async function() {
+      doHealthRequest.mockImplementation(() =>
+        Promise.resolve({
+          data: [
+            {...COUNT_OBJ, count: 100, lastCount: 50},
+            {
+              count: 80,
+              lastCount: 100,
+              release: {
+                value: {
+                  slug: 'new-release',
+                },
+              },
+            },
+          ],
+          totals: {
+            count: 180,
           },
-        ],
-        totals: {
-          count: 180,
-        },
-      })
-    );
+        })
+      );
 
-    wrapper = mount(
-      <HealthRequestWithParams
-        {...DEFAULTS}
-        includeTimeseries={false}
-        includeTop={true}
-        includePercentages={false}
-        getCategory={({slug} = {}) => slug}
-      >
-        {mock}
-      </HealthRequestWithParams>
-    );
+      wrapper = mount(
+        <HealthRequestWithParams
+          {...DEFAULTS}
+          includeTimeseries={false}
+          includeTop={true}
+          includePercentages={false}
+          getCategory={({slug} = {}) => slug}
+        >
+          {mock}
+        </HealthRequestWithParams>
+      );
 
-    await tick();
-    wrapper.update();
+      await tick();
+      wrapper.update();
 
-    expect(mock).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        tagDataWithPercentages: null,
-      })
-    );
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          tagDataWithPercentages: null,
+        })
+      );
 
-    wrapper.setProps({includePercentages: true});
-    await tick();
-    wrapper.update();
+      wrapper.setProps({includePercentages: true});
+      await tick();
+      wrapper.update();
 
-    expect(mock).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        tagDataWithPercentages: [
-          expect.objectContaining({
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          tagDataWithPercentages: [
+            expect.objectContaining({
+              count: 100,
+              lastCount: 50,
+              percentage: 55.56,
+            }),
+            expect.objectContaining({
+              count: 80,
+              lastCount: 100,
+              percentage: 44.44,
+            }),
+          ],
+        })
+      );
+    });
+
+    it('aggreates counts per timestamp only when `includeTimeAggregation` prop is true', async function() {
+      doHealthRequest.mockImplementation(() =>
+        Promise.resolve({
+          data: [[new Date(), [COUNT_OBJ, {...COUNT_OBJ, count: 100}]]],
+        })
+      );
+
+      wrapper = mount(
+        <HealthRequestWithParams
+          {...DEFAULTS}
+          includeTimeseries={true}
+          getCategory={({slug} = {}) => slug}
+        >
+          {mock}
+        </HealthRequestWithParams>
+      );
+
+      await tick();
+      wrapper.update();
+
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          timeAggregatedData: null,
+        })
+      );
+
+      wrapper.setProps({includeTimeAggregation: 'aggregated series'});
+      await tick();
+      wrapper.update();
+
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          timeAggregatedData: {
+            seriesName: 'aggregated series',
+            data: [{name: expect.anything(), value: 223}],
+          },
+        })
+      );
+    });
+
+    it('transparently queries for top tags and then queries for timeseries data using only those top tags', async function() {
+      doHealthRequest.mockClear();
+      doHealthRequest.mockImplementation((api, props) => {
+        if (props.timeseries) {
+          return Promise.resolve({
+            data: [[new Date(), [COUNT_OBJ, {...COUNT_OBJ, count: 100}]]],
+          });
+        }
+
+        return Promise.resolve({
+          data: [{...COUNT_OBJ, count: 100}],
+          totals: {
             count: 100,
             lastCount: 50,
-            percentage: 55.56,
-          }),
-          expect.objectContaining({
-            count: 80,
-            lastCount: 100,
-            percentage: 44.44,
-          }),
-        ],
-      })
-    );
-  });
+          },
+        });
+      });
 
-  it('aggreates counts per timestamp only when `includeTimeAggregation` prop is true', async function() {
-    doHealthRequest.mockImplementation(() =>
-      Promise.resolve({
-        data: [[new Date(), [COUNT_OBJ, {...COUNT_OBJ, count: 100}]]],
-      })
-    );
+      wrapper = mount(
+        <HealthRequestWithParams
+          {...DEFAULTS}
+          includeTop
+          includeTimeseries
+          includePercentages
+          includeTimeAggregation="Aggregated"
+          includePrevious
+          getCategory={({slug} = {}) => slug}
+        >
+          {mock}
+        </HealthRequestWithParams>
+      );
 
-    wrapper = mount(
-      <HealthRequestWithParams
-        {...DEFAULTS}
-        includeTimeseries={true}
-        getCategory={({slug} = {}) => slug}
-      >
-        {mock}
-      </HealthRequestWithParams>
-    );
+      await tick();
+      wrapper.update();
 
-    await tick();
-    wrapper.update();
+      expect(doHealthRequest).toHaveBeenCalledTimes(2);
+      expect(doHealthRequest).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        expect.objectContaining({
+          timeseries: true,
+          specifiers: ['release:release-slug'],
+        })
+      );
 
-    expect(mock).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        timeAggregatedData: null,
-      })
-    );
-
-    wrapper.setProps({includeTimeAggregation: 'aggregated series'});
-    await tick();
-    wrapper.update();
-
-    expect(mock).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        timeAggregatedData: {
-          seriesName: 'aggregated series',
-          data: [{name: expect.anything(), value: 223}],
-        },
-      })
-    );
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          timeAggregatedData: {
+            seriesName: 'Aggregated',
+            data: [{name: expect.anything(), value: 223}],
+          },
+        })
+      );
+    });
   });
 });

--- a/tests/js/spec/views/organizationHealth/util/healthRequest.spec.jsx
+++ b/tests/js/spec/views/organizationHealth/util/healthRequest.spec.jsx
@@ -358,7 +358,7 @@ describe('HealthRequest', function() {
       );
     });
 
-    it('aggreates counts per timestamp only when `includeTimeAggregation` prop is true', async function() {
+    it('aggregates counts per timestamp only when `includeTimeAggregation` prop is true', async function() {
       doHealthRequest.mockImplementation(() =>
         Promise.resolve({
           data: [[new Date(), [COUNT_OBJ, {...COUNT_OBJ, count: 100}]]],
@@ -384,7 +384,10 @@ describe('HealthRequest', function() {
         })
       );
 
-      wrapper.setProps({includeTimeAggregation: 'aggregated series'});
+      wrapper.setProps({
+        includeTimeAggregation: true,
+        timeAggregationSeriesName: 'aggregated series',
+      });
       await tick();
       wrapper.update();
 
@@ -422,8 +425,9 @@ describe('HealthRequest', function() {
           includeTop
           includeTimeseries
           includePercentages
-          includeTimeAggregation="Aggregated"
+          includeTimeAggregation
           includePrevious
+          timeAggregationSeriesName="Aggregated"
           getCategory={({slug} = {}) => slug}
         >
           {mock}


### PR DESCRIPTION
This also:
* changes the requester to handle "previous period" for timeseries data. This would be nice if it was handled by the API but for now we will just expand the period size and handle it on the frontend.
* Adds options to handle fetching tag values (ordered by highest counts) that are then passed to a timeseries request.