### PR TITLE
ref(ui): Remove fake sidebar during load

### DIFF
--- a/src/sentry/static/sentry/app/views/onboarding/onboarding.less
+++ b/src/sentry/static/sentry/app/views/onboarding/onboarding.less
@@ -2,7 +2,6 @@
 
 .onboarding-container {
   margin-left: @onboarding-sidebar-width;
-  margin-left: @onboarding-sidebar-width - @sidebar-width;
 
   max-width: 800px + @onboarding-sidebar-width;
   margin-top: 30px;

--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -10,14 +10,7 @@ body {
   color: @gray-darker;
   -webkit-font-smoothing: antialiased;
   overflow-x: hidden;
-  padding-left: @sidebar-width;
   min-height: 100vh;
-
-  // Fake sidebar rendering until actual sidebar is loaded
-
-  background-image: linear-gradient(@header-bg-color, @header-bg-color);
-  background-size: @sidebar-width;
-  background-repeat: repeat-y;
 
   &.new-settings {
     overflow-y: scroll;


### PR DESCRIPTION
It's no longer the correct size or color, also it looks funny to have this during the settings page load.