### PR TITLE
fix(integrations): Add separate validate repo method for ghe

### DIFF
--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -23,6 +23,9 @@ class GitHubRepositoryProvider(providers.IntegrationRepositoryProvider):
 
         try:
             # make sure installation has access to this specific repo
+            # use hooks endpoint since we explicity ask for those permissions
+            # when installing the app (commits can be accessed for public repos)
+            # https://developer.github.com/v3/repos/hooks/#list-hooks
             client.repo_hooks(repo)
         except ApiError as e:
             raise IntegrationError('You must grant Sentry access to {}'.format(repo))

--- a/src/sentry/integrations/github_enterprise/repository.py
+++ b/src/sentry/integrations/github_enterprise/repository.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import logging
 
 from sentry.models import Integration
+from sentry.integrations.exceptions import ApiError, IntegrationError
 from sentry.integrations.github.repository import GitHubRepositoryProvider
 
 
@@ -13,6 +14,20 @@ class GitHubEnterpriseRepositoryProvider(GitHubRepositoryProvider):
     name = 'GitHub Enterprise'
     logger = logging.getLogger('sentry.plugins.github_enterprise')
     repo_provider = 'github_enterprise'
+
+    def _validate_repo(self, client, installation, repo):
+        try:
+            repo_data = client.get_repo(repo)
+        except Exception as e:
+            installation.raise_error(e)
+
+        try:
+            # make sure installation has access to this specific repo
+            client.get_commits(repo)
+        except ApiError as e:
+            raise IntegrationError('You must grant Sentry access to {}'.format(repo))
+
+        return repo_data
 
     def create_repository(self, organization, data):
         integration = Integration.objects.get(

--- a/src/sentry/integrations/github_enterprise/repository.py
+++ b/src/sentry/integrations/github_enterprise/repository.py
@@ -25,7 +25,7 @@ class GitHubEnterpriseRepositoryProvider(GitHubRepositoryProvider):
             # make sure installation has access to this specific repo
             client.get_commits(repo)
         except ApiError as e:
-            raise IntegrationError('You must grant Sentry access to {}'.format(repo))
+            raise IntegrationError(u'You must grant Sentry access to {}'.format(repo))
 
         return repo_data
 


### PR DESCRIPTION
For GH we explicitly ask for permission for Repository Webhooks but there doesn't seem to be the option for that in GHE.

We can use the commits endpoint to check if the repo is available for GHE since there isn't the problem of public vs. private repos