### PR TITLE
feat(integrations): Structure integration features

### DIFF
--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 
-from sentry.integrations import IntegrationInstallation, IntegrationFeatures, IntegrationProvider, IntegrationMetadata
+from sentry.integrations import (
+    IntegrationInstallation, IntegrationFeatures, IntegrationProvider,
+    IntegrationMetadata, FeatureDescription,
+)
 from sentry.integrations.atlassian_connect import AtlassianConnectValidationError, get_integration_from_request
 from sentry.integrations.repositories import RepositoryMixin
 from sentry.pipeline import NestedPipelineView, PipelineView
@@ -17,14 +20,41 @@ from .client import BitbucketApiClient
 from .issues import BitbucketIssueBasicMixin
 
 DESCRIPTION = """
-With the Bitbucket integration, you can:
- * Track commits and releases (learn more [here](https://docs.sentry.io/learn/releases/))
- * Create Bitbucket issues from Sentry
- * Link Sentry issues to existing Bitbucket issues
- * Resolve Sentry issues via Bitbucket commits and pull requests by including `Fixes PROJ-ID` in the message
+Connect your Sentry organization to Bitbucket, enabling the following features:
 """
+
+FEATURES = [
+    FeatureDescription(
+        """
+        Track commits and releases (learn more
+        [here](https://docs.sentry.io/learn/releases/))
+        """,
+        IntegrationFeatures.COMMITS,
+    ),
+    FeatureDescription(
+        """
+        Resolve Sentry issues via Bitbucket commits and pull requests by
+        including `Fixes PROJ-ID` in the message
+        """,
+        IntegrationFeatures.COMMITS,
+    ),
+    FeatureDescription(
+        """
+        Create Bitbucket issues from Sentry
+        """,
+        IntegrationFeatures.ISSUE_BASIC,
+    ),
+    FeatureDescription(
+        """
+        Link Sentry issues to existing Bitbucket issues
+        """,
+        IntegrationFeatures.ISSUE_BASIC,
+    ),
+]
+
 metadata = IntegrationMetadata(
     description=DESCRIPTION.strip(),
+    features=FEATURES,
     author='The Sentry Team',
     noun=_('Installation'),
     issue_url='https://github.com/getsentry/sentry/issues/new?title=Bitbucket%20Integration:%20&labels=Component%3A%20Integrations',

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -35,7 +35,7 @@ This is an example integration. Descriptions support _markdown rendering_.
 
 FEATURES = [
     FeatureDescription(
-        "This is a feature discription. Also *supports markdown*",
+        "This is a feature description. Also *supports markdown*",
         IntegrationFeatures.ISSUE_SYNC,
     ),
 ]

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import
 
 from django.http import HttpResponse
 from sentry.integrations import (
-    IntegrationInstallation, IntegrationFeatures, IntegrationMetadata, IntegrationProvider
+    IntegrationInstallation, IntegrationFeatures, IntegrationMetadata,
+    IntegrationProvider, FeatureDescription
 )
 from sentry.integrations.exceptions import IntegrationError
 from sentry.integrations.issues import IssueSyncMixin
@@ -29,13 +30,19 @@ class ExampleSetupView(PipelineView):
 
 
 DESCRIPTION = """
-This is an example integration
-
- * Descriptions support _markdown rendering_.
+This is an example integration. Descriptions support _markdown rendering_.
 """
+
+FEATURES = [
+    FeatureDescription(
+        "This is a feature discription. Also *supports markdown*",
+        IntegrationFeatures.ISSUE_SYNC,
+    ),
+]
 
 metadata = IntegrationMetadata(
     description=DESCRIPTION.strip(),
+    features=FEATURES,
     author='The Sentry Team',
     noun='example',
     issue_url='https://github.com/getsentry/sentry/issues/new',

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -7,7 +7,7 @@ from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.identity.github import get_user_info
 from sentry.integrations import (
     IntegrationInstallation, IntegrationFeatures, IntegrationProvider,
-    IntegrationMetadata
+    IntegrationMetadata, FeatureDescription,
 )
 from sentry.integrations.exceptions import ApiError
 from sentry.integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
@@ -28,15 +28,27 @@ Connect your Sentry organization into your GitHub organization or user account.
 Take a step towards augmenting your sentry issues with commits from your
 repositories ([using releases](https://docs.sentry.io/learn/releases/)) and
 linking up your GitHub issues and pull requests directly to issues in Sentry.
-
- * Create and link Sentry issue groups directly to a GitHub issue or pull
-   request in any of your repositories, providing a quick way to jump from
-   Sentry bug to tracked issue or PR!
-
- * Authorize repositories to be added to your Sentry organization to augmenting
-   sentry issues with commit data with [deployment
-   tracking](https://docs.sentry.io/learn/releases/).
 """
+
+FEATURES = [
+    FeatureDescription(
+        """
+        Create and link Sentry issue groups directly to a GitHub issue or pull
+        request in any of your repositories, providing a quick way to jump from
+        Sentry bug to tracked issue or PR!
+        """,
+        IntegrationFeatures.ISSUE_BASIC,
+    ),
+    FeatureDescription(
+        """
+        Authorize repositories to be added to your Sentry organization to augmenting
+        sentry issues with commit data with [deployment
+        tracking](https://docs.sentry.io/learn/releases/).
+        """,
+        IntegrationFeatures.COMMITS,
+    ),
+]
+
 disable_dialog = {
     'actionText': 'Visit GitHub',
     'body': 'Before deleting this integration, you must uninstall this'
@@ -54,6 +66,7 @@ removal_dialog = {
 
 metadata = IntegrationMetadata(
     description=DESCRIPTION.strip(),
+    features=FEATURES,
     author='The Sentry Team',
     noun=_('Installation'),
     issue_url='https://github.com/getsentry/sentry/issues/new?title=GitHub%20Integration:%20&labels=Component%3A%20Integrations',

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -8,7 +8,7 @@ from sentry import http
 from sentry.web.helpers import render_to_response
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.identity.github_enterprise import get_user_info
-from sentry.integrations import IntegrationMetadata, IntegrationInstallation
+from sentry.integrations import IntegrationMetadata, IntegrationInstallation, FeatureDescription, IntegrationFeatures
 from sentry.integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
 from sentry.integrations.exceptions import ApiError
 from sentry.integrations.repositories import RepositoryMixin
@@ -27,15 +27,27 @@ instances. Take a step towards augmenting your sentry issues with commits from
 your repositories ([using releases](https://docs.sentry.io/learn/releases/))
 and linking up your GitHub issues and pull requests directly to issues in
 Sentry.
-
- * Create and link Sentry issue groups directly to a GitHub issue or pull
-   request in any of your repositories, providing a quick way to jump from
-   Sentry bug to tracked issue or PR!
-
- * Authorize repositories to be added to your Sentry organization to augmenting
-   sentry issues with commit data with [deployment
-   tracking](https://docs.sentry.io/learn/releases/).
 """
+
+FEATURES = [
+    FeatureDescription(
+        """
+        Create and link Sentry issue groups directly to a GitHub issue or pull
+        request in any of your repositories, providing a quick way to jump from
+        Sentry bug to tracked issue or PR!
+        """,
+        IntegrationFeatures.ISSUE_BASIC,
+    ),
+    FeatureDescription(
+        """
+        Authorize repositories to be added to your Sentry organization to augmenting
+        sentry issues with commit data with [deployment
+        tracking](https://docs.sentry.io/learn/releases/).
+        """,
+        IntegrationFeatures.COMMITS,
+    ),
+]
+
 
 disable_dialog = {
     'actionText': 'Visit GitHub Enterprise',
@@ -63,6 +75,7 @@ setup_alert = {
 
 metadata = IntegrationMetadata(
     description=DESCRIPTION.strip(),
+    features=FEATURES,
     author='The Sentry Team',
     noun=_('Installation'),
     issue_url='https://github.com/getsentry/sentry/issues/new?title=GitHub%20Integration:%20&labels=Component%3A%20Integrations',

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -18,8 +18,11 @@ DESCRIPTION = """
 Fill me out
 """
 
+FEATURES = []
+
 metadata = IntegrationMetadata(
     description=DESCRIPTION.strip(),
+    features=FEATURES,
     author='The Sentry Team',
     noun=_('Installation'),
     issue_url='https://github.com/getsentry/sentry/issues/',

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext as _
 
 from sentry import features
 from sentry.integrations import (
-    IntegrationInstallation, IntegrationFeatures, IntegrationProvider, IntegrationMetadata
+    IntegrationInstallation, IntegrationFeatures, IntegrationProvider, IntegrationMetadata, FeatureDescription,
 )
 from sentry.integrations.exceptions import ApiUnauthorized, ApiError, IntegrationError, IntegrationFormError
 from sentry.integrations.issues import IssueSyncMixin
@@ -25,16 +25,33 @@ DESCRIPTION = """
 Connect your Sentry organization into one or more of your Jira cloud instances.
 Get started streamlining your bug squashing workflow by unifying your Sentry and
 Jira instances together.
-
- * Create and link Sentry issue groups directly to a Jira ticket in any of your
-   projects, providing a quick way to jump from Sentry bug to tracked ticket!
- * Automatically synchronize assignees to and from Jira. Don't get confused
-   who's fixing what, let us handle ensuring your issues and tickets match up
-   to your Sentry and Jira assignees.
- * Synchronize Comments on Sentry Issues directly to the linked Jira ticket.
 """
 
-INSTALL_NOTICE_TEXt = """
+FEATURE_DESCRIPTIONS = [
+    FeatureDescription(
+        """
+        Create and link Sentry issue groups directly to a Jira ticket in any of your
+        projects, providing a quick way to jump from Sentry bug to tracked ticket!
+        """,
+        IntegrationFeatures.ISSUE_BASIC,
+    ),
+    FeatureDescription(
+        """
+        Automatically synchronize assignees to and from Jira. Don't get confused
+        who's fixing what, let us handle ensuring your issues and tickets match up
+        to your Sentry and Jira assignees.
+        """,
+        IntegrationFeatures.ISSUE_SYNC,
+    ),
+    FeatureDescription(
+        """
+        Synchronize Comments on Sentry Issues directly to the linked Jira ticket.
+        """,
+        IntegrationFeatures.ISSUE_SYNC,
+    ),
+]
+
+INSTALL_NOTICE_TEXT = """
 Visit the Jira Marketplace to install this integration. After installing the
 Sentry add-on, access the settings panel in your Jira instance to enable the
 integration for this Organization.
@@ -43,11 +60,12 @@ integration for this Organization.
 external_install = {
     'url': 'https://marketplace.atlassian.com/apps/1219432/sentry-for-jira',
     'buttonText': _('Jira Marketplace'),
-    'noticeText': _(INSTALL_NOTICE_TEXt.strip()),
+    'noticeText': _(INSTALL_NOTICE_TEXT.strip()),
 }
 
 metadata = IntegrationMetadata(
     description=_(DESCRIPTION.strip()),
+    features=FEATURE_DESCRIPTIONS,
     author='The Sentry Team',
     noun=_('Instance'),
     issue_url='https://github.com/getsentry/sentry/issues/new?title=Jira%20Integration:%20&labels=Component%3A%20Integrations',
@@ -664,7 +682,10 @@ class JiraIntegrationProvider(IntegrationProvider):
     metadata = metadata
     integration_cls = JiraIntegration
 
-    features = frozenset([IntegrationFeatures.ISSUE_SYNC])
+    features = frozenset([
+        IntegrationFeatures.ISSUE_BASIC,
+        IntegrationFeatures.ISSUE_SYNC
+    ])
 
     can_add = False
 

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext_lazy as _
 from sentry import http
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.integrations import (
-    IntegrationFeatures, IntegrationMetadata, IntegrationProvider,
+    IntegrationFeatures, IntegrationMetadata, IntegrationProvider, FeatureDescription,
 )
 from sentry.pipeline import NestedPipelineView
 from sentry.utils.http import absolute_uri
@@ -14,14 +14,31 @@ DESCRIPTION = """
 Connect your Sentry organization to one or more Slack workspaces, and start
 getting errors right in front of you where all the action happens in your
 office!
-
- * Unfurls Sentry URLs directly within Slack, providing you context and
-   actionability on issues right at your fingertips.
- * Resolve, ignore, and assign issues with minimal context switching.
- * Configure rule based Slack notifications to automatically be posted into a
-   specific channel. Want any error that's happening more than 100 times a
-   minute to be posted in `#critical-errors`? Setup a rule for it!
 """
+
+FEATURES = [
+    FeatureDescription(
+        """
+        Unfurls Sentry URLs directly within Slack, providing you context and
+        actionability on issues right at your fingertips.
+        """,
+        IntegrationFeatures.CHAT_UNFURL,
+    ),
+    FeatureDescription(
+        """
+        Resolve, ignore, and assign issues with minimal context switching.
+        """,
+        IntegrationFeatures.ACTION_NOTIFICATION,
+    ),
+    FeatureDescription(
+        """
+        Configure rule based Slack notifications to automatically be posted into a
+        specific channel. Want any error that's happening more than 100 times a
+        minute to be posted in `#critical-errors`? Setup a rule for it!
+        """,
+        IntegrationFeatures.ALERT_RULE,
+    ),
+]
 
 setup_alert = {
     'type': 'info',
@@ -30,6 +47,7 @@ setup_alert = {
 
 metadata = IntegrationMetadata(
     description=_(DESCRIPTION.strip()),
+    features=FEATURES,
     author='The Sentry Team',
     noun=_('Workspace'),
     issue_url='https://github.com/getsentry/sentry/issues/new?title=Slack%20Integration:%20&labels=Component%3A%20Integrations',
@@ -45,7 +63,7 @@ class SlackIntegrationProvider(IntegrationProvider):
     name = 'Slack'
     metadata = metadata
     features = frozenset([
-        IntegrationFeatures.NOTIFICATION,
+        IntegrationFeatures.ACTION_NOTIFICATION,
         IntegrationFeatures.CHAT_UNFURL,
         IntegrationFeatures.ALERT_RULE,
     ])

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -12,7 +12,7 @@ from sentry.models import (
     Integration as IntegrationModel, IntegrationExternalProject, Organization,
     OrganizationIntegration,
 )
-from sentry.integrations import IntegrationInstallation, IntegrationFeatures, IntegrationProvider, IntegrationMetadata
+from sentry.integrations import IntegrationInstallation, IntegrationFeatures, IntegrationProvider, IntegrationMetadata, FeatureDescription
 from sentry.integrations.exceptions import ApiError, IntegrationError
 from sentry.integrations.repositories import RepositoryMixin
 from sentry.integrations.vsts.issues import VstsIssueSync
@@ -29,17 +29,47 @@ from .repository import VstsRepositoryProvider
 from .webhooks import WorkItemWebhook
 
 DESCRIPTION = """
-Connect your Sentry organization to one or more of your Azure DevOps organizations. Get started streamlining your bug squashing workflow by unifying your Sentry and Azure DevOps accounts together.
-
-* Create and link Sentry issue groups directly to a Azure DevOps work item in any of your projects, providing a quick way to jump from Sentry bug to tracked work item!
-* Automatically synchronize assignees to and from Azure DevOps. Don't get confused who's fixing what, let us handle ensuring your issues and work items match up to your Sentry and Azure DevOps assignees.
-* Never forget to close a resolved workitem! Resolving an issue in Sentry will resolve your linked workitems and viceversa.
-* Synchronize comments on Sentry Issues directly to the linked Azure DevOps workitems.
-
+Connect your Sentry organization to one or more of your Azure DevOps
+organizations. Get started streamlining your bug squashing workflow by unifying
+your Sentry and Azure DevOps organization together.
 """
+
+FEATURES = [
+    FeatureDescription(
+        """
+        Create and link Sentry issue groups directly to a Azure DevOps work item in any of
+        your projects, providing a quick way to jump from Sentry bug to tracked
+        work item!
+        """,
+        IntegrationFeatures.ISSUE_BASIC,
+    ),
+    FeatureDescription(
+        """
+        Automatically synchronize assignees to and from Azure DevOps. Don't get
+        confused who's fixing what, let us handle ensuring your issues and work
+        items match up to your Sentry and Azure DevOps assignees.
+        """,
+        IntegrationFeatures.ISSUE_SYNC,
+    ),
+    FeatureDescription(
+        """
+        Never forget to close a resolved workitem! Resolving an issue in Sentry
+        will resolve your linked workitems and viceversa.
+        """,
+        IntegrationFeatures.ISSUE_SYNC,
+    ),
+    FeatureDescription(
+        """
+        Synchronize comments on Sentry Issues directly to the linked Azure
+        DevOps workitems.
+        """,
+        IntegrationFeatures.ISSUE_SYNC,
+    )
+]
 
 metadata = IntegrationMetadata(
     description=DESCRIPTION.strip(),
+    features=FEATURES,
     author='The Sentry Team',
     noun=_('Installation'),
     issue_url='https://github.com/getsentry/sentry/issues/new?title=VSTS%20Integration:%20&labels=Component%3A%20Integrations',
@@ -266,7 +296,12 @@ class VstsIntegrationProvider(IntegrationProvider):
     oauth_redirect_url = '/extensions/vsts/setup/'
     needs_default_identity = True
     integration_cls = VstsIntegration
-    features = frozenset([IntegrationFeatures.ISSUE_SYNC, IntegrationFeatures.COMMITS])
+
+    features = frozenset([
+        IntegrationFeatures.ISSUE_SYNC,
+        IntegrationFeatures.ISSUE_SYNC,
+        IntegrationFeatures.COMMITS
+    ])
 
     setup_dialog_config = {
         'width': 600,

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -298,7 +298,7 @@ class VstsIntegrationProvider(IntegrationProvider):
     integration_cls = VstsIntegration
 
     features = frozenset([
-        IntegrationFeatures.ISSUE_SYNC,
+        IntegrationFeatures.ISSUE_BASIC,
         IntegrationFeatures.ISSUE_SYNC,
         IntegrationFeatures.COMMITS
     ])

--- a/src/sentry/static/sentry/app/components/modals/integrationDetailsModal.jsx
+++ b/src/sentry/static/sentry/app/components/modals/integrationDetailsModal.jsx
@@ -37,7 +37,7 @@ const defaultFeatureGateComponents = {
   FeatureList: p => (
     <ul>
       {p.features.map((f, i) => (
-        <li key={i} dangerouslySetInnerHTML={{__html: markedSimple(f.description)}} />
+        <li key={i} dangerouslySetInnerHTML={{__html: p.formatter(f.description)}} />
       ))}
     </ul>
   ),
@@ -131,7 +131,7 @@ class IntegrationDetailsModal extends React.Component {
           </Flex>
         </Flex>
         <Description dangerouslySetInnerHTML={{__html: description}} />
-        <FeatureList {...featureProps} />
+        <FeatureList {...featureProps} formatter={markedSimple} />
 
         <Metadata>
           <AuthorName flex={1}>{t('By %s', provider.metadata.author)}</AuthorName>

--- a/src/sentry/static/sentry/app/components/modals/integrationDetailsModal.jsx
+++ b/src/sentry/static/sentry/app/components/modals/integrationDetailsModal.jsx
@@ -30,7 +30,8 @@ const markedSimple = text => marked(text, {renderer: noParagraphRenderer});
 const defaultFeatureGateComponents = {
   IntegrationFeatures: p =>
     p.children({
-      mustUpgrade: false,
+      disabled: false,
+      disabledReason: null,
       ungatedFeatures: p.features,
       gatedFeatureGroups: [],
     }),
@@ -148,13 +149,13 @@ class IntegrationDetailsModal extends React.Component {
         ))}
 
         <IntegrationFeatures {...featureProps}>
-          {({mustUpgrade}) => (
+          {({disabled, disabledReason}) => (
             <div className="modal-footer">
-              {!!mustUpgrade && <DisabledNotice reason={mustUpgrade} />}
+              {disabled && <DisabledNotice reason={disabledReason} />}
               <Button size="small" onClick={closeModal}>
                 {t('Cancel')}
               </Button>
-              <AddButton disabled={!!mustUpgrade} />
+              <AddButton disabled={disabled} />
             </div>
           )}
         </IntegrationFeatures>

--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -23,6 +23,7 @@ let validHookNames = new Set([
   'analytics:log-experiment',
   'sidebar:organization-dropdown-menu',
   'sidebar:help-menu',
+  'interations:feature-gates',
 ]);
 
 const HookStore = Reflux.createStore({

--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -23,7 +23,7 @@ let validHookNames = new Set([
   'analytics:log-experiment',
   'sidebar:organization-dropdown-menu',
   'sidebar:help-menu',
-  'interations:feature-gates',
+  'integrations:feature-gates',
 ]);
 
 const HookStore = Reflux.createStore({

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegrationButton.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegrationButton.jsx
@@ -34,7 +34,7 @@ export default class AddIntegrationButton extends React.Component {
         <span>
           <AddIntegration provider={provider} onInstall={onAddIntegration}>
             {onClick => (
-              <Button {...buttonProps} disabled={!provider.canAdd} onClick={onClick}>
+              <Button disabled={!provider.canAdd} {...buttonProps} onClick={onClick}>
                 {label}
               </Button>
             )}

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
@@ -11,14 +11,9 @@ import AsyncComponent from 'app/components/asyncComponent';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import MigrationWarnings from 'app/views/organizationIntegrations/migrationWarnings';
 import ProviderRow from 'app/views/organizationIntegrations/providerRow';
-import SentryTypes from 'app/sentryTypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 
 export default class OrganizationIntegrations extends AsyncComponent {
-  static contextTypes = {
-    organization: SentryTypes.Organization,
-  };
-
   // Some integrations require visiting a different website to add them. When
   // we come back to the tab we want to show our integrations as soon as we can.
   reloadOnVisible = true;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.jsx
@@ -11,7 +11,7 @@ import Confirm from 'app/components/confirm';
 import IntegrationItem from 'app/views/organizationIntegrations/integrationItem';
 import Tooltip from 'app/components/tooltip';
 
-const CONFIGURABLE_FEATURES = ['commits', 'alert_rule'];
+const CONFIGURABLE_FEATURES = ['commits', 'alert-rule'];
 
 export default class InstalledIntegration extends React.Component {
   static propTypes = {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.jsx
@@ -59,9 +59,10 @@ export default class ProviderRow extends React.Component {
   // Actions
 
   openModal = () => {
+    const organization = this.context.organization;
     const provider = this.props.provider;
     const onAddIntegration = this.props.onInstall;
-    openIntegrationDetails({provider, onAddIntegration});
+    openIntegrationDetails({provider, organization, onAddIntegration});
   };
 
   // Rendering

--- a/src/sentry/static/sentry/app/views/settings/organizationIntegrations/configureIntegration.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationIntegrations/configureIntegration.jsx
@@ -54,7 +54,7 @@ export default class ConfigureIntegration extends AsyncView {
           </Form>
         )}
 
-        {provider.features.includes('alert_rule') && (
+        {provider.features.includes('alert-rule') && (
           <IntegrationAlertRules integration={integration} />
         )}
 

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -558,6 +558,7 @@ window.TestStubs = {
       },
       metadata: {
         description: '*markdown* formatted _description_',
+        features: [{description: '*markdown* feature description'}],
         author: 'Morty',
         noun: 'Installation',
         issue_url: 'http://example.com/integration_issue_url',
@@ -584,6 +585,7 @@ window.TestStubs = {
       features: [],
       metadata: {
         description: '*markdown* formatted Jira _description_',
+        features: [{description: '*markdown* feature description'}],
         author: 'Rick',
         noun: 'Instance',
         issue_url: 'http://example.com/jira_integration_issue_url',
@@ -647,6 +649,7 @@ window.TestStubs = {
       features: [],
       metadata: {
         description: '*markdown* formatted VSTS _description_',
+        features: [{description: '*markdown* feature description'}],
         author: 'Frank',
         noun: 'Instance',
         issue_url: 'http://example.com/vsts_issue_url',

--- a/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
+++ b/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
@@ -1,28 +1,126 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`IntegrationDetailsModal renders simple integration 1`] = `
-<Fragment>
+<IntegrationDetailsModal
+  closeModal={[MockFunction]}
+  onAddIntegration={[MockFunction]}
+  provider={
+    Object {
+      "canAdd": true,
+      "config": Array [],
+      "externalIssues": Array [],
+      "features": Array [],
+      "key": "github",
+      "metadata": Object {
+        "aspects": Object {
+          "alerts": Array [
+            Object {
+              "text": "This is a an alert example",
+              "type": "warning",
+            },
+          ],
+        },
+        "author": "Morty",
+        "description": "*markdown* formatted _description_",
+        "features": Array [
+          Object {
+            "description": "*markdown* feature description",
+          },
+        ],
+        "issue_url": "http://example.com/integration_issue_url",
+        "noun": "Installation",
+        "source_url": "http://example.com/integration_source_url",
+      },
+      "name": "GitHub",
+      "setupDialog": Object {
+        "height": 100,
+        "url": "/github-integration-setup-uri/",
+        "width": 100,
+      },
+    }
+  }
+>
   <Flex
     align="center"
     mb={2}
   >
-    <PluginIcon
-      pluginId="github"
-      size={50}
-    />
-    <Flex
-      align="flex-start"
-      direction="column"
-      justify="center"
-      pl={1}
+    <Base
+      align="center"
+      className="css-oc829x"
+      mb={2}
     >
-      <ProviderName>
-        GitHub Integration
-      </ProviderName>
-      <Flex>
-        0
-      </Flex>
-    </Flex>
+      <div
+        className="css-oc829x"
+        is={null}
+      >
+        <PluginIcon
+          pluginId="github"
+          size={50}
+        >
+          <IntegrationIcon
+            image={Object {}}
+            size={50}
+          >
+            <div
+              className="css-duaev8-IntegrationIcon e1bhjds90"
+              size={50}
+            />
+          </IntegrationIcon>
+        </PluginIcon>
+        <Flex
+          align="flex-start"
+          direction="column"
+          justify="center"
+          pl={1}
+        >
+          <Base
+            align="flex-start"
+            className="css-1wqjzd8"
+            direction="column"
+            justify="center"
+            pl={1}
+          >
+            <div
+              className="css-1wqjzd8"
+              is={null}
+            >
+              <ProviderName>
+                <Component
+                  className="css-1pygq0m-ProviderName e1rf4mlr1"
+                >
+                  <Box
+                    className="css-1pygq0m-ProviderName e1rf4mlr1"
+                  >
+                    <Base
+                      className="e1rf4mlr1 css-cswdqk-ProviderName"
+                    >
+                      <div
+                        className="e1rf4mlr1 css-cswdqk-ProviderName"
+                        is={null}
+                      >
+                        GitHub Integration
+                      </div>
+                    </Base>
+                  </Box>
+                </Component>
+              </ProviderName>
+              <Flex>
+                <Base
+                  className="css-sncxrr"
+                >
+                  <div
+                    className="css-sncxrr"
+                    is={null}
+                  >
+                    0
+                  </div>
+                </Base>
+              </Flex>
+            </div>
+          </Base>
+        </Flex>
+      </div>
+    </Base>
   </Flex>
   <Description
     dangerouslySetInnerHTML={
@@ -31,104 +129,399 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
 ",
       }
     }
-  />
-  <ul>
-    <li
+  >
+    <div
+      className="css-zqji3g-Description e1rf4mlr2"
       dangerouslySetInnerHTML={
         Object {
-          "__html": "<em>markdown</em> feature description",
+          "__html": "<p><em>markdown</em> formatted <em>description</em></p>
+",
         }
       }
-      key="0"
     />
-  </ul>
+  </Description>
+  <FeatureList
+    features={
+      Array [
+        Object {
+          "description": "*markdown* feature description",
+        },
+      ]
+    }
+    formatter={[Function]}
+  >
+    <ul>
+      <li
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<em>markdown</em> feature description",
+          }
+        }
+        key="0"
+      />
+    </ul>
+  </FeatureList>
   <Metadata>
-    <AuthorName
-      flex={1}
+    <Base
+      className="css-xm93tv-Metadata e1rf4mlr3"
     >
-      By Morty
-    </AuthorName>
-    <Box>
-      <ExternalLink
-        href="http://example.com/integration_source_url"
-        rel="noreferrer noopener"
-        target="_blank"
+      <div
+        className="css-xm93tv-Metadata e1rf4mlr3"
+        is={null}
       >
-        View Source
-      </ExternalLink>
-      <ExternalLink
-        href="http://example.com/integration_issue_url"
-        rel="noreferrer noopener"
-        target="_blank"
-      >
-        Report Issue
-      </ExternalLink>
-    </Box>
+        <AuthorName
+          flex={1}
+        >
+          <Base
+            className="css-1uwqb6n-AuthorName e1rf4mlr4"
+            flex={1}
+          >
+            <div
+              className="css-1uwqb6n-AuthorName e1rf4mlr4"
+              is={null}
+            >
+              By Morty
+            </div>
+          </Base>
+        </AuthorName>
+        <Box>
+          <Base
+            className="css-roynbj"
+          >
+            <div
+              className="css-roynbj"
+              is={null}
+            >
+              <ExternalLink
+                href="http://example.com/integration_source_url"
+                rel="noreferrer noopener"
+                target="_blank"
+              >
+                <a
+                  href="http://example.com/integration_source_url"
+                  rel="noreferrer noopener"
+                  target="_blank"
+                >
+                  View Source
+                </a>
+              </ExternalLink>
+              <ExternalLink
+                href="http://example.com/integration_issue_url"
+                rel="noreferrer noopener"
+                target="_blank"
+              >
+                <a
+                  href="http://example.com/integration_issue_url"
+                  rel="noreferrer noopener"
+                  target="_blank"
+                >
+                  Report Issue
+                </a>
+              </ExternalLink>
+            </div>
+          </Base>
+        </Box>
+      </div>
+    </Base>
   </Metadata>
   <Alert
     key="0"
     type="warning"
   >
-    <span
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "This is a an alert example",
-        }
-      }
-    />
-  </Alert>
-  <div
-    className="modal-footer"
-  >
-    <Button
-      alignLabel="left"
-      disabled={false}
-      onClick={[MockFunction]}
-      size="small"
+    <AlertWrapper
+      className="ref-warning"
+      type="warning"
     >
-      Cancel
-    </Button>
-    <AddIntegrationButton
-      className="css-1isemmb"
-      onAddIntegration={[Function]}
-      priority="primary"
-      provider={
+      <Base
+        className="ref-warning css-s8q8dm-AlertWrapper e1xb5l7j1"
+        type="warning"
+      >
+        <div
+          className="ref-warning css-s8q8dm-AlertWrapper e1xb5l7j1"
+          is={null}
+          type="warning"
+        >
+          <StyledTextBlock>
+            <Component
+              className="css-1h3n7tg-TextBlock-StyledTextBlock e1xb5l7j2"
+            >
+              <div
+                className="css-1h3n7tg-TextBlock-StyledTextBlock e1xb5l7j2"
+              >
+                <span
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "This is a an alert example",
+                    }
+                  }
+                />
+              </div>
+            </Component>
+          </StyledTextBlock>
+        </div>
+      </Base>
+    </AlertWrapper>
+  </Alert>
+  <IntegrationFeatures
+    features={
+      Array [
         Object {
-          "canAdd": true,
-          "config": Array [],
-          "externalIssues": Array [],
-          "features": Array [],
-          "key": "github",
-          "metadata": Object {
-            "aspects": Object {
-              "alerts": Array [
-                Object {
-                  "text": "This is a an alert example",
-                  "type": "warning",
+          "description": "*markdown* feature description",
+        },
+      ]
+    }
+  >
+    <div
+      className="modal-footer"
+    >
+      <Button
+        alignLabel="left"
+        disabled={false}
+        onClick={[MockFunction]}
+        size="small"
+      >
+        <StyledButton
+          aria-label="Cancel"
+          disabled={false}
+          onClick={[Function]}
+          role="button"
+          size="small"
+        >
+          <Component
+            aria-label="Cancel"
+            className="css-dkprmi-StyledButton-getColors eqrebog0"
+            disabled={false}
+            onClick={[Function]}
+            role="button"
+            size="small"
+          >
+            <button
+              aria-label="Cancel"
+              className="css-dkprmi-StyledButton-getColors eqrebog0"
+              disabled={false}
+              onClick={[Function]}
+              role="button"
+              size="small"
+            >
+              <ButtonLabel
+                justify="flex-start"
+                size="small"
+              >
+                <Component
+                  className="css-o42ntg-ButtonLabel eqrebog1"
+                  justify="flex-start"
+                  size="small"
+                >
+                  <Flex
+                    align="center"
+                    className="css-o42ntg-ButtonLabel eqrebog1"
+                    justify="flex-start"
+                  >
+                    <Base
+                      align="center"
+                      className="eqrebog1 css-gzxb22-ButtonLabel"
+                      justify="flex-start"
+                    >
+                      <div
+                        className="eqrebog1 css-gzxb22-ButtonLabel"
+                        is={null}
+                      >
+                        Cancel
+                      </div>
+                    </Base>
+                  </Flex>
+                </Component>
+              </ButtonLabel>
+            </button>
+          </Component>
+        </StyledButton>
+      </Button>
+      <AddButton
+        disabled={false}
+      >
+        <AddIntegrationButton
+          disabled={false}
+          onAddIntegration={[Function]}
+          priority="primary"
+          provider={
+            Object {
+              "canAdd": true,
+              "config": Array [],
+              "externalIssues": Array [],
+              "features": Array [],
+              "key": "github",
+              "metadata": Object {
+                "aspects": Object {
+                  "alerts": Array [
+                    Object {
+                      "text": "This is a an alert example",
+                      "type": "warning",
+                    },
+                  ],
                 },
-              ],
-            },
-            "author": "Morty",
-            "description": "*markdown* formatted _description_",
-            "features": Array [
-              Object {
-                "description": "*markdown* feature description",
+                "author": "Morty",
+                "description": "*markdown* formatted _description_",
+                "features": Array [
+                  Object {
+                    "description": "*markdown* feature description",
+                  },
+                ],
+                "issue_url": "http://example.com/integration_issue_url",
+                "noun": "Installation",
+                "source_url": "http://example.com/integration_source_url",
               },
-            ],
-            "issue_url": "http://example.com/integration_issue_url",
-            "noun": "Installation",
-            "source_url": "http://example.com/integration_source_url",
-          },
-          "name": "GitHub",
-          "setupDialog": Object {
-            "height": 100,
-            "url": "/github-integration-setup-uri/",
-            "width": 100,
-          },
-        }
-      }
-      size="small"
-    />
-  </div>
-</Fragment>
+              "name": "GitHub",
+              "setupDialog": Object {
+                "height": 100,
+                "url": "/github-integration-setup-uri/",
+                "width": 100,
+              },
+            }
+          }
+          size="small"
+          style={
+            Object {
+              "marginLeft": "8px",
+            }
+          }
+        >
+          <Tooltip
+            disabled={true}
+            title="Integration cannot be added on Sentry. Enable this integration via the GitHub instance."
+          >
+            <span>
+              <AddIntegration
+                onInstall={[Function]}
+                provider={
+                  Object {
+                    "canAdd": true,
+                    "config": Array [],
+                    "externalIssues": Array [],
+                    "features": Array [],
+                    "key": "github",
+                    "metadata": Object {
+                      "aspects": Object {
+                        "alerts": Array [
+                          Object {
+                            "text": "This is a an alert example",
+                            "type": "warning",
+                          },
+                        ],
+                      },
+                      "author": "Morty",
+                      "description": "*markdown* formatted _description_",
+                      "features": Array [
+                        Object {
+                          "description": "*markdown* feature description",
+                        },
+                      ],
+                      "issue_url": "http://example.com/integration_issue_url",
+                      "noun": "Installation",
+                      "source_url": "http://example.com/integration_source_url",
+                    },
+                    "name": "GitHub",
+                    "setupDialog": Object {
+                      "height": 100,
+                      "url": "/github-integration-setup-uri/",
+                      "width": 100,
+                    },
+                  }
+                }
+              >
+                <Button
+                  alignLabel="left"
+                  disabled={false}
+                  onClick={[Function]}
+                  priority="primary"
+                  size="small"
+                  style={
+                    Object {
+                      "marginLeft": "8px",
+                    }
+                  }
+                >
+                  <StyledButton
+                    aria-label="Add Installation"
+                    disabled={false}
+                    onClick={[Function]}
+                    priority="primary"
+                    role="button"
+                    size="small"
+                    style={
+                      Object {
+                        "marginLeft": "8px",
+                      }
+                    }
+                  >
+                    <Component
+                      aria-label="Add Installation"
+                      className="css-zvpqlo-StyledButton-getColors eqrebog0"
+                      disabled={false}
+                      onClick={[Function]}
+                      priority="primary"
+                      role="button"
+                      size="small"
+                      style={
+                        Object {
+                          "marginLeft": "8px",
+                        }
+                      }
+                    >
+                      <button
+                        aria-label="Add Installation"
+                        className="css-zvpqlo-StyledButton-getColors eqrebog0"
+                        disabled={false}
+                        onClick={[Function]}
+                        priority="primary"
+                        role="button"
+                        size="small"
+                        style={
+                          Object {
+                            "marginLeft": "8px",
+                          }
+                        }
+                      >
+                        <ButtonLabel
+                          justify="flex-start"
+                          priority="primary"
+                          size="small"
+                        >
+                          <Component
+                            className="css-o42ntg-ButtonLabel eqrebog1"
+                            justify="flex-start"
+                            priority="primary"
+                            size="small"
+                          >
+                            <Flex
+                              align="center"
+                              className="css-o42ntg-ButtonLabel eqrebog1"
+                              justify="flex-start"
+                            >
+                              <Base
+                                align="center"
+                                className="eqrebog1 css-gzxb22-ButtonLabel"
+                                justify="flex-start"
+                              >
+                                <div
+                                  className="eqrebog1 css-gzxb22-ButtonLabel"
+                                  is={null}
+                                >
+                                  Add Installation
+                                </div>
+                              </Base>
+                            </Flex>
+                          </Component>
+                        </ButtonLabel>
+                      </button>
+                    </Component>
+                  </StyledButton>
+                </Button>
+              </AddIntegration>
+            </span>
+          </Tooltip>
+        </AddIntegrationButton>
+      </AddButton>
+    </div>
+  </IntegrationFeatures>
+</IntegrationDetailsModal>
 `;

--- a/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
+++ b/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
@@ -32,6 +32,16 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
       }
     }
   />
+  <ul>
+    <li
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<em>markdown</em> feature description",
+        }
+      }
+      key="0"
+    />
+  </ul>
   <Metadata>
     <AuthorName
       flex={1}
@@ -100,6 +110,11 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
             },
             "author": "Morty",
             "description": "*markdown* formatted _description_",
+            "features": Array [
+              Object {
+                "description": "*markdown* feature description",
+              },
+            ],
             "issue_url": "http://example.com/integration_issue_url",
             "noun": "Installation",
             "source_url": "http://example.com/integration_source_url",

--- a/tests/js/spec/components/modals/integrationDetailsModal.spec.jsx
+++ b/tests/js/spec/components/modals/integrationDetailsModal.spec.jsx
@@ -60,7 +60,11 @@ describe('IntegrationDetailsModal', function() {
     const provider = TestStubs.GitHubIntegrationProvider();
 
     const wrapper = mount(
-      <IntegrationDetailsModal provider={provider} onAddIntegration={integrationAdded} />,
+      <IntegrationDetailsModal
+        provider={provider}
+        onAddIntegration={integrationAdded}
+        closeModal={() => null}
+      />,
       routerContext
     );
 

--- a/tests/js/spec/components/modals/integrationDetailsModal.spec.jsx
+++ b/tests/js/spec/components/modals/integrationDetailsModal.spec.jsx
@@ -1,21 +1,23 @@
 import React from 'react';
 
-import {shallow} from 'enzyme';
+import {mount} from 'enzyme';
 import IntegrationDetailsModal from 'app/components/modals/integrationDetailsModal';
 
 describe('IntegrationDetailsModal', function() {
   const integrationAdded = jest.fn();
+  const routerContext = TestStubs.routerContext();
 
   it('renders simple integration', function() {
     const onClose = jest.fn();
     const provider = TestStubs.GitHubIntegrationProvider();
 
-    const wrapper = shallow(
+    const wrapper = mount(
       <IntegrationDetailsModal
         provider={provider}
         closeModal={onClose}
         onAddIntegration={integrationAdded}
-      />
+      />,
+      routerContext
     );
 
     expect(wrapper).toMatchSnapshot();
@@ -30,12 +32,13 @@ describe('IntegrationDetailsModal', function() {
     const onClose = jest.fn();
     const provider = TestStubs.JiraIntegrationProvider();
 
-    const wrapper = shallow(
+    const wrapper = mount(
       <IntegrationDetailsModal
         provider={provider}
         closeModal={onClose}
         onAddIntegration={integrationAdded}
-      />
+      />,
+      routerContext
     );
 
     expect(wrapper.find('Button[external]').exists()).toBe(true);

--- a/tests/js/spec/components/modals/integrationDetailsModal.spec.jsx
+++ b/tests/js/spec/components/modals/integrationDetailsModal.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mount} from 'enzyme';
 import IntegrationDetailsModal from 'app/components/modals/integrationDetailsModal';
+import HookStore from 'app/stores/hookStore';
 
 describe('IntegrationDetailsModal', function() {
   const integrationAdded = jest.fn();
@@ -42,5 +43,28 @@ describe('IntegrationDetailsModal', function() {
     );
 
     expect(wrapper.find('Button[external]').exists()).toBe(true);
+  });
+
+  it('disables the button via a hookstore IntegrationFeatures component', function() {
+    HookStore.add('integrations:feature-gates', () => ({
+      FeatureList: p => null,
+      IntegrationFeatures: p =>
+        p.children({
+          disabled: true,
+          disabledReason: 'Integration disabled',
+          ungatedFeatures: p.features,
+          gatedFeatureGroups: [],
+        }),
+    }));
+
+    const provider = TestStubs.GitHubIntegrationProvider();
+
+    const wrapper = mount(
+      <IntegrationDetailsModal provider={provider} onAddIntegration={integrationAdded} />,
+      routerContext
+    );
+
+    expect(wrapper.find('Button[disabled]').exists()).toBe(true);
+    expect(wrapper.find('DisabledNotice').text()).toBe('Integration disabled');
   });
 });

--- a/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
@@ -83,6 +83,11 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
             },
             "author": "Morty",
             "description": "*markdown* formatted _description_",
+            "features": Array [
+              Object {
+                "description": "*markdown* feature description",
+              },
+            ],
             "issue_url": "http://example.com/integration_issue_url",
             "noun": "Installation",
             "source_url": "http://example.com/integration_source_url",
@@ -127,6 +132,11 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
             },
             "author": "Rick",
             "description": "*markdown* formatted Jira _description_",
+            "features": Array [
+              Object {
+                "description": "*markdown* feature description",
+              },
+            ],
             "issue_url": "http://example.com/jira_integration_issue_url",
             "noun": "Instance",
             "source_url": "http://example.com/jira_integration_source_url",
@@ -258,6 +268,11 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                     },
                     "author": "Morty",
                     "description": "*markdown* formatted _description_",
+                    "features": Array [
+                      Object {
+                        "description": "*markdown* feature description",
+                      },
+                    ],
                     "issue_url": "http://example.com/integration_issue_url",
                     "noun": "Installation",
                     "source_url": "http://example.com/integration_source_url",
@@ -1030,6 +1045,11 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                             },
                             "author": "Morty",
                             "description": "*markdown* formatted _description_",
+                            "features": Array [
+                              Object {
+                                "description": "*markdown* feature description",
+                              },
+                            ],
                             "issue_url": "http://example.com/integration_issue_url",
                             "noun": "Installation",
                             "source_url": "http://example.com/integration_source_url",
@@ -1102,6 +1122,11 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                               },
                               "author": "Morty",
                               "description": "*markdown* formatted _description_",
+                              "features": Array [
+                                Object {
+                                  "description": "*markdown* feature description",
+                                },
+                              ],
                               "issue_url": "http://example.com/integration_issue_url",
                               "noun": "Installation",
                               "source_url": "http://example.com/integration_source_url",
@@ -1174,6 +1199,11 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                 },
                                 "author": "Morty",
                                 "description": "*markdown* formatted _description_",
+                                "features": Array [
+                                  Object {
+                                    "description": "*markdown* feature description",
+                                  },
+                                ],
                                 "issue_url": "http://example.com/integration_issue_url",
                                 "noun": "Installation",
                                 "source_url": "http://example.com/integration_source_url",
@@ -1610,6 +1640,11 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                     },
                     "author": "Rick",
                     "description": "*markdown* formatted Jira _description_",
+                    "features": Array [
+                      Object {
+                        "description": "*markdown* feature description",
+                      },
+                    ],
                     "issue_url": "http://example.com/jira_integration_issue_url",
                     "noun": "Instance",
                     "source_url": "http://example.com/jira_integration_source_url",
@@ -2375,6 +2410,11 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                             },
                             "author": "Rick",
                             "description": "*markdown* formatted Jira _description_",
+                            "features": Array [
+                              Object {
+                                "description": "*markdown* feature description",
+                              },
+                            ],
                             "issue_url": "http://example.com/jira_integration_issue_url",
                             "noun": "Instance",
                             "source_url": "http://example.com/jira_integration_source_url",
@@ -2440,6 +2480,11 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                               },
                               "author": "Rick",
                               "description": "*markdown* formatted Jira _description_",
+                              "features": Array [
+                                Object {
+                                  "description": "*markdown* feature description",
+                                },
+                              ],
                               "issue_url": "http://example.com/jira_integration_issue_url",
                               "noun": "Instance",
                               "source_url": "http://example.com/jira_integration_source_url",
@@ -2505,6 +2550,11 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                 },
                                 "author": "Rick",
                                 "description": "*markdown* formatted Jira _description_",
+                                "features": Array [
+                                  Object {
+                                    "description": "*markdown* feature description",
+                                  },
+                                ],
                                 "issue_url": "http://example.com/jira_integration_issue_url",
                                 "noun": "Instance",
                                 "source_url": "http://example.com/jira_integration_source_url",
@@ -2950,6 +3000,11 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
             },
             "author": "Morty",
             "description": "*markdown* formatted _description_",
+            "features": Array [
+              Object {
+                "description": "*markdown* feature description",
+              },
+            ],
             "issue_url": "http://example.com/integration_issue_url",
             "noun": "Installation",
             "source_url": "http://example.com/integration_source_url",
@@ -2978,6 +3033,11 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
             },
             "author": "Rick",
             "description": "*markdown* formatted Jira _description_",
+            "features": Array [
+              Object {
+                "description": "*markdown* feature description",
+              },
+            ],
             "issue_url": "http://example.com/jira_integration_issue_url",
             "noun": "Instance",
             "source_url": "http://example.com/jira_integration_source_url",
@@ -3075,6 +3135,11 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                     },
                     "author": "Morty",
                     "description": "*markdown* formatted _description_",
+                    "features": Array [
+                      Object {
+                        "description": "*markdown* feature description",
+                      },
+                    ],
                     "issue_url": "http://example.com/integration_issue_url",
                     "noun": "Installation",
                     "source_url": "http://example.com/integration_source_url",
@@ -3819,6 +3884,11 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                     },
                     "author": "Rick",
                     "description": "*markdown* formatted Jira _description_",
+                    "features": Array [
+                      Object {
+                        "description": "*markdown* feature description",
+                      },
+                    ],
                     "issue_url": "http://example.com/jira_integration_issue_url",
                     "noun": "Instance",
                     "source_url": "http://example.com/jira_integration_source_url",

--- a/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
@@ -66,6 +66,7 @@ describe('OrganizationIntegrations', function() {
         const options = {
           provider: githubProvider,
           onAddIntegration: wrapper.instance().onInstall,
+          organization: routerContext.context.organization,
         };
 
         wrapper


### PR DESCRIPTION
This allows us to support visually marking specific features of an integration as behind a feature flag.

 - Provides a HookStore hook for overriding integration feature list rendering. This will be needed for the sentry.io SASS to display plan gating details

 - Currently doesn't group based on feature flags (integration flags are enabled by default for integrations at the moment anyway).