### PR TITLE
fix(integrations): Azure DevOps removed default collection from urls as it's no longer needed.

### DIFF
--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -17,15 +17,15 @@ INVALID_ACCESS_TOKEN = 'HTTP 400 (invalid_request): The access token is not vali
 
 
 class VstsApiPath(object):
-    commits = u'{instance}DefaultCollection/_apis/git/repositories/{repo_id}/commits'
-    commits_batch = u'{instance}DefaultCollection/_apis/git/repositories/{repo_id}/commitsBatch'
-    commits_changes = u'{instance}DefaultCollection/_apis/git/repositories/{repo_id}/commits/{commit_id}/changes'
-    projects = u'{instance}DefaultCollection/_apis/projects'
-    repository = u'{instance}DefaultCollection/{project}_apis/git/repositories/{repo_id}'
+    commits = u'{instance}_apis/git/repositories/{repo_id}/commits'
+    commits_batch = u'{instance}_apis/git/repositories/{repo_id}/commitsBatch'
+    commits_changes = u'{instance}_apis/git/repositories/{repo_id}/commits/{commit_id}/changes'
+    projects = u'{instance}_apis/projects'
+    repository = u'{instance}{project}_apis/git/repositories/{repo_id}'
     repositories = u'{instance}{project}_apis/git/repositories'
     subscription = u'{instance}_apis/hooks/subscriptions/{subscription_id}'
     subscriptions = u'{instance}_apis/hooks/subscriptions'
-    work_items = u'{instance}DefaultCollection/_apis/wit/workitems/{id}'
+    work_items = u'{instance}_apis/wit/workitems/{id}'
     work_items_create = u'{instance}{project}/_apis/wit/workitems/${type}'
     # TODO(lb): Fix this url so that the base url is given by vsts rather than built by us
     work_item_search = u'https://{account_name}.almsearch.visualstudio.com/_apis/search/workitemsearchresults'

--- a/tests/sentry/integrations/vsts/test_client.py
+++ b/tests/sentry/integrations/vsts/test_client.py
@@ -37,7 +37,7 @@ class VstsApiClientTest(VstsIntegrationTestCase):
 
         # Then we request the Projects with the new token
         assert responses.calls[-1].request.url == \
-            u'{}DefaultCollection/_apis/projects?stateFilter=WellFormed'.format(
+            u'{}_apis/projects?stateFilter=WellFormed'.format(
                 self.vsts_base_url.lower(),
         )
 

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -46,7 +46,7 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
         accessible_repo = Repository.objects.create(
             organization_id=self.organization.id,
             name=self.project_a['name'],
-            url=u'{}/DefaultCollection/_git/{}'.format(
+            url=u'{}/_git/{}'.format(
                 self.vsts_base_url,
                 self.repo_name,
             ),
@@ -88,7 +88,7 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
         Repository.objects.create(
             organization_id=self.organization.id,
             name=self.project_a['name'],
-            url=u'https://{}.visualstudio.com/DefaultCollection/_git/{}'.format(
+            url=u'https://{}.visualstudio.com/_git/{}'.format(
                 self.vsts_account_name,
                 self.repo_name,
             ),
@@ -113,7 +113,7 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
         Repository.objects.create(
             organization_id=self.organization.id,
             name=self.project_a['name'],
-            url=u'https://{}.visualstudio.com/DefaultCollection/_git/{}'.format(
+            url=u'https://{}.visualstudio.com/_git/{}'.format(
                 self.vsts_account_name,
                 self.repo_name,
             ),

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -115,7 +115,7 @@ class VstsIssueSycnTest(TestCase):
     def test_get_issue(self):
         responses.add(
             responses.GET,
-            'https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/wit/workitems/%s' % self.issue_id,
+            'https://fabrikam-fiber-inc.visualstudio.com/_apis/wit/workitems/%s' % self.issue_id,
             body=WORK_ITEM_RESPONSE,
             content_type='application/json',
         )
@@ -135,7 +135,7 @@ class VstsIssueSycnTest(TestCase):
         vsts_work_item_id = 5
         responses.add(
             responses.PATCH,
-            'https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/wit/workitems/%d' % vsts_work_item_id,
+            'https://fabrikam-fiber-inc.visualstudio.com/_apis/wit/workitems/%d' % vsts_work_item_id,
             body=WORK_ITEM_RESPONSE,
             content_type='application/json',
         )
@@ -158,7 +158,7 @@ class VstsIssueSycnTest(TestCase):
         assert len(responses.calls) == 2
         assert responses.calls[0].request.url == 'https://fabrikam-fiber-inc.vssps.visualstudio.com/_apis/graph/users'
         assert responses.calls[0].response.status_code == 200
-        assert responses.calls[1].request.url == 'https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/wit/workitems/%d' % vsts_work_item_id
+        assert responses.calls[1].request.url == 'https://fabrikam-fiber-inc.visualstudio.com/_apis/wit/workitems/%d' % vsts_work_item_id
         assert responses.calls[1].response.status_code == 200
 
     @responses.activate
@@ -166,7 +166,7 @@ class VstsIssueSycnTest(TestCase):
         vsts_work_item_id = 5
         responses.add(
             responses.PATCH,
-            'https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/wit/workitems/%d' % vsts_work_item_id,
+            'https://fabrikam-fiber-inc.visualstudio.com/_apis/wit/workitems/%d' % vsts_work_item_id,
             body=WORK_ITEM_RESPONSE,
             content_type='application/json',
         )
@@ -178,13 +178,13 @@ class VstsIssueSycnTest(TestCase):
         )
         responses.add(
             responses.GET,
-            'https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/wit/workitems/%d' % vsts_work_item_id,
+            'https://fabrikam-fiber-inc.visualstudio.com/_apis/wit/workitems/%d' % vsts_work_item_id,
             body=WORK_ITEM_RESPONSE,
             content_type='application/json',
         )
         responses.add(
             responses.GET,
-            'https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/projects',
+            'https://fabrikam-fiber-inc.visualstudio.com/_apis/projects',
             body=GET_PROJECTS_RESPONSE,
             content_type='application/json',
         )
@@ -206,7 +206,7 @@ class VstsIssueSycnTest(TestCase):
         self.integration.sync_status_outbound(external_issue, True, self.project.id)
         assert len(responses.calls) == 3
         req = responses.calls[2].request
-        assert req.url == 'https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/wit/workitems/%d' % vsts_work_item_id
+        assert req.url == 'https://fabrikam-fiber-inc.visualstudio.com/_apis/wit/workitems/%d' % vsts_work_item_id
         assert req.body == '[{"path": "/fields/System.State", "value": "Resolved", "op": "replace"}]'
         assert responses.calls[2].response.status_code == 200
 

--- a/tests/sentry/integrations/vsts/test_repository.py
+++ b/tests/sentry/integrations/vsts/test_repository.py
@@ -28,12 +28,12 @@ class VisualStudioRepositoryProviderTest(TestCase):
 
         responses.add(
             responses.POST,
-            'https://visualstudio.com/DefaultCollection/_apis/git/repositories/None/commitsBatch',
+            'https://visualstudio.com/_apis/git/repositories/None/commitsBatch',
             body=COMPARE_COMMITS_EXAMPLE,
         )
         responses.add(
             responses.GET,
-            'https://visualstudio.com/DefaultCollection/_apis/git/repositories/None/commits/6c36052c58bde5e57040ebe6bdb9f6a52c906fff/changes',
+            'https://visualstudio.com/_apis/git/repositories/None/commits/6c36052c58bde5e57040ebe6bdb9f6a52c906fff/changes',
             body=FILE_CHANGES_EXAMPLE,
         )
         integration = Integration.objects.create(

--- a/tests/sentry/integrations/vsts/testutils.py
+++ b/tests/sentry/integrations/vsts/testutils.py
@@ -102,7 +102,7 @@ class VstsIntegrationTestCase(IntegrationTestCase):
 
         responses.add(
             responses.GET,
-            u'https://{}.visualstudio.com/DefaultCollection/_apis/projects'.format(
+            u'https://{}.visualstudio.com/_apis/projects'.format(
                 self.vsts_account_name.lower(),
             ),
             json={
@@ -139,7 +139,7 @@ class VstsIntegrationTestCase(IntegrationTestCase):
 
         responses.add(
             responses.GET,
-            u'https://{}.visualstudio.com/DefaultCollection/ProjectA/_apis/git/repositories/ProjectA'.format(
+            u'https://{}.visualstudio.com/ProjectA/_apis/git/repositories/ProjectA'.format(
                 self.vsts_account_name.lower(),
             ),
             json={


### PR DESCRIPTION
The DefaultCollection does not work with users whose orgs use `https://dev.azure.com/organization/` It appears that the DefaultCollection is simply just the default when an api call is entered. For example, when getting projects, `{instance}DefaultCollection/_apis/projects` becomes `{instance}/_apis/projects` and yields the same result.