### PR TITLE
feat(releases): Add endpoint for project release setup status

### DIFF
--- a/src/sentry/api/endpoints/project_release_setup.py
+++ b/src/sentry/api/endpoints/project_release_setup.py
@@ -39,16 +39,18 @@ class ProjectReleaseSetupEndpoint(ProjectEndpoint):
         return Response([
             {
                 'step': 'tag',
-                'complete': bool(tag)
+                'complete': bool(tag),
             },
             {
                 'step': 'commit',
-                'complete': bool(commit)
+                'complete': bool(commit),
             },
-            {'step': 'deploy',
-             'complete': bool(deploy)
-             },
-            {'step': 'repo',
-             'complete': bool(repo)
-             }
+            {
+                'step': 'deploy',
+                'complete': bool(deploy),
+            },
+            {
+                'step': 'repo',
+                'complete': bool(repo),
+            }
         ])

--- a/src/sentry/api/endpoints/project_release_setup.py
+++ b/src/sentry/api/endpoints/project_release_setup.py
@@ -5,7 +5,7 @@ from sentry.models import Group, ReleaseCommit, Repository, Deploy
 from rest_framework.response import Response
 
 
-class ProjectReleaseSetupEndpoint(ProjectEndpoint):
+class ProjectReleaseSetupCompletionEndpoint(ProjectEndpoint):
     permission_classes = (ProjectReleasePermission, )
 
     def get(self, request, project):
@@ -22,6 +22,10 @@ class ProjectReleaseSetupEndpoint(ProjectEndpoint):
             first_release__isnull=False,
         ).exists()
 
+        repo = Repository.objects.filter(
+            organization_id=project.organization_id,
+        ).exists()
+
         commit = ReleaseCommit.objects.filter(
             organization_id=project.organization_id,
             release__projects=project.id,
@@ -32,14 +36,14 @@ class ProjectReleaseSetupEndpoint(ProjectEndpoint):
             release__projects=project.id,
         ).exists()
 
-        repo = Repository.objects.filter(
-            organization_id=project.organization_id,
-        ).exists()
-
         return Response([
             {
                 'step': 'tag',
                 'complete': bool(tag),
+            },
+            {
+                'step': 'repo',
+                'complete': bool(repo),
             },
             {
                 'step': 'commit',
@@ -48,9 +52,5 @@ class ProjectReleaseSetupEndpoint(ProjectEndpoint):
             {
                 'step': 'deploy',
                 'complete': bool(deploy),
-            },
-            {
-                'step': 'repo',
-                'complete': bool(repo),
             }
         ])

--- a/src/sentry/api/endpoints/project_release_setup.py
+++ b/src/sentry/api/endpoints/project_release_setup.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import
+
+from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
+from sentry.models import Group, ReleaseCommit, Repository, Deploy
+from rest_framework.response import Response
+
+
+class ProjectReleaseSetupEndpoint(ProjectEndpoint):
+    permission_classes = (ProjectReleasePermission, )
+
+    def get(self, request, project):
+        """
+        Checks how set up a project is on releases.
+        1. tag an error
+        2. link a repo
+        3. associate commits
+        4. tell sentry about a deploy
+        """
+
+        tag = Group.objects.filter(
+            project=project.id,
+            first_release__isnull=False,
+        ).exists()
+
+        commit = ReleaseCommit.objects.filter(
+            organization_id=project.organization_id,
+            release__projects=project.id,
+        ).exists()
+
+        deploy = Deploy.objects.filter(
+            organization_id=project.organization_id,
+            release__projects=project.id,
+        ).exists()
+
+        # [2] see if any repos have been linked for this org
+        repo = Repository.objects.filter(
+            organization_id=project.organization_id,
+        ).exists()
+
+        return Response({'tag': tag,
+                         'commit': commit,
+                         'repo': repo,
+                         'deploy': deploy})

--- a/src/sentry/api/endpoints/project_release_setup.py
+++ b/src/sentry/api/endpoints/project_release_setup.py
@@ -32,7 +32,6 @@ class ProjectReleaseSetupEndpoint(ProjectEndpoint):
             release__projects=project.id,
         ).exists()
 
-        # [2] see if any repos have been linked for this org
         repo = Repository.objects.filter(
             organization_id=project.organization_id,
         ).exists()

--- a/src/sentry/api/endpoints/project_release_setup.py
+++ b/src/sentry/api/endpoints/project_release_setup.py
@@ -10,7 +10,7 @@ class ProjectReleaseSetupEndpoint(ProjectEndpoint):
 
     def get(self, request, project):
         """
-        Checks how set up a project is on releases.
+        Get list with release setup progress for a project
         1. tag an error
         2. link a repo
         3. associate commits
@@ -36,7 +36,19 @@ class ProjectReleaseSetupEndpoint(ProjectEndpoint):
             organization_id=project.organization_id,
         ).exists()
 
-        return Response({'tag': tag,
-                         'commit': commit,
-                         'repo': repo,
-                         'deploy': deploy})
+        return Response([
+            {
+                'step': 'tag',
+                'complete': bool(tag)
+            },
+            {
+                'step': 'commit',
+                'complete': bool(commit)
+            },
+            {'step': 'deploy',
+             'complete': bool(deploy)
+             },
+            {'step': 'repo',
+             'complete': bool(repo)
+             }
+        ])

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -123,6 +123,7 @@ from .endpoints.project_release_files import ProjectReleaseFilesEndpoint
 from .endpoints.project_release_file_details import ProjectReleaseFileDetailsEndpoint
 from .endpoints.project_release_commits import ProjectReleaseCommitsEndpoint
 from .endpoints.project_releases import ProjectReleasesEndpoint
+from .endpoints.project_release_setup import ProjectReleaseSetupEndpoint
 from .endpoints.project_releases_token import ProjectReleasesTokenEndpoint
 from .endpoints.project_rules import ProjectRulesEndpoint
 from .endpoints.project_rules_configuration import ProjectRulesConfigurationEndpoint
@@ -809,6 +810,11 @@ urlpatterns = patterns(
         r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/token/$',
         ProjectReleasesTokenEndpoint.as_view(),
         name='sentry-api-0-project-releases-token'
+    ),
+    url(
+        r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/status/$',
+        ProjectReleaseSetupEndpoint.as_view(),
+        name='sentry-api-0-project-releases-status'
     ),
     url(
         r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/(?P<version>[^/]+)/$',

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -123,7 +123,7 @@ from .endpoints.project_release_files import ProjectReleaseFilesEndpoint
 from .endpoints.project_release_file_details import ProjectReleaseFileDetailsEndpoint
 from .endpoints.project_release_commits import ProjectReleaseCommitsEndpoint
 from .endpoints.project_releases import ProjectReleasesEndpoint
-from .endpoints.project_release_setup import ProjectReleaseSetupEndpoint
+from .endpoints.project_release_setup import ProjectReleaseSetupCompletionEndpoint
 from .endpoints.project_releases_token import ProjectReleasesTokenEndpoint
 from .endpoints.project_rules import ProjectRulesEndpoint
 from .endpoints.project_rules_configuration import ProjectRulesConfigurationEndpoint
@@ -812,8 +812,8 @@ urlpatterns = patterns(
         name='sentry-api-0-project-releases-token'
     ),
     url(
-        r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/status/$',
-        ProjectReleaseSetupEndpoint.as_view(),
+        r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/completion/$',
+        ProjectReleaseSetupCompletionEndpoint.as_view(),
         name='sentry-api-0-project-releases-status'
     ),
     url(

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -814,7 +814,7 @@ urlpatterns = patterns(
     url(
         r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/completion/$',
         ProjectReleaseSetupCompletionEndpoint.as_view(),
-        name='sentry-api-0-project-releases-status'
+        name='sentry-api-0-project-releases-completion-status'
     ),
     url(
         r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/(?P<version>[^/]+)/$',

--- a/tests/sentry/api/endpoints/test_project_release_setup.py
+++ b/tests/sentry/api/endpoints/test_project_release_setup.py
@@ -1,0 +1,49 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from sentry.models import Commit, ReleaseCommit, Repository
+from sentry.testutils import APITestCase
+
+
+class ProjectReleaseSetupCompletionTest(APITestCase):
+    def test_simple(self):
+        project = self.create_project()
+        release = self.create_release(project, self.user)
+        self.create_group(project=project, first_release=release)
+
+        repo = Repository.objects.create(
+            organization_id=project.organization_id,
+            name=project.name,
+        )
+
+        commit = Commit.objects.create(
+            organization_id=project.organization_id,
+            repository_id=repo.id,
+            key='b' * 40,
+        )
+
+        ReleaseCommit.objects.create(
+            organization_id=project.organization_id,
+            release=release,
+            commit=commit,
+            order=0,
+        )
+
+        url = reverse(
+            'sentry-api-0-project-releases-completion-status',
+            kwargs={
+                'organization_slug': project.organization.slug,
+                'project_slug': project.slug,
+            }
+        )
+
+        self.login_as(user=self.user)
+
+        response = self.client.get(url)
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 4
+        assert response.data[2]['step'] == 'commit'
+        assert response.data[2]['complete'] is True
+        assert response.data[3]['step'] == 'deploy'
+        assert response.data[3]['complete'] is False


### PR DESCRIPTION
This sets up the first base for updates to the releases tab. This returns info on what steps the project has completed so far. See spec [here](https://paper.dropbox.com/doc/Spec-Releases-tab--ANo1zkOS8drR7JA7ey_QLKKMAg-Ie1TFu4Vn1znYvYwlVp3G)