### PR TITLE
feat: add hovercard to exports

### DIFF
--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -126,7 +126,7 @@ export default {
     FormState: require('app/components/forms/index').FormState,
     GuideAnchor: require('app/components/assistant/guideAnchor').default,
     HookStore: require('app/stores/hookStore').default,
-    HoverCard: require('app/components/hovercard').default,
+    Hovercard: require('app/components/hovercard').default,
     Indicators: require('app/components/indicators').default,
     IndicatorStore: require('app/stores/indicatorStore').default,
     InlineSvg: require('app/components/inlineSvg').default,

--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -126,6 +126,7 @@ export default {
     FormState: require('app/components/forms/index').FormState,
     GuideAnchor: require('app/components/assistant/guideAnchor').default,
     HookStore: require('app/stores/hookStore').default,
+    HoverCard: require('app/components/hovercard').default,
     Indicators: require('app/components/indicators').default,
     IndicatorStore: require('app/stores/indicatorStore').default,
     InlineSvg: require('app/components/inlineSvg').default,


### PR DESCRIPTION
For use in getsentry.

Seems to work:
![image](https://user-images.githubusercontent.com/14812505/45911890-f91a5d00-bdcd-11e8-85c3-ac87a2bd8349.png)
