### PR TITLE
ref(integrations): Add logging to repo migrate task

### DIFF
--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import logging
+
 from sentry import analytics, features
 from sentry.models import (
     ExternalIssue, Group, GroupLink, GroupStatus, Integration, Organization, Repository, User
@@ -7,6 +9,8 @@ from sentry.models import (
 from sentry.integrations.exceptions import IntegrationError
 from sentry.integrations.migrate import PluginMigrator
 from sentry.tasks.base import instrumented_task, retry
+
+logger = logging.getLogger('sentry.tasks.integrations')
 
 
 @instrumented_task(
@@ -173,6 +177,14 @@ def migrate_repo(repo_id, integration_id, organization_id):
     if installation.has_repo_access(repo):
         repo.integration_id = integration_id
         repo.save()
+        logger.info(
+            'repo.migrated',
+            extra={
+                'integration_id': integration_id,
+                'organization_id': organization_id,
+                'repo_id': repo.id,
+            }
+        )
 
         PluginMigrator(
             integration,


### PR DESCRIPTION
we definitely need logging in other places too, but i kind of wanted to get this in before starting up a bunch of the migrations that didn't complete juuust in case