### PR TITLE
feat: Snuba single-query version of get_keys_and_top_values

### DIFF
--- a/src/sentry/api/endpoints/group_tagkey_details.py
+++ b/src/sentry/api/endpoints/group_tagkey_details.py
@@ -52,23 +52,11 @@ class GroupTagKeyDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             raise ResourceDoesNotExist
 
         if group_tag_key.count is None:
-            total_values = tagstore.get_group_tag_value_count(
+            group_tag_key.count = tagstore.get_group_tag_value_count(
                 group.project_id, group.id, environment_id, lookup_key)
-        else:
-            total_values = group_tag_key.count
 
         if group_tag_key.top_values is None:
-            top_values = tagstore.get_top_group_tag_values(
-                group.project_id, group.id, environment_id, lookup_key, limit=9)
-        else:
-            top_values = group_tag_key.top_values
+            group_tag_key.top_values = tagstore.get_top_group_tag_values(
+                group.project_id, group.id, environment_id, lookup_key)
 
-        data = {
-            'key': key,
-            'name': tagstore.get_tag_key_label(group_tag_key.key),
-            'uniqueValues': group_tag_key.values_seen,
-            'totalValues': total_values,
-            'topValues': serialize(top_values, request.user),
-        }
-
-        return Response(data)
+        return Response(serialize(group_tag_key, request.user))

--- a/src/sentry/api/endpoints/group_tags.py
+++ b/src/sentry/api/endpoints/group_tags.py
@@ -5,18 +5,34 @@ from rest_framework.response import Response
 from sentry import tagstore
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.group import GroupEndpoint
+from sentry.api.serializers import serialize
 from sentry.models import Environment
 
 
 class GroupTagsEndpoint(GroupEndpoint, EnvironmentMixin):
     def get(self, request, group):
+
+        # optional queryparam `key` can be used to get results
+        # only for specific keys.
+        keys = [tagstore.prefix_reserved_key(k)
+                for k in request.GET.getlist('key') if k] or None
+
+        # There are 2 use-cases for this method. For the 'Tags' tab we
+        # get the top 10 values, for the tag distribution bars we get 9
+        # This should ideally just be specified by the client
+        if keys:
+            value_limit = 9
+        else:
+            value_limit = 10
+
         try:
             environment_id = self._get_environment_id_from_request(
                 request, group.project.organization_id)
         except Environment.DoesNotExist:
-            data = []
+            tag_keys = []
         else:
-            data = tagstore.get_group_tag_keys_and_top_values(
-                group.project_id, group.id, environment_id)
+            tag_keys = tagstore.get_group_tag_keys_and_top_values(
+                group.project_id, group.id, environment_id, keys=keys,
+                value_limit=value_limit)
 
-        return Response(data)
+        return Response(serialize(tag_keys, request.user))

--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -78,6 +78,24 @@ const GroupSidebar = createReactClass({
         });
       },
     });
+
+    // Fetch the top values for the current group's top tags.
+    this.api.request(`/issues/${group.id}/tags/`, {
+      query: _.pickBy({
+        key: group.tags.map(data => data.key),
+        environment: this.props.environment && this.props.environment.name
+      }),
+      success: data => {
+        this.setState({
+          tagsWithTopValues: _.keyBy(data, 'key')
+        });
+      },
+      error: () => {
+        this.setState({
+          error: true,
+        });
+      },
+    });
   },
 
   subscriptionReasons: {
@@ -241,16 +259,21 @@ const GroupSidebar = createReactClass({
         <h6>
           <span>{t('Tags')}</span>
         </h6>
-        {group.tags.map(data => {
+        {this.state.tagsWithTopValues && group.tags.map(tag => {
+          let tagWithTopValues = this.state.tagsWithTopValues[tag.key];
+          let topValues = tagWithTopValues ? tagWithTopValues.topValues : [];
+          let topValuesTotal = tagWithTopValues ? tagWithTopValues.totalValues : 0;
           return (
             <TagDistributionMeter
-              key={data.key}
+              key={tag.key}
+              tag={tag.key}
+              totalValues={tag.totalValues || topValuesTotal}
+              topValues={topValues}
+              name={tag.name}
               data-test-id="group-tag"
               orgId={orgId}
               projectId={projectId}
               group={group}
-              name={data.name}
-              tag={data.key}
             />
           );
         })}

--- a/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
+++ b/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
@@ -24,6 +24,8 @@ const TagDistributionMeter = createReactClass({
     orgId: PropTypes.string.isRequired,
     projectId: PropTypes.string.isRequired,
     environment: SentryTypes.Environment,
+    totalValues: PropTypes.number,
+    topValues: PropTypes.array,
   },
 
   mixins: [ApiMixin],
@@ -32,7 +34,6 @@ const TagDistributionMeter = createReactClass({
     return {
       loading: true,
       error: false,
-      data: null,
     };
   },
 
@@ -46,7 +47,9 @@ const TagDistributionMeter = createReactClass({
       this.state.error !== nextState.error ||
       this.props.tag !== nextProps.tag ||
       this.props.name !== nextProps.name ||
-      this.props.environment !== nextProps.environment
+      this.props.environment !== nextProps.environment ||
+      this.props.totalValues !== nextProps.totalValues ||
+      this.props.topValues !== nextProps.topValues
     );
   },
 
@@ -57,24 +60,14 @@ const TagDistributionMeter = createReactClass({
   },
 
   fetchData() {
-    const {group, tag, environment} = this.props;
-    const url = `/issues/${group.id}/tags/${encodeURIComponent(tag)}/`;
-    const query = environment ? {environment: environment.name} : {};
-
     this.setState({
       loading: true,
       error: false,
     });
 
-    Promise.all([
-      this.api.requestPromise(url, {
-        query,
-      }),
-      loadDeviceListModule(),
-    ])
-      .then(([data, iOSDeviceList]) => {
+      loadDeviceListModule()
+      .then(iOSDeviceList => {
         this.setState({
-          data,
           iOSDeviceList,
           error: false,
           loading: false,
@@ -99,19 +92,16 @@ const TagDistributionMeter = createReactClass({
    */
 
   renderSegments() {
-    let data = this.state.data;
-    let totalValues = data.totalValues;
+    let {orgId, projectId, group, totalValues, topValues, tag} = this.props;
 
-    let totalVisible = data.topValues.reduce((sum, value) => sum + value.count, 0);
-
+    let totalVisible = topValues.reduce((sum, value) => sum + value.count, 0);
     let hasOther = totalVisible < totalValues;
     let otherPct = percent(totalValues - totalVisible, totalValues);
     let otherPctLabel = Math.floor(otherPct);
 
-    let {orgId, projectId} = this.props;
     return (
       <div className="segments">
-        {data.topValues.map((value, index) => {
+        {topValues.map((value, index) => {
           const pct = percent(value.count, totalValues);
           const pctLabel = Math.floor(pct);
           const className = 'segment segment-' + index;
@@ -128,8 +118,7 @@ const TagDistributionMeter = createReactClass({
               <Link
                 className={className}
                 style={{width: pct + '%'}}
-                to={`/${orgId}/${projectId}/issues/${this.props.group.id}/tags/${this
-                  .props.tag}/`}
+                to={`/${orgId}/${projectId}/issues/${group.id}/tags/${tag}/`}
               >
                 <span className="tag-description">
                   <span className="tag-percentage">{pctLabel}%</span>
@@ -163,7 +152,7 @@ const TagDistributionMeter = createReactClass({
   renderBody() {
     if (this.state.loading || this.state.error) return null;
 
-    if (!this.state.data.totalValues) return <p>{t('No recent data.')}</p>;
+    if (!this.props.totalValues) return <p>{t('No recent data.')}</p>;
 
     return this.renderSegments();
   },

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -17,6 +17,10 @@ from sentry.utils.services import Service, raises
 # Valid pattern for tag key names
 TAG_KEY_RE = re.compile(r'^[a-zA-Z0-9_\.:-]+$')
 
+# Number of tag values to return by default for any query returning the "top"
+# values for a tag.
+TOP_VALUES_DEFAULT_LIMIT = 9
+
 # These tags are special and are used in pairing with `sentry:{}`
 # they should not be allowed to be set via data ingest due to ambiguity
 INTERNAL_TAG_KEYS = frozenset(
@@ -234,7 +238,7 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def get_group_tag_keys(self, project_id, group_id, environment_id, limit=None):
+    def get_group_tag_keys(self, project_id, group_id, environment_id, limit=None, keys=None):
         """
         >>> get_group_tag_key(1, 2, 3)
         """
@@ -341,7 +345,7 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def get_top_group_tag_values(self, project_id, group_id, environment_id, key, limit=3):
+    def get_top_group_tag_values(self, project_id, group_id, environment_id, key, limit=TOP_VALUES_DEFAULT_LIMIT):
         """
         >>> get_top_group_tag_values(1, 2, 3, 'key1')
         """
@@ -396,16 +400,14 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def get_group_tag_keys_and_top_values(self, project_id, group_id, environment_id, user=None):
-        from sentry.api.serializers import serialize
+    def get_group_tag_keys_and_top_values(self, project_id, group_id, environment_id, keys=None, value_limit=TOP_VALUES_DEFAULT_LIMIT):
 
-        tag_keys = self.get_group_tag_keys(project_id, group_id, environment_id)
+        # If keys is unspecified, we will grab all tag keys for this group.
+        tag_keys = self.get_group_tag_keys(project_id, group_id, environment_id, keys=keys)
 
-        return [dict(
-            totalValues=(self.get_group_tag_value_count(
-                project_id, group_id, environment_id, tk.key)
-                if tk.count is None else tk.count),
-            topValues=serialize(self.get_top_group_tag_values(
-                project_id, group_id, environment_id, tk.key, limit=10)),
-            **serialize([tk])[0]
-        ) for tk in tag_keys]
+        for tk in tag_keys:
+            tk.top_values = self.get_top_group_tag_values(project_id, group_id, environment_id, tk.key, limit=value_limit)
+            if tk.count is None:
+                tk.count = self.get_group_tag_value_count(project_id, group_id, environment_id, tk.key)
+
+        return tag_keys

--- a/src/sentry/tagstore/v2/models/grouptagkey.py
+++ b/src/sentry/tagstore/v2/models/grouptagkey.py
@@ -7,11 +7,8 @@ sentry.tagstore.v2.models.grouptagkey
 """
 from __future__ import absolute_import
 
-import six
-
 from django.db import router, transaction, DataError, connections
 
-from sentry.api.serializers import Serializer, register
 from sentry.db.models import (
     Model, BoundedPositiveIntegerField, BoundedBigIntegerField, FlexibleForeignKey, sane_repr
 )
@@ -94,27 +91,3 @@ class GroupTagKey(Model):
         except DataError:
             # it's possible to hit an out of range value for counters
             pass
-
-
-@register(GroupTagKey)
-class GroupTagKeySerializer(Serializer):
-    def get_attrs(self, item_list, user):
-        from sentry import tagstore
-
-        result = {}
-        for item in item_list:
-            key = tagstore.get_standardized_key(item.key)
-            result[item] = {
-                'name': tagstore.get_tag_key_label(item.key),
-                'key': key,
-            }
-
-        return result
-
-    def serialize(self, obj, attrs, user):
-        return {
-            'id': six.text_type(obj.id),
-            'name': attrs['name'],
-            'key': attrs['key'],
-            'uniqueValues': obj.values_seen,
-        }

--- a/src/sentry/tagstore/v2/models/tagkey.py
+++ b/src/sentry/tagstore/v2/models/tagkey.py
@@ -8,12 +8,9 @@ sentry.tagstore.v2.models.tagkey
 
 from __future__ import absolute_import, print_function
 
-import six
-
 from django.db import models, router, connections, transaction, IntegrityError
 from django.utils.translation import ugettext_lazy as _
 
-from sentry.api.serializers import Serializer, register
 from sentry.tagstore import TagKeyStatus
 from sentry.tagstore.query import TagStoreManager
 from sentry.constants import MAX_TAG_KEY_LENGTH
@@ -172,16 +169,3 @@ class TagKey(Model):
             key_to_model[key] = cls.get_or_create(project_id, environment_id, key)[0]
 
         return key_to_model
-
-
-@register(TagKey)
-class TagKeySerializer(Serializer):
-    def serialize(self, obj, attrs, user):
-        from sentry import tagstore
-
-        return {
-            'id': six.text_type(obj.id),
-            'key': tagstore.get_standardized_key(obj.key),
-            'name': tagstore.get_tag_key_label(obj.key),
-            'uniqueValues': obj.values_seen,
-        }

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -61,7 +61,7 @@ _snuba_pool = urllib3.connectionpool.connection_from_url(
 def raw_query(start, end, groupby=None, conditions=None, filter_keys=None,
               aggregations=None, rollup=None, arrayjoin=None, limit=None, offset=None,
               orderby=None, having=None, referrer=None, is_grouprelease=False,
-              selected_columns=None, totals=None):
+              selected_columns=None, totals=None, limitby=None):
     """
     Sends a query to snuba.
 
@@ -159,6 +159,7 @@ def raw_query(start, end, groupby=None, conditions=None, filter_keys=None,
         'arrayjoin': arrayjoin,
         'limit': limit,
         'offset': offset,
+        'limitby': limitby,
         'orderby': orderby,
         'selected_columns': selected_columns,
     }) if v is not None}
@@ -193,7 +194,7 @@ def raw_query(start, end, groupby=None, conditions=None, filter_keys=None,
 def query(start, end, groupby, conditions=None, filter_keys=None,
           aggregations=None, rollup=None, arrayjoin=None, limit=None, offset=None,
           orderby=None, having=None, referrer=None, is_grouprelease=False,
-          selected_columns=None, totals=None):
+          selected_columns=None, totals=None, limitby=None):
 
     aggregations = aggregations or [['count()', '', 'aggregate']]
     filter_keys = filter_keys or {}
@@ -204,7 +205,7 @@ def query(start, end, groupby, conditions=None, filter_keys=None,
             start, end, groupby=groupby, conditions=conditions, filter_keys=filter_keys,
             selected_columns=selected_columns, aggregations=aggregations, rollup=rollup,
             arrayjoin=arrayjoin, limit=limit, offset=offset, orderby=orderby, having=having,
-            referrer=referrer, is_grouprelease=is_grouprelease, totals=totals
+            referrer=referrer, is_grouprelease=is_grouprelease, totals=totals, limitby=limitby
         )
     except (QueryOutsideRetentionError, QueryOutsideGroupActivityError):
         return OrderedDict()

--- a/tests/js/fixtures/tags.js
+++ b/tests/js/fixtures/tags.js
@@ -1,9 +1,9 @@
 export function Tags(params = {}) {
   return [
-    {key: 'browser', name: 'Browser', canDelete: true},
-    {key: 'device', name: 'Device', canDelete: true},
-    {key: 'url', name: 'URL', canDelete: true},
-    {key: 'environment', name: 'Environment', canDelete: false},
+    {key: 'browser', name: 'Browser', canDelete: true, totalValues: 30},
+    {key: 'device', name: 'Device', canDelete: true, totalValues: 5},
+    {key: 'url', name: 'URL', canDelete: true, totalValues: 7},
+    {key: 'environment', name: 'Environment', canDelete: false, totalValues: 100},
     ...params,
   ];
 }

--- a/tests/js/fixtures/tagvalues.js
+++ b/tests/js/fixtures/tagvalues.js
@@ -1,0 +1,20 @@
+export function TagValues(params = {}) {
+  return [
+    {key: 'browser', name: 'Browser', 'topValues': [
+        {value: 'Chrome', count: 10},
+        {value: 'Firefox', count: 5},
+    ]},
+    {key: 'device', name: 'Device', 'topValues': [
+        {value: 'iPhone', count: 1},
+        {value: 'Pixel', count: 2},
+    ]},
+    {key: 'url', name: 'URL', 'topValues': [
+        {value: 'foo.com', count: 2},
+        {value: 'bar.com', count: 5},
+    ]},
+    {key: 'environment', name: 'Environment', 'topValues': [
+        {value: 'prod', count: 100},
+    ]},
+    ...params,
+  ];
+}

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -187,6 +187,5 @@ window.TestStubs = {
   AllAuthenticators: () => {
     return Object.values(fixtures.Authenticators()).map(x => x());
   },
-
   ...fixtures,
 };

--- a/tests/js/spec/components/group/__snapshots__/sidebar.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/sidebar.spec.jsx.snap
@@ -50,21 +50,25 @@ exports[`GroupSidebar renders with tags renders 1`] = `
             "canDelete": true,
             "key": "browser",
             "name": "Browser",
+            "totalValues": 30,
           },
           Object {
             "canDelete": true,
             "key": "device",
             "name": "Device",
+            "totalValues": 5,
           },
           Object {
             "canDelete": true,
             "key": "url",
             "name": "URL",
+            "totalValues": 7,
           },
           Object {
             "canDelete": false,
             "key": "environment",
             "name": "Environment",
+            "totalValues": 100,
           },
         ],
       }
@@ -104,21 +108,25 @@ exports[`GroupSidebar renders with tags renders 1`] = `
             "canDelete": true,
             "key": "browser",
             "name": "Browser",
+            "totalValues": 30,
           },
           Object {
             "canDelete": true,
             "key": "device",
             "name": "Device",
+            "totalValues": 5,
           },
           Object {
             "canDelete": true,
             "key": "url",
             "name": "URL",
+            "totalValues": 7,
           },
           Object {
             "canDelete": false,
             "key": "environment",
             "name": "Environment",
+            "totalValues": 100,
           },
         ],
       }
@@ -167,21 +175,25 @@ exports[`GroupSidebar renders with tags renders 1`] = `
               "canDelete": true,
               "key": "browser",
               "name": "Browser",
+              "totalValues": 30,
             },
             Object {
               "canDelete": true,
               "key": "device",
               "name": "Device",
+              "totalValues": 5,
             },
             Object {
               "canDelete": true,
               "key": "url",
               "name": "URL",
+              "totalValues": 7,
             },
             Object {
               "canDelete": false,
               "key": "environment",
               "name": "Environment",
+              "totalValues": 100,
             },
           ],
         }
@@ -231,21 +243,25 @@ exports[`GroupSidebar renders with tags renders 1`] = `
             "canDelete": true,
             "key": "browser",
             "name": "Browser",
+            "totalValues": 30,
           },
           Object {
             "canDelete": true,
             "key": "device",
             "name": "Device",
+            "totalValues": 5,
           },
           Object {
             "canDelete": true,
             "key": "url",
             "name": "URL",
+            "totalValues": 7,
           },
           Object {
             "canDelete": false,
             "key": "environment",
             "name": "Environment",
+            "totalValues": 100,
           },
         ],
       }
@@ -255,6 +271,19 @@ exports[`GroupSidebar renders with tags renders 1`] = `
     orgId="org-slug"
     projectId="project-slug"
     tag="browser"
+    topValues={
+      Array [
+        Object {
+          "count": 10,
+          "value": "Chrome",
+        },
+        Object {
+          "count": 5,
+          "value": "Firefox",
+        },
+      ]
+    }
+    totalValues={30}
   />
   <withEnvironment(TagDistributionMeter)
     data-test-id="group-tag"
@@ -293,21 +322,25 @@ exports[`GroupSidebar renders with tags renders 1`] = `
             "canDelete": true,
             "key": "browser",
             "name": "Browser",
+            "totalValues": 30,
           },
           Object {
             "canDelete": true,
             "key": "device",
             "name": "Device",
+            "totalValues": 5,
           },
           Object {
             "canDelete": true,
             "key": "url",
             "name": "URL",
+            "totalValues": 7,
           },
           Object {
             "canDelete": false,
             "key": "environment",
             "name": "Environment",
+            "totalValues": 100,
           },
         ],
       }
@@ -317,6 +350,19 @@ exports[`GroupSidebar renders with tags renders 1`] = `
     orgId="org-slug"
     projectId="project-slug"
     tag="device"
+    topValues={
+      Array [
+        Object {
+          "count": 1,
+          "value": "iPhone",
+        },
+        Object {
+          "count": 2,
+          "value": "Pixel",
+        },
+      ]
+    }
+    totalValues={5}
   />
   <withEnvironment(TagDistributionMeter)
     data-test-id="group-tag"
@@ -355,21 +401,25 @@ exports[`GroupSidebar renders with tags renders 1`] = `
             "canDelete": true,
             "key": "browser",
             "name": "Browser",
+            "totalValues": 30,
           },
           Object {
             "canDelete": true,
             "key": "device",
             "name": "Device",
+            "totalValues": 5,
           },
           Object {
             "canDelete": true,
             "key": "url",
             "name": "URL",
+            "totalValues": 7,
           },
           Object {
             "canDelete": false,
             "key": "environment",
             "name": "Environment",
+            "totalValues": 100,
           },
         ],
       }
@@ -379,6 +429,19 @@ exports[`GroupSidebar renders with tags renders 1`] = `
     orgId="org-slug"
     projectId="project-slug"
     tag="url"
+    topValues={
+      Array [
+        Object {
+          "count": 2,
+          "value": "foo.com",
+        },
+        Object {
+          "count": 5,
+          "value": "bar.com",
+        },
+      ]
+    }
+    totalValues={7}
   />
   <withEnvironment(TagDistributionMeter)
     data-test-id="group-tag"
@@ -417,21 +480,25 @@ exports[`GroupSidebar renders with tags renders 1`] = `
             "canDelete": true,
             "key": "browser",
             "name": "Browser",
+            "totalValues": 30,
           },
           Object {
             "canDelete": true,
             "key": "device",
             "name": "Device",
+            "totalValues": 5,
           },
           Object {
             "canDelete": true,
             "key": "url",
             "name": "URL",
+            "totalValues": 7,
           },
           Object {
             "canDelete": false,
             "key": "environment",
             "name": "Environment",
+            "totalValues": 100,
           },
         ],
       }
@@ -441,6 +508,15 @@ exports[`GroupSidebar renders with tags renders 1`] = `
     orgId="org-slug"
     projectId="project-slug"
     tag="environment"
+    topValues={
+      Array [
+        Object {
+          "count": 100,
+          "value": "prod",
+        },
+      ]
+    }
+    totalValues={100}
   />
   <h6>
     <span>

--- a/tests/js/spec/components/group/sidebar.spec.jsx
+++ b/tests/js/spec/components/group/sidebar.spec.jsx
@@ -7,6 +7,7 @@ describe('GroupSidebar', function() {
   let group = TestStubs.Group({tags: TestStubs.Tags()});
   let environment = {name: 'production', displayName: 'Production', id: '1'};
   let wrapper;
+  let tagValuesMock;
 
   beforeEach(function() {
     MockApiClient.addMockResponse({
@@ -19,6 +20,11 @@ describe('GroupSidebar', function() {
       body: group,
     });
 
+    tagValuesMock = MockApiClient.addMockResponse({
+      url: '/issues/1/tags/',
+      body: TestStubs.TagValues(),
+    });
+
     wrapper = shallow(
       <GroupSidebar group={group} event={TestStubs.Event()} environment={environment} />,
       TestStubs.routerContext()
@@ -27,6 +33,12 @@ describe('GroupSidebar', function() {
 
   afterEach(function() {
     MockApiClient.clearMockResponses();
+  });
+
+  describe('sidebar', function() {
+    it('should make a request to the /tags/ endpoint to get top values', function() {
+      expect(tagValuesMock).toHaveBeenCalled();
+    });
   });
 
   describe('renders with tags', function() {
@@ -47,6 +59,11 @@ describe('GroupSidebar', function() {
         url: '/issues/1/',
         body: group,
       });
+      MockApiClient.addMockResponse({
+        url: '/issues/1/tags/',
+        body: [],
+      });
+
       wrapper = shallow(
         <GroupSidebar
           group={group}

--- a/tests/js/spec/components/group/tagDistributionMeter.spec.jsx
+++ b/tests/js/spec/components/group/tagDistributionMeter.spec.jsx
@@ -8,39 +8,38 @@ import {TagDistributionMeter} from 'app/components/group/tagDistributionMeter';
 
 describe('TagDistributionMeter', function() {
   let sandbox;
-  let stubbedApiRequest;
   let element;
+  let emptyElement;
 
   beforeEach(function() {
     sandbox = sinon.sandbox.create();
 
-    stubbedApiRequest = sandbox.stub(Client.prototype, 'request');
-
     element = TestUtils.renderIntoDocument(
       <TagDistributionMeter
+        key="element"
         tag="browser"
         group={{id: '1337'}}
         orgId="123"
         projectId="456"
+        totalValues={TestStubs.Tags()[0].totalValues}
+        topValues={TestStubs.TagValues()[0].topValues}
+      />
+    );
+
+    emptyElement = TestUtils.renderIntoDocument(
+      <TagDistributionMeter
+        key="emptyElement"
+        tag="browser"
+        group={{id: '1337'}}
+        orgId="123"
+        projectId="456"
+        totalValues={0}
       />
     );
   });
 
   afterEach(function() {
     sandbox.restore();
-  });
-
-  describe('fetchData()', function() {
-    it('should make a request to the groups/tags endpoint', function() {
-      // NOTE: creation of OrganizationTeams causes a bunch of API requests to fire ...
-      //       reset the request stub so that we can get an accurate count
-      stubbedApiRequest.reset();
-
-      element.fetchData();
-
-      expect(stubbedApiRequest.callCount).toEqual(1);
-      expect(stubbedApiRequest.getCall(0).args[0]).toEqual('/issues/1337/tags/browser/');
-    });
   });
 
   describe('renderBody()', function() {
@@ -71,16 +70,13 @@ describe('TagDistributionMeter', function() {
     });
 
     it('should return "no recent data" if no total values present', function(done) {
-      element.setState(
+      emptyElement.setState(
         {
           error: false,
           loading: false,
-          data: {
-            totalValues: 0,
-          },
         },
         () => {
-          let out = element.renderBody();
+          let out = emptyElement.renderBody();
           expect(ReactDOMServer.renderToStaticMarkup(out)).toEqual(
             '<p>No recent data.</p>'
           );
@@ -96,9 +92,6 @@ describe('TagDistributionMeter', function() {
         {
           error: false,
           loading: false,
-          data: {
-            totalValues: 100,
-          },
         },
         () => {
           element.renderBody();

--- a/tests/js/spec/components/group/tagDistributionMeter.spec.jsx
+++ b/tests/js/spec/components/group/tagDistributionMeter.spec.jsx
@@ -3,7 +3,6 @@ import ReactDOMServer from 'react-dom/server';
 
 import TestUtils from 'react-dom/test-utils';
 
-import {Client} from 'app/api';
 import {TagDistributionMeter} from 'app/components/group/tagDistributionMeter';
 
 describe('TagDistributionMeter', function() {

--- a/tests/sentry/api/endpoints/test_group_tags.py
+++ b/tests/sentry/api/endpoints/test_group_tags.py
@@ -64,6 +64,21 @@ class GroupTagsTest(APITestCase):
         assert data[2]['key'] == 'release'  # Formatted from sentry:release
         assert len(data[2]['topValues']) == 1
 
+        # Use the key= queryparam to grab results for specific tags
+        url = u'/api/0/issues/{}/tags/?key=foo&key=sentry:release'.format(this_group.id)
+        response = self.client.get(url, format='json')
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 2
+
+        data = sorted(response.data, key=lambda r: r['key'])
+
+        assert data[0]['key'] == 'foo'
+        assert len(data[0]['topValues']) == 2
+        assert set(v['value'] for v in data[0]['topValues']) == set(['bar', 'quux'])
+
+        assert data[1]['key'] == 'release'
+        assert len(data[1]['topValues']) == 1
+
     def test_invalid_env(self):
         this_group = self.create_group()
         self.login_as(user=self.user)

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -85,28 +85,47 @@ class TagStorageTest(SnubaTestCase):
         assert requests.post(settings.SENTRY_SNUBA + '/tests/insert', data=data).status_code == 200
 
     def test_get_group_tag_keys_and_top_values(self):
-        # TODO: `release` should be `sentry:release`
         result = self.ts.get_group_tag_keys_and_top_values(
             self.proj1.id,
             self.proj1group1.id,
             self.proj1env1.id,
         )
-        tags = [r['key'] for r in result]
-        assert set(tags) == set(['foo', 'baz', 'environment', 'release', 'user'])
+        tags = [r.key for r in result]
+        assert set(tags) == set(['foo', 'baz', 'environment', 'sentry:release', 'sentry:user'])
 
-        result.sort(key=lambda r: r['key'])
-        assert result[0]['key'] == 'baz'
-        assert result[0]['uniqueValues'] == 1
-        assert result[0]['totalValues'] == 2
-        assert result[0]['topValues'][0]['value'] == 'quux'
+        result.sort(key=lambda r: r.key)
+        assert result[0].key == 'baz'
+        assert result[0].top_values[0].value == 'quux'
+        # assert result[0].values_seen == 1
+        # assert result[0].count == 2
 
-        assert result[3]['key'] == 'release'
-        assert result[3]['uniqueValues'] == 2
-        assert result[3]['totalValues'] == 2
-        top_release_values = result[3]['topValues']
+        assert result[3].key == 'sentry:release'
+        # assert result[3].values_seen == 2
+        # assert result[3].count == 2
+        top_release_values = result[3].top_values
         assert len(top_release_values) == 2
-        assert set(v['value'] for v in top_release_values) == set(['100', '200'])
-        assert all(v['count'] == 1 for v in top_release_values)
+        assert set(v.value for v in top_release_values) == set(['100', '200'])
+        assert all(v.times_seen == 1 for v in top_release_values)
+
+        # Now with only a specific set of keys,
+        result = self.ts.get_group_tag_keys_and_top_values(
+            self.proj1.id,
+            self.proj1group1.id,
+            self.proj1env1.id,
+            keys=['environment', 'sentry:release'],
+        )
+        tags = [r.key for r in result]
+        assert set(tags) == set(['environment', 'sentry:release'])
+
+        result.sort(key=lambda r: r.key)
+        assert result[0].key == 'environment'
+        assert result[0].top_values[0].value == 'test'
+
+        assert result[1].key == 'sentry:release'
+        top_release_values = result[1].top_values
+        assert len(top_release_values) == 2
+        assert set(v.value for v in top_release_values) == set(['100', '200'])
+        assert all(v.times_seen == 1 for v in top_release_values)
 
     def test_get_top_group_tag_values(self):
         resp = self.ts.get_top_group_tag_values(


### PR DESCRIPTION
Snuba tagstore now implements this as an actual query instead
of the superclass iterating over each key and making 2 queries for each.

This should allow the entire tag distribution sidebar to be rendered
with 1 API call.

One limitation is that we would have to do a second query to get the
count and values_seen, which may or may not be worth it as the client
should already know what these values are for the keys it is querying.