### PR TITLE
fix(ui) Switch remaining logout links to form submit

### DIFF
--- a/src/sentry/templates/sentry/accept-organization-invite.html
+++ b/src/sentry/templates/sentry/accept-organization-invite.html
@@ -23,7 +23,11 @@
           <div class="alert alert-block">
             <p>Your account (<strong>{{ request.user.username }}</strong>) is already a member of this organization.</p>
 
-            <p>Did you want to <a href="{{ logout_url }}">switch accounts</a>?</p>
+            <p>Did you want to <a href="#" onclick="document.logoutForm.submit()">switch accounts</a>?</p>
+
+            <form action="{{ logout_url }}" method="POST" name="logoutForm" style="display:none;">
+              {% csrf_token %}
+            </form>
           </div>
         {% endif %}
 

--- a/src/sentry/templates/sentry/bases/modal.html
+++ b/src/sentry/templates/sentry/bases/modal.html
@@ -15,7 +15,10 @@
         {% block modal_header_signout %}
           {% if request.user.is_authenticated %}
             <div class="pull-right">
-              <a href="{% url 'sentry-logout' %}?next={{ request.get_full_path|urlencode }}">{% trans "Sign out" %}</a>
+              <a href="#" onclick="document.modalLogoutForm.submit()">{% trans "Sign out" %}</a>
+              <form style="display:none;" name="modalLogoutForm" action="{% url 'sentry-logout' %}?next={{ request.get_full_path|urlencode }}" method="POST">
+                {% csrf_token %}
+              </form>
             </div>
           {% endif %}
         {% endblock %}

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -107,66 +107,6 @@
     {% endblock %}
 
     {% block header %}
-    {% comment %}
-    <header>
-      <div class="container">
-        {% if request.user.is_authenticated %}
-        {% block account_nav %}
-        <div class="pull-right">
-          <div class="dropdown">
-            <a class="dropdown-toggle" data-toggle="dropdown">
-              <span class="avatar">
-                {% avatar request.user %}
-              </span>
-              <i class="icon-arrow-down"></i>
-            </a>
-            <ul class="dropdown-menu dropdown-menu-right">
-              <li><a href="{% url 'sentry-account-settings' %}">{% trans "Account" %}</a></li>
-              <li><a href="{% url 'sentry-api' %}">{% trans "API" %}</a></li>
-              {% if request.is_superuser %}
-                <li><a href="{% url 'sentry-admin-overview' %}">{% trans "Admin" %}</a></li>
-              {% endif %}
-              <li><a href="{% url 'sentry-logout' %}">{% trans "Sign out" %}</a></li>
-            </ul>
-          </div>
-        </div>
-        {% endblock %}
-        {% endif %}
-
-        {% block logo %}
-        <a href="/" class="logo"><span class="icon-sentry-logo"></span></a>
-        {% endblock %}
-
-        <ul class="global-nav pull-right">
-          {% block global_nav %}
-          <li><a href="https://docs.sentry.io">{% trans "Docs" %}</a></li>
-          {% endblock %}
-        </ul>
-
-        {% if not SINGLE_ORGANIZATION and request.user.is_authenticated and organization %}
-        {% block org_selector %}
-        <div class="org-selector pull-right">
-          <div class="dropdown">
-            <a class="dropdown-toggle" data-toggle="dropdown">
-              {{ organization.name }}
-              <i class="icon-arrow-down"></i>
-            </a>
-            <ul class="dropdown-menu dropdown-menu-right">
-              {% for org in request.user|list_organizations %}
-                <li><a href="{% url 'sentry-organization-home' org.slug %}">{{ org.name }}</a></li>
-              {% endfor %}
-              {% feature organizations:create %}
-                <li class="divider"></li>
-                <li><a href="{% absolute_uri '/organizations/new/' %}">New Organization</a></li>
-              {% endfeature %}
-            </ul>
-          </div>
-        </div>
-        {% endblock %}
-        {% endif %}
-      </div>
-    </header>
-    {% endcomment %}
     {% endblock %}
 
     {% if organization and ACCESS.org_read %}


### PR DESCRIPTION
I missed a few logout links when I switched logout to POST only. I've opted to use a hidden form submit with DOM1 event handlers as it requires the least amount of Javascript/CSS being added to the django templates. I pruned out another logout link that was in a block of commented code that we no longer need.

Refs APP-568