### PR TITLE
feat(api): Include PII meta data in API context

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -55,7 +55,7 @@ redis-py-cluster==1.3.4
 redis>=2.10.3,<2.10.6
 requests[security]>=2.18.4,<2.19.0
 selenium==3.11.0
-semaphore>=0.1.0,<0.2.0
+semaphore>=0.2.0,<0.3.0
 setproctitle>=1.1.7,<1.2.0
 simplejson>=3.2.0,<3.9.0
 six>=1.10.0,<1.11.0

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -5,6 +5,7 @@ import six
 from datetime import datetime
 from django.utils import timezone
 
+from semaphore import meta_with_chunks
 from sentry.api.serializers import Serializer, register
 from sentry.models import Event, EventError
 
@@ -16,7 +17,10 @@ class EventSerializer(Serializer):
 
     def _get_entries(self, event, user, is_public=False):
         # XXX(dcramer): These are called entries for future-proofing
+
+        meta = event.data.get('_meta') or {}
         interface_list = []
+
         for key, interface in six.iteritems(event.interfaces):
             # we treat user as a special contextual item
             if key in self._reserved_keys:
@@ -31,41 +35,61 @@ class EventSerializer(Serializer):
                 'data': data,
                 'type': interface.get_alias(),
             }
-            interface_list.append((interface, entry))
+
+            api_meta = None
+            if meta.get(key):
+                api_meta = interface.get_api_meta(meta[key], is_public=is_public)
+
+            interface_list.append((interface, entry, api_meta))
+
         interface_list.sort(
             key=lambda x: x[0].get_display_score(), reverse=True)
 
-        return [i[1] for i in interface_list]
+        return (
+            [i[1] for i in interface_list],
+            {k: {'data': i[2]} for k, i in enumerate(interface_list)}
+        )
+
+    def _get_interface_with_meta(self, event, name, is_public=False):
+        interface = event.interfaces.get(name)
+        if not interface:
+            return (None, None)
+
+        data = interface.get_api_context(is_public=is_public)
+        event_meta = event.data.get('_meta') or {}
+        if not data or not event_meta.get(name):
+            return (data, None)
+
+        api_meta = interface.get_api_meta(event_meta[name], is_public=is_public)
+        # data might not be returned for e.g. a public HTTP repr
+        if not api_meta:
+            return (data, None)
+
+        return (data, meta_with_chunks(data, api_meta))
 
     def get_attrs(self, item_list, user, is_public=False):
         Event.objects.bind_nodes(item_list, 'data')
 
         results = {}
         for item in item_list:
-            user_interface = item.interfaces.get('sentry.interfaces.User')
             # TODO(dcramer): convert to get_api_context
-            if user_interface:
-                user_data = user_interface.to_json()
-            else:
-                user_data = None
+            (user_data, user_meta) = self._get_interface_with_meta(item, 'user', is_public)
+            (contexts_data, contexts_meta) = self._get_interface_with_meta(item, 'contexts', is_public)
+            (sdk_data, sdk_meta) = self._get_interface_with_meta(item, 'sdk', is_public)
 
-            contexts_interface = item.interfaces.get('contexts')
-            if contexts_interface:
-                contexts_data = contexts_interface.get_api_context()
-            else:
-                contexts_data = {}
-
-            sdk_interface = item.interfaces.get('sdk')
-            if sdk_interface:
-                sdk_data = sdk_interface.get_api_context()
-            else:
-                sdk_data = None
+            (entries, entries_meta) = self._get_entries(item, user, is_public=is_public)
 
             results[item] = {
-                'entries': self._get_entries(item, user, is_public=is_public),
+                'entries': entries,
                 'user': user_data,
-                'contexts': contexts_data,
+                'contexts': contexts_data or {},
                 'sdk': sdk_data,
+                '_meta': {
+                    'entries': entries_meta,
+                    'user': user_meta,
+                    'contexts': contexts_meta,
+                    'sdk': sdk_meta,
+                }
             }
         return results
 
@@ -131,6 +155,7 @@ class EventSerializer(Serializer):
                 md5_from_hash(h)
                 for h in get_hashes_from_fingerprint(obj, obj.data.get('fingerprint', ['{{ default }}']))
             ],
+            '_meta': dict(**attrs['_meta'])
         }
         return d
 

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -75,21 +75,21 @@ class EventSerializer(Serializer):
             [{
                 'key': k.split('sentry:', 1)[-1],
                 'value': v,
-                '_meta': meta.get(k, None),
-            } for k, v in event.get_tags()],
+                '_meta': meta.get(k) or meta.get(six.text_type(i), {}).get('1') or None,
+            } for i, (k, v) in enumerate(event.data.get('tags') or ())],
             key=lambda x: x['key']
         )
 
         tags_meta = {
             six.text_type(i): {'value': e.pop('_meta')}
-            for i, e in enumerate(tags) if e.get('meta')
+            for i, e in enumerate(tags) if e.get('_meta')
         }
 
         return (tags, meta_with_chunks(tags, tags_meta))
 
     def _get_attr_with_meta(self, event, attr, default=None):
         value = event.data.get(attr, default)
-        meta = (event.data.get('_meta') or {}).get('tags')
+        meta = (event.data.get('_meta') or {}).get(attr)
         return (value, meta_with_chunks(value, meta))
 
     def get_attrs(self, item_list, user, is_public=False):

--- a/src/sentry/interfaces/base.py
+++ b/src/sentry/interfaces/base.py
@@ -67,7 +67,7 @@ class Interface(object):
         self._data = data or {}
 
     def __eq__(self, other):
-        if type(self) != type(other):
+        if not isinstance(self, type(other)):
             return False
         return self._data == other._data
 
@@ -94,6 +94,9 @@ class Interface(object):
 
     def get_api_context(self, is_public=False):
         return self.to_json()
+
+    def get_api_meta(self, meta, is_public=False):
+        return meta
 
     def to_json(self):
         # eliminate empty values for serialization to compress the keyspace

--- a/src/sentry/interfaces/breadcrumbs.py
+++ b/src/sentry/interfaces/breadcrumbs.py
@@ -130,3 +130,9 @@ class Breadcrumbs(Interface):
         return {
             'values': [_convert(v) for v in self.values],
         }
+
+    def get_api_meta(self, meta, is_public=False):
+        if meta and 'values' not in meta:
+            return {'values': meta}
+        else:
+            return meta

--- a/src/sentry/interfaces/exception.py
+++ b/src/sentry/interfaces/exception.py
@@ -940,6 +940,7 @@ class SingleException(Interface):
             else None
 
         return {
+            '': meta.get(''),
             'type': meta.get('type'),
             'value': meta.get('value'),
             'mechanism': mechanism_meta,

--- a/src/sentry/interfaces/http.py
+++ b/src/sentry/interfaces/http.py
@@ -284,6 +284,7 @@ class Http(Interface):
                 cookies[''] = cookies_meta
 
         return {
+            '': meta.get(''),
             'method': meta.get('method'),
             'url': meta.get('url'),
             'query': meta.get('query_string'),

--- a/src/sentry/interfaces/http.py
+++ b/src/sentry/interfaces/http.py
@@ -264,3 +264,31 @@ class Http(Interface):
             'inferredContentType': self.inferred_content_type,
         }
         return data
+
+    def get_api_meta(self, meta, is_public=False):
+        if is_public:
+            return None
+
+        headers = meta.get('headers')
+        if headers:
+            headers_meta = headers.pop('', None)
+            headers = {six.text_type(i): {'1': h[1]} for i, h in enumerate(sorted(headers.items()))}
+            if headers_meta:
+                headers[''] = headers_meta
+
+        cookies = meta.get('cookies')
+        if cookies:
+            cookies_meta = cookies.pop('', None)
+            cookies = {six.text_type(i): {'1': h[1]} for i, h in enumerate(sorted(cookies.items()))}
+            if cookies_meta:
+                cookies[''] = cookies_meta
+
+        return {
+            'method': meta.get('method'),
+            'url': meta.get('url'),
+            'query': meta.get('query_string'),
+            'data': meta.get('data'),
+            'headers': headers,
+            'cookies': cookies,
+            'env': meta.get('env'),
+        }

--- a/src/sentry/interfaces/message.py
+++ b/src/sentry/interfaces/message.py
@@ -61,7 +61,7 @@ class Message(Interface):
 
         if kwargs['formatted']:
             if not isinstance(kwargs['formatted'], six.string_types):
-                data['formatted'] = json.dumps(data['formatted'])
+                kwargs['formatted'] = json.dumps(data['formatted'])
         # support python-esque formatting (e.g. %s)
         elif '%' in kwargs['message'] and kwargs['params']:
             if isinstance(kwargs['params'], list):

--- a/src/sentry/interfaces/sdk.py
+++ b/src/sentry/interfaces/sdk.py
@@ -104,6 +104,7 @@ class Sdk(Interface):
 
     def get_api_meta(self, meta, is_public=False):
         return {
+            '': meta.get(''),
             'name': meta.get('name'),
             'version': meta.get('version'),
         }

--- a/src/sentry/interfaces/sdk.py
+++ b/src/sentry/interfaces/sdk.py
@@ -34,9 +34,15 @@ class Sdk(Interface):
     The SDK used to transmit this event.
 
     >>> {
-    >>>     "name": "sentry-java",
-    >>>     "version": "1.0",
-    >>>     "integrations": ["log4j"]
+    >>>     "name": "sentry.java",
+    >>>     "version": "1.7.10",
+    >>>     "integrations": ["log4j"],
+    >>>     "packages": [
+    >>>         {
+    >>>             "name": "maven:io.sentry.sentry",
+    >>>             "version": "1.7.10",
+    >>>         }
+    >>>     ]
     >>> }
     """
 
@@ -54,17 +60,23 @@ class Sdk(Interface):
         if integrations and not isinstance(integrations, list):
             raise InterfaceValidationError("'integrations' must be a list")
 
+        packages = data.get('packages')
+        if packages and not isinstance(packages, list):
+            raise InterfaceValidationError("'packages' must be a list")
+
         kwargs = {
             'name': trim(name, 128),
             'version': trim(version, 128),
             'integrations': integrations,
+            'packages': packages,
         }
+
         return cls(**kwargs)
 
     def get_path(self):
         return 'sdk'
 
-    def get_api_context(self):
+    def get_api_context(self, is_public=False):
         newest_version = get_with_prefix(settings.SDK_VERSIONS, self.name)
         newest_name = get_with_prefix(settings.DEPRECATED_SDKS, self.name, self.name)
         if newest_version is not None:
@@ -88,4 +100,10 @@ class Sdk(Interface):
                 'isNewer': is_newer,
                 'url': get_with_prefix(settings.SDK_URLS, newest_name),
             },
+        }
+
+    def get_api_meta(self, meta, is_public=False):
+        return {
+            'name': meta.get('name'),
+            'version': meta.get('version'),
         }

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -773,6 +773,7 @@ class Stacktrace(Interface):
             frame_meta[index] = frame.get_api_meta(value, is_public=is_public)
 
         return {
+            '': meta.get(''),
             'frames': frame_meta,
             'framesOmitted': meta.get('frames_omitted'),
             'registers': meta.get('registers'),

--- a/src/sentry/interfaces/template.py
+++ b/src/sentry/interfaces/template.py
@@ -95,16 +95,26 @@ class Template(Interface):
 
     def get_api_context(self, is_public=False):
         return {
-            'lineNo':
-            self.lineno,
-            'filename':
-            self.filename,
-            'context':
-            get_context(
+            'lineNo': self.lineno,
+            'filename': self.filename,
+            'context': get_context(
                 lineno=self.lineno,
                 context_line=self.context_line,
                 pre_context=self.pre_context,
                 post_context=self.post_context,
                 filename=self.filename,
+            ),
+        }
+
+    def get_api_meta(self, meta, is_public=False):
+        return {
+            'lineNo': meta.get('lineno'),
+            'filename': meta.get('filename'),
+            'context': get_context(
+                lineno=meta.get('lineno'),
+                context_line=meta.get('context_line'),
+                pre_context=meta.get('pre_context'),
+                post_context=meta.get('post_context'),
+                filename=meta.get('filename'),
             ),
         }

--- a/src/sentry/interfaces/template.py
+++ b/src/sentry/interfaces/template.py
@@ -108,6 +108,7 @@ class Template(Interface):
 
     def get_api_meta(self, meta, is_public=False):
         return {
+            '': meta.get(''),
             'lineNo': meta.get('lineno'),
             'filename': meta.get('filename'),
             'context': get_context(

--- a/src/sentry/interfaces/threads.py
+++ b/src/sentry/interfaces/threads.py
@@ -75,6 +75,12 @@ class Threads(Interface):
             'values': [export_thread(x) for x in self.values],
         }
 
+    def get_meta_context(self, meta, is_public=False):
+        if meta and 'values' not in meta:
+            return {'values': meta}
+        else:
+            return meta
+
     def get_path(self):
         return 'threads'
 

--- a/src/sentry/interfaces/user.py
+++ b/src/sentry/interfaces/user.py
@@ -114,9 +114,19 @@ class User(Interface):
             'id': self.id,
             'email': self.email,
             'username': self.username,
-            'ipAddress': self.ip_address,
+            'ip_address': self.ip_address,
             'name': self.name,
             'data': self.data,
+        }
+
+    def get_api_meta(self, meta, is_public=False):
+        return {
+            'id': meta.get('id'),
+            'email': meta.get('email'),
+            'username': meta.get('username'),
+            'ip_address': meta.get('ip_address'),
+            'name': meta.get('name'),
+            'data': meta.get('data'),
         }
 
     def get_path(self):

--- a/src/sentry/interfaces/user.py
+++ b/src/sentry/interfaces/user.py
@@ -121,6 +121,7 @@ class User(Interface):
 
     def get_api_meta(self, meta, is_public=False):
         return {
+            '': meta.get(''),
             'id': meta.get('id'),
             'email': meta.get('email'),
             'username': meta.get('username'),

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -35,6 +35,57 @@ class EventSerializerTest(TestCase):
         assert u'ü' in result['errors'][0]['message']
         assert result['errors'][0]['data'] == {'name': u'ü'}
 
+    def test_message_interface(self):
+        event = self.create_event(
+            data={
+                'logentry': {'message': 'bar'},
+                '_meta': {
+                    'logentry': {
+                        'message': {'': {'err': ['some error']}},
+                    },
+                },
+            }
+        )
+
+        result = serialize(event)
+        assert result['message'] == 'bar'
+        assert result['_meta']['message'] == {'': {'err': ['some error']}}
+
+    def test_message_formatted(self):
+        event = self.create_event(
+            data={
+                'logentry': {'message': 'bar', 'formatted': 'baz'},
+                '_meta': {
+                    'logentry': {
+                        'formatted': {'': {'err': ['some error']}},
+                    },
+                },
+            }
+        )
+
+        result = serialize(event)
+        assert result['message'] == 'baz'
+        assert result['_meta']['message'] == {'': {'err': ['some error']}}
+
+    def test_message_legacy(self):
+        # TODO: This test case can be removed once validation is implemented by
+        # libsemaphore and enforced on all payloads
+        event = self.create_event(
+            data={
+                'message': 'foo',
+                '_meta': {
+                    'message': {'': {'err': ['some error']}},
+                },
+            }
+        )
+
+        # create_event automatically creates the logentry interface
+        del event.data['logentry']
+
+        result = serialize(event)
+        assert result['message'] == 'foo'
+        assert result['_meta']['message'] == {'': {'err': ['some error']}}
+
     def test_tags_tuples(self):
         event = self.create_event(
             data={

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -35,6 +35,25 @@ class EventSerializerTest(TestCase):
         assert u'ü' in result['errors'][0]['message']
         assert result['errors'][0]['data'] == {'name': u'ü'}
 
+    def test_renamed_attributes(self):
+        # Only includes meta for simple top-level attributes
+        event = self.create_event(
+            data={
+                'extra': {'extra': True},
+                'modules': {'modules': True},
+                '_meta': {
+                    'extra': {'': {'err': ['extra error']}},
+                    'modules': {'': {'err': ['modules error']}},
+                }
+            }
+        )
+
+        result = serialize(event)
+        assert result['context'] == {'extra': True}
+        assert result['_meta']['context'] == {'': {'err': ['extra error']}}
+        assert result['packages'] == {'modules': True}
+        assert result['_meta']['packages'] == {'': {'err': ['modules error']}}
+
     def test_message_interface(self):
         event = self.create_event(
             data={


### PR DESCRIPTION
This PR exposes `_meta` generated during PII stripping and normalization to the UI. 

It introduces a new method `get_api_meta(self, meta, is_public=False)` on interfaces that should map the provided meta data to the same schema as `get_api_context` would return. The return value is then piped through `meta_with_chunks` which splits strings into chunks for rendering.

Note that we perform more normalization in event_manager and interfaces, so some _meta keys might still not be correct. Depending on how we move forward with the store refactor, this might be solved implicitly.

**This requires a bump to `semaphore:0.2.0` in getsentry**