### PR TITLE
fix(saved-searches): Allow users to always see searches they created

### DIFF
--- a/src/sentry/api/endpoints/project_searches.py
+++ b/src/sentry/api/endpoints/project_searches.py
@@ -30,16 +30,11 @@ class ProjectSearchesEndpoint(ProjectEndpoint):
             {method} {path}
 
         """
-        if request.access.has_scope('project:write'):
-            results = list(
-                SavedSearch.objects.filter(project=project, owner__isnull=True).order_by('name')
-            )
-        else:
-            results = list(
-                SavedSearch.objects.filter(
-                    Q(owner=request.user) | Q(owner__isnull=True), project=project
-                ).order_by('name')
-            )
+        results = list(
+            SavedSearch.objects.filter(
+                Q(owner=request.user) | Q(owner__isnull=True), project=project
+            ).order_by('name')
+        )
 
         return Response(serialize(results, request.user))
 


### PR DESCRIPTION
Users cannot see saved searches they created as an organization role `member`, once they're given `project:write` permissions.