### PR TITLE
feat(ui): Make AsyncComponentSearchInput easier to use

### DIFF
--- a/src/sentry/static/sentry/app/components/asyncComponent.jsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.jsx
@@ -247,14 +247,18 @@ export default class AsyncComponent extends React.Component {
     return [['data', endpoint, this.getEndpointParams()]];
   }
 
-  renderSearchInput({onSearchSubmit, stateKey, ...other}) {
+  renderSearchInput({onSearchSubmit, stateKey, url, ...other}) {
+    const [firstEndpoint] = this.getEndpoints() || [];
+    const stateKeyOrDefault = stateKey || (firstEndpoint && firstEndpoint[0]);
+    const urlOrDefault = url || (firstEndpoint && firstEndpoint[1]);
     return (
       <AsyncComponentSearchInput
         onSearchSubmit={onSearchSubmit}
-        stateKey={stateKey}
+        stateKey={stateKeyOrDefault}
+        url={urlOrDefault}
         api={this.api}
         onSuccess={(data, jqXHR) => {
-          this.handleRequestSuccess({stateKey, data, jqXHR});
+          this.handleRequestSuccess({stateKey: stateKeyOrDefault, data, jqXHR});
         }}
         onError={() => {
           this.renderError(new Error('Error with AsyncComponentSearchInput'));

--- a/src/sentry/static/sentry/app/components/asyncComponentSearchInput.jsx
+++ b/src/sentry/static/sentry/app/components/asyncComponentSearchInput.jsx
@@ -50,6 +50,7 @@ export default class AsyncComponentSearchInput extends React.Component {
 
   handleSearch = evt => {
     let {onSearchSubmit} = this.props;
+    evt.preventDefault();
     if (typeof onSearchSubmit !== 'function') return;
     onSearchSubmit(this.state.query, evt);
   };


### PR DESCRIPTION
By default it should now use `stateKey` and `url` from the
first endpoint from `this.getEndpoints`.

Also when we handle search submit, by default `preventDefault` on the submit event.