### PR TITLE
fix(integration): Don't block on unmigratable repo

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
@@ -32,7 +32,6 @@ export default class OrganizationIntegrations extends AsyncComponent {
       ['config', `/organizations/${orgId}/config/integrations/`],
       ['integrations', `/organizations/${orgId}/integrations/`],
       ['plugins', `/organizations/${orgId}/plugins/`, {query}],
-      ['unmigratableRepos', `/organizations/${orgId}/repos/?status=unmigratable`],
     ];
   }
 
@@ -140,7 +139,7 @@ export default class OrganizationIntegrations extends AsyncComponent {
         {!this.props.hideHeader && <SettingsPageHeader title={t('Integrations')} />}
 
         <MigrationWarnings
-          unmigratableRepos={this.unmigratableReposByOrg}
+          orgId={this.props.params.orgId}
           providers={this.providers}
           onInstall={this.onInstall}
         />

--- a/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
@@ -46,6 +46,7 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
   </SettingsPageHeading>
   <MigrationWarnings
     onInstall={[Function]}
+    orgId="org-slug"
     providers={
       Array [
         Object {
@@ -135,7 +136,6 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
         },
       ]
     }
-    unmigratableRepos={Object {}}
   />
   <Panel>
     <Component
@@ -2929,6 +2929,7 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
   </SettingsPageHeading>
   <MigrationWarnings
     onInstall={[Function]}
+    orgId="org-slug"
     providers={
       Array [
         Object {
@@ -2986,7 +2987,6 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
         },
       ]
     }
-    unmigratableRepos={Object {}}
   />
   <Panel>
     <Component

--- a/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
@@ -169,11 +169,6 @@ describe('OrganizationIntegrations', function() {
 
       const wrapper = mount(<OrganizationIntegrations params={params} />, routerContext);
 
-      it('fetches unmigratable repositories', function() {
-        expect(wrapper.instance().state.unmigratableRepos).toHaveLength(1);
-        expect(wrapper.instance().state.unmigratableRepos[0].name).toBe('Test-Org/foo');
-      });
-
       it('displays an Upgrade when the Plugin is enabled but a new Integration is not', function() {
         expect(
           wrapper
@@ -205,30 +200,6 @@ describe('OrganizationIntegrations', function() {
             .first()
             .text()
         ).toBe('Install');
-      });
-
-      it('displays a warning for each Org with unmigratable repos', () => {
-        // Use a regex because React/Enzyme/Jest/Whatever turns single quotes into
-        // apostrophes, so you can't match it explicitly.
-        expect(
-          wrapper
-            .find('AlertLink')
-            .first()
-            .text()
-        ).toMatch(/Your Test-Org repositories can.t send commit data to Sentry/);
-      });
-
-      it('opens the new Integration dialog when the warning is clicked', () => {
-        wrapper
-          .find('AlertLink')
-          .first()
-          .simulate('click');
-
-        expect(open.mock.calls).toHaveLength(1);
-        expect(focus.mock.calls).toHaveLength(1);
-        expect(open.mock.calls[0][2]).toBe(
-          'scrollbars=yes,width=100,height=100,top=334,left=462'
-        );
       });
     });
   });

--- a/tests/js/spec/views/settings/organizationIntegrations/migrationWarnings.spec.jsx
+++ b/tests/js/spec/views/settings/organizationIntegrations/migrationWarnings.spec.jsx
@@ -1,0 +1,82 @@
+/*global global*/
+import React from 'react';
+
+import {Client} from 'app/api';
+import {mount} from 'enzyme';
+import MigrationWarnings from 'app/views/organizationIntegrations/migrationWarnings';
+
+jest.mock('app/actionCreators/modal', () => ({
+  openIntegrationDetails: jest.fn(),
+}));
+
+describe('MigrationWarnings', function() {
+  beforeEach(function() {
+    Client.clearMockResponses();
+  });
+
+  describe('render()', function() {
+    const org = TestStubs.Organization();
+    const routerContext = TestStubs.routerContext();
+
+    const jiraProvider = TestStubs.JiraIntegrationProvider();
+    const githubProvider = TestStubs.GitHubIntegrationProvider({
+      integrations: [],
+      isInstalled: false,
+    });
+
+    const focus = jest.fn();
+    const open = jest.fn().mockReturnValue({focus});
+    global.open = open;
+
+    Client.addMockResponse({
+      url: `/organizations/${org.slug}/repos/?status=unmigratable`,
+      body: [
+        {
+          provider: {
+            id: 'github',
+            name: 'GitHub',
+          },
+          name: 'Test-Org/foo',
+        },
+      ],
+    });
+
+    const wrapper = mount(
+      <MigrationWarnings
+        orgId={org.slug}
+        providers={[githubProvider, jiraProvider]}
+        onInstall={() => {}}
+      />,
+      routerContext
+    );
+
+    it('fetches unmigratable repositories', function() {
+      expect(wrapper.instance().state.unmigratableRepos).toHaveLength(1);
+      expect(wrapper.instance().state.unmigratableRepos[0].name).toBe('Test-Org/foo');
+    });
+
+    it('displays a warning for each Org with unmigratable repos', () => {
+      // Use a regex because React/Enzyme/Jest/Whatever turns single quotes into
+      // apostrophes, so you can't match it explicitly.
+      expect(
+        wrapper
+          .find('AlertLink')
+          .first()
+          .text()
+      ).toMatch(/Your Test-Org repositories can.t send commit data to Sentry/);
+    });
+
+    it('opens the new Integration dialog when the warning is clicked', () => {
+      wrapper
+        .find('AlertLink')
+        .first()
+        .simulate('click');
+
+      expect(open.mock.calls).toHaveLength(1);
+      expect(focus.mock.calls).toHaveLength(1);
+      expect(open.mock.calls[0][2]).toBe(
+        'scrollbars=yes,width=100,height=100,top=334,left=462'
+      );
+    });
+  });
+});


### PR DESCRIPTION
Moves the request to retrieve unmigratable repos into the warning component. That request then goes out and requests things from the various Integration providers, so we're dependent on their performance.

This will allow the page to load while it does that work, instead of blocking everything like before.