### PR TITLE
Move unreachable warning before return

### DIFF
--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -66,12 +66,13 @@ def recover(request):
         limit=5,
         window=60,  # 5 per minute should be enough for anyone
     ):
+        logger.warning('recover.rate-limited', extra=extra)
+
         return HttpResponse(
             'You have made too many password recovery attempts. Please try again later.',
             content_type='text/plain',
             status=429,
         )
-        logger.warning('recover.rate-limited', extra=extra)
 
     prefill = {'user': request.GET.get('email')}
 


### PR DESCRIPTION
`src/sentry/web/frontend/accounts.py` contains the following code:
``` 
    if request.method == 'POST' and ratelimiter.is_limited(
        u'accounts:recover:{}'.format(extra['ip_address']),
        limit=5,
        window=60,  # 5 per minute should be enough for anyone
    ):
        return HttpResponse(
            'You have made too many password recovery attempts. Please try again later.',
            content_type='text/plain',
            status=429,
        )
        logger.warning('recover.rate-limited', extra=extra)
```
`logger.warning('recover.rate-limited', extra=extra)` is called after the `return`, and thus never reached. This PR moves the line above the return.
