### PR TITLE
fix(integrations): Limit disabling of plugins to migrating integration

### DIFF
--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -124,8 +124,7 @@ class ExampleIntegrationProvider(IntegrationProvider):
         }]
 
     def post_install(self, integration, organization):
-        installation = self.get_installation(integration, organization.id)
-        PluginMigrator(installation, organization).call()
+        PluginMigrator(integration, organization).call()
 
     def build_integration(self, state):
         return {

--- a/src/sentry/integrations/migrate.py
+++ b/src/sentry/integrations/migrate.py
@@ -5,14 +5,6 @@ from sentry.plugins import plugins
 from sentry.utils.cache import memoize
 
 
-DISABLEABLE_PLUGINS = (
-    'vsts',
-    'bitbucket',
-    'github',
-    'example',  # Tests
-)
-
-
 class PluginMigrator(object):
     def __init__(self, integration, organization):
         self.integration = integration
@@ -21,7 +13,7 @@ class PluginMigrator(object):
     def call(self):
         for project in self.projects:
             for plugin in plugins.for_project(project):
-                if plugin.slug not in DISABLEABLE_PLUGINS:
+                if plugin.slug != self.integration.provider:
                     continue
 
                 if self.all_repos_migrated(plugin.slug):

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -280,7 +280,7 @@ class VstsIntegrationProvider(IntegrationProvider):
         for repo in repos:
             repo.update(integration_id=integration.id)
 
-        PluginMigrator(installation, organization).call()
+        PluginMigrator(integration, organization).call()
 
     def get_pipeline_views(self):
         identity_pipeline_config = {

--- a/tests/sentry/integrations/test_migrate.py
+++ b/tests/sentry/integrations/test_migrate.py
@@ -22,22 +22,20 @@ class PluginMigratorTest(TestCase):
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
 
-        self.integration = ExampleIntegrationProvider()
+        self.integration = Integration.objects.create(
+            provider=ExampleIntegrationProvider.key,
+        )
 
         self.migrator = PluginMigrator(self.integration, self.organization)
 
     def test_all_repos_migrated(self):
-        integration = Integration.objects.create(
-            provider=ExampleIntegrationProvider.key,
-        )
-
         Repository.objects.create(
             organization_id=self.organization.id,
-            provider=self.integration.key,
-            integration_id=integration.id,
+            provider=self.integration.provider,
+            integration_id=self.integration.id,
         )
 
-        assert self.migrator.all_repos_migrated(self.integration.key)
+        assert self.migrator.all_repos_migrated(self.integration.provider)
 
     def test_disable_for_all_projects(self):
         plugin = plugins.get('example')


### PR DESCRIPTION
there was some inconsistency as to what was being passed as the `integration` arg -- in tests it was an `IntegrationProvider` instance, for bitbucket and vsts it was an instance of the `Integration` non-model class (what we've been referring to as "installation". In this pr, i made it the `Integration` model https://github.com/getsentry/sentry/pull/9639 because that's what I thought it referred to. 

Anyway, didn't matter as it wasn't in use until now, but I made it consistently the integration model, so lmk if anyone is opposed to that