### PR TITLE
Add bulk delete queries to new models and stop querying them for child relation cleanup.

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -100,6 +100,8 @@ def create_deletion_task(days, project_id, model, dtfield, order_by):
         # Handled by other parts of cleanup
         models.Event,
         models.EventMapping,
+        models.EventAttachment,
+        models.UserReport,
         models.Group,
         models.GroupEmailThread,
         models.GroupRuleStatus,
@@ -198,6 +200,8 @@ def cleanup(days, project, concurrency, max_procs, silent, model, router, timed)
     # (model, datetime_field, order_by)
     BULK_QUERY_DELETES = [
         (models.EventMapping, 'date_added', '-date_added'),
+        (models.EventAttachment, 'date_added', None),
+        (models.UserReport, 'date_added', None),
         (models.GroupHashTombstone, 'deleted_at', None),
         (models.GroupEmailThread, 'date', None),
         (models.GroupRuleStatus, 'date_added', None),


### PR DESCRIPTION
It was discussed earlier that these two models follow the same retention policy as Events, therefore we can clean them up just as we do with the other `BULK_QUERY_DELETES` models.