### PR TITLE
ref(integrations): Refactor identity / integration oauth refresh

### DIFF
--- a/src/sentry/identity/base.py
+++ b/src/sentry/identity/base.py
@@ -70,9 +70,9 @@ class Provider(PipelineProvider):
         """
         return new_data
 
-    def refresh_identity(self, auth_identity, *args, **kwargs):
+    def refresh_identity(self, auth_identity, **kwargs):
         """
-        Updates the AuthIdentity with any changes from upstream. The primary
+        Updates the Identity with any changes from upstream. The primary
         example of a change would be signalling this identity is no longer
         valid.
 

--- a/src/sentry/identity/vsts/provider.py
+++ b/src/sentry/identity/vsts/provider.py
@@ -59,9 +59,6 @@ class VSTSIdentityProvider(OAuth2Provider):
     def get_oauth_client_secret(self):
         return options.get('vsts.client-secret')
 
-    def get_refresh_token_url(self):
-        return self.oauth_access_token_url
-
     def get_pipeline_views(self):
         return [
             OAuth2LoginView(

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -255,7 +255,6 @@ class IntegrationInstallation(object):
         """
         For Integrations that rely solely on user auth for authentication
         """
-
         identity = Identity.objects.get(id=self.org_integration.default_auth_id)
         return identity
 

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from six.moves.urllib.parse import quote
 
-from sentry.integrations.client import ApiClient, OAuth2RefreshMixin
+from sentry.integrations.client import ApiClient
 from sentry.integrations.exceptions import ApiError
 
 API_VERSION = u'/api/v4'
@@ -26,7 +26,7 @@ class GitLabApiClientPath(object):
         )
 
 
-class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
+class GitLabApiClient(ApiClient):
 
     def __init__(self, installation):
         self.installation = installation

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -164,25 +164,6 @@ class GitlabIntegrationProvider(IntegrationProvider):
             config=identity_pipeline_config,
         )
 
-    def get_oauth_data(self, payload):
-        data = {'access_token': payload['access_token']}
-
-        # https://docs.gitlab.com/ee/api/oauth2.html#2-requesting-access-token
-        # doesn't seem to be correct, format we actually get:
-        # {
-        #   "access_token": "123432sfh29uhs29347",
-        #   "token_type": "bearer",
-        #   "refresh_token": "29f43sdfsk22fsj929",
-        #   "created_at": 1536798907,
-        #   "scope": "api sudo"
-        # }
-        if 'refresh_token' in payload:
-            data['refresh_token'] = payload['refresh_token']
-        if 'token_type' in payload:
-            data['token_type'] = payload['token_type']
-
-        return data
-
     def get_group_info(self, access_token, installation_data):
         session = http.build_session()
         resp = session.get(
@@ -207,7 +188,7 @@ class GitlabIntegrationProvider(IntegrationProvider):
 
     def build_integration(self, state):
         data = state['identity']['data']
-        oauth_data = self.get_oauth_data(data)
+        oauth_data = GitlabIdentityProvider.get_oauth_data(data)
         user = get_user_info(data['access_token'], state['installation_data'])
         group = self.get_group_info(data['access_token'], state['installation_data'])
         scopes = sorted(GitlabIdentityProvider.oauth_scopes)

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from sentry.integrations.client import ApiClient, OAuth2RefreshMixin
+from sentry.integrations.client import ApiClient, ClientTokenRefresh
 from sentry.utils.http import absolute_uri
 
 UNSET = object()
@@ -34,7 +34,7 @@ class VstsApiPath(object):
     users = u'https://{account_name}.vssps.visualstudio.com/_apis/graph/users'
 
 
-class VstsApiClient(ApiClient, OAuth2RefreshMixin):
+class VstsApiClient(ApiClient):
     api_version = '4.1'
     api_version_preview = '-preview.1'
 
@@ -46,7 +46,8 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
             raise ValueError('Vsts Identity missing access token')
 
     def request(self, method, path, data=None, params=None, api_preview=False, timeout=None):
-        self.check_auth(redirect_url=self.oauth_redirect_url)
+        ClientTokenRefresh.check_auth(self.identity, redirect_url=self.oauth_redirect_url)
+
         headers = {
             'Accept': u'application/json; api-version={}{}'.format(self.api_version, self.api_version_preview if api_preview else ''),
             'Content-Type': 'application/json-patch+json' if method == 'PATCH' else 'application/json',

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from time import time
 import logging
 import re
 
@@ -351,7 +350,7 @@ class VstsIntegrationProvider(IntegrationProvider):
 
     def build_integration(self, state):
         data = state['identity']['data']
-        oauth_data = self.get_oauth_data(data)
+        oauth_data = VSTSIdentityProvider.get_oauth_data(data)
         account = state['account']
         user = get_user_info(data['access_token'])
         scopes = sorted(VSTSIdentityProvider.oauth_scopes)
@@ -409,18 +408,6 @@ class VstsIntegrationProvider(IntegrationProvider):
 
         subscription_id = subscription['publisherInputs']['tfsSubscriptionId']
         return subscription_id, shared_secret
-
-    def get_oauth_data(self, payload):
-        data = {'access_token': payload['access_token']}
-
-        if 'expires_in' in payload:
-            data['expires'] = int(time()) + int(payload['expires_in'])
-        if 'refresh_token' in payload:
-            data['refresh_token'] = payload['refresh_token']
-        if 'token_type' in payload:
-            data['token_type'] = payload['token_type']
-
-        return data
 
     @classmethod
     def get_base_url(cls, access_token, account_id):

--- a/tests/sentry/integrations/test_client.py
+++ b/tests/sentry/integrations/test_client.py
@@ -165,7 +165,7 @@ class OAuth2ApiClientTest(TestCase):
             data={
                 'access_token': 'access_token',
                 'refresh_token': 'refresh_token',
-                'expires': int(time()) - 3600
+                'expires_at': int(time()) - 3600
             }
         )
 
@@ -174,7 +174,7 @@ class OAuth2ApiClientTest(TestCase):
 
         assert client.identity.data['access_token'] == new_auth['access_token']
         assert client.identity.data['refresh_token'] == new_auth['refresh_token']
-        assert client.identity.data['expires'] > int(time())
+        assert client.identity.data['expires_at'] > int(time())
 
     @responses.activate
     def test_check_auth_no_refresh(self):
@@ -186,7 +186,7 @@ class OAuth2ApiClientTest(TestCase):
         old_auth = {
             'access_token': 'access_token',
             'refresh_token': 'refresh_token',
-            'expires': int(time()) + 3600
+            'expires_at': int(time()) + 3600
         }
         responses.add(
             responses.POST,


### PR DESCRIPTION
This makes a number of changes to provide a cleaner interface for dealing with refreshing tokens used with integrations and external identities.

 - The `AuthApiClient` has been removed from sentry.integrations.client as this was not in use at all.

 - A new `ClientTokenRefresh` object has been introduced which encapsulates the functionality needed to refresh access tokens. It has the functionality to refresh access tokens stored in Integration and Identity objects.

   - Azure DevOps has been migrated to use this and the OAuth2RefreshMixin has been removed.

   - GitHub now uses the ClientTokenRefresh functionality with a custom refresh strategy.

 - The `oauth_refresh_url` is now retrieved using the `_get_oauth_parameter` method, allowing the parameter to be looked up from the variety of places where the parameter may exist depending on the current context of the provider instance.

 - `get_refresh_token_headers` is moved down in the class to live near other token refresh methods.

 - A new staticmethod `get_oauth_data` is introduced onto the OAuth2Provider which provides data mapping for common OAuth2 parameters.

   A method by the same name previously lived on the provider class instance. We expose it as a static method so that integration providers which use the identity provider pipeline may consistently use this method to map the oauth2 parameters.

   Both Gitlab and Azure DevOps have been switched to use this.  - The `expires` parameter has been renamed `expires_at`.

   **IMPORTANT**: Since token expirations for providers using the identity provider (Azure DevOps, GitLab) previously used the `expires` key, tokens will be immediately renewed since we will now be looking for the `expires_at` key. When renewed the expires_at key will be used.

 - The `refresh_identity` method on the OAuth2Provider has been split into two separate methods

   - `refresh_oauth_data`: Makes the necessary API requests to refresh the token, but does not update any models. This method will return the new oauth data.

   - `refresh_identity`: Does what it did before, refreshes the OAuth token and updates the identity model.

     The `*args` parameter has also been removed from this method as it was not used.

These changes will also support Slack's "new" workspace token requirement for refresh tokens.