### PR TITLE
fix(integrations): Upgrade vs Add Another

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
@@ -56,7 +56,12 @@ export default class OrganizationIntegrations extends AsyncComponent {
         i => i.provider.key == provider.key
       );
       const isInstalled = integrations.length > 0;
-      return Object.assign({integrations, isInstalled}, provider);
+
+      return {
+        ...provider,
+        integrations,
+        isInstalled,
+      };
     });
   }
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.jsx
@@ -69,7 +69,9 @@ export default class ProviderRow extends React.Component {
   get buttonText() {
     let buttonText = this.isEnabled > 0 ? t('Add Another') : t('Install');
 
-    return this.isEnabledPlugin && this.isUpgradable ? t('Upgrade') : buttonText;
+    return !this.isEnabled && this.isEnabledPlugin && this.isUpgradable
+      ? t('Upgrade')
+      : buttonText;
   }
 
   renderButton() {

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -564,7 +564,7 @@ window.TestStubs = {
 
   GitHubIntegration: params => {
     return {
-      domainName: 'gtithub.com/test-integration',
+      domainName: 'github.com/test-integration',
       icon: 'http://example.com/integration_icon.png',
       id: '1',
       name: 'Test Integration',
@@ -596,6 +596,25 @@ window.TestStubs = {
       projects: [],
       configOrganization: [],
       configData: {},
+      ...params,
+    };
+  },
+
+  VstsIntegrationProvider: params => {
+    return {
+      key: 'vsts',
+      name: 'VSTS',
+      canAdd: true,
+      config: [],
+      features: [],
+      metadata: {
+        description: '*markdown* formatted VSTS _description_',
+        author: 'Frank',
+        noun: 'Instance',
+        issue_url: 'http://example.com/vsts_issue_url',
+        source_url: 'http://example.com/vsts_source_url',
+        aspects: {},
+      },
       ...params,
     };
   },

--- a/tests/js/spec/components/group/__snapshots__/externalIssueActions.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/externalIssueActions.spec.jsx.snap
@@ -11,7 +11,7 @@ exports[`ExternalIssueActions with an external issue linked renders 1`] = `
         Object {
           "configData": Object {},
           "configOrganization": Array [],
-          "domainName": "gtithub.com/test-integration",
+          "domainName": "github.com/test-integration",
           "externalIssues": Array [
             Object {
               "id": 100,
@@ -50,7 +50,7 @@ exports[`ExternalIssueActions with an external issue linked renders 1`] = `
               Object {
                 "configData": Object {},
                 "configOrganization": Array [],
-                "domainName": "gtithub.com/test-integration",
+                "domainName": "github.com/test-integration",
                 "externalIssues": Array [
                   Object {
                     "id": 100,
@@ -199,7 +199,7 @@ exports[`ExternalIssueActions with no external issues linked renders 1`] = `
     Object {
       "configData": Object {},
       "configOrganization": Array [],
-      "domainName": "gtithub.com/test-integration",
+      "domainName": "github.com/test-integration",
       "externalIssues": Array [],
       "icon": "http://example.com/integration_icon.png",
       "id": "1",
@@ -224,7 +224,7 @@ exports[`ExternalIssueActions with no external issues linked renders 1`] = `
           Object {
             "configData": Object {},
             "configOrganization": Array [],
-            "domainName": "gtithub.com/test-integration",
+            "domainName": "github.com/test-integration",
             "externalIssues": Array [],
             "icon": "http://example.com/integration_icon.png",
             "id": "1",
@@ -257,7 +257,7 @@ exports[`ExternalIssueActions with no external issues linked renders 1`] = `
                 Object {
                   "configData": Object {},
                   "configOrganization": Array [],
-                  "domainName": "gtithub.com/test-integration",
+                  "domainName": "github.com/test-integration",
                   "externalIssues": Array [],
                   "icon": "http://example.com/integration_icon.png",
                   "id": "1",

--- a/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
@@ -53,8 +53,24 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
           "config": Array [],
           "externalIssues": Array [],
           "features": Array [],
-          "integrations": Array [],
-          "isInstalled": false,
+          "integrations": Array [
+            Object {
+              "configData": Object {},
+              "configOrganization": Array [],
+              "domainName": "github.com/test-integration",
+              "icon": "http://example.com/integration_icon.png",
+              "id": "1",
+              "name": "Test Integration",
+              "projects": Array [],
+              "provider": Object {
+                "canAdd": true,
+                "features": Array [],
+                "key": "github",
+                "name": "GitHub",
+              },
+            },
+          ],
+          "isInstalled": true,
           "key": "github",
           "metadata": Object {
             "aspects": Object {
@@ -181,7 +197,25 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
           >
             <ProviderRow
               enabledPlugins={Array []}
-              integrations={Array []}
+              integrations={
+                Array [
+                  Object {
+                    "configData": Object {},
+                    "configOrganization": Array [],
+                    "domainName": "github.com/test-integration",
+                    "icon": "http://example.com/integration_icon.png",
+                    "id": "1",
+                    "name": "Test Integration",
+                    "projects": Array [],
+                    "provider": Object {
+                      "canAdd": true,
+                      "features": Array [],
+                      "key": "github",
+                      "name": "GitHub",
+                    },
+                  },
+                ]
+              }
               key="github"
               onDisable={[Function]}
               onInstall={[Function]}
@@ -194,8 +228,24 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                   "config": Array [],
                   "externalIssues": Array [],
                   "features": Array [],
-                  "integrations": Array [],
-                  "isInstalled": false,
+                  "integrations": Array [
+                    Object {
+                      "configData": Object {},
+                      "configOrganization": Array [],
+                      "domainName": "github.com/test-integration",
+                      "icon": "http://example.com/integration_icon.png",
+                      "id": "1",
+                      "name": "Test Integration",
+                      "projects": Array [],
+                      "provider": Object {
+                        "canAdd": true,
+                        "features": Array [],
+                        "key": "github",
+                        "name": "GitHub",
+                      },
+                    },
+                  ],
+                  "isInstalled": true,
                   "key": "github",
                   "metadata": Object {
                     "aspects": Object {
@@ -290,15 +340,15 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                       is={null}
                                     >
                                       <Status
-                                        enabled={false}
+                                        enabled={true}
                                       >
                                         <WithTheme(Component)
-                                          className="css-1xs0jyz-Status e1egfpwi2"
-                                          enabled={false}
+                                          className="css-1rvre0-Status e1egfpwi2"
+                                          enabled={true}
                                         >
                                           <Component
-                                            className="css-1xs0jyz-Status e1egfpwi2"
-                                            enabled={false}
+                                            className="css-1rvre0-Status e1egfpwi2"
+                                            enabled={true}
                                             theme={
                                               Object {
                                                 "alert": Object {
@@ -526,24 +576,24 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                                   is={null}
                                                 >
                                                   <CircleIndicator
-                                                    color="#9585A3"
+                                                    color="#57be8c"
                                                     enabled={true}
                                                     size={6}
                                                   >
                                                     <Circle
-                                                      color="#9585A3"
+                                                      color="#57be8c"
                                                       enabled={true}
                                                       size={6}
                                                     >
                                                       <div
-                                                        className="css-xhz9xw-Circle eljqieg0"
-                                                        color="#9585A3"
+                                                        className="css-18at6gu-Circle eljqieg0"
+                                                        color="#57be8c"
                                                         size={6}
                                                       />
                                                     </Circle>
                                                   </CircleIndicator>
                                                   <div
-                                                    className="css-1xs0jyz-Status e1egfpwi2"
+                                                    className="css-1rvre0-Status e1egfpwi2"
                                                     theme={
                                                       Object {
                                                         "alert": Object {
@@ -759,7 +809,7 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                                       }
                                                     }
                                                   >
-                                                    Not Installed
+                                                    Installed
                                                   </div>
                                                 </div>
                                               </Base>
@@ -803,14 +853,14 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                   size="small"
                                 >
                                   <StyledButton
-                                    aria-label="Install"
+                                    aria-label="Add Another"
                                     disabled={false}
                                     onClick={[Function]}
                                     role="button"
                                     size="small"
                                   >
                                     <Component
-                                      aria-label="Install"
+                                      aria-label="Add Another"
                                       className="css-dkprmi-StyledButton-getColors eqrebog0"
                                       disabled={false}
                                       onClick={[Function]}
@@ -818,7 +868,7 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                       size="small"
                                     >
                                       <button
-                                        aria-label="Install"
+                                        aria-label="Add Another"
                                         className="css-dkprmi-StyledButton-getColors eqrebog0"
                                         disabled={false}
                                         onClick={[Function]}
@@ -900,7 +950,7 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                                       </Box>
                                                     </Component>
                                                   </Icon>
-                                                  Install
+                                                  Add Another
                                                 </div>
                                               </Base>
                                             </Flex>
@@ -916,6 +966,575 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                         </div>
                       </Base>
                     </Flex>
+                    <StyledInstalledIntegration
+                      integration={
+                        Object {
+                          "configData": Object {},
+                          "configOrganization": Array [],
+                          "domainName": "github.com/test-integration",
+                          "icon": "http://example.com/integration_icon.png",
+                          "id": "1",
+                          "name": "Test Integration",
+                          "projects": Array [],
+                          "provider": Object {
+                            "canAdd": true,
+                            "features": Array [],
+                            "key": "github",
+                            "name": "GitHub",
+                          },
+                        }
+                      }
+                      key="1"
+                      onDisable={[Function]}
+                      onReinstallIntegration={[Function]}
+                      onRemove={[Function]}
+                      orgId="org-slug"
+                      provider={
+                        Object {
+                          "canAdd": true,
+                          "config": Array [],
+                          "externalIssues": Array [],
+                          "features": Array [],
+                          "integrations": Array [
+                            Object {
+                              "configData": Object {},
+                              "configOrganization": Array [],
+                              "domainName": "github.com/test-integration",
+                              "icon": "http://example.com/integration_icon.png",
+                              "id": "1",
+                              "name": "Test Integration",
+                              "projects": Array [],
+                              "provider": Object {
+                                "canAdd": true,
+                                "features": Array [],
+                                "key": "github",
+                                "name": "GitHub",
+                              },
+                            },
+                          ],
+                          "isInstalled": true,
+                          "key": "github",
+                          "metadata": Object {
+                            "aspects": Object {
+                              "alerts": Array [
+                                Object {
+                                  "text": "This is a an alert example",
+                                  "type": "warning",
+                                },
+                              ],
+                            },
+                            "author": "Morty",
+                            "description": "*markdown* formatted _description_",
+                            "issue_url": "http://example.com/integration_issue_url",
+                            "noun": "Installation",
+                            "source_url": "http://example.com/integration_source_url",
+                          },
+                          "name": "GitHub",
+                          "setupDialog": Object {
+                            "height": 100,
+                            "url": "/github-integration-setup-uri/",
+                            "width": 100,
+                          },
+                        }
+                      }
+                    >
+                      <Component
+                        className="css-1gojchp-StyledInstalledIntegration e1egfpwi4"
+                        integration={
+                          Object {
+                            "configData": Object {},
+                            "configOrganization": Array [],
+                            "domainName": "github.com/test-integration",
+                            "icon": "http://example.com/integration_icon.png",
+                            "id": "1",
+                            "name": "Test Integration",
+                            "projects": Array [],
+                            "provider": Object {
+                              "canAdd": true,
+                              "features": Array [],
+                              "key": "github",
+                              "name": "GitHub",
+                            },
+                          }
+                        }
+                        onDisable={[Function]}
+                        onReinstallIntegration={[Function]}
+                        onRemove={[Function]}
+                        orgId="org-slug"
+                        provider={
+                          Object {
+                            "canAdd": true,
+                            "config": Array [],
+                            "externalIssues": Array [],
+                            "features": Array [],
+                            "integrations": Array [
+                              Object {
+                                "configData": Object {},
+                                "configOrganization": Array [],
+                                "domainName": "github.com/test-integration",
+                                "icon": "http://example.com/integration_icon.png",
+                                "id": "1",
+                                "name": "Test Integration",
+                                "projects": Array [],
+                                "provider": Object {
+                                  "canAdd": true,
+                                  "features": Array [],
+                                  "key": "github",
+                                  "name": "GitHub",
+                                },
+                              },
+                            ],
+                            "isInstalled": true,
+                            "key": "github",
+                            "metadata": Object {
+                              "aspects": Object {
+                                "alerts": Array [
+                                  Object {
+                                    "text": "This is a an alert example",
+                                    "type": "warning",
+                                  },
+                                ],
+                              },
+                              "author": "Morty",
+                              "description": "*markdown* formatted _description_",
+                              "issue_url": "http://example.com/integration_issue_url",
+                              "noun": "Installation",
+                              "source_url": "http://example.com/integration_source_url",
+                            },
+                            "name": "GitHub",
+                            "setupDialog": Object {
+                              "height": 100,
+                              "url": "/github-integration-setup-uri/",
+                              "width": 100,
+                            },
+                          }
+                        }
+                      >
+                        <InstalledIntegration
+                          className="css-1gojchp-StyledInstalledIntegration e1egfpwi4"
+                          integration={
+                            Object {
+                              "configData": Object {},
+                              "configOrganization": Array [],
+                              "domainName": "github.com/test-integration",
+                              "icon": "http://example.com/integration_icon.png",
+                              "id": "1",
+                              "name": "Test Integration",
+                              "projects": Array [],
+                              "provider": Object {
+                                "canAdd": true,
+                                "features": Array [],
+                                "key": "github",
+                                "name": "GitHub",
+                              },
+                            }
+                          }
+                          onDisable={[Function]}
+                          onReinstallIntegration={[Function]}
+                          onRemove={[Function]}
+                          orgId="org-slug"
+                          provider={
+                            Object {
+                              "canAdd": true,
+                              "config": Array [],
+                              "externalIssues": Array [],
+                              "features": Array [],
+                              "integrations": Array [
+                                Object {
+                                  "configData": Object {},
+                                  "configOrganization": Array [],
+                                  "domainName": "github.com/test-integration",
+                                  "icon": "http://example.com/integration_icon.png",
+                                  "id": "1",
+                                  "name": "Test Integration",
+                                  "projects": Array [],
+                                  "provider": Object {
+                                    "canAdd": true,
+                                    "features": Array [],
+                                    "key": "github",
+                                    "name": "GitHub",
+                                  },
+                                },
+                              ],
+                              "isInstalled": true,
+                              "key": "github",
+                              "metadata": Object {
+                                "aspects": Object {
+                                  "alerts": Array [
+                                    Object {
+                                      "text": "This is a an alert example",
+                                      "type": "warning",
+                                    },
+                                  ],
+                                },
+                                "author": "Morty",
+                                "description": "*markdown* formatted _description_",
+                                "issue_url": "http://example.com/integration_issue_url",
+                                "noun": "Installation",
+                                "source_url": "http://example.com/integration_source_url",
+                              },
+                              "name": "GitHub",
+                              "setupDialog": Object {
+                                "height": 100,
+                                "url": "/github-integration-setup-uri/",
+                                "width": 100,
+                              },
+                            }
+                          }
+                        >
+                          <Flex
+                            align="center"
+                            className="css-1gojchp-StyledInstalledIntegration e1egfpwi4"
+                            key="1"
+                          >
+                            <Base
+                              align="center"
+                              className="e1egfpwi4 css-1r8fo78-StyledInstalledIntegration"
+                            >
+                              <div
+                                className="e1egfpwi4 css-1r8fo78-StyledInstalledIntegration"
+                                is={null}
+                              >
+                                <Box
+                                  flex={1}
+                                >
+                                  <Base
+                                    className="css-vti0ei"
+                                    flex={1}
+                                  >
+                                    <div
+                                      className="css-vti0ei"
+                                      is={null}
+                                    >
+                                      <IntegrationItem
+                                        compact={true}
+                                        integration={
+                                          Object {
+                                            "configData": Object {},
+                                            "configOrganization": Array [],
+                                            "domainName": "github.com/test-integration",
+                                            "icon": "http://example.com/integration_icon.png",
+                                            "id": "1",
+                                            "name": "Test Integration",
+                                            "projects": Array [],
+                                            "provider": Object {
+                                              "canAdd": true,
+                                              "features": Array [],
+                                              "key": "github",
+                                              "name": "GitHub",
+                                            },
+                                          }
+                                        }
+                                      >
+                                        <Flex>
+                                          <Base
+                                            className="css-sncxrr"
+                                          >
+                                            <div
+                                              className="css-sncxrr"
+                                              is={null}
+                                            >
+                                              <Box>
+                                                <Base
+                                                  className="css-roynbj"
+                                                >
+                                                  <div
+                                                    className="css-roynbj"
+                                                    is={null}
+                                                  >
+                                                    <IntegrationIcon
+                                                      integration={
+                                                        Object {
+                                                          "configData": Object {},
+                                                          "configOrganization": Array [],
+                                                          "domainName": "github.com/test-integration",
+                                                          "icon": "http://example.com/integration_icon.png",
+                                                          "id": "1",
+                                                          "name": "Test Integration",
+                                                          "projects": Array [],
+                                                          "provider": Object {
+                                                            "canAdd": true,
+                                                            "features": Array [],
+                                                            "key": "github",
+                                                            "name": "GitHub",
+                                                          },
+                                                        }
+                                                      }
+                                                      size={22}
+                                                    >
+                                                      <Icon
+                                                        size={22}
+                                                        src="http://example.com/integration_icon.png"
+                                                      >
+                                                        <img
+                                                          className="css-f8xrkt-Icon e17bf5d30"
+                                                          size={22}
+                                                          src="http://example.com/integration_icon.png"
+                                                        />
+                                                      </Icon>
+                                                    </IntegrationIcon>
+                                                  </div>
+                                                </Base>
+                                              </Box>
+                                              <Labels
+                                                compact={true}
+                                              >
+                                                <Flex
+                                                  align="center"
+                                                  direction="row"
+                                                  pl={1}
+                                                >
+                                                  <Base
+                                                    align="center"
+                                                    className="css-x3jwi"
+                                                    direction="row"
+                                                    pl={1}
+                                                  >
+                                                    <div
+                                                      className="css-x3jwi"
+                                                      is={null}
+                                                    >
+                                                      <IntegrationName>
+                                                        <div
+                                                          className="css-ksmg3c-IntegrationName ettpo130"
+                                                        >
+                                                          Test Integration
+                                                        </div>
+                                                      </IntegrationName>
+                                                      <DomainName
+                                                        compact={true}
+                                                      >
+                                                        <div
+                                                          className="css-1wocc7i-DomainName ettpo131"
+                                                        >
+                                                          github.com/test-integration
+                                                        </div>
+                                                      </DomainName>
+                                                    </div>
+                                                  </Base>
+                                                </Flex>
+                                              </Labels>
+                                            </div>
+                                          </Base>
+                                        </Flex>
+                                      </IntegrationItem>
+                                    </div>
+                                  </Base>
+                                </Box>
+                                <Box>
+                                  <Base
+                                    className="css-roynbj"
+                                  >
+                                    <div
+                                      className="css-roynbj"
+                                      is={null}
+                                    />
+                                  </Base>
+                                </Box>
+                                <Box>
+                                  <Base
+                                    className="css-roynbj"
+                                  >
+                                    <div
+                                      className="css-roynbj"
+                                      is={null}
+                                    >
+                                      <Confirm
+                                        cancelText="Cancel"
+                                        confirmText="Delete"
+                                        disableConfirmButton={false}
+                                        message={
+                                          <React.Fragment>
+                                            <Alert
+                                              icon="icon-circle-exclamation"
+                                              type="error"
+                                            >
+                                              Deleting this integration has consequences!
+                                            </Alert>
+                                            Deleting this integration will remove any project associated data. This action cannot be undone. Are you sure you want to delete this integration?
+                                          </React.Fragment>
+                                        }
+                                        onConfirm={[Function]}
+                                        priority="danger"
+                                      >
+                                        <StyledButton
+                                          borderless={true}
+                                          icon="icon-trash"
+                                          onClick={[Function]}
+                                        >
+                                          <Button
+                                            borderless={true}
+                                            className="css-1j0nrmm-StyledButton ejqw4f70"
+                                            disabled={false}
+                                            icon="icon-trash"
+                                            onClick={[Function]}
+                                          >
+                                            <StyledButton
+                                              aria-label="Remove"
+                                              borderless={true}
+                                              className="css-1j0nrmm-StyledButton ejqw4f70"
+                                              disabled={false}
+                                              onClick={[Function]}
+                                              role="button"
+                                            >
+                                              <Component
+                                                aria-label="Remove"
+                                                borderless={true}
+                                                className="ejqw4f70 css-1rs3lxn-StyledButton-getColors-StyledButton eqrebog0"
+                                                disabled={false}
+                                                onClick={[Function]}
+                                                role="button"
+                                              >
+                                                <button
+                                                  aria-label="Remove"
+                                                  className="ejqw4f70 css-1rs3lxn-StyledButton-getColors-StyledButton eqrebog0"
+                                                  disabled={false}
+                                                  onClick={[Function]}
+                                                  role="button"
+                                                >
+                                                  <ButtonLabel
+                                                    borderless={true}
+                                                  >
+                                                    <Component
+                                                      borderless={true}
+                                                      className="css-6q5v1w-ButtonLabel eqrebog1"
+                                                    >
+                                                      <Flex
+                                                        align="center"
+                                                        className="css-6q5v1w-ButtonLabel eqrebog1"
+                                                      >
+                                                        <Base
+                                                          align="center"
+                                                          className="eqrebog1 css-dqr4rq-ButtonLabel"
+                                                        >
+                                                          <div
+                                                            className="eqrebog1 css-dqr4rq-ButtonLabel"
+                                                            is={null}
+                                                          >
+                                                            <Icon
+                                                              hasChildren={true}
+                                                            >
+                                                              <Component
+                                                                className="css-1jxtush-Icon eqrebog2"
+                                                                hasChildren={true}
+                                                              >
+                                                                <Box
+                                                                  className="css-1jxtush-Icon eqrebog2"
+                                                                >
+                                                                  <Base
+                                                                    className="eqrebog2 css-md8goh-Icon"
+                                                                  >
+                                                                    <div
+                                                                      className="eqrebog2 css-md8goh-Icon"
+                                                                      is={null}
+                                                                    >
+                                                                      <StyledInlineSvg
+                                                                        size="16px"
+                                                                        src="icon-trash"
+                                                                      >
+                                                                        <InlineSvg
+                                                                          className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                                          size="16px"
+                                                                          src="icon-trash"
+                                                                        >
+                                                                          <StyledSvg
+                                                                            className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                                            height="16px"
+                                                                            viewBox={Object {}}
+                                                                            width="16px"
+                                                                          >
+                                                                            <svg
+                                                                              className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                                              height="16px"
+                                                                              viewBox={Object {}}
+                                                                              width="16px"
+                                                                            >
+                                                                              <use
+                                                                                href="#test"
+                                                                                xlinkHref="#test"
+                                                                              />
+                                                                            </svg>
+                                                                          </StyledSvg>
+                                                                        </InlineSvg>
+                                                                      </StyledInlineSvg>
+                                                                    </div>
+                                                                  </Base>
+                                                                </Box>
+                                                              </Component>
+                                                            </Icon>
+                                                            Remove
+                                                          </div>
+                                                        </Base>
+                                                      </Flex>
+                                                    </Component>
+                                                  </ButtonLabel>
+                                                </button>
+                                              </Component>
+                                            </StyledButton>
+                                          </Button>
+                                        </StyledButton>
+                                        <Modal
+                                          animation={false}
+                                          autoFocus={true}
+                                          backdrop={true}
+                                          bsClass="modal"
+                                          dialogComponentClass={[Function]}
+                                          enforceFocus={true}
+                                          keyboard={true}
+                                          manager={
+                                            ModalManager {
+                                              "add": [Function],
+                                              "containers": Array [],
+                                              "data": Array [],
+                                              "handleContainerOverflow": true,
+                                              "hideSiblingNodes": true,
+                                              "isTopModal": [Function],
+                                              "modals": Array [],
+                                              "remove": [Function],
+                                            }
+                                          }
+                                          onHide={[Function]}
+                                          renderBackdrop={[Function]}
+                                          restoreFocus={true}
+                                          show={false}
+                                        >
+                                          <Modal
+                                            autoFocus={true}
+                                            backdrop={true}
+                                            backdropClassName="modal-backdrop"
+                                            containerClassName="modal-open"
+                                            enforceFocus={true}
+                                            keyboard={true}
+                                            manager={
+                                              ModalManager {
+                                                "add": [Function],
+                                                "containers": Array [],
+                                                "data": Array [],
+                                                "handleContainerOverflow": true,
+                                                "hideSiblingNodes": true,
+                                                "isTopModal": [Function],
+                                                "modals": Array [],
+                                                "remove": [Function],
+                                              }
+                                            }
+                                            onEntering={[Function]}
+                                            onExited={[Function]}
+                                            onHide={[Function]}
+                                            renderBackdrop={[Function]}
+                                            restoreFocus={true}
+                                            show={false}
+                                          />
+                                        </Modal>
+                                      </Confirm>
+                                    </div>
+                                  </Base>
+                                </Box>
+                              </div>
+                            </Base>
+                          </Flex>
+                        </InstalledIntegration>
+                      </Component>
+                    </StyledInstalledIntegration>
                   </div>
                 </Base>
               </PanelItem>

--- a/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
@@ -23,6 +23,7 @@ describe('OrganizationIntegrations', function() {
       isInstalled: false,
     });
     const jiraProvider = TestStubs.JiraIntegrationProvider();
+    const vstsProvider = TestStubs.VstsIntegrationProvider();
 
     const githubIntegration = TestStubs.GitHubIntegration();
     const jiraIntegration = TestStubs.JiraIntegration();
@@ -134,13 +135,17 @@ describe('OrganizationIntegrations', function() {
       });
       Client.addMockResponse({
         url: `/organizations/${org.slug}/config/integrations/`,
-        body: {providers: [githubProvider, jiraProvider]},
+        body: {providers: [githubProvider, jiraProvider, vstsProvider]},
       });
       Client.addMockResponse({
         url: `/organizations/${org.slug}/plugins/`,
         body: [
           {
             slug: 'github',
+            enabled: true,
+          },
+          {
+            slug: 'vsts',
             enabled: true,
           },
           {
@@ -169,7 +174,18 @@ describe('OrganizationIntegrations', function() {
         expect(wrapper.instance().state.unmigratableRepos[0].name).toBe('Test-Org/foo');
       });
 
-      it('displays an Upgrade button instead of Install', function() {
+      it('displays an Upgrade when the Plugin is enabled but a new Integration is not', function() {
+        expect(
+          wrapper
+            .find('ProviderRow')
+            .filterWhere(n => n.key() === 'vsts')
+            .find('Button')
+            .first()
+            .text()
+        ).toBe('Upgrade');
+      });
+
+      it('displays Add Another button when both Integration and Plugin are enabled', () => {
         expect(
           wrapper
             .find('ProviderRow')
@@ -177,7 +193,7 @@ describe('OrganizationIntegrations', function() {
             .find('Button')
             .first()
             .text()
-        ).toBe('Upgrade');
+        ).toBe('Add Another');
       });
 
       it('display an Install button when its not an upgradable Integration', () => {


### PR DESCRIPTION
When both Plugin AND new Integration are installed, we should display "Add Another".

Previously, this wasn't handled and it showed "Upgrade" because the Plugin was installed. This changes that.