### PR TITLE
ref(app-platform): Move feature flagging into decorators

### DIFF
--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -1,13 +1,12 @@
 from __future__ import absolute_import
 
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.base import Endpoint, SessionAuthentication
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.constants import SentryAppStatus
+from sentry.features.helpers import requires_feature
 from sentry.models import SentryApp
 
 
@@ -15,11 +14,8 @@ class SentryAppsEndpoint(Endpoint):
     authentication_classes = (SessionAuthentication, )
     permission_classes = (IsAuthenticated, )
 
+    @requires_feature('organizations:internal-catchall', any_org=True)
     def get(self, request):
-        if not any(features.has('organizations:internal-catchall', org)
-                   for org in request.user.get_orgs()):
-            return Response(status=404)
-
         if request.user.is_superuser:
             # Superusers have access to all apps, published and unpublished
             queryset = SentryApp.objects.all()

--- a/src/sentry/features/helpers.py
+++ b/src/sentry/features/helpers.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import
+
+from rest_framework.response import Response
+
+from sentry import features
+
+
+def requires_feature(feature, any_org=None):
+    def decorator(func):
+        def wrapped(self, request, *args, **kwargs):
+            # The endpoint is accessible if any of the User's Orgs have the feature
+            # flag enabled.
+            if any_org:
+                if not any(features.has(feature, org) for org in request.user.get_orgs()):
+                    return Response(status=404)
+
+                return func(self, request, *args, **kwargs)
+            # The Org in scope for the request must have the feature flag enabled.
+            else:
+                if 'organization' not in kwargs:
+                    return Response(status=404)
+
+                if not features.has(feature, kwargs['organization']):
+                    return Response(status=404)
+
+                return func(self, request, *args, **kwargs)
+        return wrapped
+    return decorator

--- a/src/sentry/testutils/helpers/features.py
+++ b/src/sentry/testutils/helpers/features.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-__all__ = ['Feature']
+__all__ = ['Feature', 'with_feature']
 
 import six
 import collections
@@ -39,3 +39,12 @@ def Feature(names):
     with patch('sentry.features.has') as features_has:
         features_has.side_effect = lambda x, *a, **k: names.get(x, False)
         yield
+
+
+def with_feature(feature):
+    def decorator(func):
+        def wrapped(self, *args, **kwargs):
+            with Feature(feature):
+                return func(self, *args, **kwargs)
+        return wrapped
+    return decorator

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers import with_feature
 from sentry.mediators.sentry_apps import Creator
 from sentry.constants import SentryAppStatus
 
@@ -28,25 +29,21 @@ class SentryAppsTest(APITestCase):
         )
         self.url = reverse('sentry-api-0-sentry-apps')
 
+    @with_feature('organizations:internal-catchall')
     def test_superuser_sees_all_apps(self):
         self.login_as(user=self.superuser)
 
-        with self.feature({
-            'organizations:internal-catchall': True,
-        }):
-            response = self.client.get(self.url, format='json')
+        response = self.client.get(self.url, format='json')
 
         assert response.status_code == 200
         assert set(o['uuid'] for o in response.data) == set(
             [self.published_app.uuid, self.unpublished_app.uuid])
 
+    @with_feature('organizations:internal-catchall')
     def test_users_only_see_published_apps(self):
         self.login_as(user=self.user)
 
-        with self.feature({
-            'organizations:internal-catchall': True,
-        }):
-            response = self.client.get(self.url, format='json')
+        response = self.client.get(self.url, format='json')
 
         assert response.status_code == 200
         assert response.data == [{

--- a/tests/sentry/features/test_helpers.py
+++ b/tests/sentry/features/test_helpers.py
@@ -1,0 +1,76 @@
+from __future__ import absolute_import
+
+from contextlib import contextmanager
+from django.http import HttpRequest
+from rest_framework.response import Response
+from mock import patch
+
+from sentry import features
+from sentry.features import OrganizationFeature
+from sentry.testutils import TestCase
+from sentry.features.helpers import requires_feature
+
+
+class TestFeatureHelpers(TestCase):
+    def setUp(self):
+        self.user = self.create_user()
+        self.org = self.create_organization(owner=self.user)
+        self.out_of_scope_org = self.create_organization(owner=self.user)
+
+        self.request = HttpRequest()
+        self.request.user = self.user
+
+        features.add('foo', OrganizationFeature)
+
+    def test_org_missing_from_request_fails(self):
+        @requires_feature('foo')
+        def get(self, request):
+            return Response()
+
+        assert get(None, self.request).status_code == 404
+
+    def test_org_without_feature_flag_fails(self):
+        @requires_feature('foo')
+        def get(self, request):
+            return Response()
+
+        assert get(None, self.request, organization=self.org).status_code == 404
+
+    def test_org_with_feature_flag_succeeds(self):
+        # The Org in scope of the request has the flag.
+        with org_with_feature(self.org, 'foo'):
+            @requires_feature('foo')
+            def get(self, request, *args, **kwargs):
+                return Response()
+
+            response = get(None, self.request, organization=self.org)
+            assert response.status_code == 200
+
+    def test_any_org_true_when_users_other_org_has_flag_succeeds(self):
+        # The Org in scope of the request does not have the flag, but another
+        # Org the User belongs to does.
+        #
+        with org_with_feature(self.out_of_scope_org, 'foo'):
+            @requires_feature('foo', any_org=True)
+            def get(self, request, *args, **kwargs):
+                return Response()
+
+            response = get(None, self.request, organization=self.org)
+            assert response.status_code == 200
+
+    def test_any_org_false_when_users_other_org_has_flag_fails(self):
+        with org_with_feature(self.out_of_scope_org, 'foo'):
+            @requires_feature('foo')
+            def get(self, request, *args, **kwargs):
+                return Response()
+
+            response = get(None, self.request, organization=self.org)
+            assert response.status_code == 404
+
+
+@contextmanager
+def org_with_feature(org, feature):
+    with patch('sentry.features.has') as has:
+        has.side_effect = lambda f, _org, *a, **k: \
+            f == feature and org == _org
+        yield

--- a/tests/sentry/testutils/helpers/test_features.py
+++ b/tests/sentry/testutils/helpers/test_features.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+
+from sentry import features
+from sentry.testutils import TestCase
+from sentry.testutils.helpers import with_feature
+
+
+class TestTestUtilsFeatureHelper(TestCase):
+    def setUp(self):
+        self.org = self.create_organization()
+
+    def test_without_feature(self):
+        assert not features.has('organizations:internal-catchall', self.org)
+
+    @with_feature('organizations:internal-catchall')
+    def test_with_feature(self):
+        assert features.has('organizations:internal-catchall', self.org)


### PR DESCRIPTION
This is mainly for use in the Sentry App work @MeredithAnya and I are doing, but could be used elsewhere. These are just to clean up some of the boilerplate code we'll use in a lot of endpoints/tests.

This adds two main things:
- A decorator to restrict an entire endpoint to Organizations that have a specific feature flag
- A decorator to stub the feature lookup in tests

### Endpoint Feature Gate

The Organization in scope of this request _must_ have the feature flag specified:

```python
@requires_feature('organizations:internal-catchall')
def get(self, request, organization=None):
    return Response(stuff)
```

At least one Organization the User is a part of must have the feature flag specified:

```python
@requires_feature('organizations:internal-catchall', any_org=True)
def get(self, request, organization=None):
    return Response(stuff)
```

When the feature flag lookup fails, for any reason (Org missing, flag not there, etc.) it returns a 404.

### Feature Flag Stub

Any call to `feature.has(...)` will return `True`:

```python
@with_feature('organizations:internal-catchall')
def test_a_thing_happens(self):
    assert features.has('organizations:internal-catchall', org)
```

NOTE: This is not Org-specific. It'll return `True` no matter what actor the code is checking.