### PR TITLE
perf: Improve index usage during tag searches using v2 tagstore

### DIFF
--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -927,6 +927,14 @@ class V2TagStorage(TagStorage):
         # get initial matches to start the filter
         matches = candidates or []
 
+        def get_quoted_column_name(field):
+            model = field.field.model
+            quote_name = connections[router.db_for_read(model)].ops.quote_name
+            return '{}.{}'.format(
+                quote_name(model._meta.db_table),
+                quote_name(field.field.column),
+            )
+
         # for each remaining tag, find matches contained in our
         # existing set, pruning it down each iteration
         for k, v in tag_lookups:
@@ -937,9 +945,13 @@ class V2TagStorage(TagStorage):
                     _key__key=k,
                     _value__project_id=project_id,
                     _value__value=v,
-                )
+                ).extra(where=[
+                    '{} = {}'.format(
+                        get_quoted_column_name(models.TagValue._key),
+                        get_quoted_column_name(models.GroupTagValue._key),
+                    ),
+                ])
                 base_qs = self._add_environment_filter(base_qs, environment_id)
-
             else:
                 base_qs = models.GroupTagValue.objects.filter(
                     project_id=project_id,

--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -940,6 +940,7 @@ class V2TagStorage(TagStorage):
                     _value__value=v,
                 )
                 base_qs = self._add_environment_filter(base_qs, environment_id)
+
             else:
                 base_qs = models.GroupTagValue.objects.filter(
                     project_id=project_id,


### PR DESCRIPTION
Adding `tagstore_grouptagvalue.key_id` to the `WHERE`clause ensures that the `btree (project_id, key_id, value_id, last_seen)` index on `tagstore_grouptagvalue` can be used for this query, drastically improving performance.

Fixes SNS-139.