### PR TITLE
fix(charts): Add missing pieCharts method to calc percentages for series

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/pieChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/pieChart.jsx
@@ -34,15 +34,13 @@ class PieChart extends React.Component {
   // echarts Legend does not have access to percentages (but tooltip does :/)
   getSeriesPercentages = series => {
     const total = series.data.reduce((acc, {value}) => acc + value, 0);
-    return series.data
-      .map(({name, value}) => [name, Math.round(value / total * 10000) / 100])
-      .reduce(
-        (acc, [name, value]) => ({
-          ...acc,
-          [name]: value,
-        }),
-        {}
-      );
+    return series.data.reduce(
+      (acc, {name, value}) => ({
+        ...acc,
+        [name]: Math.round(value / total * 10000) / 100,
+      }),
+      {}
+    );
   };
 
   // Select a series to highlight (e.g. shows details of series)

--- a/src/sentry/static/sentry/app/components/charts/pieChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/pieChart.jsx
@@ -68,6 +68,20 @@ class PieChart extends React.Component {
     });
   };
 
+  // echarts Legend does not have access to percentages (but tooltip does :/)
+  getSeriesPercentages = series => {
+    const total = series.data.reduce((acc, {value}) => acc + value, 0);
+    return series.data
+      .map(({name, value}) => [name, Math.round(value / total * 10000) / 100])
+      .reduce(
+        (acc, [name, value]) => ({
+          ...acc,
+          [name]: value,
+        }),
+        {}
+      );
+  };
+
   render() {
     const {series, ...props} = this.props;
     if (!series || !series.length) return null;


### PR DESCRIPTION
This is used to calculate the percentage text for series for use in the Legend.
ECharts has this info available in tooltips but not the Legend.