### PR TITLE
fix(integrations): Change logger level for commit fetching failures

### DIFF
--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -93,7 +93,8 @@ def fetch_commits(release_id, user_id, refs, prev_release_id=None, **kwargs):
             )
             continue
 
-        binding_key = 'integration-repository.provider' if is_integration_provider(repo.provider) else 'repository.provider'
+        binding_key = 'integration-repository.provider' if is_integration_provider(
+            repo.provider) else 'repository.provider'
         try:
             provider_cls = bindings.get(binding_key).get(repo.provider)
         except KeyError:
@@ -127,9 +128,8 @@ def fetch_commits(release_id, user_id, refs, prev_release_id=None, **kwargs):
         except NotImplementedError:
             pass
         except Exception as exc:
-            logger.exception(
+            logger.info(
                 'fetch_commits.error',
-                exc_info=True,
                 extra={
                     'organization_id': repo.organization_id,
                     'user_id': user_id,


### PR DESCRIPTION
fixes SENTRY-781

this just means this will go into kibana rather than sentry