### PR TITLE
ref(security) Add `moz-extension:` scheme to DEFAULT_DISALLOWED_SOURCES

### DIFF
--- a/src/sentry/interfaces/security.py
+++ b/src/sentry/interfaces/security.py
@@ -41,6 +41,7 @@ DEFAULT_DISALLOWED_SOURCES = (
     'mbinit://*',
     'symres://*',
     'resource://*',
+    'moz-extension://*',
     '*.metrext.com',
     'static.image2play.com',
     '*.tlscdn.com',


### PR DESCRIPTION
Similar to `chrome-extension:`, `safari-extension:`, and `ms-browser-extension:`, need to add `moz-extension:` as well.