### PR TITLE
fix(docs) Fix missing whitespace and path properties

### DIFF
--- a/api-docs/generator.py
+++ b/api-docs/generator.py
@@ -242,8 +242,9 @@ def output_markdown(sections, scenarios, section_mapping):
             payload = dict(
                 title=title,
                 sidebar_order=i,
-                description=''.join(endpoint['text']),
+                description=' '.join(endpoint['text']),
                 method=endpoint['method'],
+                path=endpoint['path'],
                 query_parameters=endpoint['params'].get('query'),
                 path_parameters=endpoint['params'].get('path'),
                 parameters=endpoint['params'].get('params'),

--- a/api-docs/generator.py
+++ b/api-docs/generator.py
@@ -242,7 +242,8 @@ def output_markdown(sections, scenarios, section_mapping):
             payload = dict(
                 title=title,
                 sidebar_order=i,
-                description=' '.join(endpoint['text']),
+                description='\n'.join(endpoint['text']).strip(),
+                warning=endpoint['warning'],
                 method=endpoint['method'],
                 path=endpoint['path'],
                 query_parameters=endpoint['params'].get('query'),

--- a/api-docs/generator.py
+++ b/api-docs/generator.py
@@ -240,15 +240,15 @@ def output_markdown(sections, scenarios, section_mapping):
             if len(endpoint['params'].get('auth', [])):
                 auth = endpoint['params']['auth'][0]['description']
             payload = dict(
-                title=title,
+                title=endpoint['title'],
                 sidebar_order=i,
                 description='\n'.join(endpoint['text']).strip(),
                 warning=endpoint['warning'],
                 method=endpoint['method'],
-                path=endpoint['path'],
+                api_path=endpoint['path'],
                 query_parameters=endpoint['params'].get('query'),
                 path_parameters=endpoint['params'].get('path'),
-                parameters=endpoint['params'].get('params'),
+                parameters=endpoint['params'].get('param'),
                 authentication=auth,
                 example_request=format_request(endpoint, scenarios),
                 example_response=format_response(endpoint, scenarios)

--- a/src/sentry/api/endpoints/dsym_files.py
+++ b/src/sentry/api/endpoints/dsym_files.py
@@ -132,8 +132,8 @@ class DSymFilesEndpoint(ProjectEndpoint):
 
     def post(self, request, project):
         """
-        Upload a New Files
-        ``````````````````
+        Upload a New File
+        `````````````````
 
         Upload a new dsym file for the given release.
 

--- a/src/sentry/api/endpoints/organization_eventid.py
+++ b/src/sentry/api/endpoints/organization_eventid.py
@@ -36,14 +36,7 @@ class EventIdLookupEndpoint(OrganizationEndpoint):
                                           event ID should be looked up in.
         :param string event_id: the event ID to look up.
         :auth: required
-
-        Return:
-            organizationSlug
-            projectSlug
-            groupId
-            eventId (optional)
         """
-
         # Largely copied from ProjectGroupIndexEndpoint
         if len(event_id) != 32:
             return Response({'detail': 'Event ID must be 32 characters.'}, status=400)

--- a/src/sentry/api/endpoints/project_servicehook_details.py
+++ b/src/sentry/api/endpoints/project_servicehook_details.py
@@ -17,8 +17,8 @@ class ProjectServiceHookDetailsEndpoint(ProjectEndpoint):
 
     def get(self, request, project, hook_id):
         """
-        Retrieve a Service Hooks
-        ````````````````````````
+        Retrieve a Service Hook
+        ```````````````````````
 
         Return a service hook bound to a project.
 

--- a/src/sentry/templates/sentry/apidocs/index.md
+++ b/src/sentry/templates/sentry/apidocs/index.md
@@ -5,4 +5,4 @@ title: {{ title }}
 ---
 
 {% for link in links %}
-- [{{ link.title }}]({% templatetag openblock %}- link _documentation/api/{{ link.path }} -{% templatetag closeblock %}){% endfor %}
+- [{{ link.title }}]({% templatetag openblock %}- link _api/{{ link.path }} -{% templatetag closeblock %}){% endfor %}

--- a/src/sentry/templates/sentry/apidocs/index.md
+++ b/src/sentry/templates/sentry/apidocs/index.md
@@ -5,4 +5,4 @@ title: {{ title }}
 ---
 
 {% for link in links %}
-- [{{ link.title }}]({% templatetag openblock %}- link _api/{{ link.path }} -{% templatetag closeblock %}){% endfor %}
+- [{{ link.title }}]({% templatetag openblock %}- link _documentation/api/{{ link.path }} -{% templatetag closeblock %}){% endfor %}

--- a/src/sentry/utils/apidocs.py
+++ b/src/sentry/utils/apidocs.py
@@ -152,12 +152,23 @@ def parse_doc_string(doc):
 def get_node_text(nodes):
     """Recursively read text from a node tree."""
     text = []
+    format_tags = {
+        'literal': '`',
+        'strong': '**',
+        'emphasis': '*',
+    }
     for node in nodes:
+        # Handle inline formatting elements.
+        if (node.nodeType == node.ELEMENT_NODE and
+                node.tagName in format_tags):
+            wrap = format_tags[node.tagName]
+            text.append(wrap + get_node_text(node.childNodes) + wrap)
+            continue
         if node.nodeType == node.TEXT_NODE:
             text.append(node.data)
         if node.nodeType == node.ELEMENT_NODE:
             text.append(get_node_text(node.childNodes))
-    return ' '.join(text)
+    return ''.join(text)
 
 
 def parse_params(params):

--- a/src/sentry/utils/apidocs.py
+++ b/src/sentry/utils/apidocs.py
@@ -103,31 +103,32 @@ def parse_doc_string(doc):
     iterable = iter((doc or u'').splitlines())
 
     for line in iterable:
+        stripped = line.strip()
         if title is None:
             if not line:
                 continue
-            title = line
-        elif line and line[0] * len(line) == line:
+            title = line.strip()
+        elif stripped and stripped[0] * len(stripped) == stripped:
             # is an RST underline
             continue
-        elif rst_block_re.match(line):
+        elif rst_block_re.match(stripped):
             # Presently the only RST block we use is `caution` which
             # displays as a 'warning'
             in_warning = True
-        elif line and line.startswith(':'):
+        elif line and stripped.startswith(':'):
             # Is a new parameter or other annotation
             if current_param:
                 param_lines.append(current_param)
-            current_param = line.strip()
+            current_param = stripped
         elif current_param:
             # Adding to an existing parameter annotation
-            current_param = current_param + ' ' + line.strip()
+            current_param = current_param + ' ' + stripped
         else:
             if in_warning:
                 # If we're indented at least 2 spaces assume
                 # we're in the RST block
                 if rst_indent_re.match(line) or not line:
-                    warning.append(line.strip())
+                    warning.append(stripped)
                     continue
                 # An un-indented non-empty line means we
                 # have other content.
@@ -135,7 +136,7 @@ def parse_doc_string(doc):
                     in_warning = False
             # Normal text. We want empty lines here so we can
             # preserve paragraph breaks.
-            lines.append(line.strip())
+            lines.append(stripped)
 
     if current_param:
         param_lines.append(current_param)

--- a/tests/sentry/utils/test_apidocs.py
+++ b/tests/sentry/utils/test_apidocs.py
@@ -15,29 +15,77 @@ def test_parse_doc_string():
 Glory!
 ~~~~~~
 
-This is a glorious function
+This is a glorious function.
+
+It has a multi-line description.
 
 :param int id: An id.
 :qparam bool louder: Make it louder?
-:pparam string orgid: The orgid
+:pparam string orgid: The orgid.
+                      On a second line.
 :auth: required
 """
     result = apidocs.parse_doc_string(text)
     assert result[0] == 'Glory!'
-    assert result[1] == ['This is a glorious function']
-    params = result[2]
+    expected = [
+        '',
+        'This is a glorious function.',
+        '',
+        'It has a multi-line description.',
+        ''
+    ]
+    assert result[1] == expected
+    assert result[2] is None, 'no warning present'
+
+    params = result[3]
     assert 'path' in params, 'Should have path params'
     assert params['path'][0] == dict(name='orgid', type="string",
-                                     description='The orgid')
+                                     description='The orgid. On a second line.')
     assert 'query' in params, 'Should have query params'
     assert params['query'][0] == dict(name='louder', type="bool",
-                                     description='Make it louder?')
+                                      description='Make it louder?')
     assert 'auth' in params, 'Should have auth'
     assert params['auth'][0] == dict(name='', type="", description='required')
 
     assert 'param' in params, 'Should have regular param'
     assert params['param'][0] == dict(name='id', type="int",
-                                     description='An id.')
+                                      description='An id.')
+
+
+def test_parse_doc_string_warning():
+    text = """
+Danger!
+~~~~~~~
+
+This is a dangerous function.
+
+.. warning::
+    This is a warning
+
+    It has multiple lines
+
+It has a multi-line description.
+
+:param int id: An id.
+"""
+    result = apidocs.parse_doc_string(text)
+    assert result[0] == 'Danger!'
+    expected = [
+        '',
+        'This is a dangerous function.',
+        '',
+        'It has a multi-line description.',
+        ''
+    ]
+    assert result[1] == expected
+
+    expected = 'This is a warning\n\nIt has multiple lines'
+    assert result[2] == expected
+
+    params = result[3]
+    assert 'param' in params, 'Should have regular param'
+    assert params['param'][0] == dict(name='id', type="int",
+                                      description='An id.')
 
 
 def test_camelcase_to_dashes():

--- a/tests/sentry/utils/test_apidocs.py
+++ b/tests/sentry/utils/test_apidocs.py
@@ -19,9 +19,9 @@ This is a glorious function.
 
 It has a multi-line description.
 
-:param int id: An id.
-:qparam bool louder: Make it louder?
-:pparam string orgid: The orgid.
+:param int id: An ``id``.
+:qparam bool louder: Make it **louder**?
+:pparam string orgid: The *orgid*.
                       On a second line.
 :auth: required
 """
@@ -40,16 +40,16 @@ It has a multi-line description.
     params = result[3]
     assert 'path' in params, 'Should have path params'
     assert params['path'][0] == dict(name='orgid', type="string",
-                                     description='The orgid. On a second line.')
+                                     description='The *orgid*. On a second line.')
     assert 'query' in params, 'Should have query params'
     assert params['query'][0] == dict(name='louder', type="bool",
-                                      description='Make it louder?')
+                                      description='Make it **louder**?')
     assert 'auth' in params, 'Should have auth'
     assert params['auth'][0] == dict(name='', type="", description='required')
 
     assert 'param' in params, 'Should have regular param'
     assert params['param'][0] == dict(name='id', type="int",
-                                      description='An id.')
+                                      description='An `id`.')
 
 
 def test_parse_doc_string_warning():


### PR DESCRIPTION
I missed adding the request path earlier, and the description needs to be joined on spaces to not awkwardly join multi line descriptions.