### PR TITLE
Change team slug name constraint wording

### DIFF
--- a/src/sentry/locale/en/LC_MESSAGES/django.po
+++ b/src/sentry/locale/en/LC_MESSAGES/django.po
@@ -3590,7 +3590,7 @@ msgid "e.g. operations, web-frontend, desktop"
 msgstr ""
 
 #: static/sentry/app/components/createTeam/createTeamForm.jsx:45
-msgid "May contain lowercase letters, numbers, dashes and underscores."
+msgid "May only contain lowercase letters, numbers, dashes and underscores."
 msgstr ""
 
 #: static/sentry/app/components/customIgnoreCountModal.jsx:56


### PR DESCRIPTION
Change team slug name constraint wording to specify the rest is excluded. For example, uppercase letters are not allowed.