### PR TITLE
fix(integrations): Add logging to PluginMigrator

### DIFF
--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -6,7 +6,7 @@ from sentry.integrations import (
 )
 from sentry.integrations.exceptions import IntegrationError
 from sentry.integrations.issues import IssueSyncMixin
-from sentry.integrations.migrate import PluginMigrator
+from sentry.mediators.plugins import Migrator
 from sentry.pipeline import PipelineView
 
 
@@ -124,7 +124,10 @@ class ExampleIntegrationProvider(IntegrationProvider):
         }]
 
     def post_install(self, integration, organization):
-        PluginMigrator(integration, organization).call()
+        Migrator.run(
+            integration=integration,
+            organization=organization
+        )
 
     def build_integration(self, state):
         return {

--- a/src/sentry/mediators/plugins/__init__.py
+++ b/src/sentry/mediators/plugins/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+
+from .migrator import Migrator  # NOQA

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -7,7 +7,7 @@ from sentry.models import (
     ExternalIssue, Group, GroupLink, GroupStatus, Integration, Organization, Repository, User
 )
 from sentry.integrations.exceptions import IntegrationError
-from sentry.integrations.migrate import PluginMigrator
+from sentry.mediators.plugins import Migrator
 from sentry.tasks.base import instrumented_task, retry
 
 logger = logging.getLogger('sentry.tasks.integrations')
@@ -199,7 +199,7 @@ def migrate_repo(repo_id, integration_id, organization_id):
             }
         )
 
-        PluginMigrator(
-            integration,
-            Organization.objects.get(id=organization_id),
-        ).call()
+        Migrator.run(
+            integration=integration,
+            organization=Organization.objects.get(id=organization_id),
+        )

--- a/src/sentry/testutils/helpers/faux.py
+++ b/src/sentry/testutils/helpers/faux.py
@@ -1,0 +1,170 @@
+from __future__ import absolute_import
+
+import six
+
+from collections import deque
+
+from sentry.utils.functional import compact
+
+
+class Faux(object):
+    """
+    Convenience functions for testing, and asserting, with ``unittest.mock``
+    objects.
+
+    Usage:
+        >>> with patch('module.ClassName.func') as mock:
+        >>>     ClassName.func('foo', extra={'bar': {'baz': 1}})
+        >>>
+        >>>     assert faux(mock).args == ('foo',)
+        >>>     assert faux(mock).args_contain('foo')
+        >>>     assert faux(mock).kwargs_contain('extra')
+        >>>     assert faux(mock).kwargs_contain('extra.bar')
+        >>>     assert faux(mock).kwarg_equals('extra.bar.baz', 1)
+
+    Dot Notation:
+        Functions that deal with ``kwargs`` will accept a dot notation
+        shorthand for dealing with deeply nested ``dict`` keys.
+
+        >>> with patch('module.ClassName.func') as mock:
+        >>>     ClassName.func('foo', extra={'bar': {'baz': 1}})
+        >>>
+        >>>     assert faux(mock).kwargs_contain('extra.foo.baz')
+        >>>     assert faux(mock).kwarg_equals('extra.foo.baz', 1)
+
+    Multiple Calls
+        By default, ``faux`` will select the last call to a ``mock``. You can
+        specify which call you want by passing the index as a second parameter.
+
+        >>> with patch('module.ClassName.func') as mock:
+        >>>     ClassName.func('foo', extra={'bar': {'baz': 1}})
+        >>>     ClassName.func(None)
+        >>>
+        >>>     assert faux(mock).args == (None,)
+        >>>     assert faux(mock, 0).args == ('foo',)
+    """
+
+    def __init__(self, call):
+        self.call = call
+
+    @property
+    def args(self):
+        return self.call[1]
+
+    @property
+    def kwargs(self):
+        return self.call[2]
+
+    def called_with(self, *args, **kwargs):
+        if self.args == tuple(args) and self.kwargs == kwargs:
+            return True
+
+        raise AssertionError(
+            u'Expected to be called with {}. Received {}.'.format(
+                self._invocation_to_s(*args, **kwargs),
+                self._invocation_to_s(*self.args, **self.kwargs),
+            )
+        )
+
+    def kwargs_contain(self, key):
+        if self._kwarg_exists(key):
+            return True
+
+        raise AssertionError(
+            u'Expected kwargs to contain key \'{}\'. Received ({}).'.format(
+                key,
+                self._kwargs_to_s(**self.kwargs),
+            ),
+        )
+
+    def kwarg_equals(self, key, expected):
+        if self._kwarg_value(key) == expected:
+            return True
+
+        raise AssertionError(
+            u'Expected kwargs[{}] to equal {!r}. Received {!r}.'.format(
+                key,
+                expected,
+                self._kwarg_value(key),
+            )
+        )
+
+    def args_contain(self, value):
+        if value in self.args:
+            return True
+
+        raise AssertionError(
+            u'Expected args to contain {!r}. Received ({}).'.format(
+                value,
+                self._args_to_s(*self.args),
+            ),
+        )
+
+    def args_equals(self, *args):
+        if self.args == tuple(args):
+            return True
+
+        raise AssertionError(
+            u'Expected args to equal ({}). Received ({}).'.format(
+                self._args_to_s(*args),
+                self._args_to_s(*self.args),
+            )
+        )
+
+    def _kwarg_exists(self, key):
+        try:
+            self._kwarg_value(key)
+            return True
+        except (KeyError, TypeError):
+            return False
+
+    def _kwarg_value(self, key):
+        """
+        Support a dot notation shortcut for deeply nested dicts or just look
+        up the value if passed a normal key.
+
+        >>> self.kwargs = {'foo': {'bar': {'baz': 1}}}
+        >>> self._kwarg_value('foo.bar.baz')
+        1
+        >>> self._kwarg_value('foo')
+        {'bar': {'baz': 1}}
+        """
+        if '.' in key:
+            keys = deque(key.split('.'))
+        else:
+            return self.kwargs[key]
+
+        kwarg = dict(self.kwargs)
+
+        while keys:
+            kwarg = kwarg[keys.popleft()]
+
+        return kwarg
+
+    def _invocation_to_s(self, *args, **kwargs):
+        """
+        Convert a function invocation into a pretty printable string.
+        """
+        return u'({})'.format(
+            ', '.join(compact([
+                self._args_to_s(*args),
+                self._kwargs_to_s(**kwargs),
+            ]))
+        )
+
+    def _args_to_s(self, *args):
+        if not len(args):
+            return None
+        return ', '.join(u'{!r}'.format(arg) for arg in args)
+
+    def _kwargs_to_s(self, **kwargs):
+        if not len(kwargs):
+            return None
+        return ', '.join(u'{}={!r}'.format(k, v) for k, v in six.iteritems(kwargs))
+
+
+def faux(mock, call=None):
+    if call is not None:
+        return Faux(mock.mock_calls[call])
+    else:
+        return Faux(mock.mock_calls[-1])

--- a/src/sentry/utils/functional.py
+++ b/src/sentry/utils/functional.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import six
+
 from django.utils.functional import empty
 
 
@@ -39,3 +41,26 @@ def apply_values(function, mapping):
             function(values),
         ),
     )
+
+
+def compact(seq):
+    """
+    Removes ``None`` values from various sequence-based data structures.
+
+    dict:
+        Removes keys with a corresponding ``None`` value.
+
+    list:
+        Removes ``None`` valules.
+
+    >>> compact({'foo': 'bar', 'baz': None})
+    {'foo': 'bar'}
+
+    >>> compact([1, None, 2])
+    [1, 2]
+    """
+    if isinstance(seq, dict):
+        return {k: v for k, v in six.iteritems(seq) if v is not None}
+
+    elif isinstance(seq, list):
+        return [k for k in seq if k is not None]

--- a/tests/sentry/integrations/test_migrate.py
+++ b/tests/sentry/integrations/test_migrate.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from sentry.integrations.example import ExampleIntegrationProvider
-from sentry.integrations.migrate import PluginMigrator
+from sentry.mediators.plugins import Migrator
 from sentry.models import Integration, Repository
 from sentry.plugins import plugins
 from sentry.plugins.bases.issue2 import IssuePlugin2
@@ -15,9 +15,9 @@ class ExamplePlugin(IssuePlugin2):
 plugins.register(ExamplePlugin)
 
 
-class PluginMigratorTest(TestCase):
+class MigratorTest(TestCase):
     def setUp(self):
-        super(PluginMigratorTest, self).setUp()
+        super(MigratorTest, self).setUp()
 
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
@@ -26,7 +26,10 @@ class PluginMigratorTest(TestCase):
             provider=ExampleIntegrationProvider.key,
         )
 
-        self.migrator = PluginMigrator(self.integration, self.organization)
+        self.migrator = Migrator(
+            integration=self.integration,
+            organization=self.organization,
+        )
 
     def test_all_repos_migrated(self):
         Repository.objects.create(
@@ -60,3 +63,9 @@ class PluginMigratorTest(TestCase):
 
         self.migrator.call()
         assert plugin in plugins.for_project(self.project)
+
+    def test_logs(self):
+        Migrator.run(
+            integration=self.integration,
+            organization=self.organization,
+        )

--- a/tests/sentry/integrations/test_pipeline.py
+++ b/tests/sentry/integrations/test_pipeline.py
@@ -210,7 +210,7 @@ class FinishPipelineTestCase(IntegrationTestCase):
         assert org_integration.default_auth_id == old_identity_id
         assert Identity.objects.filter(external_id='AccountId').exists()
 
-    @patch('sentry.integrations.migrate.PluginMigrator.call')
+    @patch('sentry.mediators.plugins.Migrator.call')
     def test_disabled_plugin_when_fully_migrated(self, call, *args):
         Repository.objects.create(
             organization_id=self.organization.id,

--- a/tests/sentry/mediators/test_mediator.py
+++ b/tests/sentry/mediators/test_mediator.py
@@ -4,11 +4,18 @@ import logging
 import six
 import types
 
-from mock import patch
+from mock import patch, PropertyMock
 
 from sentry.mediators import Mediator, Param
 from sentry.models import User
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.faux import faux
+
+
+class Double(object):
+    def __init__(self, **kwargs):
+        for k, v in six.iteritems(kwargs):
+            setattr(self, k, v)
 
 
 class MockMediator(Mediator):
@@ -55,19 +62,60 @@ class TestMediator(TestCase):
 
         mock.assert_called_with(None, extra={'at': 'test'})
 
+    @patch('sentry.app.env', new_callable=PropertyMock(
+        return_value=Double(
+            request=Double(
+                resolver_match=Double(
+                    kwargs={'organization_slug': 'beep'}
+                )
+            )
+        )
+    ))
+    def test_log_with_request_org(self, _):
+        with patch.object(self.logger, 'info') as log:
+            self.mediator.log(at='test')
+            assert faux(log).kwarg_equals('extra.org', 'beep')
+
+    @patch('sentry.app.env', new_callable=PropertyMock(
+        return_value=Double(
+            request=Double(
+                resolver_match=Double(
+                    kwargs={'team_slug': 'foo'}
+                )
+            )
+        )
+    ))
+    def test_log_with_request_team(self, _):
+        with patch.object(self.logger, 'info') as log:
+            self.mediator.log(at='test')
+            assert faux(log).kwarg_equals('extra.team', 'foo')
+
+    @patch('sentry.app.env', new_callable=PropertyMock(
+        return_value=Double(
+            request=Double(
+                resolver_match=Double(
+                    kwargs={'project_slug': 'bar'}
+                )
+            )
+        )
+    ))
+    def test_log_with_request_project(self, _):
+        with patch.object(self.logger, 'info') as log:
+            self.mediator.log(at='test')
+            assert faux(log).kwarg_equals('extra.project', 'bar')
+
     def test_log_start(self):
         with patch.object(self.logger, 'info') as mock:
             self.mediator.call()
 
-        mock.assert_any_call(None, extra={'at': 'start'})
+        assert faux(mock, 0).args_equals(None)
+        assert faux(mock, 0).kwarg_equals('extra.at', 'start')
 
     def test_log_finish(self):
         with patch.object(self.logger, 'info') as mock:
             self.mediator.call()
 
-        call = mock.mock_calls[-1][-1]
-        assert call['extra']['at'] == 'finish'
-        assert 'elapsed' in call['extra']
+        assert faux(mock).kwarg_equals('extra.at', 'finish')
 
     def test_log_exception(self):
         def call(self):
@@ -82,9 +130,8 @@ class TestMediator(TestCase):
             except Exception:
                 pass
 
-        call = mock.mock_calls[-1][-1]
-        assert call['extra']['at'] == 'exception'
-        assert 'elapsed' in call['extra']
+        assert faux(mock).kwarg_equals('extra.at', 'exception')
+        assert faux(mock).kwargs_contain('extra.elapsed')
 
     def test_automatic_transaction(self):
         class TransactionMediator(Mediator):

--- a/tests/sentry/testutils/__init__.py
+++ b/tests/sentry/testutils/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/testutils/helpers/__init__.py
+++ b/tests/sentry/testutils/helpers/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/testutils/helpers/test_faux.py
+++ b/tests/sentry/testutils/helpers/test_faux.py
@@ -1,0 +1,86 @@
+from __future__ import absolute_import
+
+from mock import patch
+
+from sentry.testutils import TestCase
+from sentry.testutils.helpers.faux import faux
+
+
+def fakefunc(*args, **kwargs):
+    pass
+
+
+@patch('tests.sentry.testutils.helpers.test_faux.fakefunc')
+class TestFaux(TestCase):
+    def test_args(self, mock):
+        fakefunc(True)
+        assert faux(mock).args == (True,)
+
+    def test_kwargs(self, mock):
+        fakefunc(foo=1)
+        assert faux(mock).kwargs == {'foo': 1}
+
+    def test_args_and_kwargs(self, mock):
+        fakefunc(True, foo=1)
+        assert faux(mock).args == (True,)
+        assert faux(mock).kwargs == {'foo': 1}
+
+    def test_called_with(self, mock):
+        fakefunc(True, foo=1)
+        assert faux(mock).called_with(True, foo=1)
+
+    def test_called_with_error_message(self, mock):
+        fakefunc(1)
+
+        try:
+            faux(mock).called_with(False)
+        except AssertionError as e:
+            assert e.message == 'Expected to be called with (False). Received (1).'
+
+    def test_kwargs_contain(self, mock):
+        fakefunc(foo=1)
+        assert faux(mock).kwargs_contain('foo')
+
+    def test_kwargs_contain_error_message(self, mock):
+        fakefunc(foo=1)
+
+        try:
+            faux(mock).kwargs_contain('bar')
+        except AssertionError as e:
+            assert e.message == 'Expected kwargs to contain key \'bar\'. Received (foo=1).'
+
+    def test_kwarg_equals(self, mock):
+        fakefunc(foo=1, bar=2)
+        assert faux(mock).kwarg_equals('bar', 2)
+
+    def test_kwarg_equals_error_message(self, mock):
+        fakefunc(foo=1, bar=2)
+
+        try:
+            faux(mock).kwarg_equals('bar', True)
+        except AssertionError as e:
+            assert e.message == 'Expected kwargs[bar] to equal True. Received 2.'
+
+    def test_args_contain(self, mock):
+        fakefunc(1, False, None)
+        assert faux(mock).args_contain(False)
+
+    def test_args_contain_error_message(self, mock):
+        fakefunc(1, None, False)
+
+        try:
+            faux(mock).args_contain(True)
+        except AssertionError as e:
+            assert e.message == 'Expected args to contain True. Received (1, None, False).'
+
+    def test_args_equal(self, mock):
+        fakefunc(1, False, None)
+        assert faux(mock).args_equals(1, False, None)
+
+    def test_args_equal_error_message(self, mock):
+        fakefunc(1, False)
+
+        try:
+            faux(mock).args_equals(['beep'])
+        except AssertionError as e:
+            assert e.message == 'Expected args to equal ([\'beep\']). Received (1, False).'

--- a/tests/sentry/utils/test_functional.py
+++ b/tests/sentry/utils/test_functional.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+from sentry.utils.functional import compact
+from sentry.testutils import TestCase
+
+
+class CompactTest(TestCase):
+    def test_none(self):
+        assert compact({'foo': None, 'bar': 1}) == {'bar': 1}
+
+    def test_zero(self):
+        assert compact({'foo': 0}) == {'foo': 0}
+
+    def test_false(self):
+        assert compact({'foo': False}) == {'foo': False}
+
+    def test_empty_string(self):
+        assert compact({'foo': ''}) == {'foo': ''}


### PR DESCRIPTION
I refactored `PluginMigrator` to be a Mediator. This does two things that will help some of things brought up.

1. Mediators automatically log when they're invoked. We'll see the `org`, `integration` and some other info. I also manually log each `project` and `plugin` that gets disabled.

```
22:31:47 [INFO] sentry.integrations.migrate.PluginMigrator:  (integration_id=3 project=u'integral-muskox' integration_provider=u'example' plugin=u'example' org=u'smiling-grubworm' at=u'disable')
```

2. Mediators validate/check the arguments you invoke them with, via explicit declarations, ensuring they're of some type. The whole `integrations.Integration` vs `models.integration.Integration` confusion should be a little clearer now since this class specifies that it expects a `models.integration.Integration`.

https://github.com/getsentry/sentry/compare/master...mnoble:plugin-migrator-logging?expand=1#diff-06aa808e5867fe47fb24e72cbf907493R10

I also refactored the tests a bit and added some `unittest.mock` helpers.