### PR TITLE
fix(eventstream): Batch up merge and unmerge events

### DIFF
--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -31,7 +31,7 @@ from sentry.models.group import looks_like_short_id
 from sentry.receivers import DEFAULT_SAVED_SEARCHES
 from sentry.search.utils import InvalidQuery, parse_query
 from sentry.signals import advanced_search, issue_ignored, issue_resolved_in_release, issue_deleted
-from sentry.tasks.deletion import delete_group
+from sentry.tasks.deletion import delete_groups
 from sentry.tasks.integrations import kick_off_status_syncs
 from sentry.tasks.merge import merge_group
 from sentry.utils.apidocs import attach_scenarios, scenario
@@ -855,7 +855,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
             group_list_by_times_seen = sorted(group_list, key=lambda x: x.times_seen, reverse=True)
             primary_group, groups_to_merge = group_list_by_times_seen[0], group_list_by_times_seen[1:]
 
-            eventstream.merge(
+            eventstream_state = eventstream.start_merge(
                 primary_group.project_id,
                 [g.id for g in groups_to_merge],
                 primary_group.id
@@ -868,6 +868,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                     from_object_id=group.id,
                     to_object_id=primary_group.id,
                     transaction_id=transaction_id,
+                    eventstream_state=eventstream_state,
                 )
 
             Activity.objects.create(
@@ -947,6 +948,9 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
         return Response(status=204)
 
     def _delete_groups(self, request, project, group_list, delete_type):
+        if not group_list:
+            return
+
         group_ids = [g.id for g in group_list]
 
         Group.objects.filter(
@@ -956,7 +960,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
             GroupStatus.DELETION_IN_PROGRESS,
         ]).update(status=GroupStatus.PENDING_DELETION)
 
-        eventstream.delete_groups(project.id, group_ids)
+        eventstream_state = eventstream.start_delete_groups(project.id, group_ids)
 
         GroupHashTombstone.tombstone_groups(
             project_id=project.id,
@@ -965,15 +969,16 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
 
         transaction_id = uuid4().hex
 
-        for group in group_list:
-            delete_group.apply_async(
-                kwargs={
-                    'object_id': group.id,
-                    'transaction_id': transaction_id,
-                },
-                countdown=3600,
-            )
+        delete_groups.apply_async(
+            kwargs={
+                'object_ids': group_ids,
+                'transaction_id': transaction_id,
+                'eventstream_state': eventstream_state,
+            },
+            countdown=3600,
+        )
 
+        for group in group_list:
             self.create_audit_entry(
                 request=request,
                 organization_id=project.organization_id,

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -951,8 +951,6 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
         if not group_list:
             return
 
-        # delete groups from least seen ("smallest") to most seen ("largest")
-        group_list = sorted(group_list, key=lambda g: g.times_seen)
         group_ids = [g.id for g in group_list]
 
         Group.objects.filter(

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -951,6 +951,8 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
         if not group_list:
             return
 
+        # delete groups from least seen ("smallest") to most seen ("largest")
+        group_list = sorted(group_list, key=lambda g: g.times_seen)
         group_ids = [g.id for g in group_list]
 
         Group.objects.filter(

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -855,7 +855,11 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
             group_list_by_times_seen = sorted(group_list, key=lambda x: x.times_seen, reverse=True)
             primary_group, groups_to_merge = group_list_by_times_seen[0], group_list_by_times_seen[1:]
 
-            eventstream.merge(group.project_id, [g.id for g in groups_to_merge], primary_group.id)
+            eventstream.merge(
+                primary_group.project_id,
+                [g.id for g in groups_to_merge],
+                primary_group.id
+            )
 
             transaction_id = uuid4().hex
             for group in groups_to_merge:

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1026,11 +1026,8 @@ class EventManager(object):
         ).exclude(
             group=group,
         )
-
         if not bad_hashes:
             return
-
-        eventstream.merge(group.project_id, [h.group_id for h in bad_hashes], group.id)
 
         for hash in bad_hashes:
             if hash.group_id:

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1026,8 +1026,11 @@ class EventManager(object):
         ).exclude(
             group=group,
         )
+
         if not bad_hashes:
             return
+
+        eventstream.merge(group.project_id, [h.group_id for h in bad_hashes], group.id)
 
         for hash in bad_hashes:
             if hash.group_id:

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -12,9 +12,12 @@ logger = logging.getLogger(__name__)
 class EventStream(Service):
     __all__ = (
         'insert',
-        'unmerge',
-        'delete_groups',
-        'merge',
+        'start_unmerge',
+        'end_unmerge',
+        'start_delete_groups',
+        'end_delete_groups',
+        'start_merge',
+        'end_merge',
     )
 
     def insert(self, group, event, is_new, is_sample, is_regression,
@@ -32,11 +35,20 @@ class EventStream(Service):
                 primary_hash=primary_hash,
             )
 
-    def unmerge(self, project_id, hashes, new_group_id):
+    def start_unmerge(self, project_id, hashes, previous_group_id, new_group_id):
         pass
 
-    def delete_groups(self, project_id, group_ids):
+    def end_unmerge(self, state):
         pass
 
-    def merge(self, project_id, previous_group_ids, new_group_id):
+    def start_delete_groups(self, project_id, group_ids):
+        pass
+
+    def end_delete_groups(self, state):
+        pass
+
+    def start_merge(self, project_id, previous_group_ids, new_group_id):
+        pass
+
+    def end_merge(self, state):
         pass

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -12,12 +12,12 @@ logger = logging.getLogger(__name__)
 class EventStream(Service):
     __all__ = (
         'insert',
-        'start_unmerge',
-        'end_unmerge',
         'start_delete_groups',
         'end_delete_groups',
         'start_merge',
         'end_merge',
+        'start_unmerge',
+        'end_unmerge',
     )
 
     def insert(self, group, event, is_new, is_sample, is_regression,
@@ -35,12 +35,6 @@ class EventStream(Service):
                 primary_hash=primary_hash,
             )
 
-    def start_unmerge(self, project_id, hashes, previous_group_id, new_group_id):
-        pass
-
-    def end_unmerge(self, state):
-        pass
-
     def start_delete_groups(self, project_id, group_ids):
         pass
 
@@ -51,4 +45,10 @@ class EventStream(Service):
         pass
 
     def end_merge(self, state):
+        pass
+
+    def start_unmerge(self, project_id, hashes, previous_group_id, new_group_id):
+        pass
+
+    def end_unmerge(self, state):
         pass

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -32,11 +32,11 @@ class EventStream(Service):
                 primary_hash=primary_hash,
             )
 
-    def unmerge(self, project_id, new_group_id, event_ids):
+    def unmerge(self, project_id, hashes, new_group_id):
         pass
 
     def delete_groups(self, project_id, group_ids):
         pass
 
-    def merge(self, project_id, previous_group_id, new_group_id):
+    def merge(self, project_id, previous_group_ids, new_group_id):
         pass

--- a/src/sentry/eventstream/kafka.py
+++ b/src/sentry/eventstream/kafka.py
@@ -131,12 +131,14 @@ class KafkaEventStream(EventStream):
             'is_new_group_environment': is_new_group_environment,
         },))
 
-    def unmerge(self, project_id, hashes, new_group_id):
+    def unmerge(self, project_id, hashes, previous_group_id, new_group_id):
         if not hashes:
             return
 
+        # add previous group_id
         self._send(project_id, 'unmerge', extra_data=({
             'project_id': project_id,
+            'previous_group_id': previous_group_id,
             'new_group_id': new_group_id,
             'hashes': hashes,
             'datetime': datetime.now(tz=pytz.utc),

--- a/src/sentry/eventstream/kafka.py
+++ b/src/sentry/eventstream/kafka.py
@@ -157,6 +157,7 @@ class KafkaEventStream(EventStream):
         return state
 
     def end_delete_groups(self, state):
+        state = state.copy()
         state['datetime'] = datetime.now(tz=pytz.utc)
         self._send(
             state['project_id'],
@@ -185,6 +186,7 @@ class KafkaEventStream(EventStream):
         )
 
     def end_merge(self, state):
+        state = state.copy()
         state['datetime'] = datetime.now(tz=pytz.utc)
         self._send(
             state['project_id'],
@@ -216,6 +218,7 @@ class KafkaEventStream(EventStream):
         return state
 
     def end_unmerge(self, state):
+        state = state.copy()
         state['datetime'] = datetime.now(tz=pytz.utc)
         self._send(
             state['project_id'],

--- a/src/sentry/eventstream/kafka.py
+++ b/src/sentry/eventstream/kafka.py
@@ -118,14 +118,14 @@ class KafkaEventStream(EventStream):
             'is_new_group_environment': is_new_group_environment,
         },))
 
-    def unmerge(self, project_id, new_group_id, event_ids):
-        if not event_ids:
+    def unmerge(self, project_id, hashes, new_group_id):
+        if not hashes:
             return
 
         self._send(project_id, 'unmerge', extra_data=({
             'project_id': project_id,
             'new_group_id': new_group_id,
-            'event_ids': event_ids,
+            'hashes': hashes,
             'datetime': datetime.now(tz=pytz.utc),
         },), asynchronous=False)
 
@@ -139,10 +139,13 @@ class KafkaEventStream(EventStream):
             'datetime': datetime.now(tz=pytz.utc),
         },), asynchronous=False)
 
-    def merge(self, project_id, previous_group_id, new_group_id):
+    def merge(self, project_id, previous_group_ids, new_group_id):
+        if not previous_group_ids:
+            return
+
         self._send(project_id, 'merge', extra_data=({
             'project_id': project_id,
-            'previous_group_id': previous_group_id,
+            'previous_group_ids': previous_group_ids,
             'new_group_id': new_group_id,
             'datetime': datetime.now(tz=pytz.utc),
         },), asynchronous=False)

--- a/src/sentry/eventstream/kafka.py
+++ b/src/sentry/eventstream/kafka.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import logging
 import pytz
 import six
+from uuid import uuid4
 
 from confluent_kafka import Producer
 from django.utils.functional import cached_property
@@ -38,18 +39,20 @@ EVENT_PROTOCOL_VERSION = 2
 #   }, {
 #       ...state for post-processing...
 #   })
-#   Delete Groups: (2, 'delete_groups', {
+#   Delete Groups: (2, '(start_delete_groups|end_delete_groups)', {
 #       'project_id': id,
 #       'group_ids': [id2, id2, id3],
 #       'datetime': timestamp,
 #   })
-#   Unmerge: (2, 'unmerge', {
+#   Unmerge: (2, '(start_unmerge|end_unmerge)', {
+#       'transaction_id': uuid,
 #       'project_id': id,
+#       'previous_group_id': id,
 #       'new_group_id': id,
 #       'hashes': [hash2, hash2]
 #       'datetime': timestamp,
 #   })
-#   Merge: (2, 'merge', {
+#   Merge: (2, '(start_merge|end_merge)', {
 #       'project_id': id,
 #       'previous_group_ids': [id2, id2],
 #       'new_group_id': id,
@@ -131,36 +134,90 @@ class KafkaEventStream(EventStream):
             'is_new_group_environment': is_new_group_environment,
         },))
 
-    def unmerge(self, project_id, hashes, previous_group_id, new_group_id):
+    def start_unmerge(self, project_id, hashes, previous_group_id, new_group_id):
         if not hashes:
             return
 
-        # add previous group_id
-        self._send(project_id, 'unmerge', extra_data=({
+        state = {
+            'transaction_id': uuid4().hex,
             'project_id': project_id,
             'previous_group_id': previous_group_id,
             'new_group_id': new_group_id,
             'hashes': hashes,
             'datetime': datetime.now(tz=pytz.utc),
-        },), asynchronous=False)
+        }
 
-    def delete_groups(self, project_id, group_ids):
+        self._send(
+            project_id,
+            'start_unmerge',
+            extra_data=(state,),
+            asynchronous=False
+        )
+
+        return state
+
+    def end_unmerge(self, state):
+        state['datetime'] = datetime.now(tz=pytz.utc)
+        self._send(
+            state['project_id'],
+            'end_unmerge',
+            extra_data=(state,),
+            asynchronous=False
+        )
+
+    def start_delete_groups(self, project_id, group_ids):
         if not group_ids:
             return
 
-        self._send(project_id, 'delete_groups', extra_data=({
+        state = {
+            'transaction_id': uuid4().hex,
             'project_id': project_id,
             'group_ids': group_ids,
             'datetime': datetime.now(tz=pytz.utc),
-        },), asynchronous=False)
+        }
 
-    def merge(self, project_id, previous_group_ids, new_group_id):
+        self._send(
+            project_id,
+            'delete_groups',
+            extra_data=(state,),
+            asynchronous=False
+        )
+
+        return state
+
+    def end_delete_groups(self, state):
+        state['datetime'] = datetime.now(tz=pytz.utc)
+        self._send(
+            state['project_id'],
+            'end_delete_groups',
+            extra_data=(state,),
+            asynchronous=False
+        )
+
+    def start_merge(self, project_id, previous_group_ids, new_group_id):
         if not previous_group_ids:
             return
 
-        self._send(project_id, 'merge', extra_data=({
+        state = {
+            'transaction_id': uuid4().hex,
             'project_id': project_id,
             'previous_group_ids': previous_group_ids,
             'new_group_id': new_group_id,
             'datetime': datetime.now(tz=pytz.utc),
-        },), asynchronous=False)
+        }
+
+        self._send(
+            project_id,
+            'merge',
+            extra_data=(state,),
+            asynchronous=False
+        )
+
+    def end_merge(self, state):
+        state['datetime'] = datetime.now(tz=pytz.utc)
+        self._send(
+            state['project_id'],
+            'merge',
+            extra_data=(state,),
+            asynchronous=False
+        )

--- a/src/sentry/eventstream/kafka.py
+++ b/src/sentry/eventstream/kafka.py
@@ -18,30 +18,43 @@ logger = logging.getLogger(__name__)
 
 # Beware! Changing this, or the message format/fields themselves requires
 # consideration of all downstream consumers.
+EVENT_PROTOCOL_VERSION = 2
+
 # Version 1 format: (1, TYPE, [...REST...])
 #   Insert: (1, 'insert', {
 #       ...event json...
 #   }, {
 #       ...state for post-processing...
 #   })
-#   Delete Groups: (1, 'delete_groups', {
+#
+#   Mutations that *should be ignored*: (1, ('delete_groups'|'unmerge'|'merge'), {...})
+#
+#   In short, for protocol version 1 only messages starting with (1, 'insert', ...)
+#   should be processed.
+
+# Version 2 format: (2, TYPE, [...REST...])
+#   Insert: (2, 'insert', {
+#       ...event json...
+#   }, {
+#       ...state for post-processing...
+#   })
+#   Delete Groups: (2, 'delete_groups', {
 #       'project_id': id,
-#       'group_ids': [id1, id2, id3],
+#       'group_ids': [id2, id2, id3],
 #       'datetime': timestamp,
 #   })
-#   Unmerge: (1, 'unmerge', {
+#   Unmerge: (2, 'unmerge', {
 #       'project_id': id,
 #       'new_group_id': id,
-#       'event_ids': [id1, id2]
+#       'hashes': [hash2, hash2]
 #       'datetime': timestamp,
 #   })
-#   Merge: (1, 'merge', {
+#   Merge: (2, 'merge', {
 #       'project_id': id,
-#       'previous_group_id': id,
+#       'previous_group_ids': [id2, id2],
 #       'new_group_id': id,
 #       'datetime': timestamp,
 #   })
-EVENT_PROTOCOL_VERSION = 1
 
 
 class KafkaEventStream(EventStream):

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -23,11 +23,11 @@ class SnubaEventStream(EventStream):
             primary_hash, skip_consume
         )
 
-    def unmerge(self, project_id, new_group_id, event_ids):
+    def unmerge(self, project_id, hashes, new_group_id):
         pass
 
     def delete_groups(self, project_id, group_ids):
         pass
 
-    def merge(self, project_id, previous_group_id, new_group_id):
+    def merge(self, project_id, previous_group_ids, new_group_id):
         pass

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -23,12 +23,6 @@ class SnubaEventStream(EventStream):
             primary_hash, skip_consume
         )
 
-    def start_unmerge(self, project_id, hashes, previous_group_id, new_group_id):
-        pass
-
-    def end_unmerge(self, state):
-        pass
-
     def start_delete_groups(self, project_id, group_ids):
         pass
 
@@ -39,4 +33,10 @@ class SnubaEventStream(EventStream):
         pass
 
     def end_merge(self, state):
+        pass
+
+    def start_unmerge(self, project_id, hashes, previous_group_id, new_group_id):
+        pass
+
+    def end_unmerge(self, state):
         pass

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -23,11 +23,20 @@ class SnubaEventStream(EventStream):
             primary_hash, skip_consume
         )
 
-    def unmerge(self, project_id, hashes, new_group_id):
+    def start_unmerge(self, project_id, hashes, previous_group_id, new_group_id):
         pass
 
-    def delete_groups(self, project_id, group_ids):
+    def end_unmerge(self, state):
         pass
 
-    def merge(self, project_id, previous_group_ids, new_group_id):
+    def start_delete_groups(self, project_id, group_ids):
+        pass
+
+    def end_delete_groups(self, state):
+        pass
+
+    def start_merge(self, project_id, previous_group_ids, new_group_id):
+        pass
+
+    def end_merge(self, state):
         pass

--- a/src/sentry/tasks/deletion.py
+++ b/src/sentry/tasks/deletion.py
@@ -281,7 +281,6 @@ def delete_groups(object_ids, transaction_id=None, eventstream_state=None, **kwa
     if not object_ids:
         return
 
-    object_ids = sorted(object_ids)
     group_id = object_ids[0]
 
     task = deletions.get(

--- a/src/sentry/tasks/deletion.py
+++ b/src/sentry/tasks/deletion.py
@@ -278,9 +278,6 @@ def delete_groups(object_ids, transaction_id=None, eventstream_state=None, **kwa
     from sentry import deletions, eventstream
     from sentry.models import Group
 
-    if not object_ids:
-        return
-
     group_id = object_ids[0]
 
     task = deletions.get(

--- a/src/sentry/tasks/deletion.py
+++ b/src/sentry/tasks/deletion.py
@@ -292,16 +292,20 @@ def delete_groups(object_ids, transaction_id=None, eventstream_state=None, **kwa
         transaction_id=transaction_id or uuid4().hex,
     )
     has_more = task.chunk()
-    if not has_more:
+    if has_more:
+        countdown = 15
+    else:
         # *this* group is done, remove it from the list
         object_ids.pop(0)
+        # we're moving on to the next group, don't delay
+        countdown = None
 
     if object_ids:
         delete_groups.apply_async(
             kwargs={'object_ids': object_ids,
                     'transaction_id': transaction_id,
                     'eventstream_state': eventstream_state},
-            countdown=15,
+            countdown=countdown,
         )
     else:
         # all groups have been deleted

--- a/src/sentry/tasks/deletion.py
+++ b/src/sentry/tasks/deletion.py
@@ -278,6 +278,8 @@ def delete_groups(object_ids, transaction_id=None, eventstream_state=None, **kwa
     from sentry import deletions, eventstream
     from sentry.models import Group
 
+    transaction_id = transaction_id or uuid4().hex
+
     max_batch_size = 100
     current_batch, rest = object_ids[:max_batch_size], object_ids[max_batch_size:]
 
@@ -286,7 +288,7 @@ def delete_groups(object_ids, transaction_id=None, eventstream_state=None, **kwa
         query={
             'id__in': current_batch,
         },
-        transaction_id=transaction_id or uuid4().hex,
+        transaction_id=transaction_id,
     )
     has_more = task.chunk()
     if has_more or rest:

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -13,6 +13,7 @@ import logging
 from django.db import DataError, IntegrityError, router, transaction
 from django.db.models import F
 
+from sentry import eventstream
 from sentry.app import tsdb
 from sentry.similarity import features
 from sentry.tasks.base import instrumented_task
@@ -31,7 +32,8 @@ EXTRA_MERGE_MODELS = []
     max_retries=None
 )
 def merge_group(
-    from_object_id=None, to_object_id=None, transaction_id=None, recursed=False, **kwargs
+    from_object_id=None, to_object_id=None, transaction_id=None,
+    recursed=False, eventstream_state=None, **kwargs
 ):
     # TODO(mattrobenolt): Write tests for all of this
     from sentry.models import (
@@ -111,14 +113,18 @@ def merge_group(
         transaction_id=transaction_id,
     )
 
+    last_task = False
     if has_more:
         merge_group.delay(
             from_object_id=from_object_id,
             to_object_id=to_object_id,
             transaction_id=transaction_id,
             recursed=True,
+            eventstream_state=eventstream_state,
         )
         return
+    else:
+        last_task = True
 
     features.merge(new_group, [group], allow_unsafe=True)
 
@@ -188,6 +194,9 @@ def merge_group(
         )
     except DataError:
         pass
+
+    if last_task and eventstream_state:
+        eventstream.end_merge(eventstream_state)
 
 
 def _get_event_environment(event, project, cache):

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -13,7 +13,6 @@ import logging
 from django.db import DataError, IntegrityError, router, transaction
 from django.db.models import F
 
-from sentry import eventstream
 from sentry.app import tsdb
 from sentry.similarity import features
 from sentry.tasks.base import instrumented_task
@@ -189,8 +188,6 @@ def merge_group(
         )
     except DataError:
         pass
-
-    eventstream.merge(group.project_id, previous_group_id, new_group.id)
 
 
 def _get_event_environment(event, project, cache):

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -177,7 +177,7 @@ def migrate_events(caches, project, source_id, destination_id, fingerprints, eve
 
         destination_id = destination.id
 
-        eventstream.unmerge(project.id, fingerprints, destination_id)
+        eventstream.unmerge(project.id, fingerprints, source_id, destination_id)
 
         # Move the group hashes to the destination.
         GroupHash.objects.filter(

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -177,7 +177,6 @@ def migrate_events(caches, project, source_id, destination_id, fingerprints, eve
 
         destination_id = destination.id
 
-        # TODO: This blocks on having each event's full hash list as an array in ClickHouse
         eventstream.unmerge(project.id, fingerprints, destination_id)
 
         # Move the group hashes to the destination.

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -177,6 +177,9 @@ def migrate_events(caches, project, source_id, destination_id, fingerprints, eve
 
         destination_id = destination.id
 
+        # TODO: This blocks on having each event's full hash list as an array in ClickHouse
+        eventstream.unmerge(project.id, fingerprints, destination_id)
+
         # Move the group hashes to the destination.
         GroupHash.objects.filter(
             project_id=project.id,
@@ -211,8 +214,6 @@ def migrate_events(caches, project, source_id, destination_id, fingerprints, eve
         destination.update(**get_group_backfill_attributes(caches, destination, events))
 
     event_id_set = set(event.id for event in events)
-
-    eventstream.unmerge(project.id, destination_id, [event.event_id for event in events])
 
     Event.objects.filter(
         project_id=project.id,

--- a/tests/sentry/api/endpoints/test_project_group_index.py
+++ b/tests/sentry/api/endpoints/test_project_group_index.py
@@ -1419,11 +1419,13 @@ class GroupUpdateTest(APITestCase):
             from_object_id=group1.id,
             to_object_id=group2.id,
             transaction_id='abc123',
+            eventstream_state=None,
         )
         merge_group.delay.assert_any_call(
             from_object_id=group3.id,
             to_object_id=group2.id,
             transaction_id='abc123',
+            eventstream_state=None,
         )
 
     def test_assign(self):

--- a/tests/sentry/tasks/test_deletion.py
+++ b/tests/sentry/tasks/test_deletion.py
@@ -18,7 +18,7 @@ from sentry.models import (
 )
 from sentry.plugins.providers.dummy.repository import DummyRepositoryProvider
 from sentry.tasks.deletion import (
-    delete_api_application, delete_group, delete_organization, delete_project, delete_repository,
+    delete_api_application, delete_groups, delete_organization, delete_project, delete_repository,
     delete_team, generic_delete, revoke_api_tokens
 )
 from sentry.testutils import TestCase
@@ -332,7 +332,7 @@ class DeleteGroupTest(TestCase):
         )
 
         with self.tasks():
-            delete_group(object_id=group.id)
+            delete_groups(object_ids=[group.id])
 
         assert not Event.objects.filter(id=event.id).exists()
         assert not EventMapping.objects.filter(


### PR DESCRIPTION
~~This is still a WIP, as it will require CH/Snuba changes.~~

Turns out hammering CH with ALTERs is not so bueno.

* The general idea here is to send as few `merge`/`unmerge` events as possible.
* There could be some (extra) consistency issues between PG/CH because we have to proactively send out a whole merge/unmerge at the start of the bulk operation, rather than as each event/group is iterated over.
* ~~In order to handle `unmerge` as a batch we will need to store an array of hashes on each event in ClickHouse, unless someone has another idea (but I don't see what else we could filter on).~~ edit: TIL unmerge only operates on `primary_hash`
* This will also change the format of `merge` and `unmerge` events... bleh. I started `Protocol 2` for this but I'm open to better ideas.