### PR TITLE
ref(integrations): Removed temporary organization_id check from add organization

### DIFF
--- a/src/sentry/models/integration.py
+++ b/src/sentry/models/integration.py
@@ -105,11 +105,6 @@ class Integration(Model):
 
         Returns False if the OrganizationIntegration was not created
         """
-        # TODO(adhiraj): Remove when callsites in sentry-plugins are updated.
-        if isinstance(organization, int):
-            from sentry.models import Organization
-            organization = Organization.objects.get(id=organization)
-
         try:
             with transaction.atomic():
                 integration = OrganizationIntegration.objects.create(


### PR DESCRIPTION
Added in https://github.com/getsentry/sentry/pull/9667 this was a temporary workaround that @adhiraj has fixed. Removing this change.