### PR TITLE
fix(tags) Return '' instead of None

### DIFF
--- a/src/sentry/tagstore/v2/models/grouptagvalue.py
+++ b/src/sentry/tagstore/v2/models/grouptagvalue.py
@@ -105,7 +105,7 @@ class GroupTagValue(Model):
         except TagValue.DoesNotExist:
             # Data got inconsistent, I must delete myself.
             self.delete()
-            return None
+            return ''
 
         # cache for future calls
         self.value = tv


### PR DESCRIPTION
When a tag value is read and doesn't exist we should return  `''` instead of None as tag values are expected to always be a string.

Fixes APP-551
Fixes SENTRY-7M9