### PR TITLE
fix(ui): Add static backdrop to new integration modal

### DIFF
--- a/src/sentry/static/sentry/app/components/group/externalIssueActions.jsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueActions.jsx
@@ -280,6 +280,7 @@ class ExternalIssueActions extends AsyncComponent {
             onHide={this.closeModal}
             animation={false}
             enforceFocus={false}
+            backdrop="static"
           >
             <Modal.Header closeButton>
               <Modal.Title>{`${selectedIntegration.provider.name} Issue`}</Modal.Title>

--- a/tests/js/spec/components/group/__snapshots__/externalIssueActions.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/externalIssueActions.spec.jsx.snap
@@ -365,7 +365,7 @@ exports[`ExternalIssueActions with no external issues linked renders 1`] = `
   <Modal
     animation={false}
     autoFocus={true}
-    backdrop={true}
+    backdrop="static"
     bsClass="modal"
     dialogComponentClass={[Function]}
     enforceFocus={false}
@@ -389,7 +389,7 @@ exports[`ExternalIssueActions with no external issues linked renders 1`] = `
   >
     <Modal
       autoFocus={true}
-      backdrop={true}
+      backdrop="static"
       backdropClassName="modal-backdrop"
       containerClassName="modal-open"
       enforceFocus={false}


### PR DESCRIPTION
we did this for the old plugin modal, and i think it's too easy to accidentally click outside and lose your work