### PR TITLE
feat(settings): Remove old "Project quotas/rate limits"

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx
@@ -26,12 +26,6 @@ export default function getConfiguration({project}) {
           description: t('Manage alerts and alert rules for a project'),
         },
         {
-          path: `${pathPrefix}/quotas/`,
-          title: t('Rate Limits'),
-          show: ({features}) => features.has('quotas'),
-          description: t("Configure project's rate limits"),
-        },
-        {
           path: `${pathPrefix}/tags/`,
           title: t('Tags'),
           description: t("View and manage a  project's tags"),


### PR DESCRIPTION
I believe this was ported over from old settings when it should have been removed.
It was removed in https://github.com/getsentry/sentry/pull/4732