### PR TITLE
feat(discover): Format chart tooltips

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/barChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/barChart.jsx
@@ -28,6 +28,7 @@ export default class BarChart extends React.Component {
               data: s.data.map(({value, name}) => [name, value]),
             });
           }),
+          ...this.props.options,
         }}
       />
     );

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
@@ -7,9 +7,10 @@ import {Box, Flex} from 'grid-emotion';
 import {t} from 'app/locale';
 import BarChart from 'app/components/charts/barChart';
 import LineChart from 'app/components/charts/lineChart';
+import Tooltip from 'app/components/charts/components/tooltip';
 
 import Table from './table';
-import {getChartData, getChartDataByDay} from './utils';
+import {getChartData, getChartDataByDay, formatTooltip} from './utils';
 
 export default class Result extends React.Component {
   static propTypes = {
@@ -103,7 +104,17 @@ export default class Result extends React.Component {
 
         {view === 'table' && <Table data={data} />}
         {view === 'line' && <LineChart series={basicChartData} height={300} />}
-        {view === 'bar' && <BarChart series={basicChartData} height={300} />}
+        {view === 'bar' && (
+          <BarChart
+            series={basicChartData}
+            height={300}
+            options={{
+              tooltip: Tooltip({
+                formatter: formatTooltip,
+              }),
+            }}
+          />
+        )}
         {view === 'line-by-day' && (
           <LineChart
             series={getChartDataByDay(chartData.data, chartQuery)}
@@ -115,6 +126,11 @@ export default class Result extends React.Component {
             series={getChartDataByDay(chartData.data, chartQuery)}
             stacked={true}
             height={300}
+            options={{
+              tooltip: Tooltip({
+                formatter: formatTooltip,
+              }),
+            }}
           />
         )}
         {this.renderSummary()}

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
@@ -21,7 +21,7 @@ export function getChartData(data, query) {
       data: data.map(res => {
         return {
           value: res[aggregation[2]],
-          name: truncateLabel(fields.map(field => `${field} ${res[field]}`).join(' ')),
+          name: fields.map(field => `${field} ${res[field]}`).join(' '),
         };
       }),
     };
@@ -73,16 +73,27 @@ export function getChartDataByDay(data, query) {
       });
     }
 
-    result.push({seriesName: truncateLabel(key), data: output[key].data});
+    result.push({seriesName: key, data: output[key].data});
   }
 
   return result;
 }
 
+export function formatTooltip(seriesParams) {
+  const label = seriesParams.length && seriesParams[0].axisValueLabel;
+  return [
+    `<div>${truncateLabel(label)}</div>`,
+    seriesParams
+      .filter(s => s.data[1] !== null)
+      .map(s => `<div>${s.marker} ${truncateLabel(s.seriesName)}:  ${s.data[1]}</div>`)
+      .join(''),
+  ].join('');
+}
+
 function truncateLabel(seriesName) {
   let result = seriesName;
-  if (seriesName.length > 45) {
-    result = seriesName.substring(0, 45) + '…';
+  if (seriesName.length > 80) {
+    result = seriesName.substring(0, 80) + '…';
   }
   return result;
 }


### PR DESCRIPTION
Omit null tooltip values as these cause too much noise.

Also fixes a bug where labels were being formatted on raw chart data so items
could be incorrectly grouped if the truncated text was the same even if
the original was not. We now truncate only the tooltip text.

Also increases the size of the truncated tooltip text from a max of 45
to 80 characters.