### PR TITLE
fix: Only enable django admin if it's installed

### DIFF
--- a/src/sentry/conf/urls.py
+++ b/src/sentry/conf/urls.py
@@ -9,6 +9,7 @@ These are additional urls used by the Sentry-provided web server
 """
 from __future__ import absolute_import
 
+from django.conf import settings
 import debug_toolbar
 
 try:
@@ -17,7 +18,6 @@ except ImportError:
     # django < 1.5 compat
     from django.conf.urls.defaults import include, patterns, url  # NOQA
 
-from sentry import django_admin
 from sentry.web.urls import urlpatterns as web_urlpatterns
 from sentry.web.frontend.csrf_failure import CsrfFailureView
 from sentry.web.frontend.error_404 import Error404View
@@ -28,9 +28,14 @@ handler500 = Error500View.as_view()
 
 urlpatterns = patterns(
     '',
-    url(r'^admin/', include(django_admin.site.urls)),
     url(r'^500/', handler500, name='error-500'),
     url(r'^404/', handler404, name='error-404'),
     url(r'^403-csrf-failure/', CsrfFailureView.as_view(), name='error-403-csrf-failure'),
     url(r'^__debug__/', include(debug_toolbar.urls)),
-) + web_urlpatterns
+)
+
+if 'django.contrib.admin' in settings.INSTALLED_APPS:
+    from sentry import django_admin
+    urlpatterns += django_admin.urlpatterns
+
+urlpatterns += web_urlpatterns

--- a/src/sentry/django_admin.py
+++ b/src/sentry/django_admin.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from copy import copy
 from django.contrib import admin
+from django.conf.urls import include, patterns, url
 
 from sentry.auth.superuser import is_active_superuser
 
@@ -31,3 +32,8 @@ def make_site():
 
 
 site = make_site()
+
+urlpatterns = patterns(
+    '',
+    url(r'^admin/', include(site.urls)),
+)


### PR DESCRIPTION
Follow up to https://github.com/getsentry/getsentry/pull/2186