### PR TITLE
fix(discover): Fix base query object

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/resultManager.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/resultManager.jsx
@@ -48,7 +48,7 @@ export default function createResultManager(queryBuilder) {
     }
 
     return Promise.all(promises).then(resp => {
-      data.baseQuery.query = baseQuery;
+      data.baseQuery.query = query;
       data.baseQuery.data = resp[0];
 
       if (hasAggregations) {


### PR DESCRIPTION
Fixes a bug that caused project_id and event_id to be incorrectly rendered as columns in the table even when they weren't selected by the user.