### PR TITLE
fix(integrations): Show label for old plugin issues

### DIFF
--- a/src/sentry/static/sentry/app/components/group/pluginActions.jsx
+++ b/src/sentry/static/sentry/app/components/group/pluginActions.jsx
@@ -98,6 +98,7 @@ const PluginActions = createReactClass({
       <React.Fragment>
         <IssueSyncListElement
           onOpen={this.openModal}
+          externalIssueDisplayName={issue ? issue.label : null}
           externalIssueId={issue ? issue.issue_id : null}
           externalIssueLink={issue ? issue.url : null}
           onClose={this.deleteIssue}


### PR DESCRIPTION
We weren't passing anything to display for old plugins