### PR TITLE
fix(docs) Disambiguate endpoint names

### DIFF
--- a/src/sentry/api/endpoints/organization_release_files.py
+++ b/src/sentry/api/endpoints/organization_release_files.py
@@ -58,8 +58,8 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint):
 
     def post(self, request, organization, version):
         """
-        Upload a New File
-        `````````````````
+        Upload a New Organization Release File
+        ``````````````````````````````````````
 
         Upload a new file for the given release.
 

--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -92,8 +92,8 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint):
     @attach_scenarios([upload_file_scenario])
     def post(self, request, project, version):
         """
-        Upload a New File
-        `````````````````
+        Upload a New Project Release File
+        `````````````````````````````````
 
         Upload a new file for the given release.
 


### PR DESCRIPTION
These endpoints had the same name in the generated API docs. While they do effectively the same thing having separate titles makes navigation in the docs easier and makes us look less derpy.