### PR TITLE
feat(integrations): Gitlab on Prem Client

### DIFF
--- a/src/sentry/identity/gitlab/provider.py
+++ b/src/sentry/identity/gitlab/provider.py
@@ -2,16 +2,12 @@ from __future__ import absolute_import
 
 from sentry import http
 from sentry.identity.oauth2 import OAuth2Provider
-from sentry.integrations.gitlab.client import GitLabApiClientPath
 
 
 def get_user_info(access_token, installation_data):
     session = http.build_session()
     resp = session.get(
-        GitLabApiClientPath.build_api_url(
-            base_url=installation_data['url'],
-            path=GitLabApiClientPath.user,
-        ),
+        u'{}/api/v4/user'.format(installation_data['url']),
         headers={
             'Accept': 'application/json',
             'Authorization': 'Bearer %s' % access_token,

--- a/src/sentry/identity/gitlab/provider.py
+++ b/src/sentry/identity/gitlab/provider.py
@@ -2,12 +2,16 @@ from __future__ import absolute_import
 
 from sentry import http
 from sentry.identity.oauth2 import OAuth2Provider
+from sentry.integrations.gitlab.client import GitLabApiClientPath
 
 
 def get_user_info(access_token, installation_data):
     session = http.build_session()
     resp = session.get(
-        u'{}/api/v4/user'.format(installation_data['url']),
+        GitLabApiClientPath.build_api_url(
+            base_url=installation_data['url'],
+            path=GitLabApiClientPath.user,
+        ),
         headers={
             'Accept': 'application/json',
             'Authorization': 'Bearer %s' % access_token,

--- a/src/sentry/identity/gitlab/provider.py
+++ b/src/sentry/identity/gitlab/provider.py
@@ -7,7 +7,7 @@ from sentry.identity.oauth2 import OAuth2Provider
 def get_user_info(access_token, installation_data):
     session = http.build_session()
     resp = session.get(
-        u'https://{}/api/v4/user'.format(installation_data['url']),
+        u'{}/api/v4/user'.format(installation_data['url']),
         headers={
             'Accept': 'application/json',
             'Authorization': 'Bearer %s' % access_token,

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -5,65 +5,99 @@ from six.moves.urllib.parse import quote
 from sentry.integrations.client import ApiClient, OAuth2RefreshMixin
 from sentry.integrations.exceptions import ApiError
 
+API_VERSION = '/api/v4'
+
+
+def build_api_url(base_url, api, path):
+    return u'{base_url}{api}{path}'.format(
+        base_url=base_url,
+        api=api,
+        path=path,
+    )
+
+
+class GitLabApiClientPath(object):
+    issue = u'/projects/{project}/issues/{issue}'
+    issues = u'/projects/{project}/issues'
+    members = u'/projects/{project}/members'
+    notes = u'/projects/{project}/issues/{issue}/notes'
+    project = u'/projects/{project}'
+    user = u'/user'
+
 
 class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
-    api_version = '/v4/'
 
-    def __init__(self, base_url, access_token):
-        self.base_url = base_url
-        self.access_token = access_token
+    def __init__(self, installation):
+        self.installation = installation
+        verify_ssl = self.metadata['verify_ssl']
+        super(GitLabApiClient, self).__init__(verify_ssl)
+
+    @property
+    def identity(self):
+        return self.installation.default_identity
+
+    @property
+    def metadata(self):
+        return self.installation.model.metadata
 
     def request(self, method, path, data=None, params=None, api_preview=False):
-        self.check_auth(redirect_url=self.oauth_redirect_url)
+        # TODO(lb): Refresh auth
+        # self.check_auth(redirect_url=self.oauth_redirect_url)
+        access_token = self.identity.data['access_token']
         headers = {
-            'Authorization': u'Bearer {}'.format(self.identity.data['access_token'])
+            'Authorization': u'Bearer {}'.format(access_token)
         }
-        return self._request(method, '%s%s' % (self.api_version, path),
-                             headers=headers, data=data, params=params)
+        return self._request(
+            method,
+            build_api_url(
+                self.metadata['base_url'],
+                API_VERSION,
+                path
+            ),
+            headers=headers, data=data, params=params
+        )
 
     def get_user(self):
-        return self.request('GET', '/user')
+        return self.get(GitLabApiClientPath.user)
 
-    def get_project(self, repo):
-        return self.request('GET', '/projects/{}'.format(quote(repo, safe='')))
+    def get_project(self, project):
+        return self.get(
+            GitLabApiClientPath.project.format(
+                project=quote(project, safe='')
+            )
+        )
 
-    def get_issue(self, repo, issue_id):
+    def get_issue(self, project, issue_id):
         try:
-            return self.request(
-                'GET',
-                '/projects/{}/issues/{}'.format(
-                    quote(repo, safe=''),
-                    issue_id
+            return self.get(
+                GitLabApiClientPath.issue.format(
+                    project=quote(project, safe=''),
+                    issue=issue_id
                 )
             )
         except IndexError:
             raise ApiError('Issue not found with ID', 404)
 
-    def create_issue(self, repo, data):
-        return self.request(
-            'POST',
-            '/projects/{}/issues'.format(quote(repo, safe='')),
-            data=data,
-        )
-
-    def create_note(self, repo, issue_iid, data):
-        return self.request(
-            'POST',
-            '/projects/{}/issues/{}/notes'.format(
-                quote(repo, safe=''),
-                issue_iid,
+    def create_issue(self, project, data):
+        return self.post(
+            GitLabApiClientPath.issues.format(
+                project=quote(project, safe='')
             ),
             data=data,
         )
 
-    def list_project_members(self, repo):
-        return self.request(
-            'GET',
-            '/projects/{}/members'.format(quote(repo, safe='')),
+    def create_note(self, project, issue_iid, data):
+        return self.post(
+            GitLabApiClientPath.notes.format(
+                project=quote(project, safe=''),
+                issue=issue_iid,
+            ),
+            data=data,
         )
 
-    def search_repositories(self, repo):
-        pass
-
-    def search_issues(self, repo):
-        pass
+    def list_project_members(self, project):
+        return self.get(
+            GitLabApiClientPath.members.format(
+                project=quote(project, safe='')
+            ),
+        )

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -1,0 +1,79 @@
+from __future__ import absolute_import
+
+from requests.exceptions import HTTPError
+from six.moves.urllib.parse import quote
+from sentry.http import build_session
+
+from sentry.integrations.client import ApiClient, OAuth2RefreshMixin
+from sentry.integrations.exceptions import ApiError
+
+
+class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
+    def __init__(self, url, token):
+        self.url = url
+        self.token = token
+
+    def request(self, method, path, data=None, params=None):
+        headers = {
+            'Private-Token': self.token,
+        }
+        session = build_session()
+        try:
+            resp = getattr(session, method.lower())(
+                url='{}/api/v4/{}'.format(self.url, path.lstrip('/')),
+                headers=headers,
+                json=data,
+                params=params,
+                allow_redirects=False,
+            )
+            resp.raise_for_status()
+        except HTTPError as e:
+            raise ApiError.from_response(e.response)
+        return resp.json()
+
+    def auth(self):
+        return self.request('GET', '/user')
+
+    def get_project(self, repo):
+        return self.request('GET', '/projects/{}'.format(quote(repo, safe='')))
+
+    def get_issue(self, repo, issue_id):
+        try:
+            return self.request(
+                'GET',
+                '/projects/{}/issues/{}'.format(
+                    quote(repo, safe=''),
+                    issue_id
+                )
+            )
+        except IndexError:
+            raise ApiError('Issue not found with ID', 404)
+
+    def create_issue(self, repo, data):
+        return self.request(
+            'POST',
+            '/projects/{}/issues'.format(quote(repo, safe='')),
+            data=data,
+        )
+
+    def create_note(self, repo, issue_iid, data):
+        return self.request(
+            'POST',
+            '/projects/{}/issues/{}/notes'.format(
+                quote(repo, safe=''),
+                issue_iid,
+            ),
+            data=data,
+        )
+
+    def list_project_members(self, repo):
+        return self.request(
+            'GET',
+            '/projects/{}/members'.format(quote(repo, safe='')),
+        )
+
+    def search_repositories(self, repo):
+        pass
+
+    def search_issues(self, repo):
+        pass

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -5,24 +5,25 @@ from six.moves.urllib.parse import quote
 from sentry.integrations.client import ApiClient, OAuth2RefreshMixin
 from sentry.integrations.exceptions import ApiError
 
-API_VERSION = '/api/v4'
-
-
-def build_api_url(base_url, path):
-    return u'{base_url}{api}{path}'.format(
-        base_url=base_url,
-        api=API_VERSION,
-        path=path,
-    )
+API_VERSION = u'/api/v4'
 
 
 class GitLabApiClientPath(object):
+    group = u'/groups/{group}'
     issue = u'/projects/{project}/issues/{issue}'
     issues = u'/projects/{project}/issues'
     members = u'/projects/{project}/members'
     notes = u'/projects/{project}/issues/{issue}/notes'
     project = u'/projects/{project}'
     user = u'/user'
+
+    @staticmethod
+    def build_api_url(base_url, path):
+        return u'{base_url}{api}{path}'.format(
+            base_url=base_url,
+            api=API_VERSION,
+            path=path,
+        )
 
 
 class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
@@ -49,7 +50,7 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
         }
         return self._request(
             method,
-            build_api_url(
+            GitLabApiClientPath.build_api_url(
                 self.metadata['base_url'],
                 path
             ),

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -8,10 +8,10 @@ from sentry.integrations.exceptions import ApiError
 API_VERSION = '/api/v4'
 
 
-def build_api_url(base_url, api, path):
+def build_api_url(base_url, path):
     return u'{base_url}{api}{path}'.format(
         base_url=base_url,
-        api=api,
+        api=API_VERSION,
         path=path,
     )
 
@@ -51,7 +51,6 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
             method,
             build_api_url(
                 self.metadata['base_url'],
-                API_VERSION,
                 path
             ),
             headers=headers, data=data, params=params

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -13,7 +13,7 @@ from sentry.integrations import IntegrationInstallation, IntegrationFeatures, In
 from sentry.pipeline import NestedPipelineView, PipelineView
 from sentry.utils.http import absolute_uri
 
-from .client import GitLabApiClient
+from .client import GitLabApiClient, GitLabApiClientPath
 
 DESCRIPTION = """
 Fill me out
@@ -183,8 +183,12 @@ class GitlabIntegrationProvider(IntegrationProvider):
     def get_group_info(self, access_token, installation_data):
         session = http.build_session()
         resp = session.get(
-            u'{}/api/v4/groups/{}'.format(
-                installation_data['url'], installation_data['group']),
+            GitLabApiClientPath.build_api_url(
+                base_url=installation_data['url'],
+                path=GitLabApiClientPath.group.format(
+                    group=installation_data['group'],
+                )
+            ),
             headers={
                 'Accept': 'application/json',
                 'Authorization': 'Bearer %s' % access_token,

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -99,6 +99,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
             u'icon': u'https://gitlab.example.com/uploads/group/avatar/4/foo.jpg',
             u'domain_name': u'gitlab.example.com/groups/cool-group',
             u'verify_ssl': True,
+            u'base_url': 'https://gitlab.example.com'
         }
         oi = OrganizationIntegration.objects.get(
             integration=integration,


### PR DESCRIPTION
Creates the client for gitlab on prem using much of the previous gitlab plugin's client. It does not currently do refresh auth. That can be covered by a pr to follow. 