### PR TITLE
fix(integrations): Check for 'data' first in closeModal

### DIFF
--- a/src/sentry/static/sentry/app/components/group/pluginActions.jsx
+++ b/src/sentry/static/sentry/app/components/group/pluginActions.jsx
@@ -81,7 +81,7 @@ const PluginActions = createReactClass({
 
   closeModal(data) {
     this.setState({
-      issue: data.id && data.link ? {issue_id: data.id, url: data.link} : null,
+      issue: data && data.id && data.link ? {issue_id: data.id, url: data.link} : null,
       showModal: false,
     });
   },

--- a/src/sentry/static/sentry/app/components/group/pluginActions.jsx
+++ b/src/sentry/static/sentry/app/components/group/pluginActions.jsx
@@ -108,7 +108,6 @@ const PluginActions = createReactClass({
           show={this.state.showModal}
           onHide={this.closeModal}
           animation={false}
-          backdrop="static"
           enforceFocus={false}
         >
           <Modal.Header closeButton>


### PR DESCRIPTION
This makes it so you can click outside the modal and it'll close it, we made this change for the new integrations, but not for the old ones: https://github.com/getsentry/sentry/pull/9243/commits/fab5c2771634e2dbd606177f3a5b11600ac44935

Once this is the case, `data` in `closeModal` can be `undefined`. I'm not sure how people were getting in that state before, but basically the modal was closing without it being from explicitly closing it or from successfully creating/linking an issue.

FIXES [JAVASCRIPT-45Y](https://sentry.io/sentry/javascript/issues/635880167/)