### PR TITLE
ref(integrations): GH log missing integration events

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -90,6 +90,7 @@ class InstallationEventWebhook(Webhook):
                     external_id=external_id,
                     provider=self.provider,
                 )
+                self._handle_delete(event, integration)
             except Integration.DoesNotExist:
                 logger.info(
                     'github.deletion-missing-integration',
@@ -98,8 +99,6 @@ class InstallationEventWebhook(Webhook):
                         'external_id': external_id,
                     }
                 )
-            else:
-                self._handle_delete(event, integration)
 
     def _handle_delete(self, event, integration):
 

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -46,6 +46,10 @@ class Webhook(object):
                 provider=self.provider,
             )
         except Integration.DoesNotExist:
+            # It seems possible for the GH or GHE app to be installed on their
+            # end, but the integration to not exist. Possibly from deleting in
+            # Sentry first or from a failed install flow (where the integration
+            # didn't get created in the first place)
             logger.info(
                 'github.missing-integration',
                 extra={
@@ -93,6 +97,10 @@ class InstallationEventWebhook(Webhook):
                 )
                 self._handle_delete(event, integration)
             except Integration.DoesNotExist:
+                # It seems possible for the GH or GHE app to be installed on their
+                # end, but the integration to not exist. Possibly from deleting in
+                # Sentry first or from a failed install flow (where the integration
+                # didn't get created in the first place)
                 logger.info(
                     'github.deletion-missing-integration',
                     extra={

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -49,7 +49,8 @@ class Webhook(object):
             logger.info(
                 'github.missing-integration',
                 extra={
-                    'event_data': event,
+                    'action': event['action'],
+                    'repository': event.get('repository'),
                     'external_id': external_id,
                 }
             )
@@ -95,7 +96,8 @@ class InstallationEventWebhook(Webhook):
                 logger.info(
                     'github.deletion-missing-integration',
                     extra={
-                        'event_data': event,
+                        'action': event['action'],
+                        'installation_name': event['account']['login'],
                         'external_id': external_id,
                     }
                 )


### PR DESCRIPTION
Adds in explaining for why we wouldn't have the integration:
```
# It seems possible for the GH or GHE app to be installed on their
# end, but the integration to not exist. Possibly from deleting in
# Sentry first or from a failed install flow (where the integration
# didn't get created in the first place)
```

But since there isn't really anything we can do at that point, lets just log the info instead of sending it to Sentry

FIXES [SENTRY-6Y6](https://sentry.io/sentry/sentry/issues/596622679/)