### PR TITLE
fix(Project Settings): Add Guard Clause for Error When Changing Project Slugs

### DIFF
--- a/src/sentry/static/sentry/app/components/asyncComponent.jsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.jsx
@@ -277,7 +277,7 @@ export default class AsyncComponent extends React.Component {
       resp => resp && resp.status === 403
     );
 
-    // If all error responses have status code === 0, then show erorr message but don't
+    // If all error responses have status code === 0, then show error message but don't
     // log it to sentry
     let shouldLogSentry =
       !!Object.values(this.state.errors).find(resp => resp && resp.status !== 0) ||

--- a/src/sentry/static/sentry/app/views/settings/organizationTeams/teamSettings/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationTeams/teamSettings/index.jsx
@@ -52,6 +52,7 @@ export default class TeamSettings extends AsyncView {
       this.props.router.push(
         `/settings/${this.props.params.orgId}/teams/${model.getValue(id)}/settings/`
       );
+      this.forceUpdate();
       this.setState({loading: true});
     }
   };

--- a/src/sentry/static/sentry/app/views/settings/organizationTeams/teamSettings/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationTeams/teamSettings/index.jsx
@@ -52,7 +52,6 @@ export default class TeamSettings extends AsyncView {
       this.props.router.push(
         `/settings/${this.props.params.orgId}/teams/${model.getValue(id)}/settings/`
       );
-      this.forceUpdate();
       this.setState({loading: true});
     }
   };

--- a/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import styled, {css} from 'react-emotion';
 import {Box} from 'grid-emotion';
+import sdk from 'app/utils/sdk';
 
 import {removeTeamFromProject, addTeamToProject} from 'app/actionCreators/projects';
 import {getOrganizationState} from 'app/mixins/organizationState';
@@ -170,16 +171,24 @@ class ProjectTeams extends AsyncView {
   renderAddTeamToProject() {
     let projectTeams = new Set(this.state.projectTeams.map(team => team.slug));
     let canCreateTeam = this.canCreateTeam();
+    let teamsToAdd;
 
-    let teamsToAdd = this.state.allTeams
-      .filter(team => {
-        return team.hasAccess && !projectTeams.has(team.slug);
-      })
-      .map(team => ({
-        value: team.id,
-        searchKey: team.slug,
-        label: <TeamDropdownElement>#{team.slug}</TeamDropdownElement>,
-      }));
+    if (!this.state.allTeams) {
+      teamsToAdd = [];
+      sdk.captureException(new Error('This.state.allTeams is null'), {
+        extra: {state: this.state},
+      });
+    } else {
+      teamsToAdd = this.state.allTeams
+        .filter(team => {
+          return team.hasAccess && !projectTeams.has(team.slug);
+        })
+        .map(team => ({
+          value: team.id,
+          searchKey: team.slug,
+          label: <TeamDropdownElement>#{team.slug}</TeamDropdownElement>,
+        }));
+    }
 
     let menuHeader = (
       <StyledTeamsLabel>


### PR DESCRIPTION
https://sentry.io/sentry/javascript/issues/717378326/events/32467557123/
Suppresses current error, but also sends info with `this.state` to Sentry for future errors. 