### PR TITLE
Block ALL Facebook errors from their .net domain

### DIFF
--- a/src/sentry/filters/browser_extensions.py
+++ b/src/sentry/filters/browser_extensions.py
@@ -51,9 +51,9 @@ EXTENSION_EXC_SOURCES = re.compile(
     '|'.join(
         (
             # Facebook flakiness
-            r'graph\.facebook\.com'
+            r'graph\.facebook\.com',
             # Facebook blocked
-            r'connect\.facebook\.net\/en_US\/all\.js',
+            r'connect\.facebook\.net',
             # Woopra flakiness
             r'eatdifferent\.com\.woopra-ns\.com',
             r'static\.woopra\.com\/js\/woopra\.js',

--- a/tests/sentry/filters/test_browser_extensions.py
+++ b/tests/sentry/filters/test_browser_extensions.py
@@ -73,3 +73,19 @@ class BrowserExtensionsFilterTest(TestCase):
         data = self.get_mock_data()
         data['sentry.interfaces.Exception'] = None
         assert not self.apply_filter(data)
+
+    def test_filters_facebook_source(self):
+        data = self.get_mock_data(exc_source='https://graph.facebook.com/')
+        assert self.apply_filter(data)
+
+        data = self.get_mock_data(exc_source='https://connect.facebook.net/en_US/sdk.js')
+        assert self.apply_filter(data)
+
+    def test_filters_woopra_source(self):
+        data = self.get_mock_data(exc_source='https://static.woopra.com/js/woopra.js')
+        assert self.apply_filter(data)
+
+    def test_filters_itunes_source(self):
+        data = self.get_mock_data(
+            exc_source='http://metrics.itunes.apple.com.edgesuite.net/itunespreview/itunes/browser:firefo')
+        assert self.apply_filter(data)


### PR DESCRIPTION
Block all Facebook issues instead of errors originating from all.js. Other Facebook services also use the .net domain to serve content, e.g. Signals.