### PR TITLE
fix(integrations): VSTS Subscription check tasks.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -610,7 +610,7 @@ CELERYBEAT_SCHEDULE = {
         'task': 'sentry.tasks.integrations.kickoff_vsts_subscription_check',
         'schedule': timedelta(hours=6),
         'options': {
-            'expires': 60 * 25,  # TODO(lb): What does this mean exactly? what expires?
+            'expires': 60 * 25,
         }
     }
 }

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -606,6 +606,13 @@ CELERYBEAT_SCHEDULE = {
             'expires': 60 * 60 * 3,
         },
     },
+    'schedule-vsts-integration-subscription-check': {
+        'task': 'sentry.tasks.integrations.kickoff_vsts_subscription_check',
+        'schedule': timedelta(hours=6),
+        'options': {
+            'expires': 60 * 25,  # TODO(lb): What does this mean exactly? what expires?
+        }
+    }
 }
 
 BGTASKS = {

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -272,7 +272,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
         )
 
     def delete_subscription(self, instance, subscription_id):
-        self.delete(
+        return self.delete(
             VstsApiPath.subscription.format(
                 instance=instance,
                 subscription_id=subscription_id,
@@ -280,7 +280,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
         )
 
     def update_subscription(self, instance, subscription_id):
-        self.put(
+        return self.put(
             VstsApiPath.subscription.format(
                 instance=instance,
                 subscription_id=subscription_id,

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -279,6 +279,14 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
             )
         )
 
+    def update_subscription(self, instance, subscription_id):
+        self.put(
+            VstsApiPath.subscription.format(
+                instance=instance,
+                subscription_id=subscription_id,
+            )
+        )
+
     def search_issues(self, account_name, query=None):
         return self.post(
             VstsApiPath.work_item_search.format(

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -263,6 +263,14 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
             },
         )
 
+    def get_subscription(self, instance, subscription_id):
+        return self.get(
+            VstsApiPath.subscription.format(
+                instance=instance,
+                subscription_id=subscription_id,
+            )
+        )
+
     def delete_subscription(self, instance, subscription_id):
         self.delete(
             VstsApiPath.subscription.format(

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -10,10 +10,6 @@ from sentry.models import (
     ExternalIssue, Group, GroupLink, GroupStatus, Integration, Organization,
     ObjectStatus, OrganizationIntegration, Repository, User
 )
-<< << << < HEAD
-== == == =
-from sentry.mediators.plugins import Migrator
->>>>>> > fixed merge mistakes.
 
 from sentry.mediators.plugins import Migrator
 from sentry.integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
@@ -230,14 +226,14 @@ def kickoff_vsts_subscription_check():
         integration__status=ObjectStatus.VISIBLE,
         status=ObjectStatus.VISIBLE,
     ).select_related('integration')
-    six_hours_from_now = time() - mktime(timedelta(hours=6).timetuple())
+    six_hours_ago = time() - mktime(timedelta(hours=6).timetuple())
     for org_integration in organization_integrations:
         organization_id = org_integration.organization_id
         integration = org_integration.integration
 
         try:
             if 'subscription' not in integration.metadata or integration.metadata[
-                    'subscription']['check'] > six_hours_from_now:
+                    'subscription']['check'] > six_hours_ago:
                 continue
         except KeyError:
             pass

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -1,14 +1,16 @@
 from __future__ import absolute_import
+from datetime import datetime
 
 import logging
 
 from sentry import analytics, features
 from sentry.models import (
     ExternalIssue, Group, GroupLink, GroupStatus, Integration, Organization,
-    ObjectStatus, Repository, User
+    ObjectStatus, OrganizationIntegration, Repository, User
 )
-from sentry.integrations.exceptions import IntegrationError
+
 from sentry.mediators.plugins import Migrator
+from sentry.integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
 from sentry.tasks.base import instrumented_task, retry
 
 logger = logging.getLogger('sentry.tasks.integrations')
@@ -207,3 +209,61 @@ def migrate_repo(repo_id, integration_id, organization_id):
             integration=integration,
             organization=Organization.objects.get(id=organization_id),
         )
+
+@instrumented_task(
+    name='sentry.tasks.integrations.vsts_subscription_check_kickoff',
+    queue='integrations',
+    default_retry_delay=60 * 5,  # TODO(lb): not sure what this should be
+    max_retries=5,
+)
+@retry()
+def kickoff_vsts_subscription_check():
+    all_integrations = Integration.objects.filter(
+        provider='vsts',
+    )
+    subscription_check_interval = None  # RAWR
+    integrations_to_check = []
+    for integration in all_integrations:
+        try:
+            subscription = integration.metadata['subscription']
+        except KeyError:
+            continue
+        try:
+            if subscription['check'] <= subscription_check_interval:  # 6 hours?
+                integrations_to_check.append(integration)
+        except KeyError:
+            integrations_to_check.append(integration)
+
+    for integration in integrations_to_check:
+        organization_ids = OrganizationIntegration.objects.filter(
+            integration_id=integration.id,
+        ).values_list('organization_id', flatten=True)
+        for organization_id in organization_ids:
+            vsts_subscription_check(integration, organization_id)
+
+
+@instrumented_task(
+    name='sentry.tasks.integrations.vsts_subscription_check',
+    queue='integrations',
+    default_retry_delay=60 * 5,  # TODO(lb): not sure what this should be
+    max_retries=5,
+)
+@retry(exclude=(ApiError, ApiUnauthorized))
+def vsts_subscription_check(integration, organization_id):
+    installation = integration.get_installation(organization_id=organization_id)
+    client = installation.get_client()
+    subscription_id = integration.metadata['subscription']['id']
+    subscription = client.get_subscription(
+        instance=installation.instance,
+        subscription_id=subscription_id,
+    )
+
+    # TODO(lb): looked at 'onProbation' status cannot tell how/if it affects functionality
+    # https://docs.microsoft.com/en-us/rest/api/vsts/hooks/subscriptions/replace%20subscription?view=vsts-rest-4.1#subscriptionstatus
+    if subscription['status'] == 'disabledBySystem':
+        client.update_subscription(
+            instance=installation.instance,
+            subscription_id=subscription_id,
+        )
+        integration.metadata['subscription']['check'] = datetime.now()
+        integration.save()

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -215,7 +215,7 @@ def migrate_repo(repo_id, integration_id, organization_id):
 @instrumented_task(
     name='sentry.tasks.integrations.kickoff_vsts_subscription_check',
     queue='integrations',
-    default_retry_delay=60 * 5,  # TODO(lb): not sure what this should be
+    default_retry_delay=60 * 5,
     max_retries=5,
 )
 @retry()
@@ -239,7 +239,7 @@ def kickoff_vsts_subscription_check():
 
         vsts_subscription_check.apply_async(
             kwargs={
-                'integration': integration,
+                'integration_id': integration.id,
                 'organization_id': organization_id,
             }
         )
@@ -248,11 +248,12 @@ def kickoff_vsts_subscription_check():
 @instrumented_task(
     name='sentry.tasks.integrations.vsts_subscription_check',
     queue='integrations',
-    default_retry_delay=60 * 5,  # TODO(lb): not sure what this should be
+    default_retry_delay=60 * 5,
     max_retries=5,
 )
-@retry(exclude=(ApiError, ApiUnauthorized))
-def vsts_subscription_check(integration, organization_id, **kwargs):
+@retry(exclude=(ApiError, ApiUnauthorized, Integration.DoesNotExist))
+def vsts_subscription_check(integration_id, organization_id, **kwargs):
+    integration = Integration.objects.get(id=integration_id)
     installation = integration.get_installation(organization_id=organization_id)
     client = installation.get_client()
     subscription_id = integration.metadata['subscription']['id']

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
-from time import time
+from time import time, mktime
+from datetime import timedelta
 
 import logging
 
@@ -221,20 +222,17 @@ def migrate_repo(repo_id, integration_id, organization_id):
 def kickoff_vsts_subscription_check():
     organization_integrations = OrganizationIntegration.objects.filter(
         integration__provider='vsts',
-        # integration__status=ObjectStatus.VISIBLE,
-        # status=ObjectStatus.VISIBLE,
+        integration__status=ObjectStatus.VISIBLE,
+        status=ObjectStatus.VISIBLE,
     ).select_related('integration')
-    update_interval = time() - 60 * 60 * 60 * 6
+    six_hours_from_now = time() - mktime(timedelta(hours=6).timetuple())
     for org_integration in organization_integrations:
         organization_id = org_integration.organization_id
         integration = org_integration.integration
-        try:
-            subscription = org_integration.integration.metadata['subscription']
-        except KeyError:
-            continue
 
         try:
-            if subscription['check'] > update_interval:
+            if 'subscription' not in integration.metadata or integration.metadata[
+                    'subscription']['check'] > six_hours_from_now:
                 continue
         except KeyError:
             pass

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -10,6 +10,10 @@ from sentry.models import (
     ExternalIssue, Group, GroupLink, GroupStatus, Integration, Organization,
     ObjectStatus, OrganizationIntegration, Repository, User
 )
+<< << << < HEAD
+== == == =
+from sentry.mediators.plugins import Migrator
+>>>>>> > fixed merge mistakes.
 
 from sentry.mediators.plugins import Migrator
 from sentry.integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
@@ -212,6 +216,7 @@ def migrate_repo(repo_id, integration_id, organization_id):
             organization=Organization.objects.get(id=organization_id),
         )
 
+
 @instrumented_task(
     name='sentry.tasks.integrations.kickoff_vsts_subscription_check',
     queue='integrations',
@@ -262,7 +267,6 @@ def vsts_subscription_check(integration_id, organization_id, **kwargs):
         subscription_id=subscription_id,
     )
 
-    # TODO(lb): looked at 'onProbation' status cannot tell how/if it affects functionality
     # https://docs.microsoft.com/en-us/rest/api/vsts/hooks/subscriptions/replace%20subscription?view=vsts-rest-4.1#subscriptionstatus
     if subscription['status'] == 'disabledBySystem':
         client.update_subscription(

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -211,7 +211,7 @@ def migrate_repo(repo_id, integration_id, organization_id):
         )
 
 @instrumented_task(
-    name='sentry.tasks.integrations.vsts_subscription_check_kickoff',
+    name='sentry.tasks.integrations.kickoff_vsts_subscription_check',
     queue='integrations',
     default_retry_delay=60 * 5,  # TODO(lb): not sure what this should be
     max_retries=5,
@@ -239,7 +239,12 @@ def kickoff_vsts_subscription_check():
             integration_id=integration.id,
         ).values_list('organization_id', flatten=True)
         for organization_id in organization_ids:
-            vsts_subscription_check(integration, organization_id)
+            vsts_subscription_check(integration, organization_id).apply_async(
+                kwargs={
+                    'integration': integration,
+                    'organization_id': organization_id,
+                }
+            )
 
 
 @instrumented_task(
@@ -249,7 +254,7 @@ def kickoff_vsts_subscription_check():
     max_retries=5,
 )
 @retry(exclude=(ApiError, ApiUnauthorized))
-def vsts_subscription_check(integration, organization_id):
+def vsts_subscription_check(integration, organization_id, **kwargs):
     installation = integration.get_installation(organization_id=organization_id)
     client = installation.get_client()
     subscription_id = integration.metadata['subscription']['id']

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from time import time, mktime
+from time import time
 from datetime import timedelta
 
 import logging
@@ -226,7 +226,7 @@ def kickoff_vsts_subscription_check():
         integration__status=ObjectStatus.VISIBLE,
         status=ObjectStatus.VISIBLE,
     ).select_related('integration')
-    six_hours_ago = time() - mktime(timedelta(hours=6).timetuple())
+    six_hours_ago = time() - timedelta(hours=6).seconds
     for org_integration in organization_integrations:
         organization_id = org_integration.organization_id
         integration = org_integration.integration

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
-from datetime import datetime, timedelta
+
+from time import time
 
 import logging
 
@@ -223,7 +224,7 @@ def kickoff_vsts_subscription_check():
         # integration__status=ObjectStatus.VISIBLE,
         # status=ObjectStatus.VISIBLE,
     ).select_related('integration')
-    update_interval = datetime.now() - timedelta(hours=6)
+    update_interval = time() - 60 * 60 * 60 * 6
     for org_integration in organization_integrations:
         organization_id = org_integration.organization_id
         integration = org_integration.integration
@@ -238,7 +239,7 @@ def kickoff_vsts_subscription_check():
         except KeyError:
             pass
 
-        vsts_subscription_check(integration, organization_id).apply_async(
+        vsts_subscription_check.apply_async(
             kwargs={
                 'integration': integration,
                 'organization_id': organization_id,
@@ -269,5 +270,5 @@ def vsts_subscription_check(integration, organization_id, **kwargs):
             instance=installation.instance,
             subscription_id=subscription_id,
         )
-        integration.metadata['subscription']['check'] = datetime.now()
+        integration.metadata['subscription']['check'] = time()
         integration.save()

--- a/tests/sentry/tasks/test_integrations.py
+++ b/tests/sentry/tasks/test_integrations.py
@@ -58,14 +58,14 @@ class VstsSubscriptionCheckTest(TestCase):
                 }
             }
         )
-        integration1.add_organization(self.organization.id, default_auth_id=self.identity.id)
+        integration1.add_organization(self.organization, default_auth_id=self.identity.id)
         integration2 = Integration.objects.create(
             provider='vsts',
             name='vsts2',
             external_id='vsts2',
             metadata={},
         )
-        integration2.add_organization(self.organization.id, default_auth_id=self.identity.id)
+        integration2.add_organization(self.organization, default_auth_id=self.identity.id)
         integration3 = Integration.objects.create(
             provider='vsts',
             name='vsts3',
@@ -77,7 +77,7 @@ class VstsSubscriptionCheckTest(TestCase):
                 }
             }
         )
-        integration3.add_organization(self.organization.id, default_auth_id=self.identity.id)
+        integration3.add_organization(self.organization, default_auth_id=self.identity.id)
 
         with self.tasks():
             kickoff_vsts_subscription_check()

--- a/tests/sentry/tasks/test_integrations.py
+++ b/tests/sentry/tasks/test_integrations.py
@@ -1,0 +1,93 @@
+from __future__ import absolute_import, print_function
+
+from time import time
+
+from sentry.models import Integration, Identity, IdentityProvider
+from sentry.testutils import TestCase
+from sentry.tasks.integrations import kickoff_vsts_subscription_check
+
+import responses
+
+
+class VstsSubscriptionCheckTest(TestCase):
+    def setUp(self):
+        responses.add(
+            responses.GET,
+            'https://vsts1.visualstudio.com/_apis/hooks/subscriptions/subscription1',
+            json={'status': 'disabledBySystem'}
+        )
+        responses.add(
+            responses.PUT,
+            'https://vsts1.visualstudio.com/_apis/hooks/subscriptions/subscription1',
+            json={}
+        )
+        responses.add(
+            responses.GET,
+            'https://vsts1.visualstudio.com/_apis/hooks/subscriptions/subscription3',
+            json={'status': 'enabled'}
+        )
+        responses.add(
+            responses.PUT,
+            'https://vsts1.visualstudio.com/_apis/hooks/subscriptions/subscription3',
+            json={}
+        )
+        self.identity = Identity.objects.create(
+            idp=IdentityProvider.objects.create(
+                type='vsts',
+                config={}
+            ),
+            user=self.user,
+            external_id='user_identity',
+            data={
+                'access_token': 'vsts-access-token',
+                'expires': time() + 50000,
+            }
+        )
+
+    @responses.activate
+    def test_kickoff_subscription(self):
+        integration3_check_time = time()
+        integration1 = Integration.objects.create(
+            provider='vsts',
+            name='vsts1',
+            external_id='vsts1',
+            metadata={
+                'domain_name': 'https://vsts1.visualstudio.com/',
+                'subscription': {
+                    'id': 'subscription1',
+                }
+            }
+        )
+        integration1.add_organization(self.organization.id, self.identity.id)
+        integration2 = Integration.objects.create(
+            provider='vsts',
+            name='vsts2',
+            external_id='vsts2',
+            metadata={},
+        )
+        integration2.add_organization(self.organization.id, self.identity.id)
+        integration3 = Integration.objects.create(
+            provider='vsts',
+            name='vsts3',
+            external_id='vsts3',
+            metadata={
+                'subscription': {
+                    'id': 'subscription3',
+                    'check': integration3_check_time,
+                }
+            }
+        )
+        integration3.add_organization(self.organization.id, self.identity.id)
+
+        with self.tasks():
+            kickoff_vsts_subscription_check()
+
+        assert 'check' in Integration.objects.get(
+            provider='vsts',
+            external_id='vsts1',
+        ).metadata['subscription']
+        # TODO(lb): what to do if there's no subscription stored?
+        assert integration3_check_time == Integration.objects.get(
+            provider='vsts',
+            external_id='vsts3',
+        ).metadata['subscription']['check']

--- a/tests/sentry/tasks/test_integrations.py
+++ b/tests/sentry/tasks/test_integrations.py
@@ -86,7 +86,7 @@ class VstsSubscriptionCheckTest(TestCase):
             provider='vsts',
             external_id='vsts1',
         ).metadata['subscription']
-        # TODO(lb): what to do if there's no subscription stored?
+
         assert integration3_check_time == Integration.objects.get(
             provider='vsts',
             external_id='vsts3',

--- a/tests/sentry/tasks/test_integrations.py
+++ b/tests/sentry/tasks/test_integrations.py
@@ -58,14 +58,14 @@ class VstsSubscriptionCheckTest(TestCase):
                 }
             }
         )
-        integration1.add_organization(self.organization.id, self.identity.id)
+        integration1.add_organization(self.organization.id, default_auth_id=self.identity.id)
         integration2 = Integration.objects.create(
             provider='vsts',
             name='vsts2',
             external_id='vsts2',
             metadata={},
         )
-        integration2.add_organization(self.organization.id, self.identity.id)
+        integration2.add_organization(self.organization.id, default_auth_id=self.identity.id)
         integration3 = Integration.objects.create(
             provider='vsts',
             name='vsts3',
@@ -77,7 +77,7 @@ class VstsSubscriptionCheckTest(TestCase):
                 }
             }
         )
-        integration3.add_organization(self.organization.id, self.identity.id)
+        integration3.add_organization(self.organization.id, default_auth_id=self.identity.id)
 
         with self.tasks():
             kickoff_vsts_subscription_check()


### PR DESCRIPTION
VSTS subscriptions will get automatically disabled by the system if they hit too many errors. This task is meant to check vsts subscriptions and update them if they have been disabled.