### PR TITLE
fix(integrations): VSTS Use public alias rather than user id to get accounts.

### DIFF
--- a/src/sentry/identity/vsts/provider.py
+++ b/src/sentry/identity/vsts/provider.py
@@ -17,6 +17,8 @@ def get_user_info(access_token):
     )
     resp.raise_for_status()
     user = resp.json()
+    user['uuid'] = user['id']
+
     resp = session.get(
         'https://app.vssps.visualstudio.com/_apis/connectionData/',
         headers={

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -412,7 +412,7 @@ class AccountConfigView(PipelineView):
         access_token = state['data']['access_token']
         user = get_user_info(access_token)
 
-        accounts = self.get_accounts(access_token, user['id'])['value']
+        accounts = self.get_accounts(access_token, user['publicAlias'])['value']
         pipeline.bind_state('accounts', accounts)
         account_form = AccountForm(accounts)
         return render_to_response(

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -412,7 +412,7 @@ class AccountConfigView(PipelineView):
         access_token = state['data']['access_token']
         user = get_user_info(access_token)
 
-        accounts = self.get_accounts(access_token, user['publicAlias'])['value']
+        accounts = self.get_accounts(access_token, user['uuid'])['value']
         pipeline.bind_state('accounts', accounts)
         account_form = AccountForm(accounts)
         return render_to_response(


### PR DESCRIPTION
 The `get_user_info` method overwrites the user id in the response with the user's descriptor. Thankfully, the public alias is also the user's uuid. I use public alias to get the user's uuid instead.