### PR TITLE
feat(ui): Add `withOrganization` HoC

### DIFF
--- a/src/sentry/static/sentry/app/utils/__mocks__/withOrganization.jsx
+++ b/src/sentry/static/sentry/app/utils/__mocks__/withOrganization.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const withOrganizationMock = WrappedComponent =>
+  class WithOrganizationMockWrappeer extends React.Component {
+    render() {
+      return <WrappedComponent organization={TestStubs.Organization()} {...this.props} />;
+    }
+  };
+
+export default withOrganizationMock;

--- a/src/sentry/static/sentry/app/utils/withOrganization.jsx
+++ b/src/sentry/static/sentry/app/utils/withOrganization.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import SentryTypes from 'app/sentryTypes';
+import getDisplayName from 'app/utils/getDisplayName';
+
+/**
+ * Currently wraps component with organization from context
+ */
+const withOrganization = WrappedComponent =>
+  class extends React.Component {
+    static displayName = `withOrganizations(${getDisplayName(WrappedComponent)})`;
+    static contextTypes = {
+      organization: SentryTypes.Organization,
+    };
+
+    render() {
+      return (
+        <WrappedComponent organization={this.context.organization} {...this.props} />
+      );
+    }
+  };
+
+export default withOrganization;

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -53,6 +53,7 @@ jest.mock('lodash/debounce', () => jest.fn(fn => fn));
 jest.mock('app/utils/recreateRoute');
 jest.mock('app/translations');
 jest.mock('app/api');
+jest.mock('app/utils/withOrganization');
 jest.mock('scroll-to-element', () => {});
 jest.mock('react-router', () => {
   const ReactRouter = require.requireActual('react-router');


### PR DESCRIPTION
For now we are accessing organization from `context`, but this could change in the future. We should have a single interface to access organization.