### PR TITLE
feat(charts): Fix PieChart colors

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/pieChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/pieChart.jsx
@@ -1,9 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import theme from 'app/utils/theme';
+
+import BaseChart from './baseChart';
 import Legend from './components/legend';
 import PieSeries from './series/pieSeries';
-import BaseChart from './baseChart';
 
 class PieChart extends React.Component {
   static propTypes = {
@@ -96,6 +98,11 @@ class PieChart extends React.Component {
       <BaseChart
         ref={this.chart}
         onChartReady={this.handleChartReady}
+        colors={
+          firstSeries &&
+          firstSeries.data &&
+          theme.charts.getColorPalette(firstSeries.data.length)
+        }
         onEvents={{
           // when legend highlights it does NOT pass dataIndex :(
           highlight: ({name}) => {

--- a/src/sentry/static/sentry/app/sentryTypes.jsx
+++ b/src/sentry/static/sentry/app/sentryTypes.jsx
@@ -308,7 +308,14 @@ export const EChartsSeriesUnit = PropTypes.shape({
   showSymbol: PropTypes.bool,
   name: PropTypes.string,
   data: PropTypes.arrayOf(
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string]))
+    PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+      // e.g. PieCharts
+      PropTypes.shape({
+        name: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+        value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+      }),
+    ])
   ),
 });
 


### PR DESCRIPTION
Since pie charts do not support multiple series, we must base the colors on
the length of data points in the first series.