### PR TITLE
feat(buffer): Remove use of pickle

### DIFF
--- a/src/sentry/api/endpoints/team_groups_trending.py
+++ b/src/sentry/api/endpoints/team_groups_trending.py
@@ -8,6 +8,7 @@ from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.serializers import serialize, GroupSerializer
 from sentry.models import Group, GroupStatus, Project
+from sentry.utils.db import get_db_engine
 
 
 class TeamGroupsTrendingEndpoint(TeamEndpoint, EnvironmentMixin):
@@ -29,14 +30,19 @@ class TeamGroupsTrendingEndpoint(TeamEndpoint, EnvironmentMixin):
         cutoff = timedelta(minutes=minutes)
         cutoff_dt = timezone.now() - cutoff
 
+        if get_db_engine('default') == 'sqlite':
+            sort_value = 'times_seen'
+        else:
+            sort_value = 'score'
+
         group_list = list(
             Group.objects.filter(
                 project__in=project_dict.keys(),
                 status=GroupStatus.UNRESOLVED,
                 last_seen__gte=cutoff_dt,
             ).extra(
-                select={'sort_value': 'score'},
-            ).order_by('-score')[:limit]
+                select={'sort_value': sort_value},
+            ).order_by('-{}'.format(sort_value))[:limit]
         )
 
         for group in group_list:

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -57,9 +57,17 @@ class Buffer(Service):
         return []
 
     def process(self, model, columns, filters, extra=None):
+        from sentry.models import Group
+        from sentry.event_manager import ScoreClause
+
         update_kwargs = dict((c, F(c) + v) for c, v in six.iteritems(columns))
         if extra:
             update_kwargs.update(extra)
+
+        # HACK(dcramer): this is gross, but we dont have a good hook to compute this property today
+        # XXX(dcramer): remove once we can replace 'priority' with something reasonable via Snuba
+        if model is Group and 'last_seen' in update_kwargs and 'times_seen' in update_kwargs:
+            update_kwargs['score'] = ScoreClause(None)
 
         _, created = model.objects.create_or_update(values=update_kwargs, **filters)
 

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -12,13 +12,15 @@ import six
 from time import time
 from binascii import crc32
 
+from datetime import datetime
 from django.db import models
+from django.utils import timezone
 from django.utils.encoding import force_bytes
 
 from sentry.buffer import Buffer
 from sentry.exceptions import InvalidConfiguration
 from sentry.tasks.process_buffer import process_incr, process_pending
-from sentry.utils import metrics
+from sentry.utils import json, metrics
 from sentry.utils.compat import pickle
 from sentry.utils.hashlib import md5_text
 from sentry.utils.imports import import_string
@@ -110,6 +112,47 @@ class RedisBuffer(Buffer):
     def _make_lock_key(self, key):
         return 'l:%s' % (key, )
 
+    def _dump_values(self, values):
+        result = {}
+        for k, v in six.iteritems(values):
+            result[k] = self._dump_value(v)
+        return result
+
+    def _dump_value(self, value):
+        if isinstance(value, six.string_types):
+            type_ = 's'
+        elif isinstance(value, datetime):
+            type_ = 'd'
+            value = value.strftime('%s.%f')
+        elif isinstance(value, int):
+            type_ = 'i'
+        elif isinstance(value, float):
+            type_ = 'f'
+        else:
+            raise TypeError(type(value))
+        return (type_, six.text_type(value))
+
+    def _load_values(self, payload):
+        result = {}
+        for k, (t, v) in six.iteritems(payload):
+            result[k] = self._load_value((t, v))
+        return result
+
+    def _load_value(self, payload):
+        (type_, value) = payload
+        if type_ == 's':
+            return value
+        elif type_ == 'd':
+            return datetime.fromtimestamp(float(value)).replace(
+                tzinfo=timezone.utc
+            )
+        elif type_ == 'i':
+            return int(value)
+        elif type_ == 'f':
+            return float(value)
+        else:
+            raise TypeError('invalid type: {}'.format(type_))
+
     def incr(self, model, columns, filters, extra=None):
         """
         Increment the key by doing the following:
@@ -129,13 +172,16 @@ class RedisBuffer(Buffer):
 
         pipe = conn.pipeline()
         pipe.hsetnx(key, 'm', '%s.%s' % (model.__module__, model.__name__))
-        pipe.hsetnx(key, 'f', pickle.dumps(filters))
+        pipe.hsetnx(key, 'f', json.dumps(self._dump_values(filters)))
         for column, amount in six.iteritems(columns):
             pipe.hincrby(key, 'i+' + column, amount)
 
         if extra:
+            # Group tries to serialize 'score', so we'd need some kind of processing
+            # hook here
+            # e.g. "update score if last_seen or times_seen is changed"
             for column, value in six.iteritems(extra):
-                pipe.hset(key, 'e+' + column, pickle.dumps(value))
+                pipe.hset(key, 'e+' + column, json.dumps(self._dump_value(value)))
         pipe.expire(key, self.key_expire)
         pipe.zadd(pending_key, time(), key)
         pipe.execute()
@@ -229,15 +275,24 @@ class RedisBuffer(Buffer):
                 self.logger.debug('buffer.revoked.empty', extra={'redis_key': key})
                 return
 
-            model = import_string(values['m'])
-            filters = pickle.loads(values['f'])
+            model = import_string(values.pop('m'))
+            if values['f'].startswith('{'):
+                filters = self._load_values(json.loads(values.pop('f')))
+            else:
+                # TODO(dcramer): legacy pickle support - remove in Sentry 9.1
+                filters = pickle.loads(values.pop('f'))
+
             incr_values = {}
             extra_values = {}
             for k, v in six.iteritems(values):
                 if k.startswith('i+'):
                     incr_values[k[2:]] = int(v)
                 elif k.startswith('e+'):
-                    extra_values[k[2:]] = pickle.loads(v)
+                    if v.startswith('['):
+                        extra_values[k[2:]] = self._load_value(json.loads(v))
+                    else:
+                        # TODO(dcramer): legacy pickle support - remove in Sentry 9.1
+                        extra_values[k[2:]] = pickle.loads(v)
 
             super(RedisBuffer, self).process(model, incr_values, filters, extra_values)
         finally:

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -7,7 +7,6 @@ sentry.event_manager
 from __future__ import absolute_import, print_function
 
 import logging
-import math
 import re
 import six
 
@@ -242,14 +241,14 @@ try:
 except ImportError:
     # XXX(dramer): compatibility hack for Django 1.6
     class ScoreClause(object):
-        def __init__(self, group, *args, **kwargs):
+        def __init__(self, group=None, *args, **kwargs):
             self.group = group
             super(ScoreClause, self).__init__(*args, **kwargs)
 
         def __int__(self):
             # Calculate the score manually when coercing to an int.
             # This is used within create_or_update and friends
-            return self.group.get_score()
+            return self.group.get_score() if self.group else 0
 
         def prepare_database_save(self, unused):
             return self
@@ -268,10 +267,6 @@ except ImportError:
                 sql = int(self)
 
             return (sql, [])
-
-        @classmethod
-        def calculate(cls, times_seen, last_seen):
-            return math.log(times_seen) * 600 + float(last_seen.strftime('%s'))
 else:
     # XXX(dramer): compatibility hack for Django 1.8+
     class ScoreClause(Func):
@@ -282,7 +277,7 @@ else:
         def __int__(self):
             # Calculate the score manually when coercing to an int.
             # This is used within create_or_update and friends
-            return self.group.get_score()
+            return self.group.get_score() if self.group else 0
 
         def as_sql(self, compiler, connection, function=None, template=None):
             engine = get_db_engine(getattr(connection, 'alias', 'default'))
@@ -295,10 +290,6 @@ else:
                 sql = int(self)
 
             return (sql, [])
-
-        @classmethod
-        def calculate(cls, times_seen, last_seen):
-            return math.log(times_seen) * 600 + float(last_seen.strftime('%s'))
 
 
 class InvalidTimestamp(Exception):
@@ -1060,7 +1051,6 @@ class EventManager(object):
         # it should be resolved by the hash merging function later but this
         # should be better tested/reviewed
         if existing_group_id is None:
-            kwargs['score'] = ScoreClause.calculate(1, kwargs['last_seen'])
             # it's possible the release was deleted between
             # when we queried for the release and now, so
             # make sure it still exists

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -9,7 +9,7 @@ from sentry import tagstore
 from sentry.app import tsdb
 from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS_MAP
 from sentry.event_manager import (
-    ScoreClause, generate_culprit, get_fingerprint_for_event, get_hashes_from_fingerprint, md5_from_hash
+    generate_culprit, get_fingerprint_for_event, get_hashes_from_fingerprint, md5_from_hash
 )
 from sentry.models import (
     Activity, Environment, Event, EventMapping, EventUser, Group,
@@ -104,7 +104,7 @@ backfill_fields = {
         event.get_tag('sentry:release'),
     ) if event.get_tag('sentry:release') else data.get('first_release', None),
     'times_seen': lambda caches, data, event: data['times_seen'] + 1,
-    'score': lambda caches, data, event: ScoreClause.calculate(
+    'score': lambda caches, data, event: Group.calculate_score(
         data['times_seen'] + 1,
         data['last_seen'],
     ),

--- a/tests/sentry/api/endpoints/test_team_groups_new.py
+++ b/tests/sentry/api/endpoints/test_team_groups_new.py
@@ -9,8 +9,8 @@ class TeamGroupsNewTest(APITestCase):
     def test_simple(self):
         project1 = self.create_project(teams=[self.team], slug='foo')
         project2 = self.create_project(teams=[self.team], slug='bar')
-        group1 = self.create_group(checksum='a' * 32, project=project1, score=10)
-        group2 = self.create_group(checksum='b' * 32, project=project2, score=5)
+        group1 = self.create_group(checksum='a' * 32, project=project1, times_seen=10)
+        group2 = self.create_group(checksum='b' * 32, project=project2, times_seen=5)
 
         self.login_as(user=self.user)
         url = u'/api/0/teams/{}/{}/issues/new/'.format(

--- a/tests/sentry/api/endpoints/test_team_groups_trending.py
+++ b/tests/sentry/api/endpoints/test_team_groups_trending.py
@@ -9,8 +9,8 @@ class TeamGroupsTrendingTest(APITestCase):
     def test_simple(self):
         project1 = self.create_project(teams=[self.team], slug='foo')
         project2 = self.create_project(teams=[self.team], slug='bar')
-        group1 = self.create_group(checksum='a' * 32, project=project1, score=10)
-        group2 = self.create_group(checksum='b' * 32, project=project2, score=5)
+        group1 = self.create_group(checksum='a' * 32, project=project1, times_seen=10)
+        group2 = self.create_group(checksum='b' * 32, project=project2, times_seen=5)
 
         self.login_as(user=self.user)
 

--- a/tests/sentry/buffer/redis/tests.py
+++ b/tests/sentry/buffer/redis/tests.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import
 
+import pytest
 import mock
 
 from datetime import datetime
@@ -92,6 +93,8 @@ class RedisBufferTest(TestCase):
         self.buf.process('foo')
         process.assert_called_once_with(Group, columns, filters, extra)
 
+    # this test should be passing once we no longer serialize using pickle
+    @pytest.mark.xfail
     @mock.patch('sentry.buffer.redis.RedisBuffer._make_key', mock.Mock(return_value='foo'))
     @mock.patch('sentry.buffer.redis.process_incr', mock.Mock())
     def test_incr_saves_to_redis(self):

--- a/tests/sentry/buffer/redis/tests.py
+++ b/tests/sentry/buffer/redis/tests.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import
 
 import mock
 
+from datetime import datetime
+from django.utils import timezone
 from sentry.buffer.redis import RedisBuffer
 from sentry.models import Group, Project
 from sentry.testutils import TestCase
@@ -55,7 +57,26 @@ class RedisBufferTest(TestCase):
 
     @mock.patch('sentry.buffer.redis.RedisBuffer._make_key', mock.Mock(return_value='foo'))
     @mock.patch('sentry.buffer.base.Buffer.process')
-    def test_process_does_bubble_up(self, process):
+    def test_process_does_bubble_up_json(self, process):
+        client = self.buf.cluster.get_routing_client()
+        client.hmset(
+            'foo', {
+                'e+foo': '["s","bar"]',
+                'e+datetime': '["d","1493791566.000000"]',
+                'f': '{"pk": ["i","1"]}',
+                'i+times_seen': '2',
+                'm': 'sentry.models.Group',
+            }
+        )
+        columns = {'times_seen': 2}
+        filters = {'pk': 1}
+        extra = {'foo': 'bar', 'datetime': datetime(2017, 5, 3, 6, 6, 6, tzinfo=timezone.utc)}
+        self.buf.process('foo')
+        process.assert_called_once_with(Group, columns, filters, extra)
+
+    @mock.patch('sentry.buffer.redis.RedisBuffer._make_key', mock.Mock(return_value='foo'))
+    @mock.patch('sentry.buffer.base.Buffer.process')
+    def test_process_does_bubble_up_pickle(self, process):
         client = self.buf.cluster.get_routing_client()
         client.hmset(
             'foo', {
@@ -74,26 +95,29 @@ class RedisBufferTest(TestCase):
     @mock.patch('sentry.buffer.redis.RedisBuffer._make_key', mock.Mock(return_value='foo'))
     @mock.patch('sentry.buffer.redis.process_incr', mock.Mock())
     def test_incr_saves_to_redis(self):
+        now = datetime(2017, 5, 3, 6, 6, 6, tzinfo=timezone.utc)
         client = self.buf.cluster.get_routing_client()
         model = mock.Mock()
         model.__name__ = 'Mock'
         columns = {'times_seen': 1}
-        filters = {'pk': 1}
-        self.buf.incr(model, columns, filters, extra={'foo': 'bar'})
+        filters = {'pk': 1, 'datetime': now}
+        self.buf.incr(model, columns, filters, extra={'foo': 'bar', 'datetime': now})
         result = client.hgetall('foo')
         assert result == {
-            'e+foo': "S'bar'\np1\n.",
-            'f': "(dp1\nS'pk'\np2\nI1\ns.",
+            'e+foo': '["s","bar"]',
+            'e+datetime': '["d","1493791566.000000"]',
+            'f': '{"pk":["i","1"],"datetime":["d","1493791566.000000"]}',
             'i+times_seen': '1',
             'm': 'mock.mock.Mock',
         }
         pending = client.zrange('b:p', 0, -1)
         assert pending == ['foo']
-        self.buf.incr(model, columns, filters, extra={'foo': 'bar'})
+        self.buf.incr(model, columns, filters, extra={'foo': 'baz'})
         result = client.hgetall('foo')
         assert result == {
-            'e+foo': "S'bar'\np1\n.",
-            'f': "(dp1\nS'pk'\np2\nI1\ns.",
+            'e+foo': '["s","baz"]',
+            'e+datetime': '["d","1493791566.000000"]',
+            'f': '{"pk":["i","1"],"datetime":["d","1493791566.000000"]}',
             'i+times_seen': '2',
             'm': 'mock.mock.Mock',
         }

--- a/tests/sentry/search/django/tests.py
+++ b/tests/sentry/search/django/tests.py
@@ -9,7 +9,6 @@ import pytz
 from django.conf import settings
 
 from sentry import tagstore
-from sentry.event_manager import ScoreClause
 from sentry.models import (
     Environment, Event, GroupAssignee, GroupBookmark, GroupEnvironment, GroupStatus,
     GroupSubscription, Release, ReleaseEnvironment, ReleaseProjectEnvironment
@@ -35,10 +34,6 @@ class DjangoSearchBackendTest(TestCase):
             status=GroupStatus.UNRESOLVED,
             last_seen=datetime(2013, 8, 13, 3, 8, 24, 880386, tzinfo=pytz.utc),
             first_seen=datetime(2013, 7, 13, 3, 8, 24, 880386, tzinfo=pytz.utc),
-            score=ScoreClause.calculate(
-                times_seen=5,
-                last_seen=datetime(2013, 8, 13, 3, 8, 24, 880386, tzinfo=pytz.utc),
-            ),
         )
 
         self.event1 = self.create_event(
@@ -68,10 +63,6 @@ class DjangoSearchBackendTest(TestCase):
             status=GroupStatus.RESOLVED,
             last_seen=datetime(2013, 7, 14, 3, 8, 24, 880386, tzinfo=pytz.utc),
             first_seen=datetime(2013, 7, 14, 3, 8, 24, 880386, tzinfo=pytz.utc),
-            score=ScoreClause.calculate(
-                times_seen=10,
-                last_seen=datetime(2013, 7, 14, 3, 8, 24, 880386, tzinfo=pytz.utc),
-            ),
         )
 
         self.event2 = self.create_event(

--- a/tests/sentry/tasks/test_unmerge.py
+++ b/tests/sentry/tasks/test_unmerge.py
@@ -16,7 +16,6 @@ from mock import patch
 from sentry import tagstore
 from sentry.tagstore.models import GroupTagValue
 from sentry.app import tsdb
-from sentry.event_manager import ScoreClause
 from sentry.models import (
     Activity, Environment, EnvironmentProject, Event, EventMapping, Group, GroupHash, GroupRelease,
     Release, UserReport
@@ -115,7 +114,7 @@ class UnmergeTestCase(TestCase):
             'platform': 'java',
             'message': 'Hello from JavaScript',
             'level': logging.INFO,
-            'score': ScoreClause.calculate(3, now),
+            'score': Group.calculate_score(3, now),
             'logger': 'java',
             'times_seen': 3,
             'first_release': None,
@@ -138,7 +137,7 @@ class UnmergeTestCase(TestCase):
                 platform='javascript',
                 message='Hello from JavaScript',
                 level=logging.INFO,
-                score=ScoreClause.calculate(3, now),
+                score=Group.calculate_score(3, now),
                 logger='javascript',
                 times_seen=1,
                 first_release=None,
@@ -181,7 +180,7 @@ class UnmergeTestCase(TestCase):
             'active_at': now - timedelta(hours=2),
             'first_seen': now - timedelta(hours=2),
             'platform': 'java',
-            'score': ScoreClause.calculate(3, now),
+            'score': Group.calculate_score(3, now),
             'logger': 'java',
             'times_seen': 3,
             'first_release': None,

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.utils import timezone
 
 from sentry import options
-from sentry.event_manager import ScoreClause
 from sentry.models import (
     Environment, GroupAssignee, GroupBookmark, GroupStatus, GroupSubscription,
     Release, ReleaseEnvironment, ReleaseProjectEnvironment
@@ -36,10 +35,6 @@ class SnubaSearchTest(SnubaTestCase):
             status=GroupStatus.UNRESOLVED,
             last_seen=base_datetime,
             first_seen=base_datetime - timedelta(days=31),
-            score=ScoreClause.calculate(
-                times_seen=5,
-                last_seen=base_datetime,
-            ),
         )
 
         self.event1 = self.create_event(
@@ -79,10 +74,6 @@ class SnubaSearchTest(SnubaTestCase):
             status=GroupStatus.RESOLVED,
             last_seen=base_datetime - timedelta(days=30),
             first_seen=base_datetime - timedelta(days=30),
-            score=ScoreClause.calculate(
-                times_seen=10,
-                last_seen=base_datetime - timedelta(days=30),
-            ),
         )
 
         self.event2 = self.create_event(


### PR DESCRIPTION
Replace the use of pickle in buffers with a type-encoded json format.

This also removes score support from sqlite as it cannot functional correctly (and is unsupported anyways).