### PR TITLE
feat(health): Add events table chart (with separate column for bar)

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/tableChart/index.jsx
+++ b/src/sentry/static/sentry/app/components/charts/tableChart/index.jsx
@@ -8,9 +8,7 @@ import {Panel, PanelHeader, PanelItem} from 'app/components/panels';
 export const TableChart = styled(
   class TableChartComponent extends React.Component {
     static propTypes = {
-      data: PropTypes.arrayOf(
-        PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number]))
-      ),
+      data: PropTypes.arrayOf(PropTypes.any),
       /**
        * The column index where your data starts.
        * This is used to calculate totals.
@@ -117,7 +115,7 @@ export const TableChart = styled(
         ...props
       }) => {
         return (
-          <Flex flex={1} css={css}>
+          <Row>
             {items &&
               items.slice(0, dataStartIndex).map((rowHeaderValue, columnIndex) =>
                 renderCell({
@@ -156,7 +154,7 @@ export const TableChart = styled(
                   return renderCell(renderCellProps);
                 })}
             </DataGroup>
-          </Flex>
+          </Row>
         );
       };
 
@@ -291,7 +289,12 @@ export const TableChart = styled(
 
       // If we need to calculate totals...
       let dataTotals =
-        showRowTotal || showColumnTotal || shadeRowPercentage ? this.getTotals(data) : [];
+        showRowTotal || showColumnTotal || shadeRowPercentage
+          ? this.getTotals(data)
+          : {
+              rowTotals: [],
+              columnTotals: [],
+            };
       let dataMaybeWithTotals = this.getDataWithTotals(dataTotals);
 
       // For better render customization
@@ -330,7 +333,7 @@ export const TableChart = styled(
 export default TableChart;
 
 export const TableChartRow = styled(
-  class extends React.Component {
+  class TableChartRowComponent extends React.Component {
     static propTypes = {
       /**
        * Show percentage as a bar in the row
@@ -389,4 +392,8 @@ export const Cell = styled(Box)`
 
 const DataGroup = styled(Flex)`
   flex-shrink: 0;
+`;
+const Row = styled(Flex)`
+  flex: 1;
+  overflow: hidden;
 `;

--- a/src/sentry/static/sentry/app/views/organizationHealth/eventsTableChart.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/eventsTableChart.jsx
@@ -75,18 +75,18 @@ class EventsTableChart extends React.Component {
         ])}
         renderRow={({items}) => (
           <React.Fragment>
-            <NameAndEventsContainer flex={1} justify="space-between" align="center">
-              <div>{items[0]}</div>
+            <NameAndEventsContainer justify="space-between" align="center">
+              {items[0]}
               <div>{items[1]}</div>
             </NameAndEventsContainer>
-            <Flex flex={3} justify="space-between" align="center">
+            <PercentageContainer justify="space-between" align="center">
               <Flex w={[3 / 4]} align="center" key="bar">
                 {items[2]}
               </Flex>
               <Flex w={[1 / 4]} justify="flex-end" key="last-event">
                 {items[3]}
               </Flex>
-            </Flex>
+            </PercentageContainer>
           </React.Fragment>
         )}
       />
@@ -101,6 +101,11 @@ const StyledEventsTableChart = styled(EventsTableChart)`
 const NameAndEventsContainer = styled(Flex)`
   flex-shrink: 0;
   margin-right: ${space(2)};
+  width: 50%;
+`;
+
+const PercentageContainer = styled(Flex)`
+  width: 50%;
 `;
 
 const BarWrapper = styled('div')`

--- a/src/sentry/static/sentry/app/views/organizationHealth/eventsTableChart.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/eventsTableChart.jsx
@@ -1,0 +1,134 @@
+import {Flex} from 'grid-emotion';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'react-emotion';
+
+import Count from 'app/components/count';
+import InlineSvg from 'app/components/inlineSvg';
+import TableChart from 'app/components/charts/tableChart';
+import overflowEllipsis from 'app/styles/overflowEllipsis';
+import space from 'app/styles/space';
+
+const Delta = ({current, previous, className}) => {
+  const changePercent = Math.round(Math.abs(current - previous) / previous * 100);
+  const direction = !changePercent ? 0 : current - previous;
+  return (
+    <StyledDelta direction={direction} className={className}>
+      {!!direction && <DeltaCaret direction={direction} src="icon-chevron-down" />}
+      {changePercent !== 0 ? `${changePercent}%` : <span>&mdash;</span>}
+    </StyledDelta>
+  );
+};
+Delta.propTypes = {
+  current: PropTypes.number,
+  previous: PropTypes.number,
+};
+
+const DeltaCaret = styled(InlineSvg)`
+  /* should probably have a chevron-up svg (: */
+  ${p => p.direction > 0 && 'transform: rotate(180deg)'};
+  width: 10px;
+  height: 10px;
+`;
+
+const StyledDelta = styled(Flex)`
+  align-items: center;
+  padding: 0 ${space(0.25)};
+  margin-right: ${space(0.5)};
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p =>
+    p.direction > 0 ? p.theme.green : p.direction < 0 ? p.theme.red : p.theme.gray2};
+`;
+
+class EventsTableChart extends React.Component {
+  static propTypes = {
+    headers: PropTypes.arrayOf(PropTypes.node),
+    data: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.node,
+        percentage: PropTypes.number,
+        count: PropTypes.number,
+        lastCount: PropTypes.number,
+      })
+    ),
+  };
+
+  render() {
+    const {headers, data} = this.props;
+
+    return (
+      <TableChart
+        headers={headers}
+        data={data.map(({count, lastCount, name, percentage}) => [
+          <Name key="name">{name}</Name>,
+          <Events key="events">
+            <Delta current={count} previous={lastCount} />
+            <Count value={count} />
+          </Events>,
+          <React.Fragment key="bar">
+            <BarWrapper>
+              <Bar width={percentage} />
+            </BarWrapper>
+            <span>{percentage}%</span>
+          </React.Fragment>,
+          <LastEvent key="time-ago">n/a</LastEvent>,
+        ])}
+        renderRow={({items}) => (
+          <React.Fragment>
+            <NameAndEventsContainer flex={1} justify="space-between" align="center">
+              <div>{items[0]}</div>
+              <div>{items[1]}</div>
+            </NameAndEventsContainer>
+            <Flex flex={3} justify="space-between" align="center">
+              <Flex w={[3 / 4]} align="center" key="bar">
+                {items[2]}
+              </Flex>
+              <Flex w={[1 / 4]} justify="flex-end" key="last-event">
+                {items[3]}
+              </Flex>
+            </Flex>
+          </React.Fragment>
+        )}
+      />
+    );
+  }
+}
+
+const StyledEventsTableChart = styled(EventsTableChart)`
+  width: 100%;
+`;
+
+const NameAndEventsContainer = styled(Flex)`
+  flex-shrink: 0;
+  margin-right: ${space(2)};
+`;
+
+const BarWrapper = styled('div')`
+  width: 85%;
+  margin-right: ${space(1)};
+`;
+
+const Bar = styled(({width, ...props}) => <div {...props} />)`
+  flex: 1;
+  width: ${p => p.width}%;
+  background-color: ${p => p.theme.gray1};
+  height: 12px;
+  border-radius: 2px;
+`;
+
+const Name = styled('span')`
+  ${overflowEllipsis};
+`;
+
+const Events = styled(Name)`
+  display: flex;
+  align-items: center;
+  margin-left: ${space(0.5)};
+`;
+
+const LastEvent = styled(Name)`
+  text-align: right;
+  margin-left: ${space(0.5)};
+`;
+
+export default StyledEventsTableChart;

--- a/tests/js/spec/views/organizationHealth/eventsTableChart.spec.jsx
+++ b/tests/js/spec/views/organizationHealth/eventsTableChart.spec.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import EventsTableChart from 'app/views/organizationHealth/eventsTableChart';
+
+describe('EventsTableChart', function() {
+  let wrapper;
+
+  beforeEach(function() {
+    wrapper = mount(
+      <EventsTableChart
+        headers={['User', <span key="events-column">Events</span>, null, 'Last Column']}
+        data={[
+          {
+            count: 40,
+            lastCount: 20,
+            name: 'billy',
+            percentage: 40,
+          },
+          {
+            count: 60,
+            lastCount: 120,
+            name: 'not billy',
+            percentage: 60,
+          },
+        ]}
+      />
+    );
+  });
+
+  it('renders headers', function() {
+    expect(
+      wrapper.find('PanelHeader NameAndEventsContainer').prop('children')
+    ).toHaveLength(2);
+
+    expect(wrapper.find('PanelHeader').text()).toContain('User');
+    expect(wrapper.find('PanelHeader').text()).toContain('Events');
+    expect(wrapper.find('PanelHeader').text()).toContain('Last Column');
+  });
+
+  it('renders data rows', function() {
+    expect(wrapper.find('TableChartRow')).toHaveLength(2);
+
+    expect(
+      wrapper
+        .find('TableChartRow Name')
+        .at(0)
+        .text()
+    ).toBe('billy');
+
+    expect(
+      wrapper
+        .find('TableChartRow Events DeltaCaret')
+        .at(0)
+        .prop('direction')
+    ).toBeGreaterThan(0);
+
+    expect(
+      wrapper
+        .find('TableChartRow Bar')
+        .at(0)
+        .prop('width')
+    ).toBe(40);
+
+    expect(
+      wrapper
+        .find('TableChartRow Name')
+        .at(1)
+        .text()
+    ).toBe('not billy');
+
+    expect(
+      wrapper
+        .find('TableChartRow Events DeltaCaret')
+        .at(1)
+        .prop('direction')
+    ).toBeLessThan(0);
+
+    expect(
+      wrapper
+        .find('TableChartRow Bar')
+        .at(1)
+        .prop('width')
+    ).toBe(60);
+  });
+});


### PR DESCRIPTION
This adds another events table chart that has a distinct column for a bar to show percentage.

![image](https://user-images.githubusercontent.com/79684/44804127-53c8ec00-ab75-11e8-9987-986647682cae.png)
