### PR TITLE
feat(integrations) Add webhooks to gitlab repositories

### DIFF
--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -21,6 +21,7 @@ class GitLabApiClientPath(object):
     notes = u'/projects/{project}/issues/{issue}/notes'
     project = u'/projects/{project}'
     project_hooks = u'/projects/{project}/hooks'
+    project_hook = u'/projects/{project}/hooks/{hook_id}'
     projects = u'/projects'
     user = u'/user'
 
@@ -171,8 +172,8 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
             ),
         )
 
-    def create_webhook(self, project):
-        path = GitLabApiClientPath.project_hook.format(
+    def create_project_webhook(self, project):
+        path = GitLabApiClientPath.project_hooks.format(
             project=quote(project, safe=''))
         data = {
             'url': absolute_uri('/extensions/gitlab/webhooks/'),
@@ -182,6 +183,11 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
             'enable_ssl_verification': self.metadata['verify_ssl'],
         }
         resp = self.post(path, data)
-        resp.raise_for_status()
 
-        return resp.json()['id'],
+        return resp['id']
+
+    def delete_project_webhook(self, project, hook_id):
+        path = GitLabApiClientPath.project_hook.format(
+            project=quote(project, safe=''),
+            hook_id=hook_id)
+        self.delete(path)

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -112,10 +112,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
             u'domain_name': u'gitlab.example.com/cool-group',
             u'verify_ssl': True,
             u'base_url': 'https://gitlab.example.com',
-            'webhook': {
-                'id': 'webhook-id-1',
-                'secret': 'secret-token'
-            }
+            'webhook_secret': 'secret-token'
         }
         oi = OrganizationIntegration.objects.get(
             integration=integration,


### PR DESCRIPTION
Instead of system hooks we should use repository level hooks. These let us be compatible with gitlab.com and self-hosted gitlab. It also prevents us from getting a deluge of hooks from a busy gitlab instance.

Refs APP-590