### PR TITLE
feat(auth) Move logout to use DELETE instead of GET

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
@@ -15,11 +15,12 @@ import ConfigStore from 'app/stores/configStore';
 import SidebarOrgSummary from 'app/components/sidebar/sidebarOrgSummary';
 import SidebarMenuItem from 'app/components/sidebar/sidebarMenuItem';
 import SidebarDropdownMenu from 'app/components/sidebar/sidebarDropdownMenu.styled';
+import withApi from 'app/utils/withApi.jsx';
 
 import SwitchOrganization from './switchOrganization';
 import Divider from './divider.styled';
 
-class SidebarDropdown extends React.Component {
+const SidebarDropdown = withApi(class SidebarDropdown extends React.Component {
   static propTypes = {
     orientation: PropTypes.oneOf(['top', 'left']),
     collapsed: PropTypes.bool,
@@ -31,6 +32,17 @@ class SidebarDropdown extends React.Component {
 
   static defaultProps = {
     onClick: () => {},
+  };
+
+  handleLogout = (...args) => {
+    let {api} = this.props;
+
+    api.request('/auth/', {
+      method: 'DELETE',
+      success: (res) => {
+        window.location = '/auth/login';
+      }
+    });
   };
 
   render() {
@@ -140,7 +152,7 @@ class SidebarDropdown extends React.Component {
                         {user.isSuperuser && (
                           <SidebarMenuItem to={'/manage/'}>{t('Admin')}</SidebarMenuItem>
                         )}
-                        <SidebarMenuItem href="/auth/logout/">
+                        <SidebarMenuItem onClick={this.handleLogout}>
                           {t('Sign out')}
                         </SidebarMenuItem>
                       </div>
@@ -154,7 +166,7 @@ class SidebarDropdown extends React.Component {
       </DropdownMenu>
     );
   }
-}
+});
 
 export default SidebarDropdown;
 

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
@@ -20,153 +20,160 @@ import withApi from 'app/utils/withApi.jsx';
 import SwitchOrganization from './switchOrganization';
 import Divider from './divider.styled';
 
-const SidebarDropdown = withApi(class SidebarDropdown extends React.Component {
-  static propTypes = {
-    api: PropTypes.object,
-    orientation: PropTypes.oneOf(['top', 'left']),
-    collapsed: PropTypes.bool,
-    org: SentryTypes.Organization,
-    user: SentryTypes.User,
-    config: SentryTypes.Config,
-    onClick: PropTypes.func,
-  };
+const SidebarDropdown = withApi(
+  class SidebarDropdown extends React.Component {
+    static propTypes = {
+      api: PropTypes.object,
+      orientation: PropTypes.oneOf(['top', 'left']),
+      collapsed: PropTypes.bool,
+      org: SentryTypes.Organization,
+      user: SentryTypes.User,
+      config: SentryTypes.Config,
+      onClick: PropTypes.func,
+    };
 
-  static defaultProps = {
-    onClick: () => {},
-  };
+    static defaultProps = {
+      onClick: () => {},
+    };
 
-  handleLogout = (...args) => {
-    let {api} = this.props;
-    api.request('/auth/', {
-      method: 'DELETE',
-      success: (res) => {
-        window.location = '/auth/login';
-      }
-    });
-  };
+    handleLogout = (...args) => {
+      let {api} = this.props;
+      api.request('/auth/', {
+        method: 'DELETE',
+        success: res => {
+          window.location = '/auth/login';
+        },
+      });
+    };
 
-  render() {
-    let {org, orientation, collapsed, config, user, onClick} = this.props;
-    let hasOrganization = !!org;
-    let hasUser = !!user;
+    render() {
+      let {org, orientation, collapsed, config, user, onClick} = this.props;
+      let hasOrganization = !!org;
+      let hasUser = !!user;
 
-    // If there is no org in context, we use an org from `withLatestContext`
-    // (which uses an org from organizations index endpoint versus details endpoint)
-    // and does not have `access`
-    let hasOrgRead = org && org.access && org.access.indexOf('org:read') > -1;
-    let hasMemberRead = org && org.access && org.access.indexOf('member:read') > -1;
-    let hasTeamRead = org && org.access && org.access.indexOf('team:read') > -1;
-    let canCreateOrg = ConfigStore.get('features').has('organizations:create');
+      // If there is no org in context, we use an org from `withLatestContext`
+      // (which uses an org from organizations index endpoint versus details endpoint)
+      // and does not have `access`
+      let hasOrgRead = org && org.access && org.access.indexOf('org:read') > -1;
+      let hasMemberRead = org && org.access && org.access.indexOf('member:read') > -1;
+      let hasTeamRead = org && org.access && org.access.indexOf('team:read') > -1;
+      let canCreateOrg = ConfigStore.get('features').has('organizations:create');
 
-    // Avatar to use: Organization --> user --> Sentry
-    const avatar =
-      hasOrganization || hasUser ? (
-        <StyledAvatar
-          onClick={onClick}
-          collapsed={collapsed}
-          organization={org}
-          user={!org ? user : null}
-          size={32}
-        />
-      ) : (
-        <SentryLink to="/">
-          <InlineSvg css={{fontSize: 32}} src="icon-sentry" />
-        </SentryLink>
-      );
+      // Avatar to use: Organization --> user --> Sentry
+      const avatar =
+        hasOrganization || hasUser ? (
+          <StyledAvatar
+            onClick={onClick}
+            collapsed={collapsed}
+            organization={org}
+            user={!org ? user : null}
+            size={32}
+          />
+        ) : (
+          <SentryLink to="/">
+            <InlineSvg css={{fontSize: 32}} src="icon-sentry" />
+          </SentryLink>
+        );
 
-    return (
-      <DropdownMenu>
-        {({isOpen, getRootProps, getActorProps, getMenuProps}) => {
-          return (
-            <SidebarDropdownRoot {...getRootProps({isStyled: true})}>
-              <SidebarDropdownActor
-                data-test-id="sidebar-dropdown"
-                {...getActorProps({isStyled: true})}
-              >
-                <div style={{display: 'flex', alignItems: 'flex-start'}}>
-                  {avatar}
-                  {hasOrganization &&
-                    !collapsed &&
-                    orientation !== 'top' && (
-                      <NameAndOrgWrapper>
-                        <DropdownOrgName>
-                          {org.name} <i className="icon-arrow-down" />
-                        </DropdownOrgName>
-                        <DropdownUserName>{user.name}</DropdownUserName>
-                      </NameAndOrgWrapper>
-                    )}
-                </div>
-              </SidebarDropdownActor>
-
-              {isOpen && (
-                <OrgAndUserMenu {...getMenuProps({isStyled: true, org})}>
-                  {hasOrganization && (
-                    <React.Fragment>
-                      <SidebarOrgSummary organization={org} />
-                      {hasOrgRead && (
-                        <SidebarMenuItem to={`/settings/${org.slug}/`}>
-                          {t('Organization settings')}
-                        </SidebarMenuItem>
+      return (
+        <DropdownMenu>
+          {({isOpen, getRootProps, getActorProps, getMenuProps}) => {
+            return (
+              <SidebarDropdownRoot {...getRootProps({isStyled: true})}>
+                <SidebarDropdownActor
+                  data-test-id="sidebar-dropdown"
+                  {...getActorProps({isStyled: true})}
+                >
+                  <div style={{display: 'flex', alignItems: 'flex-start'}}>
+                    {avatar}
+                    {hasOrganization &&
+                      !collapsed &&
+                      orientation !== 'top' && (
+                        <NameAndOrgWrapper>
+                          <DropdownOrgName>
+                            {org.name} <i className="icon-arrow-down" />
+                          </DropdownOrgName>
+                          <DropdownUserName>{user.name}</DropdownUserName>
+                        </NameAndOrgWrapper>
                       )}
-                      {hasMemberRead && (
-                        <SidebarMenuItem to={`/settings/${org.slug}/members/`}>
-                          {t('Members')}
-                        </SidebarMenuItem>
-                      )}
+                  </div>
+                </SidebarDropdownActor>
 
-                      {hasTeamRead && (
-                        <SidebarMenuItem to={`/settings/${org.slug}/teams/`}>
-                          {t('Teams')}
-                        </SidebarMenuItem>
-                      )}
-
-                      <Hook
-                        name="sidebar:organization-dropdown-menu"
-                        organization={org}
-                        Components={{SidebarMenuItem}}
-                      />
-
-                      {!config.singleOrganization && (
-                        <SidebarMenuItem>
-                          <SwitchOrganization canCreateOrganization={canCreateOrg} />
-                        </SidebarMenuItem>
-                      )}
-
-                      <Divider />
-                    </React.Fragment>
-                  )}
-
-                  {!!user && (
-                    <React.Fragment>
-                      <UserSummary to="/settings/account/details/">
-                        <UserBadgeNoOverflow user={user} avatarSize={32} />
-                      </UserSummary>
-
-                      <div>
-                        <SidebarMenuItem to="/settings/account/">
-                          {t('User settings')}
-                        </SidebarMenuItem>
-                        <SidebarMenuItem to={'/settings/account/api/'}>
-                          {t('API keys')}
-                        </SidebarMenuItem>
-                        {user.isSuperuser && (
-                          <SidebarMenuItem to={'/manage/'}>{t('Admin')}</SidebarMenuItem>
+                {isOpen && (
+                  <OrgAndUserMenu {...getMenuProps({isStyled: true, org})}>
+                    {hasOrganization && (
+                      <React.Fragment>
+                        <SidebarOrgSummary organization={org} />
+                        {hasOrgRead && (
+                          <SidebarMenuItem to={`/settings/${org.slug}/`}>
+                            {t('Organization settings')}
+                          </SidebarMenuItem>
                         )}
-                        <SidebarMenuItem onClick={this.handleLogout}>
-                          {t('Sign out')}
-                        </SidebarMenuItem>
-                      </div>
-                    </React.Fragment>
-                  )}
-                </OrgAndUserMenu>
-              )}
-            </SidebarDropdownRoot>
-          );
-        }}
-      </DropdownMenu>
-    );
+                        {hasMemberRead && (
+                          <SidebarMenuItem to={`/settings/${org.slug}/members/`}>
+                            {t('Members')}
+                          </SidebarMenuItem>
+                        )}
+
+                        {hasTeamRead && (
+                          <SidebarMenuItem to={`/settings/${org.slug}/teams/`}>
+                            {t('Teams')}
+                          </SidebarMenuItem>
+                        )}
+
+                        <Hook
+                          name="sidebar:organization-dropdown-menu"
+                          organization={org}
+                          Components={{SidebarMenuItem}}
+                        />
+
+                        {!config.singleOrganization && (
+                          <SidebarMenuItem>
+                            <SwitchOrganization canCreateOrganization={canCreateOrg} />
+                          </SidebarMenuItem>
+                        )}
+
+                        <Divider />
+                      </React.Fragment>
+                    )}
+
+                    {!!user && (
+                      <React.Fragment>
+                        <UserSummary to="/settings/account/details/">
+                          <UserBadgeNoOverflow user={user} avatarSize={32} />
+                        </UserSummary>
+
+                        <div>
+                          <SidebarMenuItem to="/settings/account/">
+                            {t('User settings')}
+                          </SidebarMenuItem>
+                          <SidebarMenuItem to={'/settings/account/api/'}>
+                            {t('API keys')}
+                          </SidebarMenuItem>
+                          {user.isSuperuser && (
+                            <SidebarMenuItem to={'/manage/'}>
+                              {t('Admin')}
+                            </SidebarMenuItem>
+                          )}
+                          <SidebarMenuItem
+                            data-test-id="sidebarSignout"
+                            onClick={this.handleLogout}
+                          >
+                            {t('Sign out')}
+                          </SidebarMenuItem>
+                        </div>
+                      </React.Fragment>
+                    )}
+                  </OrgAndUserMenu>
+                )}
+              </SidebarDropdownRoot>
+            );
+          }}
+        </DropdownMenu>
+      );
+    }
   }
-});
+);
 
 export default SidebarDropdown;
 

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
@@ -22,6 +22,7 @@ import Divider from './divider.styled';
 
 const SidebarDropdown = withApi(class SidebarDropdown extends React.Component {
   static propTypes = {
+    api: PropTypes.object,
     orientation: PropTypes.oneOf(['top', 'left']),
     collapsed: PropTypes.bool,
     org: SentryTypes.Organization,
@@ -36,7 +37,6 @@ const SidebarDropdown = withApi(class SidebarDropdown extends React.Component {
 
   handleLogout = (...args) => {
     let {api} = this.props;
-
     api.request('/auth/', {
       method: 'DELETE',
       success: (res) => {

--- a/src/sentry/templates/sentry/bases/modal.html
+++ b/src/sentry/templates/sentry/bases/modal.html
@@ -11,7 +11,7 @@
 <section class="org-login">
   <div class="box box-modal">
     <div class="box-header">
-      {% block modal_header%}
+      {% block modal_header %}
         {% block modal_header_signout %}
           {% if request.user.is_authenticated %}
             <div class="pull-right">

--- a/src/sentry/templates/sentry/logout.html
+++ b/src/sentry/templates/sentry/logout.html
@@ -10,7 +10,7 @@
 <form class="form-stacked" method="post">
     {% csrf_token %}
     <p>We&rsquo;re gonna need you to try that again.</p>
-    <div class="p-b-2 m-t-1">
+    <div class="m-t-1">
         <button class="btn btn-primary">{% trans "Sign out" %}</button>
     </div>
 </form>

--- a/src/sentry/templates/sentry/logout.html
+++ b/src/sentry/templates/sentry/logout.html
@@ -9,7 +9,8 @@
 <h3>{% trans "Sign out" %}</h3>
 <form class="form-stacked" method="post">
     {% csrf_token %}
-    <div class="p-b-2 m-t-1 align-center">
+    <p>We&rsquo;re gonna need you to try that again.</p>
+    <div class="p-b-2 m-t-1">
         <button class="btn btn-primary">{% trans "Sign out" %}</button>
     </div>
 </form>

--- a/src/sentry/templates/sentry/logout.html
+++ b/src/sentry/templates/sentry/logout.html
@@ -3,14 +3,14 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% block title %}{% trans "Logout" %} | {{ block.super }}{% endblock %}
+{% block title %}{% trans "Sign out" %} | {{ block.super }}{% endblock %}
 
 {% block auth_main %}
-<h3>Sign out</h3>
+<h3>{% trans "Sign out" %}</h3>
 <form class="form-stacked" method="post">
     {% csrf_token %}
     <div class="p-b-2 m-t-1 align-center">
-        <button class="btn btn-primary">{% trans 'Sign out' %}</button>
+        <button class="btn btn-primary">{% trans "Sign out" %}</button>
     </div>
 </form>
 {% endblock %}

--- a/src/sentry/templates/sentry/logout.html
+++ b/src/sentry/templates/sentry/logout.html
@@ -1,0 +1,16 @@
+{% extends "sentry/bases/auth.html" %}
+
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+{% block title %}{% trans "Logout" %} | {{ block.super }}{% endblock %}
+
+{% block auth_main %}
+<h3>Sign out</h3>
+<form class="form-stacked" method="post">
+    {% csrf_token %}
+    <div class="p-b-2 m-t-1 align-center">
+        <button class="btn btn-primary">{% trans 'Sign out' %}</button>
+    </div>
+</form>
+{% endblock %}

--- a/src/sentry/web/frontend/auth_logout.py
+++ b/src/sentry/web/frontend/auth_logout.py
@@ -11,10 +11,16 @@ from sentry.utils import auth
 class AuthLogoutView(BaseView):
     auth_required = False
 
-    def handle(self, request):
+    def redirect(self, request):
         next = request.GET.get(REDIRECT_FIELD_NAME, '')
         if not is_safe_url(next, host=request.get_host()):
             next = auth.get_login_url()
+        return super(AuthLogoutView, self).redirect(next)
+
+    def get(self, request):
+        return self.respond('sentry/logout.html')
+
+    def post(self, request):
         logout(request)
         request.user = AnonymousUser()
-        return self.redirect(next)
+        return self.redirect(request)

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -926,17 +926,21 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
         </MenuItemLink>
       </SidebarMenuItem>
       <SidebarMenuItem
+        data-test-id="sidebarSignout"
         onClick={[Function]}
       >
         <MenuItemLink
+          data-test-id="sidebarSignout"
           onClick={[Function]}
         >
           <Component
             className="css-1xkywpr-MenuItemLink e1ru2gxu1"
+            data-test-id="sidebarSignout"
             onClick={[Function]}
           >
             <div
               className="css-1xkywpr-MenuItemLink e1ru2gxu1"
+              data-test-id="sidebarSignout"
               onClick={[Function]}
             >
               <MenuItemLabel
@@ -2101,17 +2105,21 @@ exports[`Sidebar renders without org and router 1`] = `
         </MenuItemLink>
       </SidebarMenuItem>
       <SidebarMenuItem
+        data-test-id="sidebarSignout"
         onClick={[Function]}
       >
         <MenuItemLink
+          data-test-id="sidebarSignout"
           onClick={[Function]}
         >
           <Component
             className="css-1xkywpr-MenuItemLink e1ru2gxu1"
+            data-test-id="sidebarSignout"
             onClick={[Function]}
           >
             <div
               className="css-1xkywpr-MenuItemLink e1ru2gxu1"
+              data-test-id="sidebarSignout"
               onClick={[Function]}
             >
               <MenuItemLabel

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -926,34 +926,29 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
         </MenuItemLink>
       </SidebarMenuItem>
       <SidebarMenuItem
-        href="/auth/logout/"
+        onClick={[Function]}
       >
         <MenuItemLink
-          href="/auth/logout/"
+          onClick={[Function]}
         >
           <Component
-            className="css-1hgw4do-MenuItemLink e1ru2gxu1"
-            href="/auth/logout/"
+            className="css-1xkywpr-MenuItemLink e1ru2gxu1"
+            onClick={[Function]}
           >
-            <Link
-              className="css-1hgw4do-MenuItemLink e1ru2gxu1"
-              href="/auth/logout/"
+            <div
+              className="css-1xkywpr-MenuItemLink e1ru2gxu1"
+              onClick={[Function]}
             >
-              <a
-                className="css-1hgw4do-MenuItemLink e1ru2gxu1"
-                href="/auth/logout/"
+              <MenuItemLabel
+                hasMenu={true}
               >
-                <MenuItemLabel
-                  hasMenu={false}
+                <span
+                  className="css-rkoh57-MenuItemLabel-MenuItemLabel e1ru2gxu0"
                 >
-                  <span
-                    className="css-3xcmix-MenuItemLabel-MenuItemLabel e1ru2gxu0"
-                  >
-                    Sign out
-                  </span>
-                </MenuItemLabel>
-              </a>
-            </Link>
+                  Sign out
+                </span>
+              </MenuItemLabel>
+            </div>
           </Component>
         </MenuItemLink>
       </SidebarMenuItem>
@@ -2106,34 +2101,29 @@ exports[`Sidebar renders without org and router 1`] = `
         </MenuItemLink>
       </SidebarMenuItem>
       <SidebarMenuItem
-        href="/auth/logout/"
+        onClick={[Function]}
       >
         <MenuItemLink
-          href="/auth/logout/"
+          onClick={[Function]}
         >
           <Component
-            className="css-1hgw4do-MenuItemLink e1ru2gxu1"
-            href="/auth/logout/"
+            className="css-1xkywpr-MenuItemLink e1ru2gxu1"
+            onClick={[Function]}
           >
-            <Link
-              className="css-1hgw4do-MenuItemLink e1ru2gxu1"
-              href="/auth/logout/"
+            <div
+              className="css-1xkywpr-MenuItemLink e1ru2gxu1"
+              onClick={[Function]}
             >
-              <a
-                className="css-1hgw4do-MenuItemLink e1ru2gxu1"
-                href="/auth/logout/"
+              <MenuItemLabel
+                hasMenu={true}
               >
-                <MenuItemLabel
-                  hasMenu={false}
+                <span
+                  className="css-rkoh57-MenuItemLabel-MenuItemLabel e1ru2gxu0"
                 >
-                  <span
-                    className="css-3xcmix-MenuItemLabel-MenuItemLabel e1ru2gxu0"
-                  >
-                    Sign out
-                  </span>
-                </MenuItemLabel>
-              </a>
-            </Link>
+                  Sign out
+                </span>
+              </MenuItemLabel>
+            </div>
           </Component>
         </MenuItemLink>
       </SidebarMenuItem>

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -141,6 +141,28 @@ describe('Sidebar', function() {
       expect(wrapper.find('SwitchOrganizationMenu')).toMatchSnapshot();
       jest.useRealTimers();
     });
+
+    it('has can logout', function() {
+      let mock = MockApiClient.addMockResponse({
+        url: '/auth/',
+        method: 'DELETE',
+        status: 204,
+      });
+
+      let org = TestStubs.Organization();
+      org = {
+        ...org,
+        access: [...org.access, 'member:read'],
+      };
+
+      wrapper = createWrapper({
+        organization: org,
+        user: TestStubs.User(),
+      });
+      wrapper.find('SidebarDropdownActor').simulate('click');
+      wrapper.find('SidebarMenuItem[data-test-id="sidebarSignout"]').simulate('click');
+      expect(mock).toHaveBeenCalled();
+    });
   });
 
   describe('SidebarPanel', function() {

--- a/tests/sentry/web/frontend/test_auth_logout.py
+++ b/tests/sentry/web/frontend/test_auth_logout.py
@@ -12,6 +12,13 @@ class AuthLogoutTest(TestCase):
     def path(self):
         return reverse('sentry-logout')
 
+    def test_get_shows_page(self):
+        self.login_as(self.user)
+
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert self.client.session.keys(), 'Not logged out yet'
+
     def test_logs_user_out(self):
         self.login_as(self.user)
 

--- a/tests/sentry/web/frontend/test_auth_logout.py
+++ b/tests/sentry/web/frontend/test_auth_logout.py
@@ -15,12 +15,12 @@ class AuthLogoutTest(TestCase):
     def test_logs_user_out(self):
         self.login_as(self.user)
 
-        resp = self.client.get(self.path)
+        resp = self.client.post(self.path)
         assert resp.status_code == 302
         assert list(self.client.session.keys()) == []
 
     def test_same_behavior_with_anonymous_user(self):
-        resp = self.client.get(self.path)
+        resp = self.client.post(self.path)
         assert resp.status_code == 302
         assert list(self.client.session.keys()) == []
 
@@ -28,15 +28,15 @@ class AuthLogoutTest(TestCase):
         self.login_as(self.user)
 
         next = '/welcome'
-        resp = self.client.get(self.path + '?next=' + next)
+        resp = self.client.post(self.path + '?next=' + next)
         assert resp.status_code == 302
         assert resp.get('Location', '').endswith(next)
 
     def test_doesnt_redirect_to_external_next_url(self):
         next = "http://example.com"
-        self.client.get(self.path + '?next=' + quote(next))
+        self.client.post(self.path + '?next=' + quote(next))
 
-        resp = self.client.get(self.path)
+        resp = self.client.post(self.path)
         assert resp.status_code == 302
         assert next not in resp['Location']
         assert resp['Location'] == 'http://testserver/auth/login/'


### PR DESCRIPTION
GET requests should not create side-effects in general. Using GET to perform logouts makes it vulnerable to drive by image tags like `<img src="https://sentry.io/auth/logout" />`. 

I've added a very minimal sign out page for the unfortunate folks who may end up there.

<img width="776" alt="screen shot 2018-09-06 at 1 02 53 pm" src="https://user-images.githubusercontent.com/24086/45173124-cb8eba80-b1f6-11e8-8217-ebb0580a158a.png">

This replaces part of #5158, and I'll be working on the 'kill all sessions' feature next.