### PR TITLE
feat(app-platform): App platform/sentry app install endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_sentry_app_installations.py
+++ b/src/sentry/api/endpoints/organization_sentry_app_installations.py
@@ -1,0 +1,63 @@
+from __future__ import absolute_import
+
+from django.utils.translation import ugettext_lazy as _
+
+from rest_framework import serializers
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from sentry.api.base import Endpoint, SessionAuthentication
+from sentry.api.paginator import OffsetPaginator
+from sentry.api.serializers import serialize
+from sentry.features.helpers import requires_feature
+from sentry.mediators.sentry_app_installation import Creator
+from sentry.models import SentryAppInstallation
+
+
+class SentryAppInstallationSerializer(serializers.Serializer):
+    slug = serializers.RegexField(
+        r'^[a-z0-9_\-]+$',
+        max_length=50,
+        required=False,
+        error_messages={
+            'invalid': _('Enter a valid slug consisting of lowercase letters, '
+                         'numbers, underscores or hyphens.'),
+        },
+    )
+
+    def validate(self, attrs):
+        if not attrs.get('slug'):
+            raise serializers.ValidationError('Sentry App slug is required')
+        return attrs
+
+
+class SentryAppInstallationEndpoint(Endpoint):
+    authentication_classes = (SessionAuthentication, )
+    permission_classes = (IsAuthenticated, )
+
+    @requires_feature('organizations:internal-catchall', any_org=True)
+    def get(self, request, organization):
+        queryset = SentryAppInstallation.objects.filter(
+            organization=organization,
+        )
+
+        return self.paginate(
+            request=request,
+            queryset=queryset,
+            order_by='-date_added',
+            paginator_cls=OffsetPaginator,
+            on_results=lambda x: serialize(x, request.user),
+        )
+
+    @requires_feature('organizations:internal-catchall', any_org=True)
+    def post(self, request, organization):
+        serializer = SentryAppInstallationSerializer(request.DATA)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+
+        slug = serializer.object.get('slug')
+        install = Creator.run(
+            organization=organization,
+            slug=slug,
+        )
+        return Response(serialize(install))

--- a/src/sentry/api/endpoints/organization_sentry_app_installations.py
+++ b/src/sentry/api/endpoints/organization_sentry_app_installations.py
@@ -14,11 +14,10 @@ from sentry.mediators.sentry_app_installation import Creator
 from sentry.models import SentryAppInstallation
 
 
-class SentryAppInstallationSerializer(serializers.Serializer):
+class OrganizationSentryAppInstallationsSerializer(serializers.Serializer):
     slug = serializers.RegexField(
         r'^[a-z0-9_\-]+$',
         max_length=50,
-        required=False,
         error_messages={
             'invalid': _('Enter a valid slug consisting of lowercase letters, '
                          'numbers, underscores or hyphens.'),
@@ -31,7 +30,7 @@ class SentryAppInstallationSerializer(serializers.Serializer):
         return attrs
 
 
-class SentryAppInstallationEndpoint(Endpoint):
+class OrganizationSentryAppInstallationsEndpoint(Endpoint):
     authentication_classes = (SessionAuthentication, )
     permission_classes = (IsAuthenticated, )
 
@@ -51,7 +50,7 @@ class SentryAppInstallationEndpoint(Endpoint):
 
     @requires_feature('organizations:internal-catchall', any_org=True)
     def post(self, request, organization):
-        serializer = SentryAppInstallationSerializer(request.DATA)
+        serializer = OrganizationSentryAppInstallationsSerializer(request.DATA)
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 

--- a/src/sentry/api/endpoints/organization_sentry_app_installations.py
+++ b/src/sentry/api/endpoints/organization_sentry_app_installations.py
@@ -3,14 +3,13 @@ from __future__ import absolute_import
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import serializers
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from sentry.api.base import Endpoint, SessionAuthentication
+from sentry.api.bases import OrganizationEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.features.helpers import requires_feature
-from sentry.mediators.sentry_app_installation import Creator
+from sentry.mediators.sentry_app_installations import Creator
 from sentry.models import SentryAppInstallation
 
 
@@ -30,11 +29,8 @@ class OrganizationSentryAppInstallationsSerializer(serializers.Serializer):
         return attrs
 
 
-class OrganizationSentryAppInstallationsEndpoint(Endpoint):
-    authentication_classes = (SessionAuthentication, )
-    permission_classes = (IsAuthenticated, )
-
-    @requires_feature('organizations:internal-catchall', any_org=True)
+class OrganizationSentryAppInstallationsEndpoint(OrganizationEndpoint):
+    @requires_feature('organizations:internal-catchall')
     def get(self, request, organization):
         queryset = SentryAppInstallation.objects.filter(
             organization=organization,
@@ -48,7 +44,7 @@ class OrganizationSentryAppInstallationsEndpoint(Endpoint):
             on_results=lambda x: serialize(x, request.user),
         )
 
-    @requires_feature('organizations:internal-catchall', any_org=True)
+    @requires_feature('organizations:internal-catchall')
     def post(self, request, organization):
         serializer = OrganizationSentryAppInstallationsSerializer(request.DATA)
         if not serializer.is_valid():

--- a/src/sentry/api/endpoints/organization_sentry_app_installations.py
+++ b/src/sentry/api/endpoints/organization_sentry_app_installations.py
@@ -46,12 +46,12 @@ class OrganizationSentryAppInstallationsEndpoint(OrganizationEndpoint):
 
     @requires_feature('organizations:internal-catchall')
     def post(self, request, organization):
-        serializer = OrganizationSentryAppInstallationsSerializer(request.DATA)
+        serializer = OrganizationSentryAppInstallationsSerializer(data=request.DATA)
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
         slug = serializer.object.get('slug')
-        install = Creator.run(
+        install, _ = Creator.run(
             organization=organization,
             slug=slug,
         )

--- a/src/sentry/api/serializers/models/sentry_app_installation.py
+++ b/src/sentry/api/serializers/models/sentry_app_installation.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import
+
+
+from sentry.api.serializers import Serializer, register
+from sentry.models import SentryAppInstallation
+
+
+@register(SentryAppInstallation)
+class SentryAppInstallationSerializer(Serializer):
+    def serialize(self, obj, attrs, user):
+        return {
+            'app': obj.sentry_app,
+            'organization': obj.organzation.slug,
+            'uuid': obj.uuid,
+        }

--- a/src/sentry/api/serializers/models/sentry_app_installation.py
+++ b/src/sentry/api/serializers/models/sentry_app_installation.py
@@ -9,7 +9,7 @@ from sentry.models import SentryAppInstallation
 class SentryAppInstallationSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         return {
-            'app': obj.sentry_app,
-            'organization': obj.organzation.slug,
+            'app': obj.sentry_app.slug,
+            'organization': obj.organization.slug,
             'uuid': obj.uuid,
         }

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -92,6 +92,7 @@ from .endpoints.organization_config_integrations import OrganizationConfigIntegr
 from .endpoints.organization_config_repositories import OrganizationConfigRepositoriesEndpoint
 from .endpoints.organization_repository_commits import OrganizationRepositoryCommitsEndpoint
 from .endpoints.organization_repository_details import OrganizationRepositoryDetailsEndpoint
+from .endpoints.organization_sentry_app_installations import OrganizationSentryAppInstallationsEndpoint
 from .endpoints.organization_stats import OrganizationStatsEndpoint
 from .endpoints.organization_teams import OrganizationTeamsEndpoint
 from .endpoints.organization_user_issues import OrganizationUserIssuesEndpoint
@@ -604,6 +605,11 @@ urlpatterns = patterns(
         r'^organizations/(?P<organization_slug>[^\/]+)/releases/(?P<version>[^/]+)/commits/$',
         OrganizationReleaseCommitsEndpoint.as_view(),
         name='sentry-api-0-organization-release-commits'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/sentry-app-installations/$',
+        OrganizationSentryAppInstallationsEndpoint.as_view(),
+        name='sentry-api-0-organization-sentry-app-installations'
     ),
     url(
         r'^organizations/(?P<organization_slug>[^\/]+)/stats/$',

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -46,7 +46,7 @@ class GetOrganizationSentryAppInstallationsTest(OrganizationSentryAppInstallatio
 
     @with_feature('organizations:internal-catchall')
     def test_superuser_sees_all_installs(self):
-        self.login_as(user=self.superuser)
+        self.login_as(user=self.superuser, superuser=True)
 
         response = self.client.get(self.url, format='json')
 

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -1,0 +1,96 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from sentry.constants import SentryAppStatus
+from sentry.testutils import APITestCase
+from sentry.testutils.helpers import with_feature
+from sentry.mediators.sentry_apps import Creator as SentryAppCreator
+from sentry.mediators.sentry_app_installations import Creator
+
+
+class OrganizationSentryAppInstallationsTest(APITestCase):
+    def setUp(self):
+        self.superuser = self.create_user(email='a@example.com', is_superuser=True)
+        self.user = self.create_user(email='boop@example.com')
+        self.org = self.create_organization(owner=self.user)
+        self.super_org = self.create_organization(owner=self.superuser)
+        self.published_app = SentryAppCreator.run(
+            name='Test',
+            organization=self.super_org,
+            scopes=(),
+            webhook_url='https://example.com',
+        )
+        self.published_app.update(status=SentryAppStatus.PUBLISHED)
+        self.installation, _ = Creator.run(
+            slug=self.published_app.slug,
+            organization=self.super_org,
+        )
+        self.unpublished_app = SentryAppCreator.run(
+            name='Testin',
+            organization=self.org,
+            scopes=(),
+            webhook_url='https://example.com',
+        )
+        self.installation2, _ = Creator.run(
+            slug=self.unpublished_app.slug,
+            organization=self.org,
+        )
+        self.url = reverse(
+            'sentry-api-0-organization-sentry-app-installations',
+            args=[
+                self.org.slug])
+
+
+class GetOrganizationSentryAppInstallationsTest(OrganizationSentryAppInstallationsTest):
+
+    @with_feature('organizations:internal-catchall')
+    def test_superuser_sees_all_installs(self):
+        self.login_as(user=self.superuser)
+
+        response = self.client.get(self.url, format='json')
+
+        assert response.status_code == 200
+        assert response.data == [{
+            'app': self.unpublished_app.slug,
+            'organization': self.org.slug,
+            'uuid': self.installation2.uuid,
+        }]
+
+        url = reverse(
+            'sentry-api-0-organization-sentry-app-installations',
+            args=[
+                self.super_org.slug])
+        response = self.client.get(url, format='json')
+        assert response.status_code == 200
+        assert response.data == [{
+            'app': self.published_app.slug,
+            'organization': self.super_org.slug,
+            'uuid': self.installation.uuid,
+        }]
+
+    @with_feature('organizations:internal-catchall')
+    def test_users_only_sees_installs_on_their_org(self):
+        self.login_as(user=self.user)
+
+        response = self.client.get(self.url, format='json')
+
+        assert response.status_code == 200
+        assert response.data == [{
+            'app': self.unpublished_app.slug,
+            'organization': self.org.slug,
+            'uuid': self.installation2.uuid,
+        }]
+
+        url = reverse(
+            'sentry-api-0-organization-sentry-app-installations',
+            args=[
+                self.super_org.slug])
+        response = self.client.get(url, format='json')
+        assert response.status_code == 403
+
+    def test_no_access_without_internal_catchall(self):
+        self.login_as(user=self.user)
+
+        response = self.client.get(self.url, format='json')
+        assert response.status_code == 404


### PR DESCRIPTION
* Adds `GET` and `POST` endpoint for App installations
  * Inherits from Organization Endpoint so `org:write` and `org:admin` scopes are needed to add an installation of an App on their organization
