### PR TITLE
fix: Generate proper SQL from ScoreClause

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -67,7 +67,11 @@ class Buffer(Service):
         # HACK(dcramer): this is gross, but we dont have a good hook to compute this property today
         # XXX(dcramer): remove once we can replace 'priority' with something reasonable via Snuba
         if model is Group and 'last_seen' in update_kwargs and 'times_seen' in update_kwargs:
-            update_kwargs['score'] = ScoreClause(None)
+            update_kwargs['score'] = ScoreClause(
+                group=None,
+                times_seen=update_kwargs['times_seen'],
+                last_seen=update_kwargs['last_seen'],
+            )
 
         _, created = model.objects.create_or_update(values=update_kwargs, **filters)
 


### PR DESCRIPTION
The check against `get_db_engine` was flawed, and never worked for
Postgres. The engine name was `postgres` not `postgresql` so it always
fell back to the `int(self)` path, yielding `0` 100% of the time when no
Group was passed in.

Before:

```
>>> ScoreClause().evaluate(None, None, None)
(0, [])
```

After:

```
>>> ScoreClause().evaluate(None, None, None)
('log(times_seen) * 600 + last_seen::abstime::int', [])
>>> ScoreClause(times_seen=F('times_seen')+10, last_seen=timezone.now()).evaluate(None,
None, None)
('log(times_seen + 10) * 600 + 1539368619', [])
```

Fixes ISSUE-166