### PR TITLE
fix(ui): Fix LazyLoad container

### DIFF
--- a/src/sentry/static/sentry/app/components/lazyLoad.jsx
+++ b/src/sentry/static/sentry/app/components/lazyLoad.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'react-emotion';
 
 import sdk from 'app/utils/sdk';
 import {t} from 'app/locale';
@@ -114,10 +115,21 @@ class LazyLoad extends React.Component {
       );
     }
 
-    if (!Component && !hideBusy) return <LoadingIndicator />;
+    if (!Component && !hideBusy) {
+      return (
+        <LoadingContainer>
+          <LoadingIndicator />
+        </LoadingContainer>
+      );
+    }
 
     return <Component {...otherProps} />;
   }
 }
 
+const LoadingContainer = styled('div')`
+  display: flex;
+  flex: 1;
+  align-items: center;
+`;
 export default LazyLoad;

--- a/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
@@ -14,7 +14,7 @@ import {
   parseSavedQuery,
   getView,
 } from './utils';
-import {LoadingContainer} from './styles';
+import {DiscoverWrapper, LoadingContainer} from './styles';
 
 const OrganizationDiscoverContainer = createReactClass({
   displayName: 'OrganizationDiscoverContainer',
@@ -104,7 +104,7 @@ const OrganizationDiscoverContainer = createReactClass({
     if (!hasFeature) return this.renderComingSoon();
 
     return (
-      <div>
+      <DiscoverWrapper>
         {isLoading ? (
           this.renderLoading()
         ) : (
@@ -118,7 +118,7 @@ const OrganizationDiscoverContainer = createReactClass({
             view={view}
           />
         )}
-      </div>
+      </DiscoverWrapper>
     );
   },
 });

--- a/src/sentry/static/sentry/app/views/organizationDiscover/styles.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/styles.jsx
@@ -14,6 +14,10 @@ const FOOTER_HEIGHT = 87;
 const HEADER_HEIGHT = 60;
 const TABS_HEIGHT = 55;
 
+export const DiscoverWrapper = styled(Flex)`
+  flex: 1;
+`;
+
 export const Discover = styled(Flex)`
   min-height: calc(100vh - ${FOOTER_HEIGHT}px);
 
@@ -53,7 +57,7 @@ export const BodyContent = styled(Flex)`
 
 export const LoadingContainer = styled(Flex)`
   flex: 1;
-  height: calc(100vh - ${FOOTER_HEIGHT}px);
+  align-items: center;
 `;
 
 export const TopBar = styled(Flex)`


### PR DESCRIPTION
LoadingIndicator should be wrapped by a flex container that grows and centers the loading indicator. Also centers the loading indicator in Discover.

Old:
https://cl.ly/e96533995125/download/Screen%20Recording%202018-10-10%20at%2004.49%20PM.gif

New:
https://cl.ly/376dbf629ffa/download/Screen%20Recording%202018-10-10%20at%2004.48%20PM.gif