### PR TITLE
feat(app-platform): App Auth[entication|orization]

### DIFF
--- a/src/sentry/api/bases/__init__.py
+++ b/src/sentry/api/bases/__init__.py
@@ -6,3 +6,4 @@ from .organizationissues import *  # NOQA
 from .organizationmember import *  # NOQA
 from .project import *  # NOQA
 from .team import *  # NOQA
+from .sentryapps import *  # NOQA

--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -1,0 +1,72 @@
+from __future__ import absolute_import
+
+from rest_framework.permissions import IsAuthenticated
+
+from sentry.api.base import Endpoint
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.permissions import ScopedPermission
+from sentry.app import raven
+from sentry.models import SentryApp, SentryAppInstallation
+
+
+class SentryAppDetailsPermission(ScopedPermission):
+    def has_object_permission(self, request, view, sentry_app):
+        return sentry_app.owner == request.user
+
+
+class SentryAppDetailsEndpoint(Endpoint):
+    authentication_classes = (IsAuthenticated, )
+    permission_classes = (SentryAppDetailsPermission, )
+
+    def convert_args(self, request, slug, *args, **kwargs):
+        try:
+            sentry_app = SentryApp.objects.get_from_cache(slug=slug)
+        except SentryApp.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        self.check_object_permissions(request, sentry_app)
+
+        raven.tags_context({
+            'sentry_app': sentry_app.id,
+        })
+
+        kwargs['sentry_app'] = sentry_app
+        return (args, kwargs)
+
+
+class SentryAppInstallationDetailsPermission(ScopedPermission):
+    def has_object_permission(self, request, view, install):
+        if not request.user:
+            return False
+        return install.organization in request.user.get_orgs()
+
+
+class SentryAppInstallationDetailsEndpoint(Endpoint):
+    authentication_classes = (IsAuthenticated, )
+    permission_classes = (SentryAppInstallationDetailsPermission, )
+
+    def convert_args(self, request, uuid, *args, **kwargs):
+        try:
+            install = SentryAppInstallation.objects.get_from_cache(uuid=uuid)
+        except SentryAppInstallation.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        self.check_object_permissions(request, install)
+
+        raven.tags_context({
+            'sentry_app_installation': install.id,
+        })
+
+        kwargs['install'] = install
+        return (args, kwargs)
+
+
+class SentryAppInstallationAuthorizationPermission(ScopedPermission):
+    def has_object_permission(self, request, view, install):
+        if not request.user.is_sentry_app:
+            return False
+        return request.user == install.sentry_app.proxy_user
+
+
+class SentryAppInstallationAuthorizationEndpoint(SentryAppInstallationDetailsEndpoint):
+    permission_classes = (SentryAppInstallationAuthorizationPermission, )

--- a/src/sentry/db/models/paranoia.py
+++ b/src/sentry/db/models/paranoia.py
@@ -1,11 +1,10 @@
 from __future__ import absolute_import
 
 from django.db import models
-from django.db.models import Manager
 from django.db.models.query import QuerySet
 from django.utils import timezone
 
-from sentry.db.models import Model
+from sentry.db.models import Model, BaseManager
 
 
 class ParanoidQuerySet(QuerySet):
@@ -18,7 +17,7 @@ class ParanoidQuerySet(QuerySet):
         self.update(date_deleted=timezone.now())
 
 
-class ParanoidManager(Manager):
+class ParanoidManager(BaseManager):
     """
     Only exposes objects that have NOT been soft-deleted.
     """

--- a/src/sentry/mediators/sentry_app_installations/__init__.py
+++ b/src/sentry/mediators/sentry_app_installations/__init__.py
@@ -2,3 +2,4 @@ from __future__ import absolute_import
 
 from .creator import Creator  # NOQA
 from .destroyer import Destroyer  # NOQA
+from .authorizer import Authorizer  # NOQA

--- a/src/sentry/mediators/sentry_app_installations/authorizer.py
+++ b/src/sentry/mediators/sentry_app_installations/authorizer.py
@@ -1,0 +1,79 @@
+from __future__ import absolute_import
+
+import six
+
+from datetime import datetime, timedelta
+
+from sentry.coreapi import APIUnauthorized
+from sentry.mediators import Mediator, Param
+from sentry.models import ApiGrant, ApiApplication, ApiToken, SentryApp
+from sentry.utils.cache import memoize
+
+
+TOKEN_LIFE_IN_HOURS = 8
+
+
+class Authorizer(Mediator):
+    install = Param('sentry.models.SentryAppInstallation')
+    grant_type = Param(six.string_types)
+    code = Param(six.string_types)
+    client_id = Param(six.string_types)
+    user = Param('sentry.models.User')
+
+    def call(self):
+        self._validate_grant_type()
+        self._validate_install()
+        self._validate_sentry_app()
+        self._validate_grant()
+        return self.exchange()
+
+    def exchange(self):
+        return ApiToken.objects.create(
+            user=self.user,
+            application=self.application,
+            scope_list=self.sentry_app.scope_list,
+            expires_at=(datetime.now() + timedelta(hours=TOKEN_LIFE_IN_HOURS)),
+        )
+
+    def _validate_grant_type(self):
+        if not self.grant_type == 'authorization_code':
+            raise APIUnauthorized
+
+    def _validate_install(self):
+        if not self.install.sentry_app.proxy_user == self.user:
+            raise APIUnauthorized
+
+    def _validate_sentry_app(self):
+        if not self.user.is_sentry_app:
+            raise APIUnauthorized
+
+    def _validate_grant(self):
+        if (
+            self.grant.application.owner != self.user or
+            self.grant.application.client_id != self.client_id
+        ):
+            raise APIUnauthorized
+
+        if self.grant.is_expired():
+            raise APIUnauthorized
+
+    @memoize
+    def sentry_app(self):
+        try:
+            return self.application.sentry_app
+        except SentryApp.DoesNotExist:
+            raise APIUnauthorized
+
+    @memoize
+    def application(self):
+        try:
+            return self.grant.application
+        except ApiApplication.DoesNotExist:
+            raise APIUnauthorized
+
+    @memoize
+    def grant(self):
+        try:
+            return ApiGrant.objects.get(code=self.code)
+        except ApiGrant.DoesNotExist:
+            raise APIUnauthorized

--- a/src/sentry/mediators/sentry_app_installations/creator.py
+++ b/src/sentry/mediators/sentry_app_installations/creator.py
@@ -10,7 +10,7 @@ from sentry.utils.cache import memoize
 
 
 class Creator(Mediator):
-    organization = Param('sentry.models.organization.Organization')
+    organization = Param('sentry.models.Organization')
     slug = Param(six.string_types)
 
     def call(self):

--- a/src/sentry/mediators/sentry_app_installations/destroyer.py
+++ b/src/sentry/mediators/sentry_app_installations/destroyer.py
@@ -4,9 +4,7 @@ from sentry.mediators import Mediator, Param
 
 
 class Destroyer(Mediator):
-    install = Param(
-        'sentry.models.sentryappinstallation.SentryAppInstallation'
-    )
+    install = Param('sentry.models.SentryAppInstallation')
 
     def call(self):
         self._destroy_authorization()

--- a/src/sentry/mediators/sentry_apps/creator.py
+++ b/src/sentry/mediators/sentry_apps/creator.py
@@ -10,7 +10,7 @@ from sentry.models import (ApiApplication, SentryApp, User)
 
 class Creator(Mediator):
     name = Param(six.string_types)
-    user = Param('sentry.models.user.User')
+    user = Param('sentry.models.User')
     scopes = Param(Iterable)
     webhook_url = Param(six.string_types)
 

--- a/src/sentry/mediators/sentry_apps/updater.py
+++ b/src/sentry/mediators/sentry_apps/updater.py
@@ -10,7 +10,7 @@ from sentry.mediators.param import if_param
 
 
 class Updater(Mediator):
-    sentry_app = Param('sentry.models.sentryapp.SentryApp')
+    sentry_app = Param('sentry.models.SentryApp')
     name = Param(six.string_types, required=False)
     scopes = Param(Iterable, required=False)
     webhook_url = Param(six.string_types, required=False)

--- a/src/sentry/middleware/auth.py
+++ b/src/sentry/middleware/auth.py
@@ -19,7 +19,7 @@ def get_user(request):
         # actions take place, this nonce will rotate causing a
         # mismatch here forcing the session to be logged out and
         # requiring re-validation.
-        if user.is_authenticated():
+        if user.is_authenticated() and not user.is_sentry_app:
             # We only need to check the nonce if there is a nonce
             # currently set on the User. By default, the value will
             # be None until the first action has been taken, at

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -9,6 +9,7 @@ from django.template.defaultfilters import slugify
 
 from sentry.constants import SentryAppStatus
 from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, ParanoidModel
+from sentry.models import Organization
 from sentry.models.apiscopes import HasApiScopes
 
 
@@ -51,9 +52,31 @@ class SentryApp(ParanoidModel, HasApiScopes):
         app_label = 'sentry'
         db_table = 'sentry_sentryapp'
 
+    @property
+    def organizations(self):
+        if not self.pk:
+            return Organization.objects.none()
+
+        return Organization \
+            .objects \
+            .select_related('sentry_app_installations') \
+            .filter(sentry_app_installations__sentry_app_id=self.id)
+
+    @property
+    def teams(self):
+        from sentry.models import Team
+
+        if not self.pk:
+            return Team.objects.none()
+
+        return Team.objects.filter(organization__in=self.organizations)
+
     def save(self, *args, **kwargs):
         self._set_slug()
         return super(SentryApp, self).save(*args, **kwargs)
+
+    def is_installed_on(self, organization):
+        return self.organizations.filter(pk=organization.pk).exists()
 
     def _set_slug(self):
         """

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -11,7 +11,6 @@ from sentry.models import (
     ObjectStatus, OrganizationIntegration, Repository, User
 )
 
-from sentry.mediators.plugins import Migrator
 from sentry.integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
 from sentry.tasks.base import instrumented_task, retry
 
@@ -207,6 +206,7 @@ def migrate_repo(repo_id, integration_id, organization_id):
             }
         )
 
+        from sentry.mediators.plugins import Migrator
         Migrator.run(
             integration=integration,
             organization=Organization.objects.get(id=organization_id),

--- a/tests/sentry/api/bases/test_sentryapps.py
+++ b/tests/sentry/api/bases/test_sentryapps.py
@@ -1,0 +1,142 @@
+from __future__ import absolute_import
+
+from django.http import HttpRequest
+
+from sentry.testutils import TestCase
+from sentry.api.bases.sentryapps import (
+    SentryAppDetailsPermission,
+    SentryAppDetailsEndpoint,
+    SentryAppInstallationDetailsPermission,
+    SentryAppInstallationDetailsEndpoint,
+)
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.mediators.sentry_apps import Creator as SentryAppCreator
+from sentry.mediators.sentry_app_installations import Creator as SentryAppInstallationCreator
+
+
+class SentryAppDetailPermissionTest(TestCase):
+    def setUp(self):
+        self.permission = SentryAppDetailsPermission()
+        self.user = self.create_user()
+        self.sentry_app = SentryAppCreator.run(
+            name='foo',
+            user=self.user,
+            scopes=(),
+            webhook_url='https://example.com',
+        )
+
+        self.request = HttpRequest()
+        self.request.user = self.user
+
+    def test_request_user_is_app_owner_succeeds(self):
+        assert self.permission.has_object_permission(self.request, None, self.sentry_app)
+
+    def test_request_user_is_not_app_owner_fails(self):
+        self.request.user = self.create_user()
+        assert not self.permission.has_object_permission(self.request, None, self.sentry_app)
+
+
+class SentryAppDetailsEndpointTest(TestCase):
+    def setUp(self):
+        self.endpoint = SentryAppDetailsEndpoint()
+
+        self.user = self.create_user()
+        self.request = HttpRequest()
+        self.request.user = self.user
+        self.request.successful_authenticator = True
+
+        self.sentry_app = SentryAppCreator.run(
+            name='foo',
+            user=self.user,
+            scopes=(),
+            webhook_url='https://example.com',
+        )
+
+    def test_retrieves_sentry_app(self):
+        args, kwargs = self.endpoint.convert_args(self.request, self.sentry_app.slug)
+        assert kwargs['sentry_app'] == self.sentry_app
+
+    def test_raises_when_sentry_app_not_found(self):
+        with self.assertRaises(ResourceDoesNotExist):
+            self.endpoint.convert_args(self.request, 'notanapp')
+
+
+class SentryAppInstallationDetailPermissionTest(TestCase):
+    def setUp(self):
+        self.permission = SentryAppInstallationDetailsPermission()
+
+        self.user = self.create_user()
+        self.member = self.create_user()
+        self.org = self.create_organization(owner=self.member)
+
+        self.sentry_app = SentryAppCreator.run(
+            name='foo',
+            user=self.user,
+            scopes=(),
+            webhook_url='https://example.com',
+        )
+
+        self.installation, _ = SentryAppInstallationCreator.run(
+            slug=self.sentry_app.slug,
+            organization=self.org,
+        )
+
+        self.request = HttpRequest()
+        self.request.user = self.user
+
+    def test_missing_request_user(self):
+        self.request.user = None
+
+        assert not self.permission.has_object_permission(
+            self.request,
+            None,
+            self.installation,
+        )
+
+    def test_request_user_in_organization(self):
+        self.request.user = self.member
+
+        assert self.permission.has_object_permission(
+            self.request,
+            None,
+            self.installation,
+        )
+
+    def test_request_user_not_in_organization(self):
+        assert not self.permission.has_object_permission(
+            self.request,
+            None,
+            self.installation,
+        )
+
+
+class SentryAppInstallationDetailsEndpointTest(TestCase):
+    def setUp(self):
+        self.endpoint = SentryAppInstallationDetailsEndpoint()
+
+        self.user = self.create_user()
+        self.org = self.create_organization(owner=self.user)
+
+        self.request = HttpRequest()
+        self.request.user = self.user
+        self.request.successful_authenticator = True
+
+        self.sentry_app = SentryAppCreator.run(
+            name='foo',
+            user=self.user,
+            scopes=(),
+            webhook_url='https://example.com',
+        )
+
+        self.installation, _ = SentryAppInstallationCreator.run(
+            slug=self.sentry_app.slug,
+            organization=self.org,
+        )
+
+    def test_retrieves_installation(self):
+        args, kwargs = self.endpoint.convert_args(self.request, self.installation.uuid)
+        assert kwargs['install'] == self.installation
+
+    def test_raises_when_sentry_app_not_found(self):
+        with self.assertRaises(ResourceDoesNotExist):
+            self.endpoint.convert_args(self.request, '1234')

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -5,6 +5,9 @@ from mock import Mock
 
 from sentry.auth import access
 from sentry.models import AuthProvider, AuthIdentity, Organization
+from sentry.mediators.sentry_apps import Creator as SentryAppCreator
+from sentry.mediators.sentry_app_installations import Creator as \
+    SentryAppInstallationCreator
 from sentry.testutils import TestCase
 
 
@@ -152,6 +155,45 @@ class FromUserTest(TestCase):
         organization = self.create_organization(owner=user)
         result = access.from_user(user, organization)
         assert result is access.DEFAULT
+
+
+class FromSentryAppTest(TestCase):
+    def setUp(self):
+        super(FromSentryAppTest, self).setUp()
+
+        # Partner's normal Sentry account.
+        self.user = self.create_user('integration@example.com')
+
+        self.org = self.create_organization()
+        self.out_of_scope_org = self.create_organization()
+
+        self.team = self.create_team(organization=self.org)
+        self.out_of_scope_team = self.create_team(
+            organization=self.out_of_scope_org
+        )
+
+        self.sentry_app = SentryAppCreator.run(
+            name='SlowDB',
+            user=self.user,
+            scopes=(),
+            webhook_url='http://example.com',
+        )
+
+        self.proxy_user = self.sentry_app.proxy_user
+
+        self.install = SentryAppInstallationCreator.run(
+            organization=self.org,
+            slug=self.sentry_app.slug,
+        )
+
+    def test_has_access(self):
+        result = access.from_sentry_app(self.proxy_user, self.org)
+        assert result.is_active
+        assert result.has_team_access(self.team)
+
+    def test_no_access(self):
+        result = access.from_sentry_app(self.proxy_user, self.out_of_scope_org)
+        assert not result.has_team_access(self.out_of_scope_team)
 
 
 class DefaultAccessTest(TestCase):

--- a/tests/sentry/mediators/sentry_app_installations/test_authorizer.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_authorizer.py
@@ -1,0 +1,72 @@
+from __future__ import absolute_import
+
+from datetime import datetime, timedelta
+
+from sentry.coreapi import APIUnauthorized
+from sentry.mediators.sentry_apps import Creator as SentryAppCreator
+from sentry.mediators.sentry_app_installations import Authorizer, Creator
+from sentry.testutils import TestCase
+
+
+class TestAuthorizer(TestCase):
+    def setUp(self):
+        self.user = self.create_user()
+        self.org = self.create_organization()
+
+        self.sentry_app = SentryAppCreator.run(
+            name='nulldb',
+            user=self.user,
+            scopes=(),
+            webhook_url='http://example.com',
+        )
+
+        self.install, self.grant = Creator.run(
+            organization=self.org,
+            slug='nulldb',
+        )
+
+        self.authorizer = Authorizer(
+            install=self.install,
+            grant_type='authorization_code',
+            code=self.grant.code,
+            client_id=self.sentry_app.application.client_id,
+            user=self.sentry_app.proxy_user,
+        )
+
+    def test_simple(self):
+        token = self.authorizer.call()
+        assert token is not None
+
+    def test_token_expires_in_eight_hours(self):
+        token = self.authorizer.call()
+        assert token.expires_at.hour == (datetime.now() + timedelta(hours=8)).hour
+
+    def test_invalid_grant_type(self):
+        self.authorizer.grant_type = 'stuff'
+
+        with self.assertRaises(APIUnauthorized):
+            self.authorizer.call()
+
+    def test_non_owner(self):
+        self.authorizer.user = self.create_user(is_sentry_app=True)
+
+        with self.assertRaises(APIUnauthorized):
+            self.authorizer.call()
+
+    def test_non_sentry_app(self):
+        self.authorizer.user = self.create_user()
+
+        with self.assertRaises(APIUnauthorized):
+            self.authorizer.call()
+
+    def test_missing_grant(self):
+        self.authorizer.code = '123'
+
+        with self.assertRaises(APIUnauthorized):
+            self.authorizer.call()
+
+    def test_mismatching_client_id(self):
+        self.authorizer.client_id = '123'
+
+        with self.assertRaises(APIUnauthorized):
+            self.authorizer.call()

--- a/tests/sentry/mediators/test_param.py
+++ b/tests/sentry/mediators/test_param.py
@@ -27,7 +27,7 @@ class TestParam(TestCase):
             name.validate(None, 'name', None)
 
     def test_validate_user_defined_type(self):
-        user = Param('sentry.models.user.User')
+        user = Param('sentry.models.User')
         assert user.validate(None, 'user', User())
 
     def test_setup(self):


### PR DESCRIPTION
Modifies the Access granting logic to be SentryApp-aware. When a request is made as a SentryApp (using an Access Token they exchanged for), we grant access to Organizations, and Teams, it's installed on.

Also adds a few Endpoint/Permission base classes for future Endpoint work.