### PR TITLE
tests(snuba): Add group_id to all Snuba test inserts

### DIFF
--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -42,6 +42,7 @@ class TagStorageTest(SnubaTestCase):
         data = json.dumps([{
             'event_id': six.text_type(r) * 32,
             'primary_hash': hash1,
+            'group_id': int(hash1[:16], 16),
             'project_id': self.proj1.id,
             'message': 'message 1',
             'platform': 'python',
@@ -63,6 +64,7 @@ class TagStorageTest(SnubaTestCase):
         } for r in [1, 2]] + [{
             'event_id': '3' * 32,
             'primary_hash': hash2,
+            'group_id': int(hash2[:16], 16),
             'project_id': self.proj1.id,
             'message': 'message 2',
             'platform': 'python',

--- a/tests/snuba/test_snuba.py
+++ b/tests/snuba/test_snuba.py
@@ -19,6 +19,7 @@ class SnubaTest(SnubaTestCase):
         events = [{
             'event_id': 'x' * 32,
             'primary_hash': '1' * 32,
+            'group_id': 1,
             'project_id': self.project.id,
             'message': 'message',
             'platform': 'python',
@@ -74,6 +75,7 @@ class SnubaTest(SnubaTestCase):
         self.snuba_insert({
             'event_id': uuid.uuid4().hex,
             'primary_hash': hash,
+            'group_id': int(hash[:16], 16),
             'project_id': self.project.id,
             'message': 'message',
             'platform': 'python',

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -109,6 +109,7 @@ class SnubaTSDBTest(TestCase):
         data = json.dumps([{
             'event_id': (six.text_type(r) * 32)[:32],
             'primary_hash': [hash1, hash2][(r // 600) % 2],  # Switch every 10 mins
+            'group_id': int([hash1, hash2][(r // 600) % 2][:16], 16),
             'project_id': self.proj1.id,
             'message': 'message 1',
             'platform': 'python',


### PR DESCRIPTION
This will allow us to revert the Snuba hack that adds group_id 0 to add
events: https://github.com/getsentry/snuba/commit/df09874de7fe9600665aab9a17c73a441f2643e2

Leaving it in will likely cause errors in the future when we silently
forget group_id or add tests that actually manipulate the group_id.

`int(hash[:16], 16)` is a way to convert an existing `primary_hash` to
an *extremely likely* unique group integer ID.