### PR TITLE
fix: Do not include newlines in dsn selector

### DIFF
--- a/src/sentry/static/sentry/app/components/autoSelectText.jsx
+++ b/src/sentry/static/sentry/app/components/autoSelectText.jsx
@@ -36,14 +36,13 @@ class AutoSelectText extends React.Component {
       });
     }
 
+    // use an inner span here for the selection as otherwise the selectText
+    // function will create a range that includes the entire part of the
+    // div (including the div itself) which causes newlines to be selected
+    // in chrome.
     return (
-      <div
-        {...props}
-        ref={this.handleMount}
-        onClick={this.selectText}
-        className="auto-select-text"
-      >
-        {children}
+      <div {...props} onClick={this.selectText} className="auto-select-text">
+        <span ref={this.handleMount}>{children}</span>
       </div>
     );
   }

--- a/tests/js/spec/views/__snapshots__/groupSimilarView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/groupSimilarView.spec.jsx.snap
@@ -889,7 +889,9 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                                     className="auto-select-text"
                                                     onClick={[Function]}
                                                   >
-                                                    INTERNAL-4G
+                                                    <span>
+                                                      INTERNAL-4G
+                                                    </span>
                                                   </div>
                                                 </AutoSelectText>
                                               </div>


### PR DESCRIPTION
The dsn selector in the onboarding docs included newlines when copy pasting causing
frustrations when copying this into string literals or bash sessions.

This makes me happy.