### PR TITLE
feat(auth) Don't expose account existence

### DIFF
--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -279,7 +279,14 @@ class RecoverPasswordForm(forms.Form):
             return
         users = find_users(value, with_valid_password=False)
         if not users:
-            raise forms.ValidationError(_("We were unable to find a matching user."))
+            return
+
+        # If we find more than one user, we likely matched on email address.
+        # We silently bail here as we emailing the 'wrong' person isn't great.
+        # They will have to retry with their username which is guaranteed
+        # to be unique
+        if len(users) > 1:
+            return
 
         users = [u for u in users if not u.is_managed]
         if not users:
@@ -287,11 +294,6 @@ class RecoverPasswordForm(forms.Form):
                 _(
                     "The account you are trying to recover is managed and does not support password recovery."
                 )
-            )
-
-        if len(users) > 1:
-            raise forms.ValidationError(
-                _("Multiple accounts were found matching this email address.")
             )
         return users[0]
 

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -80,16 +80,17 @@ def recover(request):
 
     if form.is_valid():
         email = form.cleaned_data['user']
-        password_hash = LostPasswordHash.for_user(email)
-        password_hash.send_email(request)
+        if email:
+            password_hash = LostPasswordHash.for_user(email)
+            password_hash.send_email(request)
 
-        extra['passwordhash_id'] = password_hash.id
-        extra['user_id'] = password_hash.user_id
+            extra['passwordhash_id'] = password_hash.id
+            extra['user_id'] = password_hash.user_id
 
-        logger.info('recover.sent', extra=extra)
+            logger.info('recover.sent', extra=extra)
 
         tpl = 'sentry/account/recover/sent.html'
-        context = {'email': password_hash.user.email}
+        context = {'email': email}
 
         return render_to_response(tpl, context, request)
 

--- a/tests/sentry/web/frontend/test_accounts.py
+++ b/tests/sentry/web/frontend/test_accounts.py
@@ -1,0 +1,59 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+from exam import fixture
+
+from sentry.models import LostPasswordHash
+from sentry.testutils import TestCase
+
+
+class TestAccounts(TestCase):
+    @fixture
+    def path(self):
+        return reverse('sentry-account-recover')
+
+    def test_get_renders_form(self):
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        self.assertTemplateUsed('sentry/account/recover/index.html')
+
+    def test_post_unknown_user(self):
+        resp = self.client.post(self.path, {'user': 'nobody'})
+        assert resp.status_code == 200
+        self.assertTemplateUsed('sentry/account/recover/sent.html')
+        assert 0 == len(LostPasswordHash.objects.all())
+
+    def test_post_success(self):
+        user = self.create_user()
+
+        resp = self.client.post(self.path, {'user': user.email})
+        assert resp.status_code == 200
+        self.assertTemplateUsed('sentry/account/recover/sent.html')
+        assert 1 == len(LostPasswordHash.objects.all())
+
+    def test_post_managed_user(self):
+        user = self.create_user()
+        user.is_managed = True
+        user.save()
+
+        resp = self.client.post(self.path, {'user': user.email})
+        assert resp.status_code == 200
+        self.assertTemplateUsed('sentry/account/recover/index.html')
+        self.assertContains(
+            resp,
+            'The account you are trying to recover is managed')
+        assert 0 == len(LostPasswordHash.objects.all())
+
+    def test_post_multiple_users(self):
+        user = self.create_user(email='bob')
+        user.email = 'bob@example.com'
+        user.save()
+
+        user_dup = self.create_user(email="jill")
+        user_dup.email = user.email
+        user_dup.save()
+
+        resp = self.client.post(self.path, {'user': user.email})
+        assert resp.status_code == 200
+        self.assertTemplateUsed('sentry/account/recover/index.html')
+        assert 0 == len(LostPasswordHash.objects.all())


### PR DESCRIPTION
Reduce the scenarios that we expose account information. Now when a non-existent account has its password reset we respond the same as if the password reset email was sent. Only for managed SSO accounts do we respond with an error.