### PR TITLE
feat(discover): Support relative time ranges in Discover API

### DIFF
--- a/src/sentry/api/endpoints/organization_discover.py
+++ b/src/sentry/api/endpoints/organization_discover.py
@@ -88,7 +88,6 @@ class DiscoverSerializer(serializers.Serializer):
         if has_start != has_end or has_range == has_start:
             raise serializers.ValidationError("Either start and end dates or range is required")
 
-
     def validate(self, data):
         data['arrayjoin'] = self.arrayjoin
 

--- a/src/sentry/api/endpoints/organization_discover.py
+++ b/src/sentry/api/endpoints/organization_discover.py
@@ -86,7 +86,7 @@ class DiscoverSerializer(serializers.Serializer):
         has_range = bool(data.get('range'))
 
         if has_start != has_end or has_range == has_start:
-            raise serializers.ValidationError("Either start and end dates or range is required")
+            raise serializers.ValidationError('Either start and end dates or range is required')
 
     def validate(self, data):
         data['arrayjoin'] = self.arrayjoin
@@ -96,7 +96,12 @@ class DiscoverSerializer(serializers.Serializer):
     def validate_range(self, attrs, source):
         # Populate start and end if only range is provided
         if (attrs.get(source)):
-            attrs['start'] = timezone.now() - parse_stats_period(attrs[source])
+            delta = parse_stats_period(attrs[source])
+
+            if (delta is None):
+                raise serializers.ValidationError('Invalid range')
+
+            attrs['start'] = timezone.now() - delta
             attrs['end'] = timezone.now()
 
         return attrs

--- a/src/sentry/api/endpoints/organization_discover.py
+++ b/src/sentry/api/endpoints/organization_discover.py
@@ -1,12 +1,17 @@
 from __future__ import absolute_import
 
 import re
-
 import six
 
+from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.response import Response
 from rest_framework.exceptions import PermissionDenied
+
+from sentry.utils.dates import (
+    parse_stats_period,
+)
+
 from sentry.api.serializers.rest_framework import ListField
 from sentry.api.bases.organization import OrganizationPermission
 from sentry.api.bases import OrganizationEndpoint
@@ -28,8 +33,9 @@ class DiscoverSerializer(serializers.Serializer):
         required=True,
         allow_null=False,
     )
-    start = serializers.DateTimeField(required=True)
-    end = serializers.DateTimeField(required=True)
+    start = serializers.DateTimeField(required=False)
+    end = serializers.DateTimeField(required=False)
+    range = serializers.CharField(required=False)
     fields = ListField(
         child=serializers.CharField(),
         required=False,
@@ -60,7 +66,9 @@ class DiscoverSerializer(serializers.Serializer):
         self.member = OrganizationMember.objects.get(
             user=self.context['user'], organization=self.context['organization'])
 
-        fields = kwargs['data'].get('fields') or []
+        data = kwargs['data']
+
+        fields = data.get('fields') or []
 
         match = next(
             (
@@ -73,9 +81,26 @@ class DiscoverSerializer(serializers.Serializer):
         )
         self.arrayjoin = match if match else None
 
+        has_start = bool(data.get('start'))
+        has_end = bool(data.get('end'))
+        has_range = bool(data.get('range'))
+
+        if has_start != has_end or has_range == has_start:
+            raise serializers.ValidationError("Either start and end dates or range is required")
+
+
     def validate(self, data):
         data['arrayjoin'] = self.arrayjoin
+
         return data
+
+    def validate_range(self, attrs, source):
+        # Populate start and end if only range is provided
+        if (attrs.get(source)):
+            attrs['start'] = timezone.now() - parse_stats_period(attrs[source])
+            attrs['end'] = timezone.now()
+
+        return attrs
 
     def validate_projects(self, attrs, source):
         organization = self.context['organization']

--- a/src/sentry/api/endpoints/organization_discover.py
+++ b/src/sentry/api/endpoints/organization_discover.py
@@ -81,19 +81,19 @@ class DiscoverSerializer(serializers.Serializer):
         )
         self.arrayjoin = match if match else None
 
-        has_start = bool(data.get('start'))
-        has_end = bool(data.get('end'))
-        has_range = bool(data.get('range'))
-
-        if has_start != has_end or has_range == has_start:
-            raise serializers.ValidationError('Either start and end dates or range is required')
-
     def validate(self, data):
         data['arrayjoin'] = self.arrayjoin
 
         return data
 
     def validate_range(self, attrs, source):
+        has_start = bool(attrs.get('start'))
+        has_end = bool(attrs.get('end'))
+        has_range = bool(attrs.get('range'))
+
+        if has_start != has_end or has_range == has_start:
+            raise serializers.ValidationError('Either start and end dates or range is required')
+
         # Populate start and end if only range is provided
         if (attrs.get(source)):
             delta = parse_stats_period(attrs[source])

--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -8,6 +8,7 @@ sentry.utils.dates
 from __future__ import absolute_import
 
 import six
+import re
 
 from datetime import (
     datetime,
@@ -115,3 +116,19 @@ def parse_timestamp(value):
         except ValueError:
             rv = None
     return rv.replace(tzinfo=pytz.utc)
+
+def parse_stats_period(period):
+    """
+    Convert a value such as 1h into a
+    proper timedelta.
+    """
+    m = re.match('^(\d+)([hdms]?)$', period)
+    if not m:
+        return None
+    value, unit = m.groups()
+    value = int(value)
+    if not unit:
+        unit = 's'
+    return timedelta(**{
+        {'h': 'hours', 'd': 'days', 'm': 'minutes', 's': 'seconds'}[unit]: value,
+    })

--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -117,6 +117,7 @@ def parse_timestamp(value):
             rv = None
     return rv.replace(tzinfo=pytz.utc)
 
+
 def parse_stats_period(period):
     """
     Convert a value such as 1h into a

--- a/tests/sentry/utils/test_dates.py
+++ b/tests/sentry/utils/test_dates.py
@@ -15,6 +15,7 @@ def test_timestamp_conversions():
     assert int(to_timestamp(value)) == int(value.strftime('%s'))
     assert to_datetime(to_timestamp(value)) == value
 
+
 def test_parse_stats_period():
     assert parse_stats_period('3s') == datetime.timedelta(seconds=3)
     assert parse_stats_period('30m') == datetime.timedelta(minutes=30)

--- a/tests/sentry/utils/test_dates.py
+++ b/tests/sentry/utils/test_dates.py
@@ -21,3 +21,5 @@ def test_parse_stats_period():
     assert parse_stats_period('30m') == datetime.timedelta(minutes=30)
     assert parse_stats_period('1h') == datetime.timedelta(hours=1)
     assert parse_stats_period('20d') == datetime.timedelta(days=20)
+    assert parse_stats_period('20f') is None
+    assert parse_stats_period('-1s') is None

--- a/tests/sentry/utils/test_dates.py
+++ b/tests/sentry/utils/test_dates.py
@@ -6,6 +6,7 @@ import pytz
 from sentry.utils.dates import (
     to_datetime,
     to_timestamp,
+    parse_stats_period,
 )
 
 
@@ -13,3 +14,9 @@ def test_timestamp_conversions():
     value = datetime.datetime(2015, 10, 1, 21, 19, 5, 648517, tzinfo=pytz.utc)
     assert int(to_timestamp(value)) == int(value.strftime('%s'))
     assert to_datetime(to_timestamp(value)) == value
+
+def test_parse_stats_period():
+    assert parse_stats_period('3s') == datetime.timedelta(seconds=3)
+    assert parse_stats_period('30m') == datetime.timedelta(minutes=30)
+    assert parse_stats_period('1h') == datetime.timedelta(hours=1)
+    assert parse_stats_period('20d') == datetime.timedelta(days=20)

--- a/tests/snuba/test_organization_discover.py
+++ b/tests/snuba/test_organization_discover.py
@@ -107,6 +107,18 @@ class OrganizationDiscoverTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 400, response.content
 
+    def test_invalid_range_value(self):
+        with self.feature('organizations:discover'):
+            url = reverse('sentry-api-0-organization-discover', args=[self.org.slug])
+            response = self.client.post(url, {
+                'projects': [self.project.id],
+                'fields': ['message', 'platform'],
+                'range': '1x',
+                'orderby': '-timestamp',
+            })
+
+        assert response.status_code == 400, response.content
+
     def test_boolean_condition(self):
         with self.feature('organizations:discover'):
             url = reverse('sentry-api-0-organization-discover', args=[self.org.slug])

--- a/tests/snuba/test_organization_discover.py
+++ b/tests/snuba/test_organization_discover.py
@@ -93,6 +93,20 @@ class OrganizationDiscoverTest(APITestCase, SnubaTestCase):
         assert response.data['data'][0]['message'] == 'message!'
         assert response.data['data'][0]['platform'] == 'python'
 
+    def test_invalid_date_request(self):
+        with self.feature('organizations:discover'):
+            url = reverse('sentry-api-0-organization-discover', args=[self.org.slug])
+            response = self.client.post(url, {
+                'projects': [self.project.id],
+                'fields': ['message', 'platform'],
+                'range': '1d',
+                'start': (datetime.now() - timedelta(seconds=10)).strftime('%Y-%m-%dT%H:%M:%S'),
+                'end': (datetime.now()).strftime('%Y-%m-%dT%H:%M:%S'),
+                'orderby': '-timestamp',
+            })
+
+        assert response.status_code == 400, response.content
+
     def test_boolean_condition(self):
         with self.feature('organizations:discover'):
             url = reverse('sentry-api-0-organization-discover', args=[self.org.slug])
@@ -101,7 +115,7 @@ class OrganizationDiscoverTest(APITestCase, SnubaTestCase):
                 'fields': ['message', 'platform', 'exception_frames.in_app'],
                 'conditions': [['exception_frames.in_app', '=', True]],
                 'start': (datetime.now() - timedelta(seconds=10)).strftime('%Y-%m-%dT%H:%M:%S'),
-                'end': (datetime.now() + timedelta(seconds=10)).strftime('%Y-%m-%dT%H:%M:%S'),
+                'end': (datetime.now()).strftime('%Y-%m-%dT%H:%M:%S'),
                 'orderby': '-timestamp',
             })
 
@@ -132,7 +146,7 @@ class OrganizationDiscoverTest(APITestCase, SnubaTestCase):
                 'conditions': [['exception_stacks.type', '=', 'ValidationError']],
                 'fields': ['message'],
                 'start': (datetime.now() - timedelta(seconds=10)).strftime('%Y-%m-%dT%H:%M:%S'),
-                'end': (datetime.now() + timedelta(seconds=10)).strftime('%Y-%m-%dT%H:%M:%S'),
+                'end': (datetime.now()).strftime('%Y-%m-%dT%H:%M:%S'),
                 'orderby': '-timestamp',
             })
         assert response.status_code == 200, response.content
@@ -146,7 +160,7 @@ class OrganizationDiscoverTest(APITestCase, SnubaTestCase):
                 'conditions': [['exception_stacks.type', '!=', 'ValidationError']],
                 'fields': ['message'],
                 'start': (datetime.now() - timedelta(seconds=10)).strftime('%Y-%m-%dT%H:%M:%S'),
-                'end': (datetime.now() + timedelta(seconds=10)).strftime('%Y-%m-%dT%H:%M:%S'),
+                'end': (datetime.now()).strftime('%Y-%m-%dT%H:%M:%S'),
                 'orderby': '-timestamp',
             })
 


### PR DESCRIPTION
We want to support relative date ranges (e.g. `1s`, `2m`, `3h`, `4d`) as well as absolute datetimes in the discover API