### PR TITLE
ref(well) Remove .well from shared-components

### DIFF
--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -2546,22 +2546,6 @@ ul.radio-inputs {
 * Well
 * ============================================================================
 */
-.well {
-  border: 1px solid @trim;
-  box-shadow: none;
-  background: @white-dark;
-  padding: 15px 20px;
-  margin-bottom: 20px;
-  border-radius: 3px;
-  p {
-    &:last-child {
-      margin-bottom: 0;
-    }
-  }
-  &.image-well {
-    padding: 80px 30px;
-  }
-}
 .blankslate {
   text-align: center;
   padding: 50px 0;


### PR DESCRIPTION
With its usage removed from getsentry we can drop this block of CSS.