### PR TITLE
fix(eventstream): Use logger.exception and not logger.error

### DIFF
--- a/src/sentry/eventstream/kafka.py
+++ b/src/sentry/eventstream/kafka.py
@@ -104,7 +104,7 @@ class KafkaEventStream(EventStream):
                 on_delivery=self.delivery_callback,
             )
         except Exception as error:
-            logger.error('Could not publish message: %s', error, exc_info=True)
+            logger.exception('Could not publish message: %s', error)
             return
 
         if not asynchronous:


### PR DESCRIPTION
This isn't going to Sentry currently. We'd like it to. I guess I expected `error` (esp with `exc_info`) to do the trick but apparently not?