### PR TITLE
feat(ui): Improve "org not found" Error

### DIFF
--- a/src/sentry/static/sentry/app/components/avatar/userAvatar.jsx
+++ b/src/sentry/static/sentry/app/components/avatar/userAvatar.jsx
@@ -41,6 +41,7 @@ class UserAvatar extends React.Component {
 
     return (
       <BaseAvatar
+        round
         {...props}
         type={type}
         uploadPath="avatar"
@@ -53,7 +54,6 @@ class UserAvatar extends React.Component {
             : userDisplayName(user)
         }
         title={user.name || user.email || user.username || ''}
-        round
       />
     );
   }

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
@@ -68,6 +68,7 @@ const SidebarDropdown = withApi(
             organization={org}
             user={!org ? user : null}
             size={32}
+            round={false}
           />
         ) : (
           <SentryLink to="/">

--- a/src/sentry/static/sentry/app/views/admin/adminLayout.jsx
+++ b/src/sentry/static/sentry/app/views/admin/adminLayout.jsx
@@ -3,9 +3,12 @@ import DocumentTitle from 'react-document-title';
 import React from 'react';
 
 import Footer from 'app/components/footer';
-import Sidebar from 'app/components/sidebar';
 import HookStore from 'app/stores/hookStore';
 import ListLink from 'app/components/listLink';
+import Sidebar from 'app/components/sidebar';
+import withLatestContext from 'app/utils/withLatestContext';
+
+const SidebarWithLatest = withLatestContext(Sidebar);
 
 export default class AdminLayout extends React.Component {
   constructor(props) {
@@ -29,7 +32,7 @@ export default class AdminLayout extends React.Component {
     return (
       <DocumentTitle title={this.getTitle()}>
         <div className="app" css={{paddingTop: 20}}>
-          <Sidebar />
+          <SidebarWithLatest />
           <div className="container">
             <div className="content">
               <div className="row">

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -1,11 +1,14 @@
 import DocumentTitle from 'react-document-title';
+import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 import moment from 'moment';
+import styled from 'react-emotion';
 
 import {setActiveOrganization} from 'app/actionCreators/organizations';
 import {t} from 'app/locale';
+import Alert from 'app/components/alert';
 import ApiMixin from 'app/mixins/apiMixin';
 import BroadcastModal from 'app/components/broadcastModal';
 import ConfigStore from 'app/stores/configStore';
@@ -15,7 +18,9 @@ import LoadingIndicator from 'app/components/loadingIndicator';
 import ProjectActions from 'app/actions/projectActions';
 import ProjectsStore from 'app/stores/projectsStore';
 import SentryTypes from 'app/sentryTypes';
+import Sidebar from 'app/components/sidebar';
 import TeamStore from 'app/stores/teamStore';
+import space from 'app/styles/space';
 
 let ERROR_TYPES = {
   ORG_NOT_FOUND: 'ORG_NOT_FOUND',
@@ -23,6 +28,10 @@ let ERROR_TYPES = {
 
 const OrganizationContext = createReactClass({
   displayName: 'OrganizationContext',
+
+  propTypes: {
+    includeSidebar: PropTypes.bool,
+  },
 
   childContextTypes: {
     organization: SentryTypes.Organization,
@@ -151,6 +160,27 @@ const OrganizationContext = createReactClass({
     this.setState({showBroadcast: false});
   },
 
+  renderSidebar() {
+    if (!this.props.includeSidebar) return null;
+
+    return <Sidebar {...this.props} organization={this.state.organization} />;
+  },
+
+  renderError() {
+    switch (this.state.errorType) {
+      case ERROR_TYPES.ORG_NOT_FOUND:
+        return (
+          <OrganizationNotFound>
+            <Alert type="error">
+              {t('The organization you were looking for was not found.')}
+            </Alert>
+          </OrganizationNotFound>
+        );
+      default:
+        return <LoadingError onRetry={this.remountComponent} />;
+    }
+  },
+
   render() {
     if (this.state.loading) {
       return (
@@ -159,18 +189,12 @@ const OrganizationContext = createReactClass({
         </LoadingIndicator>
       );
     } else if (this.state.error) {
-      switch (this.state.errorType) {
-        case ERROR_TYPES.ORG_NOT_FOUND:
-          return (
-            <div className="container">
-              <div className="alert alert-block">
-                {t('The organization you were looking for was not found.')}
-              </div>
-            </div>
-          );
-        default:
-          return <LoadingError onRetry={this.remountComponent} />;
-      }
+      return (
+        <React.Fragment>
+          {this.renderSidebar()}
+          {this.renderError()}
+        </React.Fragment>
+      );
     }
 
     return (
@@ -180,6 +204,8 @@ const OrganizationContext = createReactClass({
           {this.state.showBroadcast && (
             <BroadcastModal closeBroadcast={this.closeBroadcast} />
           )}
+          {this.renderSidebar()}
+
           {this.props.children}
         </div>
       </DocumentTitle>
@@ -188,3 +214,7 @@ const OrganizationContext = createReactClass({
 });
 
 export default OrganizationContext;
+
+const OrganizationNotFound = styled('div')`
+  margin: ${space(3)};
+`;

--- a/src/sentry/static/sentry/app/views/organizationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDetails.jsx
@@ -8,7 +8,6 @@ import {Client} from 'app/api';
 import OrganizationContext from 'app/views/organizationContext';
 import NarrowLayout from 'app/components/narrowLayout';
 import Footer from 'app/components/footer';
-import LazyLoad from 'app/components/lazyLoad';
 import {t, tct} from 'app/locale';
 
 class DeletionInProgress extends Component {
@@ -135,15 +134,6 @@ class OrganizationDetailsBody extends Component {
       }
     return (
       <React.Fragment>
-        <LazyLoad
-          component={() =>
-            import(/*webpackChunkName: "NewSidebar"*/ 'app/components/sidebar').then(
-              mod => mod.default
-            )}
-          {...this.props}
-          organization={organization}
-        />
-
         <ErrorBoundary>{this.props.children}</ErrorBoundary>
         <Footer />
       </React.Fragment>
@@ -154,7 +144,7 @@ class OrganizationDetailsBody extends Component {
 export default class OrganizationDetails extends Component {
   render() {
     return (
-      <OrganizationContext {...this.props}>
+      <OrganizationContext includeSidebar {...this.props}>
         <OrganizationDetailsBody>{this.props.children}</OrganizationDetailsBody>
       </OrganizationContext>
     );

--- a/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
@@ -5,6 +5,393 @@ exports[`OrganizationDetails render() deletion in progress should render a delet
   class="app"
 >
   <div
+    class="css-11c8i4p-StyledSidebar-responsiveFlex e1sgxx350"
+  >
+    <div
+      class="css-1uxlgm0-SidebarSectionGroup-responsiveFlex e1sgxx351"
+    >
+      <div
+        class="css-tlukoq-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      >
+        <div
+          class="css-jdsvwb-SidebarDropdownRoot e1fowdfw3"
+        >
+          <div
+            class="css-1d9hpgj-SidebarDropdownActor e1fowdfw7"
+            data-test-id="sidebar-dropdown"
+          >
+            <div
+              style="display:flex;align-items:flex-start"
+            >
+              <span
+                class="avatar e1fowdfw8 css-yd0wz3-StyledBaseAvatar-StyledAvatar e1z0ohzl0"
+                style="width:32px;height:32px"
+              >
+                <svg
+                  class="css-123ijso-Svg e1knxa8x0"
+                  viewBox="0 0 120 120"
+                >
+                  <rect
+                    fill="#4674ca"
+                    height="120"
+                    rx="15"
+                    ry="15"
+                    width="120"
+                    x="0"
+                    y="0"
+                  />
+                  <text
+                    fill="#FFFFFF"
+                    font-size="65"
+                    style="dominant-baseline:central"
+                    text-anchor="middle"
+                    x="50%"
+                    y="50%"
+                  >
+                    OS
+                  </text>
+                </svg>
+              </span>
+              <div
+                class="css-a5a05a-NameAndOrgWrapper e1fowdfw4"
+              >
+                <div
+                  class="css-1cbli9p-TextOverflow-DropdownOrgName e1fowdfw5"
+                >
+                  Organization Name 
+                  <i
+                    class="icon-arrow-down"
+                  />
+                </div>
+                <div
+                  class="css-1djvv1k-TextOverflow-DropdownUserName e1fowdfw6"
+                >
+                  Foo Bar
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="css-tlukoq-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      >
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Projects
+              </div>
+            </span>
+          </div>
+        </a>
+      </div>
+      <div
+        class="css-tlukoq-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      >
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Assigned to me
+              </div>
+            </span>
+          </div>
+        </a>
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Bookmarked issues
+              </div>
+            </span>
+          </div>
+        </a>
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Recently viewed
+              </div>
+            </span>
+          </div>
+        </a>
+      </div>
+      <div
+        class="css-tlukoq-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      >
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Activity
+              </div>
+            </span>
+          </div>
+        </a>
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Stats
+              </div>
+            </span>
+          </div>
+        </a>
+      </div>
+    </div>
+    <div
+      class="css-1uxlgm0-SidebarSectionGroup-responsiveFlex e1sgxx351"
+    >
+      <div
+        class="css-tlukoq-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      >
+        <div
+          class="css-1dvxhjs-HelpRoot e1q2bb9t0"
+        >
+          <div
+            class="css-d4wreg-HelpActor e1q2bb9t1"
+          >
+            <a
+              class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+            >
+              <div
+                class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+              >
+                <span
+                  class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+                >
+                  <svg
+                    class="css-ryh69w-StyledSvg e2idor0"
+                    height="1em"
+                    viewBox="[object Object]"
+                    width="1em"
+                  >
+                    <use
+                      href="#test"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+                >
+                  <div
+                    class="css-179hf69-TextOverflow e8qi82q0"
+                  >
+                    Help
+                  </div>
+                </span>
+              </div>
+            </a>
+          </div>
+        </div>
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+          data-test-id="sidebar-broadcasts"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="22px"
+                viewBox="[object Object]"
+                width="22px"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                What's new
+              </div>
+            </span>
+          </div>
+        </a>
+      </div>
+      <div
+        class="css-1j3ay2q-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      />
+      <div
+        class="css-tlukoq-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      >
+        <a
+          class="e1sgxx354 css-7c155y-StyledSidebarItem-SidebarCollapseItem e1qdnaq70"
+          data-test-id="sidebar-collapse"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="e1sgxx353 css-coblwz-StyledSvg-StyledInlineSvg-ExpandedIcon e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Collapse
+              </div>
+            </span>
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+  <div
     class="app"
   >
     <div
@@ -54,6 +441,393 @@ exports[`OrganizationDetails render() pending deletion should render a restorati
 <div
   class="app"
 >
+  <div
+    class="css-11c8i4p-StyledSidebar-responsiveFlex e1sgxx350"
+  >
+    <div
+      class="css-1uxlgm0-SidebarSectionGroup-responsiveFlex e1sgxx351"
+    >
+      <div
+        class="css-tlukoq-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      >
+        <div
+          class="css-jdsvwb-SidebarDropdownRoot e1fowdfw3"
+        >
+          <div
+            class="css-1d9hpgj-SidebarDropdownActor e1fowdfw7"
+            data-test-id="sidebar-dropdown"
+          >
+            <div
+              style="display:flex;align-items:flex-start"
+            >
+              <span
+                class="avatar e1fowdfw8 css-yd0wz3-StyledBaseAvatar-StyledAvatar e1z0ohzl0"
+                style="width:32px;height:32px"
+              >
+                <svg
+                  class="css-123ijso-Svg e1knxa8x0"
+                  viewBox="0 0 120 120"
+                >
+                  <rect
+                    fill="#4674ca"
+                    height="120"
+                    rx="15"
+                    ry="15"
+                    width="120"
+                    x="0"
+                    y="0"
+                  />
+                  <text
+                    fill="#FFFFFF"
+                    font-size="65"
+                    style="dominant-baseline:central"
+                    text-anchor="middle"
+                    x="50%"
+                    y="50%"
+                  >
+                    OS
+                  </text>
+                </svg>
+              </span>
+              <div
+                class="css-a5a05a-NameAndOrgWrapper e1fowdfw4"
+              >
+                <div
+                  class="css-1cbli9p-TextOverflow-DropdownOrgName e1fowdfw5"
+                >
+                  Organization Name 
+                  <i
+                    class="icon-arrow-down"
+                  />
+                </div>
+                <div
+                  class="css-1djvv1k-TextOverflow-DropdownUserName e1fowdfw6"
+                >
+                  Foo Bar
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="css-tlukoq-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      >
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Projects
+              </div>
+            </span>
+          </div>
+        </a>
+      </div>
+      <div
+        class="css-tlukoq-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      >
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Assigned to me
+              </div>
+            </span>
+          </div>
+        </a>
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Bookmarked issues
+              </div>
+            </span>
+          </div>
+        </a>
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Recently viewed
+              </div>
+            </span>
+          </div>
+        </a>
+      </div>
+      <div
+        class="css-tlukoq-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      >
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Activity
+              </div>
+            </span>
+          </div>
+        </a>
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Stats
+              </div>
+            </span>
+          </div>
+        </a>
+      </div>
+    </div>
+    <div
+      class="css-1uxlgm0-SidebarSectionGroup-responsiveFlex e1sgxx351"
+    >
+      <div
+        class="css-tlukoq-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      >
+        <div
+          class="css-1dvxhjs-HelpRoot e1q2bb9t0"
+        >
+          <div
+            class="css-d4wreg-HelpActor e1q2bb9t1"
+          >
+            <a
+              class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+            >
+              <div
+                class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+              >
+                <span
+                  class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+                >
+                  <svg
+                    class="css-ryh69w-StyledSvg e2idor0"
+                    height="1em"
+                    viewBox="[object Object]"
+                    width="1em"
+                  >
+                    <use
+                      href="#test"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+                >
+                  <div
+                    class="css-179hf69-TextOverflow e8qi82q0"
+                  >
+                    Help
+                  </div>
+                </span>
+              </div>
+            </a>
+          </div>
+        </div>
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+          data-test-id="sidebar-broadcasts"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="22px"
+                viewBox="[object Object]"
+                width="22px"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                What's new
+              </div>
+            </span>
+          </div>
+        </a>
+      </div>
+      <div
+        class="css-1j3ay2q-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      />
+      <div
+        class="css-tlukoq-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      >
+        <a
+          class="e1sgxx354 css-7c155y-StyledSidebarItem-SidebarCollapseItem e1qdnaq70"
+          data-test-id="sidebar-collapse"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="e1sgxx353 css-coblwz-StyledSvg-StyledInlineSvg-ExpandedIcon e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Collapse
+              </div>
+            </span>
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
   <div
     class="app"
   >
@@ -131,6 +905,393 @@ exports[`OrganizationDetails render() pending deletion should render a restorati
 <div
   class="app"
 >
+  <div
+    class="css-11c8i4p-StyledSidebar-responsiveFlex e1sgxx350"
+  >
+    <div
+      class="css-1uxlgm0-SidebarSectionGroup-responsiveFlex e1sgxx351"
+    >
+      <div
+        class="css-tlukoq-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      >
+        <div
+          class="css-jdsvwb-SidebarDropdownRoot e1fowdfw3"
+        >
+          <div
+            class="css-1d9hpgj-SidebarDropdownActor e1fowdfw7"
+            data-test-id="sidebar-dropdown"
+          >
+            <div
+              style="display:flex;align-items:flex-start"
+            >
+              <span
+                class="avatar e1fowdfw8 css-yd0wz3-StyledBaseAvatar-StyledAvatar e1z0ohzl0"
+                style="width:32px;height:32px"
+              >
+                <svg
+                  class="css-123ijso-Svg e1knxa8x0"
+                  viewBox="0 0 120 120"
+                >
+                  <rect
+                    fill="#4674ca"
+                    height="120"
+                    rx="15"
+                    ry="15"
+                    width="120"
+                    x="0"
+                    y="0"
+                  />
+                  <text
+                    fill="#FFFFFF"
+                    font-size="65"
+                    style="dominant-baseline:central"
+                    text-anchor="middle"
+                    x="50%"
+                    y="50%"
+                  >
+                    OS
+                  </text>
+                </svg>
+              </span>
+              <div
+                class="css-a5a05a-NameAndOrgWrapper e1fowdfw4"
+              >
+                <div
+                  class="css-1cbli9p-TextOverflow-DropdownOrgName e1fowdfw5"
+                >
+                  Organization Name 
+                  <i
+                    class="icon-arrow-down"
+                  />
+                </div>
+                <div
+                  class="css-1djvv1k-TextOverflow-DropdownUserName e1fowdfw6"
+                >
+                  Foo Bar
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="css-tlukoq-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      >
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Projects
+              </div>
+            </span>
+          </div>
+        </a>
+      </div>
+      <div
+        class="css-tlukoq-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      >
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Assigned to me
+              </div>
+            </span>
+          </div>
+        </a>
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Bookmarked issues
+              </div>
+            </span>
+          </div>
+        </a>
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Recently viewed
+              </div>
+            </span>
+          </div>
+        </a>
+      </div>
+      <div
+        class="css-tlukoq-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      >
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Activity
+              </div>
+            </span>
+          </div>
+        </a>
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Stats
+              </div>
+            </span>
+          </div>
+        </a>
+      </div>
+    </div>
+    <div
+      class="css-1uxlgm0-SidebarSectionGroup-responsiveFlex e1sgxx351"
+    >
+      <div
+        class="css-tlukoq-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      >
+        <div
+          class="css-1dvxhjs-HelpRoot e1q2bb9t0"
+        >
+          <div
+            class="css-d4wreg-HelpActor e1q2bb9t1"
+          >
+            <a
+              class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+            >
+              <div
+                class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+              >
+                <span
+                  class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+                >
+                  <svg
+                    class="css-ryh69w-StyledSvg e2idor0"
+                    height="1em"
+                    viewBox="[object Object]"
+                    width="1em"
+                  >
+                    <use
+                      href="#test"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+                >
+                  <div
+                    class="css-179hf69-TextOverflow e8qi82q0"
+                  >
+                    Help
+                  </div>
+                </span>
+              </div>
+            </a>
+          </div>
+        </div>
+        <a
+          class="css-1l9toro-StyledSidebarItem e1qdnaq70"
+          data-test-id="sidebar-broadcasts"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="css-ryh69w-StyledSvg e2idor0"
+                height="22px"
+                viewBox="[object Object]"
+                width="22px"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                What's new
+              </div>
+            </span>
+          </div>
+        </a>
+      </div>
+      <div
+        class="css-1j3ay2q-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      />
+      <div
+        class="css-tlukoq-SidebarSectionGroup-responsiveFlex-SidebarSection e1sgxx352"
+      >
+        <a
+          class="e1sgxx354 css-7c155y-StyledSidebarItem-SidebarCollapseItem e1qdnaq70"
+          data-test-id="sidebar-collapse"
+        >
+          <div
+            class="css-gn87gt-SidebarItemWrapper e1qdnaq71"
+          >
+            <span
+              class="css-1murlm5-SidebarItemIcon e1qdnaq72"
+            >
+              <svg
+                class="e1sgxx353 css-coblwz-StyledSvg-StyledInlineSvg-ExpandedIcon e2idor0"
+                height="1em"
+                viewBox="[object Object]"
+                width="1em"
+              >
+                <use
+                  href="#test"
+                />
+              </svg>
+            </span>
+            <span
+              class="css-1wgok4l-SidebarItemLabel e1qdnaq73"
+            >
+              <div
+                class="css-179hf69-TextOverflow e8qi82q0"
+              >
+                Collapse
+              </div>
+            </span>
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
   <div
     class="app"
   >

--- a/tests/js/spec/views/organizationsDetails.spec.jsx
+++ b/tests/js/spec/views/organizationsDetails.spec.jsx
@@ -1,18 +1,21 @@
 import React from 'react';
 import {render} from 'enzyme';
 
-import {Client} from 'app/api';
 import OrganizationDetails from 'app/views/organizationDetails';
 
 describe('OrganizationDetails', function() {
   beforeEach(function() {
-    Client.clearMockResponses();
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/broadcasts/',
+      body: [],
+    });
   });
 
   describe('render()', function() {
     describe('pending deletion', () => {
       it('should render a restoration prompt', function() {
-        Client.addMockResponse({
+        MockApiClient.addMockResponse({
           url: '/organizations/org-slug/',
           body: TestStubs.Organization({
             slug: 'org-slug',
@@ -30,7 +33,7 @@ describe('OrganizationDetails', function() {
       });
 
       it('should render a restoration prompt without action for members', function() {
-        Client.addMockResponse({
+        MockApiClient.addMockResponse({
           url: '/organizations/org-slug/',
           body: TestStubs.Organization({
             slug: 'org-slug',
@@ -51,7 +54,7 @@ describe('OrganizationDetails', function() {
 
     describe('deletion in progress', () => {
       beforeEach(() => {
-        Client.addMockResponse({
+        MockApiClient.addMockResponse({
           url: '/organizations/org-slug/',
           body: TestStubs.Organization({
             slug: 'org-slug',


### PR DESCRIPTION
* Refactors Sidebar from `OrganizationDetails` -> `OrganizationContext` (and
uses a prop to control Sidebar visibility) so that we can still have the Sidebar when an organization is not found.
* Allows `UserAvatar` to have shape be overridden


Old:
![image](https://user-images.githubusercontent.com/79684/45892921-31e71180-bd8f-11e8-8d22-219e020adb86.png)

New:
![image](https://user-images.githubusercontent.com/79684/45892898-1f6cd800-bd8f-11e8-8dc5-cba261ac4288.png)
