### PR TITLE
feat(discover): Link to event if raw results are displayed

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 import {browserHistory} from 'react-router';
+import {uniq} from 'lodash';
 
 import {addErrorMessage, clearIndicators} from 'app/actionCreators/indicator';
 import {t} from 'app/locale';
@@ -78,7 +79,18 @@ export default class OrganizationDiscover extends React.Component {
 
     clearIndicators();
 
-    queryBuilder.fetch().then(
+    // If there are no aggregations, always ensure we fetch event ID and
+    // project ID so we can display the link to event
+    const externalQuery = queryBuilder.getExternal();
+    const queryToFetch =
+      !externalQuery.aggregations.length && externalQuery.fields.length
+        ? {
+            ...externalQuery,
+            fields: uniq([...externalQuery.fields, 'event_id', 'project_id']),
+          }
+        : externalQuery;
+
+    queryBuilder.fetch(queryToFetch).then(
       data => {
         const query = queryBuilder.getInternal();
         const queryCopy = {...query};

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
@@ -109,7 +109,7 @@ export default class Result extends React.Component {
       <div>
         {this.renderToggle()}
 
-        {view === 'table' && <Table data={data} />}
+        {view === 'table' && <Table data={data} query={query} />}
         {view === 'line' && (
           <LineChart
             series={basicChartData}

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/table.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/table.jsx
@@ -152,7 +152,7 @@ export default class ResultTable extends React.Component {
               columnCount={cols.length + (showEventLinks ? 1 : 0)}
               fixedRowCount={1}
               rowHeight={30}
-              columnWidth={opts => this.getColumnWidth(opts, width)}
+              columnWidth={this.getColumnWidth}
               cellRenderer={this.cellRenderer}
               styleBottomRightGrid={{
                 border: `1px solid ${theme.borderDark}`,

--- a/tests/js/spec/views/organizationDiscover/discover.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/discover.spec.jsx
@@ -61,11 +61,24 @@ describe('Discover', function() {
       );
     });
 
-    it('runs query', async function() {
+    it('runs basic query', async function() {
       wrapper.instance().runQuery();
       await tick();
       expect(queryBuilder.fetch).toHaveBeenCalledTimes(1);
-      expect(queryBuilder.fetch).toHaveBeenCalledWith();
+      expect(queryBuilder.fetch).toHaveBeenCalledWith(queryBuilder.getExternal());
+      expect(wrapper.state().data).toEqual(mockResponse);
+    });
+
+    it('always requests event_id and project_id for basic queries', async function() {
+      queryBuilder.updateField('fields', ['message']);
+      wrapper.instance().runQuery();
+      await tick();
+      expect(queryBuilder.fetch).toHaveBeenCalledTimes(1);
+      expect(queryBuilder.fetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fields: ['message', 'event_id', 'project_id'],
+        })
+      );
       expect(wrapper.state().data).toEqual(mockResponse);
     });
 
@@ -90,7 +103,7 @@ describe('Discover', function() {
       wrapper.instance().runQuery();
       await tick();
       expect(queryBuilder.fetch).toHaveBeenCalledTimes(2);
-      expect(queryBuilder.fetch).toHaveBeenNthCalledWith(1);
+      expect(queryBuilder.fetch).toHaveBeenNthCalledWith(1, queryBuilder.getExternal());
       expect(queryBuilder.fetch).toHaveBeenNthCalledWith(2, {
         ...queryBuilder.getExternal(),
         groupby: ['time'],


### PR DESCRIPTION
If a raw event is displayed (i.e. there are no aggregations), include a
link to the event as the last column on the table.