### PR TITLE
fix(search) Handle invalid numeric values in query

### DIFF
--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -234,16 +234,20 @@ numeric_modifiers = [
 
 
 def get_numeric_field_value(field, raw_value, type=int):
-    for modifier, function in numeric_modifiers:
-        if raw_value.startswith(modifier):
-            return function(
-                field,
-                type(raw_value[len(modifier):]),
-            )
-    else:
-        return {
-            field: type(raw_value),
-        }
+    try:
+        for modifier, function in numeric_modifiers:
+            if raw_value.startswith(modifier):
+                return function(
+                    field,
+                    type(raw_value[len(modifier):]),
+                )
+        else:
+            return {
+                field: type(raw_value),
+            }
+    except ValueError:
+        msg = u'"{}" could not be converted to a number.'.format(raw_value)
+        raise InvalidQuery(msg)
 
 
 def tokenize_query(query):

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -8,7 +8,11 @@ from django.utils import timezone
 from sentry.models import EventUser, GroupStatus, Team, User
 from sentry.testutils import TestCase
 from sentry.search.base import ANY
-from sentry.search.utils import parse_query, get_numeric_field_value
+from sentry.search.utils import (
+    parse_query,
+    get_numeric_field_value,
+    InvalidQuery
+)
 
 
 def test_get_numeric_field_value():
@@ -49,6 +53,11 @@ def test_get_numeric_field_value():
         'foo_upper': -3.5,
         'foo_upper_inclusive': True,
     }
+
+
+def test_get_numeric_field_value_invalid():
+    with pytest.raises(InvalidQuery):
+        get_numeric_field_value('foo', '>=1k')
 
 
 class ParseQueryTest(TestCase):


### PR DESCRIPTION
Numeric fields should not raise 500 errors when non-numeric values are provided.

Fixes SENTRY-6J2
Fixes APP-537