### PR TITLE
fix(integrations): Gitlab add base url to gitlab identity external_id.

### DIFF
--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -225,7 +225,7 @@ class GitlabIntegrationProvider(IntegrationProvider):
             },
             'user_identity': {
                 'type': 'gitlab',
-                'external_id': user['id'],
+                'external_id': u'{}:{}'.format(urlparse(base_url).netloc, user['id']),
                 'scopes': scopes,
                 'data': oauth_data,
             },

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -111,7 +111,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
         identity = Identity.objects.get(
             idp=idp,
             user=self.user,
-            external_id='user_id_1',
+            external_id='gitlab.example.com:user_id_1',
         )
         assert identity.status == IdentityStatus.VALID
         assert identity.data == {


### PR DESCRIPTION
Before we were just using user_id, which probably isn't unique between gitlab on prem instances. Since we use external_id for lookup, I wanted to make sure it was unique by adding the base_url.