### PR TITLE
feat(releases): Empty state releases landing page

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "react-virtualized": "^9.20.1",
     "reflux": "0.4.1",
     "scroll-to-element": "^2.0.0",
+    "sentry-dreamy-components": "getsentry/dreamy-components",
     "sprintf-js": "1.0.3",
     "style-loader": "0.12.4",
     "svg-sprite-loader": "^3.4.1",

--- a/src/sentry/static/sentry/app/views/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/index.jsx
@@ -18,7 +18,7 @@ import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 
 import ReleaseList from 'app/views/projectReleases/releaseList';
-import ReleaseLanding from 'app/views/projectReleases/releaseLanding.jsx';
+import ReleaseLanding from 'app/views/projectReleases/releaseLanding';
 import withEnvironmentInQueryString from 'app/utils/withEnvironmentInQueryString';
 
 const DEFAULT_QUERY = '';

--- a/src/sentry/static/sentry/app/views/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/index.jsx
@@ -18,7 +18,7 @@ import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 
 import ReleaseList from 'app/views/projectReleases/releaseList';
-
+import ReleaseLanding from 'app/views/projectReleases/releaseLanding.jsx';
 import withEnvironmentInQueryString from 'app/utils/withEnvironmentInQueryString';
 
 const DEFAULT_QUERY = '';
@@ -171,8 +171,7 @@ const ProjectReleases = createReactClass({
           env: environment.displayName,
         })
       : t("There don't seem to be any releases yet.");
-
-    return (
+    return environment ? (
       <EmptyStateWarning>
         <p>{message}</p>
         <p>
@@ -181,6 +180,8 @@ const ProjectReleases = createReactClass({
           </a>
         </p>
       </EmptyStateWarning>
+    ) : (
+      <ReleaseLanding />
     );
   },
 

--- a/src/sentry/static/sentry/app/views/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/index.jsx
@@ -18,7 +18,6 @@ import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 
 import ReleaseList from 'app/views/projectReleases/releaseList';
-import ReleaseLanding from 'app/views/projectReleases/releaseLanding';
 import withEnvironmentInQueryString from 'app/utils/withEnvironmentInQueryString';
 
 const DEFAULT_QUERY = '';
@@ -171,7 +170,7 @@ const ProjectReleases = createReactClass({
           env: environment.displayName,
         })
       : t("There don't seem to be any releases yet.");
-    return environment ? (
+    return (
       <EmptyStateWarning>
         <p>{message}</p>
         <p>
@@ -180,8 +179,6 @@ const ProjectReleases = createReactClass({
           </a>
         </p>
       </EmptyStateWarning>
-    ) : (
-      <ReleaseLanding />
     );
   },
 

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseLanding.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseLanding.jsx
@@ -67,14 +67,15 @@ const ReleaseLanding = createReactClass({
   handleClick() {
     let {stepId} = this.state;
 
-    // see docs as last step? push to the docs for more info
     if (stepId >= cards.length - 1) return;
-    this.setState({stepId: stepId + 1});
+    this.setState(state => ({
+      stepId: state.stepId + 1,
+    }));
   },
 
   getCard(stepId) {
-    let displayCard = cards.filter(card => card.id === stepId);
-    return displayCard[0];
+    let displayCard = cards.find(card => card.id === stepId);
+    return displayCard;
   },
 
   render() {
@@ -85,10 +86,10 @@ const ReleaseLanding = createReactClass({
       <div className="container">
         <div className="row">
           <ReleaseLandingCard
-            className="landing-card"
             onClick={this.handleClick}
             card={card}
             step={stepId}
+            cardsLength={cards.length}
           />
         </div>
       </div>

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseLanding.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseLanding.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import {t} from 'app/locale';
+import styled from 'react-emotion';
+
 import {
   BashCard,
   Issues,
@@ -7,8 +9,14 @@ import {
   Emails,
   Contributors,
 } from 'sentry-dreamy-components';
+
 import ReleaseLandingCard from 'app/views/projectReleases/releaseLandingCard';
 import withApi from 'app/utils/withApi';
+
+const StyledSuggestedAssignees = styled(SuggestedAssignees)`
+  width: 200px;
+  height: 200px;
+`;
 
 const cards = [
   {
@@ -23,7 +31,7 @@ const cards = [
     message: t(
       'Sentry suggests which commit caused an issue and who is likely responsible so you can triage'
     ),
-    component: SuggestedAssignees,
+    component: StyledSuggestedAssignees,
   },
   {
     title: t('Release Stats'),

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseLanding.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseLanding.jsx
@@ -8,7 +8,7 @@ import {
   Contributors,
 } from 'sentry-dreamy-components';
 import ReleaseLandingCard from 'app/views/projectReleases/releaseLandingCard';
-import withApi from 'app/utils/withApi.jsx';
+import withApi from 'app/utils/withApi';
 
 const cards = [
   {

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseLanding.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseLanding.jsx
@@ -14,8 +14,9 @@ import ReleaseLandingCard from 'app/views/projectReleases/releaseLandingCard';
 import withApi from 'app/utils/withApi';
 
 const StyledSuggestedAssignees = styled(SuggestedAssignees)`
-  width: 200px;
-  height: 200px;
+  width: 150px;
+  height: 150px;
+  padding-left: 250px;
 `;
 
 const cards = [

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseLanding.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseLanding.jsx
@@ -12,7 +12,6 @@ import withApi from 'app/utils/withApi.jsx';
 
 const cards = [
   {
-    id: 0,
     title: t("You Haven't Set Up Releases!"),
     message: t(
       'Releases provide additional context, with rich commits, so you know which errors were addressed and which were introduced for the first time'
@@ -20,7 +19,6 @@ const cards = [
     component: Contributors,
   },
   {
-    id: 1,
     title: t('Suspect Commits'),
     message: t(
       'Sentry suggests which commit caused an issue and who is likely responsible so you can triage'
@@ -28,7 +26,6 @@ const cards = [
     component: SuggestedAssignees,
   },
   {
-    id: 2,
     title: t('Release Stats'),
     message: t(
       'Set the commits in each release, and which issues were introduced or fixed in the release.'
@@ -36,7 +33,6 @@ const cards = [
     component: Issues,
   },
   {
-    id: 3,
     title: t('Easy Resolution'),
     message: t(
       'Automatically resolve issues by including the issue number in your commit message.'
@@ -44,7 +40,6 @@ const cards = [
     component: BashCard,
   },
   {
-    id: 4,
     title: t('Deploy Emails'),
     message: t('Receive email notifications when your code gets deployed.'),
     component: Emails,
@@ -70,8 +65,7 @@ const ReleaseLanding = withApi(
     };
 
     getCard = stepId => {
-      let displayCard = cards.find(card => card.id === stepId);
-      return displayCard;
+      return cards[stepId];
     };
 
     render() {

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseLanding.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseLanding.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import {t} from 'app/locale';
+import createReactClass from 'create-react-class';
+import {
+  BashCard,
+  Issues,
+  SuggestedAssignees,
+  Emails,
+  Contributors,
+} from 'sentry-dreamy-components';
+import ApiMixin from 'app/mixins/apiMixin';
+import ReleaseLandingCard from 'app/views/projectReleases/releaseLandingCard';
+
+//move to utils
+const cards = [
+  {
+    id: 0,
+    title: t("You Haven't Set Up Releases!"),
+    message: t(
+      'Releases provide additional context, with rich commits, so you know which errors were addressed and which were introduced for the first time'
+    ),
+    component: Contributors,
+  },
+  {
+    id: 1,
+    title: t('Suspect Commits'),
+    message: t(
+      'Sentry suggests which commit caused an issue and who is likely responsible so you can triage'
+    ),
+    component: SuggestedAssignees,
+  },
+  {
+    id: 2,
+    title: t('Release Stats'),
+    message: t(
+      'Set the commits in each release, and which issues were introduced or fixed in the release.'
+    ),
+    component: Issues,
+  },
+  {
+    id: 3,
+    title: t('Easy Resolution'),
+    message: t(
+      'Automatically resolve issues by including the issue number in your commit message.'
+    ),
+    component: BashCard,
+  },
+  {
+    id: 4,
+    title: t('Deploy Emails'),
+    message: t('Receive email notifications when your code gets deployed.'),
+    component: Emails,
+  },
+];
+
+const ReleaseLanding = createReactClass({
+  displayName: 'ReleaseLanding',
+
+  mixins: [ApiMixin],
+
+  getInitialState() {
+    return {
+      stepId: 0,
+    };
+  },
+
+  handleClick() {
+    let {stepId} = this.state;
+
+    // see docs as last step? push to the docs for more info
+    if (stepId >= cards.length - 1) return;
+    this.setState({stepId: stepId + 1});
+  },
+
+  getCard(stepId) {
+    let displayCard = cards.filter(card => card.id === stepId);
+    return displayCard[0];
+  },
+
+  render() {
+    let {stepId} = this.state;
+    let card = this.getCard(stepId);
+
+    return (
+      <div className="container">
+        <div className="row">
+          <ReleaseLandingCard
+            className="landing-card"
+            onClick={this.handleClick}
+            card={card}
+            step={stepId}
+          />
+        </div>
+      </div>
+    );
+  },
+});
+
+export default ReleaseLanding;

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseLanding.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseLanding.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {t} from 'app/locale';
-import createReactClass from 'create-react-class';
 import {
   BashCard,
   Issues,
@@ -8,10 +7,9 @@ import {
   Emails,
   Contributors,
 } from 'sentry-dreamy-components';
-import ApiMixin from 'app/mixins/apiMixin';
 import ReleaseLandingCard from 'app/views/projectReleases/releaseLandingCard';
+import withApi from 'app/utils/withApi.jsx';
 
-//move to utils
 const cards = [
   {
     id: 0,
@@ -53,48 +51,47 @@ const cards = [
   },
 ];
 
-const ReleaseLanding = createReactClass({
-  displayName: 'ReleaseLanding',
+const ReleaseLanding = withApi(
+  class ReleaseLanding extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {
+        stepId: 0,
+      };
+    }
 
-  mixins: [ApiMixin],
+    handleClick = () => {
+      let {stepId} = this.state;
 
-  getInitialState() {
-    return {
-      stepId: 0,
+      if (stepId >= cards.length - 1) return;
+      this.setState(state => ({
+        stepId: state.stepId + 1,
+      }));
     };
-  },
 
-  handleClick() {
-    let {stepId} = this.state;
+    getCard = stepId => {
+      let displayCard = cards.find(card => card.id === stepId);
+      return displayCard;
+    };
 
-    if (stepId >= cards.length - 1) return;
-    this.setState(state => ({
-      stepId: state.stepId + 1,
-    }));
-  },
+    render() {
+      let {stepId} = this.state;
+      let card = this.getCard(stepId);
 
-  getCard(stepId) {
-    let displayCard = cards.find(card => card.id === stepId);
-    return displayCard;
-  },
-
-  render() {
-    let {stepId} = this.state;
-    let card = this.getCard(stepId);
-
-    return (
-      <div className="container">
-        <div className="row">
-          <ReleaseLandingCard
-            onClick={this.handleClick}
-            card={card}
-            step={stepId}
-            cardsLength={cards.length}
-          />
+      return (
+        <div className="container">
+          <div className="row">
+            <ReleaseLandingCard
+              onClick={this.handleClick}
+              card={card}
+              step={stepId}
+              cardsLength={cards.length}
+            />
+          </div>
         </div>
-      </div>
-    );
-  },
-});
+      );
+    }
+  }
+);
 
 export default ReleaseLanding;

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseLandingCard.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseLandingCard.jsx
@@ -17,11 +17,11 @@ class ReleaseLandingCard extends React.Component {
   getMessage = () => {
     let {cardsLength, step} = this.props;
     if (step == 0) {
-      return 'Tell Me More';
+      return t('Tell Me More');
     } else if (step < cardsLength - 1) {
-      return 'Next';
+      return t('Next');
     } else {
-      return 'See Docs for Setup';
+      return t('See Docs for Setup');
     }
   };
 
@@ -50,7 +50,7 @@ class ReleaseLandingCard extends React.Component {
               </StyledButton>
             ) : (
               <StyledButton onClick={this.props.onClick}>
-                {t(this.getMessage())}
+                {this.getMessage()}
               </StyledButton>
             )}
           </StyledBox>

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseLandingCard.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseLandingCard.jsx
@@ -42,8 +42,8 @@ const ReleaseLandingCard = createReactClass({
 
         <div className="col-md-6">
           <StyledBox>
-            <h3> {t(card.title)}</h3>
-            <p> {t(card.message)}</p>
+            <h3> {card.title}</h3>
+            <p> {card.message}</p>
             {finalStep ? (
               <StyledButton
                 href={'https://docs.sentry.io/learn/releases/'}

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseLandingCard.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseLandingCard.jsx
@@ -1,23 +1,20 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
 import {Box} from 'grid-emotion';
 import {t} from 'app/locale';
 
 import Button from 'app/components/button';
 
-const ReleaseLandingCard = createReactClass({
-  displayName: 'ReleaseLandingCard',
-
-  propTypes: {
+class ReleaseLandingCard extends React.Component {
+  static propTypes = {
     card: PropTypes.object.isRequired,
     cardsLength: PropTypes.number.isRequired,
     step: PropTypes.number.isRequired,
     onClick: PropTypes.func.isRequired,
-  },
+  };
 
-  getMessage() {
+  getMessage = () => {
     let {cardsLength, step} = this.props;
     if (step == 0) {
       return 'Tell Me More';
@@ -26,7 +23,7 @@ const ReleaseLandingCard = createReactClass({
     } else {
       return 'See Docs for Setup';
     }
-  },
+  };
 
   render() {
     let {card, cardsLength, step} = this.props;
@@ -60,8 +57,8 @@ const ReleaseLandingCard = createReactClass({
         </div>
       </div>
     );
-  },
-});
+  }
+}
 
 const StyledBox = styled(Box)`
   padding: 80px;

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseLandingCard.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseLandingCard.jsx
@@ -39,8 +39,8 @@ class ReleaseLandingCard extends React.Component {
 
         <div className="col-md-6">
           <StyledBox>
-            <h3> {card.title}</h3>
-            <p> {card.message}</p>
+            <h3>{card.title}</h3>
+            <p>{card.message}</p>
             {finalStep ? (
               <StyledButton
                 href={'https://docs.sentry.io/learn/releases/'}

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseLandingCard.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseLandingCard.jsx
@@ -1,0 +1,63 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import createReactClass from 'create-react-class';
+import styled from 'react-emotion';
+import {Box} from 'grid-emotion';
+
+import Button from 'app/components/button';
+
+const ReleaseLandingCard = createReactClass({
+  displayName: 'ReleaseLandingCard',
+
+  propTypes: {
+    card: PropTypes.object.isRequired,
+    step: PropTypes.number.isRequired,
+    onClick: PropTypes.func.isRequired,
+  },
+
+  getMessage() {
+    let {step} = this.props;
+    if (step == 0) {
+      return 'Tell Me More';
+    } else if (step < 4) {
+      return 'Next';
+    } else {
+      return 'See Docs for Setup';
+    }
+  },
+
+  render() {
+    let {card} = this.props;
+    let CardComponent = card.component;
+    return (
+      <div className="row">
+        <div className="col-md-6">
+          <StyledBox className="align-center">
+            <CardComponent />
+          </StyledBox>
+        </div>
+
+        <div className="col-md-6">
+          <StyledBox className="align-left">
+            <h3> {card.title}</h3>
+            <p> {card.message}</p>
+            <div className="align-left">
+              <Button
+                href={this.props.step === 4 && 'https://docs.sentry.io/learn/releases/'}
+                onClick={this.props.onClick}
+              >
+                {this.getMessage()}
+              </Button>
+            </div>
+          </StyledBox>
+        </div>
+      </div>
+    );
+  },
+});
+
+const StyledBox = styled(Box)`
+  padding: 80px;
+  align-items: center;
+`;
+export default ReleaseLandingCard;

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseLandingCard.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseLandingCard.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
 import {Box} from 'grid-emotion';
+import {t} from 'app/locale';
 
 import Button from 'app/components/button';
 
@@ -11,15 +12,16 @@ const ReleaseLandingCard = createReactClass({
 
   propTypes: {
     card: PropTypes.object.isRequired,
+    cardsLength: PropTypes.number.isRequired,
     step: PropTypes.number.isRequired,
     onClick: PropTypes.func.isRequired,
   },
 
   getMessage() {
-    let {step} = this.props;
+    let {cardsLength, step} = this.props;
     if (step == 0) {
       return 'Tell Me More';
-    } else if (step < 4) {
+    } else if (step < cardsLength - 1) {
       return 'Next';
     } else {
       return 'See Docs for Setup';
@@ -27,28 +29,33 @@ const ReleaseLandingCard = createReactClass({
   },
 
   render() {
-    let {card} = this.props;
+    let {card, cardsLength, step} = this.props;
     let CardComponent = card.component;
+    let finalStep = step === cardsLength - 1;
     return (
       <div className="row">
         <div className="col-md-6">
-          <StyledBox className="align-center">
+          <StyledBox>
             <CardComponent />
           </StyledBox>
         </div>
 
         <div className="col-md-6">
-          <StyledBox className="align-left">
-            <h3> {card.title}</h3>
-            <p> {card.message}</p>
-            <div className="align-left">
-              <Button
-                href={this.props.step === 4 && 'https://docs.sentry.io/learn/releases/'}
+          <StyledBox>
+            <h3> {t(card.title)}</h3>
+            <p> {t(card.message)}</p>
+            {finalStep ? (
+              <StyledButton
+                href={'https://docs.sentry.io/learn/releases/'}
                 onClick={this.props.onClick}
               >
-                {this.getMessage()}
-              </Button>
-            </div>
+                {t(this.getMessage())}
+              </StyledButton>
+            ) : (
+              <StyledButton onClick={this.props.onClick}>
+                {t(this.getMessage())}
+              </StyledButton>
+            )}
           </StyledBox>
         </div>
       </div>
@@ -59,5 +66,9 @@ const ReleaseLandingCard = createReactClass({
 const StyledBox = styled(Box)`
   padding: 80px;
   align-items: center;
+`;
+
+const StyledButton = styled(Button)`
+  align-items: left;
 `;
 export default ReleaseLandingCard;

--- a/tests/js/spec/views/releasesLanding.spec.jsx
+++ b/tests/js/spec/views/releasesLanding.spec.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import ReleaseLanding from 'app/views/projectReleases/releaseLanding';
+
+describe('ProjectReleasesLanding', function() {
+  let wrapper;
+
+  beforeEach(function() {
+    wrapper = mount(<ReleaseLanding />, TestStubs.routerContext());
+  });
+
+  it('renders first step', function() {
+    expect(wrapper.find('Contributors')).toHaveLength(1);
+  });
+
+  it('renders next steps', function() {
+    wrapper.find('Button').simulate('click');
+    expect(wrapper.find('SuggestedAssignees')).toHaveLength(1);
+    wrapper.find('Button').simulate('click');
+    expect(wrapper.find('Issues')).toHaveLength(1);
+    wrapper.find('Button').simulate('click');
+    expect(wrapper.find('BashCard')).toHaveLength(1);
+    wrapper.find('Button').simulate('click');
+    expect(wrapper.find('Emails')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
This is what will show if they have never sent a release on this particular project. 
See spec [here](https://paper.dropbox.com/doc/Spec-Releases-tab--ANo1zkOS8drR7JA7ey_QLKKMAg-Ie1TFu4Vn1znYvYwlVp3G)
Note: This will not render anywhere for now. It will be released to a subset of users at first.

TODO
- [x] tests
- [x] make second circular card padding work not overflow

Before
<img width="1065" alt="screen shot 2018-09-28 at 12 25 10 pm" src="https://user-images.githubusercontent.com/16228317/46229179-966b1900-c319-11e8-9114-36b160fb1127.png">

After
![releases_landing_2](https://user-images.githubusercontent.com/16228317/46546809-04b25d00-c87f-11e8-8d09-547a714b5c23.gif)


