### PR TITLE
feat(ui): Throttle Broadcasts on lost visibility

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/broadcasts.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/broadcasts.jsx
@@ -12,7 +12,7 @@ import SidebarPanelEmpty from 'app/components/sidebar/sidebarPanelEmpty';
 import SidebarPanelItem from 'app/components/sidebar/sidebarPanelItem';
 
 const MARK_SEEN_DELAY = 1000;
-const POLLER_DELAY = 60000;
+const POLLER_DELAY = 600000; // 10 minute poll (60 * 10 * 1000)
 
 const Broadcasts = createReactClass({
   displayName: 'Broadcasts',


### PR DESCRIPTION
Do not poll for broadcasts when sentry loses visiblity (e.g. tab change or browser minimized)