### PR TITLE
feat(slack): Set level to color on slack attachment

### DIFF
--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -19,12 +19,11 @@ logger = logging.getLogger('sentry.integrations.slack')
 
 # Attachment colors used for issues with no actions take
 ACTIONED_ISSUE_COLOR = '#EDEEEF'
-NEW_ISSUE_COLOR = '#E03E2F'
 LEVEL_TO_COLOR = {
     'debug': '#fbe14f',
     'info': '#2788ce',
     'warning': '#f18500',
-    'error': NEW_ISSUE_COLOR,
+    'error': '#E03E2F',
     'fatal': '#d20f2a',
 }
 
@@ -159,7 +158,7 @@ def build_attachment(group, event=None, tags=None, identity=None, actions=None, 
     teams = get_team_assignees(group)
 
     logo_url = absolute_uri(get_asset_url('sentry', 'images/sentry-email-avatar.png'))
-    color = LEVEL_TO_COLOR.get(event.get_tag('level'), 'error') if event else NEW_ISSUE_COLOR
+    color = LEVEL_TO_COLOR.get(event.get_tag('level'), 'error') if event else LEVEL_TO_COLOR['error']
 
     text = build_attachment_text(group, event) or ''
 

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -18,8 +18,15 @@ from sentry.models import (
 logger = logging.getLogger('sentry.integrations.slack')
 
 # Attachment colors used for issues with no actions take
-NEW_ISSUE_COLOR = '#E03E2F'
 ACTIONED_ISSUE_COLOR = '#EDEEEF'
+NEW_ISSUE_COLOR = '#E03E2F'
+LEVEL_TO_COLOR = {
+    'debug': '#fbe14f',
+    'info': '#2788ce',
+    'warning': '#f18500',
+    'error': NEW_ISSUE_COLOR,
+    'fatal': '#d20f2a',
+}
 
 
 def format_actor_option(actor):
@@ -152,7 +159,7 @@ def build_attachment(group, event=None, tags=None, identity=None, actions=None, 
     teams = get_team_assignees(group)
 
     logo_url = absolute_uri(get_asset_url('sentry', 'images/sentry-email-avatar.png'))
-    color = NEW_ISSUE_COLOR
+    color = LEVEL_TO_COLOR.get(event.get_tag('level'), 'error') if event else NEW_ISSUE_COLOR
 
     text = build_attachment_text(group, event) or ''
 


### PR DESCRIPTION
hello, 
I want to see again the color of level on slack notification like before sentry integration(web hook).

Like this
![webhook-screenshot](https://imgur.com/1m7D69E.jpg)
