### PR TITLE
fix(vsts): Hide VSTS Extension from integrations

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -62,6 +62,10 @@ class IntegrationProvider(PipelineProvider):
     # than ``key``. See: VstsExtensionIntegrationProvider.
     _integration_key = None
 
+    # Whether this integration should show up in the list on the Organization
+    # Integrations page.
+    visible = True
+
     # a human readable name (e.g. 'Slack')
     name = None
 

--- a/src/sentry/integrations/manager.py
+++ b/src/sentry/integrations/manager.py
@@ -18,7 +18,9 @@ class IntegrationManager(object):
 
     def all(self):
         for key in six.iterkeys(self.__values):
-            yield self.get(key)
+            integration = self.get(key)
+            if integration.visible:
+                yield integration
 
     def get(self, key, **kwargs):
         try:

--- a/src/sentry/integrations/vsts_extension/integration.py
+++ b/src/sentry/integrations/vsts_extension/integration.py
@@ -14,6 +14,10 @@ class VstsExtensionIntegrationProvider(VstsIntegrationProvider):
     key = 'vsts-extension'
     integration_key = 'vsts'
 
+    # This is only to enable the VSTS -> Sentry installation flow, so we don't
+    # want it to actually appear of the Integrations page.
+    visible = False
+
     def get_pipeline_views(self):
         views = super(VstsExtensionIntegrationProvider, self).get_pipeline_views()
         views = [view for view in views if not isinstance(view, AccountConfigView)]

--- a/tests/sentry/integrations/test_manager.py
+++ b/tests/sentry/integrations/test_manager.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+from sentry import integrations
+from sentry.integrations.vsts_extension import VstsExtensionIntegrationProvider
+from sentry.testutils import TestCase
+
+
+class TestIntegrations(TestCase):
+    def test_excludes_non_visible_integrations(self):
+        # The VSTSExtension is not visible
+        assert all(
+            not isinstance(i, VstsExtensionIntegrationProvider)
+            for i in integrations.all()
+        )


### PR DESCRIPTION
The VSTS Extension is just meant to enable a VSTS -> Sentry flow, so we don't want to show it in the list of installable integrations.