### PR TITLE
fix(discover): Dropdown input retains value when reopend

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/aggregations/aggregation.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/aggregations/aggregation.jsx
@@ -68,6 +68,14 @@ export default class Aggregation extends React.Component {
     }
   };
 
+  handleOpen = () => {
+    if (this.state.inputValue === '') {
+      this.setState({
+        inputValue: getInternal(this.props.value),
+      });
+    }
+  };
+
   inputRenderer = props => {
     return (
       <input
@@ -102,6 +110,7 @@ export default class Aggregation extends React.Component {
           options={this.getOptions()}
           filterOptions={this.filterOptions}
           onChange={this.handleChange}
+          onOpen={this.handleOpen}
           closeOnSelect={true}
           openOnFocus={true}
           autoBlur={true}

--- a/src/sentry/static/sentry/app/views/organizationDiscover/conditions/condition.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/conditions/condition.jsx
@@ -50,6 +50,14 @@ export default class Condition extends React.Component {
     );
   };
 
+  handleOpen = () => {
+    if (this.state.inputValue === '') {
+      this.setState({
+        inputValue: getInternal(this.props.value),
+      });
+    }
+  };
+
   getOptions() {
     const currentValue = getInternal(this.props.value);
     const shouldDisplayValue = currentValue || this.state.inputValue;
@@ -155,6 +163,7 @@ export default class Condition extends React.Component {
           options={this.getOptions()}
           filterOptions={this.filterOptions}
           onChange={this.handleChange}
+          onOpen={this.handleOpen}
           closeOnSelect={true}
           openOnFocus={true}
           autoBlur={true}


### PR DESCRIPTION
This is a bit of a workaround since react-select v1 doesn't support
controlling open/close state of dropdowns and open/close is called far
more than we actually want it to be (we use focus() to get around this).
inputState == "" implies that the dropdown is in a real closed state and
we want to reset the input preserving it's value for editing.

Updating to v2 would be the ideal longer term solution.