### PR TITLE
fix(integrations): Disabled unmigratable repos

### DIFF
--- a/src/sentry/api/endpoints/organization_repositories.py
+++ b/src/sentry/api/endpoints/organization_repositories.py
@@ -61,7 +61,7 @@ class OrganizationRepositoriesEndpoint(OrganizationEndpoint):
             )
 
             integrations = Integration.objects.filter(
-                id__in=org_integrations,
+                id__in=org_integrations.values('integration_id'),
                 provider__in=('bitbucket', 'github', 'vsts'),
             )
 


### PR DESCRIPTION
Don't show "Unmigratable Repos" for Integrations that have been disabled.

Fixes SENTRY-78N