### PR TITLE
feat(discover): Add support for browser navigation events

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -26,7 +26,7 @@ import {isValidCondition} from './conditions/utils';
 import {isValidAggregation} from './aggregations/utils';
 import {Fieldset, PlaceholderText, ButtonSpinner, SidebarLabel} from './styles';
 
-import {getQueryStringFromQuery} from './utils';
+import {getQueryStringFromQuery, getQueryFromQueryString} from './utils';
 import {trackQuery} from './analytics';
 
 export default class OrganizationDiscover extends React.Component {
@@ -47,16 +47,22 @@ export default class OrganizationDiscover extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const {queryBuilder, location: {search}} = nextProps;
-    if (search === '') {
-      queryBuilder.reset();
-      this.setState({
-        data: null,
-        query: null,
-        chartData: null,
-        chartQuery: null,
-      });
+    const {queryBuilder, location: {search, action}} = nextProps;
+    const currentSearch = this.props.location.search;
+
+    if (currentSearch === search || action === 'REPLACE') {
+      return;
     }
+
+    const newQuery = getQueryFromQueryString(search);
+    queryBuilder.reset(newQuery);
+
+    this.setState({
+      data: null,
+      query: null,
+      chartData: null,
+      chartQuery: null,
+    });
   }
 
   updateField = (field, value) => {

--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -212,7 +212,7 @@ export default function createQueryBuilder(initial = {}, organization) {
    *
    * @returns {Void}
    */
-  function reset() {
-    query = applyDefaults({});
+  function reset(q = {}) {
+    query = applyDefaults(q);
   }
 }

--- a/tests/js/spec/views/organizationDiscover/discover.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/discover.spec.jsx
@@ -121,6 +121,7 @@ describe('Discover', function() {
         wrapper.setProps({
           location: {
             search: url.pathname.replace('/organizations/org-slug/discover/', ''),
+            action: 'PUSH',
           },
         });
       });
@@ -176,6 +177,17 @@ describe('Discover', function() {
       wrapper.instance().reset();
       wrapper.update();
       expect(wrapper.find('NumberField[name="limit"]').prop('value')).toBe(1000);
+    });
+
+    it('does not reset on location replace', function() {
+      const prevCallCount = queryBuilder.reset.mock.calls.length;
+      wrapper.setProps({
+        location: {
+          search: '?fields=[]',
+          action: 'REPLACE',
+        },
+      });
+      expect(queryBuilder.reset.mock.calls).toHaveLength(prevCallCount);
     });
   });
 });


### PR DESCRIPTION
Back and forward buttons should clear results and update query builder.