### PR TITLE
ref(discover): Update endpoint URL

### DIFF
--- a/src/sentry/api/endpoints/organization_discover_query.py
+++ b/src/sentry/api/endpoints/organization_discover_query.py
@@ -169,7 +169,7 @@ class DiscoverSerializer(serializers.Serializer):
         return set(requested_projects).issubset(set(member_project_list))
 
 
-class OrganizationDiscoverEndpoint(OrganizationEndpoint):
+class OrganizationDiscoverQueryEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationDiscoverPermission, )
 
     def do_query(self, start, end, groupby, **kwargs):

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -58,7 +58,7 @@ from .endpoints.organization_auth_provider_details import OrganizationAuthProvid
 from .endpoints.organization_auth_provider_send_reminders import OrganizationAuthProviderSendRemindersEndpoint
 from .endpoints.organization_avatar import OrganizationAvatarEndpoint
 from .endpoints.organization_details import OrganizationDetailsEndpoint
-from .endpoints.organization_discover import OrganizationDiscoverEndpoint
+from .endpoints.organization_discover_query import OrganizationDiscoverQueryEndpoint
 from .endpoints.organization_health import OrganizationHealthTopEndpoint, OrganizationHealthGraphEndpoint
 from .endpoints.organization_shortid import ShortIdLookupEndpoint
 from .endpoints.organization_environments import OrganizationEnvironmentsEndpoint
@@ -375,9 +375,9 @@ urlpatterns = patterns(
         name='sentry-api-0-organization-details'
     ),
     url(
-        r'^organizations/(?P<organization_slug>[^\/]+)/discover/$',
-        OrganizationDiscoverEndpoint.as_view(),
-        name='sentry-api-0-organization-discover'
+        r'^organizations/(?P<organization_slug>[^\/]+)/discover/query/$',
+        OrganizationDiscoverQueryEndpoint.as_view(),
+        name='sentry-api-0-organization-discover-query'
     ),
     url(
         r'^organizations/(?P<organization_slug>[^\/]+)/health/top/$',

--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -172,7 +172,7 @@ export default function createQueryBuilder(initial = {}, organization) {
    */
   function fetch(data) {
     const api = new Client();
-    const endpoint = `/organizations/${organization.slug}/discover/`;
+    const endpoint = `/organizations/${organization.slug}/discover/query/`;
 
     data = data || getExternal();
 

--- a/tests/js/spec/views/organizationDiscover/queryBuilder.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/queryBuilder.spec.jsx
@@ -26,7 +26,7 @@ describe('Query Builder', function() {
 
     it('loads tags', async function() {
       const discoverMock = MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/discover/',
+        url: '/organizations/org-slug/discover/query/',
         method: 'POST',
         body: {
           data: [{tags_key: 'tag1', count: 5}, {tags_key: 'tag2', count: 1}],
@@ -39,7 +39,7 @@ describe('Query Builder', function() {
       await queryBuilder.load();
 
       expect(discoverMock).toHaveBeenCalledWith(
-        '/organizations/org-slug/discover/',
+        '/organizations/org-slug/discover/query/',
         expect.objectContaining({
           data: expect.objectContaining({
             fields: ['tags_key'],
@@ -68,7 +68,7 @@ describe('Query Builder', function() {
 
     it('loads hardcoded tags when API request fails', async function() {
       const discoverMock = MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/discover/',
+        url: '/organizations/org-slug/discover/query/',
         method: 'POST',
       });
       const queryBuilder = createQueryBuilder(
@@ -99,7 +99,7 @@ describe('Query Builder', function() {
         TestStubs.Organization({projects: [TestStubs.Project()]})
       );
       discoverMock = MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/discover/',
+        url: '/organizations/org-slug/discover/query/',
         method: 'POST',
       });
     });
@@ -112,7 +112,7 @@ describe('Query Builder', function() {
       const data = {projects: [1], fields: ['event_id']};
       await queryBuilder.fetch(data);
       expect(discoverMock).toHaveBeenCalledWith(
-        '/organizations/org-slug/discover/',
+        '/organizations/org-slug/discover/query/',
         expect.objectContaining({
           data,
         })

--- a/tests/snuba/test_organization_discover_query.py
+++ b/tests/snuba/test_organization_discover_query.py
@@ -9,9 +9,9 @@ from django.core.urlresolvers import reverse
 from sentry.testutils import SnubaTestCase
 
 
-class OrganizationDiscoverTest(APITestCase, SnubaTestCase):
+class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationDiscoverTest, self).setUp()
+        super(OrganizationDiscoverQueryTest, self).setUp()
 
         one_second_ago = datetime.now() - timedelta(seconds=1)
 
@@ -64,7 +64,7 @@ class OrganizationDiscoverTest(APITestCase, SnubaTestCase):
 
     def test(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover', args=[self.org.slug])
+            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'fields': ['message', 'platform'],
@@ -80,7 +80,7 @@ class OrganizationDiscoverTest(APITestCase, SnubaTestCase):
 
     def test_relative_dates(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover', args=[self.org.slug])
+            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'fields': ['message', 'platform'],
@@ -95,7 +95,7 @@ class OrganizationDiscoverTest(APITestCase, SnubaTestCase):
 
     def test_invalid_date_request(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover', args=[self.org.slug])
+            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'fields': ['message', 'platform'],
@@ -109,7 +109,7 @@ class OrganizationDiscoverTest(APITestCase, SnubaTestCase):
 
     def test_invalid_range_value(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover', args=[self.org.slug])
+            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'fields': ['message', 'platform'],
@@ -121,7 +121,7 @@ class OrganizationDiscoverTest(APITestCase, SnubaTestCase):
 
     def test_boolean_condition(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover', args=[self.org.slug])
+            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'fields': ['message', 'platform', 'exception_frames.in_app'],
@@ -138,7 +138,7 @@ class OrganizationDiscoverTest(APITestCase, SnubaTestCase):
 
     def test_array_join(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover', args=[self.org.slug])
+            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'fields': ['message', 'exception_stacks.type'],
@@ -152,7 +152,7 @@ class OrganizationDiscoverTest(APITestCase, SnubaTestCase):
 
     def test_array_condition_equals(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover', args=[self.org.slug])
+            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'conditions': [['exception_stacks.type', '=', 'ValidationError']],
@@ -166,7 +166,7 @@ class OrganizationDiscoverTest(APITestCase, SnubaTestCase):
 
     def test_array_condition_not_equals(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover', args=[self.org.slug])
+            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'conditions': [['exception_stacks.type', '!=', 'ValidationError']],


### PR DESCRIPTION
It turns out we'll need more endpoints under discover than originally envisaged so this would be better as /discover/query rather than /discover