### PR TITLE
feat(releases) Add delete button to releases interface

### DIFF
--- a/src/sentry/static/sentry/app/sentryTypes.jsx
+++ b/src/sentry/static/sentry/app/sentryTypes.jsx
@@ -203,6 +203,14 @@ export const ProjectDetail = PropTypes.shape({
   status: PropTypes.string,
 });
 
+export const Release = PropTypes.shape({
+  version: PropTypes.string.isRequired,
+  ref: PropTypes.string,
+  url: PropTypes.string,
+  dateReleased: PropTypes.string,
+  owner: User,
+});
+
 export const NavigationObject = PropTypes.shape({
   name: PropTypes.string,
   items: PropTypes.arrayOf(
@@ -338,6 +346,7 @@ let SentryTypes = {
   PluginShape,
   PluginsStore,
   ProjectKey,
+  Release,
   User,
 };
 

--- a/src/sentry/static/sentry/app/views/releaseDetails.jsx
+++ b/src/sentry/static/sentry/app/views/releaseDetails.jsx
@@ -97,17 +97,9 @@ const ReleaseDetails = createReactClass({
     let params = this.props.params;
     let orgId = params.orgId;
     let projectId = params.projectId;
-    let version = params.version;
+    let version = encodeURIComponent(params.version);
 
-    return (
-      '/projects/' +
-      orgId +
-      '/' +
-      projectId +
-      '/releases/' +
-      encodeURIComponent(version) +
-      '/'
-    );
+    return `/projects/${orgId}/${projectId}/releases/${version}/`
   },
 
   render() {
@@ -116,6 +108,8 @@ const ReleaseDetails = createReactClass({
 
     let release = this.state.release;
     let {orgId, projectId} = this.props.params;
+    let releasePath = `/${orgId}/${projectId}/releases/${encodeURIComponent(release.version)}`
+
     return (
       <DocumentTitle title={this.getTitle()}>
         <div className="ref-release-details">
@@ -183,9 +177,7 @@ const ReleaseDetails = createReactClass({
             </div>
             <ul className="nav nav-tabs">
               <ListLink
-                to={`/${orgId}/${projectId}/releases/${encodeURIComponent(
-                  release.version
-                )}/`}
+                to={`${releasePath}/`}
                 isActive={loc => {
                   // react-router isActive will return true for any route that is part of the active route
                   // e.g. parent routes. To avoid matching on sub-routes, insist on strict path equality.
@@ -194,32 +186,16 @@ const ReleaseDetails = createReactClass({
               >
                 {t('Overview')}
               </ListLink>
-              <ListLink
-                to={`/${orgId}/${projectId}/releases/${encodeURIComponent(
-                  release.version
-                )}/new-events/`}
-              >
+              <ListLink to={`${releasePath}/new-events/`}>
                 {t('New Issues')}
               </ListLink>
-              <ListLink
-                to={`/${orgId}/${projectId}/releases/${encodeURIComponent(
-                  release.version
-                )}/all-events/`}
-              >
+              <ListLink to={`${releasePath}/all-events/`}>
                 {t('All Issues')}
               </ListLink>
-              <ListLink
-                to={`/${orgId}/${projectId}/releases/${encodeURIComponent(
-                  release.version
-                )}/artifacts/`}
-              >
+              <ListLink to={`${releasePath}/artifacts/`}>
                 {t('Artifacts')}
               </ListLink>
-              <ListLink
-                to={`/${orgId}/${projectId}/releases/${encodeURIComponent(
-                  release.version
-                )}/commits/`}
-              >
+              <ListLink to={`${releasePath}/commits/`}>
                 {t('Commits')}
               </ListLink>
             </ul>

--- a/tests/js/spec/views/releaseDetails.spec.jsx
+++ b/tests/js/spec/views/releaseDetails.spec.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import ReleaseDetails from 'app/views/releaseDetails';
+
+describe('ReleaseDetails', function() {
+  let deleteMock;
+
+  beforeEach(function() {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/projects/acme/anvils/releases/9.1.1/',
+      body: {
+        version: '9.1.1',
+        ref: 'some-tag',
+        dateCreated: '2018-10-30',
+        dateReleased: '2018-08-30',
+        url: 'http://example.com/api/v1/docs',
+        newGroups: 0,
+        firstEvent: null,
+        lastEvent: null,
+      },
+    });
+
+    deleteMock = MockApiClient.addMockResponse({
+      url: '/organizations/acme/releases/9.1.1/',
+      method: 'DELETE',
+      status: 204,
+    });
+  });
+
+  it('shows release details', function() {
+    let noop = () => {};
+    let params = {
+      orgId: 'acme',
+      projectId: 'anvils',
+      project: {
+        slug: 'anvils',
+      },
+      version: '9.1.1',
+    };
+    let location = {
+      pathname: '/',
+    };
+
+    let wrapper = mount(
+      <ReleaseDetails location={location} params={params} setProjectNavSection={noop}>
+        <div>hi</div>
+      </ReleaseDetails>,
+      TestStubs.routerContext()
+    );
+
+    // Click delete button
+    wrapper
+      .find('button[aria-label="Delete"]')
+      .first()
+      .simulate('click');
+
+    wrapper.update();
+
+    // Click on ok button which is at index 2
+    wrapper
+      .find('Modal Button')
+      .at(1)
+      .simulate('click');
+
+    expect(deleteMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Add a delete button to the release details view. Error messages from the server will be bubbled up as indicator messages.

![screen shot 2018-08-28 at 12 23 05 pm](https://user-images.githubusercontent.com/24086/44753397-6dcee400-ab0d-11e8-89fd-009648dd2ce6.png)

Refs #4969