### PR TITLE
fix(ui): Fix PanelBody to accept `className`

### DIFF
--- a/src/sentry/static/sentry/app/components/panels/panelBody.jsx
+++ b/src/sentry/static/sentry/app/components/panels/panelBody.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import space from 'app/styles/space';
 import textStyles from 'app/styles/text';
 
-const PanelBody = ({disablePadding, flex, direction, ...props}) => {
+const PanelBody = ({className, disablePadding, flex, direction, ...props}) => {
   let padding = !disablePadding
     ? css`
         padding: ${space(2)};
@@ -16,7 +16,11 @@ const PanelBody = ({disablePadding, flex, direction, ...props}) => {
   let Comp = flex ? Flex : 'div';
 
   return (
-    <Comp className={cx(padding, textStyles)} {...props} direction={flexDirection} />
+    <Comp
+      className={cx(padding, textStyles, className)}
+      {...props}
+      direction={flexDirection}
+    />
   );
 };
 

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -401,7 +401,7 @@ exports[`CreateProject should render roles when available and allowed, and handl
                 flex={false}
               >
                 <div
-                  className="grouping-controls team-choices"
+                  className="css-9vq8an-textStyles grouping-controls team-choices"
                 >
                   <PanelItem
                     className="css-1jkp9i7"

--- a/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
@@ -247,7 +247,7 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                 flex={false}
               >
                 <div
-                  className="css-8atqhb"
+                  className="css-o3jmd1-textStyles"
                 >
                   <PanelItem
                     align="center"


### PR DESCRIPTION
This allows us to create a new styled component that extends `PanelBody`