### PR TITLE
Add GroupHashTombstone to list of models to skip since it has a bulk cleanup query.

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -103,6 +103,7 @@ def create_deletion_task(days, project_id, model, dtfield, order_by):
         models.Group,
         models.GroupEmailThread,
         models.GroupRuleStatus,
+        models.GroupHashTombstone,
         # Handled by TTL
         similarity.features,
     ] + [b[0] for b in EXTRA_BULK_QUERY_DELETES]


### PR DESCRIPTION
Since we're already issuing a bulk cleanup query [here](https://github.com/getsentry/sentry/blob/master/src/sentry/runner/commands/cleanup.py#L201), we don't need to query GroupHashTombstone as a child during cleanup deletion.