### PR TITLE
fix: Correct behavior of post-processing lock for Redis Cluster

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -66,7 +66,7 @@ def check_event_already_post_processed(event):
         nx=True,
     )
 
-    return not result.value
+    return not result
 
 
 @instrumented_task(name='sentry.tasks.post_process.post_process_group')


### PR DESCRIPTION
We're no longer using RB for this so don't need to unwrap the result value.

Fixes SENTRY-7SP.