### PR TITLE
feat(ui): Allow use of react-virtualized in dropdown menus

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -463,9 +463,10 @@ const getItemPaddingForSize = size => {
   return space(1);
 };
 
-const AutoCompleteItem = styled(Flex)`
+const AutoCompleteItem = styled('div')`
   /* needed for virtualized lists that do not fill parent height */
   /* e.g. breadcrumbs (org height > project, but want same fixed height for both) */
+  display: flex;
   flex-direction: column;
   justify-content: center;
 

--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -1,3 +1,4 @@
+import {AutoSizer, List} from 'react-virtualized';
 import {Flex} from 'grid-emotion';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -82,6 +83,14 @@ class DropdownAutoCompleteMenu extends React.Component {
     maxHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
     /**
+     * Supplying this height will force the dropdown menu to be a virtualized list.
+     * This is very useful (and probably required) if you have a large list. e.g. Project selector with many projects.
+     *
+     * Currently, our implementation of the virtualized list requires a fixed height.
+     */
+    virtualizedHeight: PropTypes.number,
+
+    /**
      * Search input's placeholder text
      */
     searchPlaceholder: PropTypes.string,
@@ -156,6 +165,72 @@ class DropdownAutoCompleteMenu extends React.Component {
     }
 
     return this.filterItems(items, inputValue).map((item, index) => ({...item, index}));
+  };
+
+  renderList = ({items, ...otherProps}) => {
+    const {maxHeight, virtualizedHeight} = this.props;
+
+    // If `virtualizedHeight` is defined, use a virtualized list
+    if (typeof virtualizedHeight !== 'undefined') {
+      return (
+        <AutoSizer disableHeight>
+          {({width}) => (
+            <List
+              width={width}
+              height={Math.min(items.length * virtualizedHeight, maxHeight)}
+              rowCount={items.length}
+              rowHeight={virtualizedHeight}
+              rowRenderer={({key, index, style}) => {
+                const item = items[index];
+                return this.renderRow({
+                  item,
+                  style,
+                  key,
+                  ...otherProps,
+                });
+              }}
+            />
+          )}
+        </AutoSizer>
+      );
+    }
+
+    return items.map(item => {
+      const {index} = item;
+      const key = `${item.value}-${index}`;
+
+      return this.renderRow({item, key, ...otherProps});
+    });
+  };
+
+  renderRow = ({
+    item,
+    style,
+    itemSize,
+    key,
+    highlightedIndex,
+    inputValue,
+    getItemProps,
+  }) => {
+    const {index} = item;
+
+    return item.groupLabel ? (
+      !item.hideGroupLabel && (
+        <LabelWithBorder style={style} key={item.label || item.id}>
+          {item.label && <GroupLabel>{item.label}</GroupLabel>}
+        </LabelWithBorder>
+      )
+    ) : (
+      <AutoCompleteItem
+        size={itemSize}
+        key={key}
+        index={index}
+        highlightedIndex={highlightedIndex}
+        {...getItemProps({item, index, style})}
+      >
+        {typeof item.label === 'function' ? item.label({inputValue}) : item.label}
+      </AutoCompleteItem>
+    );
   };
 
   render() {
@@ -267,28 +342,13 @@ class DropdownAutoCompleteMenu extends React.Component {
                         </Flex>
                       )}
                       {!busy &&
-                        autoCompleteResults.map(
-                          ({index, ...item}) =>
-                            item.groupLabel ? (
-                              !item.hideGroupLabel && (
-                                <LabelWithBorder key={item.label || item.id}>
-                                  {item.label && <GroupLabel>{item.label}</GroupLabel>}
-                                </LabelWithBorder>
-                              )
-                            ) : (
-                              <AutoCompleteItem
-                                size={itemSize}
-                                key={`${item.value}-${index}`}
-                                index={index}
-                                highlightedIndex={highlightedIndex}
-                                {...getItemProps({item, index})}
-                              >
-                                {typeof item.label === 'function'
-                                  ? item.label({inputValue})
-                                  : item.label}
-                              </AutoCompleteItem>
-                            )
-                        )}
+                        this.renderList({
+                          items: autoCompleteResults,
+                          itemSize,
+                          highlightedIndex,
+                          inputValue,
+                          getItemProps,
+                        })}
                     </StyledItemList>
 
                     {menuFooter && <LabelWithPadding>{menuFooter}</LabelWithPadding>}
@@ -403,7 +463,12 @@ const getItemPaddingForSize = size => {
   return space(1);
 };
 
-const AutoCompleteItem = styled('div')`
+const AutoCompleteItem = styled(Flex)`
+  /* needed for virtualized lists that do not fill parent height */
+  /* e.g. breadcrumbs (org height > project, but want same fixed height for both) */
+  flex-direction: column;
+  justify-content: center;
+
   font-size: 0.9em;
   background-color: ${p =>
     p.index == p.highlightedIndex ? p.theme.offWhite : 'transparent'};

--- a/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
@@ -112,6 +112,7 @@ const ProjectSelector = withRouter(
           inputProps={{style: {padding: 8, paddingLeft: 14}}}
           emptyMessage={t('You have no projects')}
           noResultsMessage={t('No projects found')}
+          virtualizedHeight={33}
           menuFooter={
             !hasProjects && hasProjectWrite ? (
               <CreateProjectButton

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.jsx
@@ -96,6 +96,7 @@ class BreadcrumbDropdown extends React.Component {
         items={items}
         onSelect={onSelect}
         isStyled
+        virtualizedHeight={41}
       >
         {({getActorProps, actions, isOpen}) => {
           return (

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -39,6 +39,16 @@ jest.mock('react-lazyload', () => {
   return LazyLoadMock;
 });
 
+jest.mock('react-virtualized', () => {
+  const ActualReactVirtualized = require.requireActual('react-virtualized');
+  return {
+    ...ActualReactVirtualized,
+    AutoSizer: ({children}) => {
+      return children({width: 100, height: 100});
+    },
+  };
+});
+
 jest.mock('echarts-for-react/lib/core', () => {
   // We need to do this because `jest.mock` gets hoisted by babel and `React` is not
   // guaranteed to be in scope

--- a/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
@@ -138,7 +138,7 @@ exports[`DropdownAutoCompleteMenu renders with a group 1`] = `
                         onClick={[Function]}
                       >
                         <div
-                          className="css-le5ima-AutoCompleteItem ejumqxq3"
+                          className="css-2znhnp-AutoCompleteItem ejumqxq3"
                           onClick={[Function]}
                         >
                           <div>
@@ -153,7 +153,7 @@ exports[`DropdownAutoCompleteMenu renders with a group 1`] = `
                         onClick={[Function]}
                       >
                         <div
-                          className="css-14kg2cv-AutoCompleteItem ejumqxq3"
+                          className="css-zryfsl-AutoCompleteItem ejumqxq3"
                           onClick={[Function]}
                         >
                           <div>
@@ -297,7 +297,7 @@ exports[`DropdownAutoCompleteMenu renders without a group 1`] = `
                         onClick={[Function]}
                       >
                         <div
-                          className="css-le5ima-AutoCompleteItem ejumqxq3"
+                          className="css-2znhnp-AutoCompleteItem ejumqxq3"
                           onClick={[Function]}
                         >
                           <div>
@@ -312,7 +312,7 @@ exports[`DropdownAutoCompleteMenu renders without a group 1`] = `
                         onClick={[Function]}
                       >
                         <div
-                          className="css-14kg2cv-AutoCompleteItem ejumqxq3"
+                          className="css-zryfsl-AutoCompleteItem ejumqxq3"
                           onClick={[Function]}
                         >
                           <div>
@@ -327,7 +327,7 @@ exports[`DropdownAutoCompleteMenu renders without a group 1`] = `
                         onClick={[Function]}
                       >
                         <div
-                          className="css-14kg2cv-AutoCompleteItem ejumqxq3"
+                          className="css-zryfsl-AutoCompleteItem ejumqxq3"
                           onClick={[Function]}
                         >
                           <div>

--- a/tests/js/spec/components/settingsBreadcrumbDropdown.spec.jsx
+++ b/tests/js/spec/components/settingsBreadcrumbDropdown.spec.jsx
@@ -3,15 +3,16 @@ import {mount} from 'enzyme';
 
 import BreadcrumbDropdown from 'app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown';
 
-// Need to mock AutoSizer:/
-//
-const ActualReactVirtualized = require.requireActual('react-virtualized');
-jest.mock('react-virtualized', () => ({
-  ...ActualReactVirtualized,
-  AutoSizer: ({children}) => {
-    return children({width: 100, height: 100});
-  },
-}));
+jest.mock('react-virtualized', () => {
+  const ActualReactVirtualized = require.requireActual('react-virtualized');
+  return {
+    ...ActualReactVirtualized,
+    AutoSizer: ({children}) => {
+      return children({width: 100, height: 100});
+    },
+  };
+});
+
 jest.useFakeTimers();
 
 const CLOSE_DELAY = 0;

--- a/tests/js/spec/components/settingsBreadcrumbDropdown.spec.jsx
+++ b/tests/js/spec/components/settingsBreadcrumbDropdown.spec.jsx
@@ -3,16 +3,6 @@ import {mount} from 'enzyme';
 
 import BreadcrumbDropdown from 'app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown';
 
-jest.mock('react-virtualized', () => {
-  const ActualReactVirtualized = require.requireActual('react-virtualized');
-  return {
-    ...ActualReactVirtualized,
-    AutoSizer: ({children}) => {
-      return children({width: 100, height: 100});
-    },
-  };
-});
-
 jest.useFakeTimers();
 
 const CLOSE_DELAY = 0;

--- a/tests/js/spec/components/settingsBreadcrumbDropdown.spec.jsx
+++ b/tests/js/spec/components/settingsBreadcrumbDropdown.spec.jsx
@@ -3,6 +3,15 @@ import {mount} from 'enzyme';
 
 import BreadcrumbDropdown from 'app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown';
 
+// Need to mock AutoSizer:/
+//
+const ActualReactVirtualized = require.requireActual('react-virtualized');
+jest.mock('react-virtualized', () => ({
+  ...ActualReactVirtualized,
+  AutoSizer: ({children}) => {
+    return children({width: 100, height: 100});
+  },
+}));
 jest.useFakeTimers();
 
 const CLOSE_DELAY = 0;


### PR DESCRIPTION
Use `react-virtualized` if `virtualizedHeight` property is used. This only works for uniform height list items.

This will help in things like the Project selector for orgs with a large number of projects.

Note: This doesn't work in AssigneeSelector (and maybe other dropdowns) where we have item headers
that have non-uniform row heights.