### PR TITLE
feat(saved-searches): Allow users to delete their searches

### DIFF
--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -92,7 +92,8 @@ class RelaxedSearchPermission(ProjectPermission):
         # members can do writes
         'POST': ['project:write', 'project:admin', 'project:read'],
         'PUT': ['project:write', 'project:admin', 'project:read'],
-        'DELETE': ['project:admin'],
+        # members can delete their own searches
+        'DELETE': ['project:read', 'project:write', 'project:admin'],
     }
 
 

--- a/src/sentry/api/endpoints/project_search_details.py
+++ b/src/sentry/api/endpoints/project_search_details.py
@@ -119,6 +119,14 @@ class ProjectSearchDetailsEndpoint(ProjectEndpoint):
         except SavedSearch.DoesNotExist:
             raise ResourceDoesNotExist
 
-        search.delete()
+        is_search_owner = request.user and request.user == search.owner
 
-        return Response(status=204)
+        if request.access.has_scope('project:write'):
+            if not search.owner or is_search_owner:
+                search.delete()
+                return Response(status=204)
+        elif is_search_owner:
+            search.delete()
+            return Response(status=204)
+
+        return Response(status=403)

--- a/src/sentry/static/sentry/app/views/projectSavedSearches.jsx
+++ b/src/sentry/static/sentry/app/views/projectSavedSearches.jsx
@@ -52,6 +52,7 @@ class SavedSearchRow extends React.Component {
 
   render() {
     let {data, canModify} = this.props;
+    let deleteDisabled = !canModify && !data.isPrivate;
 
     return (
       <PanelItem p={0} py={2} align="center">
@@ -76,20 +77,20 @@ class SavedSearchRow extends React.Component {
                 name="default"
                 checked={data.isDefault}
                 onChange={this.handleDefault}
+                disabled={data.isPrivate}
               />
             </InputColumn>
           )}
 
-          {canModify && (
-            <InputColumn>
-              <Confirm
-                message={t('Are you sure you want to remove this?')}
-                onConfirm={this.handleRemove}
-              >
-                <Button size="small" icon="icon-trash" />
-              </Confirm>
-            </InputColumn>
-          )}
+          <InputColumn>
+            <Confirm
+              message={t('Are you sure you want to remove this?')}
+              onConfirm={this.handleRemove}
+              disabled={deleteDisabled}
+            >
+              <Button size="small" icon="icon-trash" />
+            </Confirm>
+          </InputColumn>
         </Flex>
       </PanelItem>
     );
@@ -226,7 +227,7 @@ class ProjectSavedSearches extends AsyncView {
               <Flex flex="1">
                 <InputColumn>{t('My Default')}</InputColumn>
                 {canModify && <InputColumn>{t('Team Default')}</InputColumn>}
-                {canModify && <InputColumn>{t('Remove')}</InputColumn>}
+                {<InputColumn>{t('Remove')}</InputColumn>}
               </Flex>
             </Flex>
           </PanelHeader>

--- a/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
@@ -322,6 +322,7 @@ exports[`ProjectSavedSearches renders 1`] = `
                                       >
                                         <input
                                           checked={true}
+                                          disabled={false}
                                           name="default"
                                           onChange={[Function]}
                                           type="radio"
@@ -348,6 +349,7 @@ exports[`ProjectSavedSearches renders 1`] = `
                                           cancelText="Cancel"
                                           confirmText="Confirm"
                                           disableConfirmButton={false}
+                                          disabled={false}
                                           message="Are you sure you want to remove this?"
                                           onConfirm={[Function]}
                                           priority="primary"
@@ -658,6 +660,7 @@ exports[`ProjectSavedSearches renders 1`] = `
                                       >
                                         <input
                                           checked={false}
+                                          disabled={false}
                                           name="default"
                                           onChange={[Function]}
                                           type="radio"
@@ -684,6 +687,7 @@ exports[`ProjectSavedSearches renders 1`] = `
                                           cancelText="Cancel"
                                           confirmText="Confirm"
                                           disableConfirmButton={false}
+                                          disabled={false}
                                           message="Are you sure you want to remove this?"
                                           onConfirm={[Function]}
                                           priority="primary"


### PR DESCRIPTION
- Allow members without `project:write` permissions to delete searches they created
- Prevent owners from setting personal searches as team defaults

Follow-up to #9539. Fixes #6051

<img width="913" alt="screen shot 2018-09-08 at 2 48 09 pm" src="https://user-images.githubusercontent.com/16394317/45258946-d708ef80-b376-11e8-8c0a-72f7b938f16d.png">