### PR TITLE
fix(api) Don't 500 when auth verify gets no password

### DIFF
--- a/src/sentry/api/validators/auth.py
+++ b/src/sentry/api/validators/auth.py
@@ -8,3 +8,11 @@ class AuthVerifyValidator(serializers.Serializer):
     # For u2f
     challenge = serializers.CharField(required=False)
     response = serializers.CharField(required=False)
+
+    def validate(self, data):
+        if 'password' in data:
+            return data
+        if 'challenge' in data and 'response' in data:
+            return data
+        raise serializers.ValidationError(
+            'You must provide `password` or `challenge` and `response`.')

--- a/tests/sentry/api/endpoints/test_auth_index.py
+++ b/tests/sentry/api/endpoints/test_auth_index.py
@@ -66,6 +66,12 @@ class AuthVerifyEndpointTest(APITestCase):
         })
         assert response.status_code == 403
 
+    def test_no_password_no_u2f(self):
+        user = self.create_user('foo@example.com')
+        self.login_as(user)
+        response = self.client.put(self.path, data={})
+        assert response.status_code == 400
+
 
 class AuthLogoutEndpointTest(APITestCase):
     path = '/api/0/auth/'


### PR DESCRIPTION
Make the password a required field if we 500 when it is not present. The password is required when a u2f challenge/response is not present.

Fixes APP-555