### PR TITLE
feat(discover): Cast boolean values in conditions to 0 / 1

### DIFF
--- a/src/sentry/api/endpoints/organization_discover.py
+++ b/src/sentry/api/endpoints/organization_discover.py
@@ -108,6 +108,10 @@ class DiscoverSerializer(serializers.Serializer):
         array_field = self.get_array_field(condition[0])
         has_equality_operator = condition[1] in ('=', '!=')
 
+        # Cast boolean values to 1 / 0
+        if isinstance(condition[2], bool):
+            condition[2] = int(condition[2])
+
         # Apply has function to any array field if it's = / != and not part of arrayjoin
         if array_field and has_equality_operator and (array_field.group(1) != self.arrayjoin):
             value = condition[2]

--- a/src/sentry/static/sentry/app/views/organizationDiscover/conditions/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/conditions/utils.jsx
@@ -84,6 +84,15 @@ export function getExternal(internal, columns) {
       const num = parseInt(external[2], 10);
       external[2] = !isNaN(num) ? num : null;
     }
+
+    if (type === 'boolean') {
+      if (external[2] === 'true') {
+        external[2] = true;
+      }
+      if (external[2] === 'false') {
+        external[2] = false;
+      }
+    }
   }
 
   return external;

--- a/src/sentry/static/sentry/app/views/organizationDiscover/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/data.jsx
@@ -15,7 +15,7 @@ const PROMOTED_TAGS = [
   {name: 'tags[browser_name]', type: 'string'},
   {name: 'tags[os]', type: 'string'},
   {name: 'tags[os_name]', type: 'string'},
-  {name: 'tags[os_rooted]', type: 'number'},
+  {name: 'tags[os_rooted]', type: 'boolean'},
   {name: 'tags[sentry:release]', type: 'string'},
 ];
 
@@ -63,7 +63,7 @@ const COLUMNS = [
   {name: 'exception_frames.package', type: 'string'},
   {name: 'exception_frames.module', type: 'string'},
   {name: 'exception_frames.function', type: 'string'},
-  {name: 'exception_frames.in_app', type: 'string'},
+  {name: 'exception_frames.in_app', type: 'boolean'},
   {name: 'exception_frames.colno', type: 'string'},
   {name: 'exception_frames.lineno', type: 'string'},
   {name: 'exception_frames.stack_level', type: 'string'},

--- a/tests/js/spec/views/organizationDiscover/conditions/utils.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/conditions/utils.spec.jsx
@@ -35,6 +35,10 @@ const conditionList = [
     internal: 'message LIKE',
     external: ['message', 'LIKE', null],
   },
+  {
+    internal: 'exception_frames.in_app = true',
+    external: ['exception_frames.in_app', '=', true],
+  },
 ];
 
 describe('Conditions', function() {

--- a/tests/snuba/test_organization_discover.py
+++ b/tests/snuba/test_organization_discover.py
@@ -78,6 +78,23 @@ class OrganizationDiscoverTest(APITestCase, SnubaTestCase):
         assert response.data['data'][0]['message'] == 'message!'
         assert response.data['data'][0]['platform'] == 'python'
 
+    def test_boolean_condition(self):
+        with self.feature('organizations:discover'):
+            url = reverse('sentry-api-0-organization-discover', args=[self.org.slug])
+            response = self.client.post(url, {
+                'projects': [self.project.id],
+                'fields': ['message', 'platform', 'exception_frames.in_app'],
+                'conditions': [['exception_frames.in_app', '=', True]],
+                'start': (datetime.now() - timedelta(seconds=10)).strftime('%Y-%m-%dT%H:%M:%S'),
+                'end': (datetime.now() + timedelta(seconds=10)).strftime('%Y-%m-%dT%H:%M:%S'),
+                'orderby': '-timestamp',
+            })
+
+        assert response.status_code == 200, response.content
+        assert len(response.data['data']) == 1
+        assert response.data['data'][0]['message'] == 'message!'
+        assert response.data['data'][0]['platform'] == 'python'
+
     def test_array_join(self):
         with self.feature('organizations:discover'):
             url = reverse('sentry-api-0-organization-discover', args=[self.org.slug])


### PR DESCRIPTION
We need to cast boolean values in conditions to 0 / 1 for Snuba otherwise queries with these values will fail. This also fixes autocompletion on the UI