### PR TITLE
fix(ui): Align nav and page heading baselines

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/settingsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsLayout.jsx
@@ -76,6 +76,7 @@ const ContentContainerWrapper = styled(Box)`
 const SidebarWrapper = styled(Box)`
   flex-shrink: 0;
   width: ${p => p.theme.settings.sidebarWidth};
+  margin-top: 7px;
 `;
 
 /**


### PR DESCRIPTION
Because my entire life is dictated by a grid and slight OCD, this has been bothering me.

This may not be an issue in anyone's mind (or maybe things were vertically aligned in a different way?) so feel free reject it with a _thunderous_ "NOOOOOOPPPEEEEE".

I moved the sidebar nav down a few pixels (7, to be exact) so that the baseline of the first nav heading and the page heading, are aligned.

Before:
![sentry](https://user-images.githubusercontent.com/36059/46176474-73326200-c264-11e8-84c0-07c3fc9abb91.png)

After:
![sentry](https://user-images.githubusercontent.com/36059/46176653-0d92a580-c265-11e8-8c18-c9ef5798c3ef.png)

Just let me know when the Best Pull Request Awards are and I'll make sure to be free that night.