### PR TITLE
fix(discover): Fix page width

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/styles.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/styles.jsx
@@ -19,6 +19,7 @@ export const DiscoverWrapper = styled(Flex)`
 `;
 
 export const Discover = styled(Flex)`
+  width: 100%;
   min-height: calc(100vh - ${FOOTER_HEIGHT}px);
 
   margin-bottom: -20px;


### PR DESCRIPTION
Fixes a bug where contents do not fill the whole page

<img width="1548" alt="screen shot 2018-10-11 at 3 28 33 pm" src="https://user-images.githubusercontent.com/1779792/46837506-72bcbf80-cd6a-11e8-8015-acfc13262871.png">
