### PR TITLE
From six.moves import xrange

### DIFF
--- a/src/sentry/utils/concurrent.py
+++ b/src/sentry/utils/concurrent.py
@@ -8,6 +8,8 @@ from concurrent.futures import Future
 from concurrent.futures._base import RUNNING, FINISHED
 from time import time
 
+from six.moves import xrange
+
 
 logger = logging.getLogger(__name__)
 

--- a/tests/sentry/db/test_deletion.py
+++ b/tests/sentry/db/test_deletion.py
@@ -7,6 +7,8 @@ from sentry.db.deletion import BulkDeleteQuery
 from sentry.models import Group, Project
 from sentry.testutils import TestCase, TransactionTestCase
 
+from six.moves import xrange
+
 
 class BulkDeleteQueryTest(TestCase):
     def test_project_restriction(self):

--- a/tests/sentry/db/test_deletion.py
+++ b/tests/sentry/db/test_deletion.py
@@ -7,8 +7,6 @@ from sentry.db.deletion import BulkDeleteQuery
 from sentry.models import Group, Project
 from sentry.testutils import TestCase, TransactionTestCase
 
-from six.moves import xrange
-
 
 class BulkDeleteQueryTest(TestCase):
     def test_project_restriction(self):
@@ -48,7 +46,7 @@ class BulkDeleteQueryTest(TestCase):
 class BulkDeleteQueryIteratorTestCase(TransactionTestCase):
     def test_iteration(self):
         target_project = self.project
-        expected_group_ids = set([self.create_group().id for i in xrange(2)])
+        expected_group_ids = set([self.create_group().id for i in range(2)])
 
         other_project = self.create_project()
         self.create_group(other_project)


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/getsentry/sentry on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./src/sentry/api/endpoints/broadcast_index.py:77:52: F821 undefined name 'reduce'
                        queryset = queryset.filter(reduce(or_, filters))
                                                   ^
./src/sentry/models/projectownership.py:96:17: F821 undefined name 'reduce'
                reduce(
                ^
./src/sentry/integrations/github/testutils.py:213:0: E999 SyntaxError: bytes can only contain ASCII literal characters.
}"""
^
./src/sentry/utils/concurrent.py:169:22: F821 undefined name 'xrange'
            for i in xrange(self.__worker_count):
                     ^
./tests/sentry/integrations/github/testutils.py:224:0: E999 SyntaxError: bytes can only contain ASCII literal characters.
}"""
^
./tests/sentry/db/test_deletion.py:49:67: F821 undefined name 'xrange'
        expected_group_ids = set([self.create_group().id for i in xrange(2)])
                                                                  ^
2     E999 SyntaxError: bytes can only contain ASCII literal characters.
4     F821 undefined name 'reduce'
6
```