### PR TITLE
misc(eventstream): Log eventstream state at end of unmerge task

### DIFF
--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -20,6 +20,9 @@ from sentry.tasks.base import instrumented_task
 from six.moves import reduce
 
 
+logger = logging.getLogger(__name__)
+
+
 def cache(function):
     results = {}
 
@@ -593,6 +596,7 @@ def unmerge(
         tagstore.update_group_tag_key_values_seen(project_id, [source_id, destination_id])
         unlock_hashes(project_id, fingerprints)
 
+        logger.warning('Unmerge complete (eventstream state: %s)', eventstream_state)
         if eventstream_state:
             eventstream.end_unmerge(eventstream_state)
 


### PR DESCRIPTION
This is a hail mary to attempt to debug...

Will this get to Kibana? Should it be a `warning` or do any lower levels get to Kibana?