### PR TITLE
fix(environments) Disallow `/` in future environment names

### DIFF
--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -16,8 +16,6 @@ from sentry.plugins.interfaces.releasehook import ReleaseHook
 from sentry.constants import VERSION_LENGTH
 from sentry.signals import release_created
 
-BAD_RELEASE_CHARS = '\n\f\t/'
-
 
 class ReleaseSerializer(serializers.Serializer):
     version = serializers.CharField(max_length=VERSION_LENGTH, required=True)

--- a/src/sentry/api/endpoints/release_deploys.py
+++ b/src/sentry/api/endpoints/release_deploys.py
@@ -23,6 +23,12 @@ class DeploySerializer(serializers.Serializer):
     dateStarted = serializers.DateTimeField(required=False)
     dateFinished = serializers.DateTimeField(required=False)
 
+    def validate_environment(self, attrs, source):
+        value = attrs[source]
+        if not Environment.is_valid_name(value):
+            raise serializers.ValidationError('Invalid value for environment')
+        return attrs
+
 
 class ReleaseDeploysEndpoint(OrganizationReleasesBaseEndpoint):
     doc_section = DocSection.RELEASES

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -76,6 +76,9 @@ MAX_TAG_VALUE_LENGTH = 200
 MAX_CULPRIT_LENGTH = 200
 MAX_EMAIL_FIELD_LENGTH = 75
 
+ENVIRONMENT_NAME_PATTERN = r'^[^\n\r\f\/]*$'
+ENVIRONMENT_NAME_MAX_LENGTH = 64
+
 # Team slugs which may not be used. Generally these are top level URL patterns
 # which we don't want to worry about conflicts on.
 RESERVED_ORGANIZATION_SLUGS = frozenset(

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -1,6 +1,6 @@
 """
 sentry.interfaces.schemas
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
@@ -20,6 +20,8 @@ from sentry.constants import (
     MAX_TAG_KEY_LENGTH,
     MAX_TAG_VALUE_LENGTH,
     VALID_PLATFORMS,
+    ENVIRONMENT_NAME_MAX_LENGTH,
+    ENVIRONMENT_NAME_PATTERN,
 )
 from sentry.interfaces.base import InterfaceValidationError
 from sentry.models import EventError
@@ -417,7 +419,8 @@ EVENT_SCHEMA = {
         },
         'environment': {
             'type': 'string',
-            'maxLength': 64,
+            'maxLength': ENVIRONMENT_NAME_MAX_LENGTH,
+            'pattern': ENVIRONMENT_NAME_PATTERN,
         },
         'modules': {'type': 'object'},
         'extra': {'type': 'object'},
@@ -781,7 +784,6 @@ def validate_and_default_interface(data, interface, name=None,
                     default = schema['properties'][p]['default']
                     data[p] = default() if callable(default) else default
                 else:
-                    # TODO raise as shortcut?
                     errors.append({'type': EventError.MISSING_ATTRIBUTE, 'name': p})
 
     validator_errors = list(validator.iter_errors(data))

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -795,7 +795,12 @@ def validate_and_default_interface(data, interface, name=None,
     for key, group in groupby(keyed_errors, lambda e: e.path[0]):
         ve = six.next(group)
         is_max = ve.validator.startswith('max')
-        error_type = EventError.VALUE_TOO_LONG if is_max else EventError.INVALID_DATA
+        if is_max:
+            error_type = EventError.VALUE_TOO_LONG
+        elif key == 'environment':
+            error_type = EventError.INVALID_ENVIRONMENT
+        else:
+            error_type = EventError.INVALID_DATA
         errors.append({'type': error_type, 'name': name or key, 'value': data[key]})
 
         if 'default' in ve.schema:

--- a/src/sentry/models/eventerror.py
+++ b/src/sentry/models/eventerror.py
@@ -28,6 +28,7 @@ class EventError(object):
     RESTRICTED_IP = 'restricted_ip'
     FUTURE_TIMESTAMP = 'future_timestamp'
     PAST_TIMESTAMP = 'past_timestamp'
+    INVALID_ENVIRONMENT = 'invalid_environment'
 
     JS_GENERIC_FETCH_ERROR = 'js_generic_fetch_error'  # deprecated in favor of FETCH_GENERIC_ERROR
     FETCH_GENERIC_ERROR = 'fetch_generic_error'
@@ -67,6 +68,7 @@ class EventError(object):
         RESTRICTED_IP: u'Cannot fetch resource due to restricted IP address on {url}',
         FUTURE_TIMESTAMP: u'Invalid timestamp (in future)',
         PAST_TIMESTAMP: u'Invalid timestamp (too old)',
+        INVALID_ENVIRONMENT: u'Environment cannot contain / or newlines.',
         # deprecated in favor of FETCH_GENERIC_ERROR
         JS_GENERIC_FETCH_ERROR: u'Unable to fetch resource: {url}',
         FETCH_GENERIC_ERROR: u'Unable to fetch resource: {url}',

--- a/tests/sentry/api/endpoints/test_release_deploys.py
+++ b/tests/sentry/api/endpoints/test_release_deploys.py
@@ -111,3 +111,32 @@ class ReleaseDeploysCreateTest(APITestCase):
             project=project, release=release, environment=environment
         )
         assert rpe.last_deploy_id == deploy.id
+
+    def test_environment_validation_failure(self):
+        project = self.create_project(name='example')
+        release = Release.objects.create(
+            organization_id=project.organization_id,
+            version='123',
+            total_deploys=0,
+        )
+        release.add_project(project)
+
+        url = reverse(
+            'sentry-api-0-organization-release-deploys',
+            kwargs={
+                'organization_slug': project.organization.slug,
+                'version': release.version,
+            }
+        )
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            url,
+            data={
+                'name': 'foo',
+                'environment': 'bad/name',
+                'url': 'https://www.example.com',
+            }
+        )
+        assert response.status_code == 400, response.content
+        assert 0 == Deploy.objects.count()

--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -441,6 +441,16 @@ class ValidateDataTest(BaseAPITest):
         assert data['errors'][0]['name'] == 'environment'
         assert data['errors'][0]['value'] == 'a' * 65
 
+    def test_environment_invalid(self):
+        data = self.validate_and_normalize({
+            'environment': 'a/b',
+        })
+        assert not data.get('environment')
+        assert len(data['errors']) == 1
+        assert data['errors'][0]['type'] == 'invalid_data'
+        assert data['errors'][0]['name'] == 'environment'
+        assert data['errors'][0]['value'] == 'a/b'
+
     def test_environment_as_non_string(self):
         data = self.validate_and_normalize({
             'environment': 42,

--- a/tests/sentry/coreapi/tests.py
+++ b/tests/sentry/coreapi/tests.py
@@ -447,7 +447,7 @@ class ValidateDataTest(BaseAPITest):
         })
         assert not data.get('environment')
         assert len(data['errors']) == 1
-        assert data['errors'][0]['type'] == 'invalid_data'
+        assert data['errors'][0]['type'] == 'invalid_environment'
         assert data['errors'][0]['name'] == 'environment'
         assert data['errors'][0]['value'] == 'a/b'
 

--- a/tests/sentry/models/test_environment.py
+++ b/tests/sentry/models/test_environment.py
@@ -36,3 +36,20 @@ class GetOrCreateTest(TestCase):
                 project.organization_id,
                 'prod',
             ).id == env.id
+
+
+@pytest.mark.parametrize('val,expected', [
+    ('42', True),
+    ('ok', True),
+    ('production', True),
+    ('deadbeef', True),
+    ('staging.0.1.company', True),
+    ('valid_under', True),
+    ('spaces ok', True),
+    ('no/slashes', False),
+    ('no\nnewlines', False),
+    ('no\rcarriage', False),
+    ('no\fform-feed', False),
+])
+def test_valid_name(val, expected):
+    assert Environment.is_valid_name(val) == expected

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -955,6 +955,14 @@ class EventManagerTest(TransactionTestCase):
 
         assert dict(event.tags).get('environment') == 'beta'
 
+    def test_invalid_environment(self):
+        manager = EventManager(self.make_event(**{
+            'environment': 'bad/name',
+        }))
+        manager.normalize()
+        event = manager.save(self.project.id)
+        assert dict(event.tags).get('environment') is None
+
     @mock.patch('sentry.event_manager.eventstream.insert')
     def test_group_environment(self, eventstream_insert):
         release_version = '1.0'


### PR DESCRIPTION
While we can't reasonably change existing data, we can prevent more in the future. Having `/` in an environment name makes it impossible to hide the environment.

Refs APP-323
Refs ISSUE-24