### PR TITLE
ref(ui): Query tagstore once for all tag-distribution bars

### DIFF
--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -78,6 +78,24 @@ const GroupSidebar = createReactClass({
         });
       },
     });
+
+    // Fetch the top values for the current group's top tags.
+    this.api.request(`/issues/${group.id}/tags/`, {
+      query: _.pickBy({
+        key: group.tags.map(data => data.key),
+        environment: this.props.environment && this.props.environment.name
+      }),
+      success: data => {
+        this.setState({
+          tagsWithTopValues: _.keyBy(data, 'key')
+        });
+      },
+      error: () => {
+        this.setState({
+          error: true,
+        });
+      },
+    });
   },
 
   subscriptionReasons: {
@@ -241,16 +259,21 @@ const GroupSidebar = createReactClass({
         <h6>
           <span>{t('Tags')}</span>
         </h6>
-        {group.tags.map(data => {
+        {this.state.tagsWithTopValues && group.tags.map(tag => {
+          let tagWithTopValues = this.state.tagsWithTopValues[tag.key]
+          let topValues = tagWithTopValues ? tagWithTopValues.topValues: [];
+          let topValuesTotal = tagWithTopValues ? tagWithTopValues.totalValues: 0;
           return (
             <TagDistributionMeter
-              key={data.key}
+              key={tag.key}
+              tag={tag.key}
+              totalValues={tag.totalValues || topValuesTotal}
+              topValues={topValues}
+              name={tag.name}
               data-test-id="group-tag"
               orgId={orgId}
               projectId={projectId}
               group={group}
-              name={data.name}
-              tag={data.key}
             />
           );
         })}

--- a/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
+++ b/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
@@ -24,6 +24,8 @@ const TagDistributionMeter = createReactClass({
     orgId: PropTypes.string.isRequired,
     projectId: PropTypes.string.isRequired,
     environment: SentryTypes.Environment,
+    totalValues: PropTypes.number,
+    topValues: PropTypes.array,
   },
 
   mixins: [ApiMixin],
@@ -32,7 +34,6 @@ const TagDistributionMeter = createReactClass({
     return {
       loading: true,
       error: false,
-      data: null,
     };
   },
 
@@ -46,7 +47,9 @@ const TagDistributionMeter = createReactClass({
       this.state.error !== nextState.error ||
       this.props.tag !== nextProps.tag ||
       this.props.name !== nextProps.name ||
-      this.props.environment !== nextProps.environment
+      this.props.environment !== nextProps.environment ||
+      this.props.totalValues !== nextProps.totalValues ||
+      this.props.topValues !== nextProps.topValues
     );
   },
 
@@ -57,24 +60,14 @@ const TagDistributionMeter = createReactClass({
   },
 
   fetchData() {
-    const {group, tag, environment} = this.props;
-    const url = `/issues/${group.id}/tags/${encodeURIComponent(tag)}/`;
-    const query = environment ? {environment: environment.name} : {};
-
     this.setState({
       loading: true,
       error: false,
     });
 
-    Promise.all([
-      this.api.requestPromise(url, {
-        query,
-      }),
-      loadDeviceListModule(),
-    ])
-      .then(([data, iOSDeviceList]) => {
+      loadDeviceListModule()
+      .then(iOSDeviceList => {
         this.setState({
-          data,
           iOSDeviceList,
           error: false,
           loading: false,
@@ -99,19 +92,16 @@ const TagDistributionMeter = createReactClass({
    */
 
   renderSegments() {
-    let data = this.state.data;
-    let totalValues = data.totalValues;
+    let {orgId, projectId, group, totalValues, topValues, tag} = this.props;
 
-    let totalVisible = data.topValues.reduce((sum, value) => sum + value.count, 0);
-
+    let totalVisible = topValues.reduce((sum, value) => sum + value.count, 0);
     let hasOther = totalVisible < totalValues;
     let otherPct = percent(totalValues - totalVisible, totalValues);
     let otherPctLabel = Math.floor(otherPct);
 
-    let {orgId, projectId} = this.props;
     return (
       <div className="segments">
-        {data.topValues.map((value, index) => {
+        {topValues.map((value, index) => {
           const pct = percent(value.count, totalValues);
           const pctLabel = Math.floor(pct);
           const className = 'segment segment-' + index;
@@ -128,8 +118,7 @@ const TagDistributionMeter = createReactClass({
               <Link
                 className={className}
                 style={{width: pct + '%'}}
-                to={`/${orgId}/${projectId}/issues/${this.props.group.id}/tags/${this
-                  .props.tag}/`}
+                to={`/${orgId}/${projectId}/issues/${group.id}/tags/${tag}/`}
               >
                 <span className="tag-description">
                   <span className="tag-percentage">{pctLabel}%</span>
@@ -163,7 +152,7 @@ const TagDistributionMeter = createReactClass({
   renderBody() {
     if (this.state.loading || this.state.error) return null;
 
-    if (!this.state.data.totalValues) return <p>{t('No recent data.')}</p>;
+    if (!this.props.totalValues) return <p>{t('No recent data.')}</p>;
 
     return this.renderSegments();
   },


### PR DESCRIPTION
Utilize the /api/0/issues/$id/tags/?key=foo&key=bar endpoint to grab the
top values for the entire set of top tags in one call, avoiding a ton of
round trips. This is especially useful when the backend is powered by
snuba as the entire request can also be served by a single database
request.

To accomplish this, move the top values query out of the
tagDistributionMeter and into the sidebar component.