### PR TITLE
fix: Better border highlighting for highlighted fields

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldWrapper.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldWrapper.jsx
@@ -16,7 +16,19 @@ const inlineStyle = p =>
 const highlightedStyle = p =>
   p.highlighted
     ? css`
-        outline: 1px solid ${p.theme.purple};
+        position: relative;
+
+        &:after {
+          content: '';
+          display: block;
+          position: absolute;
+          top: -1px;
+          left: -1px;
+          right: -1px;
+          bottom: -1px;
+          border: 1px solid ${p.theme.purple};
+          pointer-events: none;
+        }
       `
     : '';
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1421724/45391387-8fcd6980-b5d7-11e8-983b-7808a49887d0.png)

Now correctly covers up vertical borders

 - Breaks outside of parent elements to ensure top parent element borders are covered.
 - Covers the bottom border.