### PR TITLE
feat(ui): Add custom fingerprint for `RouteError`

### DIFF
--- a/src/sentry/static/sentry/app/utils/sdk.js
+++ b/src/sentry/static/sentry/app/utils/sdk.js
@@ -27,6 +27,10 @@ function setContextInScope(context) {
         scope.setExtra(key, context.extra[key]);
       });
     }
+
+    if (context.fingerprint) {
+      scope.setFingerprint(context.fingerprint);
+    }
   });
 }
 

--- a/src/sentry/static/sentry/app/views/routeError.jsx
+++ b/src/sentry/static/sentry/app/views/routeError.jsx
@@ -36,6 +36,7 @@ class RouteError extends React.Component {
     // throw this in a timeout so if it errors we dont fall over
     this._timeout = window.setTimeout(() => {
       sdk.captureException(error, {
+        fingerprint: ['route-error', ...(route ? [route] : [])],
         extra: {
           route,
           orgFeatures: (organization && organization.features) || [],


### PR DESCRIPTION
This adds the route path as a fingerprint for `RouteError`. Also fixes adding fingerprints to sdk lib?