### PR TITLE
fix(options): Also ignore OperationalError

### DIFF
--- a/src/sentry/options/store.py
+++ b/src/sentry/options/store.py
@@ -14,7 +14,7 @@ from collections import namedtuple
 from time import time
 from random import random
 
-from django.db.utils import ProgrammingError
+from django.db.utils import ProgrammingError, OperationalError
 from django.utils import timezone
 from django.utils.functional import cached_property
 from sentry.db.models.query import create_or_update
@@ -164,7 +164,7 @@ class OptionsStore(object):
         """
         try:
             value = self.model.objects.get(key=key.name).value
-        except (self.model.DoesNotExist, ProgrammingError):
+        except (self.model.DoesNotExist, ProgrammingError, OperationalError):
             value = None
         except Exception:
             if not silent:


### PR DESCRIPTION
This also will spam when the database doesn't exist yet, or if the
database is down, this is the least of our concerns to yell. But happens
all the time during process startups and during commands that attempt to
create the database, etc.