### PR TITLE
fix(settings): Handle no organization

### DIFF
--- a/src/sentry/static/sentry/app/components/loadingIndicator.jsx
+++ b/src/sentry/static/sentry/app/components/loadingIndicator.jsx
@@ -15,6 +15,7 @@ function LoadingIndicator(props) {
     style,
     relative,
     size,
+    hideSpinner,
   } = props;
   let cx = classNames(className, {
     overlay,
@@ -40,9 +41,11 @@ function LoadingIndicator(props) {
 
   return (
     <div className={cx} style={style}>
-      <div className={loadingCx} style={loadingStyle}>
-        {finished ? <div className="checkmark draw" /> : null}
-      </div>
+      {!hideSpinner && (
+        <div className={loadingCx} style={loadingStyle}>
+          {finished ? <div className="checkmark draw" /> : null}
+        </div>
+      )}
 
       {!hideMessage && <div className="loading-message">{children}</div>}
     </div>
@@ -58,6 +61,7 @@ LoadingIndicator.propTypes = {
   relative: PropTypes.bool,
   hideMessage: PropTypes.bool,
   size: PropTypes.number,
+  hideSpinner: PropTypes.bool,
 };
 
 export default LoadingIndicator;

--- a/src/sentry/static/sentry/app/views/settings/settingsIndex.jsx
+++ b/src/sentry/static/sentry/app/views/settings/settingsIndex.jsx
@@ -99,7 +99,7 @@ class SettingsIndex extends React.Component {
             <Box w={1 / 3} px={2}>
               {/* if admin */}
               <Panel>
-                {!organization && <LoadingIndicator overlay />}
+                {!organization && <LoadingIndicator overlay hideSpinner />}
                 <HomePanelHeader>
                   <HomeLinkIcon to={organizationSettingsUrl}>
                     {organization ? (
@@ -112,7 +112,7 @@ class SettingsIndex extends React.Component {
                       </HomeIcon>
                     )}
                     <OrganizationName css={{lineHeight: '1.1em'}}>
-                      {organization ? organization.slug : t('Organization')}
+                      {organization ? organization.slug : t('No Organization')}
                     </OrganizationName>
                   </HomeLinkIcon>
                 </HomePanelHeader>


### PR DESCRIPTION
Handle users having no organization on the settings page, esp. during the require 2FA flow. Otherwise the loading indicator goes continuously.

<img width="778" alt="screen shot 2018-09-26 at 12 31 54 pm" src="https://user-images.githubusercontent.com/16394317/46104856-4e1cf100-c189-11e8-86f3-584f58e45595.png">
