### PR TITLE
fix(discover): Do not use invalid characters in aliases

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/aggregations/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/aggregations/utils.jsx
@@ -64,14 +64,15 @@ export function getInternal(external) {
 
 /**
 * Returns an alias for a given column name, which is either just the column name
-* or a string with an underscore instead of square brackets for tags
+* or a string with an underscore instead of square brackets for tags. We'll also
+* replace the characters `.`, `:` and `-` from aliases.
 *
 * @param {String} columnName Name of column
 * @return {String} Alias
 */
 function getAlias(columnName) {
   const tagMatch = columnName.match(/^tags\[(.+)]$/);
-  return tagMatch ? `tags_${tagMatch[1]}` : columnName;
+  return tagMatch ? `tags_${tagMatch[1].replace(/[.:-]/, '_')}` : columnName;
 }
 
 /**

--- a/tests/js/spec/views/organizationDiscover/aggregations/utils.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/aggregations/utils.spec.jsx
@@ -23,6 +23,10 @@ const aggregationList = [
     internal: 'uniq(tags[server_name])',
     external: ['uniq', 'tags[server_name]', 'uniq_tags_server_name'],
   },
+  {
+    internal: 'uniq(tags[browser.name])',
+    external: ['uniq', 'tags[browser.name]', 'uniq_tags_browser_name'],
+  },
 ];
 
 describe('Aggregations', function() {


### PR DESCRIPTION
The characters ., :, and - are valid in tag keys but we don't want to
use them in aliases.