### PR TITLE
feat(discover): Show page title / layout on load

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -32,7 +32,7 @@ import {
 import {isValidCondition} from './conditions/utils';
 import {isValidAggregation} from './aggregations/utils';
 import {
-  Discover,
+  DiscoverContainer,
   Body,
   BodyContent,
   TopBar,
@@ -325,7 +325,7 @@ export default class OrganizationDiscover extends React.Component {
     const projects = organization.projects.filter(project => project.isMember);
 
     return (
-      <Discover>
+      <DiscoverContainer>
         <Sidebar>
           <PageTitle>{t('Discover')}</PageTitle>
           {this.renderSidebarNav()}
@@ -347,7 +347,7 @@ export default class OrganizationDiscover extends React.Component {
           )}
           {shouldRenderSavedList && <SavedQueryList organization={organization} />}
         </Sidebar>
-        <Body direction="column" flex="1">
+        <Body>
           <TopBar>
             <MultipleProjectSelector
               value={currentQuery.projects}
@@ -379,7 +379,7 @@ export default class OrganizationDiscover extends React.Component {
             <EarlyAdopterMessage />
           </BodyContent>
         </Body>
-      </Discover>
+      </DiscoverContainer>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
@@ -4,6 +4,7 @@ import createReactClass from 'create-react-class';
 import {browserHistory} from 'react-router';
 import OrganizationState from 'app/mixins/organizationState';
 import LoadingIndicator from 'app/components/loadingIndicator';
+import {t} from 'app/locale';
 
 import Discover from './discover';
 import createQueryBuilder from './queryBuilder';
@@ -14,7 +15,16 @@ import {
   parseSavedQuery,
   getView,
 } from './utils';
-import {DiscoverWrapper, LoadingContainer} from './styles';
+
+import {
+  DiscoverWrapper,
+  DiscoverContainer,
+  Sidebar,
+  Body,
+  PageTitle,
+  TopBar,
+  LoadingContainer,
+} from './styles';
 
 const OrganizationDiscoverContainer = createReactClass({
   displayName: 'OrganizationDiscoverContainer',
@@ -92,9 +102,17 @@ const OrganizationDiscoverContainer = createReactClass({
 
   renderLoading: function() {
     return (
-      <LoadingContainer>
-        <LoadingIndicator />
-      </LoadingContainer>
+      <DiscoverContainer>
+        <Sidebar>
+          <PageTitle>{t('Discover')}</PageTitle>
+        </Sidebar>
+        <Body>
+          <TopBar />
+          <LoadingContainer>
+            <LoadingIndicator />
+          </LoadingContainer>
+        </Body>
+      </DiscoverContainer>
     );
   },
 

--- a/src/sentry/static/sentry/app/views/organizationDiscover/styles.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/styles.jsx
@@ -18,7 +18,7 @@ export const DiscoverWrapper = styled(Flex)`
   flex: 1;
 `;
 
-export const Discover = styled(Flex)`
+export const DiscoverContainer = styled(Flex)`
   width: 100%;
   min-height: calc(100vh - ${FOOTER_HEIGHT}px);
 
@@ -48,7 +48,10 @@ export const Sidebar = styled(props => (
   min-width: 320px;
 `;
 
-export const Body = styled(Flex)``;
+export const Body = styled(Flex)`
+  flex: 1;
+  flex-direction: column;
+`;
 
 export const BodyContent = styled(Flex)`
   flex: 1;


### PR DESCRIPTION
Displays the Discover page title and layout while tags are loading
instead of the full page spinner.