### PR TITLE
fix(integrations): Handle no matches on repo search dropdown

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -42,6 +42,11 @@ class DropdownAutoCompleteMenu extends React.Component {
      */
     busy: PropTypes.bool,
 
+    /**
+    * When AutoComplete items are fetched asynchronously
+    */
+    isAsync: PropTypes.bool,
+
     onSelect: PropTypes.func,
     /**
      * When AutoComplete input changes
@@ -126,6 +131,7 @@ class DropdownAutoCompleteMenu extends React.Component {
     onSelect: () => {},
     maxHeight: 300,
     blendCorner: true,
+    isAsync: false,
     emptyMessage: t('No items'),
     searchPlaceholder: t('Filter search'),
   };
@@ -254,6 +260,7 @@ class DropdownAutoCompleteMenu extends React.Component {
       searchPlaceholder,
       itemSize,
       busy,
+      isAsync,
       ...props
     } = this.props;
 
@@ -314,7 +321,7 @@ class DropdownAutoCompleteMenu extends React.Component {
                   })}
                 >
                   {itemsLoading && <LoadingIndicator mini />}
-                  {hasItems && (
+                  {(hasItems || isAsync) && (
                     <Flex>
                       <StyledInput
                         autoFocus

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
@@ -205,25 +205,12 @@ export default class IntegrationRepos extends AsyncComponent {
       ? this.handleSearchRepositories
       : null;
 
-    // need a default cause DropdownAutoCompleteMenu won't render the input box
-    // if there aren't any options to perform a search on (when items is empty).
-    // When a search doesn't have repos matches we get items == [].
-    let defaultItem = [
-      {
-        searchKey: '',
-        value: '',
-        label: (
-          <StyledListElement>
-            <StyledName>Loading...</StyledName>
-          </StyledListElement>
-        ),
-      },
-    ];
     return (
       <DropdownAutoComplete
-        items={!!items.length ? items : defaultItem}
+        items={items}
         onSelect={this.addRepo.bind(this)}
         onChange={onChange}
+        isAsync={true}
         menuHeader={menuHeader}
         emptyMessage={t('No repositories available')}
       >

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
@@ -205,9 +205,23 @@ export default class IntegrationRepos extends AsyncComponent {
       ? this.handleSearchRepositories
       : null;
 
+    // need a default cause DropdownAutoCompleteMenu won't render the input box
+    // if there aren't any options to perform a search on (when items is empty).
+    // When a search doesn't have repos matches we get items == [].
+    let defaultItem = [
+      {
+        searchKey: '',
+        value: '',
+        label: (
+          <StyledListElement>
+            <StyledName>Loading...</StyledName>
+          </StyledListElement>
+        ),
+      },
+    ];
     return (
       <DropdownAutoComplete
-        items={items}
+        items={!!items.length ? items : defaultItem}
         onSelect={this.addRepo.bind(this)}
         onChange={onChange}
         menuHeader={menuHeader}

--- a/src/sentry/static/sentry/app/views/settings/organizationTeams/teamMembers.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationTeams/teamMembers.jsx
@@ -242,6 +242,7 @@ const TeamMembers = createReactClass({
         emptyMessage={t('No members')}
         onChange={this.handleMemberFilterChange}
         busy={this.state.dropdownBusy}
+        isAsync={true}
         onClose={() => this.debouncedFetchMembersRequest('')}
       >
         {({isOpen, selectedItem}) => (


### PR DESCRIPTION
Stops the input search box from disappearing when search has no repo matches:

![ezgif com-video-to-gif 2](https://user-images.githubusercontent.com/15368179/45720946-1267a300-bb5b-11e8-9736-b2e0aa7e8c85.gif)

Made the default search value `''` so that can't be searched on. When there is no input, we display the first 100 repositories that installation has access to. 

cc @ceorourke 