### PR TITLE
ref(eventstream): Call superclass from KafkaEventStream.insert

### DIFF
--- a/src/sentry/eventstream/kafka.py
+++ b/src/sentry/eventstream/kafka.py
@@ -113,6 +113,14 @@ class KafkaEventStream(EventStream):
 
     def insert(self, group, event, is_new, is_sample, is_regression,
                is_new_group_environment, primary_hash, skip_consume=False):
+        # ensure the superclass's insert() is called, regardless of what happens
+        # attempting to send to Kafka
+        super(KafkaEventStream, self).insert(
+            group, event, is_new, is_sample,
+            is_regression, is_new_group_environment,
+            primary_hash, skip_consume
+        )
+
         project = event.project
         retention_days = quotas.get_event_retention(
             organization=Organization(project.organization_id)


### PR DESCRIPTION
This will allow for using KafkaEventStream as the primary (and only)
service backend, so that callers can make use of return values if
desired.

---

I guess we already had precedent for this in the "development mode" eventstream:

https://github.com/getsentry/sentry/blob/15edc46dff1857212424043a29ea38dc8f4c0e48/src/sentry/eventstream/snuba.py#L20-L24