### PR TITLE
"Owners" -> "Issue owners" in Issue Owners

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/index.jsx
@@ -99,9 +99,9 @@ class ProjectOwnership extends AsyncView {
                   {
                     name: 'fallthrough',
                     type: 'boolean',
-                    label: t('All users with access to this project are owners'),
+                    label: t('All users with access to this project are issue owners'),
                     help: t(
-                      'Owners will receive notifications for issues they are responsible for.'
+                      'Issue owners will receive notifications for issues they are responsible for.'
                     ),
                   },
                 ],

--- a/tests/js/spec/views/__snapshots__/projectOwnership.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectOwnership.spec.jsx.snap
@@ -165,8 +165,8 @@ exports[`ProjectTeamsSettings render() renders 1`] = `
             Object {
               "fields": Array [
                 Object {
-                  "help": "Owners will receive notifications for issues they are responsible for.",
-                  "label": "All users with access to this project are owners",
+                  "help": "Issue owners will receive notifications for issues they are responsible for.",
+                  "label": "All users with access to this project are issue owners",
                   "name": "fallthrough",
                   "type": "boolean",
                 },


### PR DESCRIPTION
Owners seems to general and might be confused with membership's owner role.