### PR TITLE
fix(ui) Fix overflow on organization dashboard card

### DIFF
--- a/src/sentry/static/sentry/app/components/idBadge/baseBadge.jsx
+++ b/src/sentry/static/sentry/app/components/idBadge/baseBadge.jsx
@@ -79,7 +79,9 @@ class BaseBadge extends React.Component {
         )}
 
         <DisplayNameAndDescription>
-          {!hideName && <div data-test-id="badge-display-name">{displayName}</div>}
+          {!hideName && (
+            <DisplayName data-test-id="badge-display-name">{displayName}</DisplayName>
+          )}
           {!!description && <Description>{description}</Description>}
         </DisplayNameAndDescription>
       </Flex>
@@ -97,6 +99,12 @@ const StyledAvatar = styled(Avatar)`
 const DisplayNameAndDescription = styled(Flex)`
   flex-direction: column;
   line-height: 1;
+  overflow: hidden;
+`;
+
+const DisplayName = styled('span')`
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const Description = styled('div')`

--- a/src/sentry/static/sentry/app/components/platformList.jsx
+++ b/src/sentry/static/sentry/app/components/platformList.jsx
@@ -69,6 +69,7 @@ const getOverlapWidth = size => Math.round(size / 4);
 const PlatformIcons = styled('div')`
   margin-right: ${space(0.5)};
   display: flex;
+  flex-shrink: 0;
   flex-direction: row;
   justify-content: ${p => (p.direction === 'right' ? 'flex-end' : 'flex-start')};
   ${p =>

--- a/src/sentry/static/sentry/app/views/organizationDashboard/projectCard.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/projectCard.jsx
@@ -1,4 +1,4 @@
-import {Flex, Box} from 'grid-emotion';
+import {Box} from 'grid-emotion';
 import {withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -15,7 +15,6 @@ import Link from 'app/components/link';
 import ProjectsStatsStore from 'app/stores/projectsStatsStore';
 import SentryTypes from 'app/sentryTypes';
 import Tooltip from 'app/components/tooltip';
-import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 
 import Chart from './chart';
@@ -66,24 +65,20 @@ class ProjectCard extends React.Component {
       <ProjectCardWrapper data-test-id={slug} width={['100%', '50%', '33%', '25%']}>
         {stats ? (
           <StyledProjectCard>
-            <Flex justify="space-between" align="center">
-              <Box ml={2}>
-                <IdBadge
-                  project={project}
-                  avatarSize={24}
-                  displayName={
-                    <StyledTitle>
-                      {hasProjectAccess ? (
-                        <Link to={`/${params.orgId}/${slug}/`}>
-                          <strong>{slug}</strong>
-                        </Link>
-                      ) : (
-                        <div>{slug}</div>
-                      )}
-                    </StyledTitle>
-                  }
-                />
-              </Box>
+            <StyledProjectCardHeader>
+              <StyledIdBadge
+                project={project}
+                avatarSize={24}
+                displayName={
+                  hasProjectAccess ? (
+                    <Link to={`/${params.orgId}/${slug}/`}>
+                      <strong>{slug}</strong>
+                    </Link>
+                  ) : (
+                    <span>{slug}</span>
+                  )
+                }
+              />
               <Tooltip title={bookmarkText}>
                 <Star
                   active={isBookmarked}
@@ -91,7 +86,7 @@ class ProjectCard extends React.Component {
                   onClick={this.toggleProjectBookmark}
                 />
               </Tooltip>
-            </Flex>
+            </StyledProjectCardHeader>
             <ChartContainer>
               <Chart stats={stats} noEvents={!firstEvent} />
               {!firstEvent && <NoEvents />}
@@ -150,9 +145,11 @@ const ChartContainer = styled.div`
   padding-top: ${space(1)};
 `;
 
-const StyledTitle = styled.div`
-  ${overflowEllipsis};
-  padding: 16px 4px;
+const StyledProjectCardHeader = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 12px ${space(2)};
 `;
 
 const ProjectCardWrapper = styled(Box)`
@@ -168,7 +165,7 @@ const StyledProjectCard = styled.div`
 
 const Star = styled.a`
   color: ${p => (p.active ? p.theme.yellowOrange : p.theme.gray6)};
-  margin-right: 16px;
+  margin-left: ${space(1)};
   &:hover {
     color: ${p => p.theme.yellowOrange};
     opacity: 0.6;
@@ -179,6 +176,11 @@ const LoadingCard = styled('div')`
   border: 1px solid transparent;
   background-color: ${p => p.theme.offWhite};
   height: 210px;
+`;
+
+const StyledIdBadge = styled(IdBadge)`
+  white-space: nowrap;
+  overflow: hidden;
 `;
 
 export {ProjectCard};

--- a/src/sentry/static/sentry/app/views/organizationDashboard/projectCard.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/projectCard.jsx
@@ -179,8 +179,8 @@ const LoadingCard = styled('div')`
 `;
 
 const StyledIdBadge = styled(IdBadge)`
-  white-space: nowrap;
   overflow: hidden;
+  white-space: nowrap;
 `;
 
 export {ProjectCard};

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -523,31 +523,36 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                               >
                                                 <DisplayNameAndDescription>
                                                   <Base
-                                                    className="css-1eifx5k-DisplayNameAndDescription e165dl3i1"
+                                                    className="css-1h9j57p-DisplayNameAndDescription e165dl3i1"
                                                   >
                                                     <div
-                                                      className="css-1eifx5k-DisplayNameAndDescription e165dl3i1"
+                                                      className="css-1h9j57p-DisplayNameAndDescription e165dl3i1"
                                                       is={null}
                                                     >
-                                                      <div
+                                                      <DisplayName
                                                         data-test-id="badge-display-name"
                                                       >
-                                                        <BadgeDisplayName
-                                                          hideOverflow={true}
+                                                        <span
+                                                          className="css-1wwlq08-DisplayName e165dl3i2"
+                                                          data-test-id="badge-display-name"
                                                         >
-                                                          <Component
-                                                            className="css-1boiawc-BadgeDisplayName eeoia0v0"
+                                                          <BadgeDisplayName
                                                             hideOverflow={true}
                                                           >
-                                                            <span
+                                                            <Component
                                                               className="css-1boiawc-BadgeDisplayName eeoia0v0"
+                                                              hideOverflow={true}
                                                             >
-                                                              #
-                                                              bar
-                                                            </span>
-                                                          </Component>
-                                                        </BadgeDisplayName>
-                                                      </div>
+                                                              <span
+                                                                className="css-1boiawc-BadgeDisplayName eeoia0v0"
+                                                              >
+                                                                #
+                                                                bar
+                                                              </span>
+                                                            </Component>
+                                                          </BadgeDisplayName>
+                                                        </span>
+                                                      </DisplayName>
                                                     </div>
                                                   </Base>
                                                 </DisplayNameAndDescription>
@@ -671,31 +676,36 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                               >
                                                 <DisplayNameAndDescription>
                                                   <Base
-                                                    className="css-1eifx5k-DisplayNameAndDescription e165dl3i1"
+                                                    className="css-1h9j57p-DisplayNameAndDescription e165dl3i1"
                                                   >
                                                     <div
-                                                      className="css-1eifx5k-DisplayNameAndDescription e165dl3i1"
+                                                      className="css-1h9j57p-DisplayNameAndDescription e165dl3i1"
                                                       is={null}
                                                     >
-                                                      <div
+                                                      <DisplayName
                                                         data-test-id="badge-display-name"
                                                       >
-                                                        <BadgeDisplayName
-                                                          hideOverflow={true}
+                                                        <span
+                                                          className="css-1wwlq08-DisplayName e165dl3i2"
+                                                          data-test-id="badge-display-name"
                                                         >
-                                                          <Component
-                                                            className="css-1boiawc-BadgeDisplayName eeoia0v0"
+                                                          <BadgeDisplayName
                                                             hideOverflow={true}
                                                           >
-                                                            <span
+                                                            <Component
                                                               className="css-1boiawc-BadgeDisplayName eeoia0v0"
+                                                              hideOverflow={true}
                                                             >
-                                                              #
-                                                              foo
-                                                            </span>
-                                                          </Component>
-                                                        </BadgeDisplayName>
-                                                      </div>
+                                                              <span
+                                                                className="css-1boiawc-BadgeDisplayName eeoia0v0"
+                                                              >
+                                                                #
+                                                                foo
+                                                              </span>
+                                                            </Component>
+                                                          </BadgeDisplayName>
+                                                        </span>
+                                                      </DisplayName>
                                                     </div>
                                                   </Base>
                                                 </DisplayNameAndDescription>

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -102,7 +102,7 @@ exports[`ProjectCard renders 1`] = `
                 >
                   <IdBadge
                     avatarSize={24}
-                    className="css-7zhm7y-StyledIdBadge efesc7i6"
+                    className="css-1gy4gs4-StyledIdBadge efesc7i6"
                     displayName={
                       <span>
                         project-slug
@@ -142,7 +142,7 @@ exports[`ProjectCard renders 1`] = `
                       >
                         <ProjectBadge
                           avatarSize={24}
-                          className="css-7zhm7y-StyledIdBadge efesc7i6"
+                          className="css-1gy4gs4-StyledIdBadge efesc7i6"
                           displayName={
                             <span>
                               project-slug
@@ -178,7 +178,7 @@ exports[`ProjectCard renders 1`] = `
                           <BaseBadge
                             avatarProps={Object {}}
                             avatarSize={24}
-                            className="css-7zhm7y-StyledIdBadge efesc7i6"
+                            className="css-1gy4gs4-StyledIdBadge efesc7i6"
                             displayName={
                               <span>
                                 project-slug
@@ -212,14 +212,14 @@ exports[`ProjectCard renders 1`] = `
                           >
                             <Flex
                               align="center"
-                              className="css-7zhm7y-StyledIdBadge efesc7i6"
+                              className="css-1gy4gs4-StyledIdBadge efesc7i6"
                             >
                               <Base
                                 align="center"
-                                className="efesc7i6 css-16xfyz0-StyledIdBadge"
+                                className="efesc7i6 css-v2wlq8-StyledIdBadge"
                               >
                                 <div
-                                  className="efesc7i6 css-16xfyz0-StyledIdBadge"
+                                  className="efesc7i6 css-v2wlq8-StyledIdBadge"
                                   is={null}
                                 >
                                   <StyledAvatar
@@ -328,7 +328,7 @@ exports[`ProjectCard renders 1`] = `
                                             size={24}
                                           >
                                             <div
-                                              className="css-zaq10o-PlatformIcons ezvce7z0"
+                                              className="css-12u7e6y-PlatformIcons ezvce7z0"
                                               direction="right"
                                               max={3}
                                               size={24}
@@ -372,19 +372,24 @@ exports[`ProjectCard renders 1`] = `
                                   </StyledAvatar>
                                   <DisplayNameAndDescription>
                                     <Base
-                                      className="css-1eifx5k-DisplayNameAndDescription e165dl3i1"
+                                      className="css-1h9j57p-DisplayNameAndDescription e165dl3i1"
                                     >
                                       <div
-                                        className="css-1eifx5k-DisplayNameAndDescription e165dl3i1"
+                                        className="css-1h9j57p-DisplayNameAndDescription e165dl3i1"
                                         is={null}
                                       >
-                                        <div
+                                        <DisplayName
                                           data-test-id="badge-display-name"
                                         >
-                                          <span>
-                                            project-slug
+                                          <span
+                                            className="css-1wwlq08-DisplayName e165dl3i2"
+                                            data-test-id="badge-display-name"
+                                          >
+                                            <span>
+                                              project-slug
+                                            </span>
                                           </span>
-                                        </div>
+                                        </DisplayName>
                                       </div>
                                     </Base>
                                   </DisplayNameAndDescription>

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -64,39 +64,92 @@ exports[`ProjectCard renders 1`] = `
           <div
             className="css-18be1td-StyledProjectCard efesc7i3"
           >
-            <Flex
-              align="center"
-              justify="space-between"
-            >
-              <Base
-                align="center"
-                className="css-v7pzd9"
-                justify="space-between"
+            <StyledProjectCardHeader>
+              <div
+                className="css-v59cbs-StyledProjectCardHeader efesc7i1"
               >
-                <div
-                  className="css-v7pzd9"
-                  is={null}
+                <StyledIdBadge
+                  avatarSize={24}
+                  displayName={
+                    <span>
+                      project-slug
+                    </span>
+                  }
+                  project={
+                    Object {
+                      "hasAccess": true,
+                      "id": "2",
+                      "isBookmarked": false,
+                      "isMember": true,
+                      "name": "Project Name",
+                      "platforms": Array [
+                        "javascript",
+                      ],
+                      "slug": "project-slug",
+                      "stats": Array [
+                        Array [
+                          1525042800,
+                          1,
+                        ],
+                        Array [
+                          1525046400,
+                          2,
+                        ],
+                      ],
+                      "teams": Array [],
+                    }
+                  }
                 >
-                  <Box
-                    ml={2}
+                  <IdBadge
+                    avatarSize={24}
+                    className="css-7zhm7y-StyledIdBadge efesc7i6"
+                    displayName={
+                      <span>
+                        project-slug
+                      </span>
+                    }
+                    project={
+                      Object {
+                        "hasAccess": true,
+                        "id": "2",
+                        "isBookmarked": false,
+                        "isMember": true,
+                        "name": "Project Name",
+                        "platforms": Array [
+                          "javascript",
+                        ],
+                        "slug": "project-slug",
+                        "stats": Array [
+                          Array [
+                            1525042800,
+                            1,
+                          ],
+                          Array [
+                            1525046400,
+                            2,
+                          ],
+                        ],
+                        "teams": Array [],
+                      }
+                    }
                   >
-                    <Base
-                      className="css-1dvsqd3"
-                      ml={2}
+                    <InlineErrorBoundary
+                      mini={true}
                     >
-                      <div
-                        className="css-1dvsqd3"
-                        is={null}
+                      <ErrorBoundary
+                        className="css-otlbo1-InlineErrorBoundary e83vi020"
+                        mini={true}
                       >
-                        <IdBadge
+                        <ProjectBadge
                           avatarSize={24}
+                          className="css-7zhm7y-StyledIdBadge efesc7i6"
                           displayName={
-                            <StyledTitle>
-                              <div>
-                                project-slug
-                              </div>
-                            </StyledTitle>
+                            <span>
+                              project-slug
+                            </span>
                           }
+                          hideAvatar={false}
+                          hideOverflow={true}
                           project={
                             Object {
                               "hasAccess": true,
@@ -122,298 +175,246 @@ exports[`ProjectCard renders 1`] = `
                             }
                           }
                         >
-                          <InlineErrorBoundary
-                            mini={true}
+                          <BaseBadge
+                            avatarProps={Object {}}
+                            avatarSize={24}
+                            className="css-7zhm7y-StyledIdBadge efesc7i6"
+                            displayName={
+                              <span>
+                                project-slug
+                              </span>
+                            }
+                            hideAvatar={false}
+                            project={
+                              Object {
+                                "hasAccess": true,
+                                "id": "2",
+                                "isBookmarked": false,
+                                "isMember": true,
+                                "name": "Project Name",
+                                "platforms": Array [
+                                  "javascript",
+                                ],
+                                "slug": "project-slug",
+                                "stats": Array [
+                                  Array [
+                                    1525042800,
+                                    1,
+                                  ],
+                                  Array [
+                                    1525046400,
+                                    2,
+                                  ],
+                                ],
+                                "teams": Array [],
+                              }
+                            }
                           >
-                            <ErrorBoundary
-                              className="css-otlbo1-InlineErrorBoundary e83vi020"
-                              mini={true}
+                            <Flex
+                              align="center"
+                              className="css-7zhm7y-StyledIdBadge efesc7i6"
                             >
-                              <ProjectBadge
-                                avatarSize={24}
-                                displayName={
-                                  <StyledTitle>
-                                    <div>
-                                      project-slug
-                                    </div>
-                                  </StyledTitle>
-                                }
-                                hideAvatar={false}
-                                hideOverflow={true}
-                                project={
-                                  Object {
-                                    "hasAccess": true,
-                                    "id": "2",
-                                    "isBookmarked": false,
-                                    "isMember": true,
-                                    "name": "Project Name",
-                                    "platforms": Array [
-                                      "javascript",
-                                    ],
-                                    "slug": "project-slug",
-                                    "stats": Array [
-                                      Array [
-                                        1525042800,
-                                        1,
-                                      ],
-                                      Array [
-                                        1525046400,
-                                        2,
-                                      ],
-                                    ],
-                                    "teams": Array [],
-                                  }
-                                }
+                              <Base
+                                align="center"
+                                className="efesc7i6 css-16xfyz0-StyledIdBadge"
                               >
-                                <BaseBadge
-                                  avatarProps={Object {}}
-                                  avatarSize={24}
-                                  displayName={
-                                    <StyledTitle>
-                                      <div>
-                                        project-slug
-                                      </div>
-                                    </StyledTitle>
-                                  }
-                                  hideAvatar={false}
-                                  project={
-                                    Object {
-                                      "hasAccess": true,
-                                      "id": "2",
-                                      "isBookmarked": false,
-                                      "isMember": true,
-                                      "name": "Project Name",
-                                      "platforms": Array [
-                                        "javascript",
-                                      ],
-                                      "slug": "project-slug",
-                                      "stats": Array [
-                                        Array [
-                                          1525042800,
-                                          1,
-                                        ],
-                                        Array [
-                                          1525046400,
-                                          2,
-                                        ],
-                                      ],
-                                      "teams": Array [],
-                                    }
-                                  }
+                                <div
+                                  className="efesc7i6 css-16xfyz0-StyledIdBadge"
+                                  is={null}
                                 >
-                                  <Flex
-                                    align="center"
+                                  <StyledAvatar
+                                    className="css-0"
+                                    project={
+                                      Object {
+                                        "hasAccess": true,
+                                        "id": "2",
+                                        "isBookmarked": false,
+                                        "isMember": true,
+                                        "name": "Project Name",
+                                        "platforms": Array [
+                                          "javascript",
+                                        ],
+                                        "slug": "project-slug",
+                                        "stats": Array [
+                                          Array [
+                                            1525042800,
+                                            1,
+                                          ],
+                                          Array [
+                                            1525046400,
+                                            2,
+                                          ],
+                                        ],
+                                        "teams": Array [],
+                                      }
+                                    }
+                                    size={24}
                                   >
-                                    <Base
-                                      align="center"
-                                      className="css-5ipae5"
+                                    <Avatar
+                                      className="css-robds0-StyledAvatar e165dl3i0"
+                                      hasTooltip={false}
+                                      project={
+                                        Object {
+                                          "hasAccess": true,
+                                          "id": "2",
+                                          "isBookmarked": false,
+                                          "isMember": true,
+                                          "name": "Project Name",
+                                          "platforms": Array [
+                                            "javascript",
+                                          ],
+                                          "slug": "project-slug",
+                                          "stats": Array [
+                                            Array [
+                                              1525042800,
+                                              1,
+                                            ],
+                                            Array [
+                                              1525046400,
+                                              2,
+                                            ],
+                                          ],
+                                          "teams": Array [],
+                                        }
+                                      }
+                                      size={24}
                                     >
-                                      <div
-                                        className="css-5ipae5"
-                                        is={null}
+                                      <ProjectAvatar
+                                        className="css-robds0-StyledAvatar e165dl3i0"
+                                        hasTooltip={false}
+                                        project={
+                                          Object {
+                                            "hasAccess": true,
+                                            "id": "2",
+                                            "isBookmarked": false,
+                                            "isMember": true,
+                                            "name": "Project Name",
+                                            "platforms": Array [
+                                              "javascript",
+                                            ],
+                                            "slug": "project-slug",
+                                            "stats": Array [
+                                              Array [
+                                                1525042800,
+                                                1,
+                                              ],
+                                              Array [
+                                                1525046400,
+                                                2,
+                                              ],
+                                            ],
+                                            "teams": Array [],
+                                          }
+                                        }
+                                        size={24}
                                       >
-                                        <StyledAvatar
-                                          className="css-0"
-                                          project={
-                                            Object {
-                                              "hasAccess": true,
-                                              "id": "2",
-                                              "isBookmarked": false,
-                                              "isMember": true,
-                                              "name": "Project Name",
-                                              "platforms": Array [
-                                                "javascript",
-                                              ],
-                                              "slug": "project-slug",
-                                              "stats": Array [
-                                                Array [
-                                                  1525042800,
-                                                  1,
-                                                ],
-                                                Array [
-                                                  1525046400,
-                                                  2,
-                                                ],
-                                              ],
-                                              "teams": Array [],
-                                            }
+                                        <PlatformList
+                                          className="css-robds0-StyledAvatar e165dl3i0"
+                                          consistentWidth={false}
+                                          direction="right"
+                                          hasTooltip={false}
+                                          max={3}
+                                          platforms={
+                                            Array [
+                                              "javascript",
+                                            ]
                                           }
                                           size={24}
                                         >
-                                          <Avatar
-                                            className="css-robds0-StyledAvatar e165dl3i0"
-                                            hasTooltip={false}
-                                            project={
-                                              Object {
-                                                "hasAccess": true,
-                                                "id": "2",
-                                                "isBookmarked": false,
-                                                "isMember": true,
-                                                "name": "Project Name",
-                                                "platforms": Array [
-                                                  "javascript",
-                                                ],
-                                                "slug": "project-slug",
-                                                "stats": Array [
-                                                  Array [
-                                                    1525042800,
-                                                    1,
-                                                  ],
-                                                  Array [
-                                                    1525046400,
-                                                    2,
-                                                  ],
-                                                ],
-                                                "teams": Array [],
-                                              }
-                                            }
+                                          <PlatformIcons
+                                            consistentWidth={false}
+                                            direction="right"
+                                            max={3}
                                             size={24}
                                           >
-                                            <ProjectAvatar
-                                              className="css-robds0-StyledAvatar e165dl3i0"
-                                              hasTooltip={false}
-                                              project={
-                                                Object {
-                                                  "hasAccess": true,
-                                                  "id": "2",
-                                                  "isBookmarked": false,
-                                                  "isMember": true,
-                                                  "name": "Project Name",
-                                                  "platforms": Array [
-                                                    "javascript",
-                                                  ],
-                                                  "slug": "project-slug",
-                                                  "stats": Array [
-                                                    Array [
-                                                      1525042800,
-                                                      1,
-                                                    ],
-                                                    Array [
-                                                      1525046400,
-                                                      2,
-                                                    ],
-                                                  ],
-                                                  "teams": Array [],
-                                                }
-                                              }
+                                            <div
+                                              className="css-zaq10o-PlatformIcons ezvce7z0"
+                                              direction="right"
+                                              max={3}
                                               size={24}
                                             >
-                                              <PlatformList
-                                                className="css-robds0-StyledAvatar e165dl3i0"
-                                                consistentWidth={false}
-                                                direction="right"
-                                                hasTooltip={false}
-                                                max={3}
-                                                platforms={
-                                                  Array [
-                                                    "javascript",
-                                                  ]
-                                                }
+                                              <StyledPlatformIcon
+                                                key="javascript"
+                                                platform="javascript"
                                                 size={24}
                                               >
-                                                <PlatformIcons
-                                                  consistentWidth={false}
-                                                  direction="right"
-                                                  max={3}
+                                                <Component
+                                                  className="css-1rk01z5-StyledPlatformIcon ezvce7z1"
+                                                  platform="javascript"
                                                   size={24}
                                                 >
-                                                  <div
-                                                    className="css-zaq10o-PlatformIcons ezvce7z0"
-                                                    direction="right"
-                                                    max={3}
-                                                    size={24}
+                                                  <Platformicon
+                                                    className="css-1rk01z5-StyledPlatformIcon ezvce7z1"
+                                                    platform="javascript"
+                                                    size="24px"
                                                   >
-                                                    <StyledPlatformIcon
-                                                      key="javascript"
-                                                      platform="javascript"
-                                                      size={24}
-                                                    >
-                                                      <Component
-                                                        className="css-1rk01z5-StyledPlatformIcon ezvce7z1"
-                                                        platform="javascript"
-                                                        size={24}
-                                                      >
-                                                        <Platformicon
-                                                          className="css-1rk01z5-StyledPlatformIcon ezvce7z1"
-                                                          platform="javascript"
-                                                          size="24px"
-                                                        >
-                                                          <img
-                                                            className="css-1rk01z5-StyledPlatformIcon ezvce7z1"
-                                                            height="24px"
-                                                            src={
-                                                              Object {
-                                                                "default": Object {
-                                                                  "id": "test",
-                                                                  "viewBox": Object {},
-                                                                },
-                                                              }
-                                                            }
-                                                            width="24px"
-                                                          />
-                                                        </Platformicon>
-                                                      </Component>
-                                                    </StyledPlatformIcon>
-                                                  </div>
-                                                </PlatformIcons>
-                                              </PlatformList>
-                                            </ProjectAvatar>
-                                          </Avatar>
-                                        </StyledAvatar>
-                                        <DisplayNameAndDescription>
-                                          <Base
-                                            className="css-1eifx5k-DisplayNameAndDescription e165dl3i1"
-                                          >
-                                            <div
-                                              className="css-1eifx5k-DisplayNameAndDescription e165dl3i1"
-                                              is={null}
-                                            >
-                                              <div
-                                                data-test-id="badge-display-name"
-                                              >
-                                                <StyledTitle>
-                                                  <div
-                                                    className="css-25y8kw-StyledTitle efesc7i1"
-                                                  >
-                                                    <div>
-                                                      project-slug
-                                                    </div>
-                                                  </div>
-                                                </StyledTitle>
-                                              </div>
+                                                    <img
+                                                      className="css-1rk01z5-StyledPlatformIcon ezvce7z1"
+                                                      height="24px"
+                                                      src={
+                                                        Object {
+                                                          "default": Object {
+                                                            "id": "test",
+                                                            "viewBox": Object {},
+                                                          },
+                                                        }
+                                                      }
+                                                      width="24px"
+                                                    />
+                                                  </Platformicon>
+                                                </Component>
+                                              </StyledPlatformIcon>
                                             </div>
-                                          </Base>
-                                        </DisplayNameAndDescription>
+                                          </PlatformIcons>
+                                        </PlatformList>
+                                      </ProjectAvatar>
+                                    </Avatar>
+                                  </StyledAvatar>
+                                  <DisplayNameAndDescription>
+                                    <Base
+                                      className="css-1eifx5k-DisplayNameAndDescription e165dl3i1"
+                                    >
+                                      <div
+                                        className="css-1eifx5k-DisplayNameAndDescription e165dl3i1"
+                                        is={null}
+                                      >
+                                        <div
+                                          data-test-id="badge-display-name"
+                                        >
+                                          <span>
+                                            project-slug
+                                          </span>
+                                        </div>
                                       </div>
                                     </Base>
-                                  </Flex>
-                                </BaseBadge>
-                              </ProjectBadge>
-                            </ErrorBoundary>
-                          </InlineErrorBoundary>
-                        </IdBadge>
-                      </div>
-                    </Base>
-                  </Box>
-                  <Tooltip
+                                  </DisplayNameAndDescription>
+                                </div>
+                              </Base>
+                            </Flex>
+                          </BaseBadge>
+                        </ProjectBadge>
+                      </ErrorBoundary>
+                    </InlineErrorBoundary>
+                  </IdBadge>
+                </StyledIdBadge>
+                <Tooltip
+                  title="Add to bookmarks"
+                >
+                  <Star
+                    active={false}
+                    className="tip project-select-bookmark icon icon-star-solid"
+                    onClick={[Function]}
                     title="Add to bookmarks"
                   >
-                    <Star
-                      active={false}
-                      className="tip project-select-bookmark icon icon-star-solid"
+                    <a
+                      className="tip project-select-bookmark icon icon-star-solid css-1gdf7jd-Star efesc7i4"
                       onClick={[Function]}
                       title="Add to bookmarks"
-                    >
-                      <a
-                        className="tip project-select-bookmark icon icon-star-solid css-9lfgnk-Star efesc7i4"
-                        onClick={[Function]}
-                        title="Add to bookmarks"
-                      />
-                    </Star>
-                  </Tooltip>
-                </div>
-              </Base>
-            </Flex>
+                    />
+                  </Star>
+                </Tooltip>
+              </div>
+            </StyledProjectCardHeader>
             <ChartContainer>
               <div
                 className="css-1s8o1vf-ChartContainer efesc7i0"


### PR DESCRIPTION
Hide overflow text on project cards. Due to the dom structure ellipsis isn't entirely visible.

### Before

![screen shot 2018-09-21 at 5 16 25 pm](https://user-images.githubusercontent.com/24086/45906441-9fbd2880-bde3-11e8-9eed-5585f462f4f0.png)

### After

![screen shot 2018-09-21 at 4 48 57 pm](https://user-images.githubusercontent.com/24086/45906414-8916d180-bde3-11e8-86a8-090344a17dd8.png)
