### PR TITLE
feat: Allow event_id in the /events/id/ endpoint

### DIFF
--- a/src/sentry/api/endpoints/event_details.py
+++ b/src/sentry/api/endpoints/event_details.py
@@ -10,6 +10,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.constants import EVENT_ORDERING_KEY
 from sentry.models import Event, Release, UserReport
+from sentry.utils.validators import is_event_id
 
 
 class EventDetailsEndpoint(Endpoint):
@@ -34,13 +35,26 @@ class EventDetailsEndpoint(Endpoint):
         Retrieve an Event
         `````````````````
 
-        This endpoint returns the data for a specific event.  The event ID
-        is the event as it appears in the Sentry database and not the event
-        ID that is reported by the client upon submission.
+        This endpoint returns the data for a specific event.
+
+        :pparam string event_id: either the numeric database primary key for the
+                                 event or the 32-character hexadecimal event_id.
         """
-        try:
-            event = Event.objects.get(id=event_id)
-        except Event.DoesNotExist:
+        event = None
+        # If its a numeric string, srr if it's an event Primary Key first
+        if event_id.isdigit():
+            try:
+                event = Event.objects.get(id=event_id)
+            except Event.DoesNotExist:
+                pass
+        # If it was not found as a PK, and its a possible event_id, search by that instead.
+        if event is None and is_event_id(event_id):
+            try:
+                event = Event.objects.get(event_id=event_id)
+            except Event.DoesNotExist:
+                pass
+
+        if event is None:
             raise ResourceDoesNotExist
 
         self.check_object_permissions(request, event.group)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1068,7 +1068,7 @@ urlpatterns = patterns(
 
     # Events
     url(
-        r'^events/(?P<event_id>\d+)/$',
+        r'^events/(?P<event_id>(?:\d+|[A-Fa-f0-9]{32}))/$',
         EventDetailsEndpoint.as_view(),
         name='sentry-api-0-event-details'
     ),

--- a/src/sentry/static/sentry/app/views/projectEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectEvents/index.jsx
@@ -176,7 +176,7 @@ const ProjectEvents = createReactClass({
           <td>
             <h5>
               <ProjectLink
-                to={`/${orgId}/${projectId}/issues/${event.groupID}/events/${event.id}/`}
+                to={`/${orgId}/${projectId}/issues/${event.groupID}/events/${event.id || event.eventID}/`}
               >
                 {this.getEventTitle(event)}
               </ProjectLink>

--- a/tests/sentry/api/endpoints/test_event_details.py
+++ b/tests/sentry/api/endpoints/test_event_details.py
@@ -15,17 +15,17 @@ class EventDetailsTest(APITestCase):
 
         group = self.create_group()
         prev_event = self.create_event(
-            event_id='a',
+            event_id='a' * 32,
             group=group,
             datetime=datetime(2013, 8, 13, 3, 8, 24),
         )
         cur_event = self.create_event(
-            event_id='b',
+            event_id='9' * 32,
             group=group,
             datetime=datetime(2013, 8, 13, 3, 8, 25),
         )
         next_event = self.create_event(
-            event_id='c',
+            event_id='c' * 32,
             group=group,
             datetime=datetime(2013, 8, 13, 3, 8, 26),
         )
@@ -71,6 +71,41 @@ class EventDetailsTest(APITestCase):
         assert response.data['previousEventID'] == six.text_type(cur_event.id)
         assert response.data['groupID'] == six.text_type(group.id)
         assert not response.data['userReport']
+
+        # prev_event.event_id is a valid event_id but not a valid id, so we
+        # will look for it for it by event_id, but not id.
+        url = reverse(
+            'sentry-api-0-event-details', kwargs={
+                'event_id': prev_event.event_id,
+            }
+        )
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert response.data['id'] == six.text_type(prev_event.id)
+
+        # cur_event has a 32-character numeric id so it could be either a
+        # numeric PK or a hex event_id. Make sure we find it as the latter even
+        # after it doesn't match the former.
+        url = reverse(
+            'sentry-api-0-event-details', kwargs={
+                'event_id': cur_event.id,
+            }
+        )
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert response.data['id'] == six.text_type(cur_event.id)
+
+        # nonexistent event_id
+        url = reverse(
+            'sentry-api-0-event-details', kwargs={
+                'event_id': 'f' * 32
+            }
+        )
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 404, response.content
 
     def test_identical_datetime(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
For use with events that don't have postgres primary keys
because they don't come from postgres.