### PR TITLE
ref(snuba): Refactor project events query to use snuba backend

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -227,6 +227,8 @@ class Endpoint(APIView):
         # map results based on callback
         if on_results:
             results = on_results(cursor_result.results)
+        else:
+            results = cursor_result.results
 
         response = Response(results)
         self.add_cursor_headers(request, response, cursor_result)

--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -91,6 +91,10 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
 
             events = events.filter(q)
 
+        # TODO currently snuba can be used to get this filter of event_ids matching
+        # the search tags, which is then used to further filter a postgres QuerySet
+        # Ideally we would just use snuba to completely replace the fetching of the
+        # events.
         if tags:
             event_filter = tagstore.get_group_event_filter(
                 group.project_id,

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -364,6 +364,9 @@ class SnubaOffsetPaginator(object):
         # dataset, which is the same meaning as SQLs `OFFSET`.
         return CursorResult(
             data,
-            prev=Cursor(0, max(0, offset - limit), True, offset != 0),
-            next=Cursor(0, max(0, offset + limit), True, has_more)
+            prev=Cursor(0, max(0, offset - limit), True, offset > 0),
+            next=Cursor(0, max(0, offset + limit), False, has_more)
         )
+        # TODO use Cursor.value as the `end` argument to data_fn() so that
+        # subsequent pages returned using these cursors are using the same end
+        # date for queries, this should stop drift from new incoming events.

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -241,6 +241,7 @@ class SnubaEvent(object):
     ]
 
     def __init__(self, kv):
+        assert set(kv.keys()) == set(self.selected_columns)
         self.__dict__ = kv
 
 
@@ -253,7 +254,6 @@ class SnubaEventSerializer(Serializer):
     """
     def serialize(self, obj, attrs, user):
         return {
-            'id': 0,  # This is not relevant for snuba-sourced events, but some things expect it
             'eventID': six.text_type(obj.event_id),
             'message': obj.message,
             'user': {

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -49,9 +49,9 @@ class SnubaTagStorage(TagStorage):
     def get_time_range(self, days=90):
         """
         Returns the default (start, end) time range for querrying snuba.
+        The snuba util may further reduce this range based on the project
+        retention, and first/last seen dates of the groups being queried.
         """
-        # TODO this should use the per-project retention figure to limit
-        # the query to looking at only the retention window for the project.
         end = timezone.now()
         return (end - timedelta(days=days), end)
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -843,15 +843,16 @@ class SnubaTestCase(TestCase):
         if not data.get('received'):
             data['received'] = calendar.timegm(event.datetime.timetuple())
 
-        environment = Environment.get_or_create(
-            event.project,
-            tags['environment'],
-        )
+        if 'environment' in tags:
+            environment = Environment.get_or_create(
+                event.project,
+                tags['environment'],
+            )
 
-        GroupEnvironment.objects.get_or_create(
-            environment_id=environment.id,
-            group_id=event.group_id,
-        )
+            GroupEnvironment.objects.get_or_create(
+                environment_id=environment.id,
+                group_id=event.group_id,
+            )
 
         hashes = get_hashes_from_fingerprint(
             event,

--- a/tests/snuba/api/endpoints/test_project_events.py
+++ b/tests/snuba/api/endpoints/test_project_events.py
@@ -8,13 +8,17 @@ from sentry.testutils import APITestCase, SnubaTestCase
 
 
 class ProjectEventsTest(APITestCase, SnubaTestCase):
+    def setUp(self):
+        super(ProjectEventsTest, self).setUp()
+        self.min_ago = timezone.now() - timedelta(minutes=1)
+
     def test_simple(self):
         self.login_as(user=self.user)
 
         project = self.create_project()
         group = self.create_group(project=project)
-        event_1 = self.create_event('a' * 32, group=group, datetime=timezone.now() - timedelta(minutes=1))
-        event_2 = self.create_event('b' * 32, group=group, datetime=timezone.now() - timedelta(minutes=1))
+        event_1 = self.create_event('a' * 32, group=group, datetime=self.min_ago)
+        event_2 = self.create_event('b' * 32, group=group, datetime=self.min_ago)
 
         url = reverse(
             'sentry-api-0-project-events',
@@ -39,8 +43,8 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
 
         project = self.create_project()
         group = self.create_group(project=project)
-        self.create_event('x' * 32, group=group, message="how to make fast", datetime=timezone.now() - timedelta(minutes=1))
-        event_2 = self.create_event('y' * 32, group=group, message="delet the data", datetime=timezone.now() - timedelta(minutes=1))
+        self.create_event('x' * 32, group=group, message="how to make fast", datetime=self.min_ago)
+        event_2 = self.create_event('y' * 32, group=group, message="delet the data", datetime=self.min_ago)
 
         url = reverse(
             'sentry-api-0-project-events',
@@ -61,13 +65,9 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
 
         project = self.create_project()
         group = self.create_group(project=project)
-        self.create_event(
-            'a' *
-            32,
-            group=group,
-            datetime=timezone.now() - timedelta(days=2),
-        )
-        event_2 = self.create_event('b' * 32, group=group)
+        two_days_ago = timezone.now() - timedelta(days=2)
+        self.create_event('c' * 32, group=group, datetime=two_days_ago)
+        event_2 = self.create_event('d' * 32, group=group, datetime=self.min_ago)
 
         with self.options({'system.event-retention-days': 1}):
             url = reverse(

--- a/tests/snuba/api/endpoints/test_project_events.py
+++ b/tests/snuba/api/endpoints/test_project_events.py
@@ -1,22 +1,20 @@
 from __future__ import absolute_import
 
-import six
-
 from datetime import timedelta
 from django.utils import timezone
 from django.core.urlresolvers import reverse
 
-from sentry.testutils import APITestCase
+from sentry.testutils import APITestCase, SnubaTestCase
 
 
-class ProjectEventsTest(APITestCase):
+class ProjectEventsTest(APITestCase, SnubaTestCase):
     def test_simple(self):
         self.login_as(user=self.user)
 
         project = self.create_project()
         group = self.create_group(project=project)
-        event_1 = self.create_event('a' * 32, group=group)
-        event_2 = self.create_event('b' * 32, group=group)
+        event_1 = self.create_event('a' * 32, group=group, datetime=timezone.now() - timedelta(minutes=1))
+        event_2 = self.create_event('b' * 32, group=group, datetime=timezone.now() - timedelta(minutes=1))
 
         url = reverse(
             'sentry-api-0-project-events',
@@ -29,12 +27,34 @@ class ProjectEventsTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(map(lambda x: x['id'], response.data)) == sorted(
+        assert sorted(map(lambda x: x['eventID'], response.data)) == sorted(
             [
-                six.text_type(event_1.id),
-                six.text_type(event_2.id),
+                event_1.event_id,
+                event_2.event_id,
             ]
         )
+
+    def test_message_search(self):
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+        group = self.create_group(project=project)
+        self.create_event('x' * 32, group=group, message="how to make fast", datetime=timezone.now() - timedelta(minutes=1))
+        event_2 = self.create_event('y' * 32, group=group, message="delet the data", datetime=timezone.now() - timedelta(minutes=1))
+
+        url = reverse(
+            'sentry-api-0-project-events',
+            kwargs={
+                'organization_slug': project.organization.slug,
+                'project_slug': project.slug,
+            }
+        )
+        response = self.client.get(url, {'query': 'delet'}, format='json')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]['eventID'] == event_2.event_id
+        assert response.data[0]['message'] == 'delet the data'
 
     def test_filters_based_on_retention(self):
         self.login_as(user=self.user)
@@ -61,8 +81,4 @@ class ProjectEventsTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        assert sorted(map(lambda x: x['id'], response.data)) == sorted(
-            [
-                six.text_type(event_2.id),
-            ]
-        )
+        assert response.data[0]['eventID'] == event_2.event_id


### PR DESCRIPTION
Replace the existing django queryset implementation with a snuba query.
This also involves creating a SnubaEvent/SnubaEventSerializer to turn
snuba result rows into recognizable API response objects, as well as a
custom SnubaOffsetPaginator that allows paging through the result set
using the offset/limit technique.