### PR TITLE
feat(discover): Create set_projects method for saved queries

### DIFF
--- a/src/sentry/api/endpoints/organization_discover_saved_queries.py
+++ b/src/sentry/api/endpoints/organization_discover_saved_queries.py
@@ -110,6 +110,6 @@ class OrganizationDiscoverSavedQueriesEndpoint(OrganizationEndpoint):
             query=data['query'],
         )
 
-        model.add_projects(data['project_ids'])
+        model.set_projects(data['project_ids'])
 
         return Response(serialize(model), status=201)

--- a/src/sentry/models/discoversavedquery.py
+++ b/src/sentry/models/discoversavedquery.py
@@ -37,11 +37,21 @@ class DiscoverSavedQuery(Model):
 
     __repr__ = sane_repr('organization_id', 'name')
 
-    def add_projects(self, project_ids):
+    def set_projects(self, project_ids):
+        DiscoverSavedQueryProject.objects.filter(
+            discover_saved_query=self,
+        ).exclude(project__in=project_ids).delete()
+
+        existing_project_ids = DiscoverSavedQueryProject.objects.filter(
+            discover_saved_query=self,
+        ).values('project')
+
+        new_project_ids = list(set(project_ids) - set(existing_project_ids))
+
         DiscoverSavedQueryProject.objects.bulk_create(
             [
                 DiscoverSavedQueryProject(
                     project_id=project_id, discover_saved_query=self)
-                for project_id in project_ids
+                for project_id in new_project_ids
             ]
         )

--- a/src/sentry/models/discoversavedquery.py
+++ b/src/sentry/models/discoversavedquery.py
@@ -45,7 +45,7 @@ class DiscoverSavedQuery(Model):
 
             existing_project_ids = DiscoverSavedQueryProject.objects.filter(
                 discover_saved_query=self,
-            ).values('project')
+            ).values_list('project', flat=True)
 
             new_project_ids = list(set(project_ids) - set(existing_project_ids))
 

--- a/src/sentry/models/discoversavedquery.py
+++ b/src/sentry/models/discoversavedquery.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from django.db import models
+from django.db import models, transaction
 from jsonfield import JSONField
 from sentry.db.models import (
     Model, FlexibleForeignKey, sane_repr
@@ -38,20 +38,21 @@ class DiscoverSavedQuery(Model):
     __repr__ = sane_repr('organization_id', 'name')
 
     def set_projects(self, project_ids):
-        DiscoverSavedQueryProject.objects.filter(
-            discover_saved_query=self,
-        ).exclude(project__in=project_ids).delete()
+        with transaction.atomic():
+            DiscoverSavedQueryProject.objects.filter(
+                discover_saved_query=self,
+            ).exclude(project__in=project_ids).delete()
 
-        existing_project_ids = DiscoverSavedQueryProject.objects.filter(
-            discover_saved_query=self,
-        ).values('project')
+            existing_project_ids = DiscoverSavedQueryProject.objects.filter(
+                discover_saved_query=self,
+            ).values('project')
 
-        new_project_ids = list(set(project_ids) - set(existing_project_ids))
+            new_project_ids = list(set(project_ids) - set(existing_project_ids))
 
-        DiscoverSavedQueryProject.objects.bulk_create(
-            [
-                DiscoverSavedQueryProject(
-                    project_id=project_id, discover_saved_query=self)
-                for project_id in new_project_ids
-            ]
-        )
+            DiscoverSavedQueryProject.objects.bulk_create(
+                [
+                    DiscoverSavedQueryProject(
+                        project_id=project_id, discover_saved_query=self)
+                    for project_id in new_project_ids
+                ]
+            )

--- a/tests/sentry/models/test_discoversavedquery.py
+++ b/tests/sentry/models/test_discoversavedquery.py
@@ -5,23 +5,49 @@ from sentry.models import DiscoverSavedQuery, DiscoverSavedQueryProject
 
 
 class DiscoverSavedQueryTest(TestCase):
-    def test_create(self):
-        org = self.create_organization()
-        project_ids = [
-            self.create_project(organization=org).id,
-            self.create_project(organization=org).id
+    def setUp(self):
+        super(DiscoverSavedQueryTest, self).setUp()
+        self.org = self.create_organization()
+        self.project_ids = [
+            self.create_project(organization=self.org).id,
+            self.create_project(organization=self.org).id
         ]
-        query = {
+        self.query = {
             'fields': ['test'],
             'conditions': [],
             'limit': 10
         }
 
-        model = DiscoverSavedQuery.objects.create(organization=org, name="Test query", query=query)
+    def test_create(self):
+        model = DiscoverSavedQuery.objects.create(
+            organization=self.org,
+            name="Test query",
+            query=self.query
+        )
 
-        model.add_projects(project_ids)
+        model.set_projects(self.project_ids)
 
-        assert DiscoverSavedQuery.objects.get(id=model.id).query == query
+        assert DiscoverSavedQuery.objects.get(id=model.id).query == self.query
         assert sorted(
             DiscoverSavedQueryProject.objects.all().values_list('project_id', flat=True)
-        ) == project_ids
+        ) == self.project_ids
+
+    def test_update_projects(self):
+        model = DiscoverSavedQuery.objects.create(
+            organization=self.org,
+            name="Test query",
+            query=self.query
+        )
+
+        model.set_projects(self.project_ids)
+
+        model.set_projects([])
+
+        assert sorted(
+            DiscoverSavedQueryProject.objects.all().values_list('project_id', flat=True)
+        ) == []
+
+        model.set_projects([self.project_ids[0]])
+        assert sorted(
+            DiscoverSavedQueryProject.objects.all().values_list('project_id', flat=True)
+        ) == [self.project_ids[0]]

--- a/tests/snuba/test_organization_discover_saved_queries.py
+++ b/tests/snuba/test_organization_discover_saved_queries.py
@@ -25,7 +25,7 @@ class OrganizationDiscoverSavedQueriesTest(APITestCase, SnubaTestCase):
         model = DiscoverSavedQuery.objects.create(
             organization=self.org, name="Test query", query=query)
 
-        model.add_projects(self.project_ids)
+        model.set_projects(self.project_ids)
 
     def test_get(self):
         with self.feature('organizations:discover'):

--- a/tests/snuba/test_organization_discover_saved_query_detail.py
+++ b/tests/snuba/test_organization_discover_saved_query_detail.py
@@ -27,7 +27,7 @@ class OrganizationDiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
         model = DiscoverSavedQuery.objects.create(
             organization=self.org, name="Test query", query=query)
 
-        model.add_projects(self.project_ids)
+        model.set_projects(self.project_ids)
 
         self.query_id = model.id
 


### PR DESCRIPTION
We'll need set_projects instead of add_projects in order to handle put
requests