### PR TITLE
fix(discover): Stop showing the in progress state on failed request

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -165,6 +165,7 @@ export default class OrganizationDiscover extends React.Component {
       .catch(err => {
         const message = (err && err.message) || t('An error occurred');
         addErrorMessage(message);
+        this.setState({isFetchingQuery: false});
       });
   };
 


### PR DESCRIPTION
Required to allow the user to submit a subsequent request