### PR TITLE
Remove unreachable return statement in engine.py

### DIFF
--- a/src/sentry/lint/engine.py
+++ b/src/sentry/lint/engine.py
@@ -85,7 +85,6 @@ def get_less_files(file_list=None):
     if file_list is None:
         file_list = ['src/sentry/static/sentry/less', 'src/sentry/static/sentry/app']
     return [x for x in get_files_for_list(file_list) if x.endswith(('.less'))]
-    return file_list
 
 
 def get_python_files(file_list=None):


### PR DESCRIPTION
`engine.py` has two `return` statements in the `get_less_files` function:
```
return [x for x in get_files_for_list(file_list) if x.endswith(('.less'))]
return file_list
```

This PR removes the second one (that will never be reached.)