### PR TITLE
ref(vsts): Remove url parsing for the base url in the vsts integration.

### DIFF
--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -23,7 +23,7 @@ class VstsApiPath(object):
     projects = u'{instance}DefaultCollection/_apis/projects'
     repository = u'{instance}DefaultCollection/{project}_apis/git/repositories/{repo_id}'
     repositories = u'{instance}{project}_apis/git/repositories'
-    subscription = '{instance}_apis/hooks/subscriptions/{subscription_id}'
+    subscription = u'{instance}_apis/hooks/subscriptions/{subscription_id}'
     subscriptions = u'{instance}_apis/hooks/subscriptions'
     work_items = u'{instance}DefaultCollection/_apis/wit/workitems/{id}'
     work_items_create = u'{instance}{project}/_apis/wit/workitems/${type}'

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -27,10 +27,10 @@ class VstsApiPath(object):
     subscriptions = u'{instance}_apis/hooks/subscriptions'
     work_items = u'{instance}DefaultCollection/_apis/wit/workitems/{id}'
     work_items_create = u'{instance}{project}/_apis/wit/workitems/${type}'
-    # TODO(lb): how do I fix this?
+    # TODO(lb): Fix this url so that the base url is given by vsts rather than built by us
     work_item_search = u'https://{account_name}.almsearch.visualstudio.com/_apis/search/workitemsearchresults'
     work_item_states = u'{instance}{project}/_apis/wit/workitemtypes/{type}/states'
-    # TODO(lb): how do I fix this one?
+    # TODO(lb): Fix this url so that the base url is given by vsts rather than built by us
     users = u'https://{account_name}.vssps.visualstudio.com/_apis/graph/users'
 
 

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -17,18 +17,20 @@ INVALID_ACCESS_TOKEN = 'HTTP 400 (invalid_request): The access token is not vali
 
 
 class VstsApiPath(object):
-    commits = u'https://{account_name}/DefaultCollection/_apis/git/repositories/{repo_id}/commits'
-    commits_batch = u'https://{account_name}/DefaultCollection/_apis/git/repositories/{repo_id}/commitsBatch'
-    commits_changes = u'https://{account_name}/DefaultCollection/_apis/git/repositories/{repo_id}/commits/{commit_id}/changes'
-    projects = u'https://{account_name}/DefaultCollection/_apis/projects'
-    repository = u'https://{account_name}/DefaultCollection/{project}_apis/git/repositories/{repo_id}'
-    repositories = u'https://{account_name}/{project}_apis/git/repositories'
-    subscription = 'https://{account_name}/_apis/hooks/subscriptions/{subscription_id}'
-    subscriptions = u'https://{account_name}/_apis/hooks/subscriptions'
-    work_items = u'https://{account_name}/DefaultCollection/_apis/wit/workitems/{id}'
-    work_items_create = u'https://{account_name}/{project}/_apis/wit/workitems/${type}'
+    commits = u'{instance}DefaultCollection/_apis/git/repositories/{repo_id}/commits'
+    commits_batch = u'{instance}DefaultCollection/_apis/git/repositories/{repo_id}/commitsBatch'
+    commits_changes = u'{instance}DefaultCollection/_apis/git/repositories/{repo_id}/commits/{commit_id}/changes'
+    projects = u'{instance}DefaultCollection/_apis/projects'
+    repository = u'{instance}DefaultCollection/{project}_apis/git/repositories/{repo_id}'
+    repositories = u'{instance}{project}_apis/git/repositories'
+    subscription = '{instance}_apis/hooks/subscriptions/{subscription_id}'
+    subscriptions = u'{instance}_apis/hooks/subscriptions'
+    work_items = u'{instance}DefaultCollection/_apis/wit/workitems/{id}'
+    work_items_create = u'{instance}{project}/_apis/wit/workitems/${type}'
+    # TODO(lb): how do I fix this?
     work_item_search = u'https://{account_name}.almsearch.visualstudio.com/_apis/search/workitemsearchresults'
-    work_item_states = u'https://{account_name}/{project}/_apis/wit/workitemtypes/{type}/states'
+    work_item_states = u'{instance}{project}/_apis/wit/workitemtypes/{type}/states'
+    # TODO(lb): how do I fix this one?
     users = u'https://{account_name}.vssps.visualstudio.com/_apis/graph/users'
 
 
@@ -88,7 +90,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
 
         return self.patch(
             VstsApiPath.work_items_create.format(
-                account_name=instance,
+                instance=instance,
                 project=project,
                 type='Bug'
             ),
@@ -129,7 +131,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
 
         return self.patch(
             VstsApiPath.work_items.format(
-                account_name=instance,
+                instance=instance,
                 id=id,
             ),
             data=data,
@@ -138,7 +140,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
     def get_work_item(self, instance, id):
         return self.get(
             VstsApiPath.work_items.format(
-                account_name=instance,
+                instance=instance,
                 id=id,
             ),
         )
@@ -146,7 +148,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
     def get_work_item_states(self, instance, project):
         return self.get(
             VstsApiPath.work_item_states.format(
-                account_name=instance,
+                instance=instance,
                 project=project,
                 # TODO(lb): might want to make this custom like jira at some point
                 type='Bug',
@@ -157,7 +159,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
     def get_work_item_types(self, instance, process_id):
         return self.get(
             VstsApiPath.work_item_types.format(
-                account_name=instance,
+                instance=instance,
                 process_id=process_id,
             ),
             api_preview=True,
@@ -166,7 +168,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
     def get_repo(self, instance, name_or_id, project=None):
         return self.get(
             VstsApiPath.repository.format(
-                account_name=instance,
+                instance=instance,
                 project='{}/'.format(project) if project else '',
                 repo_id=name_or_id,
             ),
@@ -175,7 +177,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
     def get_repos(self, instance, project=None):
         return self.get(
             VstsApiPath.repositories.format(
-                account_name=instance,
+                instance=instance,
                 project='{}/'.format(project) if project else '',
             ),
         )
@@ -183,7 +185,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
     def get_commits(self, instance, repo_id, commit, limit=100):
         return self.get(
             VstsApiPath.commits.format(
-                account_name=instance,
+                instance=instance,
                 repo_id=repo_id,
             ),
             params={
@@ -196,7 +198,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
 
         resp = self.get(
             VstsApiPath.commits_changes.format(
-                account_name=instance,
+                instance=instance,
                 repo_id=repo_id,
                 commit_id=commit,
             )
@@ -207,7 +209,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
     def get_commit_range(self, instance, repo_id, start_sha, end_sha):
         return self.post(
             VstsApiPath.commits_batch.format(
-                account_name=instance,
+                instance=instance,
                 repo_id=repo_id,
             ),
             data={
@@ -227,7 +229,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
         # making the assumption that a user has 100 or less projects today.
         return self.get(
             VstsApiPath.projects.format(
-                account_name=instance,
+                instance=instance,
             ),
             params={'stateFilter': 'WellFormed'}
         )
@@ -243,7 +245,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
     def create_subscription(self, instance, external_id, shared_secret):
         return self.post(
             VstsApiPath.subscriptions.format(
-                account_name=instance
+                instance=instance
             ),
             data={
                 'publisherId': 'tfs',
@@ -262,7 +264,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
     def delete_subscription(self, instance, subscription_id):
         self.delete(
             VstsApiPath.subscription.format(
-                account_name=instance,
+                instance=instance,
                 subscription_id=subscription_id,
             )
         )

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -103,6 +103,7 @@ class VstsIntegration(Integration, RepositoryMixin, VstsIssueSync):
         base_url = VstsIntegrationProvider.get_base_url(
             self.default_identity.data['access_token'], self.model.external_id)
         self.model.metadata['domain_name'] = base_url
+        self.model.save()
 
     def get_organization_config(self):
         client = self.get_client()

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -293,7 +293,7 @@ class VstsIntegrationProvider(IntegrationProvider):
         account = state['account']
         user = get_user_info(data['access_token'])
         scopes = sorted(VSTSIdentityProvider.oauth_scopes)
-        base_url = self.get_base_url(data['access_token'], account['accountId'])['locationUrl']
+        base_url = self.get_base_url(data['access_token'], account['accountId'])
 
         integration = {
             'name': account['accountName'],
@@ -371,7 +371,7 @@ class VstsIntegrationProvider(IntegrationProvider):
             },
         )
         if response.status_code == 200:
-            return response.json()
+            return response.json()['locationUrl']
         return None
 
     def setup(self):

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -253,6 +253,8 @@ class VstsIntegrationProvider(IntegrationProvider):
         'height': 800,
     }
 
+    VSTS_ACCOUNT_LOOKUP_URL = 'https://app.vssps.visualstudio.com/_apis/resourceareas/79134C72-4A58-4B42-976C-04E7115F32BF?hostId=%s&api-preview=5.0-preview.1'
+
     def post_install(self, integration, organization):
         installation = self.get_installation(integration, organization.id)
 
@@ -362,7 +364,7 @@ class VstsIntegrationProvider(IntegrationProvider):
 
     def get_base_url(self, access_token, account_id):
         session = http.build_session()
-        url = 'https://app.vssps.visualstudio.com/_apis/resourceareas/79134C72-4A58-4B42-976C-04E7115F32BF?hostId=%s&api-preview=5.0-preview.1' % account_id
+        url = self.VSTS_ACCOUNT_LOOKUP_URL % account_id
         response = session.get(
             url,
             headers={

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -386,7 +386,7 @@ class AccountConfigView(PipelineView):
         access_token = state['data']['access_token']
         user = get_user_info(access_token)
 
-        accounts = self.get_accounts(access_token, user['publicAlias'])['value']
+        accounts = self.get_accounts(access_token, user['id'])['value']
         pipeline.bind_state('accounts', accounts)
         account_form = AccountForm(accounts)
         return render_to_response(

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -61,7 +61,7 @@ class VstsIssueSync(IssueSyncMixin):
         return fields
 
     def get_issue_url(self, key, **kwargs):
-        return 'https://%s/_workitems/edit/%s' % (self.instance, six.text_type(key))
+        return '%s_workitems/edit/%s' % (self.instance, six.text_type(key))
 
     def create_issue(self, data, **kwargs):
         """

--- a/src/sentry/integrations/vsts_extension/integration.py
+++ b/src/sentry/integrations/vsts_extension/integration.py
@@ -26,13 +26,9 @@ class VstsExtensionIntegrationProvider(VstsIntegrationProvider):
 
     def build_integration(self, state):
         state['account'] = {
-            'AccountId': state['vsts']['AccountId'],
-            'AccountName': state['vsts']['AccountName'],
+            'accountId': state['vsts']['accountId'],
+            'accountName': state['vsts']['accountName'],
         }
-
-        state['instance'] = '{}.visualstudio.com'.format(
-            state['vsts']['AccountName']
-        )
 
         return super(
             VstsExtensionIntegrationProvider,

--- a/src/sentry/web/frontend/vsts_extension_configuration.py
+++ b/src/sentry/web/frontend/vsts_extension_configuration.py
@@ -71,8 +71,8 @@ class VstsExtensionConfigurationView(BaseView):
 
         pipeline.initialize()
         pipeline.bind_state('vsts', {
-            'AccountId': id,
-            'AccountName': name,
+            'accountId': id,
+            'accountName': name,
         })
 
         return pipeline

--- a/tests/sentry/integrations/vsts/test_client.py
+++ b/tests/sentry/integrations/vsts/test_client.py
@@ -28,7 +28,7 @@ class VstsApiClientTest(VstsIntegrationTestCase):
         integration \
             .get_installation(integration.organizations.first().id) \
             .get_client() \
-            .get_projects('{}.visualstudio.com'.format(self.vsts_account_name))
+            .get_projects(self.vsts_base_url)
 
         # Second to last request, before the Projects request, was to refresh
         # the Access Token.
@@ -37,8 +37,8 @@ class VstsApiClientTest(VstsIntegrationTestCase):
 
         # Then we request the Projects with the new token
         assert responses.calls[-1].request.url == \
-            'https://{}.visualstudio.com/DefaultCollection/_apis/projects?stateFilter=WellFormed'.format(
-                self.vsts_account_name.lower(),
+            '{}DefaultCollection/_apis/projects?stateFilter=WellFormed'.format(
+                self.vsts_base_url.lower(),
         )
 
         identity = Identity.objects.get(id=identity.id)

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -127,7 +127,6 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
                 'accountId': self.vsts_account_id,
             },
             'base_url': self.vsts_base_url,
-            'instance': self.vsts_base_url,
             'identity': {
                 'data': {
                     'access_token': self.access_token,
@@ -160,7 +159,6 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
                 'accountId': self.vsts_account_id,
             },
             'base_url': self.vsts_base_url,
-            'instance': self.vsts_base_url,
             'identity': {
                 'data': {
                     'access_token': self.access_token,
@@ -189,7 +187,6 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
                 'accountId': external_id,
             },
             'base_url': self.vsts_base_url,
-            'instance': self.vsts_base_url,
             'identity': {
                 'data': {
                     'access_token': self.access_token,

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -28,16 +28,14 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
         assert metadata['scopes'] == list(VSTSIdentityProvider.oauth_scopes)
         assert metadata['subscription']['id'] == \
             CREATE_SUBSCRIPTION['publisherInputs']['tfsSubscriptionId']
-        assert metadata['domain_name'] == '{}.visualstudio.com'.format(
-            self.vsts_account_name
-        )
+        assert metadata['domain_name'] == self.vsts_base_url
 
     def test_migrate_repositories(self):
         accessible_repo = Repository.objects.create(
             organization_id=self.organization.id,
             name=self.project_a['name'],
-            url='https://{}.visualstudio.com/DefaultCollection/_git/{}'.format(
-                self.vsts_account_name,
+            url='{}/DefaultCollection/_git/{}'.format(
+                self.vsts_base_url,
                 self.repo_name,
             ),
             provider='visualstudio',
@@ -125,10 +123,11 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
     def test_build_integration(self):
         state = {
             'account': {
-                'AccountName': self.vsts_account_name,
-                'AccountId': self.vsts_account_id,
+                'accountName': self.vsts_account_name,
+                'accountId': self.vsts_account_id,
             },
-            'instance': '{}.visualstudio.com'.format(self.vsts_account_name),
+            'base_url': self.vsts_base_url,
+            'instance': self.vsts_base_url,
             'identity': {
                 'data': {
                     'access_token': self.access_token,
@@ -144,8 +143,7 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
 
         assert integration_dict['name'] == self.vsts_account_name
         assert integration_dict['external_id'] == self.vsts_account_id
-        assert integration_dict['metadata']['domain_name'] == \
-            '{}.visualstudio.com'.format(self.vsts_account_name)
+        assert integration_dict['metadata']['domain_name'] == self.vsts_base_url
 
         assert integration_dict['user_identity']['type'] == 'vsts'
         assert integration_dict['user_identity']['external_id'] == \
@@ -158,10 +156,11 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
 
         state = {
             'account': {
-                'AccountName': self.vsts_account_name,
-                'AccountId': self.vsts_account_id,
+                'accountName': self.vsts_account_name,
+                'accountId': self.vsts_account_id,
             },
-            'instance': '{}.visualstudio.com'.format(self.vsts_account_name),
+            'base_url': self.vsts_base_url,
+            'instance': self.vsts_base_url,
             'identity': {
                 'data': {
                     'access_token': self.access_token,
@@ -186,10 +185,11 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
         )
         data = VstsIntegrationProvider().build_integration({
             'account': {
-                'AccountName': self.vsts_account_name,
-                'AccountId': external_id,
+                'accountName': self.vsts_account_name,
+                'accountId': external_id,
             },
-            'instance': '{}.visualstudio.com'.format(self.vsts_account_name),
+            'base_url': self.vsts_base_url,
+            'instance': self.vsts_base_url,
             'identity': {
                 'data': {
                     'access_token': self.access_token,

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -354,3 +354,20 @@ class VstsIntegrationTest(VstsIntegrationTestCase):
             'sync_status_forward': True,
             'other_option': 'hello',
         }
+
+    def test_update_domain_name(self):
+        account_name = 'MyVSTSAccount.visualstudio.com'
+        account_uri = 'https://MyVSTSAccount.visualstudio.com/'
+
+        self.assert_installation()
+
+        model = Integration.objects.get(provider='vsts')
+        model.metadata['domain_name'] = account_name
+        model.save()
+
+        integration = VstsIntegration(model, self.organization.id)
+        integration.get_client()
+
+        domain_name = integration.model.metadata['domain_name']
+        assert domain_name == account_uri
+        assert Integration.objects.get(provider='vsts').metadata['domain_name'] == account_uri

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -28,7 +28,7 @@ class VstsIssueSycnTest(TestCase):
             external_id='vsts_external_id',
             name='fabrikam-fiber-inc',
             metadata={
-                'domain_name': 'fabrikam-fiber-inc.visualstudio.com',
+                'domain_name': 'https://fabrikam-fiber-inc.visualstudio.com/',
                 'default_project': '0987654321',
             }
         )

--- a/tests/sentry/integrations/vsts/test_provider.py
+++ b/tests/sentry/integrations/vsts/test_provider.py
@@ -57,11 +57,13 @@ class TestVSTSOAuthCallbackView(TestCase):
 
 class TestAccountConfigView(TestCase):
     def setUp(self):
+        account_id = '1234567-8910'
+        self.base_url = 'http://sentry2.visualstudio.com/'
         self.accounts = [
             {
-                'AccountId': '1234567-89',
+                'accountId': '1234567-89',
                 'NamespaceId': '00000000-0000-0000-0000-000000000000',
-                'AccountName': 'sentry',
+                'accountName': 'sentry',
                 'OrganizationName': None,
                 'AccountType': 0,
                 'AccountOwner': '00000000-0000-0000-0000-000000000000',
@@ -73,9 +75,9 @@ class TestAccountConfigView(TestCase):
                 'Properties': {},
             },
             {
-                'AccountId': '1234567-8910',
+                'accountId': account_id,
                 'NamespaceId': '00000000-0000-0000-0000-000000000000',
-                'AccountName': 'sentry2',
+                'accountName': 'sentry2',
                 'OrganizationName': None,
                 'AccountType': 0,
                 'AccountOwner': '00000000-0000-0000-0000-000000000000',
@@ -95,6 +97,13 @@ class TestAccountConfigView(TestCase):
             status=200,
 
         )
+        responses.add(
+            responses.GET,
+            'https://app.vssps.visualstudio.com/_apis/resourceareas/79134C72-4A58-4B42-976C-04E7115F32BF?hostId=%s&api-preview=5.0-preview.1' % account_id,
+            json={
+                'locationUrl': self.base_url,
+            }
+        )
 
     @responses.activate
     def test_dispatch(self):
@@ -103,22 +112,27 @@ class TestAccountConfigView(TestCase):
         request.POST = {'account': '1234567-8910'}
 
         pipeline = Mock()
-        pipeline.state = {'accounts': self.accounts}
+        pipeline.state = {
+            'accounts': self.accounts,
+            'identity': {
+                'data': {'access_token': '123456789'}
+            }
+        }
         pipeline.fetch_state = lambda key: pipeline.state[key]
         pipeline.bind_state = lambda name, value: pipeline.state.update({name: value})
 
         view.dispatch(request, pipeline)
 
-        assert pipeline.fetch_state(key='instance') == 'sentry2.visualstudio.com'
+        assert pipeline.fetch_state(key='base_url') == self.base_url
         assert pipeline.fetch_state(key='account') == self.accounts[1]
         assert pipeline.next_step.call_count == 1
 
     @responses.activate
     def test_get_accounts(self):
         view = AccountConfigView()
-        accounts = view.get_accounts('access-token')
-        assert accounts[0]['AccountName'] == 'sentry'
-        assert accounts[1]['AccountName'] == 'sentry2'
+        accounts = view.get_accounts('access-token', 'user-id')
+        assert accounts[0]['accountName'] == 'sentry'
+        assert accounts[1]['accountName'] == 'sentry2'
 
     def test_account_form(self):
         account_form = AccountForm(self.accounts)

--- a/tests/sentry/integrations/vsts/test_provider.py
+++ b/tests/sentry/integrations/vsts/test_provider.py
@@ -123,7 +123,6 @@ class TestAccountConfigView(TestCase):
 
         view.dispatch(request, pipeline)
 
-        assert pipeline.fetch_state(key='base_url') == self.base_url
         assert pipeline.fetch_state(key='account') == self.accounts[1]
         assert pipeline.next_step.call_count == 1
 

--- a/tests/sentry/integrations/vsts/test_repository.py
+++ b/tests/sentry/integrations/vsts/test_repository.py
@@ -15,6 +15,9 @@ from .testutils import (
 
 
 class VisualStudioRepositoryProviderTest(TestCase):
+    def setUp(self):
+        self.base_url = 'https://visualstudio.com/'
+
     @fixture
     def provider(self):
         return VstsRepositoryProvider('integrations:vsts')
@@ -57,7 +60,7 @@ class VisualStudioRepositoryProviderTest(TestCase):
             name='example',
             organization_id=self.organization.id,
             config={
-                'instance': 'visualstudio.com',
+                'instance': self.base_url,
                 'project': 'project-name',
                 'name': 'example',
             },
@@ -88,7 +91,7 @@ class VisualStudioRepositoryProviderTest(TestCase):
             'name': 'MyFirstProject',
             'external_id': '654321',
             'url': 'https://mbittker.visualstudio.com/_git/MyFirstProject/',
-            'instance': 'https://visualstudio.com',
+            'instance': self.base_url,
             'project': 'MyFirstProject',
             'installation': integration.id,
         }
@@ -102,7 +105,7 @@ class VisualStudioRepositoryProviderTest(TestCase):
             'config': {
                 'project': 'MyFirstProject',
                 'name': 'MyFirstProject',
-                'instance': 'https://visualstudio.com'
+                'instance': self.base_url
 
             },
             'integration_id': integration.id,

--- a/tests/sentry/integrations/vsts/test_repository.py
+++ b/tests/sentry/integrations/vsts/test_repository.py
@@ -17,6 +17,7 @@ from .testutils import (
 class VisualStudioRepositoryProviderTest(TestCase):
     def setUp(self):
         self.base_url = 'https://visualstudio.com/'
+        self.vsts_external_id = '654321'
 
     @fixture
     def provider(self):
@@ -37,8 +38,11 @@ class VisualStudioRepositoryProviderTest(TestCase):
         )
         integration = Integration.objects.create(
             provider='vsts',
-            external_id='vsts_external_id',
+            external_id=self.vsts_external_id,
             name='Hello world',
+            metadata={
+                'domain_name': self.base_url,
+            }
         )
         default_auth = Identity.objects.create(
             idp=IdentityProvider.objects.create(
@@ -84,8 +88,11 @@ class VisualStudioRepositoryProviderTest(TestCase):
         organization = self.create_organization()
         integration = Integration.objects.create(
             provider='vsts',
-            external_id='vsts_external_id',
+            external_id=self.vsts_external_id,
             name='Hello world',
+            metadata={
+                'domain_name': self.base_url,
+            }
         )
         data = {
             'name': 'MyFirstProject',
@@ -99,7 +106,7 @@ class VisualStudioRepositoryProviderTest(TestCase):
 
         assert data == {
             'name': 'MyFirstProject',
-            'external_id': '654321',
+            'external_id': self.vsts_external_id,
             'url': 'https://mbittker.visualstudio.com/_git/MyFirstProject/',
 
             'config': {

--- a/tests/sentry/integrations/vsts/test_webhooks.py
+++ b/tests/sentry/integrations/vsts/test_webhooks.py
@@ -22,14 +22,14 @@ class VstsWebhookWorkItemTest(APITestCase):
         self.project = self.create_project(organization=self.organization)
         self.access_token = '1234567890'
         self.account_id = u'80ded3e8-3cd3-43b1-9f96-52032624aa3a'
-        self.instance = 'instance.visualstudio.com'
+        self.instance = 'https://instance.visualstudio.com/'
         self.shared_secret = '1234567890'
         self.model = Integration.objects.create(
             provider='vsts',
             external_id=self.account_id,
             name='vsts_name',
             metadata={
-                 'domain_name': 'instance.visualstudio.com',
+                 'domain_name': self.instance,
                  'subscription': {
                      'id': 1234,
                      'secret': self.shared_secret,

--- a/tests/sentry/integrations/vsts/testutils.py
+++ b/tests/sentry/integrations/vsts/testutils.py
@@ -20,6 +20,7 @@ class VstsIntegrationTestCase(IntegrationTestCase):
         self.vsts_account_id = 'c8a585ae-b61f-4ba6-833c-9e8d5d1674d8'
         self.vsts_account_name = 'MyVSTSAccount'
         self.vsts_account_uri = 'https://MyVSTSAccount.vssps.visualstudio.com:443/'
+        self.vsts_base_url = 'https://MyVSTSAccount.visualstudio.com/'
 
         self.vsts_user_id = 'd6245f20-2af8-44f4-9451-8107cb2767db'
         self.vsts_user_name = 'Foo Bar'
@@ -60,15 +61,25 @@ class VstsIntegrationTestCase(IntegrationTestCase):
 
         responses.add(
             responses.GET,
-            'https://app.vssps.visualstudio.com/_apis/accounts',
-            json=[{
-                'AccountId': self.vsts_account_id,
-                'AccountUri': self.vsts_account_uri,
-                'AccountName': self.vsts_account_name,
-                'Properties': {},
-            }],
+            'https://app.vssps.visualstudio.com/_apis/accounts?ownerId=%s&api-version=4.1' % self.vsts_user_id,
+            json={
+                'count': 1,
+                'value': [{
+                    'accountId': self.vsts_account_id,
+                    'accountUri': self.vsts_account_uri,
+                    'accountName': self.vsts_account_name,
+                    'properties': {},
+                }]
+            },
         )
 
+        responses.add(
+            responses.GET,
+            'https://app.vssps.visualstudio.com/_apis/resourceareas/79134C72-4A58-4B42-976C-04E7115F32BF?hostId=%s&api-preview=5.0-preview.1' % self.vsts_account_id,
+            json={
+                'locationUrl': self.vsts_base_url,
+            }
+        )
         responses.add(
             responses.GET,
             'https://app.vssps.visualstudio.com/_apis/profile/profiles/me?api-version=1.0',

--- a/tests/sentry/integrations/vsts_extension/__init__.py
+++ b/tests/sentry/integrations/vsts_extension/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/integrations/vsts_extension/test_provider.py
+++ b/tests/sentry/integrations/vsts_extension/test_provider.py
@@ -33,10 +33,10 @@ class VstsExtensionIntegrationProviderTest(VstsIntegrationTestCase):
 
         integration = self.provider.build_integration({
             'vsts': {
-                'AccountId': '123',
-                'AccountName': 'test',
+                'accountId': '123',
+                'accountName': 'test',
             },
-            'instance': 'test.visualstudio.com',
+            'instance': 'https://test.visualstudio.com/',
             'identity': {
                 'data': {
                     'access_token': '123',


### PR DESCRIPTION
The way we parse the base url for Vsts requests is brittle and harder to maintain. This pull request gets the base url from VSTS api during integration creation. 

Integrations instances created prior to this change will need to be deleted and re-added in order to function again.