### PR TITLE
fix(ui): break long frame titles

### DIFF
--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1329,6 +1329,7 @@ div.traceback > ul {
 
     &.system-frame .title {
       background: @white-dark;
+      word-break: break-all;
     }
 
     &.missing-frame .title {


### PR DESCRIPTION
Closes [ISSUE-117](https://getsentry.atlassian.net/browse/ISSUE-117).

<img width="789" alt="screen shot 2018-10-07 at 6 18 10 pm" src="https://user-images.githubusercontent.com/30713/46589337-6b8d6d00-ca5d-11e8-890a-488bb9a7671e.png">
