### PR TITLE
feat(health): Change loading indicators in Health

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationHealth/loadingPanel.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/loadingPanel.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import styled from 'react-emotion';
+
+import HealthPanelChart from 'app/views/organizationHealth/styles/healthPanelChart';
+
+const LoadingMask = styled('div')`
+  background-color: ${p => p.theme.offWhite};
+  border-radius: ${p => p.theme.borderRadius};
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+`;
+
+const LoadingPanel = styled(props => (
+  <HealthPanelChart {...props}>
+    <LoadingMask />
+  </HealthPanelChart>
+))`
+  flex: 1;
+  height: 200px;
+  position: relative;
+  border-color: transparent;
+`;
+
+export default LoadingPanel;

--- a/src/sentry/static/sentry/app/views/organizationHealth/util/healthRequest.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/util/healthRequest.jsx
@@ -1,4 +1,4 @@
-import {isEqual, pickBy} from 'lodash';
+import {isEqual, omitBy} from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -123,27 +123,21 @@ class HealthRequestWithParams extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const propNamesToCheck = [
-      'environments',
-      'includePrevious',
-      'includeTimeseries',
-      'includeTop',
-      'includeTransformedData',
-      'interval',
-      'limit',
-      'period',
-      'projects',
-      'showLoading',
-      'specifiers',
-      'tag',
+    const propNamesToIgnore = [
+      'api',
+      'children',
+      'getCategory',
+      'organization',
+      'organizations',
+      'project',
     ];
 
-    const prevPropsToCheck = pickBy(prevProps, (value, key) =>
-      propNamesToCheck.includes(key)
+    const prevPropsToCheck = omitBy(prevProps, (value, key) =>
+      propNamesToIgnore.includes(key)
     );
 
-    const propsToCheck = pickBy(this.props, (value, key) =>
-      propNamesToCheck.includes(key)
+    const propsToCheck = omitBy(this.props, (value, key) =>
+      propNamesToIgnore.includes(key)
     );
 
     if (isEqual(prevPropsToCheck, propsToCheck)) return;


### PR DESCRIPTION
Use a lightweight "panel" square as an indicator instead. Also update `HealthRequest` component to be more careful before fetching data

Doesn't really show up well on the gif...
https://cl.ly/1ab38ab25d07/download/Screen%20Recording%202018-09-11%20at%2006.11%20PM.gif