### PR TITLE
feat: Send raw events to Kafka for later offline processing

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,4 +1,5 @@
+confluent-kafka==0.11.5
+GeoIP==1.3.2
 google-cloud-pubsub>=0.35.4,<0.36.0
 google-cloud-storage>=1.10.0,<1.11.0
 python3-saml>=1.4.0,<1.5
-GeoIP==1.3.2

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -139,3 +139,7 @@ register('snuba.search.max-pre-snuba-candidates', default=500)
 register('snuba.search.chunk-growth-rate', default=1.5)
 register('snuba.search.max-chunk-size', default=2000)
 register('snuba.search.max-total-chunk-time-seconds', default=30.0)
+
+# Kafka Publisher
+register('kafka-publisher.raw-event-sample-rate', default=0.0)
+register('kafka-publisher.max-event-size', default=100000)

--- a/src/sentry/utils/pubsub.py
+++ b/src/sentry/utils/pubsub.py
@@ -2,14 +2,12 @@ from __future__ import absolute_import
 
 import redis
 import logging
-import random
 
-from django.conf import settings
 from threading import Thread
 from six.moves.queue import Queue, Full
 
 
-class QueuedPublisher(object):
+class QueuedPublisherService(object):
     """
     A publisher that queues items locally and publishes them to a
     remote pubsub service on a background thread.
@@ -51,12 +49,10 @@ class QueuedPublisher(object):
         if not self._start():
             return
 
-        sample_channel = getattr(settings, 'PUBSUB_SAMPLING', 1.0)
-        if random.random() <= sample_channel:
-            try:
-                self.q.put((channel, key, value), block=False)
-            except Full:
-                return
+        try:
+            self.q.put((channel, key, value), block=False)
+        except Full:
+            return
 
 
 class RedisPublisher(object):
@@ -66,3 +62,16 @@ class RedisPublisher(object):
     def publish(self, channel, value, key=None):
         if self.rds is not None:
             self.rds.publish(channel, value)
+
+
+class KafkaPublisher(object):
+    def __init__(self, connection, asynchronous=True):
+        from confluent_kafka import Producer
+
+        self.producer = Producer(connection or {})
+        self.asynchronous = asynchronous
+
+    def publish(self, channel, value, key=None):
+        self.producer.produce(topic=channel, value=value, key=key)
+        if not self.asynchronous:
+            self.producer.flush()

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -6,6 +6,7 @@ import math
 import jsonschema
 import logging
 import os
+import random
 import six
 import traceback
 import uuid
@@ -28,7 +29,7 @@ from querystring_parser import parser
 from raven.contrib.django.models import client as Raven
 from symbolic import ProcessMinidumpError
 
-from sentry import features, quotas, tsdb
+from sentry import features, quotas, tsdb, options
 from sentry.attachments import CachedAttachment
 from sentry.coreapi import (
     APIError, APIForbidden, APIRateLimited, ClientApiHelper, SecurityApiHelper, LazyData,
@@ -50,7 +51,7 @@ from sentry.utils.http import (
     get_origins,
     is_same_domain,
 )
-from sentry.utils.pubsub import QueuedPublisher, RedisPublisher
+from sentry.utils.pubsub import QueuedPublisherService, KafkaPublisher
 from sentry.utils.safe import safe_execute
 from sentry.web.helpers import render_to_response
 
@@ -62,10 +63,14 @@ PIXEL = base64.b64decode('R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=')
 
 PROTOCOL_VERSIONS = frozenset(('2.0', '3', '4', '5', '6', '7'))
 
-
-pubsub = QueuedPublisher(
-    RedisPublisher(getattr(settings, 'REQUESTS_PUBSUB_CONNECTION', None))
-) if getattr(settings, 'REQUESTS_PUBSUB_ENABLED', False) else None
+kafka_publisher = QueuedPublisherService(
+    KafkaPublisher(
+        getattr(
+            settings,
+            'KAFKA_RAW_EVENTS_PUBLISHER_CONNECTION',
+            None),
+        asynchronous=False)
+) if getattr(settings, 'KAFKA_RAW_EVENTS_PUBLISHER_ENABLED', False) else None
 
 
 def api(func):
@@ -112,6 +117,35 @@ class APIView(BaseView):
 
         return auth
 
+    def _publish_to_kafka(self, request):
+        """
+        Sends raw event data to Kafka for later offline processing.
+        """
+        try:
+            if len(request.body) > options.get('kafka-publisher.max-event-size'):
+                return
+
+            # Sampling
+            if random.random() >= options.get('kafka-publisher.raw-event-sample-rate'):
+                return
+
+            # We want to send only serializable items from request.META
+            headers = {}
+            for key, value in request.META.items():
+                try:
+                    json.dumps([key, value])
+                    headers[key] = value
+                except TypeError:
+                    pass
+
+            data = json.dumps([headers, request.body])
+            kafka_publisher.publish(
+                channel=getattr(settings, 'KAFKA_RAW_EVENTS_PUBLISHER_TOPIC', 'raw_store_events'),
+                value=data
+            )
+        except Exception as e:
+            logger.debug("Cannot publish event to Kafka: {}".format(e.message))
+
     @csrf_exempt
     @never_cache
     def dispatch(self, request, project_id=None, *args, **kwargs):
@@ -121,6 +155,9 @@ class APIView(BaseView):
             ip_address=request.META['REMOTE_ADDR'],
         )
         origin = None
+
+        if kafka_publisher is None or request.body is None:
+            self._publish_to_kafka(request)
 
         try:
             origin = helper.origin_from_request(request)
@@ -306,9 +343,6 @@ class StoreView(APIView):
             # sane exception to catch here. This will ultimately
             # bubble up as an APIError.
             data = None
-
-        if pubsub is not None and data is not None:
-            pubsub.publish('requests', data)
 
         response_or_event_id = self.process(request, data=data, **kwargs)
         if isinstance(response_or_event_id, HttpResponse):


### PR DESCRIPTION
We'll be sending some percent of events to Kafka for later (offline) processing, e.g. comparing new normalization implementations in libsemaphore with the existing one in Python code.

I intentionally didn't use `KafkaEventStream`... 
https://github.com/getsentry/sentry/blob/6a29882faa037bdd18bf176f5311b98c388669af/src/sentry/eventstream/kafka.py#L47 
...because it's more high-level and used for publishing structured data.