### PR TITLE
fix(discover): Add 1px buffer to column width calculation

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/table.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/table.jsx
@@ -152,7 +152,10 @@ export default class ResultTable extends React.Component {
     }
     const context = this.canvas.getContext('2d');
     context.font = isHeader ? 'bold 14px Rubik' : 'normal 14px Rubik';
-    return Math.ceil(context.measureText(text).width);
+
+    // The measureText function sometimes slightly miscalculates text width.
+    // Add 1px to compensate since we want to avoid rows breaking unnecessarily.
+    return Math.ceil(context.measureText(text).width) + 1;
   };
 
   renderTable() {

--- a/tests/js/spec/views/organizationDiscover/result/table.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/result/table.spec.jsx
@@ -30,6 +30,6 @@ describe('ResultTable', function() {
       query: {fields: ['col1'], aggregations: []},
     });
     const widths = wrapper.instance().getColumnWidths(500);
-    expect(widths).toEqual([340, 40, 118]);
+    expect(widths).toEqual([341, 40, 117]);
   });
 });


### PR DESCRIPTION
The canvas measureText sometimes slightly underestimates text width by small amounts. We'll add 1px to the calulated value in order to prevent text from breaking to the next line unnecessarily.