### PR TITLE
ref(ui) Don't use div inside Button component

### DIFF
--- a/src/sentry/static/sentry/app/components/button/index.jsx
+++ b/src/sentry/static/sentry/app/components/button/index.jsx
@@ -1,4 +1,3 @@
-import {Flex, Box} from 'grid-emotion';
 import {Link} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -7,12 +6,6 @@ import styled, {css} from 'react-emotion';
 import ExternalLink from 'app/components/externalLink';
 import InlineSvg from 'app/components/inlineSvg';
 import Tooltip from 'app/components/tooltip';
-
-const alignToFlexMap = {
-  left: 'flex-start',
-  center: 'center',
-  right: 'flex-end',
-};
 
 class Button extends React.Component {
   static propTypes = {
@@ -50,17 +43,11 @@ class Button extends React.Component {
      */
     label: PropTypes.string,
 
-    /**
-     * Button label alignment
-     */
-    alignLabel: PropTypes.oneOf(['left', 'center', 'right']),
-
     onClick: PropTypes.func,
   };
 
   static defaultProps = {
     disabled: false,
-    alignLabel: 'left',
   };
 
   // Intercept onClick and propagate
@@ -92,7 +79,6 @@ class Button extends React.Component {
       label,
       borderless,
       priority,
-      alignLabel,
 
       // destructure from `buttonProps`
       // not necessary, but just in case someone re-orders props
@@ -103,8 +89,6 @@ class Button extends React.Component {
 
     // For `aria-label`
     let screenReaderLabel = label || typeof children === 'string' ? children : undefined;
-
-    let buttonLabelJustify = alignToFlexMap[alignLabel] || 'left';
 
     // Buttons come in 4 flavors: <Link>, <ExternalLink>, <a>, and <button>.
     // Let's use props to determine which to serve up, so we don't have to think about it.
@@ -121,12 +105,7 @@ class Button extends React.Component {
         onClick={this.handleClick}
         role="button"
       >
-        <ButtonLabel
-          justify={buttonLabelJustify}
-          size={size}
-          priority={priority}
-          borderless={borderless}
-        >
+        <ButtonLabel size={size} priority={priority} borderless={borderless}>
           {icon && (
             <Icon size={size} hasChildren={!!children}>
               <StyledInlineSvg
@@ -271,8 +250,11 @@ const getLabelPadding = ({size, priority, borderless}) => {
 };
 
 const ButtonLabel = styled(({size, priority, borderless, ...props}) => (
-  <Flex align="center" {...props} />
+  <span {...props} />
 ))`
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: ${getLabelPadding};
 `;
 
@@ -285,7 +267,7 @@ const getIconMargin = ({size, hasChildren}) => {
   return size && size.endsWith('small') ? '6px' : '8px';
 };
 
-const Icon = styled(({hasChildren, ...props}) => <Box {...props} />)`
+const Icon = styled(({hasChildren, ...props}) => <span {...props} />)`
   margin-right: ${getIconMargin};
 `;
 

--- a/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
@@ -117,7 +117,6 @@ const ProjectSelector = withRouter(
           menuFooter={
             !hasProjects && hasProjectWrite ? (
               <CreateProjectButton
-                alignLabel="center"
                 priority="primary"
                 size="small"
                 to={`${this.urlPrefix()}/projects/new/`}

--- a/tests/js/spec/components/__snapshots__/button.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/button.spec.jsx.snap
@@ -10,7 +10,6 @@ exports[`Button renders 1`] = `
   size="large"
 >
   <ButtonLabel
-    justify="flex-start"
     priority="primary"
     size="large"
   >
@@ -27,9 +26,7 @@ exports[`Button renders disabled normal link 1`] = `
   onClick={[Function]}
   role="button"
 >
-  <ButtonLabel
-    justify="flex-start"
-  >
+  <ButtonLabel>
     Normal Link
   </ButtonLabel>
 </StyledButton>
@@ -43,9 +40,7 @@ exports[`Button renders normal link 1`] = `
   onClick={[Function]}
   role="button"
 >
-  <ButtonLabel
-    justify="flex-start"
-  >
+  <ButtonLabel>
     Normal Link
   </ButtonLabel>
 </StyledButton>
@@ -59,9 +54,7 @@ exports[`Button renders react-router link 1`] = `
   role="button"
   to="/some/route"
 >
-  <ButtonLabel
-    justify="flex-start"
-  >
+  <ButtonLabel>
     Router Link
   </ButtonLabel>
 </StyledButton>

--- a/tests/js/spec/components/__snapshots__/confirm.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/confirm.spec.jsx.snap
@@ -45,7 +45,6 @@ exports[`Confirm renders 1`] = `
       className="modal-footer"
     >
       <Button
-        alignLabel="left"
         disabled={false}
         onClick={[Function]}
         style={
@@ -57,7 +56,6 @@ exports[`Confirm renders 1`] = `
         Cancel
       </Button>
       <Button
-        alignLabel="left"
         autoFocus={true}
         data-test-id="confirm-modal"
         disabled={false}

--- a/tests/js/spec/components/__snapshots__/confirmDelete.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/confirmDelete.spec.jsx.snap
@@ -239,7 +239,6 @@ exports[`ConfirmDelete renders 1`] = `
           className="modal-footer"
         >
           <Button
-            alignLabel="left"
             disabled={false}
             onClick={[Function]}
             style={
@@ -283,31 +282,15 @@ exports[`ConfirmDelete renders 1`] = `
                     }
                   }
                 >
-                  <ButtonLabel
-                    justify="flex-start"
-                  >
+                  <ButtonLabel>
                     <Component
-                      className="css-1emshjx-ButtonLabel eqrebog1"
-                      justify="flex-start"
+                      className="css-ga4b18-ButtonLabel eqrebog1"
                     >
-                      <Flex
-                        align="center"
-                        className="css-1emshjx-ButtonLabel eqrebog1"
-                        justify="flex-start"
+                      <span
+                        className="css-ga4b18-ButtonLabel eqrebog1"
                       >
-                        <Base
-                          align="center"
-                          className="eqrebog1 css-11rqwwm-ButtonLabel"
-                          justify="flex-start"
-                        >
-                          <div
-                            className="eqrebog1 css-11rqwwm-ButtonLabel"
-                            is={null}
-                          >
-                            Cancel
-                          </div>
-                        </Base>
-                      </Flex>
+                        Cancel
+                      </span>
                     </Component>
                   </ButtonLabel>
                 </button>
@@ -315,7 +298,6 @@ exports[`ConfirmDelete renders 1`] = `
             </StyledButton>
           </Button>
           <Button
-            alignLabel="left"
             autoFocus={true}
             data-test-id="confirm-modal"
             disabled={true}
@@ -358,32 +340,17 @@ exports[`ConfirmDelete renders 1`] = `
                   to={null}
                 >
                   <ButtonLabel
-                    justify="flex-start"
                     priority="primary"
                   >
                     <Component
-                      className="css-1emshjx-ButtonLabel eqrebog1"
-                      justify="flex-start"
+                      className="css-ga4b18-ButtonLabel eqrebog1"
                       priority="primary"
                     >
-                      <Flex
-                        align="center"
-                        className="css-1emshjx-ButtonLabel eqrebog1"
-                        justify="flex-start"
+                      <span
+                        className="css-ga4b18-ButtonLabel eqrebog1"
                       >
-                        <Base
-                          align="center"
-                          className="eqrebog1 css-11rqwwm-ButtonLabel"
-                          justify="flex-start"
-                        >
-                          <div
-                            className="eqrebog1 css-11rqwwm-ButtonLabel"
-                            is={null}
-                          >
-                            Confirm
-                          </div>
-                        </Base>
-                      </Flex>
+                        Confirm
+                      </span>
                     </Component>
                   </ButtonLabel>
                 </button>

--- a/tests/js/spec/components/assistant/__snapshots__/guideDrawer.spec.jsx.snap
+++ b/tests/js/spec/components/assistant/__snapshots__/guideDrawer.spec.jsx.snap
@@ -38,7 +38,6 @@ exports[`GuideDrawer gets dismissed 1`] = `
     >
       <div>
         <Button
-          alignLabel="left"
           disabled={false}
           onClick={[Function]}
           priority="success"
@@ -113,7 +112,6 @@ exports[`GuideDrawer renders next step 1`] = `
           Did you find this guide useful?
         </p>
         <Button
-          alignLabel="left"
           disabled={false}
           onClick={[Function]}
           priority="success"
@@ -125,7 +123,6 @@ exports[`GuideDrawer renders next step 1`] = `
           </span>
         </Button>
         <Button
-          alignLabel="left"
           disabled={false}
           onClick={[Function]}
           priority="success"
@@ -180,7 +177,6 @@ exports[`GuideDrawer renders tip 1`] = `
         }
       >
         <Button
-          alignLabel="left"
           disabled={false}
           onClick={[Function]}
           priority="success"
@@ -189,7 +185,6 @@ exports[`GuideDrawer renders tip 1`] = `
           cta_text
         </Button>
         <Button
-          alignLabel="left"
           disabled={false}
           onClick={[Function]}
           priority="success"

--- a/tests/js/spec/components/forms/__snapshots__/formField.spec.jsx.snap
+++ b/tests/js/spec/components/forms/__snapshots__/formField.spec.jsx.snap
@@ -321,7 +321,6 @@ exports[`FormField + model renders with Form 1`] = `
     >
       <Observer>
         <Button
-          alignLabel="left"
           data-test-id="form-submit"
           disabled={false}
           priority="primary"
@@ -357,32 +356,17 @@ exports[`FormField + model renders with Form 1`] = `
                 type="submit"
               >
                 <ButtonLabel
-                  justify="flex-start"
                   priority="primary"
                 >
                   <Component
-                    className="css-1emshjx-ButtonLabel eqrebog1"
-                    justify="flex-start"
+                    className="css-ga4b18-ButtonLabel eqrebog1"
                     priority="primary"
                   >
-                    <Flex
-                      align="center"
-                      className="css-1emshjx-ButtonLabel eqrebog1"
-                      justify="flex-start"
+                    <span
+                      className="css-ga4b18-ButtonLabel eqrebog1"
                     >
-                      <Base
-                        align="center"
-                        className="eqrebog1 css-11rqwwm-ButtonLabel"
-                        justify="flex-start"
-                      >
-                        <div
-                          className="eqrebog1 css-11rqwwm-ButtonLabel"
-                          is={null}
-                        >
-                          Save Changes
-                        </div>
-                      </Base>
-                    </Flex>
+                      Save Changes
+                    </span>
                   </Component>
                 </ButtonLabel>
               </button>

--- a/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
+++ b/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
@@ -275,7 +275,6 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
       className="modal-footer"
     >
       <Button
-        alignLabel="left"
         disabled={false}
         onClick={[MockFunction]}
         size="small"
@@ -304,32 +303,17 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
               size="small"
             >
               <ButtonLabel
-                justify="flex-start"
                 size="small"
               >
                 <Component
-                  className="css-o42ntg-ButtonLabel eqrebog1"
-                  justify="flex-start"
+                  className="css-7ui8bl-ButtonLabel eqrebog1"
                   size="small"
                 >
-                  <Flex
-                    align="center"
-                    className="css-o42ntg-ButtonLabel eqrebog1"
-                    justify="flex-start"
+                  <span
+                    className="css-7ui8bl-ButtonLabel eqrebog1"
                   >
-                    <Base
-                      align="center"
-                      className="eqrebog1 css-gzxb22-ButtonLabel"
-                      justify="flex-start"
-                    >
-                      <div
-                        className="eqrebog1 css-gzxb22-ButtonLabel"
-                        is={null}
-                      >
-                        Cancel
-                      </div>
-                    </Base>
-                  </Flex>
+                    Cancel
+                  </span>
                 </Component>
               </ButtonLabel>
             </button>
@@ -429,7 +413,6 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
                 }
               >
                 <Button
-                  alignLabel="left"
                   disabled={false}
                   onClick={[Function]}
                   priority="primary"
@@ -482,34 +465,19 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
                         }
                       >
                         <ButtonLabel
-                          justify="flex-start"
                           priority="primary"
                           size="small"
                         >
                           <Component
-                            className="css-o42ntg-ButtonLabel eqrebog1"
-                            justify="flex-start"
+                            className="css-7ui8bl-ButtonLabel eqrebog1"
                             priority="primary"
                             size="small"
                           >
-                            <Flex
-                              align="center"
-                              className="css-o42ntg-ButtonLabel eqrebog1"
-                              justify="flex-start"
+                            <span
+                              className="css-7ui8bl-ButtonLabel eqrebog1"
                             >
-                              <Base
-                                align="center"
-                                className="eqrebog1 css-gzxb22-ButtonLabel"
-                                justify="flex-start"
-                              >
-                                <div
-                                  className="eqrebog1 css-gzxb22-ButtonLabel"
-                                  is={null}
-                                >
-                                  Add Installation
-                                </div>
-                              </Base>
-                            </Flex>
+                              Add Installation
+                            </span>
                           </Component>
                         </ButtonLabel>
                       </button>

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -1191,7 +1191,6 @@ exports[`Sidebar SidebarPanel can show Incidents in Sidebar Panel 1`] = `
         </div>
         <div>
           <Button
-            alignLabel="left"
             disabled={false}
             external={true}
             href="https://status.sentry.io"
@@ -1239,32 +1238,17 @@ exports[`Sidebar SidebarPanel can show Incidents in Sidebar Panel 1`] = `
                     target="_blank"
                   >
                     <ButtonLabel
-                      justify="flex-start"
                       size="small"
                     >
                       <Component
-                        className="css-o42ntg-ButtonLabel eqrebog1"
-                        justify="flex-start"
+                        className="css-7ui8bl-ButtonLabel eqrebog1"
                         size="small"
                       >
-                        <Flex
-                          align="center"
-                          className="css-o42ntg-ButtonLabel eqrebog1"
-                          justify="flex-start"
+                        <span
+                          className="css-7ui8bl-ButtonLabel eqrebog1"
                         >
-                          <Base
-                            align="center"
-                            className="eqrebog1 css-gzxb22-ButtonLabel"
-                            justify="flex-start"
-                          >
-                            <div
-                              className="eqrebog1 css-gzxb22-ButtonLabel"
-                              is={null}
-                            >
-                              Learn more
-                            </div>
-                          </Base>
-                        </Flex>
+                          Learn more
+                        </span>
                       </Component>
                     </ButtonLabel>
                   </a>

--- a/tests/js/spec/views/__snapshots__/accountIdentities.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/accountIdentities.spec.jsx.snap
@@ -70,7 +70,6 @@ exports[`AccountIdentities renders list 1`] = `
             p={2}
           >
             <Button
-              alignLabel="left"
               disabled={false}
               onClick={[Function]}
               size="small"

--- a/tests/js/spec/views/__snapshots__/apiTokens.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/apiTokens.spec.jsx.snap
@@ -8,7 +8,6 @@ exports[`ApiTokens renders empty result 1`] = `
     <SettingsPageHeading
       action={
         <Button
-          alignLabel="left"
           className="ref-create-token"
           disabled={false}
           priority="primary"
@@ -100,7 +99,6 @@ exports[`ApiTokens renders with result 1`] = `
     <SettingsPageHeading
       action={
         <Button
-          alignLabel="left"
           className="ref-create-token"
           disabled={false}
           priority="primary"

--- a/tests/js/spec/views/__snapshots__/groupMergedView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/groupMergedView.spec.jsx.snap
@@ -392,7 +392,6 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                           </Confirm>
                         </LinkWithConfirmation>
                         <Button
-                          alignLabel="left"
                           disabled={true}
                           onClick={[Function]}
                           size="small"
@@ -447,32 +446,17 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                                 to={null}
                               >
                                 <ButtonLabel
-                                  justify="flex-start"
                                   size="small"
                                 >
                                   <Component
-                                    className="css-o42ntg-ButtonLabel eqrebog1"
-                                    justify="flex-start"
+                                    className="css-7ui8bl-ButtonLabel eqrebog1"
                                     size="small"
                                   >
-                                    <Flex
-                                      align="center"
-                                      className="css-o42ntg-ButtonLabel eqrebog1"
-                                      justify="flex-start"
+                                    <span
+                                      className="css-7ui8bl-ButtonLabel eqrebog1"
                                     >
-                                      <Base
-                                        align="center"
-                                        className="eqrebog1 css-gzxb22-ButtonLabel"
-                                        justify="flex-start"
-                                      >
-                                        <div
-                                          className="eqrebog1 css-gzxb22-ButtonLabel"
-                                          is={null}
-                                        >
-                                          Compare
-                                        </div>
-                                      </Base>
-                                    </Flex>
+                                      Compare
+                                    </span>
                                   </Component>
                                 </ButtonLabel>
                               </button>
@@ -491,7 +475,6 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                     >
                       <div>
                         <Button
-                          alignLabel="left"
                           className="toggle-collapse-all"
                           disabled={false}
                           onClick={[Function]}
@@ -522,32 +505,17 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                                 size="small"
                               >
                                 <ButtonLabel
-                                  justify="flex-start"
                                   size="small"
                                 >
                                   <Component
-                                    className="css-o42ntg-ButtonLabel eqrebog1"
-                                    justify="flex-start"
+                                    className="css-7ui8bl-ButtonLabel eqrebog1"
                                     size="small"
                                   >
-                                    <Flex
-                                      align="center"
-                                      className="css-o42ntg-ButtonLabel eqrebog1"
-                                      justify="flex-start"
+                                    <span
+                                      className="css-7ui8bl-ButtonLabel eqrebog1"
                                     >
-                                      <Base
-                                        align="center"
-                                        className="eqrebog1 css-gzxb22-ButtonLabel"
-                                        justify="flex-start"
-                                      >
-                                        <div
-                                          className="eqrebog1 css-gzxb22-ButtonLabel"
-                                          is={null}
-                                        >
-                                          Collapse All
-                                        </div>
-                                      </Base>
-                                    </Flex>
+                                      Collapse All
+                                    </span>
                                   </Component>
                                 </ButtonLabel>
                               </button>
@@ -1861,7 +1829,6 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                           </Confirm>
                         </LinkWithConfirmation>
                         <Button
-                          alignLabel="left"
                           disabled={true}
                           onClick={[Function]}
                           size="small"
@@ -1916,32 +1883,17 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                                 to={null}
                               >
                                 <ButtonLabel
-                                  justify="flex-start"
                                   size="small"
                                 >
                                   <Component
-                                    className="css-o42ntg-ButtonLabel eqrebog1"
-                                    justify="flex-start"
+                                    className="css-7ui8bl-ButtonLabel eqrebog1"
                                     size="small"
                                   >
-                                    <Flex
-                                      align="center"
-                                      className="css-o42ntg-ButtonLabel eqrebog1"
-                                      justify="flex-start"
+                                    <span
+                                      className="css-7ui8bl-ButtonLabel eqrebog1"
                                     >
-                                      <Base
-                                        align="center"
-                                        className="eqrebog1 css-gzxb22-ButtonLabel"
-                                        justify="flex-start"
-                                      >
-                                        <div
-                                          className="eqrebog1 css-gzxb22-ButtonLabel"
-                                          is={null}
-                                        >
-                                          Compare
-                                        </div>
-                                      </Base>
-                                    </Flex>
+                                      Compare
+                                    </span>
                                   </Component>
                                 </ButtonLabel>
                               </button>
@@ -1960,7 +1912,6 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                     >
                       <div>
                         <Button
-                          alignLabel="left"
                           className="toggle-collapse-all"
                           disabled={false}
                           onClick={[Function]}
@@ -1991,32 +1942,17 @@ exports[`Issues -> Merged View renders with mocked data 2`] = `
                                 size="small"
                               >
                                 <ButtonLabel
-                                  justify="flex-start"
                                   size="small"
                                 >
                                   <Component
-                                    className="css-o42ntg-ButtonLabel eqrebog1"
-                                    justify="flex-start"
+                                    className="css-7ui8bl-ButtonLabel eqrebog1"
                                     size="small"
                                   >
-                                    <Flex
-                                      align="center"
-                                      className="css-o42ntg-ButtonLabel eqrebog1"
-                                      justify="flex-start"
+                                    <span
+                                      className="css-7ui8bl-ButtonLabel eqrebog1"
                                     >
-                                      <Base
-                                        align="center"
-                                        className="eqrebog1 css-gzxb22-ButtonLabel"
-                                        justify="flex-start"
-                                      >
-                                        <div
-                                          className="eqrebog1 css-gzxb22-ButtonLabel"
-                                          is={null}
-                                        >
-                                          Collapse All
-                                        </div>
-                                      </Base>
-                                    </Flex>
+                                      Collapse All
+                                    </span>
                                   </Component>
                                 </ButtonLabel>
                               </button>

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -131,7 +131,6 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                             size="xsmall"
                                           >
                                             <Button
-                                              alignLabel="left"
                                               className="css-o27a2e-StyledButton e1yghndz1"
                                               disabled={false}
                                               size="xsmall"
@@ -158,61 +157,46 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                                     size="xsmall"
                                                   >
                                                     <ButtonLabel
-                                                      justify="flex-start"
                                                       size="xsmall"
                                                     >
                                                       <Component
-                                                        className="css-6q5v1w-ButtonLabel eqrebog1"
-                                                        justify="flex-start"
+                                                        className="css-uthd1f-ButtonLabel eqrebog1"
                                                         size="xsmall"
                                                       >
-                                                        <Flex
-                                                          align="center"
-                                                          className="css-6q5v1w-ButtonLabel eqrebog1"
-                                                          justify="flex-start"
+                                                        <span
+                                                          className="css-uthd1f-ButtonLabel eqrebog1"
                                                         >
-                                                          <Base
-                                                            align="center"
-                                                            className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                                            justify="flex-start"
-                                                          >
-                                                            <div
-                                                              className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                                              is={null}
+                                                          Add Project
+                                                          <StyledChevronDown>
+                                                            <Component
+                                                              className="css-17v3tc-StyledChevronDown e1yghndz0"
                                                             >
-                                                              Add Project
-                                                              <StyledChevronDown>
-                                                                <Component
+                                                              <InlineSvg
+                                                                className="css-17v3tc-StyledChevronDown e1yghndz0"
+                                                                src="icon-chevron-down"
+                                                              >
+                                                                <StyledSvg
                                                                   className="css-17v3tc-StyledChevronDown e1yghndz0"
+                                                                  height="1em"
+                                                                  viewBox={Object {}}
+                                                                  width="1em"
                                                                 >
-                                                                  <InlineSvg
-                                                                    className="css-17v3tc-StyledChevronDown e1yghndz0"
-                                                                    src="icon-chevron-down"
+                                                                  <svg
+                                                                    className="e1yghndz0 css-1gdv3x4-StyledSvg-StyledChevronDown e2idor0"
+                                                                    height="1em"
+                                                                    viewBox={Object {}}
+                                                                    width="1em"
                                                                   >
-                                                                    <StyledSvg
-                                                                      className="css-17v3tc-StyledChevronDown e1yghndz0"
-                                                                      height="1em"
-                                                                      viewBox={Object {}}
-                                                                      width="1em"
-                                                                    >
-                                                                      <svg
-                                                                        className="e1yghndz0 css-1gdv3x4-StyledSvg-StyledChevronDown e2idor0"
-                                                                        height="1em"
-                                                                        viewBox={Object {}}
-                                                                        width="1em"
-                                                                      >
-                                                                        <use
-                                                                          href="#test"
-                                                                          xlinkHref="#test"
-                                                                        />
-                                                                      </svg>
-                                                                    </StyledSvg>
-                                                                  </InlineSvg>
-                                                                </Component>
-                                                              </StyledChevronDown>
-                                                            </div>
-                                                          </Base>
-                                                        </Flex>
+                                                                    <use
+                                                                      href="#test"
+                                                                      xlinkHref="#test"
+                                                                    />
+                                                                  </svg>
+                                                                </StyledSvg>
+                                                              </InlineSvg>
+                                                            </Component>
+                                                          </StyledChevronDown>
+                                                        </span>
                                                       </Component>
                                                     </ButtonLabel>
                                                   </button>
@@ -395,7 +379,6 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                     title="You do not have enough permission to change project association."
                   >
                     <Button
-                      alignLabel="left"
                       disabled={false}
                       onClick={[Function]}
                       size="small"
@@ -421,62 +404,47 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                             size="small"
                           >
                             <ButtonLabel
-                              justify="flex-start"
                               size="small"
                             >
                               <Component
-                                className="css-o42ntg-ButtonLabel eqrebog1"
-                                justify="flex-start"
+                                className="css-7ui8bl-ButtonLabel eqrebog1"
                                 size="small"
                               >
-                                <Flex
-                                  align="center"
-                                  className="css-o42ntg-ButtonLabel eqrebog1"
-                                  justify="flex-start"
+                                <span
+                                  className="css-7ui8bl-ButtonLabel eqrebog1"
                                 >
-                                  <Base
-                                    align="center"
-                                    className="eqrebog1 css-gzxb22-ButtonLabel"
-                                    justify="flex-start"
-                                  >
-                                    <div
-                                      className="eqrebog1 css-gzxb22-ButtonLabel"
-                                      is={null}
+                                  <RemoveIcon>
+                                    <Component
+                                      className="css-1e2j5j0-RemoveIcon eqsa6vb0"
                                     >
-                                      <RemoveIcon>
-                                        <Component
+                                      <InlineSvg
+                                        className="css-1e2j5j0-RemoveIcon eqsa6vb0"
+                                        src="icon-circle-subtract"
+                                      >
+                                        <StyledSvg
                                           className="css-1e2j5j0-RemoveIcon eqsa6vb0"
+                                          height="1em"
+                                          viewBox={Object {}}
+                                          width="1em"
                                         >
-                                          <InlineSvg
-                                            className="css-1e2j5j0-RemoveIcon eqsa6vb0"
-                                            src="icon-circle-subtract"
+                                          <svg
+                                            className="eqsa6vb0 css-10g0ex9-StyledSvg-RemoveIcon e2idor0"
+                                            height="1em"
+                                            viewBox={Object {}}
+                                            width="1em"
                                           >
-                                            <StyledSvg
-                                              className="css-1e2j5j0-RemoveIcon eqsa6vb0"
-                                              height="1em"
-                                              viewBox={Object {}}
-                                              width="1em"
-                                            >
-                                              <svg
-                                                className="eqsa6vb0 css-10g0ex9-StyledSvg-RemoveIcon e2idor0"
-                                                height="1em"
-                                                viewBox={Object {}}
-                                                width="1em"
-                                              >
-                                                <use
-                                                  href="#test"
-                                                  xlinkHref="#test"
-                                                />
-                                              </svg>
-                                            </StyledSvg>
-                                          </InlineSvg>
-                                        </Component>
-                                      </RemoveIcon>
-                                       
-                                      Remove
-                                    </div>
-                                  </Base>
-                                </Flex>
+                                            <use
+                                              href="#test"
+                                              xlinkHref="#test"
+                                            />
+                                          </svg>
+                                        </StyledSvg>
+                                      </InlineSvg>
+                                    </Component>
+                                  </RemoveIcon>
+                                   
+                                  Remove
+                                </span>
                               </Component>
                             </ButtonLabel>
                           </button>

--- a/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
@@ -107,11 +107,11 @@ exports[`OrganizationDetails render() pending deletion should render a restorati
                 priority="primary"
                 role="button"
               >
-                <div
-                  class="eqrebog1 css-11rqwwm-ButtonLabel"
+                <span
+                  class="css-ga4b18-ButtonLabel eqrebog1"
                 >
                   Restore Organization
-                </div>
+                </span>
               </button>
             </p>
           </div>

--- a/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
@@ -810,7 +810,6 @@ exports[`Project Ownership Input renders 1`] = `
           size="small"
         >
           <Button
-            alignLabel="left"
             className="css-po7kq7-AddButton e1hyuoc79"
             disabled={true}
             icon="icon-circle-add"
@@ -849,89 +848,63 @@ exports[`Project Ownership Input renders 1`] = `
                   to={null}
                 >
                   <ButtonLabel
-                    justify="flex-start"
                     priority="primary"
                     size="small"
                   >
                     <Component
-                      className="css-o42ntg-ButtonLabel eqrebog1"
-                      justify="flex-start"
+                      className="css-7ui8bl-ButtonLabel eqrebog1"
                       priority="primary"
                       size="small"
                     >
-                      <Flex
-                        align="center"
-                        className="css-o42ntg-ButtonLabel eqrebog1"
-                        justify="flex-start"
+                      <span
+                        className="css-7ui8bl-ButtonLabel eqrebog1"
                       >
-                        <Base
-                          align="center"
-                          className="eqrebog1 css-gzxb22-ButtonLabel"
-                          justify="flex-start"
+                        <Icon
+                          hasChildren={false}
+                          size="small"
                         >
-                          <div
-                            className="eqrebog1 css-gzxb22-ButtonLabel"
-                            is={null}
+                          <Component
+                            className="css-ljhpxy-Icon eqrebog2"
+                            hasChildren={false}
+                            size="small"
                           >
-                            <Icon
-                              hasChildren={false}
+                            <span
+                              className="css-ljhpxy-Icon eqrebog2"
                               size="small"
                             >
-                              <Component
-                                className="css-ljhpxy-Icon eqrebog2"
-                                hasChildren={false}
-                                size="small"
+                              <StyledInlineSvg
+                                size="12px"
+                                src="icon-circle-add"
                               >
-                                <Box
-                                  className="css-ljhpxy-Icon eqrebog2"
-                                  size="small"
+                                <InlineSvg
+                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                  size="12px"
+                                  src="icon-circle-add"
                                 >
-                                  <Base
-                                    className="eqrebog2 css-7mohvl-Icon"
-                                    size="small"
+                                  <StyledSvg
+                                    className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                    height="12px"
+                                    viewBox={Object {}}
+                                    width="12px"
                                   >
-                                    <div
-                                      className="eqrebog2 css-7mohvl-Icon"
-                                      is={null}
-                                      size="small"
+                                    <svg
+                                      className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                      height="12px"
+                                      viewBox={Object {}}
+                                      width="12px"
                                     >
-                                      <StyledInlineSvg
-                                        size="12px"
-                                        src="icon-circle-add"
-                                      >
-                                        <InlineSvg
-                                          className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                          size="12px"
-                                          src="icon-circle-add"
-                                        >
-                                          <StyledSvg
-                                            className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                            height="12px"
-                                            viewBox={Object {}}
-                                            width="12px"
-                                          >
-                                            <svg
-                                              className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                              height="12px"
-                                              viewBox={Object {}}
-                                              width="12px"
-                                            >
-                                              <use
-                                                href="#test"
-                                                xlinkHref="#test"
-                                              />
-                                            </svg>
-                                          </StyledSvg>
-                                        </InlineSvg>
-                                      </StyledInlineSvg>
-                                    </div>
-                                  </Base>
-                                </Box>
-                              </Component>
-                            </Icon>
-                          </div>
-                        </Base>
-                      </Flex>
+                                      <use
+                                        href="#test"
+                                        xlinkHref="#test"
+                                      />
+                                    </svg>
+                                  </StyledSvg>
+                                </InlineSvg>
+                              </StyledInlineSvg>
+                            </span>
+                          </Component>
+                        </Icon>
+                      </span>
                     </Component>
                   </ButtonLabel>
                 </button>
@@ -1010,7 +983,6 @@ url:http://example.com/settings/* #product"
               className="css-5zvod-SaveButton en3n9di1"
             >
               <Button
-                alignLabel="left"
                 disabled={false}
                 onClick={[Function]}
                 priority="primary"
@@ -1043,34 +1015,19 @@ url:http://example.com/settings/* #product"
                       size="small"
                     >
                       <ButtonLabel
-                        justify="flex-start"
                         priority="primary"
                         size="small"
                       >
                         <Component
-                          className="css-o42ntg-ButtonLabel eqrebog1"
-                          justify="flex-start"
+                          className="css-7ui8bl-ButtonLabel eqrebog1"
                           priority="primary"
                           size="small"
                         >
-                          <Flex
-                            align="center"
-                            className="css-o42ntg-ButtonLabel eqrebog1"
-                            justify="flex-start"
+                          <span
+                            className="css-7ui8bl-ButtonLabel eqrebog1"
                           >
-                            <Base
-                              align="center"
-                              className="eqrebog1 css-gzxb22-ButtonLabel"
-                              justify="flex-start"
-                            >
-                              <div
-                                className="eqrebog1 css-gzxb22-ButtonLabel"
-                                is={null}
-                              >
-                                Save Changes
-                              </div>
-                            </Base>
-                          </Flex>
+                            Save Changes
+                          </span>
                         </Component>
                       </ButtonLabel>
                     </button>

--- a/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
@@ -670,7 +670,6 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                       className="css-1d10zz4-RuleNodeControls e1qnqozx2"
                                     >
                                       <Button
-                                        alignLabel="left"
                                         disabled={false}
                                         icon="icon-trash"
                                         onClick={[Function]}
@@ -705,87 +704,61 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                               type="button"
                                             >
                                               <ButtonLabel
-                                                justify="flex-start"
                                                 size="small"
                                               >
                                                 <Component
-                                                  className="css-o42ntg-ButtonLabel eqrebog1"
-                                                  justify="flex-start"
+                                                  className="css-7ui8bl-ButtonLabel eqrebog1"
                                                   size="small"
                                                 >
-                                                  <Flex
-                                                    align="center"
-                                                    className="css-o42ntg-ButtonLabel eqrebog1"
-                                                    justify="flex-start"
+                                                  <span
+                                                    className="css-7ui8bl-ButtonLabel eqrebog1"
                                                   >
-                                                    <Base
-                                                      align="center"
-                                                      className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                      justify="flex-start"
+                                                    <Icon
+                                                      hasChildren={false}
+                                                      size="small"
                                                     >
-                                                      <div
-                                                        className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                        is={null}
+                                                      <Component
+                                                        className="css-ljhpxy-Icon eqrebog2"
+                                                        hasChildren={false}
+                                                        size="small"
                                                       >
-                                                        <Icon
-                                                          hasChildren={false}
+                                                        <span
+                                                          className="css-ljhpxy-Icon eqrebog2"
                                                           size="small"
                                                         >
-                                                          <Component
-                                                            className="css-ljhpxy-Icon eqrebog2"
-                                                            hasChildren={false}
-                                                            size="small"
+                                                          <StyledInlineSvg
+                                                            size="12px"
+                                                            src="icon-trash"
                                                           >
-                                                            <Box
-                                                              className="css-ljhpxy-Icon eqrebog2"
-                                                              size="small"
+                                                            <InlineSvg
+                                                              className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                              size="12px"
+                                                              src="icon-trash"
                                                             >
-                                                              <Base
-                                                                className="eqrebog2 css-7mohvl-Icon"
-                                                                size="small"
+                                                              <StyledSvg
+                                                                className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                                height="12px"
+                                                                viewBox={Object {}}
+                                                                width="12px"
                                                               >
-                                                                <div
-                                                                  className="eqrebog2 css-7mohvl-Icon"
-                                                                  is={null}
-                                                                  size="small"
+                                                                <svg
+                                                                  className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                                  height="12px"
+                                                                  viewBox={Object {}}
+                                                                  width="12px"
                                                                 >
-                                                                  <StyledInlineSvg
-                                                                    size="12px"
-                                                                    src="icon-trash"
-                                                                  >
-                                                                    <InlineSvg
-                                                                      className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                      size="12px"
-                                                                      src="icon-trash"
-                                                                    >
-                                                                      <StyledSvg
-                                                                        className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                        height="12px"
-                                                                        viewBox={Object {}}
-                                                                        width="12px"
-                                                                      >
-                                                                        <svg
-                                                                          className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                          height="12px"
-                                                                          viewBox={Object {}}
-                                                                          width="12px"
-                                                                        >
-                                                                          <use
-                                                                            href="#test"
-                                                                            xlinkHref="#test"
-                                                                          />
-                                                                        </svg>
-                                                                      </StyledSvg>
-                                                                    </InlineSvg>
-                                                                  </StyledInlineSvg>
-                                                                </div>
-                                                              </Base>
-                                                            </Box>
-                                                          </Component>
-                                                        </Icon>
-                                                      </div>
-                                                    </Base>
-                                                  </Flex>
+                                                                  <use
+                                                                    href="#test"
+                                                                    xlinkHref="#test"
+                                                                  />
+                                                                </svg>
+                                                              </StyledSvg>
+                                                            </InlineSvg>
+                                                          </StyledInlineSvg>
+                                                        </span>
+                                                      </Component>
+                                                    </Icon>
+                                                  </span>
                                                 </Component>
                                               </ButtonLabel>
                                             </button>
@@ -1456,7 +1429,6 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                       className="css-1d10zz4-RuleNodeControls e1qnqozx2"
                                     >
                                       <Button
-                                        alignLabel="left"
                                         disabled={false}
                                         icon="icon-trash"
                                         onClick={[Function]}
@@ -1491,87 +1463,61 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                               type="button"
                                             >
                                               <ButtonLabel
-                                                justify="flex-start"
                                                 size="small"
                                               >
                                                 <Component
-                                                  className="css-o42ntg-ButtonLabel eqrebog1"
-                                                  justify="flex-start"
+                                                  className="css-7ui8bl-ButtonLabel eqrebog1"
                                                   size="small"
                                                 >
-                                                  <Flex
-                                                    align="center"
-                                                    className="css-o42ntg-ButtonLabel eqrebog1"
-                                                    justify="flex-start"
+                                                  <span
+                                                    className="css-7ui8bl-ButtonLabel eqrebog1"
                                                   >
-                                                    <Base
-                                                      align="center"
-                                                      className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                      justify="flex-start"
+                                                    <Icon
+                                                      hasChildren={false}
+                                                      size="small"
                                                     >
-                                                      <div
-                                                        className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                        is={null}
+                                                      <Component
+                                                        className="css-ljhpxy-Icon eqrebog2"
+                                                        hasChildren={false}
+                                                        size="small"
                                                       >
-                                                        <Icon
-                                                          hasChildren={false}
+                                                        <span
+                                                          className="css-ljhpxy-Icon eqrebog2"
                                                           size="small"
                                                         >
-                                                          <Component
-                                                            className="css-ljhpxy-Icon eqrebog2"
-                                                            hasChildren={false}
-                                                            size="small"
+                                                          <StyledInlineSvg
+                                                            size="12px"
+                                                            src="icon-trash"
                                                           >
-                                                            <Box
-                                                              className="css-ljhpxy-Icon eqrebog2"
-                                                              size="small"
+                                                            <InlineSvg
+                                                              className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                              size="12px"
+                                                              src="icon-trash"
                                                             >
-                                                              <Base
-                                                                className="eqrebog2 css-7mohvl-Icon"
-                                                                size="small"
+                                                              <StyledSvg
+                                                                className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                                height="12px"
+                                                                viewBox={Object {}}
+                                                                width="12px"
                                                               >
-                                                                <div
-                                                                  className="eqrebog2 css-7mohvl-Icon"
-                                                                  is={null}
-                                                                  size="small"
+                                                                <svg
+                                                                  className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                                  height="12px"
+                                                                  viewBox={Object {}}
+                                                                  width="12px"
                                                                 >
-                                                                  <StyledInlineSvg
-                                                                    size="12px"
-                                                                    src="icon-trash"
-                                                                  >
-                                                                    <InlineSvg
-                                                                      className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                      size="12px"
-                                                                      src="icon-trash"
-                                                                    >
-                                                                      <StyledSvg
-                                                                        className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                        height="12px"
-                                                                        viewBox={Object {}}
-                                                                        width="12px"
-                                                                      >
-                                                                        <svg
-                                                                          className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                          height="12px"
-                                                                          viewBox={Object {}}
-                                                                          width="12px"
-                                                                        >
-                                                                          <use
-                                                                            href="#test"
-                                                                            xlinkHref="#test"
-                                                                          />
-                                                                        </svg>
-                                                                      </StyledSvg>
-                                                                    </InlineSvg>
-                                                                  </StyledInlineSvg>
-                                                                </div>
-                                                              </Base>
-                                                            </Box>
-                                                          </Component>
-                                                        </Icon>
-                                                      </div>
-                                                    </Base>
-                                                  </Flex>
+                                                                  <use
+                                                                    href="#test"
+                                                                    xlinkHref="#test"
+                                                                  />
+                                                                </svg>
+                                                              </StyledSvg>
+                                                            </InlineSvg>
+                                                          </StyledInlineSvg>
+                                                        </span>
+                                                      </Component>
+                                                    </Icon>
+                                                  </span>
                                                 </Component>
                                               </ButtonLabel>
                                             </button>
@@ -2302,7 +2248,6 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                           to="/settings/org-slug/project-slug/alerts/rules/"
                         >
                           <Button
-                            alignLabel="left"
                             className="css-1yc33o1-CancelButton elb7f1e1"
                             disabled={false}
                             to="/settings/org-slug/project-slug/alerts/rules/"
@@ -2341,31 +2286,15 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                     role="button"
                                     style={Object {}}
                                   >
-                                    <ButtonLabel
-                                      justify="flex-start"
-                                    >
+                                    <ButtonLabel>
                                       <Component
-                                        className="css-1emshjx-ButtonLabel eqrebog1"
-                                        justify="flex-start"
+                                        className="css-ga4b18-ButtonLabel eqrebog1"
                                       >
-                                        <Flex
-                                          align="center"
-                                          className="css-1emshjx-ButtonLabel eqrebog1"
-                                          justify="flex-start"
+                                        <span
+                                          className="css-ga4b18-ButtonLabel eqrebog1"
                                         >
-                                          <Base
-                                            align="center"
-                                            className="eqrebog1 css-11rqwwm-ButtonLabel"
-                                            justify="flex-start"
-                                          >
-                                            <div
-                                              className="eqrebog1 css-11rqwwm-ButtonLabel"
-                                              is={null}
-                                            >
-                                              Cancel
-                                            </div>
-                                          </Base>
-                                        </Flex>
+                                          Cancel
+                                        </span>
                                       </Component>
                                     </ButtonLabel>
                                   </a>
@@ -2375,7 +2304,6 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                           </Button>
                         </CancelButton>
                         <Button
-                          alignLabel="left"
                           disabled={false}
                           priority="primary"
                         >
@@ -2403,32 +2331,17 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                 role="button"
                               >
                                 <ButtonLabel
-                                  justify="flex-start"
                                   priority="primary"
                                 >
                                   <Component
-                                    className="css-1emshjx-ButtonLabel eqrebog1"
-                                    justify="flex-start"
+                                    className="css-ga4b18-ButtonLabel eqrebog1"
                                     priority="primary"
                                   >
-                                    <Flex
-                                      align="center"
-                                      className="css-1emshjx-ButtonLabel eqrebog1"
-                                      justify="flex-start"
+                                    <span
+                                      className="css-ga4b18-ButtonLabel eqrebog1"
                                     >
-                                      <Base
-                                        align="center"
-                                        className="eqrebog1 css-11rqwwm-ButtonLabel"
-                                        justify="flex-start"
-                                      >
-                                        <div
-                                          className="eqrebog1 css-11rqwwm-ButtonLabel"
-                                          is={null}
-                                        >
-                                          Save Rule
-                                        </div>
-                                      </Base>
-                                    </Flex>
+                                      Save Rule
+                                    </span>
                                   </Component>
                                 </ButtonLabel>
                               </button>
@@ -4459,7 +4372,6 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                           to="/settings/org-slug/project-slug/alerts/rules/"
                         >
                           <Button
-                            alignLabel="left"
                             className="css-1yc33o1-CancelButton elb7f1e1"
                             disabled={false}
                             to="/settings/org-slug/project-slug/alerts/rules/"
@@ -4498,31 +4410,15 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                     role="button"
                                     style={Object {}}
                                   >
-                                    <ButtonLabel
-                                      justify="flex-start"
-                                    >
+                                    <ButtonLabel>
                                       <Component
-                                        className="css-1emshjx-ButtonLabel eqrebog1"
-                                        justify="flex-start"
+                                        className="css-ga4b18-ButtonLabel eqrebog1"
                                       >
-                                        <Flex
-                                          align="center"
-                                          className="css-1emshjx-ButtonLabel eqrebog1"
-                                          justify="flex-start"
+                                        <span
+                                          className="css-ga4b18-ButtonLabel eqrebog1"
                                         >
-                                          <Base
-                                            align="center"
-                                            className="eqrebog1 css-11rqwwm-ButtonLabel"
-                                            justify="flex-start"
-                                          >
-                                            <div
-                                              className="eqrebog1 css-11rqwwm-ButtonLabel"
-                                              is={null}
-                                            >
-                                              Cancel
-                                            </div>
-                                          </Base>
-                                        </Flex>
+                                          Cancel
+                                        </span>
                                       </Component>
                                     </ButtonLabel>
                                   </a>
@@ -4532,7 +4428,6 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                           </Button>
                         </CancelButton>
                         <Button
-                          alignLabel="left"
                           disabled={false}
                           priority="primary"
                         >
@@ -4560,32 +4455,17 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                 role="button"
                               >
                                 <ButtonLabel
-                                  justify="flex-start"
                                   priority="primary"
                                 >
                                   <Component
-                                    className="css-1emshjx-ButtonLabel eqrebog1"
-                                    justify="flex-start"
+                                    className="css-ga4b18-ButtonLabel eqrebog1"
                                     priority="primary"
                                   >
-                                    <Flex
-                                      align="center"
-                                      className="css-1emshjx-ButtonLabel eqrebog1"
-                                      justify="flex-start"
+                                    <span
+                                      className="css-ga4b18-ButtonLabel eqrebog1"
                                     >
-                                      <Base
-                                        align="center"
-                                        className="eqrebog1 css-11rqwwm-ButtonLabel"
-                                        justify="flex-start"
-                                      >
-                                        <div
-                                          className="eqrebog1 css-11rqwwm-ButtonLabel"
-                                          is={null}
-                                        >
-                                          Save Rule
-                                        </div>
-                                      </Base>
-                                    </Flex>
+                                      Save Rule
+                                    </span>
                                   </Component>
                                 </ButtonLabel>
                               </button>

--- a/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
@@ -23,7 +23,6 @@ exports[`projectAlertRules renders 1`] = `
             title="You do not have permission to edit alert rules."
           >
             <Button
-              alignLabel="left"
               disabled={false}
               icon="icon-circle-add"
               priority="primary"
@@ -110,7 +109,6 @@ exports[`projectAlertRules renders 1`] = `
                       title="You do not have permission to edit alert rules."
                     >
                       <Button
-                        alignLabel="left"
                         disabled={false}
                         icon="icon-circle-add"
                         priority="primary"
@@ -159,90 +157,64 @@ exports[`projectAlertRules renders 1`] = `
                                 style={Object {}}
                               >
                                 <ButtonLabel
-                                  justify="flex-start"
                                   priority="primary"
                                   size="small"
                                 >
                                   <Component
-                                    className="css-o42ntg-ButtonLabel eqrebog1"
-                                    justify="flex-start"
+                                    className="css-7ui8bl-ButtonLabel eqrebog1"
                                     priority="primary"
                                     size="small"
                                   >
-                                    <Flex
-                                      align="center"
-                                      className="css-o42ntg-ButtonLabel eqrebog1"
-                                      justify="flex-start"
+                                    <span
+                                      className="css-7ui8bl-ButtonLabel eqrebog1"
                                     >
-                                      <Base
-                                        align="center"
-                                        className="eqrebog1 css-gzxb22-ButtonLabel"
-                                        justify="flex-start"
+                                      <Icon
+                                        hasChildren={true}
+                                        size="small"
                                       >
-                                        <div
-                                          className="eqrebog1 css-gzxb22-ButtonLabel"
-                                          is={null}
+                                        <Component
+                                          className="css-1vdnsie-Icon eqrebog2"
+                                          hasChildren={true}
+                                          size="small"
                                         >
-                                          <Icon
-                                            hasChildren={true}
+                                          <span
+                                            className="css-1vdnsie-Icon eqrebog2"
                                             size="small"
                                           >
-                                            <Component
-                                              className="css-1vdnsie-Icon eqrebog2"
-                                              hasChildren={true}
-                                              size="small"
+                                            <StyledInlineSvg
+                                              size="12px"
+                                              src="icon-circle-add"
                                             >
-                                              <Box
-                                                className="css-1vdnsie-Icon eqrebog2"
-                                                size="small"
+                                              <InlineSvg
+                                                className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                size="12px"
+                                                src="icon-circle-add"
                                               >
-                                                <Base
-                                                  className="eqrebog2 css-nk081r-Icon"
-                                                  size="small"
+                                                <StyledSvg
+                                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                  height="12px"
+                                                  viewBox={Object {}}
+                                                  width="12px"
                                                 >
-                                                  <div
-                                                    className="eqrebog2 css-nk081r-Icon"
-                                                    is={null}
-                                                    size="small"
+                                                  <svg
+                                                    className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                    height="12px"
+                                                    viewBox={Object {}}
+                                                    width="12px"
                                                   >
-                                                    <StyledInlineSvg
-                                                      size="12px"
-                                                      src="icon-circle-add"
-                                                    >
-                                                      <InlineSvg
-                                                        className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                        size="12px"
-                                                        src="icon-circle-add"
-                                                      >
-                                                        <StyledSvg
-                                                          className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                          height="12px"
-                                                          viewBox={Object {}}
-                                                          width="12px"
-                                                        >
-                                                          <svg
-                                                            className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                            height="12px"
-                                                            viewBox={Object {}}
-                                                            width="12px"
-                                                          >
-                                                            <use
-                                                              href="#test"
-                                                              xlinkHref="#test"
-                                                            />
-                                                          </svg>
-                                                        </StyledSvg>
-                                                      </InlineSvg>
-                                                    </StyledInlineSvg>
-                                                  </div>
-                                                </Base>
-                                              </Box>
-                                            </Component>
-                                          </Icon>
-                                          New Alert Rule
-                                        </div>
-                                      </Base>
-                                    </Flex>
+                                                    <use
+                                                      href="#test"
+                                                      xlinkHref="#test"
+                                                    />
+                                                  </svg>
+                                                </StyledSvg>
+                                              </InlineSvg>
+                                            </StyledInlineSvg>
+                                          </span>
+                                        </Component>
+                                      </Icon>
+                                      New Alert Rule
+                                    </span>
                                   </Component>
                                 </ButtonLabel>
                               </a>
@@ -405,7 +377,6 @@ exports[`projectAlertRules renders 1`] = `
                               title="You do not have permission to edit alert rules."
                             >
                               <Button
-                                alignLabel="left"
                                 data-test-id="edit-rule"
                                 disabled={false}
                                 size="small"
@@ -476,32 +447,17 @@ exports[`projectAlertRules renders 1`] = `
                                         }
                                       >
                                         <ButtonLabel
-                                          justify="flex-start"
                                           size="small"
                                         >
                                           <Component
-                                            className="css-o42ntg-ButtonLabel eqrebog1"
-                                            justify="flex-start"
+                                            className="css-7ui8bl-ButtonLabel eqrebog1"
                                             size="small"
                                           >
-                                            <Flex
-                                              align="center"
-                                              className="css-o42ntg-ButtonLabel eqrebog1"
-                                              justify="flex-start"
+                                            <span
+                                              className="css-7ui8bl-ButtonLabel eqrebog1"
                                             >
-                                              <Base
-                                                align="center"
-                                                className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                justify="flex-start"
-                                              >
-                                                <div
-                                                  className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                  is={null}
-                                                >
-                                                  Edit Rule
-                                                </div>
-                                              </Base>
-                                            </Flex>
+                                              Edit Rule
+                                            </span>
                                           </Component>
                                         </ButtonLabel>
                                       </a>
@@ -524,7 +480,6 @@ exports[`projectAlertRules renders 1`] = `
                                 priority="primary"
                               >
                                 <Button
-                                  alignLabel="left"
                                   disabled={false}
                                   icon="icon-trash"
                                   onClick={[Function]}
@@ -551,87 +506,61 @@ exports[`projectAlertRules renders 1`] = `
                                         size="small"
                                       >
                                         <ButtonLabel
-                                          justify="flex-start"
                                           size="small"
                                         >
                                           <Component
-                                            className="css-o42ntg-ButtonLabel eqrebog1"
-                                            justify="flex-start"
+                                            className="css-7ui8bl-ButtonLabel eqrebog1"
                                             size="small"
                                           >
-                                            <Flex
-                                              align="center"
-                                              className="css-o42ntg-ButtonLabel eqrebog1"
-                                              justify="flex-start"
+                                            <span
+                                              className="css-7ui8bl-ButtonLabel eqrebog1"
                                             >
-                                              <Base
-                                                align="center"
-                                                className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                justify="flex-start"
+                                              <Icon
+                                                hasChildren={false}
+                                                size="small"
                                               >
-                                                <div
-                                                  className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                  is={null}
+                                                <Component
+                                                  className="css-ljhpxy-Icon eqrebog2"
+                                                  hasChildren={false}
+                                                  size="small"
                                                 >
-                                                  <Icon
-                                                    hasChildren={false}
+                                                  <span
+                                                    className="css-ljhpxy-Icon eqrebog2"
                                                     size="small"
                                                   >
-                                                    <Component
-                                                      className="css-ljhpxy-Icon eqrebog2"
-                                                      hasChildren={false}
-                                                      size="small"
+                                                    <StyledInlineSvg
+                                                      size="12px"
+                                                      src="icon-trash"
                                                     >
-                                                      <Box
-                                                        className="css-ljhpxy-Icon eqrebog2"
-                                                        size="small"
+                                                      <InlineSvg
+                                                        className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                        size="12px"
+                                                        src="icon-trash"
                                                       >
-                                                        <Base
-                                                          className="eqrebog2 css-7mohvl-Icon"
-                                                          size="small"
+                                                        <StyledSvg
+                                                          className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                          height="12px"
+                                                          viewBox={Object {}}
+                                                          width="12px"
                                                         >
-                                                          <div
-                                                            className="eqrebog2 css-7mohvl-Icon"
-                                                            is={null}
-                                                            size="small"
+                                                          <svg
+                                                            className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                            height="12px"
+                                                            viewBox={Object {}}
+                                                            width="12px"
                                                           >
-                                                            <StyledInlineSvg
-                                                              size="12px"
-                                                              src="icon-trash"
-                                                            >
-                                                              <InlineSvg
-                                                                className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                size="12px"
-                                                                src="icon-trash"
-                                                              >
-                                                                <StyledSvg
-                                                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                  height="12px"
-                                                                  viewBox={Object {}}
-                                                                  width="12px"
-                                                                >
-                                                                  <svg
-                                                                    className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                    height="12px"
-                                                                    viewBox={Object {}}
-                                                                    width="12px"
-                                                                  >
-                                                                    <use
-                                                                      href="#test"
-                                                                      xlinkHref="#test"
-                                                                    />
-                                                                  </svg>
-                                                                </StyledSvg>
-                                                              </InlineSvg>
-                                                            </StyledInlineSvg>
-                                                          </div>
-                                                        </Base>
-                                                      </Box>
-                                                    </Component>
-                                                  </Icon>
-                                                </div>
-                                              </Base>
-                                            </Flex>
+                                                            <use
+                                                              href="#test"
+                                                              xlinkHref="#test"
+                                                            />
+                                                          </svg>
+                                                        </StyledSvg>
+                                                      </InlineSvg>
+                                                    </StyledInlineSvg>
+                                                  </span>
+                                                </Component>
+                                              </Icon>
+                                            </span>
                                           </Component>
                                         </ButtonLabel>
                                       </button>

--- a/tests/js/spec/views/__snapshots__/projectAlertSettings.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertSettings.spec.jsx.snap
@@ -11,7 +11,6 @@ exports[`ProjectAlertSettings render() renders 1`] = `
         title="You do not have permission to edit alert rules."
       >
         <Button
-          alignLabel="left"
           disabled={false}
           icon="icon-circle-add"
           priority="primary"

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -456,7 +456,6 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                           size="xsmall"
                         >
                           <Button
-                            alignLabel="left"
                             className="css-10adnmx-EnvironmentButton ezuela50"
                             disabled={false}
                             onClick={[Function]}
@@ -487,32 +486,17 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                   size="xsmall"
                                 >
                                   <ButtonLabel
-                                    justify="flex-start"
                                     size="xsmall"
                                   >
                                     <Component
-                                      className="css-6q5v1w-ButtonLabel eqrebog1"
-                                      justify="flex-start"
+                                      className="css-uthd1f-ButtonLabel eqrebog1"
                                       size="xsmall"
                                     >
-                                      <Flex
-                                        align="center"
-                                        className="css-6q5v1w-ButtonLabel eqrebog1"
-                                        justify="flex-start"
+                                      <span
+                                        className="css-uthd1f-ButtonLabel eqrebog1"
                                       >
-                                        <Base
-                                          align="center"
-                                          className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                          justify="flex-start"
-                                        >
-                                          <div
-                                            className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                            is={null}
-                                          >
-                                            Set as default
-                                          </div>
-                                        </Base>
-                                      </Flex>
+                                        Set as default
+                                      </span>
                                     </Component>
                                   </ButtonLabel>
                                 </button>
@@ -580,7 +564,6 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                           size="xsmall"
                         >
                           <Button
-                            alignLabel="left"
                             className="css-10adnmx-EnvironmentButton ezuela50"
                             disabled={false}
                             onClick={[Function]}
@@ -611,32 +594,17 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                   size="xsmall"
                                 >
                                   <ButtonLabel
-                                    justify="flex-start"
                                     size="xsmall"
                                   >
                                     <Component
-                                      className="css-6q5v1w-ButtonLabel eqrebog1"
-                                      justify="flex-start"
+                                      className="css-uthd1f-ButtonLabel eqrebog1"
                                       size="xsmall"
                                     >
-                                      <Flex
-                                        align="center"
-                                        className="css-6q5v1w-ButtonLabel eqrebog1"
-                                        justify="flex-start"
+                                      <span
+                                        className="css-uthd1f-ButtonLabel eqrebog1"
                                       >
-                                        <Base
-                                          align="center"
-                                          className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                          justify="flex-start"
-                                        >
-                                          <div
-                                            className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                            is={null}
-                                          >
-                                            Set as default
-                                          </div>
-                                        </Base>
-                                      </Flex>
+                                        Set as default
+                                      </span>
                                     </Component>
                                   </ButtonLabel>
                                 </button>
@@ -649,7 +617,6 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                           size="xsmall"
                         >
                           <Button
-                            alignLabel="left"
                             className="css-10adnmx-EnvironmentButton ezuela50"
                             disabled={false}
                             onClick={[Function]}
@@ -680,32 +647,17 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                   size="xsmall"
                                 >
                                   <ButtonLabel
-                                    justify="flex-start"
                                     size="xsmall"
                                   >
                                     <Component
-                                      className="css-6q5v1w-ButtonLabel eqrebog1"
-                                      justify="flex-start"
+                                      className="css-uthd1f-ButtonLabel eqrebog1"
                                       size="xsmall"
                                     >
-                                      <Flex
-                                        align="center"
-                                        className="css-6q5v1w-ButtonLabel eqrebog1"
-                                        justify="flex-start"
+                                      <span
+                                        className="css-uthd1f-ButtonLabel eqrebog1"
                                       >
-                                        <Base
-                                          align="center"
-                                          className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                          justify="flex-start"
-                                        >
-                                          <div
-                                            className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                            is={null}
-                                          >
-                                            Hide
-                                          </div>
-                                        </Base>
-                                      </Flex>
+                                        Hide
+                                      </span>
                                     </Component>
                                   </ButtonLabel>
                                 </button>
@@ -805,7 +757,6 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                           size="xsmall"
                         >
                           <Button
-                            alignLabel="left"
                             className="css-10adnmx-EnvironmentButton ezuela50"
                             disabled={false}
                             onClick={[Function]}
@@ -836,32 +787,17 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                   size="xsmall"
                                 >
                                   <ButtonLabel
-                                    justify="flex-start"
                                     size="xsmall"
                                   >
                                     <Component
-                                      className="css-6q5v1w-ButtonLabel eqrebog1"
-                                      justify="flex-start"
+                                      className="css-uthd1f-ButtonLabel eqrebog1"
                                       size="xsmall"
                                     >
-                                      <Flex
-                                        align="center"
-                                        className="css-6q5v1w-ButtonLabel eqrebog1"
-                                        justify="flex-start"
+                                      <span
+                                        className="css-uthd1f-ButtonLabel eqrebog1"
                                       >
-                                        <Base
-                                          align="center"
-                                          className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                          justify="flex-start"
-                                        >
-                                          <div
-                                            className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                            is={null}
-                                          >
-                                            Hide
-                                          </div>
-                                        </Base>
-                                      </Flex>
+                                        Hide
+                                      </span>
                                     </Component>
                                   </ButtonLabel>
                                 </button>
@@ -1344,7 +1280,6 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                           size="xsmall"
                         >
                           <Button
-                            alignLabel="left"
                             className="css-10adnmx-EnvironmentButton ezuela50"
                             disabled={false}
                             onClick={[Function]}
@@ -1375,32 +1310,17 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                                   size="xsmall"
                                 >
                                   <ButtonLabel
-                                    justify="flex-start"
                                     size="xsmall"
                                   >
                                     <Component
-                                      className="css-6q5v1w-ButtonLabel eqrebog1"
-                                      justify="flex-start"
+                                      className="css-uthd1f-ButtonLabel eqrebog1"
                                       size="xsmall"
                                     >
-                                      <Flex
-                                        align="center"
-                                        className="css-6q5v1w-ButtonLabel eqrebog1"
-                                        justify="flex-start"
+                                      <span
+                                        className="css-uthd1f-ButtonLabel eqrebog1"
                                       >
-                                        <Base
-                                          align="center"
-                                          className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                          justify="flex-start"
-                                        >
-                                          <div
-                                            className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                            is={null}
-                                          >
-                                            Show
-                                          </div>
-                                        </Base>
-                                      </Flex>
+                                        Show
+                                      </span>
                                     </Component>
                                   </ButtonLabel>
                                 </button>

--- a/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
@@ -128,7 +128,6 @@ exports[`ProjectPluginDetails renders 1`] = `
                 className="pull-right"
               >
                 <Button
-                  alignLabel="left"
                   disabled={false}
                   onClick={[Function]}
                   size="small"
@@ -141,7 +140,6 @@ exports[`ProjectPluginDetails renders 1`] = `
                   Enable Plugin
                 </Button>
                 <Button
-                  alignLabel="left"
                   disabled={false}
                   onClick={[Function]}
                   size="small"
@@ -184,7 +182,6 @@ exports[`ProjectPluginDetails renders 1`] = `
                           className="pull-right"
                         >
                           <Button
-                            alignLabel="left"
                             disabled={false}
                             onClick={[Function]}
                             size="small"
@@ -233,32 +230,17 @@ exports[`ProjectPluginDetails renders 1`] = `
                                   }
                                 >
                                   <ButtonLabel
-                                    justify="flex-start"
                                     size="small"
                                   >
                                     <Component
-                                      className="css-o42ntg-ButtonLabel eqrebog1"
-                                      justify="flex-start"
+                                      className="css-7ui8bl-ButtonLabel eqrebog1"
                                       size="small"
                                     >
-                                      <Flex
-                                        align="center"
-                                        className="css-o42ntg-ButtonLabel eqrebog1"
-                                        justify="flex-start"
+                                      <span
+                                        className="css-7ui8bl-ButtonLabel eqrebog1"
                                       >
-                                        <Base
-                                          align="center"
-                                          className="eqrebog1 css-gzxb22-ButtonLabel"
-                                          justify="flex-start"
-                                        >
-                                          <div
-                                            className="eqrebog1 css-gzxb22-ButtonLabel"
-                                            is={null}
-                                          >
-                                            Enable Plugin
-                                          </div>
-                                        </Base>
-                                      </Flex>
+                                        Enable Plugin
+                                      </span>
                                     </Component>
                                   </ButtonLabel>
                                 </button>
@@ -266,7 +248,6 @@ exports[`ProjectPluginDetails renders 1`] = `
                             </StyledButton>
                           </Button>
                           <Button
-                            alignLabel="left"
                             disabled={false}
                             onClick={[Function]}
                             size="small"
@@ -295,32 +276,17 @@ exports[`ProjectPluginDetails renders 1`] = `
                                   size="small"
                                 >
                                   <ButtonLabel
-                                    justify="flex-start"
                                     size="small"
                                   >
                                     <Component
-                                      className="css-o42ntg-ButtonLabel eqrebog1"
-                                      justify="flex-start"
+                                      className="css-7ui8bl-ButtonLabel eqrebog1"
                                       size="small"
                                     >
-                                      <Flex
-                                        align="center"
-                                        className="css-o42ntg-ButtonLabel eqrebog1"
-                                        justify="flex-start"
+                                      <span
+                                        className="css-7ui8bl-ButtonLabel eqrebog1"
                                       >
-                                        <Base
-                                          align="center"
-                                          className="eqrebog1 css-gzxb22-ButtonLabel"
-                                          justify="flex-start"
-                                        >
-                                          <div
-                                            className="eqrebog1 css-gzxb22-ButtonLabel"
-                                            is={null}
-                                          >
-                                            Reset Configuration
-                                          </div>
-                                        </Base>
-                                      </Flex>
+                                        Reset Configuration
+                                      </span>
                                     </Component>
                                   </ButtonLabel>
                                 </button>

--- a/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
@@ -355,7 +355,6 @@ exports[`ProjectSavedSearches renders 1`] = `
                                           priority="primary"
                                         >
                                           <Button
-                                            alignLabel="left"
                                             disabled={false}
                                             icon="icon-trash"
                                             onClick={[Function]}
@@ -382,87 +381,61 @@ exports[`ProjectSavedSearches renders 1`] = `
                                                   size="small"
                                                 >
                                                   <ButtonLabel
-                                                    justify="flex-start"
                                                     size="small"
                                                   >
                                                     <Component
-                                                      className="css-o42ntg-ButtonLabel eqrebog1"
-                                                      justify="flex-start"
+                                                      className="css-7ui8bl-ButtonLabel eqrebog1"
                                                       size="small"
                                                     >
-                                                      <Flex
-                                                        align="center"
-                                                        className="css-o42ntg-ButtonLabel eqrebog1"
-                                                        justify="flex-start"
+                                                      <span
+                                                        className="css-7ui8bl-ButtonLabel eqrebog1"
                                                       >
-                                                        <Base
-                                                          align="center"
-                                                          className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                          justify="flex-start"
+                                                        <Icon
+                                                          hasChildren={false}
+                                                          size="small"
                                                         >
-                                                          <div
-                                                            className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                            is={null}
+                                                          <Component
+                                                            className="css-ljhpxy-Icon eqrebog2"
+                                                            hasChildren={false}
+                                                            size="small"
                                                           >
-                                                            <Icon
-                                                              hasChildren={false}
+                                                            <span
+                                                              className="css-ljhpxy-Icon eqrebog2"
                                                               size="small"
                                                             >
-                                                              <Component
-                                                                className="css-ljhpxy-Icon eqrebog2"
-                                                                hasChildren={false}
-                                                                size="small"
+                                                              <StyledInlineSvg
+                                                                size="12px"
+                                                                src="icon-trash"
                                                               >
-                                                                <Box
-                                                                  className="css-ljhpxy-Icon eqrebog2"
-                                                                  size="small"
+                                                                <InlineSvg
+                                                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                                  size="12px"
+                                                                  src="icon-trash"
                                                                 >
-                                                                  <Base
-                                                                    className="eqrebog2 css-7mohvl-Icon"
-                                                                    size="small"
+                                                                  <StyledSvg
+                                                                    className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                                    height="12px"
+                                                                    viewBox={Object {}}
+                                                                    width="12px"
                                                                   >
-                                                                    <div
-                                                                      className="eqrebog2 css-7mohvl-Icon"
-                                                                      is={null}
-                                                                      size="small"
+                                                                    <svg
+                                                                      className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                                      height="12px"
+                                                                      viewBox={Object {}}
+                                                                      width="12px"
                                                                     >
-                                                                      <StyledInlineSvg
-                                                                        size="12px"
-                                                                        src="icon-trash"
-                                                                      >
-                                                                        <InlineSvg
-                                                                          className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                          size="12px"
-                                                                          src="icon-trash"
-                                                                        >
-                                                                          <StyledSvg
-                                                                            className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                            height="12px"
-                                                                            viewBox={Object {}}
-                                                                            width="12px"
-                                                                          >
-                                                                            <svg
-                                                                              className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                              height="12px"
-                                                                              viewBox={Object {}}
-                                                                              width="12px"
-                                                                            >
-                                                                              <use
-                                                                                href="#test"
-                                                                                xlinkHref="#test"
-                                                                              />
-                                                                            </svg>
-                                                                          </StyledSvg>
-                                                                        </InlineSvg>
-                                                                      </StyledInlineSvg>
-                                                                    </div>
-                                                                  </Base>
-                                                                </Box>
-                                                              </Component>
-                                                            </Icon>
-                                                          </div>
-                                                        </Base>
-                                                      </Flex>
+                                                                      <use
+                                                                        href="#test"
+                                                                        xlinkHref="#test"
+                                                                      />
+                                                                    </svg>
+                                                                  </StyledSvg>
+                                                                </InlineSvg>
+                                                              </StyledInlineSvg>
+                                                            </span>
+                                                          </Component>
+                                                        </Icon>
+                                                      </span>
                                                     </Component>
                                                   </ButtonLabel>
                                                 </button>
@@ -693,7 +666,6 @@ exports[`ProjectSavedSearches renders 1`] = `
                                           priority="primary"
                                         >
                                           <Button
-                                            alignLabel="left"
                                             disabled={false}
                                             icon="icon-trash"
                                             onClick={[Function]}
@@ -720,87 +692,61 @@ exports[`ProjectSavedSearches renders 1`] = `
                                                   size="small"
                                                 >
                                                   <ButtonLabel
-                                                    justify="flex-start"
                                                     size="small"
                                                   >
                                                     <Component
-                                                      className="css-o42ntg-ButtonLabel eqrebog1"
-                                                      justify="flex-start"
+                                                      className="css-7ui8bl-ButtonLabel eqrebog1"
                                                       size="small"
                                                     >
-                                                      <Flex
-                                                        align="center"
-                                                        className="css-o42ntg-ButtonLabel eqrebog1"
-                                                        justify="flex-start"
+                                                      <span
+                                                        className="css-7ui8bl-ButtonLabel eqrebog1"
                                                       >
-                                                        <Base
-                                                          align="center"
-                                                          className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                          justify="flex-start"
+                                                        <Icon
+                                                          hasChildren={false}
+                                                          size="small"
                                                         >
-                                                          <div
-                                                            className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                            is={null}
+                                                          <Component
+                                                            className="css-ljhpxy-Icon eqrebog2"
+                                                            hasChildren={false}
+                                                            size="small"
                                                           >
-                                                            <Icon
-                                                              hasChildren={false}
+                                                            <span
+                                                              className="css-ljhpxy-Icon eqrebog2"
                                                               size="small"
                                                             >
-                                                              <Component
-                                                                className="css-ljhpxy-Icon eqrebog2"
-                                                                hasChildren={false}
-                                                                size="small"
+                                                              <StyledInlineSvg
+                                                                size="12px"
+                                                                src="icon-trash"
                                                               >
-                                                                <Box
-                                                                  className="css-ljhpxy-Icon eqrebog2"
-                                                                  size="small"
+                                                                <InlineSvg
+                                                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                                  size="12px"
+                                                                  src="icon-trash"
                                                                 >
-                                                                  <Base
-                                                                    className="eqrebog2 css-7mohvl-Icon"
-                                                                    size="small"
+                                                                  <StyledSvg
+                                                                    className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                                    height="12px"
+                                                                    viewBox={Object {}}
+                                                                    width="12px"
                                                                   >
-                                                                    <div
-                                                                      className="eqrebog2 css-7mohvl-Icon"
-                                                                      is={null}
-                                                                      size="small"
+                                                                    <svg
+                                                                      className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                                      height="12px"
+                                                                      viewBox={Object {}}
+                                                                      width="12px"
                                                                     >
-                                                                      <StyledInlineSvg
-                                                                        size="12px"
-                                                                        src="icon-trash"
-                                                                      >
-                                                                        <InlineSvg
-                                                                          className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                          size="12px"
-                                                                          src="icon-trash"
-                                                                        >
-                                                                          <StyledSvg
-                                                                            className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                            height="12px"
-                                                                            viewBox={Object {}}
-                                                                            width="12px"
-                                                                          >
-                                                                            <svg
-                                                                              className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                              height="12px"
-                                                                              viewBox={Object {}}
-                                                                              width="12px"
-                                                                            >
-                                                                              <use
-                                                                                href="#test"
-                                                                                xlinkHref="#test"
-                                                                              />
-                                                                            </svg>
-                                                                          </StyledSvg>
-                                                                        </InlineSvg>
-                                                                      </StyledInlineSvg>
-                                                                    </div>
-                                                                  </Base>
-                                                                </Box>
-                                                              </Component>
-                                                            </Icon>
-                                                          </div>
-                                                        </Base>
-                                                      </Flex>
+                                                                      <use
+                                                                        href="#test"
+                                                                        xlinkHref="#test"
+                                                                      />
+                                                                    </svg>
+                                                                  </StyledSvg>
+                                                                </InlineSvg>
+                                                              </StyledInlineSvg>
+                                                            </span>
+                                                          </Component>
+                                                        </Icon>
+                                                      </span>
                                                     </Component>
                                                   </ButtonLabel>
                                                 </button>

--- a/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
@@ -229,7 +229,6 @@ exports[`ProjectTags renders 1`] = `
                                     title="Remove tag?"
                                   >
                                     <Button
-                                      alignLabel="left"
                                       data-test-id="delete"
                                       disabled={false}
                                       icon="icon-trash"
@@ -259,87 +258,61 @@ exports[`ProjectTags renders 1`] = `
                                             size="xsmall"
                                           >
                                             <ButtonLabel
-                                              justify="flex-start"
                                               size="xsmall"
                                             >
                                               <Component
-                                                className="css-6q5v1w-ButtonLabel eqrebog1"
-                                                justify="flex-start"
+                                                className="css-uthd1f-ButtonLabel eqrebog1"
                                                 size="xsmall"
                                               >
-                                                <Flex
-                                                  align="center"
-                                                  className="css-6q5v1w-ButtonLabel eqrebog1"
-                                                  justify="flex-start"
+                                                <span
+                                                  className="css-uthd1f-ButtonLabel eqrebog1"
                                                 >
-                                                  <Base
-                                                    align="center"
-                                                    className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                                    justify="flex-start"
+                                                  <Icon
+                                                    hasChildren={false}
+                                                    size="xsmall"
                                                   >
-                                                    <div
-                                                      className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                                      is={null}
+                                                    <Component
+                                                      className="css-ljhpxy-Icon eqrebog2"
+                                                      hasChildren={false}
+                                                      size="xsmall"
                                                     >
-                                                      <Icon
-                                                        hasChildren={false}
+                                                      <span
+                                                        className="css-ljhpxy-Icon eqrebog2"
                                                         size="xsmall"
                                                       >
-                                                        <Component
-                                                          className="css-ljhpxy-Icon eqrebog2"
-                                                          hasChildren={false}
-                                                          size="xsmall"
+                                                        <StyledInlineSvg
+                                                          size="12px"
+                                                          src="icon-trash"
                                                         >
-                                                          <Box
-                                                            className="css-ljhpxy-Icon eqrebog2"
-                                                            size="xsmall"
+                                                          <InlineSvg
+                                                            className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                            size="12px"
+                                                            src="icon-trash"
                                                           >
-                                                            <Base
-                                                              className="eqrebog2 css-7mohvl-Icon"
-                                                              size="xsmall"
+                                                            <StyledSvg
+                                                              className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                              height="12px"
+                                                              viewBox={Object {}}
+                                                              width="12px"
                                                             >
-                                                              <div
-                                                                className="eqrebog2 css-7mohvl-Icon"
-                                                                is={null}
-                                                                size="xsmall"
+                                                              <svg
+                                                                className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                                height="12px"
+                                                                viewBox={Object {}}
+                                                                width="12px"
                                                               >
-                                                                <StyledInlineSvg
-                                                                  size="12px"
-                                                                  src="icon-trash"
-                                                                >
-                                                                  <InlineSvg
-                                                                    className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                    size="12px"
-                                                                    src="icon-trash"
-                                                                  >
-                                                                    <StyledSvg
-                                                                      className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                      height="12px"
-                                                                      viewBox={Object {}}
-                                                                      width="12px"
-                                                                    >
-                                                                      <svg
-                                                                        className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                        height="12px"
-                                                                        viewBox={Object {}}
-                                                                        width="12px"
-                                                                      >
-                                                                        <use
-                                                                          href="#test"
-                                                                          xlinkHref="#test"
-                                                                        />
-                                                                      </svg>
-                                                                    </StyledSvg>
-                                                                  </InlineSvg>
-                                                                </StyledInlineSvg>
-                                                              </div>
-                                                            </Base>
-                                                          </Box>
-                                                        </Component>
-                                                      </Icon>
-                                                    </div>
-                                                  </Base>
-                                                </Flex>
+                                                                <use
+                                                                  href="#test"
+                                                                  xlinkHref="#test"
+                                                                />
+                                                              </svg>
+                                                            </StyledSvg>
+                                                          </InlineSvg>
+                                                        </StyledInlineSvg>
+                                                      </span>
+                                                    </Component>
+                                                  </Icon>
+                                                </span>
                                               </Component>
                                             </ButtonLabel>
                                           </button>
@@ -477,7 +450,6 @@ exports[`ProjectTags renders 1`] = `
                                     title="Remove tag?"
                                   >
                                     <Button
-                                      alignLabel="left"
                                       data-test-id="delete"
                                       disabled={false}
                                       icon="icon-trash"
@@ -507,87 +479,61 @@ exports[`ProjectTags renders 1`] = `
                                             size="xsmall"
                                           >
                                             <ButtonLabel
-                                              justify="flex-start"
                                               size="xsmall"
                                             >
                                               <Component
-                                                className="css-6q5v1w-ButtonLabel eqrebog1"
-                                                justify="flex-start"
+                                                className="css-uthd1f-ButtonLabel eqrebog1"
                                                 size="xsmall"
                                               >
-                                                <Flex
-                                                  align="center"
-                                                  className="css-6q5v1w-ButtonLabel eqrebog1"
-                                                  justify="flex-start"
+                                                <span
+                                                  className="css-uthd1f-ButtonLabel eqrebog1"
                                                 >
-                                                  <Base
-                                                    align="center"
-                                                    className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                                    justify="flex-start"
+                                                  <Icon
+                                                    hasChildren={false}
+                                                    size="xsmall"
                                                   >
-                                                    <div
-                                                      className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                                      is={null}
+                                                    <Component
+                                                      className="css-ljhpxy-Icon eqrebog2"
+                                                      hasChildren={false}
+                                                      size="xsmall"
                                                     >
-                                                      <Icon
-                                                        hasChildren={false}
+                                                      <span
+                                                        className="css-ljhpxy-Icon eqrebog2"
                                                         size="xsmall"
                                                       >
-                                                        <Component
-                                                          className="css-ljhpxy-Icon eqrebog2"
-                                                          hasChildren={false}
-                                                          size="xsmall"
+                                                        <StyledInlineSvg
+                                                          size="12px"
+                                                          src="icon-trash"
                                                         >
-                                                          <Box
-                                                            className="css-ljhpxy-Icon eqrebog2"
-                                                            size="xsmall"
+                                                          <InlineSvg
+                                                            className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                            size="12px"
+                                                            src="icon-trash"
                                                           >
-                                                            <Base
-                                                              className="eqrebog2 css-7mohvl-Icon"
-                                                              size="xsmall"
+                                                            <StyledSvg
+                                                              className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                              height="12px"
+                                                              viewBox={Object {}}
+                                                              width="12px"
                                                             >
-                                                              <div
-                                                                className="eqrebog2 css-7mohvl-Icon"
-                                                                is={null}
-                                                                size="xsmall"
+                                                              <svg
+                                                                className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                                height="12px"
+                                                                viewBox={Object {}}
+                                                                width="12px"
                                                               >
-                                                                <StyledInlineSvg
-                                                                  size="12px"
-                                                                  src="icon-trash"
-                                                                >
-                                                                  <InlineSvg
-                                                                    className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                    size="12px"
-                                                                    src="icon-trash"
-                                                                  >
-                                                                    <StyledSvg
-                                                                      className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                      height="12px"
-                                                                      viewBox={Object {}}
-                                                                      width="12px"
-                                                                    >
-                                                                      <svg
-                                                                        className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                        height="12px"
-                                                                        viewBox={Object {}}
-                                                                        width="12px"
-                                                                      >
-                                                                        <use
-                                                                          href="#test"
-                                                                          xlinkHref="#test"
-                                                                        />
-                                                                      </svg>
-                                                                    </StyledSvg>
-                                                                  </InlineSvg>
-                                                                </StyledInlineSvg>
-                                                              </div>
-                                                            </Base>
-                                                          </Box>
-                                                        </Component>
-                                                      </Icon>
-                                                    </div>
-                                                  </Base>
-                                                </Flex>
+                                                                <use
+                                                                  href="#test"
+                                                                  xlinkHref="#test"
+                                                                />
+                                                              </svg>
+                                                            </StyledSvg>
+                                                          </InlineSvg>
+                                                        </StyledInlineSvg>
+                                                      </span>
+                                                    </Component>
+                                                  </Icon>
+                                                </span>
                                               </Component>
                                             </ButtonLabel>
                                           </button>
@@ -725,7 +671,6 @@ exports[`ProjectTags renders 1`] = `
                                     title="Remove tag?"
                                   >
                                     <Button
-                                      alignLabel="left"
                                       data-test-id="delete"
                                       disabled={false}
                                       icon="icon-trash"
@@ -755,87 +700,61 @@ exports[`ProjectTags renders 1`] = `
                                             size="xsmall"
                                           >
                                             <ButtonLabel
-                                              justify="flex-start"
                                               size="xsmall"
                                             >
                                               <Component
-                                                className="css-6q5v1w-ButtonLabel eqrebog1"
-                                                justify="flex-start"
+                                                className="css-uthd1f-ButtonLabel eqrebog1"
                                                 size="xsmall"
                                               >
-                                                <Flex
-                                                  align="center"
-                                                  className="css-6q5v1w-ButtonLabel eqrebog1"
-                                                  justify="flex-start"
+                                                <span
+                                                  className="css-uthd1f-ButtonLabel eqrebog1"
                                                 >
-                                                  <Base
-                                                    align="center"
-                                                    className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                                    justify="flex-start"
+                                                  <Icon
+                                                    hasChildren={false}
+                                                    size="xsmall"
                                                   >
-                                                    <div
-                                                      className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                                      is={null}
+                                                    <Component
+                                                      className="css-ljhpxy-Icon eqrebog2"
+                                                      hasChildren={false}
+                                                      size="xsmall"
                                                     >
-                                                      <Icon
-                                                        hasChildren={false}
+                                                      <span
+                                                        className="css-ljhpxy-Icon eqrebog2"
                                                         size="xsmall"
                                                       >
-                                                        <Component
-                                                          className="css-ljhpxy-Icon eqrebog2"
-                                                          hasChildren={false}
-                                                          size="xsmall"
+                                                        <StyledInlineSvg
+                                                          size="12px"
+                                                          src="icon-trash"
                                                         >
-                                                          <Box
-                                                            className="css-ljhpxy-Icon eqrebog2"
-                                                            size="xsmall"
+                                                          <InlineSvg
+                                                            className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                            size="12px"
+                                                            src="icon-trash"
                                                           >
-                                                            <Base
-                                                              className="eqrebog2 css-7mohvl-Icon"
-                                                              size="xsmall"
+                                                            <StyledSvg
+                                                              className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                              height="12px"
+                                                              viewBox={Object {}}
+                                                              width="12px"
                                                             >
-                                                              <div
-                                                                className="eqrebog2 css-7mohvl-Icon"
-                                                                is={null}
-                                                                size="xsmall"
+                                                              <svg
+                                                                className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                                height="12px"
+                                                                viewBox={Object {}}
+                                                                width="12px"
                                                               >
-                                                                <StyledInlineSvg
-                                                                  size="12px"
-                                                                  src="icon-trash"
-                                                                >
-                                                                  <InlineSvg
-                                                                    className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                    size="12px"
-                                                                    src="icon-trash"
-                                                                  >
-                                                                    <StyledSvg
-                                                                      className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                      height="12px"
-                                                                      viewBox={Object {}}
-                                                                      width="12px"
-                                                                    >
-                                                                      <svg
-                                                                        className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                        height="12px"
-                                                                        viewBox={Object {}}
-                                                                        width="12px"
-                                                                      >
-                                                                        <use
-                                                                          href="#test"
-                                                                          xlinkHref="#test"
-                                                                        />
-                                                                      </svg>
-                                                                    </StyledSvg>
-                                                                  </InlineSvg>
-                                                                </StyledInlineSvg>
-                                                              </div>
-                                                            </Base>
-                                                          </Box>
-                                                        </Component>
-                                                      </Icon>
-                                                    </div>
-                                                  </Base>
-                                                </Flex>
+                                                                <use
+                                                                  href="#test"
+                                                                  xlinkHref="#test"
+                                                                />
+                                                              </svg>
+                                                            </StyledSvg>
+                                                          </InlineSvg>
+                                                        </StyledInlineSvg>
+                                                      </span>
+                                                    </Component>
+                                                  </Icon>
+                                                </span>
                                               </Component>
                                             </ButtonLabel>
                                           </button>
@@ -981,7 +900,6 @@ exports[`ProjectTags renders 1`] = `
                                         title="Remove tag?"
                                       >
                                         <Button
-                                          alignLabel="left"
                                           data-test-id="delete"
                                           disabled={false}
                                           icon="icon-trash"
@@ -1011,87 +929,61 @@ exports[`ProjectTags renders 1`] = `
                                                 size="xsmall"
                                               >
                                                 <ButtonLabel
-                                                  justify="flex-start"
                                                   size="xsmall"
                                                 >
                                                   <Component
-                                                    className="css-6q5v1w-ButtonLabel eqrebog1"
-                                                    justify="flex-start"
+                                                    className="css-uthd1f-ButtonLabel eqrebog1"
                                                     size="xsmall"
                                                   >
-                                                    <Flex
-                                                      align="center"
-                                                      className="css-6q5v1w-ButtonLabel eqrebog1"
-                                                      justify="flex-start"
+                                                    <span
+                                                      className="css-uthd1f-ButtonLabel eqrebog1"
                                                     >
-                                                      <Base
-                                                        align="center"
-                                                        className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                                        justify="flex-start"
+                                                      <Icon
+                                                        hasChildren={false}
+                                                        size="xsmall"
                                                       >
-                                                        <div
-                                                          className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                                          is={null}
+                                                        <Component
+                                                          className="css-ljhpxy-Icon eqrebog2"
+                                                          hasChildren={false}
+                                                          size="xsmall"
                                                         >
-                                                          <Icon
-                                                            hasChildren={false}
+                                                          <span
+                                                            className="css-ljhpxy-Icon eqrebog2"
                                                             size="xsmall"
                                                           >
-                                                            <Component
-                                                              className="css-ljhpxy-Icon eqrebog2"
-                                                              hasChildren={false}
-                                                              size="xsmall"
+                                                            <StyledInlineSvg
+                                                              size="12px"
+                                                              src="icon-trash"
                                                             >
-                                                              <Box
-                                                                className="css-ljhpxy-Icon eqrebog2"
-                                                                size="xsmall"
+                                                              <InlineSvg
+                                                                className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                                size="12px"
+                                                                src="icon-trash"
                                                               >
-                                                                <Base
-                                                                  className="eqrebog2 css-7mohvl-Icon"
-                                                                  size="xsmall"
+                                                                <StyledSvg
+                                                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                                  height="12px"
+                                                                  viewBox={Object {}}
+                                                                  width="12px"
                                                                 >
-                                                                  <div
-                                                                    className="eqrebog2 css-7mohvl-Icon"
-                                                                    is={null}
-                                                                    size="xsmall"
+                                                                  <svg
+                                                                    className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                                    height="12px"
+                                                                    viewBox={Object {}}
+                                                                    width="12px"
                                                                   >
-                                                                    <StyledInlineSvg
-                                                                      size="12px"
-                                                                      src="icon-trash"
-                                                                    >
-                                                                      <InlineSvg
-                                                                        className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                        size="12px"
-                                                                        src="icon-trash"
-                                                                      >
-                                                                        <StyledSvg
-                                                                          className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                          height="12px"
-                                                                          viewBox={Object {}}
-                                                                          width="12px"
-                                                                        >
-                                                                          <svg
-                                                                            className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                            height="12px"
-                                                                            viewBox={Object {}}
-                                                                            width="12px"
-                                                                          >
-                                                                            <use
-                                                                              href="#test"
-                                                                              xlinkHref="#test"
-                                                                            />
-                                                                          </svg>
-                                                                        </StyledSvg>
-                                                                      </InlineSvg>
-                                                                    </StyledInlineSvg>
-                                                                  </div>
-                                                                </Base>
-                                                              </Box>
-                                                            </Component>
-                                                          </Icon>
-                                                        </div>
-                                                      </Base>
-                                                    </Flex>
+                                                                    <use
+                                                                      href="#test"
+                                                                      xlinkHref="#test"
+                                                                    />
+                                                                  </svg>
+                                                                </StyledSvg>
+                                                              </InlineSvg>
+                                                            </StyledInlineSvg>
+                                                          </span>
+                                                        </Component>
+                                                      </Icon>
+                                                    </span>
                                                   </Component>
                                                 </ButtonLabel>
                                               </button>

--- a/tests/js/spec/views/__snapshots__/providerItem.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/providerItem.spec.jsx.snap
@@ -21,7 +21,6 @@ exports[`ProviderItem renders 1`] = `
   </Box>
   <Box>
     <Button
-      alignLabel="left"
       disabled={false}
       name="provider"
       onClick={[Function]}

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -924,7 +924,6 @@ exports[`RuleBuilder renders 1`] = `
         size="small"
       >
         <Button
-          alignLabel="left"
           className="css-po7kq7-AddButton e1hyuoc79"
           disabled={true}
           icon="icon-circle-add"
@@ -963,89 +962,63 @@ exports[`RuleBuilder renders 1`] = `
                 to={null}
               >
                 <ButtonLabel
-                  justify="flex-start"
                   priority="primary"
                   size="small"
                 >
                   <Component
-                    className="css-o42ntg-ButtonLabel eqrebog1"
-                    justify="flex-start"
+                    className="css-7ui8bl-ButtonLabel eqrebog1"
                     priority="primary"
                     size="small"
                   >
-                    <Flex
-                      align="center"
-                      className="css-o42ntg-ButtonLabel eqrebog1"
-                      justify="flex-start"
+                    <span
+                      className="css-7ui8bl-ButtonLabel eqrebog1"
                     >
-                      <Base
-                        align="center"
-                        className="eqrebog1 css-gzxb22-ButtonLabel"
-                        justify="flex-start"
+                      <Icon
+                        hasChildren={false}
+                        size="small"
                       >
-                        <div
-                          className="eqrebog1 css-gzxb22-ButtonLabel"
-                          is={null}
+                        <Component
+                          className="css-ljhpxy-Icon eqrebog2"
+                          hasChildren={false}
+                          size="small"
                         >
-                          <Icon
-                            hasChildren={false}
+                          <span
+                            className="css-ljhpxy-Icon eqrebog2"
                             size="small"
                           >
-                            <Component
-                              className="css-ljhpxy-Icon eqrebog2"
-                              hasChildren={false}
-                              size="small"
+                            <StyledInlineSvg
+                              size="12px"
+                              src="icon-circle-add"
                             >
-                              <Box
-                                className="css-ljhpxy-Icon eqrebog2"
-                                size="small"
+                              <InlineSvg
+                                className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                size="12px"
+                                src="icon-circle-add"
                               >
-                                <Base
-                                  className="eqrebog2 css-7mohvl-Icon"
-                                  size="small"
+                                <StyledSvg
+                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                  height="12px"
+                                  viewBox={Object {}}
+                                  width="12px"
                                 >
-                                  <div
-                                    className="eqrebog2 css-7mohvl-Icon"
-                                    is={null}
-                                    size="small"
+                                  <svg
+                                    className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                    height="12px"
+                                    viewBox={Object {}}
+                                    width="12px"
                                   >
-                                    <StyledInlineSvg
-                                      size="12px"
-                                      src="icon-circle-add"
-                                    >
-                                      <InlineSvg
-                                        className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                        size="12px"
-                                        src="icon-circle-add"
-                                      >
-                                        <StyledSvg
-                                          className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                          height="12px"
-                                          viewBox={Object {}}
-                                          width="12px"
-                                        >
-                                          <svg
-                                            className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                            height="12px"
-                                            viewBox={Object {}}
-                                            width="12px"
-                                          >
-                                            <use
-                                              href="#test"
-                                              xlinkHref="#test"
-                                            />
-                                          </svg>
-                                        </StyledSvg>
-                                      </InlineSvg>
-                                    </StyledInlineSvg>
-                                  </div>
-                                </Base>
-                              </Box>
-                            </Component>
-                          </Icon>
-                        </div>
-                      </Base>
-                    </Flex>
+                                    <use
+                                      href="#test"
+                                      xlinkHref="#test"
+                                    />
+                                  </svg>
+                                </StyledSvg>
+                              </InlineSvg>
+                            </StyledInlineSvg>
+                          </span>
+                        </Component>
+                      </Icon>
+                    </span>
                   </Component>
                 </ButtonLabel>
               </button>
@@ -2671,7 +2644,6 @@ exports[`RuleBuilder renders with suggestions 1`] = `
         size="small"
       >
         <Button
-          alignLabel="left"
           className="css-po7kq7-AddButton e1hyuoc79"
           disabled={false}
           icon="icon-circle-add"
@@ -2704,89 +2676,63 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                 size="small"
               >
                 <ButtonLabel
-                  justify="flex-start"
                   priority="primary"
                   size="small"
                 >
                   <Component
-                    className="css-o42ntg-ButtonLabel eqrebog1"
-                    justify="flex-start"
+                    className="css-7ui8bl-ButtonLabel eqrebog1"
                     priority="primary"
                     size="small"
                   >
-                    <Flex
-                      align="center"
-                      className="css-o42ntg-ButtonLabel eqrebog1"
-                      justify="flex-start"
+                    <span
+                      className="css-7ui8bl-ButtonLabel eqrebog1"
                     >
-                      <Base
-                        align="center"
-                        className="eqrebog1 css-gzxb22-ButtonLabel"
-                        justify="flex-start"
+                      <Icon
+                        hasChildren={false}
+                        size="small"
                       >
-                        <div
-                          className="eqrebog1 css-gzxb22-ButtonLabel"
-                          is={null}
+                        <Component
+                          className="css-ljhpxy-Icon eqrebog2"
+                          hasChildren={false}
+                          size="small"
                         >
-                          <Icon
-                            hasChildren={false}
+                          <span
+                            className="css-ljhpxy-Icon eqrebog2"
                             size="small"
                           >
-                            <Component
-                              className="css-ljhpxy-Icon eqrebog2"
-                              hasChildren={false}
-                              size="small"
+                            <StyledInlineSvg
+                              size="12px"
+                              src="icon-circle-add"
                             >
-                              <Box
-                                className="css-ljhpxy-Icon eqrebog2"
-                                size="small"
+                              <InlineSvg
+                                className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                size="12px"
+                                src="icon-circle-add"
                               >
-                                <Base
-                                  className="eqrebog2 css-7mohvl-Icon"
-                                  size="small"
+                                <StyledSvg
+                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                  height="12px"
+                                  viewBox={Object {}}
+                                  width="12px"
                                 >
-                                  <div
-                                    className="eqrebog2 css-7mohvl-Icon"
-                                    is={null}
-                                    size="small"
+                                  <svg
+                                    className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                    height="12px"
+                                    viewBox={Object {}}
+                                    width="12px"
                                   >
-                                    <StyledInlineSvg
-                                      size="12px"
-                                      src="icon-circle-add"
-                                    >
-                                      <InlineSvg
-                                        className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                        size="12px"
-                                        src="icon-circle-add"
-                                      >
-                                        <StyledSvg
-                                          className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                          height="12px"
-                                          viewBox={Object {}}
-                                          width="12px"
-                                        >
-                                          <svg
-                                            className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                            height="12px"
-                                            viewBox={Object {}}
-                                            width="12px"
-                                          >
-                                            <use
-                                              href="#test"
-                                              xlinkHref="#test"
-                                            />
-                                          </svg>
-                                        </StyledSvg>
-                                      </InlineSvg>
-                                    </StyledInlineSvg>
-                                  </div>
-                                </Base>
-                              </Box>
-                            </Component>
-                          </Icon>
-                        </div>
-                      </Base>
-                    </Flex>
+                                    <use
+                                      href="#test"
+                                      xlinkHref="#test"
+                                    />
+                                  </svg>
+                                </StyledSvg>
+                              </InlineSvg>
+                            </StyledInlineSvg>
+                          </span>
+                        </Component>
+                      </Icon>
+                    </span>
                   </Component>
                 </ButtonLabel>
               </button>

--- a/tests/js/spec/views/__snapshots__/teamMembers.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/teamMembers.spec.jsx.snap
@@ -74,7 +74,6 @@ exports[`TeamMembers renders 1`] = `
       useLink={true}
     />
     <Button
-      alignLabel="left"
       disabled={false}
       onClick={[Function]}
       size="small"
@@ -120,7 +119,6 @@ exports[`TeamMembers renders 1`] = `
       useLink={true}
     />
     <Button
-      alignLabel="left"
       disabled={false}
       onClick={[Function]}
       size="small"
@@ -166,7 +164,6 @@ exports[`TeamMembers renders 1`] = `
       useLink={true}
     />
     <Button
-      alignLabel="left"
       disabled={false}
       onClick={[Function]}
       size="small"
@@ -212,7 +209,6 @@ exports[`TeamMembers renders 1`] = `
       useLink={true}
     />
     <Button
-      alignLabel="left"
       disabled={false}
       onClick={[Function]}
       size="small"

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -721,7 +721,6 @@ exports[`CreateProject should render roles when available and allowed, and handl
         </Panel>
       </TeamSelect>
       <Button
-        alignLabel="left"
         busy={false}
         className="invite-member-submit"
         disabled={false}
@@ -755,32 +754,17 @@ exports[`CreateProject should render roles when available and allowed, and handl
               role="button"
             >
               <ButtonLabel
-                justify="flex-start"
                 priority="primary"
               >
                 <Component
-                  className="css-1emshjx-ButtonLabel eqrebog1"
-                  justify="flex-start"
+                  className="css-ga4b18-ButtonLabel eqrebog1"
                   priority="primary"
                 >
-                  <Flex
-                    align="center"
-                    className="css-1emshjx-ButtonLabel eqrebog1"
-                    justify="flex-start"
+                  <span
+                    className="css-ga4b18-ButtonLabel eqrebog1"
                   >
-                    <Base
-                      align="center"
-                      className="eqrebog1 css-11rqwwm-ButtonLabel"
-                      justify="flex-start"
-                    >
-                      <div
-                        className="eqrebog1 css-11rqwwm-ButtonLabel"
-                        is={null}
-                      >
-                        Add Member
-                      </div>
-                    </Base>
-                  </Flex>
+                    Add Member
+                  </span>
                 </Component>
               </ButtonLabel>
             </button>

--- a/tests/js/spec/views/onboarding/__snapshots__/createProject.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/__snapshots__/createProject.spec.jsx.snap
@@ -12,7 +12,6 @@ exports[`CreateProject should block if you have access to no teams 1`] = `
         </PanelAlert>
         <CreateTeamBody>
           <Button
-            alignLabel="left"
             className="ref-create-team"
             disabled={false}
             onClick={[Function]}

--- a/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
@@ -269,7 +269,6 @@ exports[`Configure should render correctly render() should render platform docs 
                                                     is={null}
                                                   >
                                                     <Button
-                                                      alignLabel="left"
                                                       disabled={false}
                                                       href="/testOrg/project-slug/getting-started/"
                                                       size="small"
@@ -301,32 +300,17 @@ exports[`Configure should render correctly render() should render platform docs 
                                                             size="small"
                                                           >
                                                             <ButtonLabel
-                                                              justify="flex-start"
                                                               size="small"
                                                             >
                                                               <Component
-                                                                className="css-o42ntg-ButtonLabel eqrebog1"
-                                                                justify="flex-start"
+                                                                className="css-7ui8bl-ButtonLabel eqrebog1"
                                                                 size="small"
                                                               >
-                                                                <Flex
-                                                                  align="center"
-                                                                  className="css-o42ntg-ButtonLabel eqrebog1"
-                                                                  justify="flex-start"
+                                                                <span
+                                                                  className="css-7ui8bl-ButtonLabel eqrebog1"
                                                                 >
-                                                                  <Base
-                                                                    align="center"
-                                                                    className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                                    justify="flex-start"
-                                                                  >
-                                                                    <div
-                                                                      className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                                      is={null}
-                                                                    >
-                                                                      &lt; Back
-                                                                    </div>
-                                                                  </Base>
-                                                                </Flex>
+                                                                  &lt; Back
+                                                                </span>
                                                               </Component>
                                                             </ButtonLabel>
                                                           </a>
@@ -348,7 +332,6 @@ exports[`Configure should render correctly render() should render platform docs 
                                                     is={null}
                                                   >
                                                     <Button
-                                                      alignLabel="left"
                                                       disabled={false}
                                                       external={true}
                                                       href="https://docs.getsentry.com/hosted/clients/csharp/"
@@ -396,32 +379,17 @@ exports[`Configure should render correctly render() should render platform docs 
                                                               target="_blank"
                                                             >
                                                               <ButtonLabel
-                                                                justify="flex-start"
                                                                 size="small"
                                                               >
                                                                 <Component
-                                                                  className="css-o42ntg-ButtonLabel eqrebog1"
-                                                                  justify="flex-start"
+                                                                  className="css-7ui8bl-ButtonLabel eqrebog1"
                                                                   size="small"
                                                                 >
-                                                                  <Flex
-                                                                    align="center"
-                                                                    className="css-o42ntg-ButtonLabel eqrebog1"
-                                                                    justify="flex-start"
+                                                                  <span
+                                                                    className="css-7ui8bl-ButtonLabel eqrebog1"
                                                                   >
-                                                                    <Base
-                                                                      align="center"
-                                                                      className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                                      justify="flex-start"
-                                                                    >
-                                                                      <div
-                                                                        className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                                        is={null}
-                                                                      >
-                                                                        Full Documentation
-                                                                      </div>
-                                                                    </Base>
-                                                                  </Flex>
+                                                                    Full Documentation
+                                                                  </span>
                                                                 </Component>
                                                               </ButtonLabel>
                                                             </a>
@@ -610,7 +578,6 @@ exports[`Configure should render correctly render() should render platform docs 
                   className="pull-right"
                 >
                   <Button
-                    alignLabel="left"
                     data-test-id="configure-done"
                     disabled={false}
                     onClick={[Function]}
@@ -643,32 +610,17 @@ exports[`Configure should render correctly render() should render platform docs 
                           role="button"
                         >
                           <ButtonLabel
-                            justify="flex-start"
                             priority="primary"
                           >
                             <Component
-                              className="css-1emshjx-ButtonLabel eqrebog1"
-                              justify="flex-start"
+                              className="css-ga4b18-ButtonLabel eqrebog1"
                               priority="primary"
                             >
-                              <Flex
-                                align="center"
-                                className="css-1emshjx-ButtonLabel eqrebog1"
-                                justify="flex-start"
+                              <span
+                                className="css-ga4b18-ButtonLabel eqrebog1"
                               >
-                                <Base
-                                  align="center"
-                                  className="eqrebog1 css-11rqwwm-ButtonLabel"
-                                  justify="flex-start"
-                                >
-                                  <div
-                                    className="eqrebog1 css-11rqwwm-ButtonLabel"
-                                    is={null}
-                                  >
-                                    All done!
-                                  </div>
-                                </Base>
-                              </Flex>
+                                All done!
+                              </span>
                             </Component>
                           </ButtonLabel>
                         </button>

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -679,7 +679,6 @@ exports[`ProjectCard renders 1`] = `
                             is={null}
                           >
                             <Button
-                              alignLabel="left"
                               disabled={false}
                               external={true}
                               href="https://docs.sentry.io/learn/releases/"
@@ -727,32 +726,17 @@ exports[`ProjectCard renders 1`] = `
                                       target="_blank"
                                     >
                                       <ButtonLabel
-                                        justify="flex-start"
                                         size="xsmall"
                                       >
                                         <Component
-                                          className="css-6q5v1w-ButtonLabel eqrebog1"
-                                          justify="flex-start"
+                                          className="css-uthd1f-ButtonLabel eqrebog1"
                                           size="xsmall"
                                         >
-                                          <Flex
-                                            align="center"
-                                            className="css-6q5v1w-ButtonLabel eqrebog1"
-                                            justify="flex-start"
+                                          <span
+                                            className="css-uthd1f-ButtonLabel eqrebog1"
                                           >
-                                            <Base
-                                              align="center"
-                                              className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                              justify="flex-start"
-                                            >
-                                              <div
-                                                className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                                is={null}
-                                              >
-                                                Track deploys
-                                              </div>
-                                            </Base>
-                                          </Flex>
+                                            Track deploys
+                                          </span>
                                         </Component>
                                       </ButtonLabel>
                                     </a>

--- a/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectSecurityHeaders.spec.jsx.snap
+++ b/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectSecurityHeaders.spec.jsx.snap
@@ -135,7 +135,6 @@ exports[`ProjectSecurityHeaders renders 1`] = `
               </HeaderName>
             </Box>
             <Button
-              alignLabel="left"
               disabled={false}
               priority="primary"
               to="csp/"
@@ -162,7 +161,6 @@ exports[`ProjectSecurityHeaders renders 1`] = `
               </HeaderName>
             </Box>
             <Button
-              alignLabel="left"
               disabled={false}
               priority="primary"
               to="expect-ct/"
@@ -189,7 +187,6 @@ exports[`ProjectSecurityHeaders renders 1`] = `
               </HeaderName>
             </Box>
             <Button
-              alignLabel="left"
               disabled={false}
               priority="primary"
               to="hpkp/"

--- a/tests/js/spec/views/settings/__snapshots__/organizationAccessRequests.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationAccessRequests.spec.jsx.snap
@@ -60,7 +60,6 @@ exports[`OrganizationAccessRequests renders list 1`] = `
         p={2}
       >
         <Button
-          alignLabel="left"
           disabled={false}
           onClick={[Function]}
           priority="primary"
@@ -74,7 +73,6 @@ exports[`OrganizationAccessRequests renders list 1`] = `
           Approve
         </Button>
         <Button
-          alignLabel="left"
           disabled={false}
           onClick={[Function]}
           size="small"

--- a/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -46,7 +46,6 @@ exports[`OrganizationApiKeysList renders 1`] = `
     <SettingsPageHeading
       action={
         <Button
-          alignLabel="left"
           disabled={false}
           icon="icon-circle-add"
           priority="primary"
@@ -86,7 +85,6 @@ exports[`OrganizationApiKeysList renders 1`] = `
                 </Title>
                 <div>
                   <Button
-                    alignLabel="left"
                     disabled={false}
                     icon="icon-circle-add"
                     priority="primary"
@@ -119,90 +117,64 @@ exports[`OrganizationApiKeysList renders 1`] = `
                           size="small"
                         >
                           <ButtonLabel
-                            justify="flex-start"
                             priority="primary"
                             size="small"
                           >
                             <Component
-                              className="css-o42ntg-ButtonLabel eqrebog1"
-                              justify="flex-start"
+                              className="css-7ui8bl-ButtonLabel eqrebog1"
                               priority="primary"
                               size="small"
                             >
-                              <Flex
-                                align="center"
-                                className="css-o42ntg-ButtonLabel eqrebog1"
-                                justify="flex-start"
+                              <span
+                                className="css-7ui8bl-ButtonLabel eqrebog1"
                               >
-                                <Base
-                                  align="center"
-                                  className="eqrebog1 css-gzxb22-ButtonLabel"
-                                  justify="flex-start"
+                                <Icon
+                                  hasChildren={true}
+                                  size="small"
                                 >
-                                  <div
-                                    className="eqrebog1 css-gzxb22-ButtonLabel"
-                                    is={null}
+                                  <Component
+                                    className="css-1vdnsie-Icon eqrebog2"
+                                    hasChildren={true}
+                                    size="small"
                                   >
-                                    <Icon
-                                      hasChildren={true}
+                                    <span
+                                      className="css-1vdnsie-Icon eqrebog2"
                                       size="small"
                                     >
-                                      <Component
-                                        className="css-1vdnsie-Icon eqrebog2"
-                                        hasChildren={true}
-                                        size="small"
+                                      <StyledInlineSvg
+                                        size="12px"
+                                        src="icon-circle-add"
                                       >
-                                        <Box
-                                          className="css-1vdnsie-Icon eqrebog2"
-                                          size="small"
+                                        <InlineSvg
+                                          className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                          size="12px"
+                                          src="icon-circle-add"
                                         >
-                                          <Base
-                                            className="eqrebog2 css-nk081r-Icon"
-                                            size="small"
+                                          <StyledSvg
+                                            className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                            height="12px"
+                                            viewBox={Object {}}
+                                            width="12px"
                                           >
-                                            <div
-                                              className="eqrebog2 css-nk081r-Icon"
-                                              is={null}
-                                              size="small"
+                                            <svg
+                                              className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                              height="12px"
+                                              viewBox={Object {}}
+                                              width="12px"
                                             >
-                                              <StyledInlineSvg
-                                                size="12px"
-                                                src="icon-circle-add"
-                                              >
-                                                <InlineSvg
-                                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                  size="12px"
-                                                  src="icon-circle-add"
-                                                >
-                                                  <StyledSvg
-                                                    className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                    height="12px"
-                                                    viewBox={Object {}}
-                                                    width="12px"
-                                                  >
-                                                    <svg
-                                                      className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                      height="12px"
-                                                      viewBox={Object {}}
-                                                      width="12px"
-                                                    >
-                                                      <use
-                                                        href="#test"
-                                                        xlinkHref="#test"
-                                                      />
-                                                    </svg>
-                                                  </StyledSvg>
-                                                </InlineSvg>
-                                              </StyledInlineSvg>
-                                            </div>
-                                          </Base>
-                                        </Box>
-                                      </Component>
-                                    </Icon>
-                                    New API Key
-                                  </div>
-                                </Base>
-                              </Flex>
+                                              <use
+                                                href="#test"
+                                                xlinkHref="#test"
+                                              />
+                                            </svg>
+                                          </StyledSvg>
+                                        </InlineSvg>
+                                      </StyledInlineSvg>
+                                    </span>
+                                  </Component>
+                                </Icon>
+                                New API Key
+                              </span>
                             </Component>
                           </ButtonLabel>
                         </button>

--- a/tests/js/spec/views/settings/__snapshots__/organizationAuthProvider.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationAuthProvider.spec.jsx.snap
@@ -170,7 +170,6 @@ exports[`OrganizationAuthProvider renders 1`] = `
         className="form-actions"
       >
         <Button
-          alignLabel="left"
           disabled={false}
           onClick={[Function]}
           priority="danger"
@@ -253,7 +252,6 @@ exports[`OrganizationAuthProvider renders with Unlinked members  1`] = `
           Unlinked Members
         </h4>
         <Button
-          alignLabel="left"
           className="pull-right"
           disabled={false}
           onClick={[Function]}
@@ -424,7 +422,6 @@ exports[`OrganizationAuthProvider renders with Unlinked members  1`] = `
         className="form-actions"
       >
         <Button
-          alignLabel="left"
           disabled={false}
           onClick={[Function]}
           priority="danger"
@@ -579,7 +576,6 @@ Array [
       className="form-actions"
     >
       <Button
-        alignLabel="left"
         disabled={false}
         onClick={[Function]}
         priority="danger"

--- a/tests/js/spec/views/settings/__snapshots__/organizationAuthView.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationAuthView.spec.jsx.snap
@@ -149,7 +149,6 @@ exports[`OrganizationAuthView renders from api 1`] = `
         className="form-actions"
       >
         <Button
-          alignLabel="left"
           disabled={false}
           onClick={[Function]}
           priority="danger"

--- a/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
@@ -18,7 +18,6 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
         <SettingsPageHeading
           action={
             <Button
-              alignLabel="left"
               disabled={false}
               icon="icon-circle-add"
               priority="primary"
@@ -59,7 +58,6 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                     </Title>
                     <div>
                       <Button
-                        alignLabel="left"
                         disabled={false}
                         icon="icon-circle-add"
                         priority="primary"
@@ -108,90 +106,64 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                                 style={Object {}}
                               >
                                 <ButtonLabel
-                                  justify="flex-start"
                                   priority="primary"
                                   size="small"
                                 >
                                   <Component
-                                    className="css-o42ntg-ButtonLabel eqrebog1"
-                                    justify="flex-start"
+                                    className="css-7ui8bl-ButtonLabel eqrebog1"
                                     priority="primary"
                                     size="small"
                                   >
-                                    <Flex
-                                      align="center"
-                                      className="css-o42ntg-ButtonLabel eqrebog1"
-                                      justify="flex-start"
+                                    <span
+                                      className="css-7ui8bl-ButtonLabel eqrebog1"
                                     >
-                                      <Base
-                                        align="center"
-                                        className="eqrebog1 css-gzxb22-ButtonLabel"
-                                        justify="flex-start"
+                                      <Icon
+                                        hasChildren={true}
+                                        size="small"
                                       >
-                                        <div
-                                          className="eqrebog1 css-gzxb22-ButtonLabel"
-                                          is={null}
+                                        <Component
+                                          className="css-1vdnsie-Icon eqrebog2"
+                                          hasChildren={true}
+                                          size="small"
                                         >
-                                          <Icon
-                                            hasChildren={true}
+                                          <span
+                                            className="css-1vdnsie-Icon eqrebog2"
                                             size="small"
                                           >
-                                            <Component
-                                              className="css-1vdnsie-Icon eqrebog2"
-                                              hasChildren={true}
-                                              size="small"
+                                            <StyledInlineSvg
+                                              size="12px"
+                                              src="icon-circle-add"
                                             >
-                                              <Box
-                                                className="css-1vdnsie-Icon eqrebog2"
-                                                size="small"
+                                              <InlineSvg
+                                                className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                size="12px"
+                                                src="icon-circle-add"
                                               >
-                                                <Base
-                                                  className="eqrebog2 css-nk081r-Icon"
-                                                  size="small"
+                                                <StyledSvg
+                                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                  height="12px"
+                                                  viewBox={Object {}}
+                                                  width="12px"
                                                 >
-                                                  <div
-                                                    className="eqrebog2 css-nk081r-Icon"
-                                                    is={null}
-                                                    size="small"
+                                                  <svg
+                                                    className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                    height="12px"
+                                                    viewBox={Object {}}
+                                                    width="12px"
                                                   >
-                                                    <StyledInlineSvg
-                                                      size="12px"
-                                                      src="icon-circle-add"
-                                                    >
-                                                      <InlineSvg
-                                                        className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                        size="12px"
-                                                        src="icon-circle-add"
-                                                      >
-                                                        <StyledSvg
-                                                          className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                          height="12px"
-                                                          viewBox={Object {}}
-                                                          width="12px"
-                                                        >
-                                                          <svg
-                                                            className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                            height="12px"
-                                                            viewBox={Object {}}
-                                                            width="12px"
-                                                          >
-                                                            <use
-                                                              href="#test"
-                                                              xlinkHref="#test"
-                                                            />
-                                                          </svg>
-                                                        </StyledSvg>
-                                                      </InlineSvg>
-                                                    </StyledInlineSvg>
-                                                  </div>
-                                                </Base>
-                                              </Box>
-                                            </Component>
-                                          </Icon>
-                                          Create Project
-                                        </div>
-                                      </Base>
-                                    </Flex>
+                                                    <use
+                                                      href="#test"
+                                                      xlinkHref="#test"
+                                                    />
+                                                  </svg>
+                                                </StyledSvg>
+                                              </InlineSvg>
+                                            </StyledInlineSvg>
+                                          </span>
+                                        </Component>
+                                      </Icon>
+                                      Create Project
+                                    </span>
                                   </Component>
                                 </ButtonLabel>
                               </a>
@@ -467,7 +439,6 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                               is={null}
                             >
                               <Button
-                                alignLabel="left"
                                 disabled={false}
                                 size="small"
                                 to="/org-slug/project-slug/"
@@ -510,32 +481,17 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                                         style={Object {}}
                                       >
                                         <ButtonLabel
-                                          justify="flex-start"
                                           size="small"
                                         >
                                           <Component
-                                            className="css-o42ntg-ButtonLabel eqrebog1"
-                                            justify="flex-start"
+                                            className="css-7ui8bl-ButtonLabel eqrebog1"
                                             size="small"
                                           >
-                                            <Flex
-                                              align="center"
-                                              className="css-o42ntg-ButtonLabel eqrebog1"
-                                              justify="flex-start"
+                                            <span
+                                              className="css-7ui8bl-ButtonLabel eqrebog1"
                                             >
-                                              <Base
-                                                align="center"
-                                                className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                justify="flex-start"
-                                              >
-                                                <div
-                                                  className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                  is={null}
-                                                >
-                                                  View Issues
-                                                </div>
-                                              </Base>
-                                            </Flex>
+                                              View Issues
+                                            </span>
                                           </Component>
                                         </ButtonLabel>
                                       </a>

--- a/tests/js/spec/views/settings/__snapshots__/organizationRepositories.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationRepositories.spec.jsx.snap
@@ -94,7 +94,6 @@ exports[`OrganizationRepositories renders with a repository 1`] = `
               priority="primary"
             >
               <Button
-                alignLabel="left"
                 disabled={false}
                 icon="icon-trash"
                 size="xsmall"
@@ -190,7 +189,6 @@ exports[`OrganizationRepositories renders with github provider 1`] = `
       mb={1}
     >
       <Button
-        alignLabel="left"
         disabled={false}
         href="https://docs.sentry.io/learn/releases/"
       >
@@ -283,7 +281,6 @@ exports[`OrganizationRepositories renders without providers 1`] = `
       mb={1}
     >
       <Button
-        alignLabel="left"
         disabled={false}
         href="https://docs.sentry.io/learn/releases/"
       >

--- a/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
@@ -862,7 +862,6 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                 is={null}
                               >
                                 <Button
-                                  alignLabel="left"
                                   disabled={false}
                                   icon="icon-circle-add"
                                   onClick={[Function]}
@@ -892,88 +891,62 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                         size="small"
                                       >
                                         <ButtonLabel
-                                          justify="flex-start"
                                           size="small"
                                         >
                                           <Component
-                                            className="css-o42ntg-ButtonLabel eqrebog1"
-                                            justify="flex-start"
+                                            className="css-7ui8bl-ButtonLabel eqrebog1"
                                             size="small"
                                           >
-                                            <Flex
-                                              align="center"
-                                              className="css-o42ntg-ButtonLabel eqrebog1"
-                                              justify="flex-start"
+                                            <span
+                                              className="css-7ui8bl-ButtonLabel eqrebog1"
                                             >
-                                              <Base
-                                                align="center"
-                                                className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                justify="flex-start"
+                                              <Icon
+                                                hasChildren={true}
+                                                size="small"
                                               >
-                                                <div
-                                                  className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                  is={null}
+                                                <Component
+                                                  className="css-1vdnsie-Icon eqrebog2"
+                                                  hasChildren={true}
+                                                  size="small"
                                                 >
-                                                  <Icon
-                                                    hasChildren={true}
+                                                  <span
+                                                    className="css-1vdnsie-Icon eqrebog2"
                                                     size="small"
                                                   >
-                                                    <Component
-                                                      className="css-1vdnsie-Icon eqrebog2"
-                                                      hasChildren={true}
-                                                      size="small"
+                                                    <StyledInlineSvg
+                                                      size="12px"
+                                                      src="icon-circle-add"
                                                     >
-                                                      <Box
-                                                        className="css-1vdnsie-Icon eqrebog2"
-                                                        size="small"
+                                                      <InlineSvg
+                                                        className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                        size="12px"
+                                                        src="icon-circle-add"
                                                       >
-                                                        <Base
-                                                          className="eqrebog2 css-nk081r-Icon"
-                                                          size="small"
+                                                        <StyledSvg
+                                                          className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                          height="12px"
+                                                          viewBox={Object {}}
+                                                          width="12px"
                                                         >
-                                                          <div
-                                                            className="eqrebog2 css-nk081r-Icon"
-                                                            is={null}
-                                                            size="small"
+                                                          <svg
+                                                            className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                            height="12px"
+                                                            viewBox={Object {}}
+                                                            width="12px"
                                                           >
-                                                            <StyledInlineSvg
-                                                              size="12px"
-                                                              src="icon-circle-add"
-                                                            >
-                                                              <InlineSvg
-                                                                className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                size="12px"
-                                                                src="icon-circle-add"
-                                                              >
-                                                                <StyledSvg
-                                                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                  height="12px"
-                                                                  viewBox={Object {}}
-                                                                  width="12px"
-                                                                >
-                                                                  <svg
-                                                                    className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                    height="12px"
-                                                                    viewBox={Object {}}
-                                                                    width="12px"
-                                                                  >
-                                                                    <use
-                                                                      href="#test"
-                                                                      xlinkHref="#test"
-                                                                    />
-                                                                  </svg>
-                                                                </StyledSvg>
-                                                              </InlineSvg>
-                                                            </StyledInlineSvg>
-                                                          </div>
-                                                        </Base>
-                                                      </Box>
-                                                    </Component>
-                                                  </Icon>
-                                                  Add Another
-                                                </div>
-                                              </Base>
-                                            </Flex>
+                                                            <use
+                                                              href="#test"
+                                                              xlinkHref="#test"
+                                                            />
+                                                          </svg>
+                                                        </StyledSvg>
+                                                      </InlineSvg>
+                                                    </StyledInlineSvg>
+                                                  </span>
+                                                </Component>
+                                              </Icon>
+                                              Add Another
+                                            </span>
                                           </Component>
                                         </ButtonLabel>
                                       </button>
@@ -1398,7 +1371,6 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                           onClick={[Function]}
                                         >
                                           <Button
-                                            alignLabel="left"
                                             borderless={true}
                                             className="css-1j0nrmm-StyledButton ejqw4f70"
                                             disabled={false}
@@ -1430,82 +1402,58 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                                 >
                                                   <ButtonLabel
                                                     borderless={true}
-                                                    justify="flex-start"
                                                   >
                                                     <Component
                                                       borderless={true}
-                                                      className="css-6q5v1w-ButtonLabel eqrebog1"
-                                                      justify="flex-start"
+                                                      className="css-uthd1f-ButtonLabel eqrebog1"
                                                     >
-                                                      <Flex
-                                                        align="center"
-                                                        className="css-6q5v1w-ButtonLabel eqrebog1"
-                                                        justify="flex-start"
+                                                      <span
+                                                        className="css-uthd1f-ButtonLabel eqrebog1"
                                                       >
-                                                        <Base
-                                                          align="center"
-                                                          className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                                          justify="flex-start"
+                                                        <Icon
+                                                          hasChildren={true}
                                                         >
-                                                          <div
-                                                            className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                                            is={null}
+                                                          <Component
+                                                            className="css-1jxtush-Icon eqrebog2"
+                                                            hasChildren={true}
                                                           >
-                                                            <Icon
-                                                              hasChildren={true}
+                                                            <span
+                                                              className="css-1jxtush-Icon eqrebog2"
                                                             >
-                                                              <Component
-                                                                className="css-1jxtush-Icon eqrebog2"
-                                                                hasChildren={true}
+                                                              <StyledInlineSvg
+                                                                size="16px"
+                                                                src="icon-trash"
                                                               >
-                                                                <Box
-                                                                  className="css-1jxtush-Icon eqrebog2"
+                                                                <InlineSvg
+                                                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                                  size="16px"
+                                                                  src="icon-trash"
                                                                 >
-                                                                  <Base
-                                                                    className="eqrebog2 css-md8goh-Icon"
+                                                                  <StyledSvg
+                                                                    className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                                    height="16px"
+                                                                    viewBox={Object {}}
+                                                                    width="16px"
                                                                   >
-                                                                    <div
-                                                                      className="eqrebog2 css-md8goh-Icon"
-                                                                      is={null}
+                                                                    <svg
+                                                                      className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                                      height="16px"
+                                                                      viewBox={Object {}}
+                                                                      width="16px"
                                                                     >
-                                                                      <StyledInlineSvg
-                                                                        size="16px"
-                                                                        src="icon-trash"
-                                                                      >
-                                                                        <InlineSvg
-                                                                          className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                          size="16px"
-                                                                          src="icon-trash"
-                                                                        >
-                                                                          <StyledSvg
-                                                                            className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                            height="16px"
-                                                                            viewBox={Object {}}
-                                                                            width="16px"
-                                                                          >
-                                                                            <svg
-                                                                              className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                              height="16px"
-                                                                              viewBox={Object {}}
-                                                                              width="16px"
-                                                                            >
-                                                                              <use
-                                                                                href="#test"
-                                                                                xlinkHref="#test"
-                                                                              />
-                                                                            </svg>
-                                                                          </StyledSvg>
-                                                                        </InlineSvg>
-                                                                      </StyledInlineSvg>
-                                                                    </div>
-                                                                  </Base>
-                                                                </Box>
-                                                              </Component>
-                                                            </Icon>
-                                                            Remove
-                                                          </div>
-                                                        </Base>
-                                                      </Flex>
+                                                                      <use
+                                                                        href="#test"
+                                                                        xlinkHref="#test"
+                                                                      />
+                                                                    </svg>
+                                                                  </StyledSvg>
+                                                                </InlineSvg>
+                                                              </StyledInlineSvg>
+                                                            </span>
+                                                          </Component>
+                                                        </Icon>
+                                                        Remove
+                                                      </span>
                                                     </Component>
                                                   </ButtonLabel>
                                                 </button>
@@ -2229,7 +2177,6 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                 is={null}
                               >
                                 <Button
-                                  alignLabel="left"
                                   disabled={false}
                                   icon="icon-circle-add"
                                   onClick={[Function]}
@@ -2259,88 +2206,62 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                         size="small"
                                       >
                                         <ButtonLabel
-                                          justify="flex-start"
                                           size="small"
                                         >
                                           <Component
-                                            className="css-o42ntg-ButtonLabel eqrebog1"
-                                            justify="flex-start"
+                                            className="css-7ui8bl-ButtonLabel eqrebog1"
                                             size="small"
                                           >
-                                            <Flex
-                                              align="center"
-                                              className="css-o42ntg-ButtonLabel eqrebog1"
-                                              justify="flex-start"
+                                            <span
+                                              className="css-7ui8bl-ButtonLabel eqrebog1"
                                             >
-                                              <Base
-                                                align="center"
-                                                className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                justify="flex-start"
+                                              <Icon
+                                                hasChildren={true}
+                                                size="small"
                                               >
-                                                <div
-                                                  className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                  is={null}
+                                                <Component
+                                                  className="css-1vdnsie-Icon eqrebog2"
+                                                  hasChildren={true}
+                                                  size="small"
                                                 >
-                                                  <Icon
-                                                    hasChildren={true}
+                                                  <span
+                                                    className="css-1vdnsie-Icon eqrebog2"
                                                     size="small"
                                                   >
-                                                    <Component
-                                                      className="css-1vdnsie-Icon eqrebog2"
-                                                      hasChildren={true}
-                                                      size="small"
+                                                    <StyledInlineSvg
+                                                      size="12px"
+                                                      src="icon-circle-add"
                                                     >
-                                                      <Box
-                                                        className="css-1vdnsie-Icon eqrebog2"
-                                                        size="small"
+                                                      <InlineSvg
+                                                        className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                        size="12px"
+                                                        src="icon-circle-add"
                                                       >
-                                                        <Base
-                                                          className="eqrebog2 css-nk081r-Icon"
-                                                          size="small"
+                                                        <StyledSvg
+                                                          className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                          height="12px"
+                                                          viewBox={Object {}}
+                                                          width="12px"
                                                         >
-                                                          <div
-                                                            className="eqrebog2 css-nk081r-Icon"
-                                                            is={null}
-                                                            size="small"
+                                                          <svg
+                                                            className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                            height="12px"
+                                                            viewBox={Object {}}
+                                                            width="12px"
                                                           >
-                                                            <StyledInlineSvg
-                                                              size="12px"
-                                                              src="icon-circle-add"
-                                                            >
-                                                              <InlineSvg
-                                                                className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                size="12px"
-                                                                src="icon-circle-add"
-                                                              >
-                                                                <StyledSvg
-                                                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                  height="12px"
-                                                                  viewBox={Object {}}
-                                                                  width="12px"
-                                                                >
-                                                                  <svg
-                                                                    className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                    height="12px"
-                                                                    viewBox={Object {}}
-                                                                    width="12px"
-                                                                  >
-                                                                    <use
-                                                                      href="#test"
-                                                                      xlinkHref="#test"
-                                                                    />
-                                                                  </svg>
-                                                                </StyledSvg>
-                                                              </InlineSvg>
-                                                            </StyledInlineSvg>
-                                                          </div>
-                                                        </Base>
-                                                      </Box>
-                                                    </Component>
-                                                  </Icon>
-                                                  Add Another
-                                                </div>
-                                              </Base>
-                                            </Flex>
+                                                            <use
+                                                              href="#test"
+                                                              xlinkHref="#test"
+                                                            />
+                                                          </svg>
+                                                        </StyledSvg>
+                                                      </InlineSvg>
+                                                    </StyledInlineSvg>
+                                                  </span>
+                                                </Component>
+                                              </Icon>
+                                              Add Another
+                                            </span>
                                           </Component>
                                         </ButtonLabel>
                                       </button>
@@ -2744,7 +2665,6 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                           onClick={[Function]}
                                         >
                                           <Button
-                                            alignLabel="left"
                                             borderless={true}
                                             className="css-1j0nrmm-StyledButton ejqw4f70"
                                             disabled={false}
@@ -2776,82 +2696,58 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                                 >
                                                   <ButtonLabel
                                                     borderless={true}
-                                                    justify="flex-start"
                                                   >
                                                     <Component
                                                       borderless={true}
-                                                      className="css-6q5v1w-ButtonLabel eqrebog1"
-                                                      justify="flex-start"
+                                                      className="css-uthd1f-ButtonLabel eqrebog1"
                                                     >
-                                                      <Flex
-                                                        align="center"
-                                                        className="css-6q5v1w-ButtonLabel eqrebog1"
-                                                        justify="flex-start"
+                                                      <span
+                                                        className="css-uthd1f-ButtonLabel eqrebog1"
                                                       >
-                                                        <Base
-                                                          align="center"
-                                                          className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                                          justify="flex-start"
+                                                        <Icon
+                                                          hasChildren={true}
                                                         >
-                                                          <div
-                                                            className="eqrebog1 css-v6dd0e-ButtonLabel"
-                                                            is={null}
+                                                          <Component
+                                                            className="css-1jxtush-Icon eqrebog2"
+                                                            hasChildren={true}
                                                           >
-                                                            <Icon
-                                                              hasChildren={true}
+                                                            <span
+                                                              className="css-1jxtush-Icon eqrebog2"
                                                             >
-                                                              <Component
-                                                                className="css-1jxtush-Icon eqrebog2"
-                                                                hasChildren={true}
+                                                              <StyledInlineSvg
+                                                                size="16px"
+                                                                src="icon-trash"
                                                               >
-                                                                <Box
-                                                                  className="css-1jxtush-Icon eqrebog2"
+                                                                <InlineSvg
+                                                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                                  size="16px"
+                                                                  src="icon-trash"
                                                                 >
-                                                                  <Base
-                                                                    className="eqrebog2 css-md8goh-Icon"
+                                                                  <StyledSvg
+                                                                    className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                                    height="16px"
+                                                                    viewBox={Object {}}
+                                                                    width="16px"
                                                                   >
-                                                                    <div
-                                                                      className="eqrebog2 css-md8goh-Icon"
-                                                                      is={null}
+                                                                    <svg
+                                                                      className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                                      height="16px"
+                                                                      viewBox={Object {}}
+                                                                      width="16px"
                                                                     >
-                                                                      <StyledInlineSvg
-                                                                        size="16px"
-                                                                        src="icon-trash"
-                                                                      >
-                                                                        <InlineSvg
-                                                                          className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                          size="16px"
-                                                                          src="icon-trash"
-                                                                        >
-                                                                          <StyledSvg
-                                                                            className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                            height="16px"
-                                                                            viewBox={Object {}}
-                                                                            width="16px"
-                                                                          >
-                                                                            <svg
-                                                                              className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                              height="16px"
-                                                                              viewBox={Object {}}
-                                                                              width="16px"
-                                                                            >
-                                                                              <use
-                                                                                href="#test"
-                                                                                xlinkHref="#test"
-                                                                              />
-                                                                            </svg>
-                                                                          </StyledSvg>
-                                                                        </InlineSvg>
-                                                                      </StyledInlineSvg>
-                                                                    </div>
-                                                                  </Base>
-                                                                </Box>
-                                                              </Component>
-                                                            </Icon>
-                                                            Remove
-                                                          </div>
-                                                        </Base>
-                                                      </Flex>
+                                                                      <use
+                                                                        href="#test"
+                                                                        xlinkHref="#test"
+                                                                      />
+                                                                    </svg>
+                                                                  </StyledSvg>
+                                                                </InlineSvg>
+                                                              </StyledInlineSvg>
+                                                            </span>
+                                                          </Component>
+                                                        </Icon>
+                                                        Remove
+                                                      </span>
                                                     </Component>
                                                   </ButtonLabel>
                                                 </button>
@@ -3729,7 +3625,6 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                 is={null}
                               >
                                 <Button
-                                  alignLabel="left"
                                   disabled={false}
                                   icon="icon-circle-add"
                                   onClick={[Function]}
@@ -3759,88 +3654,62 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                         size="small"
                                       >
                                         <ButtonLabel
-                                          justify="flex-start"
                                           size="small"
                                         >
                                           <Component
-                                            className="css-o42ntg-ButtonLabel eqrebog1"
-                                            justify="flex-start"
+                                            className="css-7ui8bl-ButtonLabel eqrebog1"
                                             size="small"
                                           >
-                                            <Flex
-                                              align="center"
-                                              className="css-o42ntg-ButtonLabel eqrebog1"
-                                              justify="flex-start"
+                                            <span
+                                              className="css-7ui8bl-ButtonLabel eqrebog1"
                                             >
-                                              <Base
-                                                align="center"
-                                                className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                justify="flex-start"
+                                              <Icon
+                                                hasChildren={true}
+                                                size="small"
                                               >
-                                                <div
-                                                  className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                  is={null}
+                                                <Component
+                                                  className="css-1vdnsie-Icon eqrebog2"
+                                                  hasChildren={true}
+                                                  size="small"
                                                 >
-                                                  <Icon
-                                                    hasChildren={true}
+                                                  <span
+                                                    className="css-1vdnsie-Icon eqrebog2"
                                                     size="small"
                                                   >
-                                                    <Component
-                                                      className="css-1vdnsie-Icon eqrebog2"
-                                                      hasChildren={true}
-                                                      size="small"
+                                                    <StyledInlineSvg
+                                                      size="12px"
+                                                      src="icon-circle-add"
                                                     >
-                                                      <Box
-                                                        className="css-1vdnsie-Icon eqrebog2"
-                                                        size="small"
+                                                      <InlineSvg
+                                                        className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                        size="12px"
+                                                        src="icon-circle-add"
                                                       >
-                                                        <Base
-                                                          className="eqrebog2 css-nk081r-Icon"
-                                                          size="small"
+                                                        <StyledSvg
+                                                          className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                          height="12px"
+                                                          viewBox={Object {}}
+                                                          width="12px"
                                                         >
-                                                          <div
-                                                            className="eqrebog2 css-nk081r-Icon"
-                                                            is={null}
-                                                            size="small"
+                                                          <svg
+                                                            className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                            height="12px"
+                                                            viewBox={Object {}}
+                                                            width="12px"
                                                           >
-                                                            <StyledInlineSvg
-                                                              size="12px"
-                                                              src="icon-circle-add"
-                                                            >
-                                                              <InlineSvg
-                                                                className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                size="12px"
-                                                                src="icon-circle-add"
-                                                              >
-                                                                <StyledSvg
-                                                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                  height="12px"
-                                                                  viewBox={Object {}}
-                                                                  width="12px"
-                                                                >
-                                                                  <svg
-                                                                    className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                    height="12px"
-                                                                    viewBox={Object {}}
-                                                                    width="12px"
-                                                                  >
-                                                                    <use
-                                                                      href="#test"
-                                                                      xlinkHref="#test"
-                                                                    />
-                                                                  </svg>
-                                                                </StyledSvg>
-                                                              </InlineSvg>
-                                                            </StyledInlineSvg>
-                                                          </div>
-                                                        </Base>
-                                                      </Box>
-                                                    </Component>
-                                                  </Icon>
-                                                  Install
-                                                </div>
-                                              </Base>
-                                            </Flex>
+                                                            <use
+                                                              href="#test"
+                                                              xlinkHref="#test"
+                                                            />
+                                                          </svg>
+                                                        </StyledSvg>
+                                                      </InlineSvg>
+                                                    </StyledInlineSvg>
+                                                  </span>
+                                                </Component>
+                                              </Icon>
+                                              Install
+                                            </span>
                                           </Component>
                                         </ButtonLabel>
                                       </button>
@@ -4473,7 +4342,6 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                 is={null}
                               >
                                 <Button
-                                  alignLabel="left"
                                   disabled={false}
                                   icon="icon-circle-add"
                                   onClick={[Function]}
@@ -4503,88 +4371,62 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                         size="small"
                                       >
                                         <ButtonLabel
-                                          justify="flex-start"
                                           size="small"
                                         >
                                           <Component
-                                            className="css-o42ntg-ButtonLabel eqrebog1"
-                                            justify="flex-start"
+                                            className="css-7ui8bl-ButtonLabel eqrebog1"
                                             size="small"
                                           >
-                                            <Flex
-                                              align="center"
-                                              className="css-o42ntg-ButtonLabel eqrebog1"
-                                              justify="flex-start"
+                                            <span
+                                              className="css-7ui8bl-ButtonLabel eqrebog1"
                                             >
-                                              <Base
-                                                align="center"
-                                                className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                justify="flex-start"
+                                              <Icon
+                                                hasChildren={true}
+                                                size="small"
                                               >
-                                                <div
-                                                  className="eqrebog1 css-gzxb22-ButtonLabel"
-                                                  is={null}
+                                                <Component
+                                                  className="css-1vdnsie-Icon eqrebog2"
+                                                  hasChildren={true}
+                                                  size="small"
                                                 >
-                                                  <Icon
-                                                    hasChildren={true}
+                                                  <span
+                                                    className="css-1vdnsie-Icon eqrebog2"
                                                     size="small"
                                                   >
-                                                    <Component
-                                                      className="css-1vdnsie-Icon eqrebog2"
-                                                      hasChildren={true}
-                                                      size="small"
+                                                    <StyledInlineSvg
+                                                      size="12px"
+                                                      src="icon-circle-add"
                                                     >
-                                                      <Box
-                                                        className="css-1vdnsie-Icon eqrebog2"
-                                                        size="small"
+                                                      <InlineSvg
+                                                        className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                        size="12px"
+                                                        src="icon-circle-add"
                                                       >
-                                                        <Base
-                                                          className="eqrebog2 css-nk081r-Icon"
-                                                          size="small"
+                                                        <StyledSvg
+                                                          className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                          height="12px"
+                                                          viewBox={Object {}}
+                                                          width="12px"
                                                         >
-                                                          <div
-                                                            className="eqrebog2 css-nk081r-Icon"
-                                                            is={null}
-                                                            size="small"
+                                                          <svg
+                                                            className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                            height="12px"
+                                                            viewBox={Object {}}
+                                                            width="12px"
                                                           >
-                                                            <StyledInlineSvg
-                                                              size="12px"
-                                                              src="icon-circle-add"
-                                                            >
-                                                              <InlineSvg
-                                                                className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                size="12px"
-                                                                src="icon-circle-add"
-                                                              >
-                                                                <StyledSvg
-                                                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                  height="12px"
-                                                                  viewBox={Object {}}
-                                                                  width="12px"
-                                                                >
-                                                                  <svg
-                                                                    className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                    height="12px"
-                                                                    viewBox={Object {}}
-                                                                    width="12px"
-                                                                  >
-                                                                    <use
-                                                                      href="#test"
-                                                                      xlinkHref="#test"
-                                                                    />
-                                                                  </svg>
-                                                                </StyledSvg>
-                                                              </InlineSvg>
-                                                            </StyledInlineSvg>
-                                                          </div>
-                                                        </Base>
-                                                      </Box>
-                                                    </Component>
-                                                  </Icon>
-                                                  Install
-                                                </div>
-                                              </Base>
-                                            </Flex>
+                                                            <use
+                                                              href="#test"
+                                                              xlinkHref="#test"
+                                                            />
+                                                          </svg>
+                                                        </StyledSvg>
+                                                      </InlineSvg>
+                                                    </StyledInlineSvg>
+                                                  </span>
+                                                </Component>
+                                              </Icon>
+                                              Install
+                                            </span>
                                           </Component>
                                         </ButtonLabel>
                                       </button>

--- a/tests/js/spec/views/stream/__snapshots__/actions.spec.jsx.snap
+++ b/tests/js/spec/views/stream/__snapshots__/actions.spec.jsx.snap
@@ -144,7 +144,6 @@ exports[`StreamActions Bulk Total results < bulk limit bulk resolves 1`] = `
           className="modal-footer"
         >
           <Button
-            alignLabel="left"
             disabled={false}
             onClick={[Function]}
             style={
@@ -188,31 +187,15 @@ exports[`StreamActions Bulk Total results < bulk limit bulk resolves 1`] = `
                     }
                   }
                 >
-                  <ButtonLabel
-                    justify="flex-start"
-                  >
+                  <ButtonLabel>
                     <Component
-                      className="css-1emshjx-ButtonLabel eqrebog1"
-                      justify="flex-start"
+                      className="css-ga4b18-ButtonLabel eqrebog1"
                     >
-                      <Flex
-                        align="center"
-                        className="css-1emshjx-ButtonLabel eqrebog1"
-                        justify="flex-start"
+                      <span
+                        className="css-ga4b18-ButtonLabel eqrebog1"
                       >
-                        <Base
-                          align="center"
-                          className="eqrebog1 css-11rqwwm-ButtonLabel"
-                          justify="flex-start"
-                        >
-                          <div
-                            className="eqrebog1 css-11rqwwm-ButtonLabel"
-                            is={null}
-                          >
-                            Cancel
-                          </div>
-                        </Base>
-                      </Flex>
+                        Cancel
+                      </span>
                     </Component>
                   </ButtonLabel>
                 </button>
@@ -220,7 +203,6 @@ exports[`StreamActions Bulk Total results < bulk limit bulk resolves 1`] = `
             </StyledButton>
           </Button>
           <Button
-            alignLabel="left"
             autoFocus={true}
             data-test-id="confirm-modal"
             disabled={false}
@@ -257,32 +239,17 @@ exports[`StreamActions Bulk Total results < bulk limit bulk resolves 1`] = `
                   role="button"
                 >
                   <ButtonLabel
-                    justify="flex-start"
                     priority="primary"
                   >
                     <Component
-                      className="css-1emshjx-ButtonLabel eqrebog1"
-                      justify="flex-start"
+                      className="css-ga4b18-ButtonLabel eqrebog1"
                       priority="primary"
                     >
-                      <Flex
-                        align="center"
-                        className="css-1emshjx-ButtonLabel eqrebog1"
-                        justify="flex-start"
+                      <span
+                        className="css-ga4b18-ButtonLabel eqrebog1"
                       >
-                        <Base
-                          align="center"
-                          className="eqrebog1 css-11rqwwm-ButtonLabel"
-                          justify="flex-start"
-                        >
-                          <div
-                            className="eqrebog1 css-11rqwwm-ButtonLabel"
-                            is={null}
-                          >
-                            Bulk resolve issues
-                          </div>
-                        </Base>
-                      </Flex>
+                        Bulk resolve issues
+                      </span>
                     </Component>
                   </ButtonLabel>
                 </button>
@@ -472,7 +439,6 @@ exports[`StreamActions Bulk Total results > bulk limit bulk resolves 1`] = `
           className="modal-footer"
         >
           <Button
-            alignLabel="left"
             disabled={false}
             onClick={[Function]}
             style={
@@ -516,31 +482,15 @@ exports[`StreamActions Bulk Total results > bulk limit bulk resolves 1`] = `
                     }
                   }
                 >
-                  <ButtonLabel
-                    justify="flex-start"
-                  >
+                  <ButtonLabel>
                     <Component
-                      className="css-1emshjx-ButtonLabel eqrebog1"
-                      justify="flex-start"
+                      className="css-ga4b18-ButtonLabel eqrebog1"
                     >
-                      <Flex
-                        align="center"
-                        className="css-1emshjx-ButtonLabel eqrebog1"
-                        justify="flex-start"
+                      <span
+                        className="css-ga4b18-ButtonLabel eqrebog1"
                       >
-                        <Base
-                          align="center"
-                          className="eqrebog1 css-11rqwwm-ButtonLabel"
-                          justify="flex-start"
-                        >
-                          <div
-                            className="eqrebog1 css-11rqwwm-ButtonLabel"
-                            is={null}
-                          >
-                            Cancel
-                          </div>
-                        </Base>
-                      </Flex>
+                        Cancel
+                      </span>
                     </Component>
                   </ButtonLabel>
                 </button>
@@ -548,7 +498,6 @@ exports[`StreamActions Bulk Total results > bulk limit bulk resolves 1`] = `
             </StyledButton>
           </Button>
           <Button
-            alignLabel="left"
             autoFocus={true}
             data-test-id="confirm-modal"
             disabled={false}
@@ -585,32 +534,17 @@ exports[`StreamActions Bulk Total results > bulk limit bulk resolves 1`] = `
                   role="button"
                 >
                   <ButtonLabel
-                    justify="flex-start"
                     priority="primary"
                   >
                     <Component
-                      className="css-1emshjx-ButtonLabel eqrebog1"
-                      justify="flex-start"
+                      className="css-ga4b18-ButtonLabel eqrebog1"
                       priority="primary"
                     >
-                      <Flex
-                        align="center"
-                        className="css-1emshjx-ButtonLabel eqrebog1"
-                        justify="flex-start"
+                      <span
+                        className="css-ga4b18-ButtonLabel eqrebog1"
                       >
-                        <Base
-                          align="center"
-                          className="eqrebog1 css-11rqwwm-ButtonLabel"
-                          justify="flex-start"
-                        >
-                          <div
-                            className="eqrebog1 css-11rqwwm-ButtonLabel"
-                            is={null}
-                          >
-                            Bulk resolve issues
-                          </div>
-                        </Base>
-                      </Flex>
+                        Bulk resolve issues
+                      </span>
                     </Component>
                   </ButtonLabel>
                 </button>


### PR DESCRIPTION
Don't use `div` inside the Button component. Doing so makes Button hard to use in other block level contexts like `p` elements. By swapping out Box for span we also generate fewer DOM nodes overall.

Similarly Icon inside the Button has also been converted to a span instead of a Box trimming more DOM.o

I've removed the `alignLabel` prop from `Button` as it appears to be entirely unused, and doesn't do anything visually distinct when it is used.