### PR TITLE
fix(discover): Fix incorrect references to result data

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
@@ -95,7 +95,7 @@ export default class Result extends React.Component {
     const baseViews = ['table', 'line', 'bar'];
     const summaryData = baseViews.includes(this.state.view)
       ? baseQuery.data
-      : byDayQuery.chartData;
+      : byDayQuery.data;
 
     return (
       <ResultSummary>
@@ -144,7 +144,7 @@ export default class Result extends React.Component {
               series={basicChartData}
               height={300}
               tooltip={tooltipOptions}
-              legend={{data: [baseQuery.aggregations[0][2]]}}
+              legend={{data: [baseQuery.query.aggregations[0][2]]}}
               renderer="canvas"
             />
           </ChartWrapper>
@@ -155,7 +155,7 @@ export default class Result extends React.Component {
               series={basicChartData}
               height={300}
               tooltip={tooltipOptions}
-              legend={{data: [baseQuery.aggregations[0][2]]}}
+              legend={{data: [baseQuery.query.aggregations[0][2]]}}
               renderer="canvas"
             />
           </ChartWrapper>


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/getsentry/sentry/pull/9965 that causes the application to crash when attempting to render charts, due to the result data object having changed structure