### PR TITLE
fix(assemble): Avoid a race during symcache generation

### DIFF
--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -67,6 +67,7 @@ def assemble_dif(project_id, name, checksum, chunks, **kwargs):
                     set_assemble_status(project, checksum, ChunkFileState.ERROR,
                                         detail=error)
                     indicate_success = False
+                    dsym.delete()
 
             if indicate_success:
                 set_assemble_status(project, checksum, ChunkFileState.OK)


### PR DESCRIPTION
The current assemble poll code prioritized `ProjectDSymFile` over the cached
assemble status. However, the model needs to be created **before** symcaches
can be generated. This leads to a race in the poll code.

As a quick fix, poll now checks the assemble status first, and then falls back
to querying for ProjectDSymFiles. In both cases, we assemble error details once
the cache times out.

As a proper fix, I would propose to add the error detail as an optional column
to `sentry_projectdsymfile` in addition to caching the value.