### PR TITLE
fix(integrations): Pass through label for plugin issues

### DIFF
--- a/src/sentry/plugins/bases/issue2.py
+++ b/src/sentry/plugins/bases/issue2.py
@@ -299,6 +299,7 @@ class IssueTrackingPlugin2(Plugin):
         )
         return Response({'issue_url': self.get_issue_url(group, issue),
                          'link': self._get_issue_url_compat(group, issue),
+                         'label': self._get_issue_label_compat(group, issue),
                          'id': issue['id']})
 
     def view_link(self, request, group, **kwargs):
@@ -360,6 +361,7 @@ class IssueTrackingPlugin2(Plugin):
         )
         return Response({'message': 'Successfully linked issue.',
                          'link': self._get_issue_url_compat(group, issue),
+                         'label': self._get_issue_label_compat(group, issue),
                          'id': issue['id']})
 
     def view_unlink(self, request, group, **kwargs):

--- a/src/sentry/static/sentry/app/components/group/pluginActions.jsx
+++ b/src/sentry/static/sentry/app/components/group/pluginActions.jsx
@@ -81,7 +81,10 @@ const PluginActions = createReactClass({
 
   closeModal(data) {
     this.setState({
-      issue: data.id && data.link ? {issue_id: data.id, url: data.link} : null,
+      issue:
+        data.id && data.link
+          ? {issue_id: data.id, url: data.link, label: data.label}
+          : null,
       showModal: false,
     });
   },


### PR DESCRIPTION
Added a label to be passed through here: https://github.com/getsentry/sentry/pull/9647

However, we weren't passing the label through `closeModal` so you would have to refresh the page to see the issue you had just created/linked.

