### PR TITLE
fix(orgs) Track last used organization for API requests

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -145,8 +145,12 @@ class OrganizationEndpoint(Endpoint):
         raven.tags_context({
             'organization': organization.id,
         })
-
         request._request.organization = organization
+
+        # Track the 'active' organization when the request came from
+        # a cookie based agent (react app)
+        if request.auth is None and request.user:
+            request.session['activeorg'] = organization.slug
 
         kwargs['organization'] = organization
         return (args, kwargs)

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -19,6 +19,7 @@ class OrganizationProjectsTest(APITestCase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]['id'] == six.text_type(project.id)
+        assert self.client.session['activeorg'] == org.slug
 
     def test_with_stats(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
By tracking the organization when it changes we can redirect users to their last used organization when they visit sentry.io/. The session should only be updated when the request came from a cookie based request.

I've only instrumented this endpoint as it is used by our react app when organizations switch and I wanted to minimize the impact/overhead this may incur.

Fixes #6859