### PR TITLE
feat(api) Add default message to not found errors

### DIFF
--- a/src/sentry/api/exceptions.py
+++ b/src/sentry/api/exceptions.py
@@ -7,6 +7,7 @@ from rest_framework.exceptions import APIException
 
 class ResourceDoesNotExist(APIException):
     status_code = status.HTTP_404_NOT_FOUND
+    default_detail = 'The requested resource does not exist'
 
 
 class SentryAPIException(APIException):


### PR DESCRIPTION
Current 404 errors have a response body of

```
{"detail":""}
```

Which isn't helpful and looks broken. These changes add a default message.

Refs APP-516