### PR TITLE
fix(discover): Fix loading query fields

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -81,6 +81,7 @@ export default class OrganizationDiscover extends React.Component {
     const {resultManager} = this.state;
 
     if (savedQuery && savedQuery !== this.props.savedQuery) {
+      this.setState({view: 'saved'});
       this.runQuery();
     }
 

--- a/tests/js/spec/views/organizationDiscover/discover.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/discover.spec.jsx
@@ -61,6 +61,29 @@ describe('Discover', function() {
     });
   });
 
+  describe('componentWillRecieveProps()', function() {
+    it('handles navigating to saved query', function() {
+      const wrapper = mount(
+        <Discover
+          queryBuilder={queryBuilder}
+          organization={organization}
+          params={{}}
+          updateSavedQueryData={() => {}}
+          location={{search: ''}}
+        />,
+        TestStubs.routerContext([{organization}])
+      );
+      expect(wrapper.find('QueryEdit')).toHaveLength(1);
+      expect(wrapper.find('QueryRead')).toHaveLength(0);
+      wrapper.setProps({
+        savedQuery: TestStubs.DiscoverSavedQuery(),
+      });
+      wrapper.update();
+      expect(wrapper.find('QueryEdit')).toHaveLength(0);
+      expect(wrapper.find('QueryRead')).toHaveLength(1);
+    });
+  });
+
   describe('runQuery()', function() {
     const mockResponse = {timing: {}, data: [], meta: []};
     let wrapper;


### PR DESCRIPTION
This fixes a bug that caused the query to not be displayed upon initial
creation. This occurred since the view variable was not updated on
redirection to the saved query url.