### PR TITLE
feat(gitlab) Implement push & merge_request hooks for gitlab

### DIFF
--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
-from six.moves.urllib.parse import quote
 
 from sentry.integrations.client import ApiClient, OAuth2RefreshMixin
 from sentry.integrations.exceptions import ApiError
@@ -177,4 +176,4 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
 
     def delete_project_webhook(self, project_id, hook_id):
         path = GitLabApiClientPath.project_hook.format(project=project_id, hook_id=hook_id)
-        self.delete(path)
+        return self.delete(path)

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from django.core.urlresolvers import reverse
 from six.moves.urllib.parse import quote
 
 from sentry.integrations.client import ApiClient, OAuth2RefreshMixin
@@ -175,9 +176,10 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
     def create_project_webhook(self, project):
         path = GitLabApiClientPath.project_hooks.format(
             project=quote(project, safe=''))
+        hook_uri = reverse('sentry-extensions-gitlab-webhook')
         data = {
-            'url': absolute_uri('/extensions/gitlab/webhooks/'),
-            'token': self.metadata['webhook_secret'],
+            'url': absolute_uri(hook_uri),
+            'token': self.installation.model.external_id,
             'merge_requests_events': True,
             'push_events': True,
             'enable_ssl_verification': self.metadata['verify_ssl'],

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -111,11 +111,9 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
             }
         )
 
-    def get_project(self, project):
+    def get_project(self, project_id):
         return self.get(
-            GitLabApiClientPath.project.format(
-                project=quote(project, safe='')
-            )
+            GitLabApiClientPath.project.format(project=project_id)
         )
 
     def get_projects(self, query, simple=True):
@@ -129,22 +127,17 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
             }
         )
 
-    def get_issue(self, project, issue_id):
+    def get_issue(self, project_id, issue_id):
         try:
             return self.get(
-                GitLabApiClientPath.issue.format(
-                    project=quote(project, safe=''),
-                    issue=issue_id
-                )
+                GitLabApiClientPath.issue.format(project=project_id, issue=issue_id)
             )
         except IndexError:
             raise ApiError('Issue not found with ID', 404)
 
     def create_issue(self, project, data):
         return self.post(
-            GitLabApiClientPath.issues.format(
-                project=quote(project, safe='')
-            ),
+            GitLabApiClientPath.issues.format(project=project),
             data=data,
         )
 
@@ -157,25 +150,19 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
             }
         )
 
-    def create_note(self, project, issue_iid, data):
+    def create_note(self, project_id, issue_iid, data):
         return self.post(
-            GitLabApiClientPath.notes.format(
-                project=quote(project, safe=''),
-                issue=issue_iid,
-            ),
+            GitLabApiClientPath.notes.format(project=project_id, issue=issue_iid),
             data=data,
         )
 
-    def list_project_members(self, project):
+    def list_project_members(self, project_id):
         return self.get(
-            GitLabApiClientPath.members.format(
-                project=quote(project, safe='')
-            ),
+            GitLabApiClientPath.members.format(project=project_id)
         )
 
-    def create_project_webhook(self, project):
-        path = GitLabApiClientPath.project_hooks.format(
-            project=quote(project, safe=''))
+    def create_project_webhook(self, project_id):
+        path = GitLabApiClientPath.project_hooks.format(project=project_id)
         hook_uri = reverse('sentry-extensions-gitlab-webhook')
         data = {
             'url': absolute_uri(hook_uri),
@@ -188,8 +175,6 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
 
         return resp['id']
 
-    def delete_project_webhook(self, project, hook_id):
-        path = GitLabApiClientPath.project_hook.format(
-            project=quote(project, safe=''),
-            hook_id=hook_id)
+    def delete_project_webhook(self, project_id, hook_id):
+        path = GitLabApiClientPath.project_hook.format(project=project_id, hook_id=hook_id)
         self.delete(path)

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -163,12 +163,13 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
     def create_project_webhook(self, project_id):
         path = GitLabApiClientPath.project_hooks.format(project=project_id)
         hook_uri = reverse('sentry-extensions-gitlab-webhook')
+        model = self.installation.model
         data = {
             'url': absolute_uri(hook_uri),
-            'token': self.installation.model.external_id,
+            'token': u'{}:{}'.format(model.external_id, model.metadata['webhook_secret']),
             'merge_requests_events': True,
             'push_events': True,
-            'enable_ssl_verification': self.metadata['verify_ssl'],
+            'enable_ssl_verification': model.metadata['verify_ssl'],
         }
         resp = self.post(path, data)
 

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -258,6 +258,7 @@ class GitlabIntegrationProvider(IntegrationProvider):
             'external_id': u'{}:{}'.format(hostname, uuid4().hex),
             'metadata': {
                 'icon': group['avatar_url'],
+                'instance': hostname,
                 'domain_name': u'{}/{}'.format(hostname, group['path']),
                 'scopes': scopes,
                 'verify_ssl': verify_ssl,

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -252,10 +252,12 @@ class GitlabIntegrationProvider(IntegrationProvider):
 
         integration = {
             'name': group['name'],
-            # We splice the host & secret together to create an external id.
-            # This id is used as a webhook secret so we can find the matching
-            # sentry org later on.
-            'external_id': u'{}:{}'.format(hostname, uuid4().hex),
+            # Splice the gitlab host and project together to
+            # act as unique link between a gitlab instance, group + sentry.
+            # This value is embedded then in the webook token that we
+            # give to gitlab to allow us to find the integration a hook came
+            # from.
+            'external_id': u'{}:{}'.format(hostname, group['path']),
             'metadata': {
                 'icon': group['avatar_url'],
                 'instance': hostname,
@@ -263,6 +265,7 @@ class GitlabIntegrationProvider(IntegrationProvider):
                 'scopes': scopes,
                 'verify_ssl': verify_ssl,
                 'base_url': base_url,
+                'webhook_secret': uuid4().hex
             },
             'user_identity': {
                 'type': 'gitlab',

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -76,7 +76,7 @@ class GitlabIntegration(IntegrationInstallation, GitlabIssueBasic, RepositoryMix
         self.default_identity = None
 
     def get_group_id(self):
-        return self.model.external_id.split(':')[1]
+        return self.model.name
 
     def get_client(self):
         if self.default_identity is None:

--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -32,16 +32,17 @@ class GitlabRepositoryProvider(providers.IntegrationRepositoryProvider):
         instance = installation.model.metadata['domain_name']
 
         try:
-            repo = client.get_project(six.text_type(repo_id))
+            project = client.get_project(six.text_type(repo_id))
         except Exception as e:
             installation.raise_error(e)
         config.update({
             'instance': instance,
-            'path': repo['path_with_namespace'],
-            'name': repo['name_with_namespace'],
-            'repo_id': repo['id'],
-            'external_id': '%s:%s' % (instance, repo['path']),
-            'url': repo['web_url'],
+            'path': project['path_with_namespace'],
+            'name': project['name_with_namespace'],
+            'repo_id': project['id'],
+            # Repo names are not unique without the namespace.
+            'external_id': project['path_with_namespace'],
+            'url': project['web_url'],
         })
         return config
 

--- a/src/sentry/integrations/gitlab/search.py
+++ b/src/sentry/integrations/gitlab/search.py
@@ -39,7 +39,7 @@ class GitlabIssueSearchEndpoint(OrganizationEndpoint):
             response = installation.get_client().get_projects(query=query)
             return Response([{
                 'label': project['name_with_namespace'],
-                'value': project['path_with_namespace'],
+                'value': project['id'],
             } for project in response])
 
         return Response({'detail': 'invalid field value'}, status=400)

--- a/src/sentry/integrations/gitlab/urls.py
+++ b/src/sentry/integrations/gitlab/urls.py
@@ -13,7 +13,7 @@ urlpatterns = patterns(
         name='sentry-extensions-gitlab-search'
     ),
     url(
-        r'^webhooks/$',
+        r'^webhook/$',
         GitlabWebhookEndpoint.as_view(),
         name='sentry-extensions-gitlab-webhook'
     ),

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -32,16 +32,21 @@ class Webhook(object):
         raise NotImplementedError
 
     def get_repo(self, integration, organization, event):
-        repo_name = event['project']['path_with_namespace']
+        try:
+            repo_id = event['project']['id']
+        except KeyError:
+            logger.info('gitlab.webhook.missing-projectid')
+            raise Http404()
+
         try:
             repo = Repository.objects.get(
                 organization_id=organization.id,
                 provider=PROVIDER_NAME,
-                external_id=six.text_type(repo_name),
+                external_id=repo_id,
             )
         except Repository.DoesNotExist:
             logger.info('gitlab.webhook.missing-repo', extra={
-                'external_id': repo_name
+                'external_id': repo_id
             })
             raise Http404()
         return repo

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -33,20 +33,23 @@ class Webhook(object):
 
     def get_repo(self, integration, organization, event):
         try:
-            repo_id = event['project']['id']
+            project_id = event['project']['id']
         except KeyError:
-            logger.info('gitlab.webhook.missing-projectid')
+            logger.info('gitlab.webhook.missing-projectid', extra={
+                'integration_id': integration.id
+            })
             raise Http404()
 
+        external_id = u'{}:{}'.format(integration.metadata['instance'], project_id)
         try:
             repo = Repository.objects.get(
                 organization_id=organization.id,
                 provider=PROVIDER_NAME,
-                external_id=repo_id,
+                external_id=external_id,
             )
         except Repository.DoesNotExist:
             logger.info('gitlab.webhook.missing-repo', extra={
-                'external_id': repo_id
+                'external_id': project_id
             })
             raise Http404()
         return repo

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -72,6 +72,7 @@ class MergeEventWebhook(Webhook):
             logger.info(
                 'gitlab.webhook.invalid-merge-data',
                 extra={
+                    'integration_id': integration.id,
                     'error': six.string_type(e)
                 })
             raise Http404()
@@ -84,10 +85,10 @@ class MergeEventWebhook(Webhook):
 
         try:
             PullRequest.objects.create_or_update(
+                organization_id=organization.id,
                 repository_id=repo.id,
                 key=number,
                 values={
-                    'organization_id': organization.id,
                     'title': title,
                     'author': author,
                     'message': body,

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -104,7 +104,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
 
         integration = Integration.objects.get(provider=self.provider.key)
 
-        assert integration.external_id == 'gitlab.example.com:secret-token'
+        assert integration.external_id == 'gitlab.example.com:cool-group'
         assert integration.name == 'Cool'
         assert integration.metadata == {
             'instance': 'gitlab.example.com',
@@ -113,6 +113,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
             'domain_name': u'gitlab.example.com/cool-group',
             'verify_ssl': True,
             'base_url': 'https://gitlab.example.com',
+            'webhook_secret': 'secret-token'
         }
         oi = OrganizationIntegration.objects.get(
             integration=integration,

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -4,7 +4,7 @@ import responses
 import six
 
 from six.moves.urllib.parse import parse_qs, urlencode, urlparse
-from mock import patch
+from mock import patch, Mock
 
 from sentry.integrations.gitlab import GitlabIntegrationProvider
 from sentry.models import (
@@ -99,7 +99,10 @@ class GitlabIntegrationTest(IntegrationTestCase):
     @responses.activate
     @patch('sentry.integrations.gitlab.integration.sha1_text')
     def test_basic_flow(self, mock_sha):
-        mock_sha.return_value = 'secret-token'
+        sha = Mock()
+        sha.hexdigest.return_value = 'secret-token'
+        mock_sha.return_value = sha
+
         self.assert_setup_flow()
 
         integration = Integration.objects.get(provider=self.provider.key)

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -107,11 +107,12 @@ class GitlabIntegrationTest(IntegrationTestCase):
         assert integration.external_id == 'gitlab.example.com:secret-token'
         assert integration.name == 'Cool'
         assert integration.metadata == {
-            u'scopes': ['api', 'sudo'],
-            u'icon': u'https://gitlab.example.com/uploads/group/avatar/4/foo.jpg',
-            u'domain_name': u'gitlab.example.com/cool-group',
-            u'verify_ssl': True,
-            u'base_url': 'https://gitlab.example.com',
+            'instance': 'gitlab.example.com',
+            'scopes': ['api', 'sudo'],
+            'icon': u'https://gitlab.example.com/uploads/group/avatar/4/foo.jpg',
+            'domain_name': u'gitlab.example.com/cool-group',
+            'verify_ssl': True,
+            'base_url': 'https://gitlab.example.com',
         }
         oi = OrganizationIntegration.objects.get(
             integration=integration,

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -4,7 +4,7 @@ import responses
 import six
 
 from six.moves.urllib.parse import parse_qs, urlencode, urlparse
-from mock import patch, Mock
+from mock import patch
 
 from sentry.integrations.gitlab import GitlabIntegrationProvider
 from sentry.models import (
@@ -97,9 +97,9 @@ class GitlabIntegrationTest(IntegrationTestCase):
         self.assertDialogSuccess(resp)
 
     @responses.activate
-    @patch('sentry.integrations.gitlab.integration.uuid4')
-    def test_basic_flow(self, mock_uuid):
-        mock_uuid.return_value = Mock(hex='secret-token')
+    @patch('sentry.integrations.gitlab.integration.sha1_text')
+    def test_basic_flow(self, mock_sha):
+        mock_sha.return_value = 'secret-token'
         self.assert_setup_flow()
 
         integration = Integration.objects.get(provider=self.provider.key)

--- a/tests/sentry/integrations/gitlab/test_issues.py
+++ b/tests/sentry/integrations/gitlab/test_issues.py
@@ -93,7 +93,7 @@ class GitlabIssuesTest(GitLabTestCase):
         responses.add(
             responses.GET,
             u'https://example.gitlab.com/api/v4/projects/%s' % project_id,
-            json={'path_with_namespace': project_name}
+            json={'path_with_namespace': project_name, 'id': 10}
         )
         form_data = {
             'project': project_id,
@@ -127,7 +127,7 @@ class GitlabIssuesTest(GitLabTestCase):
         responses.add(
             responses.GET,
             u'https://example.gitlab.com/api/v4/projects/%s' % project_id,
-            json={'path_with_namespace': project_name}
+            json={'id': project_id, 'path_with_namespace': project_name}
         )
 
         assert self.installation.get_issue(issue_id='%s#%s' % (project_id, issue_iid), data={}) == {

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -24,6 +24,7 @@ class GitLabRepositoryProviderTest(PluginTestCase):
             name='Example GitLab',
             external_id='example.gitlab.com:secret-token',
             metadata={
+                'instance': 'example.gitlab.com',
                 'domain_name': 'example.gitlab.com/my-group',
                 'verify_ssl': False,
                 'base_url': 'https://example.gitlab.com',
@@ -84,19 +85,21 @@ class GitLabRepositoryProviderTest(PluginTestCase):
         return response
 
     def assert_repository(self, repository_config, organization_id=None):
-        domain_name = self.integration.metadata['domain_name']
+        instance = self.integration.metadata['instance']
+
+        external_id = u'{}:{}'.format(instance, repository_config['id'])
         repo = Repository.objects.get(
             organization_id=organization_id or self.organization.id,
             provider=self.provider_name,
-            external_id=repository_config['id']
+            external_id=external_id
         )
         assert repo.name == repository_config['name_with_namespace']
         assert repo.url == repository_config['web_url']
         assert repo.integration_id == self.integration.id
-        assert repo.external_id == str(repository_config['id'])
         assert repo.config == {
-            'instance': domain_name,
+            'instance': instance,
             'path': repository_config['path_with_namespace'],
+            'project_id': repository_config['id'],
             'webhook_id': 99,
         }
 

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -22,12 +22,11 @@ class GitLabRepositoryProviderTest(PluginTestCase):
         self.integration = Integration.objects.create(
             provider='gitlab',
             name='Example GitLab',
-            external_id='example.gitlab.com:55',
+            external_id='example.gitlab.com:secret-token',
             metadata={
                 'domain_name': 'example.gitlab.com/my-group',
                 'verify_ssl': False,
                 'base_url': 'https://example.gitlab.com',
-                'webhook_secret': 'super-secret',
             }
         )
         identity = Identity.objects.create(
@@ -89,7 +88,7 @@ class GitLabRepositoryProviderTest(PluginTestCase):
         repo = Repository.objects.get(
             organization_id=organization_id or self.organization.id,
             provider=self.provider_name,
-            external_id='%s:example-repo' % (domain_name,)
+            external_id=repository_config['path_with_namespace']
         )
         assert repo.name == repository_config['name_with_namespace']
         assert repo.url == repository_config['web_url']

--- a/tests/sentry/integrations/gitlab/test_search.py
+++ b/tests/sentry/integrations/gitlab/test_search.py
@@ -68,8 +68,8 @@ class GitlabSearchTest(GitLabTestCase):
 
             assert resp.status_code == 200
             assert resp.data == [
-                {'value': 'getsentry/sentry', 'label': 'GetSentry / Sentry'},
-                {'value': 'getsentry2/sentry2', 'label': 'GetSentry2 / Sentry2'}
+                {'value': '1', 'label': 'GetSentry / Sentry'},
+                {'value': '2', 'label': 'GetSentry2 / Sentry2'}
             ]
 
     def test_finds_no_external_issues_results(self):

--- a/tests/sentry/integrations/gitlab/test_webhook.py
+++ b/tests/sentry/integrations/gitlab/test_webhook.py
@@ -64,10 +64,7 @@ class WebhookTest(GitLabTestCase):
         assert response.status_code == 404
 
     def test_push_event_create_commits_annd_authors(self):
-        repo = self.create_repo(
-            name='getsentry/sentry',
-            external_id='getsentry/sentry'
-        )
+        repo = self.create_repo('getsentry/sentry')
         response = self.client.post(
             self.url,
             data=PUSH_EVENT,
@@ -95,10 +92,7 @@ class WebhookTest(GitLabTestCase):
             assert author.organization_id == self.organization.id
 
     def test_push_event_ignore_commit(self):
-        self.create_repo(
-            name='getsentry/sentry',
-            external_id='getsentry/sentry'
-        )
+        self.create_repo('getsentry/sentry')
         response = self.client.post(
             self.url,
             data=PUSH_EVENT_IGNORED_COMMIT,
@@ -115,10 +109,7 @@ class WebhookTest(GitLabTestCase):
             email='jordi@example.org',
             name='Jordi'
         )
-        self.create_repo(
-            name='getsentry/sentry',
-            external_id='getsentry/sentry'
-        )
+        self.create_repo('getsentry/sentry')
         response = self.client.post(
             self.url,
             data=PUSH_EVENT,
@@ -146,10 +137,7 @@ class WebhookTest(GitLabTestCase):
 
     @pytest.mark.incomplete
     def test_merge_event_create_pull_request(self):
-        self.create_repo(
-            name='getsentry/sentry',
-            external_id='getsentry/sentry'
-        )
+        self.create_repo('getsentry/sentry')
         response = self.client.post(
             self.url,
             data=MERGE_REQUEST_OPENED_EVENT,

--- a/tests/sentry/integrations/gitlab/test_webhook.py
+++ b/tests/sentry/integrations/gitlab/test_webhook.py
@@ -1,61 +1,172 @@
 from __future__ import absolute_import
 
-from sentry.testutils import APITestCase
+from sentry.models import (
+    Commit,
+    CommitAuthor,
+    PullRequest
+)
+from .testutils import (
+    GitLabTestCase,
+    WEBHOOK_SECRET,
+    MERGE_REQUEST_OPENED_EVENT,
+    PUSH_EVENT,
+    PUSH_EVENT_IGNORED_COMMIT
+)
 
 import pytest
 
 
-class WebhookTest(APITestCase):
-    url = '/extensions/gitlab/webhook'
+class WebhookTest(GitLabTestCase):
+    url = '/extensions/gitlab/webhook/'
 
-    @pytest.mark.incomplete
     def test_get(self):
-        pass
+        response = self.client.get(self.url)
+        assert response.status_code == 405
 
-    @pytest.mark.incomplete
+    def test_unknown_event(self):
+        response = self.client.post(
+            self.url,
+            data=PUSH_EVENT,
+            content_type='application/json',
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_SECRET,
+            HTTP_X_GITLAB_EVENT='lol'
+        )
+        assert response.status_code == 400
+
     def test_invalid_secret(self):
-        pass
+        response = self.client.post(
+            self.url,
+            data=PUSH_EVENT,
+            content_type='application/json',
+            HTTP_X_GITLAB_TOKEN='wrong',
+            HTTP_X_GITLAB_EVENT='Push Hook'
+        )
+        assert response.status_code == 400
 
-    @pytest.mark.incomplete
-    def test_push_event_create_repo(self):
-        pass
+    def test_invalid_payload(self):
+        response = self.client.post(
+            self.url,
+            data='lol not json',
+            content_type='application/json',
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_SECRET,
+            HTTP_X_GITLAB_EVENT='Push Hook'
+        )
+        assert response.status_code == 400
 
-    @pytest.mark.incomplete
-    def test_push_event_create_commits(self):
-        pass
+    def test_push_event_missing_repo(self):
+        response = self.client.post(
+            self.url,
+            data=PUSH_EVENT,
+            content_type='application/json',
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_SECRET,
+            HTTP_X_GITLAB_EVENT='Push Hook'
+        )
+        assert response.status_code == 404
 
-    @pytest.mark.incomplete
+    def test_push_event_create_commits_annd_authors(self):
+        repo = self.create_repo(
+            name='getsentry/sentry',
+            external_id='getsentry/sentry'
+        )
+        response = self.client.post(
+            self.url,
+            data=PUSH_EVENT,
+            content_type='application/json',
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_SECRET,
+            HTTP_X_GITLAB_EVENT='Push Hook'
+        )
+        assert response.status_code == 204
+
+        commits = Commit.objects.all()
+        assert len(commits) == 2
+        for commit in commits:
+            assert commit.key
+            assert commit.message
+            assert commit.author
+            assert commit.date_added
+            assert commit.repository_id == repo.id
+
+        authors = CommitAuthor.objects.all()
+        assert len(authors) == 2
+        for author in authors:
+            assert author.email
+            assert 'example.org' in author.email
+            assert author.name
+            assert author.organization_id == self.organization.id
+
     def test_push_event_ignore_commit(self):
-        pass
+        self.create_repo(
+            name='getsentry/sentry',
+            external_id='getsentry/sentry'
+        )
+        response = self.client.post(
+            self.url,
+            data=PUSH_EVENT_IGNORED_COMMIT,
+            content_type='application/json',
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_SECRET,
+            HTTP_X_GITLAB_EVENT='Push Hook'
+        )
+        assert response.status_code == 204
+        assert 0 == Commit.objects.count()
+
+    def test_push_event_known_author(self):
+        CommitAuthor.objects.create(
+            organization_id=self.organization.id,
+            email='jordi@example.org',
+            name='Jordi'
+        )
+        self.create_repo(
+            name='getsentry/sentry',
+            external_id='getsentry/sentry'
+        )
+        response = self.client.post(
+            self.url,
+            data=PUSH_EVENT,
+            content_type='application/json',
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_SECRET,
+            HTTP_X_GITLAB_EVENT='Push Hook'
+        )
+        assert response.status_code == 204
+        assert 2 == CommitAuthor.objects.count(), 'No dupes made'
 
     @pytest.mark.incomplete
     def test_push_event_create_commits_more_than_20(self):
         pass
 
     @pytest.mark.incomplete
-    def test_push_event_known_author(self):
-        pass
+    def test_merge_event_missing_repo(self):
+        response = self.client.post(
+            self.url,
+            data=MERGE_REQUEST_OPENED_EVENT,
+            content_type='application/json',
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_SECRET,
+            HTTP_X_GITLAB_EVENT='Merge Request Hook'
+        )
+        assert response.status_code == 404
 
     @pytest.mark.incomplete
-    def test_push_event_unknown_author(self):
-        pass
+    def test_merge_event_create_pull_request(self):
+        self.create_repo(
+            name='getsentry/sentry',
+            external_id='getsentry/sentry'
+        )
+        response = self.client.post(
+            self.url,
+            data=MERGE_REQUEST_OPENED_EVENT,
+            content_type='application/json',
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_SECRET,
+            HTTP_X_GITLAB_EVENT='Merge Request Hook'
+        )
+        assert response.status_code == 204
+        author = CommitAuthor.objects.all().first()
+        assert author.email
+        assert author.name
+        assert author.organization_id == self.organization.id
 
-    @pytest.mark.incomplete
-    def test_push_event_suspect_commit(self):
-        pass
-
-    @pytest.mark.incomplete
-    def test_merge_event_create_repo(self):
-        pass
-
-    @pytest.mark.incomplete
-    def test_merge_event_create_commits(self):
-        pass
-
-    @pytest.mark.incomplete
-    def test_merge_event_create_commits_more_than_20(self):
-        pass
-
-    @pytest.mark.incomplete
-    def test_merge_event_link_author(self):
-        pass
+        pull = PullRequest.objects.all().first()
+        assert pull.title
+        assert pull.message
+        assert pull.date_added
+        assert pull.author == author
+        assert pull.merge_commit_sha is None
+        assert pull.organization_id == self.organization.id

--- a/tests/sentry/integrations/gitlab/testutils.py
+++ b/tests/sentry/integrations/gitlab/testutils.py
@@ -23,6 +23,7 @@ class GitLabTestCase(APITestCase):
             name='Example Gitlab',
             external_id=WEBHOOK_SECRET,
             metadata={
+                'instance': 'example.gitlab.com',
                 'base_url': 'https://example.gitlab.com',
                 'domain_name': 'example.gitlab.com/sentry-group',
                 'verify_ssl': False,
@@ -44,12 +45,13 @@ class GitLabTestCase(APITestCase):
         self.installation = self.integration.get_installation(self.organization.id)
 
     def create_repo(self, name, external_id=15, url=None):
+        instance = self.integration.metadata['instance']
         return Repository.objects.create(
             organization_id=self.organization.id,
             name=name,
-            external_id=external_id,
+            external_id=u'{}:{}'.format(instance, external_id),
             url=url,
-            config={},
+            config={'project_id': external_id},
             provider='integrations:gitlab',
             integration_id=self.integration.id,
         )

--- a/tests/sentry/integrations/gitlab/testutils.py
+++ b/tests/sentry/integrations/gitlab/testutils.py
@@ -43,7 +43,7 @@ class GitLabTestCase(APITestCase):
         self.integration.add_organization(self.organization, self.user, identity.id)
         self.installation = self.integration.get_installation(self.organization.id)
 
-    def create_repo(self, name, external_id, url=None):
+    def create_repo(self, name, external_id=15, url=None):
         return Repository.objects.create(
             organization_id=self.organization.id,
             name=name,
@@ -63,6 +63,7 @@ MERGE_REQUEST_OPENED_EVENT = b"""{
     "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon"
   },
   "project": {
+    "id": 15,
     "name": "Sentry",
     "description": "",
     "web_url": "http://example.com/getsentry/sentry",

--- a/tests/sentry/integrations/gitlab/testutils.py
+++ b/tests/sentry/integrations/gitlab/testutils.py
@@ -10,7 +10,9 @@ from sentry.models import (
 )
 
 
-WEBHOOK_SECRET = 'example.gitlab.com:super-secret-token'
+EXTERNAL_ID = 'example.gitlab.com:group-x'
+WEBHOOK_SECRET = 'secret-token-value'
+WEBHOOK_TOKEN = u'{}:{}'.format(EXTERNAL_ID, WEBHOOK_SECRET)
 
 
 class GitLabTestCase(APITestCase):
@@ -21,12 +23,13 @@ class GitLabTestCase(APITestCase):
         self.integration = Integration.objects.create(
             provider=self.provider,
             name='Example Gitlab',
-            external_id=WEBHOOK_SECRET,
+            external_id=EXTERNAL_ID,
             metadata={
                 'instance': 'example.gitlab.com',
                 'base_url': 'https://example.gitlab.com',
-                'domain_name': 'example.gitlab.com/sentry-group',
+                'domain_name': 'example.gitlab.com/group-x',
                 'verify_ssl': False,
+                'webhook_secret': WEBHOOK_SECRET,
             }
         )
         identity = Identity.objects.create(
@@ -69,19 +72,19 @@ MERGE_REQUEST_OPENED_EVENT = b"""{
     "id": 15,
     "name": "Sentry",
     "description": "",
-    "web_url": "http://example.com/getsentry/sentry",
+    "web_url": "http://example.com/cool-group/sentry",
     "avatar_url": null,
-    "git_ssh_url": "git@example.com:getsentry/sentry.git",
-    "git_http_url": "http://example.com/getsentry/sentry.git",
-    "namespace": "getsentry",
+    "git_ssh_url": "git@example.com:cool-group/sentry.git",
+    "git_http_url": "http://example.com/cool-group/sentry.git",
+    "namespace": "cool-group",
     "visibility_level": 0,
-    "path_with_namespace": "getsentry/sentry",
+    "path_with_namespace": "cool-group/sentry",
     "default_branch": "master",
     "ci_config_path": "",
-    "homepage": "http://example.com/getsentry/sentry",
-    "url": "git@example.com:getsentry/sentry.git",
-    "ssh_url": "git@example.com:getsentry/sentry.git",
-    "http_url": "http://example.com/getsentry/sentry.git"
+    "homepage": "http://example.com/cool-group/sentry",
+    "url": "git@example.com:cool-group/sentry.git",
+    "ssh_url": "git@example.com:cool-group/sentry.git",
+    "http_url": "http://example.com/cool-group/sentry.git"
   },
   "object_attributes": {
     "id": 90,
@@ -192,26 +195,26 @@ PUSH_EVENT = b"""
     "id": 15,
     "name":"Diaspora",
     "description":"",
-    "web_url":"http://example.com/getsentry/sentry",
+    "web_url":"http://example.com/cool-group/sentry",
     "avatar_url":null,
-    "git_ssh_url":"git@example.com:getsentry/sentry.git",
-    "git_http_url":"http://example.com/getsentry/sentry.git",
+    "git_ssh_url":"git@example.com:cool-group/sentry.git",
+    "git_http_url":"http://example.com/cool-group/sentry.git",
     "namespace":"Mike",
     "visibility_level":0,
-    "path_with_namespace":"getsentry/sentry",
+    "path_with_namespace":"cool-group/sentry",
     "default_branch":"master",
-    "homepage":"http://example.com/getsentry/sentry",
-    "url":"git@example.com:getsentry/sentry.git",
-    "ssh_url":"git@example.com:getsentry/sentry.git",
-    "http_url":"http://example.com/getsentry/sentry.git"
+    "homepage":"http://example.com/cool-group/sentry",
+    "url":"git@example.com:cool-group/sentry.git",
+    "ssh_url":"git@example.com:cool-group/sentry.git",
+    "http_url":"http://example.com/cool-group/sentry.git"
   },
   "repository":{
     "name": "Sentry",
-    "url": "git@example.com:getsentry/sentry.git",
+    "url": "git@example.com:cool-group/sentry.git",
     "description": "",
-    "homepage": "http://example.com/getsentry/sentry",
-    "git_http_url":"http://example.com/getsentry/sentry.git",
-    "git_ssh_url":"git@example.com:getsentry/sentry.git",
+    "homepage": "http://example.com/cool-group/sentry",
+    "git_http_url":"http://example.com/cool-group/sentry.git",
+    "git_ssh_url":"git@example.com:cool-group/sentry.git",
     "visibility_level":0
   },
   "commits": [
@@ -219,7 +222,7 @@ PUSH_EVENT = b"""
       "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
       "message": "Update Catalan translation to e38cb41.",
       "timestamp": "2011-12-12T14:27:31+02:00",
-      "url": "http://example.com/getsentry/sentry/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+      "url": "http://example.com/cool-group/sentry/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
       "author": {
         "name": "Jordi",
         "email": "jordi@example.org"
@@ -232,7 +235,7 @@ PUSH_EVENT = b"""
       "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
       "message": "fixed readme",
       "timestamp": "2012-01-03T23:36:29+02:00",
-      "url": "http://example.com/getsentry/sentry/commit/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "url": "http://example.com/cool-group/sentry/commit/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
       "author": {
         "name": "GitLab dev user",
         "email": "gitlabdev@example.org"
@@ -263,26 +266,26 @@ PUSH_EVENT_IGNORED_COMMIT = b"""
     "id": 15,
     "name":"Sentry",
     "description":"",
-    "web_url":"http://example.com/getsentry/sentry",
+    "web_url":"http://example.com/cool-group/sentry",
     "avatar_url":null,
-    "git_ssh_url":"git@example.com:getsentry/sentry.git",
-    "git_http_url":"http://example.com/getsentry/sentry.git",
-    "namespace":"getsentry",
+    "git_ssh_url":"git@example.com:cool-group/sentry.git",
+    "git_http_url":"http://example.com/cool-group/sentry.git",
+    "namespace":"cool-group",
     "visibility_level":0,
-    "path_with_namespace":"getsentry/sentry",
+    "path_with_namespace":"cool-group/sentry",
     "default_branch":"master",
-    "homepage":"http://example.com/getsentry/sentry",
-    "url":"git@example.com:getsentry/sentry.git",
-    "ssh_url":"git@example.com:getsentry/sentry.git",
-    "http_url":"http://example.com/getsentry/sentry.git"
+    "homepage":"http://example.com/cool-group/sentry",
+    "url":"git@example.com:cool-group/sentry.git",
+    "ssh_url":"git@example.com:cool-group/sentry.git",
+    "http_url":"http://example.com/cool-group/sentry.git"
   },
   "repository":{
     "name": "Sentry",
-    "url": "git@example.com:getsentry/sentry.git",
+    "url": "git@example.com:cool-group/sentry.git",
     "description": "",
-    "homepage": "http://example.com/getsentry/sentry",
-    "git_http_url":"http://example.com/getsentry/sentry.git",
-    "git_ssh_url":"git@example.com:getsentry/sentry.git",
+    "homepage": "http://example.com/cool-group/sentry",
+    "git_http_url":"http://example.com/cool-group/sentry.git",
+    "git_ssh_url":"git@example.com:cool-group/sentry.git",
     "visibility_level":0
   },
   "commits": [
@@ -290,7 +293,7 @@ PUSH_EVENT_IGNORED_COMMIT = b"""
       "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
       "message": "Update things #skipsentry",
       "timestamp": "2011-12-12T14:27:31+02:00",
-      "url": "http://example.com/getsentry/sentry/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+      "url": "http://example.com/cool-group/sentry/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
       "author": {
         "name": "Jordi",
         "email": "jordi@example.org"

--- a/tests/sentry/integrations/gitlab/testutils.py
+++ b/tests/sentry/integrations/gitlab/testutils.py
@@ -44,10 +44,11 @@ class GitLabTestCase(APITestCase):
         self.integration.add_organization(self.organization, self.user, identity.id)
         self.installation = self.integration.get_installation(self.organization.id)
 
-    def create_repo(self, name, external_id=15, url=None):
+    def create_repo(self, name, external_id=15, url=None, organization_id=None):
         instance = self.integration.metadata['instance']
+        organization_id = organization_id or self.organization.id
         return Repository.objects.create(
-            organization_id=self.organization.id,
+            organization_id=organization_id,
             name=name,
             external_id=u'{}:{}'.format(instance, external_id),
             url=url,

--- a/tests/sentry/integrations/gitlab/testutils.py
+++ b/tests/sentry/integrations/gitlab/testutils.py
@@ -2,7 +2,15 @@ from __future__ import absolute_import
 
 from sentry.testutils import APITestCase
 from time import time
-from sentry.models import Identity, IdentityProvider, Integration
+from sentry.models import (
+    Identity,
+    IdentityProvider,
+    Integration,
+    Repository
+)
+
+
+WEBHOOK_SECRET = 'example.gitlab.com:super-secret-token'
 
 
 class GitLabTestCase(APITestCase):
@@ -10,9 +18,10 @@ class GitLabTestCase(APITestCase):
 
     def setUp(self):
         self.login_as(self.user)
-        integration = Integration.objects.create(
+        self.integration = Integration.objects.create(
             provider=self.provider,
             name='Example Gitlab',
+            external_id=WEBHOOK_SECRET,
             metadata={
                 'base_url': 'https://example.gitlab.com',
                 'domain_name': 'example.gitlab.com/sentry-group',
@@ -31,11 +40,22 @@ class GitLabTestCase(APITestCase):
                 'expires': time() + 1234567,
             }
         )
-        integration.add_organization(self.organization, self.user, identity.id)
-        self.installation = integration.get_installation(self.organization.id)
+        self.integration.add_organization(self.organization, self.user, identity.id)
+        self.installation = self.integration.get_installation(self.organization.id)
+
+    def create_repo(self, name, external_id, url=None):
+        return Repository.objects.create(
+            organization_id=self.organization.id,
+            name=name,
+            external_id=external_id,
+            url=url,
+            config={},
+            provider='integrations:gitlab',
+            integration_id=self.integration.id,
+        )
 
 
-MERGE_REQUEST_EVENT = b"""{
+MERGE_REQUEST_OPENED_EVENT = b"""{
   "object_kind": "merge_request",
   "user": {
     "name": "Administrator",
@@ -43,21 +63,21 @@ MERGE_REQUEST_EVENT = b"""{
     "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon"
   },
   "project": {
-    "name": "Example",
+    "name": "Sentry",
     "description": "",
-    "web_url": "http://example.com/jsmith/example",
+    "web_url": "http://example.com/getsentry/sentry",
     "avatar_url": null,
-    "git_ssh_url": "git@example.com:jsmith/example.git",
-    "git_http_url": "http://example.com/jsmith/example.git",
-    "namespace": "Jsmith",
+    "git_ssh_url": "git@example.com:getsentry/sentry.git",
+    "git_http_url": "http://example.com/getsentry/sentry.git",
+    "namespace": "getsentry",
     "visibility_level": 0,
-    "path_with_namespace": "jsmith/example",
+    "path_with_namespace": "getsentry/sentry",
     "default_branch": "master",
     "ci_config_path": "",
-    "homepage": "http://example.com/jsmith/example",
-    "url": "git@example.com:jsmith/example.git",
-    "ssh_url": "git@example.com:jsmith/example.git",
-    "http_url": "http://example.com/jsmith/example.git"
+    "homepage": "http://example.com/getsentry/sentry",
+    "url": "git@example.com:getsentry/sentry.git",
+    "ssh_url": "git@example.com:getsentry/sentry.git",
+    "http_url": "http://example.com/getsentry/sentry.git"
   },
   "object_attributes": {
     "id": 90,
@@ -66,7 +86,7 @@ MERGE_REQUEST_EVENT = b"""{
     "source_project_id": 14,
     "author_id": 51,
     "assignee_id": 6,
-    "title": "MS-Viewport",
+    "title": "Create a new Viewport",
     "created_at": "2017-09-20T08:31:45.944Z",
     "updated_at": "2017-09-28T12:23:42.365Z",
     "milestone_id": null,
@@ -74,7 +94,7 @@ MERGE_REQUEST_EVENT = b"""{
     "merge_status": "unchecked",
     "target_project_id": 14,
     "iid": 1,
-    "description": "",
+    "description": "Create a viewport for things",
     "updated_by_id": 1,
     "merge_error": null,
     "merge_params": {
@@ -151,37 +171,131 @@ MERGE_REQUEST_EVENT = b"""{
 }"""
 
 
-COMMIT_REQUEST_EVENT = b"""
+PUSH_EVENT = b"""
 {
-  "event_name": "repository_update",
-  "user_id": 1,
+  "object_kind": "push",
+  "before": "95790bf891e76fee5e1747ab589903a6a1f80f22",
+  "after": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+  "ref": "refs/heads/master",
+  "checkout_sha": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+  "user_id": 4,
   "user_name": "John Smith",
-  "user_email": "admin@example.com",
+  "user_username": "jsmith",
+  "user_email": "john@example.com",
   "user_avatar": "https://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=8://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=80",
-  "project_id": 1,
-  "project": {
-    "name":"Example",
+  "project_id": 15,
+  "project":{
+    "id": 15,
+    "name":"Diaspora",
     "description":"",
-    "web_url":"http://example.com/jsmith/example",
+    "web_url":"http://example.com/getsentry/sentry",
     "avatar_url":null,
-    "git_ssh_url":"git@example.com:jsmith/example.git",
-    "git_http_url":"http://example.com/jsmith/example.git",
-    "namespace":"Jsmith",
+    "git_ssh_url":"git@example.com:getsentry/sentry.git",
+    "git_http_url":"http://example.com/getsentry/sentry.git",
+    "namespace":"Mike",
     "visibility_level":0,
-    "path_with_namespace":"jsmith/example",
+    "path_with_namespace":"getsentry/sentry",
     "default_branch":"master",
-    "homepage":"http://example.com/jsmith/example",
-    "url":"git@example.com:jsmith/example.git",
-    "ssh_url":"git@example.com:jsmith/example.git",
-    "http_url":"http://example.com/jsmith/example.git",
+    "homepage":"http://example.com/getsentry/sentry",
+    "url":"git@example.com:getsentry/sentry.git",
+    "ssh_url":"git@example.com:getsentry/sentry.git",
+    "http_url":"http://example.com/getsentry/sentry.git"
   },
-  "changes": [
+  "repository":{
+    "name": "Sentry",
+    "url": "git@example.com:getsentry/sentry.git",
+    "description": "",
+    "homepage": "http://example.com/getsentry/sentry",
+    "git_http_url":"http://example.com/getsentry/sentry.git",
+    "git_ssh_url":"git@example.com:getsentry/sentry.git",
+    "visibility_level":0
+  },
+  "commits": [
     {
-      "before":"8205ea8d81ce0c6b90fbe8280d118cc9fdad6130",
-      "after":"4045ea7a3df38697b3730a20fb73c8bed8a3e69e",
-      "ref":"refs/heads/master"
+      "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+      "message": "Update Catalan translation to e38cb41.",
+      "timestamp": "2011-12-12T14:27:31+02:00",
+      "url": "http://example.com/getsentry/sentry/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+      "author": {
+        "name": "Jordi",
+        "email": "jordi@example.org"
+      },
+      "added": ["CHANGELOG"],
+      "modified": ["app/controller/application.rb"],
+      "removed": []
+    },
+    {
+      "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "message": "fixed readme",
+      "timestamp": "2012-01-03T23:36:29+02:00",
+      "url": "http://example.com/getsentry/sentry/commit/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "author": {
+        "name": "GitLab dev user",
+        "email": "gitlabdev@example.org"
+      },
+      "added": ["CHANGELOG"],
+      "modified": ["app/controller/application.rb"],
+      "removed": []
     }
   ],
-  "refs":["refs/heads/master"]
+  "total_commits_count": 2
+}
+"""
+
+PUSH_EVENT_IGNORED_COMMIT = b"""
+{
+  "object_kind": "push",
+  "before": "95790bf891e76fee5e1747ab589903a6a1f80f22",
+  "after": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+  "ref": "refs/heads/master",
+  "checkout_sha": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+  "user_id": 4,
+  "user_name": "John Smith",
+  "user_username": "jsmith",
+  "user_email": "john@example.com",
+  "user_avatar": "https://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=8://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=80",
+  "project_id": 15,
+  "project":{
+    "id": 15,
+    "name":"Sentry",
+    "description":"",
+    "web_url":"http://example.com/getsentry/sentry",
+    "avatar_url":null,
+    "git_ssh_url":"git@example.com:getsentry/sentry.git",
+    "git_http_url":"http://example.com/getsentry/sentry.git",
+    "namespace":"getsentry",
+    "visibility_level":0,
+    "path_with_namespace":"getsentry/sentry",
+    "default_branch":"master",
+    "homepage":"http://example.com/getsentry/sentry",
+    "url":"git@example.com:getsentry/sentry.git",
+    "ssh_url":"git@example.com:getsentry/sentry.git",
+    "http_url":"http://example.com/getsentry/sentry.git"
+  },
+  "repository":{
+    "name": "Sentry",
+    "url": "git@example.com:getsentry/sentry.git",
+    "description": "",
+    "homepage": "http://example.com/getsentry/sentry",
+    "git_http_url":"http://example.com/getsentry/sentry.git",
+    "git_ssh_url":"git@example.com:getsentry/sentry.git",
+    "visibility_level":0
+  },
+  "commits": [
+    {
+      "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+      "message": "Update things #skipsentry",
+      "timestamp": "2011-12-12T14:27:31+02:00",
+      "url": "http://example.com/getsentry/sentry/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+      "author": {
+        "name": "Jordi",
+        "email": "jordi@example.org"
+      },
+      "added": ["CHANGELOG"],
+      "modified": ["app/controller/application.rb"],
+      "removed": []
+    }
+  ],
+  "total_commits_count": 1
 }
 """


### PR DESCRIPTION
Tweak how we handle gitlab external_id and webhook secrets. GitLab push events do not provide much context for us to locate the sentry organization and repository. We need to leverage the only field we have (the webhook secret) to carry an identifier that lets us locate the integration installation. With this and the rest of the push payload we can locate the repository to sync commits in.

This does not handle pushes that contain more than 20 commits. Like GitHub we only sync the first 20 commits of any push. The remaining diff gets collected when a Release is created.

I've also made some changes around project id/project slug that aim to normalize on project id. Slugs can be changed in gitlab and require clunky URL encoding to work with.

Refs APP-597