### PR TITLE
feat(discover): Limit array field conditions to = and !=

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/conditions/condition.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/conditions/condition.jsx
@@ -5,7 +5,7 @@ import {t} from 'app/locale';
 import SelectControl from 'app/components/forms/selectControl';
 
 import {getInternal, getExternal, isValidCondition} from './utils';
-import {CONDITION_OPERATORS} from '../data';
+import {CONDITION_OPERATORS, ARRAY_FIELD_PREFIXES} from '../data';
 import {PlaceholderText} from '../styles';
 
 export default class Condition extends React.Component {
@@ -65,9 +65,15 @@ export default class Condition extends React.Component {
     return CONDITION_OPERATORS.filter(operator => {
       if (colType === 'number') {
         return !stringOnlyOperators.has(operator);
-      } else {
-        return !numberOnlyOperators.has(operator);
       }
+
+      // We currently only support = and != on array fields
+      if (ARRAY_FIELD_PREFIXES.some(prefix => colName.startsWith(prefix))) {
+        return ['=', '!='].includes(operator);
+      }
+
+      // Treat everything else like a string
+      return !numberOnlyOperators.has(operator);
     });
   }
 

--- a/src/sentry/static/sentry/app/views/organizationDiscover/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/data.jsx
@@ -1,4 +1,4 @@
-const PROMOTED_TAGS = [
+export const PROMOTED_TAGS = [
   {name: 'tags[level]', type: 'string'},
   {name: 'tags[logger]', type: 'string'},
   {name: 'tags[server_name]', type: 'string'},
@@ -19,7 +19,7 @@ const PROMOTED_TAGS = [
   {name: 'tags[sentry:release]', type: 'string'},
 ];
 
-const COLUMNS = [
+export const COLUMNS = [
   {name: 'event_id', type: 'string'},
   {name: 'project_id', type: 'string'},
   {name: 'platform', type: 'string'},
@@ -69,7 +69,7 @@ const COLUMNS = [
   {name: 'exception_frames.stack_level', type: 'string'},
 ];
 
-const CONDITION_OPERATORS = [
+export const CONDITION_OPERATORS = [
   '>',
   '<',
   '>=',
@@ -83,6 +83,6 @@ const CONDITION_OPERATORS = [
   'NOT LIKE',
 ];
 
-const NUMBER_OF_SERIES_BY_DAY = 10;
+export const ARRAY_FIELD_PREFIXES = ['exception_stacks', 'exception_frames'];
 
-export {COLUMNS, PROMOTED_TAGS, CONDITION_OPERATORS, NUMBER_OF_SERIES_BY_DAY};
+export const NUMBER_OF_SERIES_BY_DAY = 10;

--- a/tests/js/spec/views/organizationDiscover/conditions/condition.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/conditions/condition.spec.jsx
@@ -27,7 +27,11 @@ describe('Condition', function() {
   describe('filterOptions()', function() {
     let wrapper;
     beforeEach(function() {
-      const columns = [{name: 'col1', type: 'string'}, {name: 'col2', type: 'number'}];
+      const columns = [
+        {name: 'col1', type: 'string'},
+        {name: 'col2', type: 'number'},
+        {name: 'exception_stacks.type', type: 'string'},
+      ];
       wrapper = mount(
         <Condition value={[null, null, null]} onChange={jest.fn()} columns={columns} />
       );
@@ -49,6 +53,13 @@ describe('Condition', function() {
       const options = wrapper.instance().filterOptions([], 'col2');
       expect(options).toHaveLength(8);
       expect(options[0]).toEqual({value: 'col2 >', label: 'col2 >'});
+    });
+
+    it('limits operators to = and != for array fields', function() {
+      const options = wrapper.instance().filterOptions([], 'exception_stacks.type');
+      expect(options).toHaveLength(2);
+      expect(options[0].value).toEqual('exception_stacks.type =');
+      expect(options[1].value).toEqual('exception_stacks.type !=');
     });
   });
 


### PR DESCRIPTION
We're using has() functions for = and != but not handling any other functions with array fields for now