### PR TITLE
perf(snuba): Iterate the entire Snuba search process in chunks

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -94,7 +94,6 @@ register(
 register('api.rate-limit.org-create', default=5, flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
 
 # Beacon
-
 register('beacon.anonymous', type=Bool, flags=FLAG_REQUIRED)
 
 # Filestore
@@ -134,3 +133,6 @@ register('github-app.client-secret', flags=FLAG_PRIORITIZE_DISK)
 # VSTS Integration
 register('vsts.client-id', flags=FLAG_PRIORITIZE_DISK)
 register('vsts.client-secret', flags=FLAG_PRIORITIZE_DISK)
+
+# Snuba
+register('snuba.search.max-pre-snuba-candidates', default=500)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -136,3 +136,5 @@ register('vsts.client-secret', flags=FLAG_PRIORITIZE_DISK)
 
 # Snuba
 register('snuba.search.max-pre-snuba-candidates', default=500)
+register('snuba.search.chunk-growth-rate', default=1.5)
+register('snuba.search.max-chunk-size', default=2000)

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -59,9 +59,9 @@ _snuba_pool = urllib3.connectionpool.connection_from_url(
 
 
 def raw_query(start, end, groupby=None, conditions=None, filter_keys=None,
-              aggregations=None, rollup=None, arrayjoin=None, limit=None, orderby=None,
-              having=None, referrer=None, is_grouprelease=False, selected_columns=None,
-              totals=None):
+              aggregations=None, rollup=None, arrayjoin=None, limit=None, offset=None,
+              orderby=None, having=None, referrer=None, is_grouprelease=False,
+              selected_columns=None, totals=None):
     """
     Sends a query to snuba.
 
@@ -158,6 +158,7 @@ def raw_query(start, end, groupby=None, conditions=None, filter_keys=None,
         'issues': issues,
         'arrayjoin': arrayjoin,
         'limit': limit,
+        'offset': offset,
         'orderby': orderby,
         'selected_columns': selected_columns,
     }) if v is not None}
@@ -190,9 +191,9 @@ def raw_query(start, end, groupby=None, conditions=None, filter_keys=None,
 
 
 def query(start, end, groupby, conditions=None, filter_keys=None,
-          aggregations=None, rollup=None, arrayjoin=None, limit=None, orderby=None,
-          having=None, referrer=None, is_grouprelease=False, selected_columns=None,
-          totals=None):
+          aggregations=None, rollup=None, arrayjoin=None, limit=None, offset=None,
+          orderby=None, having=None, referrer=None, is_grouprelease=False,
+          selected_columns=None, totals=None):
 
     aggregations = aggregations or [['count()', '', 'aggregate']]
     filter_keys = filter_keys or {}
@@ -202,7 +203,7 @@ def query(start, end, groupby, conditions=None, filter_keys=None,
         body = raw_query(
             start, end, groupby=groupby, conditions=conditions, filter_keys=filter_keys,
             selected_columns=selected_columns, aggregations=aggregations, rollup=rollup,
-            arrayjoin=arrayjoin, limit=limit, orderby=orderby, having=having,
+            arrayjoin=arrayjoin, limit=limit, offset=offset, orderby=orderby, having=having,
             referrer=referrer, is_grouprelease=is_grouprelease, totals=totals
         )
     except (QueryOutsideRetentionError, QueryOutsideGroupActivityError):

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -376,7 +376,7 @@ class SnubaSearchTest(SnubaTestCase):
             count_hits=True,
         )
         assert list(results) == [self.group2]
-        assert results.hits == 2
+        assert results.hits is None  # NOQA
 
         results = self.backend.query(
             self.project,
@@ -387,7 +387,7 @@ class SnubaSearchTest(SnubaTestCase):
             count_hits=True,
         )
         assert list(results) == [self.group1]
-        assert results.hits == 2
+        assert results.hits is None  # NOQA
 
         results = self.backend.query(
             self.project,
@@ -398,7 +398,7 @@ class SnubaSearchTest(SnubaTestCase):
             count_hits=True,
         )
         assert list(results) == []
-        assert results.hits == 2
+        assert results.hits is None  # NOQA
 
     def test_age_filter(self):
         results = self.backend.query(


### PR DESCRIPTION
Previously, a search query for a project with 10,000 groups and very few
search parameters (such as the default project view) would effectively
return all 10,000 groups for the project, sorted by `last_seen`. Those
10,000 groups would then be pushed back down into Postgres for
filtering, and finally a Paginator would be applied to the results
(which would often be all 10,000 groups).

Now the search process is done in chunks, from Snuba to Postgres,
checking whether the paginator returns enough results and if not
re-running the loop to fetch more results and extend the paginator
result set until `limit` items are found or the Snuba groups are
exhausted.

There is still a fast-path attempted if Postgres returns a small number
of candidates at the very beginning of search. This was put behind an
option so we can try tuning it (or disabling it) in production.
