### PR TITLE
feat(discover): Use SelectControl instead of SelectField

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -11,7 +11,6 @@ import HeaderSeparator from 'app/components/organizations/headerSeparator';
 import MultipleProjectSelector from 'app/components/organizations/multipleProjectSelector';
 import NumberField from 'app/components/forms/numberField';
 import SelectControl from 'app/components/forms/selectControl';
-import SelectField from 'app/components/forms/selectField';
 import SentryTypes from 'app/sentryTypes';
 import TimeRangeSelector from 'app/components/organizations/timeRangeSelector';
 
@@ -256,13 +255,16 @@ export default class OrganizationDiscover extends React.Component {
               />
             </Fieldset>
             <Fieldset>
-              <SelectField
+              <label htmlFor="orderby" className="control-label">
+                {t('Order by')}
+              </label>
+              <SelectControl
                 name="orderby"
                 label={t('Order By')}
                 placeholder={<PlaceholderText>{t('Order by...')}</PlaceholderText>}
                 options={this.getOrderbyOptions()}
                 value={currentQuery.orderby}
-                onChange={val => this.updateField('orderby', val)}
+                onChange={val => this.updateField('orderby', val.value)}
               />
             </Fieldset>
             <Fieldset>

--- a/tests/js/spec/views/organizationDiscover/discover.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/discover.spec.jsx
@@ -100,7 +100,7 @@ describe('Discover', function() {
     });
   });
 
-  describe('reset', function() {
+  describe('reset()', function() {
     let wrapper, queryBuilder;
     beforeEach(function() {
       const organization = TestStubs.Organization({projects: [TestStubs.Project()]});
@@ -128,12 +128,10 @@ describe('Discover', function() {
     });
 
     it('resets "orderby"', function() {
-      expect(wrapper.find('SelectField[name="orderby"]').prop('value')).toBe('event_id');
+      expect(wrapper.find('SelectControl[name="orderby"]').text()).toBe('event_id asc');
       wrapper.instance().reset();
       wrapper.update();
-      expect(wrapper.find('SelectField[name="orderby"]').prop('value')).toBe(
-        '-timestamp'
-      );
+      expect(wrapper.find('SelectControl[name="orderby"]').text()).toBe('timestamp desc');
     });
 
     it('resets "limit"', function() {


### PR DESCRIPTION
Since orderby is a controlled component without any form state, use SelectControl directly instead of SelectField. SelectField doesn't always update correctly on props change.