### PR TITLE
feat(discover): Remove internal event attributes

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/data.jsx
@@ -24,8 +24,6 @@ const COLUMNS = [
   {name: 'platform', type: 'string'},
   {name: 'message', type: 'string'},
   {name: 'primary_hash', type: 'string'},
-  {name: 'deleted', type: 'number'},
-  {name: 'retention_days', type: 'number'},
   {name: 'timestamp', type: 'string'}, // TODO: handling datetime as string for now
   {name: 'received', type: 'string'}, // TODO: handling datetime as string for now
 

--- a/tests/js/spec/views/organizationDiscover/aggregations/aggregation.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/aggregations/aggregation.spec.jsx
@@ -14,8 +14,8 @@ describe('Aggregation', function() {
           expectedTextValue: 'uniq(environment)',
         },
         {
-          value: ['avg', 'retention_days', 'avg_retention_days'],
-          expectedTextValue: 'avg(retention_days)',
+          value: ['avg', 'device_battery_level', 'avg_device_battery_level'],
+          expectedTextValue: 'avg(device_battery_level)',
         },
         {
           value: ['uniq', 'tags[message]', 'uniq_tags_message'],

--- a/tests/js/spec/views/organizationDiscover/aggregations/utils.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/aggregations/utils.spec.jsx
@@ -16,8 +16,8 @@ const aggregationList = [
     external: ['uniq', 'message', 'uniq_message'],
   },
   {
-    internal: 'avg(retention_days)',
-    external: ['avg', 'retention_days', 'avg_retention_days'],
+    internal: 'avg(device_battery_level)',
+    external: ['avg', 'device_battery_level', 'avg_device_battery_level'],
   },
   {
     internal: 'uniq(tags[server_name])',

--- a/tests/js/spec/views/organizationDiscover/conditions/utils.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/conditions/utils.spec.jsx
@@ -20,12 +20,12 @@ const conditionList = [
     external: ['message', 'IS NOT NULL', null],
   },
   {
-    internal: 'retention_days = 3',
-    external: ['retention_days', '=', 3],
+    internal: 'device_battery_level = 3',
+    external: ['device_battery_level', '=', 3],
   },
   {
-    internal: 'retention_days >= 0',
-    external: ['retention_days', '>=', 0],
+    internal: 'device_battery_level >= 0',
+    external: ['device_battery_level', '>=', 0],
   },
   {
     internal: 'message NOT LIKE something%',

--- a/tests/js/spec/views/organizationDiscover/queryBuilder.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/queryBuilder.spec.jsx
@@ -11,7 +11,7 @@ describe('Query Builder', function() {
 
       expect(external.projects).toEqual([2]);
       expect(external.fields).toEqual(expect.arrayContaining([expect.any(String)]));
-      expect(external.fields).toHaveLength(47);
+      expect(external.fields).toHaveLength(45);
       expect(external.conditions).toHaveLength(0);
       expect(external.aggregations).toHaveLength(0);
       expect(external.orderby).toBe('-timestamp');


### PR DESCRIPTION
Remove `deleted` and `retention_days` as queryable properties since these are internal event
attributes.