### PR TITLE
fix(ui): svg chart excessive height / missing colors

### DIFF
--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -412,8 +412,6 @@ const StyledSvg = styled('svg')`
 const StyledFigure = styled('figure')`
   display: block;
   position: relative;
-  width: 100%;
-  height: 100%;
 `;
 
 const SvgContainer = styled('div')`

--- a/src/sentry/static/sentry/less/project-settings.less
+++ b/src/sentry/static/sentry/less/project-settings.less
@@ -12,7 +12,7 @@
 * ============================================================================
 */
 
-figure.filtered-stats-barchart {
+.filtered-stats-barchart {
   height: 100px;
 
   a,

--- a/src/sentry/static/sentry/less/project-settings.less
+++ b/src/sentry/static/sentry/less/project-settings.less
@@ -12,11 +12,14 @@
 * ============================================================================
 */
 
-.filtered-stats-barchart {
+figure.filtered-stats-barchart {
   height: 100px;
 
-  a {
-    > span {
+  a,
+  g {
+    > span,
+    > rect,
+    &:hover > rect {
       left: 2px;
       right: 2px;
 

--- a/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
@@ -213,7 +213,7 @@ exports[`GroupReleaseStats renders 1`] = `
                 }
               >
                 <figure
-                  className="sparkline barchart css-na17se-StyledFigure e5t71581"
+                  className="sparkline barchart css-lg2nde-StyledFigure e5t71581"
                   style={
                     Object {
                       "height": 40,
@@ -500,7 +500,7 @@ exports[`GroupReleaseStats renders 1`] = `
                 }
               >
                 <figure
-                  className="sparkline barchart css-na17se-StyledFigure e5t71581"
+                  className="sparkline barchart css-lg2nde-StyledFigure e5t71581"
                   style={
                     Object {
                       "height": 40,

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -515,7 +515,7 @@ exports[`ProjectCard renders 1`] = `
                             }
                           >
                             <figure
-                              className="e1wib7610 barchart css-1563gow-StyledFigure-StyledBarChart e5t71581"
+                              className="e1wib7610 barchart css-caakmb-StyledFigure-StyledBarChart e5t71581"
                               style={
                                 Object {
                                   "height": 60,


### PR DESCRIPTION
this fixes a bug where styled components are overriding common container styles for `stackedBarChart`

It also fixes a bug where colors were not working on `projectFiltersChart`