### PR TITLE
fix(minidump): Detect empty minidumps

### DIFF
--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -617,6 +617,9 @@ class MinidumpView(StoreView):
             except KeyError:
                 raise APIError('Missing minidump upload')
 
+        if minidump.size == 0:
+            raise APIError('Empty minidump upload received')
+
         if settings.SENTRY_MINIDUMP_CACHE:
             if not os.path.exists(settings.SENTRY_MINIDUMP_PATH):
                 os.mkdir(settings.SENTRY_MINIDUMP_PATH, 0o744)

--- a/tests/sentry/lang/native/test_plugin.py
+++ b/tests/sentry/lang/native/test_plugin.py
@@ -1618,3 +1618,10 @@ class MinidumpIntegrationTest(TestCase):
         assert not Event.objects.filter(event_id=event.event_id).exists()
         assert not EventAttachment.objects.filter(event_id=event.event_id).exists()
         assert not File.objects.filter(id=file.id).exists()
+
+    def test_empty_minidump(self):
+        f = BytesIO()
+        f.name = 'empty.dmp'
+        response = self._postMinidumpWithHeader(f)
+        assert response.status_code == 400
+        assert response.content == '{"error":"Empty minidump upload received"}'


### PR DESCRIPTION
Server side fix for SENTRY-6RS. This does not resolve the root cause, which I believe to be a race condition [in sentry-electron](https://github.com/getsentry/sentry-electron/blob/c260f1353d8a5a2607f53c6ae2a16e9d0515ace9/src/main/uploader.ts#L176-L187).

cc @HazAT 
Fixes SENTRY-6RS