### PR TITLE
fix(health): Initialize health context with empty projects list

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationHealth/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/index.jsx
@@ -21,13 +21,10 @@ class OrganizationHealth extends React.Component {
 
   constructor(props) {
     super(props);
-    let {organization} = props;
-    let projects = organization.projects
-      .filter(({isMember}) => isMember)
-      .map(({id}) => id);
+
     this.state = {
       params: {
-        projects,
+        projects: [],
         environments: [],
         period: '7d',
       },
@@ -60,7 +57,8 @@ class OrganizationHealth extends React.Component {
     let {organization, children} = this.props;
 
     // TODO(billy): Is this what we want, only projects user is member of?
-    let projects = organization.projects.filter(({isMember}) => isMember);
+    let projects =
+      organization.projects && organization.projects.filter(({isMember}) => isMember);
 
     return (
       <Feature feature={['health']} renderNoFeatureMessage>


### PR DESCRIPTION
Currently default is to query all projects, but this is subject to change.