### PR TITLE
feat(ui): Fix error messages on "Create Team" modal

### DIFF
--- a/src/sentry/static/sentry/app/components/createTeam/createTeamForm.jsx
+++ b/src/sentry/static/sentry/app/components/createTeam/createTeamForm.jsx
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {addSuccessMessage} from 'app/actionCreators/indicator';
-import {t, tct} from 'app/locale';
+import {t} from 'app/locale';
 import Form from 'app/views/settings/components/forms/form';
 import SentryTypes from 'app/sentryTypes';
 import TextField from 'app/views/settings/components/forms/textField';
@@ -17,7 +16,6 @@ export default class CreateTeamForm extends React.Component {
   };
 
   handleCreateTeamSuccess = data => {
-    addSuccessMessage(tct('Added team [team]', {team: `#${data.slug}`}));
     this.props.onSuccess(data);
   };
 

--- a/src/sentry/static/sentry/app/components/modals/createTeamModal.jsx
+++ b/src/sentry/static/sentry/app/components/modals/createTeamModal.jsx
@@ -17,10 +17,15 @@ class CreateTeamModal extends React.Component {
     project: SentryTypes.Project,
   };
 
-  handleSubmit = data => {
-    createTeam(new Client(), data, {orgId: this.props.organization.slug}).then(
-      this.handleSuccess
-    );
+  handleSubmit = (data, onSuccess, onError) => {
+    createTeam(new Client(), data, {orgId: this.props.organization.slug})
+      .then(resp => {
+        this.handleSuccess(resp);
+        onSuccess(resp);
+      })
+      .catch(err => {
+        onError(err);
+      });
   };
 
   handleSuccess = data => {


### PR DESCRIPTION
Fixes the unhandled promise when there is an error creating a team. This also gives
us better error handling (as previously it was not routing through default error handler.
The form will now display field specific errors when relevant.

Fixes JAVASCRIPT-3C0 (partially, as there are other sources for this issue).