### PR TITLE
Fix #assistant bug

### DIFF
--- a/src/sentry/static/sentry/app/stores/guideStore.jsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.jsx
@@ -1,3 +1,4 @@
+import {browserHistory} from 'react-router';
 import Reflux from 'reflux';
 import $ from 'jquery';
 import GuideActions from 'app/actions/guideActions';
@@ -44,8 +45,8 @@ const GuideStore = Reflux.createStore({
     this.listenTo(ProjectActions.setActive, this.onSetActiveProject);
     this.listenTo(OrganizationsActions.changeSlug, this.onChangeOrgSlug);
 
-    window.addEventListener('hashchange', this.onURLChange, false);
     window.addEventListener('load', this.onURLChange, false);
+    browserHistory.listen(() => this.onURLChange());
   },
 
   onURLChange() {

--- a/tests/js/spec/stores/guideStore.spec.jsx
+++ b/tests/js/spec/stores/guideStore.spec.jsx
@@ -87,7 +87,7 @@ describe('GuideStore', function() {
   it('should force show a guide', function() {
     GuideStore.onFetchSucceeded(data);
     window.location.hash = '#assistant';
-    window.dispatchEvent(new Event('hashchange'));
+    GuideStore.onURLChange();
     expect(GuideStore.state.currentGuide.id).toEqual(1);
     // Should prune steps that don't have anchors.
     expect(GuideStore.state.currentGuide.steps).toHaveLength(2);


### PR DESCRIPTION
When a user navigates away from the page, neither hashchange nor load fires. We need to look at the browser history to correctly determine URL change.