### PR TITLE
fix: Fix bug in combined time range selector

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/combinedSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/combinedSelector.jsx
@@ -49,16 +49,20 @@ export default class CombinedSelector extends React.Component {
       relative,
     };
 
-    if (prop === 'relative' && val === 'custom') {
-      // Convert previous relative range to absolute values
-      const statsPeriod = parseStatsPeriod(relative);
-      onChange({
-        relative: null,
-        start: statsPeriod.start,
-        end: statsPeriod.end,
-      });
+    if (prop === 'relative') {
+      if (val === 'custom') {
+        // Convert previous relative range to absolute values
+        const statsPeriod = parseStatsPeriod(relative);
+        onChange({
+          relative: null,
+          start: statsPeriod.start,
+          end: statsPeriod.end,
+        });
+      } else {
+        onChange({relative: val, start: null, end: null});
+      }
     } else {
-      onChange({...prev, [prop]: val});
+      onChange({...prev, relative: null, [prop]: val});
     }
   }
 


### PR DESCRIPTION
Fixes a bug in the combined time range selector causing it to be called
with both absolute as well as relative values. This change ensures that
the onChange callback is only called with either a relative value or
start and end times