### PR TITLE
feat(analytics): Add logging for more core events

### DIFF
--- a/src/sentry/analytics/events/alert_created.py
+++ b/src/sentry/analytics/events/alert_created.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+from sentry import analytics
+
+
+class AlertCreatedEvent(analytics.Event):
+    type = 'alert.created'
+
+    attributes = (
+        analytics.Attribute('user_id', required=False),
+        analytics.Attribute('default_user_id'),
+        analytics.Attribute('organization_id'),
+        analytics.Attribute('rule_id'),
+        analytics.Attribute('actions', type=list),
+    )
+
+
+analytics.register(AlertCreatedEvent)

--- a/src/sentry/analytics/events/first_event_sent.py
+++ b/src/sentry/analytics/events/first_event_sent.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+
+from sentry import analytics
+
+
+class FirstEventSentEvent(analytics.Event):
+    type = 'first_event.sent'
+
+    attributes = (
+        analytics.Attribute('user_id'),
+        analytics.Attribute('organization_id'),
+        analytics.Attribute('project_id'),
+        analytics.Attribute('platform', required=False),
+    )
+
+
+analytics.register(FirstEventSentEvent)

--- a/src/sentry/analytics/events/first_release_tag_sent.py
+++ b/src/sentry/analytics/events/first_release_tag_sent.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+
+from sentry import analytics
+
+
+class FirstReleaseTagSentEvent(analytics.Event):
+    type = 'first_release_tag.sent'
+
+    attributes = (
+        analytics.Attribute('user_id'),
+        analytics.Attribute('organization_id'),
+        analytics.Attribute('project_id'),
+    )
+
+
+analytics.register(FirstReleaseTagSentEvent)

--- a/src/sentry/analytics/events/first_sourcemaps_sent.py
+++ b/src/sentry/analytics/events/first_sourcemaps_sent.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+
+from sentry import analytics
+
+
+class FirstSourcemapsSentEvent(analytics.Event):
+    type = 'first_sourcemaps.sent'
+
+    attributes = (
+        analytics.Attribute('user_id'),
+        analytics.Attribute('organization_id'),
+        analytics.Attribute('project_id'),
+    )
+
+
+analytics.register(FirstSourcemapsSentEvent)

--- a/src/sentry/analytics/events/first_user_context_sent.py
+++ b/src/sentry/analytics/events/first_user_context_sent.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+
+from sentry import analytics
+
+
+class FirstUserContextSentEvent(analytics.Event):
+    type = 'first_user_context.sent'
+
+    attributes = (
+        analytics.Attribute('user_id'),
+        analytics.Attribute('organization_id'),
+        analytics.Attribute('project_id'),
+    )
+
+
+analytics.register(FirstUserContextSentEvent)

--- a/src/sentry/analytics/events/issue_assigned.py
+++ b/src/sentry/analytics/events/issue_assigned.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+
+from sentry import analytics
+
+
+class IssueAssignedEvent(analytics.Event):
+    type = 'issue.assigned'
+
+    attributes = (
+        analytics.Attribute('user_id', required=False),
+        analytics.Attribute('default_user_id'),
+        analytics.Attribute('organization_id'),
+        analytics.Attribute('group_id'),
+    )
+
+
+analytics.register(IssueAssignedEvent)

--- a/src/sentry/analytics/events/issue_deleted.py
+++ b/src/sentry/analytics/events/issue_deleted.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+from sentry import analytics
+
+
+class IssueDeletedEvent(analytics.Event):
+    type = 'issue.deleted'
+
+    attributes = (
+        analytics.Attribute('group_id'),
+        analytics.Attribute('delete_type'),
+        analytics.Attribute('organization_id'),
+        analytics.Attribute('user_id', required=False),
+        analytics.Attribute('default_user_id'),
+    )
+
+
+analytics.register(IssueDeletedEvent)

--- a/src/sentry/analytics/events/issue_resolved.py
+++ b/src/sentry/analytics/events/issue_resolved.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+from sentry import analytics
+
+
+class IssueResolvedEvent(analytics.Event):
+    type = 'issue.resolved'
+
+    attributes = (
+        analytics.Attribute('user_id', required=False),
+        analytics.Attribute('default_user_id'),
+        analytics.Attribute('organization_id'),
+        analytics.Attribute('group_id'),
+        analytics.Attribute('resolution_type'),
+    )
+
+
+analytics.register(IssueResolvedEvent)

--- a/src/sentry/analytics/events/issue_tracker_used.py
+++ b/src/sentry/analytics/events/issue_tracker_used.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+from sentry import analytics
+
+
+class IssueTrackerUsedEvent(analytics.Event):
+    type = 'issue_tracker.used'
+
+    attributes = (
+        analytics.Attribute('user_id', required=False),
+        analytics.Attribute('default_user_id'),
+        analytics.Attribute('organization_id'),
+        analytics.Attribute('issue_tracker'),
+        analytics.Attribute('project_id'),
+    )
+
+
+analytics.register(IssueTrackerUsedEvent)

--- a/src/sentry/analytics/events/plugin_enabled.py
+++ b/src/sentry/analytics/events/plugin_enabled.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+
+from sentry import analytics
+
+
+class PluginEnabledEvent(analytics.Event):
+    type = 'plugin.enabled'
+
+    attributes = (
+        analytics.Attribute('user_id'),
+        analytics.Attribute('organization_id'),
+        analytics.Attribute('project_id'),
+        analytics.Attribute('plugin'),
+    )
+
+
+analytics.register(PluginEnabledEvent)

--- a/src/sentry/analytics/events/project_created.py
+++ b/src/sentry/analytics/events/project_created.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+from sentry import analytics
+
+
+class ProjectCreatedEvent(analytics.Event):
+    type = 'project.created'
+
+    attributes = (
+        analytics.Attribute('user_id', required=False),
+        analytics.Attribute('default_user_id'),
+        analytics.Attribute('organization_id'),
+        analytics.Attribute('project_id'),
+        analytics.Attribute('platform', required=False),
+    )
+
+
+analytics.register(ProjectCreatedEvent)

--- a/src/sentry/analytics/events/repo_linked.py
+++ b/src/sentry/analytics/events/repo_linked.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+from sentry import analytics
+
+
+class RepoLinkedEvent(analytics.Event):
+    type = 'repo.linked'
+
+    attributes = (
+        analytics.Attribute('user_id', required=False),
+        analytics.Attribute('default_user_id'),
+        analytics.Attribute('organization_id'),
+        analytics.Attribute('repository_id'),
+        analytics.Attribute('provider'),
+    )
+
+
+analytics.register(RepoLinkedEvent)

--- a/src/sentry/analytics/events/search_saved.py
+++ b/src/sentry/analytics/events/search_saved.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+
+from sentry import analytics
+
+
+class SearchSavedEvent(analytics.Event):
+    type = 'search.saved'
+
+    attributes = (
+        analytics.Attribute('user_id', required=False),
+        analytics.Attribute('default_user_id'),
+        analytics.Attribute('project_id'),
+        analytics.Attribute('organization_id'),
+    )
+
+
+analytics.register(SearchSavedEvent)

--- a/src/sentry/analytics/events/second_platform_added.py
+++ b/src/sentry/analytics/events/second_platform_added.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+
+from sentry import analytics
+
+
+class SecondPlatformAddedEvent(analytics.Event):
+    type = 'second_platform.added'
+
+    attributes = (
+        analytics.Attribute('user_id'),
+        analytics.Attribute('organization_id'),
+        analytics.Attribute('project_id'),
+        analytics.Attribute('platform', required=False),
+    )
+
+
+analytics.register(SecondPlatformAddedEvent)

--- a/src/sentry/analytics/events/sso_enabled.py
+++ b/src/sentry/analytics/events/sso_enabled.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+
+from sentry import analytics
+
+
+class SSOEnabledEvent(analytics.Event):
+    type = 'sso.enabled'
+
+    attributes = (
+        analytics.Attribute('user_id'),
+        analytics.Attribute('organization_id'),
+        analytics.Attribute('provider'),
+    )
+
+
+analytics.register(SSOEnabledEvent)

--- a/src/sentry/analytics/events/team_created.py
+++ b/src/sentry/analytics/events/team_created.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+
+from sentry import analytics
+
+
+class TeamCreatedEvent(analytics.Event):
+    type = 'team.created'
+
+    attributes = (
+        analytics.Attribute('user_id', required=False),
+        analytics.Attribute('default_user_id'),
+        analytics.Attribute('organization_id'),
+        analytics.Attribute('team_id'),
+    )
+
+
+analytics.register(TeamCreatedEvent)

--- a/src/sentry/analytics/events/team_joined.py
+++ b/src/sentry/analytics/events/team_joined.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+
+from sentry import analytics
+
+
+class TeamJoinedEvent(analytics.Event):
+    type = 'team.joined'
+
+    attributes = (
+        analytics.Attribute('user_id'),
+        analytics.Attribute('organization_id'),
+        analytics.Attribute('team_id'),
+    )
+
+
+analytics.register(TeamJoinedEvent)

--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -30,6 +30,7 @@ from sentry.models import (
     UserReport,
 )
 from sentry.plugins import IssueTrackingPlugin2, plugins
+from sentry.signals import issue_deleted
 from sentry.utils.safe import safe_execute
 from sentry.utils.apidocs import scenario, attach_scenarios
 
@@ -420,5 +421,11 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                     'model': type(group).__name__,
                 }
             )
+
+            issue_deleted.send_robust(
+                group=group,
+                user=request.user,
+                delete_type='delete',
+                sender=self.__class__)
 
         return Response(status=202)

--- a/src/sentry/api/endpoints/organization_access_request_details.py
+++ b/src/sentry/api/endpoints/organization_access_request_details.py
@@ -8,6 +8,7 @@ from sentry.api.bases.organization import (OrganizationEndpoint, OrganizationPer
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.models import (AuditLogEntryEvent, OrganizationAccessRequest, OrganizationMemberTeam)
+from sentry.signals import team_joined
 
 
 class AccessRequestPermission(OrganizationPermission):
@@ -129,6 +130,12 @@ class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
                     target_user=access_request.member.user,
                     event=AuditLogEntryEvent.MEMBER_JOIN_TEAM,
                     data=omt.get_audit_log_data(),
+                )
+                team_joined.send_robust(
+                    organization=organization,
+                    user=access_request.member.user,
+                    team=access_request.team,
+                    sender=self.__class__,
                 )
 
                 access_request.send_approved_email()

--- a/src/sentry/api/endpoints/organization_member_details.py
+++ b/src/sentry/api/endpoints/organization_member_details.py
@@ -14,7 +14,6 @@ from sentry.api.serializers.rest_framework import ListField
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import (
     AuditLogEntryEvent, AuthIdentity, AuthProvider, OrganizationMember, OrganizationMemberTeam, Team, TeamStatus)
-from sentry.signals import sso_enabled
 
 ERR_NO_AUTH = 'You cannot remove this member with an unauthenticated API request.'
 
@@ -167,8 +166,6 @@ class OrganizationMemberDetailsEndpoint(OrganizationEndpoint):
             else:
                 # TODO(dcramer): proper error message
                 return Response({'detail': ERR_UNINVITABLE}, status=400)
-        if auth_provider:
-            sso_enabled.send(organization=organization, sender=request.user)
 
         if result.get('teams'):
             # dupe code from member_index

--- a/src/sentry/api/endpoints/organization_member_index.py
+++ b/src/sentry/api/endpoints/organization_member_index.py
@@ -156,8 +156,8 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
 
         if settings.SENTRY_ENABLE_INVITES:
             om.send_invite_email()
-            member_invited.send(member=om, user=request.user, sender=self,
-                                referrer=request.DATA.get('referrer'))
+            member_invited.send_robust(member=om, user=request.user, sender=self,
+                                       referrer=request.DATA.get('referrer'))
 
         self.create_audit_entry(
             request=request,

--- a/src/sentry/api/endpoints/organization_member_team_details.py
+++ b/src/sentry/api/endpoints/organization_member_team_details.py
@@ -13,6 +13,7 @@ from sentry.auth.superuser import is_active_superuser
 from sentry.models import (
     AuditLogEntryEvent, OrganizationAccessRequest, OrganizationMember, OrganizationMemberTeam, Team
 )
+from sentry.signals import team_joined
 
 ERR_INSUFFICIENT_ROLE = 'You do not have permission to edit that user\'s membership.'
 
@@ -139,6 +140,13 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationEndpoint):
             target_user=om.user,
             event=AuditLogEntryEvent.MEMBER_JOIN_TEAM,
             data=omt.get_audit_log_data(),
+        )
+
+        team_joined.send_robust(
+            organization=organization,
+            user=om.user,
+            team=team,
+            sender=self.__class__,
         )
 
         return Response(serialize(team, request.user, TeamWithProjectsSerializer()), status=201)

--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -17,6 +17,7 @@ from sentry.models import (
     AuditLogEntryEvent, OrganizationMember, OrganizationMemberTeam, Team, TeamStatus
 )
 from sentry.search.utils import tokenize_query
+from sentry.signals import team_created
 from sentry.utils.apidocs import scenario, attach_scenarios
 
 CONFLICTING_SLUG_ERROR = 'A team with this slug already exists.'
@@ -143,6 +144,13 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
                         'detail': CONFLICTING_SLUG_ERROR,
                     },
                     status=409,
+                )
+            else:
+                team_created.send_robust(
+                    organization=organization,
+                    user=request.user,
+                    team=team,
+                    sender=self.__class__,
                 )
 
             if request.user.is_authenticated():

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -61,7 +61,8 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                 event=AuditLogEntryEvent.RULE_ADD,
                 data=rule.get_audit_log_data(),
             )
-            alert_rule_created.send(project=project, rule=rule, sender=self)
+            alert_rule_created.send_robust(
+                user=request.user, project=project, rule=rule, sender=self)
 
             return Response(serialize(rule, request.user))
 

--- a/src/sentry/api/endpoints/project_searches.py
+++ b/src/sentry/api/endpoints/project_searches.py
@@ -65,7 +65,7 @@ class ProjectSearchesEndpoint(ProjectEndpoint):
                         is_default=result.get('isDefault', False),
                         owner=(None if request.access.has_scope('project:write') else request.user)
                     )
-                    save_search_created.send(project=project, sender=self)
+                    save_search_created.send_robust(project=project, user=request.user, sender=self)
 
                 except IntegrityError:
                     return Response(

--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -161,7 +161,7 @@ class TeamProjectsEndpoint(TeamEndpoint, EnvironmentMixin):
                 data=project.get_audit_log_data(),
             )
 
-            project_created.send(project=project, user=request.user, sender=self)
+            project_created.send_robust(project=project, user=request.user, sender=self)
 
             return Response(serialize(project, request.user), status=201)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -20,6 +20,7 @@ from sentry.models import (
     AuditLogEntry, AuditLogEntryEvent, AuthIdentity, AuthProvider, Organization, OrganizationMember,
     OrganizationMemberTeam, User, UserEmail
 )
+from sentry.signals import sso_enabled
 from sentry.tasks.auth import email_missing_links
 from sentry.utils import auth, metrics
 from sentry.utils.redis import clusters
@@ -782,6 +783,12 @@ class AuthHelper(object):
         )
 
         auth.mark_sso_complete(request, self.organization.id)
+
+        sso_enabled.send_robust(
+            organization=self.organization,
+            user=request.user,
+            provider=self.provider.key,
+            sender=self.__class__)
 
         AuditLogEntry.objects.create(
             organization=self.organization,

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -930,7 +930,7 @@ class EventManager(object):
         if not raw:
             if not project.first_event:
                 project.update(first_event=date)
-                first_event_received.send(project=project, group=group, sender=Project)
+                first_event_received.send_robust(project=project, group=group, sender=Project)
 
         eventstream.publish(
             group=group,

--- a/src/sentry/integrations/analytics.py
+++ b/src/sentry/integrations/analytics.py
@@ -10,6 +10,8 @@ class IntegrationAddedEvent(analytics.Event):
         analytics.Attribute('provider'),
         analytics.Attribute('id'),
         analytics.Attribute('organization_id'),
+        analytics.Attribute('user_id', required=False),
+        analytics.Attribute('default_user_id'),
     )
 
 
@@ -20,6 +22,8 @@ class IntegrationIssueCreatedEvent(analytics.Event):
         analytics.Attribute('provider'),
         analytics.Attribute('id'),
         analytics.Attribute('organization_id'),
+        analytics.Attribute('user_id', required=False),
+        analytics.Attribute('default_user_id'),
     )
 
 
@@ -30,6 +34,8 @@ class IntegrationIssueLinkedEvent(analytics.Event):
         analytics.Attribute('provider'),
         analytics.Attribute('id'),
         analytics.Attribute('organization_id'),
+        analytics.Attribute('user_id', required=False),
+        analytics.Attribute('default_user_id'),
     )
 
 

--- a/src/sentry/integrations/jira/configure.py
+++ b/src/sentry/integrations/jira/configure.py
@@ -74,8 +74,8 @@ class JiraConfigureView(View):
             form = JiraConfigForm(organizations, initial={'organizations': active_orgs})
             return self.get_response({'form': form})
 
-        enabled_orgs = form.cleaned_data['organizations']
-        disabled_orgs = list(set(o.id for o in organizations) - set(enabled_orgs))
+        enabled_orgs = [o for o in organizations if o.id in form.cleaned_data['organizations']]
+        disabled_orgs = list(set(organizations) - set(enabled_orgs))
 
         # Remove Jira integrations not in the set of enabled organizations
         OrganizationIntegration.objects.filter(
@@ -85,7 +85,7 @@ class JiraConfigureView(View):
         ).delete()
 
         # Ensure all enabled integrations.
-        for org_id in enabled_orgs:
-            integration.add_organization(org_id)
+        for org in enabled_orgs:
+            integration.add_organization(org, request.user)
 
         return self.get_response({'form': form, 'completed': True})

--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -149,15 +149,14 @@ class IntegrationPipeline(Pipeline):
                 identity_model = Identity.reattach(
                     idp, identity['external_id'], self.request.user, identity_data)
 
-        org_integration_args = {}
-
+        default_auth_id = None
         if self.provider.needs_default_identity:
             if not (identity and identity_model):
                 raise NotImplementedError('Integration requires an identity')
-            org_integration_args = {'default_auth_id': identity_model.id}
+            default_auth_id = identity_model.id
 
         org_integration = self.integration.add_organization(
-            self.organization.id, **org_integration_args)
+            self.organization, self.request.user, default_auth_id=default_auth_id)
 
         return self._dialog_response(serialize(org_integration, self.request.user), True)
 

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -174,7 +174,11 @@ class GroupAssigneeManager(BaseManager):
             })
         else:
             affected = True
-            issue_assigned.send(project=group.project, group=group, sender=acting_user)
+            issue_assigned.send_robust(
+                project=group.project,
+                group=group,
+                user=acting_user,
+                sender=self.__class__)
 
         if affected:
             activity = Activity.objects.create(

--- a/src/sentry/plugins/bases/issue.py
+++ b/src/sentry/plugins/bases/issue.py
@@ -261,7 +261,7 @@ class IssueTrackingPlugin(Plugin):
                     data=issue_information,
                 )
 
-                issue_tracker_used.send(
+                issue_tracker_used.send_robust(
                     plugin=self,
                     project=group.project,
                     user=request.user,

--- a/src/sentry/plugins/bases/issue2.py
+++ b/src/sentry/plugins/bases/issue2.py
@@ -293,7 +293,7 @@ class IssueTrackingPlugin2(Plugin):
             data=issue_information,
         )
 
-        issue_tracker_used.send(
+        issue_tracker_used.send_robust(
             plugin=self, project=group.project, user=request.user,
             sender=type(self)
         )

--- a/src/sentry/plugins/providers/base.py
+++ b/src/sentry/plugins/providers/base.py
@@ -29,7 +29,7 @@ class ProviderMixin(object):
             provider=self.auth_provider,
             external_id=usa.uid,
         )[0]
-        integration.add_organization(organization.id, default_auth_id=usa.id)
+        integration.add_organization(organization, user, default_auth_id=usa.id)
 
     def get_available_auths(self, user, organization, integrations, social_auths, **kwargs):
         if self.auth_provider is None:

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -70,7 +70,7 @@ class IntegrationRepositoryProvider(object):
                 status=400,
             )
         else:
-            repo_linked.send_robust(repo=repo, sender=self.__class__)
+            repo_linked.send_robust(repo=repo, user=request.user, sender=self.__class__)
 
         analytics.record(
             'integration.repo.added',

--- a/src/sentry/plugins/providers/repository.py
+++ b/src/sentry/plugins/providers/repository.py
@@ -102,7 +102,7 @@ class RepositoryProvider(ProviderMixin):
                 status=400,
             )
         else:
-            repo_linked.send_robust(repo=repo, sender=self.__class__)
+            repo_linked.send_robust(repo=repo, user=request.user, sender=self.__class__)
 
         return Response(serialize(repo, request.user), status=201)
 

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 
 from sentry import analytics
 from sentry.models import (
-    OnboardingTask, OnboardingTaskStatus, OrganizationOnboardingTask, OrganizationOption
+    OnboardingTask, OnboardingTaskStatus, OrganizationOnboardingTask, OrganizationOption, Organization
 )
 from sentry.plugins import IssueTrackingPlugin, IssueTrackingPlugin2, NotificationPlugin
 from sentry.signals import (
@@ -48,8 +48,21 @@ def check_for_onboarding_complete(organization_id):
 
 @project_created.connect(weak=False)
 def record_new_project(project, user, **kwargs):
-    if not user.is_authenticated():
-        user = None
+    if user.is_authenticated():
+        user_id = default_user_id = user.id
+    else:
+        user = user_id = None
+        default_user_id = Organization.objects.get(
+            id=project.organization_id).get_default_owner().id
+
+    analytics.record(
+        'project.created',
+        user_id=user_id,
+        default_user_id=default_user_id,
+        organization_id=project.organization_id,
+        project_id=project.id,
+        platform=project.platform,
+    )
 
     success = OrganizationOnboardingTask.objects.record(
         organization_id=project.organization_id,
@@ -103,32 +116,50 @@ def record_first_event(project, group, **kwargs):
         }
     )
 
-    # If first_event task is complete
-    if not rows_affected and not created:
-        try:
-            oot = OrganizationOnboardingTask.objects.filter(
-                organization_id=project.organization_id,
-                task=OnboardingTask.FIRST_EVENT,
-            )[0]
-        except IndexError:
-            return
+    user = Organization.objects.get(id=project.organization_id).get_default_owner()
 
-        # Only counts if it's a new project and platform
-        if oot.project_id != project.id and oot.data.get(
-            'platform', group.platform
-        ) != group.platform:
-            OrganizationOnboardingTask.objects.create_or_update(
+    if rows_affected or created:
+        analytics.record(
+            'first_event.sent',
+            user_id=user.id,
+            organization_id=project.organization_id,
+            project_id=project.id,
+            platform=group.platform,
+        )
+        return
+
+    try:
+        oot = OrganizationOnboardingTask.objects.filter(
+            organization_id=project.organization_id,
+            task=OnboardingTask.FIRST_EVENT,
+        )[0]
+    except IndexError:
+        return
+
+    # Only counts if it's a new project and platform
+    if oot.project_id != project.id and oot.data.get(
+        'platform', group.platform
+    ) != group.platform:
+        rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
+            organization_id=project.organization_id,
+            task=OnboardingTask.SECOND_PLATFORM,
+            status=OnboardingTaskStatus.PENDING,
+            values={
+                'status': OnboardingTaskStatus.COMPLETE,
+                'project_id': project.id,
+                'date_completed': project.first_event,
+                'data': {
+                    'platform': group.platform
+                },
+            }
+        )
+        if rows_affected or created:
+            analytics.record(
+                'second_platform.added',
+                user_id=user.id,
                 organization_id=project.organization_id,
-                task=OnboardingTask.SECOND_PLATFORM,
-                status=OnboardingTaskStatus.PENDING,
-                values={
-                    'status': OnboardingTaskStatus.COMPLETE,
-                    'project_id': project.id,
-                    'date_completed': project.first_event,
-                    'data': {
-                        'platform': group.platform
-                    },
-                }
+                project_id=project.id,
+                platform=group.platform,
             )
 
 
@@ -179,6 +210,13 @@ def record_release_received(project, group, event, **kwargs):
         project_id=project.id,
     )
     if success:
+        user = Organization.objects.get(id=project.organization_id).get_default_owner()
+        analytics.record(
+            'first_release_tag.sent',
+            user_id=user.id,
+            project_id=project.id,
+            organization_id=project.organization_id,
+        )
         check_for_onboarding_complete(project.organization_id)
 
 
@@ -198,6 +236,13 @@ def record_user_context_received(project, group, event, **kwargs):
             project_id=project.id,
         )
         if success:
+            user = Organization.objects.get(id=project.organization_id).get_default_owner()
+            analytics.record(
+                'first_user_context.sent',
+                user_id=user.id,
+                organization_id=project.organization_id,
+                project_id=project.id,
+            )
             check_for_onboarding_complete(project.organization_id)
 
 
@@ -213,6 +258,13 @@ def record_sourcemaps_received(project, group, event, **kwargs):
         project_id=project.id,
     )
     if success:
+        user = Organization.objects.get(id=project.organization_id).get_default_owner()
+        analytics.record(
+            'first_sourcemaps.sent',
+            user_id=user.id,
+            organization_id=project.organization_id,
+            project_id=project.id,
+        )
         check_for_onboarding_complete(project.organization_id)
 
 
@@ -238,6 +290,14 @@ def record_plugin_enabled(plugin, project, user, **kwargs):
     if success:
         check_for_onboarding_complete(project.organization_id)
 
+    analytics.record(
+        'plugin.enabled',
+        user_id=user.id,
+        organization_id=project.organization_id,
+        project_id=project.id,
+        plugin=plugin.slug,
+    )
+
 
 @issue_tracker_used.connect(weak=False)
 def record_issue_tracker_used(plugin, project, user, **kwargs):
@@ -255,5 +315,20 @@ def record_issue_tracker_used(plugin, project, user, **kwargs):
             }
         }
     )
+
     if rows_affected or created:
         check_for_onboarding_complete(project.organization_id)
+
+    if user and user.is_authenticated():
+        user_id = default_user_id = user.id
+    else:
+        user_id = None
+        default_user_id = project.organization.get_default_owner().id
+    analytics.record(
+        'issue_tracker.used',
+        user_id=user_id,
+        default_user_id=default_user_id,
+        organization_id=project.organization_id,
+        project_id=project.id,
+        issue_tracker=plugin.slug,
+    )

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -86,8 +86,9 @@ def resolved_in_commit(instance, created, **kwargs):
                         id=repo.integration_id,
                         organization_id=repo.organization_id,
                     )
+                user = user_list[0] if user_list else None
                 resolved_with_commit.send_robust(
-                    organization_id=repo.organization_id, sender='resolved_in_commit')
+                    organization_id=repo.organization_id, user=user, group=group, sender='resolved_in_commit')
 
 
 def resolved_in_pull_request(instance, created, **kwargs):

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -77,19 +77,30 @@ email_verified = BetterSignal(providing_args=["email"])
 mocks_loaded = BetterSignal(providing_args=["project"])
 
 user_feedback_received = BetterSignal(providing_args=["project"])
-issue_assigned = BetterSignal(providing_args=["project", "group"])
-issue_resolved_in_release = BetterSignal(providing_args=["project"])
+issue_assigned = BetterSignal(providing_args=["project", "group", "user"])
+issue_resolved_in_release = BetterSignal(
+    providing_args=[
+        "project",
+        "group",
+        "user",
+        "resolution_type"])
 advanced_search = BetterSignal(providing_args=["project"])
-save_search_created = BetterSignal(providing_args=["project"])
+save_search_created = BetterSignal(providing_args=["project", "user"])
 inbound_filter_toggled = BetterSignal(providing_args=["project"])
-sso_enabled = BetterSignal(providing_args=["organization"])
+sso_enabled = BetterSignal(providing_args=["organization", "user", "provider"])
 data_scrubber_enabled = BetterSignal(providing_args=["organization"])
-alert_rule_created = BetterSignal(providing_args=["project", "rule"])
-repo_linked = BetterSignal(providing_args=["repo"])
+alert_rule_created = BetterSignal(providing_args=["project", "rule", "user"])
+repo_linked = BetterSignal(providing_args=["repo", "user"])
 release_created = BetterSignal(providing_args=["release"])
 deploy_created = BetterSignal(providing_args=["deploy"])
-resolved_with_commit = BetterSignal(providing_args=["organization_id"])
+resolved_with_commit = BetterSignal(providing_args=["organization_id", "user", "group"])
 ownership_rule_created = BetterSignal(providing_args=["project"])
 issue_ignored = BetterSignal(providing_args=["project"])
 
 terms_accepted = BetterSignal(providing_args=["organization", "user", "ip_address"])
+team_created = BetterSignal(providing_args=["organization", "user", "team"])
+team_joined = BetterSignal(providing_args=["organization", "user", "team"])
+integration_added = BetterSignal(providing_args=["integration", "organization", "user"])
+integration_issue_created = BetterSignal(providing_args=["integration", "organization", "user"])
+integration_issue_linked = BetterSignal(providing_args=["integration", "organization", "user"])
+issue_deleted = BetterSignal(providing_args=["group", "user", "delete_type"])

--- a/tests/acceptance/test_organization_integrations_settings.py
+++ b/tests/acceptance/test_organization_integrations_settings.py
@@ -33,7 +33,7 @@ class OrganizationIntegrationSettingsTest(AcceptanceTestCase):
             },
         )
 
-        self.org_integration = self.model.add_organization(self.org.id)
+        self.org_integration = self.model.add_organization(self.org, self.user)
 
         self.login_as(self.user)
 

--- a/tests/sentry/api/endpoints/test_group_integration_details.py
+++ b/tests/sentry/api/endpoints/test_group_integration_details.py
@@ -16,7 +16,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             provider='example',
             name='Example',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
 
         path = u'/api/0/issues/{}/integrations/{}/?action=link'.format(group.id, integration.id)
 
@@ -56,7 +56,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             provider='example',
             name='Example',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
 
         path = u'/api/0/issues/{}/integrations/{}/?action=create'.format(group.id, integration.id)
 
@@ -110,7 +110,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             provider='example',
             name='Example',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
 
         path = u'/api/0/issues/{}/integrations/{}/?action=create'.format(group.id, integration.id)
 
@@ -126,7 +126,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             provider='example',
             name='Example',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
 
         path = u'/api/0/issues/{}/integrations/{}/'.format(group.id, integration.id)
 
@@ -157,7 +157,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             provider='example',
             name='Example',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
 
         path = u'/api/0/issues/{}/integrations/{}/'.format(group.id, integration.id)
 
@@ -175,7 +175,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             provider='example',
             name='Example',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
 
         path = u'/api/0/issues/{}/integrations/{}/'.format(group.id, integration.id)
 
@@ -209,7 +209,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             provider='example',
             name='Example',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
 
         path = u'/api/0/issues/{}/integrations/{}/'.format(group.id, integration.id)
 
@@ -225,7 +225,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             provider='example',
             name='Example',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
 
         external_issue = ExternalIssue.objects.get_or_create(
             organization_id=org.id,
@@ -260,7 +260,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             provider='example',
             name='Example',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
 
         external_issue = ExternalIssue.objects.get_or_create(
             organization_id=org.id,

--- a/tests/sentry/api/endpoints/test_group_integrations.py
+++ b/tests/sentry/api/endpoints/test_group_integrations.py
@@ -15,7 +15,7 @@ class GroupIntegrationsTest(APITestCase):
             provider='example',
             name='Example',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
         external_issue = ExternalIssue.objects.create(
             organization_id=org.id,
             integration_id=integration.id,
@@ -70,7 +70,7 @@ class GroupIntegrationsTest(APITestCase):
             provider='example',
             name='Example',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
         external_issue = ExternalIssue.objects.create(
             organization_id=org.id,
             integration_id=integration.id,

--- a/tests/sentry/api/endpoints/test_group_notes.py
+++ b/tests/sentry/api/endpoints/test_group_notes.py
@@ -182,7 +182,7 @@ class GroupNoteCreateTest(APITestCase):
             provider='example',
             external_id='123456',
         )
-        integration.add_organization(group.organization.id)
+        integration.add_organization(group.organization, self.user)
 
         OrganizationIntegration.objects.filter(
             integration_id=integration.id,

--- a/tests/sentry/api/endpoints/test_organization_integration_details.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_details.py
@@ -16,7 +16,7 @@ class OrganizationIntegrationDetailsTest(APITestCase):
             provider='example',
             name='Example',
         )
-        self.integration.add_organization(self.org.id, config={'setting': 'value'})
+        self.integration.add_organization(self.org, self.user)
 
         self.path = u'/api/0/organizations/{}/integrations/{}/'.format(
             self.org.slug, self.integration.id)
@@ -26,7 +26,6 @@ class OrganizationIntegrationDetailsTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert response.data['id'] == six.text_type(self.integration.id)
-        assert response.data['configData'] == {'setting': 'value'}
 
     def test_removal(self):
         with self.tasks():

--- a/tests/sentry/api/endpoints/test_organization_integration_repos.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_repos.py
@@ -15,7 +15,7 @@ class OrganizationIntegrationReposTest(APITestCase):
             provider='github',
             name='Example',
         )
-        self.integration.add_organization(self.org.id)
+        self.integration.add_organization(self.org, self.user)
         self.path = u'/api/0/organizations/{}/integrations/{}/repos/'.format(
             self.org.slug, self.integration.id)
 
@@ -35,7 +35,7 @@ class OrganizationIntegrationReposTest(APITestCase):
             provider='example',
             name='Example',
         )
-        integration.add_organization(self.org.id)
+        integration.add_organization(self.org, self.user)
         path = u'/api/0/organizations/{}/integrations/{}/repos/'.format(
             self.org.slug, integration.id)
         response = self.client.get(path, format='json')

--- a/tests/sentry/api/endpoints/test_organization_integrations.py
+++ b/tests/sentry/api/endpoints/test_organization_integrations.py
@@ -14,7 +14,7 @@ class OrganizationIntegrationsListTest(APITestCase):
             provider='example',
             name='Example',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
         path = u'/api/0/organizations/{}/integrations/'.format(org.slug)
 
         response = self.client.get(path, format='json')

--- a/tests/sentry/api/endpoints/test_project_group_index.py
+++ b/tests/sentry/api/endpoints/test_project_group_index.py
@@ -464,7 +464,7 @@ class GroupUpdateTest(APITestCase):
             provider='example',
             name='Example',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
         group = self.create_group(status=GroupStatus.UNRESOLVED, organization=org)
 
         OrganizationIntegration.objects.filter(
@@ -540,7 +540,7 @@ class GroupUpdateTest(APITestCase):
             provider='example',
             name='Example',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
         OrganizationIntegration.objects.filter(
             integration_id=integration.id,
             organization_id=group.organization.id,

--- a/tests/sentry/deletions/test_organizationintegration.py
+++ b/tests/sentry/deletions/test_organizationintegration.py
@@ -14,7 +14,7 @@ class DeleteOrganizationIntegrationTest(TestCase):
             provider='example',
             name='Example',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
         organization_integration = OrganizationIntegration.objects.get(
             integration_id=integration.id,
             organization_id=org.id,

--- a/tests/sentry/integrations/bitbucket/test_repository.py
+++ b/tests/sentry/integrations/bitbucket/test_repository.py
@@ -24,7 +24,7 @@ class BitbucketRepositoryProviderTest(TestCase):
                 'subject': self.subject,
             }
         )
-        self.integration.add_organization(self.organization.id)
+        self.integration.add_organization(self.organization, self.user)
         self.repo = Repository.objects.create(
             provider='bitbucket',
             name='sentryuser/newsdiffs',

--- a/tests/sentry/integrations/bitbucket/test_search.py
+++ b/tests/sentry/integrations/bitbucket/test_search.py
@@ -55,7 +55,7 @@ class BitbucketSearchEndpointTest(APITestCase):
         org = self.organization
         self.login_as(self.user)
 
-        self.integration.add_organization(org.id)
+        self.integration.add_organization(org, self.user)
 
         path = reverse('sentry-extensions-bitbucket-search', args=[org.slug, self.integration.id])
         resp = self.client.get('%s?field=externalIssue&repo=meredithanya&query=issue' % (path,))
@@ -70,7 +70,7 @@ class BitbucketSearchEndpointTest(APITestCase):
         org = self.organization
         self.login_as(self.user)
 
-        self.integration.add_organization(org.id)
+        self.integration.add_organization(org, self.user)
 
         path = reverse('sentry-extensions-bitbucket-search', args=[org.slug, self.integration.id])
         resp = self.client.get('%s?field=repo&query=apple' % (path,))

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -25,7 +25,7 @@ class GitHubIssueBasicTest(TestCase):
             external_id='github_external_id',
             name='getsentry',
         )
-        self.model.add_organization(self.organization.id)
+        self.model.add_organization(self.organization, self.user)
         self.integration = GitHubIntegration(self.model, self.organization.id)
 
     @responses.activate
@@ -67,7 +67,8 @@ class GitHubIssueBasicTest(TestCase):
         responses.add(
             responses.POST,
             'https://api.github.com/repos/getsentry/sentry/issues',
-            json={'number': 321, 'title': 'hello', 'body': 'This is the description', 'html_url': 'https://github.com/getsentry/sentry/issues/231'}
+            json={'number': 321, 'title': 'hello', 'body': 'This is the description',
+                  'html_url': 'https://github.com/getsentry/sentry/issues/231'}
         )
 
         form_data = {
@@ -127,7 +128,8 @@ class GitHubIssueBasicTest(TestCase):
         responses.add(
             responses.GET,
             'https://api.github.com/repos/getsentry/sentry/issues/321',
-            json={'number': issue_id, 'title': 'hello', 'body': 'This is the description', 'html_url': 'https://github.com/getsentry/sentry/issues/231'}
+            json={'number': issue_id, 'title': 'hello', 'body': 'This is the description',
+                  'html_url': 'https://github.com/getsentry/sentry/issues/231'}
         )
 
         data = {

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -25,7 +25,7 @@ class GitHubAppsProviderTest(PluginTestCase):
             provider='github',
             name='Example Github',
         )
-        integration.add_organization(organization.id)
+        integration.add_organization(organization, self.user)
         data = {
             'identifier': 'getsentry/example-repo',
             'external_id': '654321',

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -99,7 +99,7 @@ class PushEventWebhookTest(APITestCase):
             provider='github',
             metadata={'access_token': '1234', 'expires_at': future_expires.isoformat()}
         )
-        integration.add_organization(project.organization.id)
+        integration.add_organization(project.organization, self.user)
 
         response = self.client.post(
             path=url,
@@ -154,7 +154,7 @@ class PushEventWebhookTest(APITestCase):
             name='octocat',
             metadata={'access_token': '1234', 'expires_at': future_expires.isoformat()}
         )
-        integration.add_organization(project.organization.id)
+        integration.add_organization(project.organization, self.user)
 
         Repository.objects.create(
             organization_id=project.organization.id,
@@ -230,7 +230,7 @@ class PushEventWebhookTest(APITestCase):
             provider='github',
             metadata={'access_token': '1234', 'expires_at': future_expires.isoformat()}
         )
-        integration.add_organization(project.organization.id)
+        integration.add_organization(project.organization, self.user)
 
         org2 = self.create_organization()
         project2 = self.create_project(organization=org2, name='bar')
@@ -248,7 +248,7 @@ class PushEventWebhookTest(APITestCase):
             provider='github',
             metadata={'access_token': '1234', 'expires_at': future_expires.isoformat()}
         )
-        integration.add_organization(org2.id)
+        integration.add_organization(org2, self.user)
 
         response = self.client.post(
             path=url,
@@ -293,7 +293,7 @@ class PullRequestEventWebhook(APITestCase):
             name='octocat',
             metadata={'access_token': '1234', 'expires_at': future_expires.isoformat()}
         )
-        integration.add_organization(project.organization.id)
+        integration.add_organization(project.organization, self.user)
 
         repo = Repository.objects.create(
             organization_id=project.organization.id,
@@ -343,7 +343,7 @@ class PullRequestEventWebhook(APITestCase):
             name='octocat',
             metadata={'access_token': '1234', 'expires_at': future_expires.isoformat()}
         )
-        integration.add_organization(project.organization.id)
+        integration.add_organization(project.organization, self.user)
 
         repo = Repository.objects.create(
             organization_id=project.organization.id,
@@ -392,7 +392,7 @@ class PullRequestEventWebhook(APITestCase):
             name='octocat',
             metadata={'access_token': '1234', 'expires_at': future_expires.isoformat()}
         )
-        integration.add_organization(project.organization.id)
+        integration.add_organization(project.organization, self.user)
 
         repo = Repository.objects.create(
             organization_id=project.organization.id,

--- a/tests/sentry/integrations/github_enterprise/test_issues.py
+++ b/tests/sentry/integrations/github_enterprise/test_issues.py
@@ -31,7 +31,7 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
                     'id': 2,
                     'private_key': 'private_key'}}
         )
-        self.model.add_organization(self.organization.id)
+        self.model.add_organization(self.organization, self.user)
         self.integration = GitHubEnterpriseIntegration(self.model, self.organization.id)
 
     @responses.activate
@@ -73,7 +73,8 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
         responses.add(
             responses.POST,
             'https://35.232.149.196/api/v3/repos/getsentry/sentry/issues',
-            json={'number': 321, 'title': 'hello', 'body': 'This is the description', 'html_url': 'https://35.232.149.196/getsentry/sentry/issues/231'}
+            json={'number': 321, 'title': 'hello', 'body': 'This is the description',
+                  'html_url': 'https://35.232.149.196/getsentry/sentry/issues/231'}
         )
 
         form_data = {
@@ -133,7 +134,8 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
         responses.add(
             responses.GET,
             'https://35.232.149.196/api/v3/repos/getsentry/sentry/issues/321',
-            json={'number': issue_id, 'title': 'hello', 'body': 'This is the description', 'html_url': 'https://35.232.149.196/getsentry/sentry/issues/231'}
+            json={'number': issue_id, 'title': 'hello', 'body': 'This is the description',
+                  'html_url': 'https://35.232.149.196/getsentry/sentry/issues/231'}
         )
 
         data = {

--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -101,7 +101,7 @@ class PushEventWebhookTest(APITestCase):
                 }
             }
         )
-        integration.add_organization(project.organization.id)
+        integration.add_organization(project.organization, self.user)
 
         response = self.client.post(
             path=url,
@@ -166,7 +166,7 @@ class PushEventWebhookTest(APITestCase):
                 }
             }
         )
-        integration.add_organization(project.organization.id)
+        integration.add_organization(project.organization, self.user)
 
         Repository.objects.create(
             organization_id=project.organization.id,
@@ -253,7 +253,7 @@ class PushEventWebhookTest(APITestCase):
                 }
             }
         )
-        integration.add_organization(project.organization.id)
+        integration.add_organization(project.organization, self.user)
 
         org2 = self.create_organization()
         project2 = self.create_project(organization=org2, name='bar')
@@ -276,7 +276,7 @@ class PushEventWebhookTest(APITestCase):
                 }
             }
         )
-        integration.add_organization(org2.id)
+        integration.add_organization(org2, self.user)
 
         response = self.client.post(
             path=url,
@@ -332,7 +332,7 @@ class PullRequestEventWebhook(APITestCase):
                 }
             }
         )
-        integration.add_organization(project.organization.id)
+        integration.add_organization(project.organization, self.user)
 
         repo = Repository.objects.create(
             organization_id=project.organization.id,
@@ -392,7 +392,7 @@ class PullRequestEventWebhook(APITestCase):
                 }
             }
         )
-        integration.add_organization(project.organization.id)
+        integration.add_organization(project.organization, self.user)
 
         repo = Repository.objects.create(
             organization_id=project.organization.id,
@@ -451,7 +451,7 @@ class PullRequestEventWebhook(APITestCase):
                 }
             }
         )
-        integration.add_organization(project.organization.id)
+        integration.add_organization(project.organization, self.user)
 
         repo = Repository.objects.create(
             organization_id=project.organization.id,

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -371,7 +371,7 @@ class JiraIntegrationTest(APITestCase):
             provider='jira',
             name='Example Jira',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
 
         installation = integration.get_installation(org.id)
 
@@ -424,7 +424,7 @@ class JiraIntegrationTest(APITestCase):
             provider='jira',
             name='Example Jira',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
 
         installation = integration.get_installation(org.id)
 
@@ -448,7 +448,7 @@ class JiraIntegrationTest(APITestCase):
             provider='jira',
             name='Example Jira',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
 
         installation = integration.get_installation(org.id)
 
@@ -476,7 +476,7 @@ class JiraIntegrationTest(APITestCase):
             provider='jira',
             name='Example Jira',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
 
         external_issue = ExternalIssue.objects.create(
             organization_id=org.id,
@@ -517,7 +517,7 @@ class JiraIntegrationTest(APITestCase):
             provider='jira',
             name='Example Jira',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
 
         installation = integration.get_installation(org.id)
 
@@ -647,7 +647,7 @@ class JiraIntegrationTest(APITestCase):
             provider='jira',
             name='Example Jira',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
 
         org_integration = OrganizationIntegration.objects.get(
             organization_id=org.id,

--- a/tests/sentry/integrations/jira/test_search_endpoint.py
+++ b/tests/sentry/integrations/jira/test_search_endpoint.py
@@ -46,7 +46,7 @@ class JiraSearchEndpointTest(APITestCase):
             provider='jira',
             name='Example Jira',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
 
         path = reverse('sentry-extensions-jira-search', args=[org.slug, integration.id])
 

--- a/tests/sentry/integrations/jira/test_uninstalled.py
+++ b/tests/sentry/integrations/jira/test_uninstalled.py
@@ -16,7 +16,7 @@ class JiraUninstalledTest(APITestCase):
             name='Example Jira',
             status=ObjectStatus.VISIBLE,
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
 
         path = '/extensions/jira/uninstalled/'
 

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -95,7 +95,7 @@ class JiraWebhooksTest(APITestCase):
             provider='jira',
             name='Example Jira',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
 
         path = reverse('sentry-extensions-jira-issue-updated')
 
@@ -118,7 +118,7 @@ class JiraWebhooksTest(APITestCase):
             provider='jira',
             name='Example Jira',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
 
         path = reverse('sentry-extensions-jira-issue-updated')
 
@@ -141,7 +141,7 @@ class JiraWebhooksTest(APITestCase):
             provider='jira',
             name='Example Jira',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
 
         path = reverse('sentry-extensions-jira-issue-updated')
 

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -25,7 +25,7 @@ class SlackNotifyActionTest(RuleTestCase):
                 'bot_access_token': 'xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx',
             }
         )
-        self.integration.add_organization(event.project.organization_id)
+        self.integration.add_organization(event.project.organization, self.user)
 
     @responses.activate
     def test_applies_correctly(self):

--- a/tests/sentry/integrations/test_base.py
+++ b/tests/sentry/integrations/test_base.py
@@ -28,7 +28,8 @@ class IntegrationTestCase(TestCase):
                 'access_token': '11234567'
             }
         )
-        self.org_integration = self.model.add_organization(self.organization.id, self.identity.id)
+        self.org_integration = self.model.add_organization(
+            self.organization, self.user, self.identity.id)
 
     def test_no_context(self):
         integration = Integration(self.model, self.organization.id)

--- a/tests/sentry/integrations/test_issues.py
+++ b/tests/sentry/integrations/test_issues.py
@@ -15,7 +15,7 @@ class IssueSyncIntegration(TestCase):
             provider='example',
             external_id='123456',
         )
-        integration.add_organization(group.organization.id)
+        integration.add_organization(group.organization, self.user)
 
         OrganizationIntegration.objects.filter(
             integration_id=integration.id,
@@ -67,7 +67,7 @@ class IssueSyncIntegration(TestCase):
             provider='example',
             external_id='123456',
         )
-        integration.add_organization(group.organization.id)
+        integration.add_organization(group.organization, self.user)
 
         OrganizationIntegration.objects.filter(
             integration_id=integration.id,

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -44,7 +44,7 @@ class VstsIssueSycnTest(TestCase):
                 'expires': time() + 1234567,
             }
         )
-        model.add_organization(self.organization.id, identity.id)
+        model.add_organization(self.organization, self.user, identity.id)
         self.config = {
             'resolve_status': 'Resolved',
             'resolve_when': 'Resolved',

--- a/tests/sentry/integrations/vsts/test_repository.py
+++ b/tests/sentry/integrations/vsts/test_repository.py
@@ -58,7 +58,7 @@ class VisualStudioRepositoryProviderTest(TestCase):
                 'token_type': 'jwt-bearer',
             },
         )
-        integration.add_organization(self.organization.id, default_auth.id)
+        integration.add_organization(self.organization, self.user, default_auth.id)
         repo = Repository.objects.create(
             provider='visualstudio',
             name='example',

--- a/tests/sentry/integrations/vsts/test_webhooks.py
+++ b/tests/sentry/integrations/vsts/test_webhooks.py
@@ -47,7 +47,8 @@ class VstsWebhookWorkItemTest(APITestCase):
                 'expires': int(time()) + int(1234567890),
             }
         )
-        self.org_integration = self.model.add_organization(self.organization.id, self.identity.id)
+        self.org_integration = self.model.add_organization(
+            self.organization, self.user, self.identity.id)
         self.org_integration.config = {
             'sync_status_reverse': True,
             'sync_status_forward': True,

--- a/tests/sentry/models/test_groupassignee.py
+++ b/tests/sentry/models/test_groupassignee.py
@@ -112,7 +112,7 @@ class GroupAssigneeTestCase(TestCase):
             provider='example',
             external_id='123456',
         )
-        integration.add_organization(group.organization.id)
+        integration.add_organization(group.organization, self.user)
 
         OrganizationIntegration.objects.filter(
             integration_id=integration.id,
@@ -175,7 +175,7 @@ class GroupAssigneeTestCase(TestCase):
             provider='example',
             external_id='123456',
         )
-        integration.add_organization(group.organization.id)
+        integration.add_organization(group.organization, self.user)
 
         OrganizationIntegration.objects.filter(
             integration_id=integration.id,
@@ -235,7 +235,7 @@ class GroupAssigneeTestCase(TestCase):
             provider='example',
             external_id='123456',
         )
-        integration.add_organization(group.organization.id)
+        integration.add_organization(group.organization, user_no_access)
 
         OrganizationIntegration.objects.filter(
             integration_id=integration.id,
@@ -291,7 +291,7 @@ class GroupAssigneeTestCase(TestCase):
             provider='example',
             external_id='123456',
         )
-        integration.add_organization(group.organization.id)
+        integration.add_organization(group.organization, self.user)
 
         OrganizationIntegration.objects.filter(
             integration_id=integration.id,

--- a/tests/sentry/plugins/test_repository_provider.py
+++ b/tests/sentry/plugins/test_repository_provider.py
@@ -31,7 +31,7 @@ class RepositoryProviderTest(TestCase):
             provider='dummy',
             external_id='123456',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, user)
 
         assert provider.needs_auth(user, organization=org) is False
 
@@ -63,6 +63,6 @@ class RepositoryProviderTest(TestCase):
             provider='dummy',
             external_id='123456',
         )
-        integration.add_organization(org.id, default_auth_id=usa.id)
+        integration.add_organization(org, user, default_auth_id=usa.id)
 
         assert provider.get_auth(user, organization=org) == usa

--- a/tests/sentry/receivers/test_featureadoption.py
+++ b/tests/sentry/receivers/test_featureadoption.py
@@ -634,14 +634,24 @@ class FeatureAdoptionTest(TestCase):
         assert feature_complete
 
     def test_assignment(self):
-        issue_assigned.send(project=self.project, group=self.group, sender=type(self.project))
+        issue_assigned.send(
+            project=self.project,
+            group=self.group,
+            user=self.user,
+            sender='something')
         feature_complete = FeatureAdoption.objects.get_by_slug(
             organization=self.organization, slug="assignment"
         )
         assert feature_complete
 
     def test_resolved_in_release(self):
-        issue_resolved_in_release.send(project=self.project, sender=type(self.project))
+        issue_resolved_in_release.send(
+            project=self.project,
+            group=self.group,
+            user=self.user,
+            resolution_type='now',
+            sender=type(
+                self.project))
         feature_complete = FeatureAdoption.objects.get_by_slug(
             organization=self.organization, slug="resolved_in_release"
         )
@@ -655,7 +665,7 @@ class FeatureAdoptionTest(TestCase):
         assert feature_complete
 
     def test_save_search(self):
-        save_search_created.send(project=self.project, sender=type(self.project))
+        save_search_created.send(project=self.project, user=self.user, sender=type(self.project))
         feature_complete = FeatureAdoption.objects.get_by_slug(
             organization=self.organization, slug="saved_search"
         )
@@ -673,7 +683,12 @@ class FeatureAdoptionTest(TestCase):
             project=self.project, label="Trivially modified rule", data=DEFAULT_RULE_DATA
         )
 
-        alert_rule_created.send(project=self.project, rule=rule, sender=type(self.project))
+        alert_rule_created.send(
+            user=self.owner,
+            project=self.project,
+            rule=rule,
+            sender=type(
+                self.project))
         feature_complete = FeatureAdoption.objects.get_by_slug(
             organization=self.organization, slug="alert_rules"
         )
@@ -704,7 +719,12 @@ class FeatureAdoptionTest(TestCase):
         assert feature_complete
 
     def test_sso(self):
-        sso_enabled.send(organization=self.organization, sender=type(self.organization))
+        sso_enabled.send(
+            organization=self.organization,
+            user=self.user,
+            provider='google',
+            sender=type(
+                self.organization))
         feature_complete = FeatureAdoption.objects.get_by_slug(
             organization=self.organization, slug="sso"
         )

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -518,7 +518,7 @@ class EventManagerTest(TransactionTestCase):
             provider='example',
             name='Example',
         )
-        integration.add_organization(org.id)
+        integration.add_organization(org, self.user)
         OrganizationIntegration.objects.filter(
             integration_id=integration.id,
             organization_id=group.organization.id,


### PR DESCRIPTION
- Adds analytics.record() calls for a few more events using signals
- Converts some existing signal.send() calls to signal.send_robust()
- Some events have the concept of an optional user_id and a required default_user_id. This is to support tools (like Amplitude) where every event must be attributed to a user. For events done via API keys or which otherwise don't have a user, we set user_id to None and default_user_id to the owner of the org. This may result in an extra DB query but in the events we're using it for this will be very rare and not on any critical paths.
- Refactors the add_organization() method (which has a lot of callsites) to take the user as well, since we need the user_id.