### PR TITLE
feat(discover): Relax permissions on saved queries

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -129,6 +129,16 @@ class OrganizationAuthProviderPermission(OrganizationPermission):
     }
 
 
+class OrganizationDiscoverSavedQueryPermission(OrganizationPermission):
+    # Relaxed permissions for saved queries in Discover
+    scope_map = {
+        'GET': ['org:read', 'org:write', 'org:admin'],
+        'POST': ['org:read', 'org:write', 'org:admin'],
+        'PUT': ['org:read', 'org:write', 'org:admin'],
+        'DELETE': ['org:read', 'org:write', 'org:admin'],
+    }
+
+
 class OrganizationEndpoint(Endpoint):
     permission_classes = (OrganizationPermission, )
 

--- a/src/sentry/api/endpoints/organization_discover_saved_queries.py
+++ b/src/sentry/api/endpoints/organization_discover_saved_queries.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from rest_framework.response import Response
 
 from sentry.api.serializers import serialize
-from sentry.api.bases.organization import OrganizationPermission
+from sentry.api.bases.organization import OrganizationDiscoverSavedQueryPermission
 from sentry.api.bases.discoversavedquery import DiscoverSavedQuerySerializer
 from sentry.api.bases import OrganizationEndpoint
 from sentry.models import DiscoverSavedQuery
@@ -11,7 +11,7 @@ from sentry import features
 
 
 class OrganizationDiscoverSavedQueriesEndpoint(OrganizationEndpoint):
-    permission_classes = (OrganizationPermission, )
+    permission_classes = (OrganizationDiscoverSavedQueryPermission, )
 
     def get(self, request, organization):
         """

--- a/src/sentry/api/endpoints/organization_discover_saved_query_detail.py
+++ b/src/sentry/api/endpoints/organization_discover_saved_query_detail.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from rest_framework.response import Response
 from sentry.api.serializers import serialize
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.bases.organization import OrganizationPermission
+from sentry.api.bases.organization import OrganizationDiscoverSavedQueryPermission
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.bases.discoversavedquery import DiscoverSavedQuerySerializer
 from sentry import features
@@ -11,7 +11,7 @@ from sentry.models import DiscoverSavedQuery
 
 
 class OrganizationDiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
-    permission_classes = (OrganizationPermission, )
+    permission_classes = (OrganizationDiscoverSavedQueryPermission, )
 
     def get(self, request, organization, query_id):
         """


### PR DESCRIPTION
Allow users with org:read access to also create and modify saved queries
in Discover. This is in line with how access to project saved searches
work.