### PR TITLE
fix(discover): Do not use index as key for condition/aggregation lists

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/aggregations/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/aggregations/index.jsx
@@ -49,7 +49,7 @@ export default class Aggregations extends React.Component {
           <PlaceholderText>{t('None, showing raw event data')}</PlaceholderText>
         )}
         {value.map((aggregation, idx) => (
-          <SelectListItem key={idx}>
+          <SelectListItem key={`${idx}_${aggregation[2]}`}>
             <Aggregation
               value={aggregation}
               onChange={val => this.handleChange(val, idx)}

--- a/src/sentry/static/sentry/app/views/organizationDiscover/conditions/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/conditions/index.jsx
@@ -49,7 +49,7 @@ export default class Conditions extends React.Component {
           <PlaceholderText>{t('None, showing all events')}</PlaceholderText>
         )}
         {value.map((condition, idx) => (
-          <SelectListItem key={idx}>
+          <SelectListItem key={`${idx}_${condition[2]}`}>
             <Condition
               value={condition}
               onChange={val => this.handleChange(val, idx)}


### PR DESCRIPTION
Since we can remove conditions and aggregations in any position, items
in this list will change index so we shouldn't use index as a key. This
previously led to problems with components not updating correctly.