### PR TITLE
feat(auth): Client ID & Secret authentication

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import
 
+import json
+
 from django.contrib.auth.models import AnonymousUser
 from rest_framework.authentication import (BasicAuthentication, get_authorization_header)
 from rest_framework.exceptions import AuthenticationFailed
 
 from sentry.app import raven
-from sentry.models import ApiKey, ApiToken, Relay
+from sentry.models import ApiApplication, ApiKey, ApiToken, Relay
 from sentry.relay.utils import get_header_relay_id, get_header_relay_signature
 
 import semaphore
@@ -67,6 +69,40 @@ class ApiKeyAuthentication(QuietBasicAuthentication):
         })
 
         return (AnonymousUser(), key)
+
+
+class ClientIdSecretAuthentication(QuietBasicAuthentication):
+    """
+    Authenticates a Sentry Application using its Client ID and Secret
+
+    This will be the method by which we identify which Sentry Application is
+    making the request, for any requests not scoped to an installation.
+
+    For example, the request to exchange a Grant Code for an Api Token.
+    """
+
+    def authenticate(self, request):
+        data = json.loads(request.body)
+        client_id = data.get('client_id')
+        client_secret = data.get('client_secret')
+
+        invalid_pair_error = AuthenticationFailed('Invalid Client ID / Secret pair')
+
+        if not client_id or not client_secret:
+            raise invalid_pair_error
+
+        try:
+            application = ApiApplication.objects.get(client_id=client_id)
+        except ApiApplication.DoesNotExist:
+            raise invalid_pair_error
+
+        if not constant_time_compare(application.client_secret, client_secret):
+            raise invalid_pair_error
+
+        try:
+            return (application.sentry_app.proxy_user, None)
+        except Exception:
+            raise invalid_pair_error
 
 
 class TokenAuthentication(QuietBasicAuthentication):

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
-import json
-
 from django.contrib.auth.models import AnonymousUser
+from django.utils.crypto import constant_time_compare
 from rest_framework.authentication import (BasicAuthentication, get_authorization_header)
 from rest_framework.exceptions import AuthenticationFailed
 
@@ -82,9 +81,11 @@ class ClientIdSecretAuthentication(QuietBasicAuthentication):
     """
 
     def authenticate(self, request):
-        data = json.loads(request.body)
-        client_id = data.get('client_id')
-        client_secret = data.get('client_secret')
+        if not request.json_body:
+            raise AuthenticationFailed('Invalid request')
+
+        client_id = request.json_body.get('client_id')
+        client_secret = request.json_body.get('client_secret')
 
         invalid_pair_error = AuthenticationFailed('Invalid Client ID / Secret pair')
 

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -1,0 +1,80 @@
+from __future__ import absolute_import
+
+from django.http import HttpRequest
+from rest_framework.exceptions import AuthenticationFailed
+
+from sentry.api.authentication import ClientIdSecretAuthentication
+from sentry.mediators.sentry_apps import Creator
+from sentry.testutils import TestCase
+
+
+class TestClientIdSecretAuthentication(TestCase):
+    def setUp(self):
+        super(TestClientIdSecretAuthentication, self).setUp()
+
+        self.auth = ClientIdSecretAuthentication()
+
+        self.sentry_app = Creator.run(
+            name="foo",
+            user=self.user,
+            scopes=(),
+            webhook_url='https://example.com',
+        )
+
+        self.api_app = self.sentry_app.application
+
+    def test_authenticate(self):
+        request = HttpRequest()
+        request.json_body = {
+            'client_id': self.api_app.client_id,
+            'client_secret': self.api_app.client_secret,
+        }
+
+        user, _ = self.auth.authenticate(request)
+
+        assert user == self.sentry_app.proxy_user
+
+    def test_without_json_body(self):
+        request = HttpRequest()
+        request.json_body = None
+
+        with self.assertRaises(AuthenticationFailed):
+            self.auth.authenticate(request)
+
+    def test_missing_client_id(self):
+        request = HttpRequest()
+        request.json_body = {
+            'client_secret': self.api_app.client_secret,
+        }
+
+        with self.assertRaises(AuthenticationFailed):
+            self.auth.authenticate(request)
+
+    def test_missing_client_secret(self):
+        request = HttpRequest()
+        request.json_body = {
+            'client_id': self.api_app.client_id,
+        }
+
+        with self.assertRaises(AuthenticationFailed):
+            self.auth.authenticate(request)
+
+    def test_incorrect_client_id(self):
+        request = HttpRequest()
+        request.json_body = {
+            'client_id': 'notit',
+            'client_secret': self.api_app.client_secret,
+        }
+
+        with self.assertRaises(AuthenticationFailed):
+            self.auth.authenticate(request)
+
+    def test_incorrect_client_secret(self):
+        request = HttpRequest()
+        request.json_body = {
+            'client_id': self.api_app.client_id,
+            'client_secret': 'notit',
+        }
+
+        with self.assertRaises(AuthenticationFailed):
+            self.auth.authenticate(request)

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -40,3 +40,40 @@ class EndpointTest(APITestCase):
         assert response.status_code == 200, response.content
 
         assert response['Access-Control-Allow-Origin'] == 'http://example.com'
+
+
+class EndpointJSONBodyTest(APITestCase):
+    def setUp(self):
+        super(EndpointJSONBodyTest, self).setUp()
+
+        self.request = HttpRequest()
+        self.request.method = 'GET'
+        self.request.META['CONTENT_TYPE'] = 'application/json'
+
+    def test_json(self):
+        self.request._body = '{"foo":"bar"}'
+
+        Endpoint().load_json_body(self.request)
+
+        assert self.request.json_body == {'foo': 'bar'}
+
+    def test_invalid_json(self):
+        self.request._body = 'hello'
+
+        Endpoint().load_json_body(self.request)
+
+        assert not self.request.json_body
+
+    def test_empty_request_body(self):
+        self.request._body = ''
+
+        Endpoint().load_json_body(self.request)
+
+        assert not self.request.json_body
+
+    def test_non_json_content_type(self):
+        self.request.META['CONTENT_TYPE'] = 'text/plain'
+
+        Endpoint().load_json_body(self.request)
+
+        assert not self.request.json_body


### PR DESCRIPTION
Future platform Applications will need a way to authenticate with Sentry, prior to doing the exchange for an installation specific token.

That request (and any others that are not scoped to an installation) will allow them to authenticate using their Client ID and Secret.

This adds an authentication class we'll use in the future – it does nothing yet.