### PR TITLE
fix(docs) Point to release docs instead of the API docs

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectReleaseTracking.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectReleaseTracking.jsx
@@ -244,8 +244,8 @@ class ProjectReleaseTracking extends AsyncView {
             </p>
 
             <p>
-              {tct('See the [link:Releases API documentation] for more information.', {
-                link: <a href="https://docs.sentry.io/hosted/api/releases/" />,
+              {tct('See the [link:Releases documentation] for more information.', {
+                link: <a href="https://docs.sentry.io/learn/releases" />,
               })}
             </p>
           </PanelBody>


### PR DESCRIPTION
Link to more holistic docs that encourage the use of sentry-cli or the browser API instead of only showing the API docs.

Refs APP-517