### PR TITLE
fix(2fa): Handle sms authenticator unavailable in recovery options

### DIFF
--- a/src/sentry/static/sentry/app/components/modals/recoveryOptionsModal.jsx
+++ b/src/sentry/static/sentry/app/components/modals/recoveryOptionsModal.jsx
@@ -40,8 +40,6 @@ class RecoveryOptionsModal extends AsyncComponent {
       obj[item.id] = item;
       return obj;
     }, {});
-
-    let smsEnrolled = sms && sms.isEnrolled;
     let recoveryEnrolled = recovery && recovery.isEnrolled;
 
     return (
@@ -58,7 +56,7 @@ class RecoveryOptionsModal extends AsyncComponent {
             {t('You should now set up recovery options to secure your account.')}
           </TextBlock>
 
-          {!skipSms && !smsEnrolled ? (
+          {sms && !sms.isEnrolled && !skipSms ? (
             // set up backup phone number
             <Alert type="warning">
               {t('We recommend adding a phone number as a backup 2FA method.')}
@@ -74,7 +72,7 @@ class RecoveryOptionsModal extends AsyncComponent {
           )}
         </Body>
 
-        {!skipSms && !smsEnrolled ? (
+        {sms && !sms.isEnrolled && !skipSms ? (
           // set up backup phone number
           <div className="modal-footer">
             <Button onClick={this.handleSkipSms} name="skipStep" autoFocus>

--- a/src/sentry/static/sentry/app/components/modals/recoveryOptionsModal.jsx
+++ b/src/sentry/static/sentry/app/components/modals/recoveryOptionsModal.jsx
@@ -41,6 +41,7 @@ class RecoveryOptionsModal extends AsyncComponent {
       return obj;
     }, {});
     let recoveryEnrolled = recovery && recovery.isEnrolled;
+    let displaySmsPrompt = sms && !sms.isEnrolled && !skipSms;
 
     return (
       <React.Fragment>
@@ -56,7 +57,7 @@ class RecoveryOptionsModal extends AsyncComponent {
             {t('You should now set up recovery options to secure your account.')}
           </TextBlock>
 
-          {sms && !sms.isEnrolled && !skipSms ? (
+          {displaySmsPrompt ? (
             // set up backup phone number
             <Alert type="warning">
               {t('We recommend adding a phone number as a backup 2FA method.')}
@@ -72,7 +73,7 @@ class RecoveryOptionsModal extends AsyncComponent {
           )}
         </Body>
 
-        {sms && !sms.isEnrolled && !skipSms ? (
+        {displaySmsPrompt ? (
           // set up backup phone number
           <div className="modal-footer">
             <Button onClick={this.handleSkipSms} name="skipStep" autoFocus>

--- a/tests/js/spec/components/modals/recoveryOptionsModal.spec.jsx
+++ b/tests/js/spec/components/modals/recoveryOptionsModal.spec.jsx
@@ -38,7 +38,7 @@ describe('RecoveryOptionsModal', function() {
     wrapper.find('RecoveryOptionsModal Button[name="skipStep"]').simulate('click');
     expect(wrapper.find(getRecoveryCodes)).toHaveLength(1);
 
-    let mockId = 16;
+    let mockId = TestStubs.Authenticators().Recovery().authId;
     expect(
       wrapper.find('RecoveryOptionsModal Button[name="getCodes"]').prop('to')
     ).toMatch(`/settings/account/security/${mockId}/`);
@@ -57,5 +57,31 @@ describe('RecoveryOptionsModal', function() {
 
     wrapper.find(backupPhone).simulate('click');
     expect(closeModal).toHaveBeenCalled();
+  });
+
+  it('skips backup phone setup if text message authenticator unavailable', async function() {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/users/me/authenticators/',
+      method: 'GET',
+      body: [TestStubs.Authenticators().Totp(), TestStubs.Authenticators().Recovery()],
+    });
+    wrapper = mount(
+      <RecoveryOptionsModal
+        Body={Modal.Body}
+        Header={Modal.Header}
+        authenticatorName="Authenticator App"
+        closeModal={closeModal}
+        onClose={onClose}
+      />,
+      TestStubs.routerContext()
+    );
+    let mockId = TestStubs.Authenticators().Recovery().authId;
+    expect(
+      wrapper.find('RecoveryOptionsModal Button[name="getCodes"]').prop('to')
+    ).toMatch(`/settings/account/security/${mockId}/`);
+
+    expect(wrapper.find('RecoveryOptionsModal Button[name="skipStep"]')).toHaveLength(0);
+    expect(wrapper.find('RecoveryOptionsModal Button[name="addPhone"]')).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Relevant for on-prem customers without twilio setup. Fixes #9573 