### PR TITLE
fix: Count apps missing migrations as ghosts

### DIFF
--- a/src/south/migration/__init__.py
+++ b/src/south/migration/__init__.py
@@ -85,7 +85,7 @@ def check_migration_histories(histories, delete_ghosts=False, ignore_ghosts=Fals
         try:
             m = h.get_migration()
             m.migration()
-        except exceptions.UnknownMigration:
+        except (exceptions.UnknownMigration, exceptions.NoMigrations):
             ghosts.append(h)
         except ImproperlyConfigured:
             pass                        # Ignore missing applications


### PR DESCRIPTION
We (for whatever reason) had an invalid row in production that caused an issue with upgrade:

> django: 0001_initial

This is no different than an invalid migration, so let's just treat it the same way.