### PR TITLE
fix(alerts): resolve double-border issues 

### DIFF
--- a/src/sentry/static/sentry/app/components/panels/panelAlert.jsx
+++ b/src/sentry/static/sentry/app/components/panels/panelAlert.jsx
@@ -15,7 +15,7 @@ const DEFAULT_ICONS = {
 const PanelAlert = styled(({type, icon, ...props}) => (
   <Alert {...props} icon={icon || DEFAULT_ICONS[type]} type={type} />
 ))`
-  margin-bottom: ${p => p.mb || 0};
+  margin: -1px;
   border-radius: 0;
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/organizationAuth/organizationAuthList.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuth/organizationAuthList.jsx
@@ -32,7 +32,7 @@ class OrganizationAuthList extends React.Component {
         <Panel>
           <PanelHeader>{t('Choose a provider')}</PanelHeader>
           <PanelBody>
-            <PanelAlert m={0} mb={0} type="info">
+            <PanelAlert type="info">
               {tct(
                 `Get started with Single Sign-on for your organization by
                 selecting a provider. Read more in our [link:SSO documentation].`,

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
@@ -210,7 +210,7 @@ class KeyRateLimitsForm extends React.Component {
             </PanelBody>
           ) : (
             <PanelBody>
-              <PanelAlert type="info" icon="icon-circle-exclamation" m={0} mb={0}>
+              <PanelAlert type="info" icon="icon-circle-exclamation">
                 {t(
                   'Rate limits provide a flexible way to manage your event volume. If you have a noisy project or environment you can configure a rate limit for this key to reduce the number of events processed.'
                 )}
@@ -406,7 +406,7 @@ const KeySettings = createReactClass({
         <Panel>
           <PanelHeader>{t('Credentials')}</PanelHeader>
           <PanelBody>
-            <PanelAlert type="info" icon="icon-circle-exclamation" m={0} mb={0}>
+            <PanelAlert type="info" icon="icon-circle-exclamation">
               {t(
                 'Your credentials are coupled to a public and secret key. Different clients will require different credentials, so make sure you check the documentation before plugging things in.'
               )}

--- a/src/sentry/static/sentry/app/views/settings/project/projectServiceHookDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectServiceHookDetails.jsx
@@ -148,7 +148,7 @@ export default class ProjectServiceHookDetails extends AsyncView {
         <Panel>
           <PanelHeader>{t('Event Validation')}</PanelHeader>
           <PanelBody>
-            <PanelAlert type="info" icon="icon-circle-exclamation" m={0} mb={0}>
+            <PanelAlert type="info" icon="icon-circle-exclamation">
               Sentry will send the <code>X-ServiceHook-Signature</code> header built using{' '}
               <code>HMAC(SHA256, [secret], [payload])</code>. You should always verify
               this signature before trusting the information provided in the webhook.

--- a/src/sentry/static/sentry/app/views/settings/project/projectServiceHooks.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectServiceHooks.jsx
@@ -122,7 +122,7 @@ export default class ProjectServiceHooks extends AsyncView {
       <React.Fragment>
         <PanelHeader key={'header'}>{t('Service Hook')}</PanelHeader>
         <PanelBody key={'body'}>
-          <PanelAlert type="info" icon="icon-circle-exclamation" m={0} mb={0}>
+          <PanelAlert type="info" icon="icon-circle-exclamation">
             Service Hooks are an early adopter preview feature and will change in the
             future.
           </PanelAlert>

--- a/tests/js/spec/views/settings/__snapshots__/organizationAuthList.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationAuthList.spec.jsx.snap
@@ -17,8 +17,6 @@ exports[`OrganizationAuthList renders 1`] = `
       flex={false}
     >
       <PanelAlert
-        m={0}
-        mb={0}
         type="info"
       >
         <span
@@ -92,8 +90,6 @@ exports[`OrganizationAuthList renders with no providers 1`] = `
       flex={false}
     >
       <PanelAlert
-        m={0}
-        mb={0}
         type="info"
       >
         <span


### PR DESCRIPTION
I accidentally removed the `-1px` margin on `PanelAlert`:

![image](https://user-images.githubusercontent.com/435981/45248963-f6e3d900-b2cc-11e8-948f-79c23b48697a.png)

We had a lot of complicated logic around `PanelAlert` margins, which we then had to factor the `-1px` margin into. But the thing is... we never had a margin other than 0 (plus the -1) applied to it. 

So I just removed everything. If you wanna add or remove margin from it use composition (`styled(PanelAlert)`) and Chrissy will shower you in money.

![image](https://user-images.githubusercontent.com/435981/45248989-47f3cd00-b2cd-11e8-91ad-094415a470bd.png)
