### PR TITLE
feat(app-platform): Create Sentry App

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -116,7 +116,7 @@ class Endpoint(APIView):
 
         request.json_body = None
 
-        if request.META.get('CONTENT_TYPE') != 'application/json':
+        if not request.META.get('CONTENT_TYPE', '').startswith('application/json'):
             return
 
         if not len(request.body):

--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -1,12 +1,15 @@
 from __future__ import absolute_import
 
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 
 from sentry.api.base import Endpoint, SessionAuthentication
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
+from sentry.api.serializers.rest_framework import SentryAppSerializer
 from sentry.constants import SentryAppStatus
 from sentry.features.helpers import requires_feature
+from sentry.mediators.sentry_apps import Creator
 from sentry.models import SentryApp
 
 
@@ -29,4 +32,29 @@ class SentryAppsEndpoint(Endpoint):
             order_by='-date_added',
             paginator_cls=OffsetPaginator,
             on_results=lambda x: serialize(x, request.user),
+        )
+
+    @requires_feature('organizations:internal-catchall', any_org=True)
+    def post(self, request):
+        serializer = SentryAppSerializer(data=request.json_body)
+
+        if not serializer.is_valid():
+            return Response({'errors': serializer.errors}, status=422)
+
+        sentry_app = Creator.run(
+            name=request.json_body.get('name'),
+            organization=self._get_user_org(request),
+            scopes=request.json_body.get('scopes'),
+            webhook_url=request.json_body.get('webhook_url'),
+        )
+
+        return Response(serialize(sentry_app), status=201)
+
+    def _get_user_org(self, request):
+        return next(
+            (
+                org for org in request.user.get_orgs()
+                if org.slug == request.json_body['organization']
+            ),
+            None,
         )

--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -1,0 +1,23 @@
+from __future__ import absolute_import
+
+from rest_framework import serializers
+from rest_framework.serializers import Serializer, ValidationError
+
+from sentry.models import ApiScopes
+
+
+class ApiScopesField(serializers.WritableField):
+    def validate(self, data):
+        valid_scopes = ApiScopes()
+        if data is None:
+            raise ValidationError('Must provide scopes')
+
+        for scope in data:
+            if scope not in valid_scopes:
+                raise ValidationError(u'{} not a valid scope'.format(scope))
+
+
+class SentryAppSerializer(Serializer):
+    name = serializers.CharField()
+    scopes = ApiScopesField()
+    webhook_url = serializers.CharField()


### PR DESCRIPTION
Adds endpoint to create a Sentry App. The Organization that owns the App must be passed in and the User making the request must be in that Org.