### PR TITLE
style: Remove trailing slash from static symlink

### DIFF
--- a/static
+++ b/static
@@ -1,1 +1,1 @@
-src/sentry/static/sentry/
+src/sentry/static/sentry


### PR DESCRIPTION
This is very minor, but when symlinking a directory the trailing slash is not needed and makes the output of `ls -l --classify` look a little funny.

  $ ls -l --classify
  lrwxr-xr-x    1 evan staff     24 Oct  8 16:25 static -> src/sentry/static/sentry//

Where as with it removed it does not have the trailing slash:

  $ ls -l --classify
  lrwxr-xr-x    1 evan staff     24 Oct  8 16:25 static -> src/sentry/static/sentry/

Semantically it [doesn't seem important](https://unix.stackexchange.com/questions/7769/should-i-include-a-trailing-slash-in-a-symlink-to-a-directory).