### PR TITLE
ref(ui): Remove ".circle-indicator"

### DIFF
--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -2297,28 +2297,6 @@ header + .alert {
 }
 
 /**
-* Circle indicators
-* ============================================================================
-*/
-
-.circle-indicator {
-  display: inline-block;
-  .square(14px);
-  border-radius: 14px;
-  margin-right: 8px;
-  position: relative;
-  top: 1px;
-
-  &.enabled {
-    background: @green;
-  }
-
-  &.disabled {
-    background: @red;
-  }
-}
-
-/**
 * Project nav
 * ============================================================================
 */


### PR DESCRIPTION
This does not seem to be used anymore, replaced with `app/components/CircleIndicator`