### PR TITLE
fix(discover): Fix reset behavior

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -50,22 +50,25 @@ export default class OrganizationDiscover extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const {queryBuilder, location: {search, action}} = nextProps;
+    const {queryBuilder, location: {search}} = nextProps;
     const currentSearch = this.props.location.search;
 
-    if (currentSearch === search || action === 'REPLACE') {
+    if (currentSearch === search) {
       return;
     }
 
-    const newQuery = getQueryFromQueryString(search);
-    queryBuilder.reset(newQuery);
+    // Clear data only if location.search is empty (reset has been called)
+    if (!search) {
+      const newQuery = getQueryFromQueryString(search);
+      queryBuilder.reset(newQuery);
 
-    this.setState({
-      data: null,
-      query: null,
-      chartData: null,
-      chartQuery: null,
-    });
+      this.setState({
+        data: null,
+        query: null,
+        chartData: null,
+        chartQuery: null,
+      });
+    }
   }
 
   updateField = (field, value) => {

--- a/tests/js/spec/views/organizationDiscover/discover.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/discover.spec.jsx
@@ -137,7 +137,7 @@ describe('Discover', function() {
       expect(wrapper.find('NumberField[name="limit"]').prop('value')).toBe(1000);
     });
 
-    it('does not reset on location replace', function() {
+    it('does not reset if location.search is empty', function() {
       const prevCallCount = queryBuilder.reset.mock.calls.length;
       wrapper.setProps({
         location: {


### PR DESCRIPTION
Only resets forms and clears state if location.search is empty. Fixes a bug where this was being called incorrectly when other new props were received.