### PR TITLE
Don't return early when deleting children so that we don't lose our place in relations list.

### DIFF
--- a/src/sentry/deletions/base.py
+++ b/src/sentry/deletions/base.py
@@ -118,7 +118,6 @@ class BaseDeletionTask(object):
     def delete_children(self, relations):
         # Ideally this runs through the deletion manager
         for relation in relations:
-            has_more = True
             task = self.manager.get(
                 transaction_id=self.transaction_id,
                 actor_id=self.actor_id,
@@ -126,9 +125,10 @@ class BaseDeletionTask(object):
                 task=relation.task,
                 **relation.params
             )
+            has_more = True
             while has_more:
                 has_more = task.chunk()
-        return has_more
+        return False
 
     def mark_deletion_in_progress(self, instance_list):
         pass

--- a/src/sentry/deletions/base.py
+++ b/src/sentry/deletions/base.py
@@ -117,8 +117,8 @@ class BaseDeletionTask(object):
 
     def delete_children(self, relations):
         # Ideally this runs through the deletion manager
-        has_more = True
         for relation in relations:
+            has_more = True
             task = self.manager.get(
                 transaction_id=self.transaction_id,
                 actor_id=self.actor_id,

--- a/src/sentry/deletions/base.py
+++ b/src/sentry/deletions/base.py
@@ -117,7 +117,7 @@ class BaseDeletionTask(object):
 
     def delete_children(self, relations):
         # Ideally this runs through the deletion manager
-        has_more = False
+        has_more = True
         for relation in relations:
             task = self.manager.get(
                 transaction_id=self.transaction_id,
@@ -126,9 +126,8 @@ class BaseDeletionTask(object):
                 task=relation.task,
                 **relation.params
             )
-            has_more = task.chunk()
-            if has_more:
-                return has_more
+            while has_more:
+                has_more = task.chunk()
         return has_more
 
     def mark_deletion_in_progress(self, instance_list):


### PR DESCRIPTION
As it currently stands, we will return `has_more` up the chain if _any_ of the child relations have more to delete, losing our place in the list and having to issue queries all over again.

This prevents the reset of that loop by waiting on each relation to finish chunking.