### PR TITLE
fix(audit-log): Handle org options that default to true

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -351,7 +351,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                         'model': Organization.__name__,
                     }
                 )
-            else:
+            elif changed_data:
                 self.create_audit_entry(
                     request=request,
                     organization=organization,

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -12,8 +12,7 @@ from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.decorators import sudo_required
 from sentry.api.fields import AvatarField
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.organization import (
-    DetailedOrganizationSerializer)
+from sentry.api.serializers.models import organization as org_serializers
 from sentry.api.serializers.rest_framework import ListField
 from sentry.auth.providers.saml2 import SAML2Provider
 from sentry.constants import LEGACY_RATE_LIMIT_OPTIONS, RESERVED_ORGANIZATION_SLUGS
@@ -31,15 +30,18 @@ ERR_NO_USER = 'This request requires an authenticated user.'
 
 ORG_OPTIONS = (
     # serializer field name, option key name, type, default value
-    ('projectRateLimit', 'sentry:project-rate-limit', int, 100),
-    ('accountRateLimit', 'sentry:account-rate-limit', int, 0),
-    ('dataScrubber', 'sentry:require_scrub_data', bool, False),
-    ('dataScrubberDefaults', 'sentry:require_scrub_defaults', bool, False),
-    ('sensitiveFields', 'sentry:sensitive_fields', list, None),
-    ('safeFields', 'sentry:safe_fields', list, None),
-    ('storeCrashReports', 'sentry:store_crash_reports', bool, False),
-    ('scrubIPAddresses', 'sentry:require_scrub_ip_address', bool, False),
-    ('scrapeJavaScript', 'sentry:scrape_javascript', bool, True),
+    ('projectRateLimit', 'sentry:project-rate-limit', int, org_serializers.PROJECT_RATE_LIMIT_DEFAULT),
+    ('accountRateLimit', 'sentry:account-rate-limit', int, org_serializers.ACCOUNT_RATE_LIMIT_DEFAULT),
+    ('dataScrubber', 'sentry:require_scrub_data', bool, org_serializers.REQUIRE_SCRUB_DATA_DEFAULT),
+    ('sensitiveFields', 'sentry:sensitive_fields', list, org_serializers.SENSITIVE_FIELDS_DEFAULT),
+    ('safeFields', 'sentry:safe_fields', list, org_serializers.SAFE_FIELDS_DEFAULT),
+    ('scrapeJavaScript', 'sentry:scrape_javascript', bool, org_serializers.SCRAPE_JAVASCRIPT_DEFAULT),
+    ('dataScrubberDefaults', 'sentry:require_scrub_defaults',
+     bool, org_serializers.REQUIRE_SCRUB_DEFAULTS_DEFAULT),
+    ('storeCrashReports', 'sentry:store_crash_reports',
+     bool, org_serializers.STORE_CRASH_REPORTS_DEFAULT),
+    ('scrubIPAddresses', 'sentry:require_scrub_ip_address',
+     bool, org_serializers.REQUIRE_SCRUB_IP_ADDRESS_DEFAULT),
 )
 
 delete_logger = logging.getLogger('sentry.deletions.api')
@@ -295,7 +297,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         context = serialize(
             organization,
             request.user,
-            DetailedOrganizationSerializer(),
+            org_serializers.DetailedOrganizationSerializer(),
         )
         return self.respond(context)
 
@@ -362,7 +364,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                 serialize(
                     organization,
                     request.user,
-                    DetailedOrganizationSerializer(),
+                    org_serializers.DetailedOrganizationSerializer(),
                 )
             )
         return self.respond(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -432,6 +434,6 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         context = serialize(
             organization,
             request.user,
-            DetailedOrganizationSerializer(),
+            org_serializers.DetailedOrganizationSerializer(),
         )
         return self.respond(context, status=202)

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -12,6 +12,17 @@ from sentry.models import (
     OrganizationOption, OrganizationStatus, Project, ProjectStatus, Team, TeamStatus
 )
 
+# org option default values
+PROJECT_RATE_LIMIT_DEFAULT = 100
+ACCOUNT_RATE_LIMIT_DEFAULT = 0
+REQUIRE_SCRUB_DATA_DEFAULT = False
+REQUIRE_SCRUB_DEFAULTS_DEFAULT = False
+SENSITIVE_FIELDS_DEFAULT = None
+SAFE_FIELDS_DEFAULT = None
+STORE_CRASH_REPORTS_DEFAULT = False
+REQUIRE_SCRUB_IP_ADDRESS_DEFAULT = False
+SCRAPE_JAVASCRIPT_DEFAULT = True
+
 
 @register(Organization)
 class OrganizationSerializer(Serializer):
@@ -167,14 +178,14 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
                 OrganizationOption.objects.get_value(
                     organization=obj,
                     key='sentry:account-rate-limit',
-                    default=0,
+                    default=ACCOUNT_RATE_LIMIT_DEFAULT,
                 )
             ),
             'projectLimit': int(
                 OrganizationOption.objects.get_value(
                     organization=obj,
                     key='sentry:project-rate-limit',
-                    default=100,
+                    default=PROJECT_RATE_LIMIT_DEFAULT,
                 )
             ),
         }
@@ -190,13 +201,13 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             'require2FA': bool(obj.flags.require_2fa),
             'allowSharedIssues': not obj.flags.disable_shared_issues,
             'enhancedPrivacy': bool(obj.flags.enhanced_privacy),
-            'dataScrubber': bool(obj.get_option('sentry:require_scrub_data', False)),
-            'dataScrubberDefaults': bool(obj.get_option('sentry:require_scrub_defaults', False)),
-            'sensitiveFields': obj.get_option('sentry:sensitive_fields', None) or [],
-            'safeFields': obj.get_option('sentry:safe_fields', None) or [],
-            'storeCrashReports': bool(obj.get_option('sentry:store_crash_reports', False)),
-            'scrubIPAddresses': bool(obj.get_option('sentry:require_scrub_ip_address', False)),
-            'scrapeJavaScript': bool(obj.get_option('sentry:scrape_javascript', True)),
+            'dataScrubber': bool(obj.get_option('sentry:require_scrub_data', REQUIRE_SCRUB_DATA_DEFAULT)),
+            'dataScrubberDefaults': bool(obj.get_option('sentry:require_scrub_defaults', REQUIRE_SCRUB_DEFAULTS_DEFAULT)),
+            'sensitiveFields': obj.get_option('sentry:sensitive_fields', SENSITIVE_FIELDS_DEFAULT) or [],
+            'safeFields': obj.get_option('sentry:safe_fields', SAFE_FIELDS_DEFAULT) or [],
+            'storeCrashReports': bool(obj.get_option('sentry:store_crash_reports', STORE_CRASH_REPORTS_DEFAULT)),
+            'scrubIPAddresses': bool(obj.get_option('sentry:require_scrub_ip_address', REQUIRE_SCRUB_IP_ADDRESS_DEFAULT)),
+            'scrapeJavaScript': bool(obj.get_option('sentry:scrape_javascript', SCRAPE_JAVASCRIPT_DEFAULT)),
         })
         context['teams'] = serialize(team_list, user, TeamSerializer())
         context['projects'] = serialize(project_list, user, ProjectSummarySerializer())

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -173,10 +173,7 @@ class OrganizationUpdateTest(APITestCase):
     def test_various_options(self):
         org = self.create_organization(owner=self.user)
         initial = org.get_audit_log_data()
-
-        # clear logs
-        for log in AuditLogEntry.objects.filter(organization=org):
-            log.delete()
+        AuditLogEntry.objects.filter(organization=org).delete()
 
         self.login_as(user=self.user)
         url = reverse(
@@ -246,6 +243,7 @@ class OrganizationUpdateTest(APITestCase):
         assert u'to {}'.format(data['sensitiveFields']) in log.data['sensitiveFields']
         assert u'to {}'.format(data['safeFields']) in log.data['safeFields']
         assert u'to {}'.format(data['scrubIPAddresses']) in log.data['scrubIPAddresses']
+        assert u'to {}'.format(data['scrapeJavaScript']) in log.data['scrapeJavaScript']
 
     def test_setting_legacy_rate_limits(self):
         org = self.create_organization(owner=self.user)


### PR DESCRIPTION
Since this was written, new org options have been added that default to True (ex: `scrapeJavaScript`). Since they weren't handled, org audit logs were showing up with empty data the first time they were set.

From:
<img width="613" alt="screen shot 2018-09-20 at 3 07 08 pm" src="https://user-images.githubusercontent.com/16394317/45849485-f98bf880-bce6-11e8-904c-f1f65db42ded.png">
To:
<img width="617" alt="screen shot 2018-09-20 at 3 10 56 pm" src="https://user-images.githubusercontent.com/16394317/45849597-6901e800-bce7-11e8-9e48-4c6ad313f7f7.png">


