### PR TITLE
fix(integrations): Azure DevOps Subscription creation problem

### DIFF
--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -378,23 +378,22 @@ class VstsIntegrationProvider(IntegrationProvider):
                 external_id=account['accountId'],
                 status=ObjectStatus.VISIBLE,
             )
-            assert 'subscription' in integration_model.metadata
+            # preserve previously created subscription information
+            integration['metadata']['subscription'] = integration_model.metadata['subscription']
 
             assert OrganizationIntegration.objects.filter(
                 integration_id=integration_model.id,
                 status=ObjectStatus.VISIBLE,
             ).exists()
 
-        except (IntegrationModel.DoesNotExist, AssertionError):
+        except (IntegrationModel.DoesNotExist, AssertionError, KeyError):
             subscription_id, subscription_secret = self.create_subscription(
                 base_url, account['accountId'], oauth_data)
             integration['metadata']['subscription'] = {
                 'id': subscription_id,
                 'secret': subscription_secret,
             }
-        else:
-            # preserve previously created subscription information
-            integration['metadata']['subscription'] = integration_model.metadata['subscription']
+
         return integration
 
     def create_subscription(self, instance, account_id, oauth_data):

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -392,7 +392,9 @@ class VstsIntegrationProvider(IntegrationProvider):
                 'id': subscription_id,
                 'secret': subscription_secret,
             }
-
+        else:
+            # preserve previously created subscription information
+            integration['metadata']['subscription'] = integration_model.metadata['subscription']
         return integration
 
     def create_subscription(self, instance, account_id, oauth_data):

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -188,7 +188,9 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
         # The above already created the Webhook, so subsequent calls to
         # ``build_integration`` should omit that data.
         data = VstsIntegrationProvider().build_integration(state)
-        assert 'subscription' not in data['metadata']
+        assert 'subscription' in data['metadata']
+        assert Integration.objects.get(
+            provider='vsts').metadata['subscription'] == data['metadata']['subscription']
 
     def test_fix_subscription(self):
         external_id = '1234567890'


### PR DESCRIPTION
The subscription information in the Azure DevOps integrations was being overwritten if installed to multiple organizations. There is at least one user stuck in this state. This fixes the problem in the logic, but does not address those users for whom inbound sync is not working.

Fixes SENTRY-768