### PR TITLE
fix(integrations): Fix github install flow to use pipeline when exists

### DIFF
--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -35,7 +35,8 @@ class PipelineAdvancerView(BaseView):
             if pipeline:
                 break
 
-        if provider_id in FORWARD_INSTALL_FOR and request.GET.get('setup_action') == 'install':
+        if provider_id in FORWARD_INSTALL_FOR and request.GET.get(
+                'setup_action') == 'install' and pipeline is None:
             installation_id = request.GET.get('installation_id')
             return self.redirect(reverse('integration-installation', args=[installation_id]))
 


### PR DESCRIPTION
Everyone was being forced to pick an org even when they started the flow from Sentry. This fixes by only redirecting to org selector if we don't have a pipeline.