### PR TITLE
feat(api): Add ability to set integration id to repo details endpoint

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_repository_details.py
+++ b/tests/sentry/api/endpoints/test_organization_repository_details.py
@@ -155,3 +155,30 @@ class OrganizationRepositoryDeleteTest(APITestCase):
             },
             countdown=3600,
         )
+
+    def test_put(self):
+        self.login_as(user=self.user)
+
+        org = self.create_organization(owner=self.user, name='baz')
+        repo = Repository.objects.create(
+            name='example',
+            organization_id=org.id,
+            status=ObjectStatus.DISABLED,
+        )
+
+        url = reverse(
+            'sentry-api-0-organization-repository-details', args=[
+                org.slug,
+                repo.id,
+            ]
+        )
+        response = self.client.put(url, data={
+            'status': 'visible',
+            'integrationId': '123',
+        })
+
+        assert response.status_code == 200
+
+        repo = Repository.objects.get(id=repo.id)
+        assert repo.status == ObjectStatus.VISIBLE
+        assert repo.integration_id == 123

--- a/tests/sentry/api/endpoints/test_organization_repository_details.py
+++ b/tests/sentry/api/endpoints/test_organization_repository_details.py
@@ -187,7 +187,7 @@ class OrganizationRepositoryDeleteTest(APITestCase):
 
         repo = Repository.objects.get(id=repo.id)
         assert repo.status == ObjectStatus.VISIBLE
-        assert repo.integration_id == 1
+        assert repo.integration_id == integration.id
         assert repo.provider == 'integrations:example'
 
     def test_put_bad_integration_org(self):


### PR DESCRIPTION
In the case that a repository doesn't actually get migrated over correctly from old plugin to new integration (for GH, BB, or VSTS) the only way we can fix that is by doing it manually.

This PR allows us to update the repo so that it has the correct integration id and provider. (The request will be made in [here](https://github.com/getsentry/sentry/blob/master/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx#L98))