### PR TITLE
ref(integrations): Handle uninstall from Bitbucket

### DIFF
--- a/src/sentry/integrations/bitbucket/uninstalled.py
+++ b/src/sentry/integrations/bitbucket/uninstalled.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import
+
+
+from django.views.decorators.csrf import csrf_exempt
+
+from sentry.api.base import Endpoint
+from sentry.constants import ObjectStatus
+from sentry.models import Repository
+from sentry.integrations.atlassian_connect import AtlassianConnectValidationError, get_integration_from_jwt
+
+
+class BitbucketUninstalledEndpoint(Endpoint):
+    authentication_classes = ()
+    permission_classes = ()
+
+    @csrf_exempt
+    def dispatch(self, request, *args, **kwargs):
+        return super(BitbucketUninstalledEndpoint, self).dispatch(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        try:
+            token = request.META['HTTP_AUTHORIZATION'].split(' ', 1)[1]
+        except (KeyError, IndexError):
+            return self.respond(status=400)
+
+        try:
+            integration = get_integration_from_jwt(
+                token, request.path, 'bitbucket', request.GET, method='POST'
+            )
+        except AtlassianConnectValidationError:
+            return self.respond(status=400)
+
+        integration.update(status=ObjectStatus.DISABLED)
+        organizations = integration.organizations.all()
+
+        Repository.objects.filter(
+            organization_id__in=organizations.values_list('id', flat=True),
+            provider='integrations:bitbucket',
+            integration_id=integration.id,
+        ).update(status=ObjectStatus.DISABLED)
+
+        return self.respond()

--- a/src/sentry/integrations/bitbucket/urls.py
+++ b/src/sentry/integrations/bitbucket/urls.py
@@ -4,12 +4,14 @@ from django.conf.urls import patterns, url
 
 from .descriptor import BitbucketDescriptorEndpoint
 from .installed import BitbucketInstalledEndpoint
+from .uninstalled import BitbucketUninstalledEndpoint
 from .webhook import BitbucketWebhookEndpoint
 from .search import BitbucketSearchEndpoint
 urlpatterns = patterns(
     '',
     url(r'^descriptor/$', BitbucketDescriptorEndpoint.as_view()),
     url(r'^installed/$', BitbucketInstalledEndpoint.as_view()),
+    url(r'^uninstalled/$', BitbucketUninstalledEndpoint.as_view()),
     url(r'^organizations/(?P<organization_id>[^\/]+)/webhook/$',
         BitbucketWebhookEndpoint.as_view()),
     url(r'^search/(?P<organization_slug>[^\/]+)/(?P<integration_id>\d+)/$',


### PR DESCRIPTION
When uninstalling from BB their integration and associated repos will be disabled

![screen shot 2018-09-05 at 1 44 53 pm](https://user-images.githubusercontent.com/15368179/45120056-eaffe780-b111-11e8-9543-10447be7533d.png)


Current reinstall flow:
* ' Enable' actually creates a new installation for the same BitBucket account (since the `external_id` will change)
* Previously disabled repos will still be disabled and also tied to the disabled integration

**We don't really want people to uninstall from bitbucket though**