### PR TITLE
fix(svg bar charts): min heights for project filters

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.jsx
@@ -193,7 +193,7 @@ const ProjectFiltersChart = createReactClass({
                 barClasses={classes}
                 className="standard-barchart filtered-stats-barchart"
                 tooltip={this.renderTooltip}
-                minHeights={classes.map(p => p == "legacy-browsers" ? 1 : 0)}
+                minHeights={classes.map(p => p == 'legacy-browsers' ? 1 : 0)}
               />
             )}
           {hasLoaded &&

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.jsx
@@ -193,7 +193,7 @@ const ProjectFiltersChart = createReactClass({
                 barClasses={classes}
                 className="standard-barchart filtered-stats-barchart"
                 tooltip={this.renderTooltip}
-                minHeights={classes.map((p, i) => i == 0 ? 1 : 0)}
+                minHeights={classes.map(p => i == "error-message" ? 1 : 0)}
               />
             )}
           {hasLoaded &&

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.jsx
@@ -176,6 +176,7 @@ const ProjectFiltersChart = createReactClass({
     let isLoading = loading || !this.state.formattedData;
     let hasError = !isLoading && error;
     let hasLoaded = !isLoading && !error;
+    let classes = Object.keys(this.getStatOpts());
 
     return (
       <Panel>
@@ -189,9 +190,10 @@ const ProjectFiltersChart = createReactClass({
               <StackedBarChart
                 series={this.state.formattedData}
                 label="events"
-                barClasses={Object.keys(this.getStatOpts())}
+                barClasses={classes}
                 className="standard-barchart filtered-stats-barchart"
                 tooltip={this.renderTooltip}
+                minHeights={classes.map((p, i) => i == 0 ? 1 : 0)}
               />
             )}
           {hasLoaded &&

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.jsx
@@ -193,7 +193,7 @@ const ProjectFiltersChart = createReactClass({
                 barClasses={classes}
                 className="standard-barchart filtered-stats-barchart"
                 tooltip={this.renderTooltip}
-                minHeights={classes.map(p => i == "error-message" ? 1 : 0)}
+                minHeights={classes.map(p => i == "legacy-browsers" ? 1 : 0)}
               />
             )}
           {hasLoaded &&

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.jsx
@@ -193,7 +193,7 @@ const ProjectFiltersChart = createReactClass({
                 barClasses={classes}
                 className="standard-barchart filtered-stats-barchart"
                 tooltip={this.renderTooltip}
-                minHeights={classes.map(p => i == "legacy-browsers" ? 1 : 0)}
+                minHeights={classes.map(p => p == "legacy-browsers" ? 1 : 0)}
               />
             )}
           {hasLoaded &&


### PR DESCRIPTION
the project filters bar chart doesn't have min heights and the 1pt values look kinda odd because there are so many:

![image](https://user-images.githubusercontent.com/435981/46379173-d9e3c100-c652-11e8-8a12-9b9dff9b1717.png)

It's super annoying to get project filters working in dev, so I just faked some data. I added a bunch of zeroes into the fake data and it looked like this:

<img width="938" alt="before1" src="https://user-images.githubusercontent.com/435981/46379212-f67ff900-c652-11e8-9af5-4fa2581f7377.png">

you can see that all of the zero databits are sandwiched together at the bottom.

after this pull, the fake data looks like this:

<img width="937" alt="after1" src="https://user-images.githubusercontent.com/435981/46379800-dea97480-c654-11e8-9564-329c7b0f9003.png">

The reason this happens is because previously, min-heights were applied as CSS and weren't factored into the stacking of the bars. If there were multiple bars with min-heights, they would just stack on top of each other and whatever bar was last would be on top. 

This doesn't seem like an ideal behavior to me, so rather than try to replicate it, I'm just adding things here and there to make the old stuff look semi dece.