### PR TITLE
fix(integrations): Only disable relevant plugins

### DIFF
--- a/src/sentry/integrations/migrate.py
+++ b/src/sentry/integrations/migrate.py
@@ -5,6 +5,14 @@ from sentry.plugins import plugins
 from sentry.utils.cache import memoize
 
 
+DISABLEABLE_PLUGINS = (
+    'vsts',
+    'bitbucket',
+    'github',
+    'example',  # Tests
+)
+
+
 class PluginMigrator(object):
     def __init__(self, integration, organization):
         self.integration = integration
@@ -13,6 +21,9 @@ class PluginMigrator(object):
     def call(self):
         for project in self.projects:
             for plugin in plugins.for_project(project):
+                if plugin.slug not in DISABLEABLE_PLUGINS:
+                    continue
+
                 if self.all_repos_migrated(plugin.slug):
                     # Since repos are Org-level, if they're all migrated, we
                     # can disable the Plugin for all Projects. There'd be no

--- a/tests/sentry/integrations/test_migrate.py
+++ b/tests/sentry/integrations/test_migrate.py
@@ -55,3 +55,10 @@ class PluginMigratorTest(TestCase):
 
         self.migrator.call()
         assert plugin not in plugins.for_project(self.project)
+
+    def test_does_not_disable_any_plugin(self):
+        plugin = plugins.get('webhooks')
+        plugin.enable(self.project)
+
+        self.migrator.call()
+        assert plugin in plugins.for_project(self.project)


### PR DESCRIPTION
This code was incorrectly disabling non-relevant plugins after installing a new integration.

It was checking if all Repositories had a `integration_id` set, for each plugin. For plugins that didn't any repositories this would confusingly return truthy causing the plugin to be disabled.

This change limits which plugins can be disabled, explicitly.