### PR TITLE
tests(js): Add test-id to Settings Nav

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavigationGroup.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavigationGroup.jsx
@@ -36,7 +36,7 @@ export default class NavigationGroup extends React.Component {
     let {organization, project, name, items} = this.props;
 
     return (
-      <NavSection>
+      <NavSection data-test-id={name}>
         <SettingsHeading>{name}</SettingsHeading>
         {items.map(({path, title, index, show, badge}) => {
           if (typeof show === 'function' && !show(this.props)) return null;


### PR DESCRIPTION
This will fix some race conditions in getsentry with the org settings menu which causes false negatives in percy.