### PR TITLE
feat(snuba): Add group state change methods to eventstream

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 from django.utils import timezone
 from rest_framework.response import Response
 
-from sentry import tsdb, tagstore
+from sentry import eventstream, tsdb, tagstore
 from sentry.api import client
 from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases import GroupEndpoint
@@ -391,6 +391,9 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         ]).update(status=GroupStatus.PENDING_DELETION)
         if updated:
             project = group.project
+
+            eventstream.delete_groups(group.project_id, [group.id])
+
             GroupHashTombstone.tombstone_groups(
                 project_id=project.id,
                 group_ids=[group.id],

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.response import Response
 
-from sentry import analytics, features, search
+from sentry import analytics, eventstream, features, search
 from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
 from sentry.api.fields import ActorField, Actor
@@ -951,6 +951,8 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
             GroupStatus.PENDING_DELETION,
             GroupStatus.DELETION_IN_PROGRESS,
         ]).update(status=GroupStatus.PENDING_DELETION)
+
+        eventstream.delete_groups(project.id, group_ids)
 
         GroupHashTombstone.tombstone_groups(
             project_id=project.id,

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -937,7 +937,7 @@ class EventManager(object):
                 project.update(first_event=date)
                 first_event_received.send_robust(project=project, group=group, sender=Project)
 
-        eventstream.publish(
+        eventstream.insert(
             group=group,
             event=event,
             is_new=is_new,

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -11,10 +11,14 @@ logger = logging.getLogger(__name__)
 
 class EventStream(Service):
     __all__ = (
-        'publish',
+        'insert',
+        'unmerge',
+        'delete_groups',
+        'merge',
     )
 
-    def publish(self, group, event, is_new, is_sample, is_regression, is_new_group_environment, primary_hash, skip_consume=False):
+    def insert(self, group, event, is_new, is_sample, is_regression,
+               is_new_group_environment, primary_hash, skip_consume=False):
         if skip_consume:
             logger.info('post_process.skip.raw_event', extra={'event_id': event.id})
         else:
@@ -27,3 +31,12 @@ class EventStream(Service):
                 is_new_group_environment=is_new_group_environment,
                 primary_hash=primary_hash,
             )
+
+    def unmerge(self, project_id, new_group_id, event_ids):
+        pass
+
+    def delete_groups(self, project_id, group_ids):
+        pass
+
+    def merge(self, project_id, previous_group_id, new_group_id):
+        pass

--- a/src/sentry/eventstream/kafka.py
+++ b/src/sentry/eventstream/kafka.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import six
 import logging
 
 from confluent_kafka import Producer
@@ -15,7 +16,11 @@ logger = logging.getLogger(__name__)
 
 # Beware! Changing this, or the message format/fields themselves requires
 # consideration of all downstream consumers.
-# Version 1 format: (1, '(insert|delete)', {...event json...}, {...state for post-processing...})
+# Version 1 format: (1, TYPE, [...REST...])
+#   Insert: (1, 'insert', {...event json...}, {...state for post-processing...})
+#   Delete Groups: (1, 'delete_groups', {'project_id': id, 'group_ids': [id1, id2, id3]})
+#   Unmerge: (1, 'unmerge', {'project_id': id, 'new_group_id': id, 'event_ids': [id1, id2]})
+#   Merge: (1, 'merge', {'project_id': id, 'previous_group_id': id, 'new_group_id': id})
 EVENT_PROTOCOL_VERSION = 1
 
 
@@ -35,12 +40,7 @@ class KafkaEventStream(EventStream):
         if error is not None:
             logger.warning('Could not publish event (error: %s): %r', error, message)
 
-    def publish(self, group, event, is_new, is_sample, is_regression, is_new_group_environment, primary_hash, skip_consume=False):
-        project = event.project
-        retention_days = quotas.get_event_retention(
-            organization=Organization(project.organization_id)
-        )
-
+    def _send(self, project_id, _type, *data):
         # Polling the producer is required to ensure callbacks are fired. This
         # means that the latency between a message being delivered (or failing
         # to be delivered) and the corresponding callback being fired is
@@ -51,31 +51,68 @@ class KafkaEventStream(EventStream):
         # a heartbeat for the purposes of any sort of session expiration.)
         self.producer.poll(0.0)
 
+        key = six.text_type(project_id)
+
         try:
-            key = '%s:%s' % (event.project_id, event.event_id)
-            value = (EVENT_PROTOCOL_VERSION, 'insert', {
-                'group_id': event.group_id,
-                'event_id': event.event_id,
-                'organization_id': project.organization_id,
-                'project_id': event.project_id,
-                'message': event.message,
-                'platform': event.platform,
-                'datetime': event.datetime,
-                'data': dict(event.data.items()),
-                'primary_hash': primary_hash,
-                'retention_days': retention_days,
-            }, {
-                'is_new': is_new,
-                'is_sample': is_sample,
-                'is_regression': is_regression,
-                'is_new_group_environment': is_new_group_environment,
-            })
             self.producer.produce(
                 self.publish_topic,
                 key=key.encode('utf-8'),
-                value=json.dumps(value),
+                value=json.dumps(
+                    (EVENT_PROTOCOL_VERSION, _type) + data
+                ),
                 on_delivery=self.delivery_callback,
             )
         except Exception as error:
-            logger.warning('Could not publish event: %s', error, exc_info=True)
+            logger.warning('Could not publish message: %s', error, exc_info=True)
             raise
+
+    def insert(self, group, event, is_new, is_sample, is_regression,
+               is_new_group_environment, primary_hash, skip_consume=False):
+        project = event.project
+        retention_days = quotas.get_event_retention(
+            organization=Organization(project.organization_id)
+        )
+
+        self._send(project.id, 'insert', {
+            'group_id': event.group_id,
+            'event_id': event.event_id,
+            'organization_id': project.organization_id,
+            'project_id': event.project_id,
+            'message': event.message,
+            'platform': event.platform,
+            'datetime': event.datetime,
+            'data': dict(event.data.items()),
+            'primary_hash': primary_hash,
+            'retention_days': retention_days,
+        }, {
+            'is_new': is_new,
+            'is_sample': is_sample,
+            'is_regression': is_regression,
+            'is_new_group_environment': is_new_group_environment,
+        })
+
+    def unmerge(self, project_id, new_group_id, event_ids):
+        if not event_ids:
+            return
+
+        self._send(project_id, 'unmerge', {
+            'project_id': project_id,
+            'new_group_id': new_group_id,
+            'event_ids': event_ids,
+        })
+
+    def delete_groups(self, project_id, group_ids):
+        if not group_ids:
+            return
+
+        self._send(project_id, 'delete_groups', {
+            'project_id': project_id,
+            'group_ids': group_ids,
+        })
+
+    def merge(self, project_id, previous_group_id, new_group_id):
+        self._send(project_id, 'merge', {
+            'project_id': project_id,
+            'previous_group_id': previous_group_id,
+            'new_group_id': new_group_id,
+        })

--- a/src/sentry/eventstream/kafka.py
+++ b/src/sentry/eventstream/kafka.py
@@ -19,10 +19,28 @@ logger = logging.getLogger(__name__)
 # Beware! Changing this, or the message format/fields themselves requires
 # consideration of all downstream consumers.
 # Version 1 format: (1, TYPE, [...REST...])
-#   Insert: (1, 'insert', {...event json...}, {...state for post-processing...})
-#   Delete Groups: (1, 'delete_groups', {'project_id': id, 'group_ids': [id1, id2, id3]})
-#   Unmerge: (1, 'unmerge', {'project_id': id, 'new_group_id': id, 'event_ids': [id1, id2]})
-#   Merge: (1, 'merge', {'project_id': id, 'previous_group_id': id, 'new_group_id': id})
+#   Insert: (1, 'insert', {
+#       ...event json...
+#   }, {
+#       ...state for post-processing...
+#   })
+#   Delete Groups: (1, 'delete_groups', {
+#       'project_id': id,
+#       'group_ids': [id1, id2, id3],
+#       'datetime': timestamp,
+#   })
+#   Unmerge: (1, 'unmerge', {
+#       'project_id': id,
+#       'new_group_id': id,
+#       'event_ids': [id1, id2]
+#       'datetime': timestamp,
+#   })
+#   Merge: (1, 'merge', {
+#       'project_id': id,
+#       'previous_group_id': id,
+#       'new_group_id': id,
+#       'datetime': timestamp,
+#   })
 EVENT_PROTOCOL_VERSION = 1
 
 

--- a/src/sentry/eventstream/kafka.py
+++ b/src/sentry/eventstream/kafka.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 
-import six
+from datetime import datetime
 import logging
+import pytz
+import six
 
 from confluent_kafka import Producer
 from django.utils.functional import cached_property
@@ -101,6 +103,7 @@ class KafkaEventStream(EventStream):
             'project_id': project_id,
             'new_group_id': new_group_id,
             'event_ids': event_ids,
+            'datetime': datetime.now(tz=pytz.utc),
         },))
 
     def delete_groups(self, project_id, group_ids):
@@ -110,6 +113,7 @@ class KafkaEventStream(EventStream):
         self._send(project_id, 'delete_groups', extra_data=({
             'project_id': project_id,
             'group_ids': group_ids,
+            'datetime': datetime.now(tz=pytz.utc),
         },))
 
     def merge(self, project_id, previous_group_id, new_group_id):
@@ -117,4 +121,5 @@ class KafkaEventStream(EventStream):
             'project_id': project_id,
             'previous_group_id': previous_group_id,
             'new_group_id': new_group_id,
+            'datetime': datetime.now(tz=pytz.utc),
         },))

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -5,7 +5,8 @@ from sentry.utils import snuba
 
 
 class SnubaEventStream(EventStream):
-    def publish(self, group, event, is_new, is_sample, is_regression, is_new_group_environment, primary_hash, skip_consume=False):
+    def insert(self, group, event, is_new, is_sample, is_regression,
+               is_new_group_environment, primary_hash, skip_consume=False):
         snuba.insert_raw([{
             'group_id': event.group_id,
             'event_id': event.event_id,
@@ -16,4 +17,17 @@ class SnubaEventStream(EventStream):
             'data': dict(event.data.items()),
             'primary_hash': primary_hash,
         }])
-        super(SnubaEventStream, self).publish(group, event, is_new, is_sample, is_regression, is_new_group_environment, primary_hash, skip_consume)
+        super(SnubaEventStream, self).insert(
+            group, event, is_new, is_sample,
+            is_regression, is_new_group_environment,
+            primary_hash, skip_consume
+        )
+
+    def unmerge(self, project_id, new_group_id, event_ids):
+        pass
+
+    def delete_groups(self, project_id, group_ids):
+        pass
+
+    def merge(self, project_id, previous_group_id, new_group_id):
+        pass

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -13,10 +13,10 @@ import logging
 from django.db import DataError, IntegrityError, router, transaction
 from django.db.models import F
 
+from sentry import eventstream
 from sentry.app import tsdb
 from sentry.similarity import features
-from sentry.tasks.base import instrumented_task, retry
-from sentry.tasks.deletion import delete_group
+from sentry.tasks.base import instrumented_task
 
 logger = logging.getLogger('sentry.merge')
 delete_logger = logging.getLogger('sentry.deletions.async')
@@ -190,42 +190,7 @@ def merge_group(
     except DataError:
         pass
 
-
-@instrumented_task(
-    name='sentry.tasks.merge.rehash_group_events',
-    queue='merge',
-    default_retry_delay=60 * 5,
-    max_retries=None
-)
-@retry
-def rehash_group_events(group_id, transaction_id=None, **kwargs):
-    from sentry.models import Group, GroupHash
-
-    group = Group.objects.get(id=group_id)
-
-    # Clear out existing hashes to preempt new events being added
-    # This can cause the new groups to be created before we get to them, but
-    # its a tradeoff we're willing to take
-    GroupHash.objects.filter(group=group).delete()
-    has_more = _rehash_group_events(group)
-
-    if has_more:
-        rehash_group_events.delay(
-            group_id=group.id,
-            transaction_id=transaction_id,
-        )
-        return
-
-    delete_logger.info(
-        'object.delete.bulk_executed',
-        extra={
-            'group_id': group.id,
-            'transaction_id': transaction_id,
-            'model': GroupHash.__name__,
-        }
-    )
-
-    delete_group.delay(group.id, transaction_id=transaction_id)
+    eventstream.merge(group.project_id, previous_group_id, new_group.id)
 
 
 def _get_event_environment(event, project, cache):
@@ -250,53 +215,6 @@ def _get_event_environment(event, project, cache):
         cache[environment_name] = environment
 
     return cache[environment_name]
-
-
-def _rehash_group_events(group, limit=100):
-    from sentry.event_manager import (
-        EventManager, get_hashes_from_fingerprint, generate_culprit, md5_from_hash
-    )
-    from sentry.models import Event, Group
-
-    environment_cache = {}
-    project = group.project
-    event_list = list(Event.objects.filter(group_id=group.id)[:limit])
-    Event.objects.bind_nodes(event_list, 'data')
-
-    for event in event_list:
-        fingerprint = event.data.get('fingerprint', ['{{ default }}'])
-        if fingerprint and not isinstance(fingerprint, (list, tuple)):
-            fingerprint = [fingerprint]
-        elif not fingerprint:
-            fingerprint = ['{{ default }}']
-
-        manager = EventManager({})
-
-        group_kwargs = {
-            'message': event.message,
-            'platform': event.platform,
-            'culprit': generate_culprit(event.data),
-            'logger': event.get_tag('logger') or group.logger,
-            'level': group.level,
-            'last_seen': event.datetime,
-            'first_seen': event.datetime,
-            'data': group.data,
-        }
-
-        # XXX(dcramer): doesnt support checksums as they're not stored
-        hashes = map(md5_from_hash, get_hashes_from_fingerprint(event, fingerprint))
-        for hash in hashes:
-            new_group, _, _, _ = manager._save_aggregate(
-                event=event, hashes=hashes, release=None, **group_kwargs
-            )
-            event.update(group_id=new_group.id)
-            if event.data.get('tags'):
-                Group.objects.add_tags(
-                    new_group,
-                    _get_event_environment(event, project, environment_cache),
-                    event.data['tags'])
-
-    return bool(event_list)
 
 
 def merge_objects(models, group, new_group, limit=1000, logger=None, transaction_id=None):

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 from django.db import transaction
 
-from sentry import tagstore
+from sentry import eventstream, tagstore
 from sentry.app import tsdb
 from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS_MAP
 from sentry.event_manager import (
@@ -211,6 +211,8 @@ def migrate_events(caches, project, source_id, destination_id, fingerprints, eve
         destination.update(**get_group_backfill_attributes(caches, destination, events))
 
     event_id_set = set(event.id for event in events)
+
+    eventstream.unmerge(project.id, destination_id, [event.event_id for event in events])
 
     Event.objects.filter(
         project_id=project.id,

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -5,7 +5,7 @@ from mock import patch
 
 from sentry import tagstore
 from sentry.tagstore.models import GroupTagValue
-from sentry.tasks.merge import merge_group, rehash_group_events
+from sentry.tasks.merge import merge_group
 from sentry.models import Event, Group, GroupEnvironment, GroupMeta, GroupRedirect, UserReport
 from sentry.similarity import _make_index_backend
 from sentry.testutils import TestCase
@@ -237,32 +237,3 @@ class MergeGroupTest(TestCase):
         assert not Group.objects.filter(id=group1.id).exists()
 
         assert UserReport.objects.get(id=ur.id).group_id == group2.id
-
-
-class RehashGroupEventsTest(TestCase):
-    def test_simple(self):
-        project = self.create_project()
-        group = self.create_group(project)
-        event1 = self.create_event('a' * 32, message='foo', group=group, data={})
-        event2 = self.create_event('b' * 32, message='foo', group=group, data={})
-        event3 = self.create_event('c' * 32, message='bar', group=group, data={})
-
-        with self.tasks():
-            rehash_group_events(group.id)
-
-        assert not Group.objects.filter(id=group.id).exists()
-
-        # this previously would error with NodeIntegrityError due to the
-        # reference check being bound to a group
-        event1 = Event.objects.get(id=event1.id)
-        group1 = event1.group
-        assert sorted(Event.objects.filter(group_id=group1.id).values_list('id', flat=True)) == [
-            event1.id,
-            event2.id,
-        ]
-
-        event3 = Event.objects.get(id=event3.id)
-        group2 = event3.group
-        assert sorted(Event.objects.filter(group_id=group2.id).values_list('id', flat=True)) == [
-            event3.id,
-        ]

--- a/tests/sentry/test_event_manager.py
+++ b/tests/sentry/test_event_manager.py
@@ -955,8 +955,8 @@ class EventManagerTest(TransactionTestCase):
 
         assert dict(event.tags).get('environment') == 'beta'
 
-    @mock.patch('sentry.event_manager.eventstream.publish')
-    def test_group_environment(self, eventstream_publish):
+    @mock.patch('sentry.event_manager.eventstream.insert')
+    def test_group_environment(self, eventstream_insert):
         release_version = '1.0'
 
         def save_event():
@@ -983,7 +983,7 @@ class EventManagerTest(TransactionTestCase):
 
         # Ensure that the first event in the (group, environment) pair is
         # marked as being part of a new environment.
-        eventstream_publish.assert_called_with(
+        eventstream_insert.assert_called_with(
             group=event.group,
             event=event,
             is_new=True,
@@ -998,7 +998,7 @@ class EventManagerTest(TransactionTestCase):
 
         # Ensure that the next event in the (group, environment) pair is *not*
         # marked as being part of a new environment.
-        eventstream_publish.assert_called_with(
+        eventstream_insert.assert_called_with(
             group=event.group,
             event=event,
             is_new=False,


### PR DESCRIPTION
Rename `publish` to the actual action, `insert`, and add new actions for
`merge`, `unmerge` and `delete_groups`. With these in place, the
eventstream should be able to accurately represent the current Postgres
`group_id` for a given event.

---

I wasn't sure whether to bump the protocol. It's all net-new actions, the format of the existing messages don't change. I believe our two consumers expect a certain format and only look at `insert` events, so we should be good. But I can bump the protocol if we want.

Left the local development `snuba` method unimplemented for now. We can come back for those once we know what kind of queries actually need to be run on the Clickhouse side.

`rehash_group_events` was unused (called by nothing) and apparently predates the existence of `unmerge`. If we want to keep it I'll need to add more methods to handle the possibility of it being called. It would have to send a message per hash to tell the eventstream what the new group is (for each hash) I think. It got confusing and it's dead code so I just nuked it.

Oh, this also changes the message key to only go by the `project_id`, meaning all of a project's messages will go to a single Kafka topic. This is to prevent scenarios where, for example, a group delete is run almost instantly but there is another backlogged partition that still has events to insert for that group (meaning they will be inserted later and not deleted).