### PR TITLE
feat(health): Add Transactions view

### DIFF
--- a/src/sentry/static/sentry/app/__mocks__/api.jsx
+++ b/src/sentry/static/sentry/app/__mocks__/api.jsx
@@ -91,12 +91,16 @@ class Client {
 
       // mock gets returned when we add a mock response, will represent calls to api.request
       mock(url, options);
+
+      const body =
+        typeof response.body === 'function' ? response.body(url, options) : response.body;
+
       if (response.statusCode !== 200) {
         response.callCount++;
         let resp = {
           status: response.statusCode,
-          responseText: JSON.stringify(response.body),
-          responseJSON: response.body,
+          responseText: JSON.stringify(body),
+          responseJSON: body,
         };
         this.handleRequestError(
           {
@@ -110,7 +114,7 @@ class Client {
         respond(
           Client.mockAsync,
           options.success,
-          response.body,
+          body,
           {},
           {
             getResponseHeader: key => response.headers[key],

--- a/src/sentry/static/sentry/app/utils/__mocks__/withLatestContext.jsx
+++ b/src/sentry/static/sentry/app/utils/__mocks__/withLatestContext.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const MOCK_ORG = TestStubs.Organization();
+const DEFAULTS = {
+  organization: MOCK_ORG,
+  organizations: [MOCK_ORG],
+  project: TestStubs.Project(),
+  lastRoute: {},
+};
+
+const withLatestContextMock = WrappedComponent =>
+  class WithLatestContextMockWrappeer extends React.Component {
+    render() {
+      return <WrappedComponent {...DEFAULTS} {...this.props} />;
+    }
+  };
+
+export default withLatestContextMock;

--- a/src/sentry/static/sentry/app/views/organizationHealth/healthNavigationMenu.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/healthNavigationMenu.jsx
@@ -23,6 +23,9 @@ const HealthNavigationMenu = styled(
               <NavItem to={`/organizations/${organization.slug}/health/`}>
                 {t('Overview')}
               </NavItem>
+              <NavItem to={`/organizations/${organization.slug}/health/transactions/`}>
+                {t('Transaction')}
+              </NavItem>
             </NavigationGroup>
           </div>
         );

--- a/src/sentry/static/sentry/app/views/organizationHealth/propTypes/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/propTypes/index.jsx
@@ -1,0 +1,8 @@
+import PropTypes from 'prop-types';
+
+const HealthContextActions = PropTypes.shape({
+  updateParams: PropTypes.func.isRequired,
+  setSpecifier: PropTypes.func.isRequired,
+});
+
+export {HealthContextActions};

--- a/src/sentry/static/sentry/app/views/organizationHealth/styles/healthPanelChart.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/styles/healthPanelChart.jsx
@@ -1,0 +1,18 @@
+import styled from 'react-emotion';
+
+import PanelChart from 'app/components/charts/panelChart';
+import space from 'app/styles/space';
+
+const getChartMargin = () => `
+  margin-right: ${space(2)};
+  &:last-child {
+    margin-right: 0;
+  }
+`;
+
+const HealthPanelChart = styled(PanelChart)`
+  ${getChartMargin};
+  flex-shrink: 0;
+  overflow: hidden;
+`;
+export default HealthPanelChart;

--- a/src/sentry/static/sentry/app/views/organizationHealth/styles/healthPanelChart.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/styles/healthPanelChart.jsx
@@ -1,9 +1,9 @@
-import styled from 'react-emotion';
+import styled, {css} from 'react-emotion';
 
 import PanelChart from 'app/components/charts/panelChart';
 import space from 'app/styles/space';
 
-const getChartMargin = () => `
+const chartMarginCss = css`
   margin-right: ${space(2)};
   &:last-child {
     margin-right: 0;
@@ -11,7 +11,7 @@ const getChartMargin = () => `
 `;
 
 const HealthPanelChart = styled(PanelChart)`
-  ${getChartMargin};
+  ${chartMarginCss};
   flex-shrink: 0;
   overflow: hidden;
 `;

--- a/src/sentry/static/sentry/app/views/organizationHealth/transactions.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/transactions.jsx
@@ -1,9 +1,113 @@
+import {Flex} from 'grid-emotion';
+import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'react-emotion';
+
+import {t} from 'app/locale';
+import AreaChart from 'app/components/charts/areaChart';
+import LineChart from 'app/components/charts/lineChart';
+import PanelChart from 'app/components/charts/panelChart';
+import SentryTypes from 'app/sentryTypes';
+import space from 'app/styles/space';
+
+import EventsTableChart from './eventsTableChart';
+import HealthRequest from './util/healthRequest';
+import withHealth from './util/withHealth';
 
 class OrganizationHealthTransactions extends React.Component {
+  static propTypes = {
+    actions: PropTypes.object,
+    organization: SentryTypes.Organization,
+  };
+
   render() {
-    return <div>Transactions</div>;
+    let {className} = this.props;
+    return (
+      <div className={className}>
+        <HealthRequest
+          tag="transaction"
+          showLoading
+          includeTimeseries
+          includeTimeAggregation="Transactions"
+          includePrevious
+        >
+          {({timeseriesData, timeAggregatedData, previousTimeseriesData}) => {
+            return (
+              <Flex>
+                <StyledPanelChart
+                  showLegend={false}
+                  height={400}
+                  title={t('Transactions')}
+                  previousPeriod={previousTimeseriesData}
+                >
+                  {props => <LineChart {...props} series={[timeAggregatedData]} />}
+                </StyledPanelChart>
+              </Flex>
+            );
+          }}
+        </HealthRequest>
+
+        <HealthRequest
+          tag="transaction"
+          showLoading
+          includeTop
+          includeTimeseries
+          includeTimeAggregation="Transactions"
+          includePercentages
+          includePrevious
+          limit={10}
+        >
+          {({
+            timeseriesData,
+            tagDataWithPercentages,
+            timeAggregatedData,
+            previousTimeseriesData,
+          }) => {
+            return (
+              <React.Fragment>
+                <Flex>
+                  <StyledPanelChart
+                    showLegend={false}
+                    height={400}
+                    title={t('Transactions')}
+                    series={timeseriesData}
+                    previousPeriod={previousTimeseriesData}
+                  >
+                    {props => <AreaChart {...props} />}
+                  </StyledPanelChart>
+                </Flex>
+                <Flex>
+                  <EventsTableChart
+                    headers={[
+                      t('Transaction'),
+                      t('Events'),
+                      t('Percentage'),
+                      t('Last event'),
+                    ]}
+                    data={tagDataWithPercentages}
+                  />
+                </Flex>
+              </React.Fragment>
+            );
+          }}
+        </HealthRequest>
+      </div>
+    );
   }
 }
 
-export default OrganizationHealthTransactions;
+export default withHealth(OrganizationHealthTransactions);
+export {OrganizationHealthTransactions};
+
+const getChartMargin = () => `
+  margin-right: ${space(2)};
+  &:last-child {
+    margin-right: 0;
+  }
+`;
+
+const StyledPanelChart = styled(PanelChart)`
+  ${getChartMargin};
+  flex-shrink: 0;
+  overflow: hidden;
+`;

--- a/src/sentry/static/sentry/app/views/organizationHealth/transactions.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/transactions.jsx
@@ -1,23 +1,19 @@
 import {Flex} from 'grid-emotion';
-import PropTypes from 'prop-types';
 import React from 'react';
-import styled from 'react-emotion';
 
 import {t} from 'app/locale';
 import AreaChart from 'app/components/charts/areaChart';
 import LineChart from 'app/components/charts/lineChart';
-import PanelChart from 'app/components/charts/panelChart';
-import SentryTypes from 'app/sentryTypes';
-import space from 'app/styles/space';
 
+import {HealthContextActions} from './propTypes';
+import HealthPanelChart from './styles/healthPanelChart';
 import EventsTableChart from './eventsTableChart';
 import HealthRequest from './util/healthRequest';
 import withHealth from './util/withHealth';
 
 class OrganizationHealthTransactions extends React.Component {
   static propTypes = {
-    actions: PropTypes.object,
-    organization: SentryTypes.Organization,
+    actions: HealthContextActions,
   };
 
   render() {
@@ -28,20 +24,21 @@ class OrganizationHealthTransactions extends React.Component {
           tag="transaction"
           showLoading
           includeTimeseries
-          includeTimeAggregation="Transactions"
+          includeTimeAggregation
+          timeAggregationSeriesName="Transactions"
           includePrevious
         >
           {({timeseriesData, timeAggregatedData, previousTimeseriesData}) => {
             return (
               <Flex>
-                <StyledPanelChart
+                <HealthPanelChart
                   showLegend={false}
                   height={400}
                   title={t('Transactions')}
                   previousPeriod={previousTimeseriesData}
                 >
                   {props => <LineChart {...props} series={[timeAggregatedData]} />}
-                </StyledPanelChart>
+                </HealthPanelChart>
               </Flex>
             );
           }}
@@ -52,7 +49,8 @@ class OrganizationHealthTransactions extends React.Component {
           showLoading
           includeTop
           includeTimeseries
-          includeTimeAggregation="Transactions"
+          includeTimeAggregation
+          timeAggregationSeriesName="Transactions"
           includePercentages
           includePrevious
           limit={10}
@@ -66,7 +64,7 @@ class OrganizationHealthTransactions extends React.Component {
             return (
               <React.Fragment>
                 <Flex>
-                  <StyledPanelChart
+                  <HealthPanelChart
                     showLegend={false}
                     height={400}
                     title={t('Transactions')}
@@ -74,7 +72,7 @@ class OrganizationHealthTransactions extends React.Component {
                     previousPeriod={previousTimeseriesData}
                   >
                     {props => <AreaChart {...props} />}
-                  </StyledPanelChart>
+                  </HealthPanelChart>
                 </Flex>
                 <Flex>
                   <EventsTableChart
@@ -98,16 +96,3 @@ class OrganizationHealthTransactions extends React.Component {
 
 export default withHealth(OrganizationHealthTransactions);
 export {OrganizationHealthTransactions};
-
-const getChartMargin = () => `
-  margin-right: ${space(2)};
-  &:last-child {
-    margin-right: 0;
-  }
-`;
-
-const StyledPanelChart = styled(PanelChart)`
-  ${getChartMargin};
-  flex-shrink: 0;
-  overflow: hidden;
-`;

--- a/src/sentry/static/sentry/app/views/organizationHealth/util/healthRequest.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/util/healthRequest.jsx
@@ -406,7 +406,7 @@ class HealthRequestWithParams extends React.Component {
 
 const HealthRequest = withLatestContext(
   withApi(
-    class extends React.Component {
+    class HealthRequest extends React.Component {
       render() {
         return (
           <HealthContext.Consumer>

--- a/tests/acceptance/test_health.py
+++ b/tests/acceptance/test_health.py
@@ -45,8 +45,9 @@ class HealthTest(AcceptanceTestCase):
             self.browser.wait_until_not('.loading-indicator')
             self.browser.snapshot('health errors')
 
-    def test_transactions(self):
-        with self.feature('organizations:health'):
-            self.browser.get('{}/transactions/'.format(self.path))
-            self.browser.wait_until_not('.loading-indicator')
-            self.browser.snapshot('health transactions')
+    # TODO(billyvg): Skipping until API endpoints are ready
+    #  def test_transactions(self):
+        #  with self.feature('organizations:health'):
+            #  self.browser.get('{}/transactions/'.format(self.path))
+            #  self.browser.wait_until_not('.loading-indicator')
+            #  self.browser.snapshot('health transactions')

--- a/tests/js/fixtures/health.js
+++ b/tests/js/fixtures/health.js
@@ -1,0 +1,29 @@
+const COUNT_OBJ = tag => ({
+  count: 123,
+  release: {
+    _health_id: `${tag}:${tag}-slug`,
+    value: {slug: `${tag}-slug`},
+  },
+});
+
+export function Top(tag = 'release', params) {
+  const countObject = COUNT_OBJ(tag);
+  return {
+    data: [countObject],
+    totals: {
+      count: 123,
+      lastCount: 43,
+    },
+  };
+}
+
+export function Graph(tag = 'release', params) {
+  const countObject = COUNT_OBJ(tag);
+
+  return {
+    data: [
+      [new Date(), [{...countObject, count: 321}, {...countObject, count: 79}]],
+      [new Date(), [countObject]],
+    ],
+  };
+}

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -12,6 +12,7 @@ import theme from 'app/utils/theme';
 import RoleList from './fixtures/roleList';
 import Release from './fixtures/release';
 import {AsanaPlugin, AsanaCreate, AsanaAutocomplete} from './fixtures/asana';
+import {Graph, Top} from './fixtures/health';
 import {
   PhabricatorPlugin,
   PhabricatorCreate,
@@ -536,6 +537,9 @@ window.TestStubs = {
       ...params,
     };
   },
+
+  HealthGraph: Graph,
+  HealthTop: Top,
 
   JiraIntegrationProvider: params => {
     return {

--- a/tests/js/spec/views/organizationHealth/__snapshots__/transactions.spec.jsx.snap
+++ b/tests/js/spec/views/organizationHealth/__snapshots__/transactions.spec.jsx.snap
@@ -1,9 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`OrganizationHealthTransactions renders 1`] = `
-<OrganizationHealthTransactions>
-  <div>
-    Transactions
-  </div>
-</OrganizationHealthTransactions>
-`;

--- a/tests/js/spec/views/organizationHealth/transactions.spec.jsx
+++ b/tests/js/spec/views/organizationHealth/transactions.spec.jsx
@@ -3,9 +3,31 @@ import {mount} from 'enzyme';
 
 import OrganizationHealthTransactions from 'app/views/organizationHealth/transactions';
 
+jest.mock('app/utils/withLatestContext');
+jest.mock('echarts-for-react/lib/core', () => jest.fn(() => null));
+
 describe('OrganizationHealthTransactions', function() {
-  it('renders', function() {
-    let wrapper = mount(<OrganizationHealthTransactions />);
-    expect(wrapper).toMatchSnapshot();
+  const org = TestStubs.Organization();
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/health/top/',
+    body: (url, opts) => {
+      return TestStubs.HealthTop(opts.query.tag);
+    },
+  });
+
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/health/graph/',
+    body: (url, opts) => {
+      return TestStubs.HealthGraph(opts.query.tag);
+    },
+  });
+
+  it('renders with LineChart, AreaChart, and TableChart', async function() {
+    let wrapper = mount(<OrganizationHealthTransactions organization={org} />);
+    await tick();
+    wrapper.update();
+    expect(wrapper.find('TableChart')).toHaveLength(1);
+    expect(wrapper.find('AreaChart')).toHaveLength(1);
+    expect(wrapper.find('LineChart')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
This adds a line chart, an area chart, and an events table for Transactions.

Depends on PRs:
~~https://github.com/getsentry/sentry/pull/9570~~
~~https://github.com/getsentry/sentry/pull/9545~~
~~https://github.com/getsentry/sentry/pull/9535~~