### PR TITLE
feat(ui): Add basic implementation of a combined time selector

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/combinedSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/combinedSelector.jsx
@@ -57,7 +57,6 @@ export default class CombinedSelector extends React.Component {
         start: statsPeriod.start,
         end: statsPeriod.end,
       });
-      return;
     } else {
       onChange({...prev, [prop]: val});
     }

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/combinedSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/combinedSelector.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Box} from 'grid-emotion';
+
+import SelectControl from 'app/components/forms/selectControl';
+import DateTimeField from 'app/components/forms/dateTimeField';
+import {t} from 'app/locale';
+
+import {parseStatsPeriod} from './utils';
+
+export default class CombinedSelector extends React.Component {
+  static propTypes = {
+    /**
+     * List of choice tuples to use for relative dates
+     */
+    choices: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
+
+    /**
+     * The value for selector. This will be 'custom' if absolute dates are being used
+     */
+    relative: PropTypes.string,
+
+    /**
+     * Start date value for absolute date selector
+     */
+    start: PropTypes.string,
+    /**
+     * End date value for absolute date selector
+     */
+    end: PropTypes.string,
+
+    /**
+     * Callback when value changes
+     */
+    onChange: PropTypes.func,
+  };
+
+  static defaultProps = {
+    relative: null,
+    start: null,
+    end: null,
+  };
+
+  handleChange(prop, val) {
+    const {start, end, relative, onChange} = this.props;
+    const prev = {
+      start,
+      end,
+      relative,
+    };
+
+    if (prop === 'relative' && val === 'custom') {
+      // Convert previous relative range to absolute values
+      const statsPeriod = parseStatsPeriod(relative);
+      onChange({
+        relative: null,
+        start: statsPeriod.start,
+        end: statsPeriod.end,
+      });
+      return;
+    } else {
+      onChange({...prev, [prop]: val});
+    }
+  }
+
+  render() {
+    const {className, start, end, relative, choices} = this.props;
+
+    const value = relative || 'custom';
+
+    return (
+      <Box className={className}>
+        <Box mb={1}>{t('Update time range (UTC)')}</Box>
+        <Box mb={1}>
+          <SelectControl
+            value={value}
+            choices={[...choices, ['custom', t('Custom')]]}
+            onChange={val => this.handleChange('relative', val.value)}
+          />
+        </Box>
+        {relative === null && (
+          <React.Fragment>
+            <Box mb={1}>
+              <DateTimeField
+                name="start"
+                label={t('From')}
+                value={start}
+                onChange={val => this.handleChange('start', val)}
+              />
+            </Box>
+            <Box mb={1}>
+              <DateTimeField
+                name="end"
+                label={t('To')}
+                value={end}
+                onChange={val => this.handleChange('end', val)}
+              />
+            </Box>
+          </React.Fragment>
+        )}
+      </Box>
+    );
+  }
+}

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
@@ -12,6 +12,7 @@ import {t} from 'app/locale';
 
 import AbsoluteSelector from './absoluteSelector';
 import RelativeSelector from './relativeSelector';
+import CombinedSelector from './combinedSelector';
 
 const ALLOWED_RELATIVE_DATES = {
   '24h': t('Last 24 hours'),
@@ -92,20 +93,17 @@ class TimeRangeSelector extends React.Component {
       showRelative,
       onChange,
     } = this.props;
-    // Currently we will only show either absolute or relative selector, with "absolute" taking precedence
-    // Maybe an ideal selector would allow the user to choose between the two if both types of dates were allowed
-    const shouldShowAbsolute = showAbsolute || !showRelative;
-    const shouldShowRelative = !showAbsolute && showRelative;
 
-    const summary = shouldShowAbsolute
-      ? `${this.formatDate(start)} to ${this.formatDate(end)}`
-      : `${ALLOWED_RELATIVE_DATES[relative]}`;
+    const shouldShowAbsolute = showAbsolute && !showRelative;
+    const shouldShowRelative = !showAbsolute && showRelative;
+    const shouldShowBoth = showAbsolute && showRelative;
+
+    const summary = relative
+      ? `${ALLOWED_RELATIVE_DATES[relative]}`
+      : `${this.formatDate(start)} to ${this.formatDate(end)}`;
 
     return (
-      <HeaderItem
-        className={className}
-        label={t('Time frame')}
-      >
+      <HeaderItem className={className} label={t('Time frame')}>
         <DropdownLink
           title={<DynamicWrapper value={<Title>{summary}</Title>} fixed="start to end" />}
           anchorRight={true}
@@ -125,7 +123,15 @@ class TimeRangeSelector extends React.Component {
                 value={relative}
               />
             )}
-
+            {shouldShowBoth && (
+              <CombinedSelector
+                choices={Object.entries(ALLOWED_RELATIVE_DATES)}
+                onChange={onChange}
+                relative={relative}
+                start={start}
+                end={end}
+              />
+            )}
             <div>
               <Button onClick={this.handleUpdate}>{t('Update')}</Button>
             </div>

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/utils.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/utils.jsx
@@ -1,0 +1,37 @@
+import moment from 'moment';
+
+const DATE_TIME_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
+
+/**
+ * Converts a relative stats period, e.g. `1h` to an object containing a start
+ * and end date, with the end date as the current time and the start date as the
+ * time that is the current time less the statsPeriod.
+ *
+ * @param {String} val Relative stats period
+ * @returns {Object} Object containing start and end date as YYYY-MM-DDTHH:mm:ss
+ *
+ */
+export function parseStatsPeriod(statsPeriod) {
+  const statsPeriodRegex = /^(\d+)([smhd]{1})$/;
+
+  const result = statsPeriodRegex.exec(statsPeriod);
+
+  if (result === null) {
+    throw new Error('Invalid stats period');
+  }
+
+  const value = parseInt(result[1], 10);
+  const unit = {
+    d: 'days',
+    h: 'hours',
+    s: 'seconds',
+    m: 'minutes',
+  }[result[2]];
+
+  return {
+    start: moment()
+      .subtract(value, unit)
+      .format(DATE_TIME_FORMAT),
+    end: moment().format(DATE_TIME_FORMAT),
+  };
+}


### PR DESCRIPTION
Add a time selector that supports both relative and absolute time. UI is based on our existing time selectors.