### PR TITLE
fix(ui) Fix dropdown in new-project stacking under footer

### DIFF
--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -444,6 +444,12 @@ footer {
   margin-top: 20px;
   padding: 28px 0;
 
+  .container {
+    // Ensure dropdowns inside application views
+    // don't stack under footer content.
+    position: static;
+  }
+
   .pull-right {
     a {
       margin-left: 20px;


### PR DESCRIPTION
Remove positioning from the footer>container. Having position creates a new stacking context that children of the previous sibling (application content) cannot stack above.  

### Before:

![image](https://user-images.githubusercontent.com/24086/46691625-dae99500-cbf4-11e8-987a-aa291c2db9bc.png)

### After

![screen shot 2018-10-09 at 2 54 53 pm](https://user-images.githubusercontent.com/24086/46691632-e1780c80-cbf4-11e8-889f-58ddde53c7fd.png)


Fixes APP-583