### PR TITLE
Fix(issue sync): resolve padding issues in issue sync list

### DIFF
--- a/src/sentry/static/sentry/app/components/group/externalIssuesList.jsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssuesList.jsx
@@ -51,7 +51,7 @@ class ExternalIssueList extends AsyncComponent {
   renderPluginActions() {
     const {group} = this.props;
 
-    return group.pluginActions
+    return group.pluginActions && group.pluginActions.length
       ? group.pluginActions.map((plugin, i) => {
           return (
             <IssueSyncListElement externalIssueLink={plugin[1]} key={i}>
@@ -67,16 +67,21 @@ class ExternalIssueList extends AsyncComponent {
     const pluginIssues = this.renderPluginIssues();
     const pluginActions = this.renderPluginActions();
 
-    if (!integrationIssues.length && !pluginIssues.length && !pluginActions.length)
+    if (!integrationIssues && !pluginIssues && !pluginActions)
       return (
-        <AlertLink
-          icon="icon-generic-box"
-          priority="default"
-          size="small"
-          to={`/settings/${this.props.orgId}/integrations`}
-        >
-          {t('Set up Issue Tracking')}
-        </AlertLink>
+        <React.Fragment>
+          <h6>
+            <span>Linked Issues</span>
+          </h6>
+          <AlertLink
+            icon="icon-generic-box"
+            priority="default"
+            size="small"
+            to={`/settings/${this.props.orgId}/integrations`}
+          >
+            {t('Set up Issue Tracking')}
+          </AlertLink>
+        </React.Fragment>
       );
 
     return (

--- a/src/sentry/static/sentry/app/components/group/externalIssuesList.jsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssuesList.jsx
@@ -7,7 +7,6 @@ import IssueSyncListElement from 'app/components/issueSyncListElement';
 import AlertLink from 'app/components/alertLink';
 import SentryTypes from 'app/sentryTypes';
 import PluginActions from 'app/components/group/pluginActions';
-import space from 'app/styles/space';
 import {Box} from 'grid-emotion';
 import {t} from 'app/locale';
 
@@ -29,13 +28,15 @@ class ExternalIssueList extends AsyncComponent {
       integration => integration.status === 'active'
     );
 
-    return activeIntegrations.length ? activeIntegrations.map(integration => (
-      <ExternalIssueActions
-        key={integration.id}
-        integration={integration}
-        group={group}
-      />
-    )) : null;
+    return activeIntegrations.length
+      ? activeIntegrations.map(integration => (
+          <ExternalIssueActions
+            key={integration.id}
+            integration={integration}
+            group={group}
+          />
+        ))
+      : null;
   }
 
   renderPluginIssues() {

--- a/src/sentry/static/sentry/app/components/group/externalIssuesList.jsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssuesList.jsx
@@ -7,6 +7,7 @@ import IssueSyncListElement from 'app/components/issueSyncListElement';
 import AlertLink from 'app/components/alertLink';
 import SentryTypes from 'app/sentryTypes';
 import PluginActions from 'app/components/group/pluginActions';
+import space from 'app/styles/space';
 import {Box} from 'grid-emotion';
 import {t} from 'app/locale';
 
@@ -28,27 +29,13 @@ class ExternalIssueList extends AsyncComponent {
       integration => integration.status === 'active'
     );
 
-    if (!activeIntegrations.length)
-      return (
-        <AlertLink
-          icon="icon-generic-box"
-          priority="default"
-          size="small"
-          to={`/settings/${this.props.orgId}/integrations`}
-        >
-          {t('Set up Issue Tracking')}
-        </AlertLink>
-      );
-
-    const externalIssues = activeIntegrations.map(integration => (
+    return activeIntegrations.length ? activeIntegrations.map(integration => (
       <ExternalIssueActions
         key={integration.id}
         integration={integration}
         group={group}
       />
-    ));
-
-    return <Box mb={3}>{externalIssues}</Box>;
+    )) : null;
   }
 
   renderPluginIssues() {
@@ -76,15 +63,31 @@ class ExternalIssueList extends AsyncComponent {
   }
 
   renderBody() {
+    const integrationIssues = this.renderIntegrationIssues(this.state.integrations);
+    const pluginIssues = this.renderPluginIssues();
+    const pluginActions = this.renderPluginActions();
+
+    if (!integrationIssues.length && !pluginIssues.length && !pluginActions.length)
+      return (
+        <AlertLink
+          icon="icon-generic-box"
+          priority="default"
+          size="small"
+          to={`/settings/${this.props.orgId}/integrations`}
+        >
+          {t('Set up Issue Tracking')}
+        </AlertLink>
+      );
+
     return (
-      <div>
+      <React.Fragment>
         <h6>
           <span>Linked Issues</span>
         </h6>
-        {this.renderIntegrationIssues(this.state.integrations)}
-        {this.renderPluginIssues()}
-        {this.renderPluginActions()}
-      </div>
+        {integrationIssues && <Box mb={2}>{integrationIssues}</Box>}
+        {pluginIssues && <Box mb={2}>{pluginIssues}</Box>}
+        {pluginActions && <Box mb={2}>{pluginActions}</Box>}
+      </React.Fragment>
     );
   }
 }


### PR DESCRIPTION
there are some padding issues that cropped up as new features were added to the issue list, particularly when plugins are intermingling with new integrations:

<img width="404" alt="before" src="https://user-images.githubusercontent.com/435981/45112244-fe07bd00-b0fb-11e8-9741-6f5ac57b2e72.png">

In `ExternalIssuesList`, we check for three types of linked servies: plugins, plugin actions, and integrations. I changed all three of these methods to either return null or an array of integrations, and we check that before rendering the padding:

<img width="431" alt="after" src="https://user-images.githubusercontent.com/435981/45112246-ffd18080-b0fb-11e8-8b0b-be847cd3a334.png">

In addition, the new alert link would show if no integrations were added, but this looked weird if plugins were already there: 

<img width="480" alt="pluginbad" src="https://user-images.githubusercontent.com/435981/45114905-247d2680-b103-11e8-87ef-11e2410dffb6.png">

Now we will only show the alert link if _zero plugins, plugin actions, or integrations_ are enabled:

<img width="412" alt="issuetracking" src="https://user-images.githubusercontent.com/435981/45112254-08c25200-b0fc-11e8-82d9-8f47cd8d8ea9.png">

If old plugins are still there, we will just show that:

<img width="573" alt="pluginactiononly" src="https://user-images.githubusercontent.com/435981/45114915-28a94400-b103-11e8-942e-a7c7fe89f1a1.png">
