### PR TITLE
From six.moves import reduce

### DIFF
--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -74,7 +74,7 @@ class BroadcastIndexEndpoint(Endpoint):
                         else:
                             queryset = queryset.none()
                     if filters:
-                        queryset = queryset.filter(reduce(or_, filters))
+                        queryset = queryset.filter(six.moves.reduce(or_, filters))
                 else:
                     queryset = queryset.none()
 

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -8,6 +8,8 @@ from django.db import models
 from django.db.models import Q
 from django.utils import timezone
 
+from six.moves import reduce
+
 from sentry.db.models import Model, sane_repr
 from sentry.db.models.fields import FlexibleForeignKey
 from sentry.ownership.grammar import load_schema


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/getsentry/sentry on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./src/sentry/api/endpoints/broadcast_index.py:77:52: F821 undefined name 'reduce'
                        queryset = queryset.filter(reduce(or_, filters))
                                                   ^
./src/sentry/models/projectownership.py:96:17: F821 undefined name 'reduce'
                reduce(
                ^
./src/sentry/integrations/github/testutils.py:213:0: E999 SyntaxError: bytes can only contain ASCII literal characters.
}"""
^
./src/sentry/utils/concurrent.py:169:22: F821 undefined name 'xrange'
            for i in xrange(self.__worker_count):
                     ^
./tests/sentry/integrations/github/testutils.py:224:0: E999 SyntaxError: bytes can only contain ASCII literal characters.
}"""
^
./tests/sentry/db/test_deletion.py:49:67: F821 undefined name 'xrange'
        expected_group_ids = set([self.create_group().id for i in xrange(2)])
                                                                  ^
2     E999 SyntaxError: bytes can only contain ASCII literal characters.
4     F821 undefined name 'reduce'
6
```