### PR TITLE
fix: Revert "Temporarily disable cleanup for tagstore v2 #7505" (#9073)

### DIFF
--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -83,8 +83,13 @@ class V2TagStorage(TagStorage):
         self.setup_receivers()
 
     def setup_cleanup(self):
-        # TODO: fix for sharded DB
-        pass
+        from sentry.runner.commands import cleanup
+
+        cleanup.EXTRA_BULK_QUERY_DELETES += [
+            (models.GroupTagValue, 'last_seen', None),
+            (models.TagValue, 'last_seen', None),
+            (models.EventTag, 'date_added', 'date_added', 50000),
+        ]
 
     def setup_deletions(self):
         from sentry.deletions import default_manager as deletion_manager


### PR DESCRIPTION
This should work now (once we're happy with the Citus upgrade).

Do we also want to *remove* the tagstore v2 models from being part of the app-level cascading deletes? Or will bulk deleting them make Groups move along fast enough without?