### PR TITLE
feat(event_manager): Ignore the event _meta attribute

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -159,7 +159,7 @@ HTTP_METHODS = ('GET', 'POST', 'PUT', 'OPTIONS', 'HEAD',
 CLIENT_RESERVED_ATTRS = (
     'project', 'errors', 'event_id', 'message', 'checksum', 'culprit', 'fingerprint', 'level',
     'time_spent', 'logger', 'server_name', 'site', 'received', 'timestamp', 'extra', 'modules',
-    'tags', 'platform', 'release', 'dist', 'environment', 'transaction', 'key_id',
+    'tags', 'platform', 'release', 'dist', 'environment', 'transaction', 'key_id', '_meta',
 )
 
 # XXX: Must be all lowercase

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -317,6 +317,9 @@ class EventManager(object):
         data = self.data
         errors = data['errors'] = []
 
+        # Ignore event meta data for now.
+        data.pop('_meta', None)
+
         # Before validating with a schema, attempt to cast values to their desired types
         # so that the schema doesn't have to take every type variation into account.
         text = six.text_type

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -458,6 +458,9 @@ EVENT_SCHEMA = {
         'checksum': {},
         'site': TAG_VALUE,
         'received': {},
+
+        # PII stripping meta data in the same schema as events.
+        '_meta': {'type': 'object'}
     },
     'required': ['platform', 'event_id'],
     'additionalProperties': True,


### PR DESCRIPTION
Ignores the `_meta` key we send from the new SDKs. We should only start persisting it once normalization logic is in place. For ongoing work on this, see #9829 for now.