### PR TITLE
feat(discover): Allow user to select project_name

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/data.jsx
@@ -33,6 +33,7 @@ export const SPECIAL_TAGS = {
 export const COLUMNS = [
   {name: 'event_id', type: TYPES.STRING},
   {name: 'project_id', type: TYPES.STRING},
+  {name: 'project_name', type: TYPES.STRING}, // Not a snuba column
   {name: 'platform', type: TYPES.STRING},
   {name: 'message', type: TYPES.STRING},
   {name: 'primary_hash', type: TYPES.STRING},

--- a/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/queryEdit.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/queryEdit.jsx
@@ -36,8 +36,10 @@ export default class QueryEdit extends React.Component {
 
     const currentQuery = queryBuilder.getInternal();
     const columns = queryBuilder.getColumns();
-    // Do not allow conditions on projectID field
-    const columnsForConditions = columns.filter(({name}) => name !== 'project_id');
+    // Do not allow conditions on project_id or project_name fields
+    const columnsForConditions = columns.filter(
+      ({name}) => !['project_id', 'project_name'].includes(name)
+    );
 
     const fieldOptions = columns.map(({name}) => ({
       value: name,

--- a/src/sentry/static/sentry/app/views/organizationDiscover/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/utils.jsx
@@ -59,6 +59,11 @@ export function getOrderByOptions(queryBuilder) {
       }
     }
 
+    // Never allow ordering by project_name since this can't be done in Snuba
+    if (name === 'project_name') {
+      return acc;
+    }
+
     return [
       ...acc,
       {value: name, label: `${name} asc`},

--- a/tests/js/spec/views/organizationDiscover/queryBuilder.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/queryBuilder.spec.jsx
@@ -11,7 +11,7 @@ describe('Query Builder', function() {
 
       expect(external.projects).toEqual([2]);
       expect(external.fields).toEqual(expect.arrayContaining([expect.any(String)]));
-      expect(external.fields).toHaveLength(45);
+      expect(external.fields).toHaveLength(46);
       expect(external.conditions).toHaveLength(0);
       expect(external.aggregations).toHaveLength(0);
       expect(external.orderby).toBe('-timestamp');

--- a/tests/js/spec/views/organizationDiscover/utils.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/utils.spec.jsx
@@ -49,8 +49,8 @@ describe('getOrderByOptions()', function() {
   const organization = TestStubs.Organization({projects: [TestStubs.Project()]});
   const queryBuilder = createQueryBuilder({}, organization);
 
-  it('allows ordering by all fields when no aggregations', function() {
-    expect(getOrderByOptions(queryBuilder)).toHaveLength(COLUMNS.length * 2);
+  it('allows ordering by all fields when no aggregations except project_name', function() {
+    expect(getOrderByOptions(queryBuilder)).toHaveLength((COLUMNS.length - 1) * 2);
   });
 
   it('allows ordering by aggregations with aggregations and no fields', function() {


### PR DESCRIPTION
Add project_name as a selectable column. Since this data is stored in
Sentry rather than Snuba this is a somewhat restricted field and we do
not support conditions or orderby on this column.