### PR TITLE
ref(features): Clean up feature flag module

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -129,10 +129,6 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
         if 'api-keys' not in feature_list and ApiKey.objects.filter(organization=obj).exists():
             feature_list.add('api-keys')
 
-        # These are new
-        # default_manager.add('organizations:invite-members', OrganizationFeature)  # NOQA
-        # default_manager.add('organizations:release-commits', OrganizationFeature)  # NOQA
-
         # Organization flag features (not provided through the features module)
         if OrganizationOption.objects.filter(
                 organization=obj, key__in=LEGACY_RATE_LIMIT_OPTIONS).exists():

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -114,6 +114,8 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
         feature_list = set()
 
         for feature_name in org_features:
+            if not feature_name.startswith('organizations:'):
+                continue
             if features.has(feature_name, obj, actor=user):
                 # Remove the organization scope prefix
                 feature_list.add(feature_name[len('organizations:'):])

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -82,6 +82,7 @@ class OnboardingTasksSerializer(Serializer):
 class DetailedOrganizationSerializer(OrganizationSerializer):
     def serialize(self, obj, attrs, user):
         from sentry import features, experiments
+        from sentry.features.base import OrganizationFeature
         from sentry.app import env
         from sentry.api.serializers.models.project import ProjectSummarySerializer
         from sentry.api.serializers.models.team import TeamSerializer
@@ -108,56 +109,38 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             ).select_related('user')
         )
 
-        feature_list = []
-        if features.has('organizations:sso', obj, actor=user):
-            feature_list.append('sso')
-        if features.has('organizations:onboarding', obj, actor=user) and \
-                not OrganizationOption.objects.filter(organization=obj).exists():
-            feature_list.append('onboarding')
-        if features.has('organizations:api-keys', obj, actor=user) or \
-                ApiKey.objects.filter(organization=obj).exists():
-            feature_list.append('api-keys')
-        if features.has('organizations:group-unmerge', obj, actor=user):
-            feature_list.append('group-unmerge')
-        if features.has('organizations:require-2fa', obj, actor=user):
-            feature_list.append('require-2fa')
-        if features.has('organizations:repos', obj, actor=user):
-            feature_list.append('repos')
-        if features.has('organizations:internal-catchall', obj, actor=user):
-            feature_list.append('internal-catchall')
-        if features.has('organizations:new-issue-ui', obj, actor=user):
-            feature_list.append('new-issue-ui')
-        if features.has('organizations:integrations-issue-basic', obj, actor=user):
-            feature_list.append('integrations-issue-basic')
-        if features.has('organizations:integrations-issue-sync', obj, actor=user):
-            feature_list.append('integrations-issue-sync')
-        if features.has('organizations:suggested-commits', obj, actor=user):
-            feature_list.append('suggested-commits')
-        if features.has('organizations:new-teams', obj, actor=user):
-            feature_list.append('new-teams')
-        if features.has('organizations:unreleased-changes', obj, actor=user):
-            feature_list.append('unreleased-changes')
-        if features.has('organizations:relay', obj, actor=user):
-            feature_list.append('relay')
-        if features.has('organizations:js-loader', obj, actor=user):
-            feature_list.append('js-loader')
-        if features.has('organizations:health', obj, actor=user):
-            feature_list.append('health')
-        if features.has('organizations:discover', obj, actor=user):
-            feature_list.append('discover')
-        if features.has('organizations:events-stream', obj, actor=user):
-            feature_list.append('events-stream')
+        # Retrieve all registered organization features
+        org_features = features.all(feature_type=OrganizationFeature).keys()
+        feature_list = set()
+
+        for feature_name in org_features:
+            if features.has(feature_name, obj, actor=user):
+                # Remove the organization scope prefix
+                feature_list.add(feature_name[len('organizations:'):])
+
+        # Do not include the onboarding feature if OrganizationOptions exist
+        if 'onboarding' in feature_list and \
+                OrganizationOption.objects.filter(organization=obj).exists():
+            feature_list.remove('onboarding')
+
+        # Include api-keys feature if they previously had any api-keys
+        if 'api-keys' not in feature_list and ApiKey.objects.filter(organization=obj).exists():
+            feature_list.add('api-keys')
+
+        # These are new
+        # default_manager.add('organizations:invite-members', OrganizationFeature)  # NOQA
+        # default_manager.add('organizations:release-commits', OrganizationFeature)  # NOQA
+
+        # Organization flag features (not provided through the features module)
         if OrganizationOption.objects.filter(
                 organization=obj, key__in=LEGACY_RATE_LIMIT_OPTIONS).exists():
-            feature_list.append('legacy-rate-limits')
+            feature_list.add('legacy-rate-limits')
         if getattr(obj.flags, 'allow_joinleave'):
-            feature_list.append('open-membership')
+            feature_list.add('open-membership')
         if not getattr(obj.flags, 'disable_shared_issues'):
-            feature_list.append('shared-issues')
+            feature_list.add('shared-issues')
         if getattr(obj.flags, 'require_2fa'):
-            feature_list.append('require-2fa')
-        if features.has('organizations:event-attachments', obj, actor=user):
-            feature_list.append('event-attachments')
+            feature_list.add('require-2fa')
 
         experiment_assignments = experiments.all(org=obj)
 

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -170,13 +170,6 @@ class ProjectSerializer(Serializer):
                 # Remove the project scope prefix
                 feature_list.add(feature_name[len('projects:'):])
 
-        # These were not here
-        #default_manager.add('projects:sample-events', ProjectFeature)  # NOQA
-        #default_manager.add('projects:servicehooks', ProjectFeature)  # NOQA
-        #default_manager.add('projects:similarity-indexing', ProjectFeature)  # NOQA
-        #default_manager.add('projects:custom-inbound-filters', ProjectFeature)  # NOQA
-        #default_manager.add('projects:minidump', ProjectFeature)  # NOQA
-
         if obj.flags.has_releases:
             feature_list.add('releases')
 

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -164,6 +164,8 @@ class ProjectSerializer(Serializer):
         feature_list = set()
 
         for feature_name in project_features:
+            if not feature_name.startswith('projects:'):
+                continue
             if features.has(feature_name, obj, actor=user):
                 # Remove the project scope prefix
                 feature_list.add(feature_name[len('projects:'):])

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -765,39 +765,86 @@ DEBUG_TOOLBAR_PATCH_SETTINGS = False
 SENTRY_CLIENT = 'sentry.utils.raven.SentryInternalClient'
 
 SENTRY_FEATURES = {
+    # Enables user registration.
     'auth:register': True,
+
+    # Enable obtaining and using API keys.
     'organizations:api-keys': False,
+    # Enable creating organizations within sentry (if SENTRY_SINGLE_ORGANIZATION
+    # is not enabled).
     'organizations:create': True,
-    'organizations:event-attachments': False,
-    'organizations:repos': True,
-    'organizations:sso': True,
-    'organizations:sso-saml2': True,
-    'organizations:sso-rippling': False,
-    'organizations:group-unmerge': False,
-    'organizations:invite-members': True,
-    'organizations:require-2fa': False,
-    'organizations:internal-catchall': False,
-    'organizations:new-issue-ui': True,
-    'organizations:integrations-issue-basic': False,
-    'organizations:integrations-issue-sync': False,
-    'organizations:new-teams': True,
-    'organizations:unreleased-changes': False,
-    'organizations:suggested-commits': True,
-    'organizations:relay': False,
-    'organizations:js-loader': False,
-    'organizations:health': False,
+    # Enable the 'discover' interface.
     'organizations:discover': False,
+    # Enable attaching arbitrary files to events.
+    'organizations:event-attachments': False,
+    # Enable the organization wide events stream interface.
     'organizations:events-stream': False,
-    'projects:global-events': False,
-    'projects:plugins': True,
-    'projects:dsym': False,
-    'projects:sample-events': True,
-    'projects:data-forwarding': True,
-    'projects:rate-limits': True,
-    'projects:discard-groups': False,
+    # Enable the interface and functionality for unmerging event groups.
+    'organizations:group-unmerge': False,
+    # Enable the 'health' interface.
+    'organizations:health': False,
+    # Enable integration functionality to create and link groups to issues on
+    # external services.
+    'organizations:integrations-issue-basic': False,
+    # Enable interface functionality to synchronize groups between sentry and
+    # issues on external services.
+    'organizations:integrations-issue-sync': False,
+    # Special feature flag primarily used on the sentry.io SASS product for
+    # easily enabling features while in early development.
+    'organizations:internal-catchall': False,
+    # Enable inviting members to organizations.
+    'organizations:invite-members': True,
+    # DEPRECATED: pending removal.
+    'organizations:js-loader': False,
+    # DEPRECATED: pending removal.
+    'organizations:new-issue-ui': True,
+    # DEPRECATED: pending removal.
+    'organizations:new-teams': True,
+    # Enable the relay functionality, for use with sentry semaphore. See
+    # https://github.com/getsentry/semaphore.
+    'organizations:relay': False,
+    # Enable managing repositories associated to an organization.
+    'organizations:repos': True,
+    # DEPCREATED: pending removal.
+    'organizations:require-2fa': False,
+    # Enable SSO functionality, providing configurable single signon using
+    # services like GitHub / Google. This is *not* the same as the signup /
+    # login with Github / Azure DevOps that sentry.io provides.
+    'organizations:sso': True,
+    # Enable Rippling SSO functionality.
+    'organizations:sso-rippling': False,
+    # Enable SAML2 based SSO functionality. getsentry/sentry-auth-saml2 plugin
+    # must be installed to use this functionality.
+    'organizations:sso-saml2': True,
+    # Enable suggested commits associated to a event group in the UI.
+    'organizations:suggested-commits': True,
+    # DEPCREATED: pending removal.
+    'organizations:unreleased-changes': False,
+
+    # Enable functionality to specify custom inbound filters on events.
     'projects:custom-inbound-filters': False,
+    # Enable data forwarding functionality for projects.
+    'projects:data-forwarding': True,
+    # Enable functionality to discard groups.
+    'projects:discard-groups': False,
+    # DEPRECATED: pending removal
+    'projects:dsym': False,
+    # DEPRECATED: pending removal.
+    'projects:global-events': False,
+    # Enable functionality for attaching  minidumps to events and displaying
+    # then in the group UI.
     'projects:minidump': True,
+    # Enable functionality for project plugins.
+    'projects:plugins': True,
+    # Enable functionality for rate-limiting events on projects.
+    'projects:rate-limits': True,
+    # Enable functionality for sampling of events on projects.
+    'projects:sample-events': True,
+    # Enable functionality to trigger service hooks upon event ingestion.
     'projects:servicehooks': False,
+
+    # Don't add feature defaults down here! Please add them in their associated
+    # group sorted alphabetically.
 }
 
 # Default time zone for localization in the UI.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -789,7 +789,7 @@ SENTRY_FEATURES = {
     # Enable interface functionality to synchronize groups between sentry and
     # issues on external services.
     'organizations:integrations-issue-sync': False,
-    # Special feature flag primarily used on the sentry.io SASS product for
+    # Special feature flag primarily used on the sentry.io SAAS product for
     # easily enabling features while in early development.
     'organizations:internal-catchall': False,
     # Enable inviting members to organizations.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -4,35 +4,80 @@ from .base import *  # NOQA
 from .handler import *  # NOQA
 from .manager import *  # NOQA
 
+# The feature flag system provides a way to turn on or off features of Sentry.
+#
+# Registering a new feature:
+#
+# - Determine what scope your feature falls under. By convention we have a
+#   organizations and project scope which map to the OrganizationFeature and
+#   ProjectFeature feature objects. Scoping will provide the feature with
+#   context.
+#
+#   Organization and Project scoped features will automatically be added into
+#   the Organization and Project serialized representations.
+#
+#   Additional feature contexts can be found under the features.base module,
+#   but you will typically deal with the organization or project.
+#
+#   NOTE: There is no currently established convention for features which do not
+#         fall under these scopes. Use your best judgment for these.
+#
+# - Set a default for your features.
+#
+#   Feature defaults are configured in the sentry.conf.server.SENTRY_FEATURES
+#   module variable. This is the DEFAULT value for a feature, the default may be
+#   overridden by the logic in the exposed feature.manager.FeatureManager
+#   instance. See the ``has`` method here for a detailed understanding of how
+#   the default values is overridden.
+#
+# - Use your feature.
+#
+#   You can check if a feature is enabled using the following call:
+#
+#   >>> features.has('organization:my-feature', organization, actor=user)
+#
+#   NOTE: The second parameter is used to provide the feature context, again
+#         organization and project are the most common, but it is possible that
+#         other Feature objects may require more arguments.
+#
+#   NOTE: The actor kwarg should be passed when it's expected that the handler
+#         needs context of the user.
+
 default_manager = FeatureManager()  # NOQA
+
+# Unscoped features
 default_manager.add('auth:register')
-default_manager.add('organizations:api-keys', OrganizationFeature)  # NOQA
+default_manager.add('user:assistant')
 default_manager.add('organizations:create')
+
+# Organization scoped features
+default_manager.add('organizations:api-keys', OrganizationFeature)  # NOQA
+default_manager.add('organizations:discover', OrganizationFeature)  # NOQA
 default_manager.add('organizations:event-attachments', OrganizationFeature)  # NOQA
-default_manager.add('organizations:sso', OrganizationFeature)  # NOQA
-default_manager.add('organizations:sso-saml2', OrganizationFeature)  # NOQA
-default_manager.add('organizations:sso-rippling', OrganizationFeature)  # NOQA
-default_manager.add('organizations:onboarding', OrganizationFeature)  # NOQA
-default_manager.add('organizations:repos', OrganizationFeature)  # NOQA
-default_manager.add('organizations:release-commits', OrganizationFeature)  # NOQA
-default_manager.add('organizations:suggested-commits', OrganizationFeature)  # NOQA
+default_manager.add('organizations:events-stream', OrganizationFeature)  # NOQA
 default_manager.add('organizations:group-unmerge', OrganizationFeature)  # NOQA
-default_manager.add('organizations:invite-members', OrganizationFeature)  # NOQA
-default_manager.add('organizations:require-2fa', OrganizationFeature)  # NOQA
-default_manager.add('organizations:internal-catchall', OrganizationFeature)  # NOQA
-default_manager.add('organizations:new-issue-ui', OrganizationFeature)  # NOQA
+default_manager.add('organizations:health', OrganizationFeature)  # NOQA
 default_manager.add('organizations:integrations-issue-basic', OrganizationFeature)  # NOQA
 default_manager.add('organizations:integrations-issue-sync', OrganizationFeature)  # NOQA
-default_manager.add('organizations:new-teams', OrganizationFeature)  # NOQA
-default_manager.add('organizations:unreleased-changes', OrganizationFeature)  # NOQA
-default_manager.add('organizations:relay', OrganizationFeature)  # NOQA
+default_manager.add('organizations:internal-catchall', OrganizationFeature)  # NOQA
+default_manager.add('organizations:invite-members', OrganizationFeature)  # NOQA
 default_manager.add('organizations:js-loader', OrganizationFeature)  # NOQA
-default_manager.add('organizations:health', OrganizationFeature)  # NOQA
-default_manager.add('organizations:discover', OrganizationFeature)  # NOQA
-default_manager.add('organizations:events-stream', OrganizationFeature)  # NOQA
+default_manager.add('organizations:new-issue-ui', OrganizationFeature)  # NOQA
+default_manager.add('organizations:new-teams', OrganizationFeature)  # NOQA
+default_manager.add('organizations:onboarding', OrganizationFeature)  # NOQA
+default_manager.add('organizations:relay', OrganizationFeature)  # NOQA
+default_manager.add('organizations:release-commits', OrganizationFeature)  # NOQA
+default_manager.add('organizations:repos', OrganizationFeature)  # NOQA
+default_manager.add('organizations:require-2fa', OrganizationFeature)  # NOQA
+default_manager.add('organizations:sso', OrganizationFeature)  # NOQA
+default_manager.add('organizations:sso-rippling', OrganizationFeature)  # NOQA
+default_manager.add('organizations:sso-saml2', OrganizationFeature)  # NOQA
+default_manager.add('organizations:suggested-commits', OrganizationFeature)  # NOQA
+default_manager.add('organizations:unreleased-changes', OrganizationFeature)  # NOQA
+
+# Project scoped features
 default_manager.add('projects:similarity-view', ProjectFeature)  # NOQA
 default_manager.add('projects:global-events', ProjectFeature)  # NOQA
-default_manager.add('projects:plugins', ProjectPluginFeature)  # NOQA
 default_manager.add('projects:data-forwarding', ProjectFeature)  # NOQA
 default_manager.add('projects:rate-limits', ProjectFeature)  # NOQA
 default_manager.add('projects:sample-events', ProjectFeature)  # NOQA
@@ -41,10 +86,15 @@ default_manager.add('projects:similarity-indexing', ProjectFeature)  # NOQA
 default_manager.add('projects:discard-groups', ProjectFeature)  # NOQA
 default_manager.add('projects:custom-inbound-filters', ProjectFeature)  # NOQA
 default_manager.add('projects:minidump', ProjectFeature)  # NOQA
-default_manager.add('workflow:release-emails', ProjectFeature)  # NOQA
-default_manager.add('user:assistant')
+
+# Project plugin features
+default_manager.add('projects:plugins', ProjectPluginFeature)  # NOQA
+
+# NOTE: Don't add features down here! Add them to their specific group and sort
+#       them alphabetically! The order features are registered is not important.
 
 # expose public api
 add = default_manager.add
 get = default_manager.get
 has = default_manager.has
+all = default_manager.all

--- a/src/sentry/features/base.py
+++ b/src/sentry/features/base.py
@@ -7,16 +7,6 @@ class Feature(object):
     def __init__(self, name):
         self.name = name
 
-    def has(self, actor):
-        """
-        A feature may return one of three values:
-
-        - True: the feature is enabled for actor
-        - False: the feature is not enabled for actor
-        - None: defer
-        """
-        return None
-
 
 class OrganizationFeature(Feature):
     def __init__(self, name, organization):

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -62,7 +62,7 @@ class FeatureManager(object):
         2. The default configuration of the feature. This can be located in
            sentry.conf.server.SENTRY_FEATURES.
 
-        Depending on the Feature handler, additional arguments may need to be
+        Depending on the Feature class, additional arguments may need to be
         provided to assign organiation or project context to the feature.
 
         >>> FeatureManager.has('organization:feature', organization, actor=request.user)

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -15,10 +15,30 @@ class FeatureManager(object):
     def __init__(self):
         self._registry = {}
 
+    def all(self, feature_type=Feature):
+        """
+        Get a mapping of feature name -> feature class, optionally specific to a
+        particular feature type.
+        """
+        return {k: v for k, v in self._registry.items() if v == feature_type}
+
     def add(self, name, cls=Feature):
+        """
+        Register a feature.
+
+        The passed class is a Feature container object, this object can be used
+        to encapsulate the context associated to a feature.
+
+        >>> FeatureManager.has('my:feature', actor=request.user)
+        """
         self._registry[name] = cls
 
     def get(self, name, *args, **kwargs):
+        """
+        Lookup a registered feature handler given the feature name.
+
+        >>> FeatureManager.get('my:feature', actor=request.user)
+        """
         try:
             cls = self._registry[name]
         except KeyError:
@@ -27,19 +47,40 @@ class FeatureManager(object):
 
     def has(self, name, *args, **kwargs):
         """
-        >>> FeatureManager.has('my:feature', actor=request.user)
+        Determine if a feature is enabled.
+
+        Features are checked in the following order:
+
+        1. Execute Plugin feature handlers. Any plugin which returns a list of
+           instantiated ``feature.handler.FeatureHandler`` objects will have
+           each of their handlers executed in the order they are declared.
+
+           When each handler is executed should the handler return None instead
+           of True or False (feature enabled / disabled), the next registered
+           plugin feature handler will be executed.
+
+        2. The default configuration of the feature. This can be located in
+           sentry.conf.server.SENTRY_FEATURES.
+
+        Depending on the Feature handler, additional arguments may need to be
+        provided to assign organiation or project context to the feature.
+
+        >>> FeatureManager.has('organization:feature', organization, actor=request.user)
         """
         actor = kwargs.pop('actor', None)
         feature = self.get(name, *args, **kwargs)
-        rv = self._get_plugin_value(feature, actor)
-        if rv is None:
-            rv = feature.has(actor=actor)
-        if rv is None:
-            rv = self._get_default_value(feature)
-        return rv
 
-    def _get_default_value(self, feature):
-        return settings.SENTRY_FEATURES.get(feature.name, False)
+        # Check plugin feature handlers
+        rv = self._get_plugin_value(feature, actor)
+        if rv is not None:
+            return rv
+
+        rv = settings.SENTRY_FEATURES.get(feature.name, False)
+        if rv is not None:
+            return rv
+
+        # Features are by default disabled if no plugin or default enables them
+        return False
 
     def _get_plugin_value(self, feature, actor):
         for plugin in plugins.all(version=2):


### PR DESCRIPTION
- Added documentation to the features.manager module.

 - Removes the Feature.has method. No Feature classes have been declared that provide a has function, and this simply adds to the complexity of how features work.

 - Sorts and groups feature flags in both the features module where they are registered, as well as in the conf.server module where defaults are set.

 - Adds descriptions to all feature flag definitions in the conf.server.SENTRY_FEATURES module variable.

 - Improves Organization and Project serializers by automatically pulling organization and project scopped features from the manager.

   NOTE: Not all project and organization feature flags were previously exposed on the serializer, presumably because they were not needed by the frontend.

   The following flags are now exposed on the organization.features after serialization

   - organizations:invite-members
   - organizations:release-commits

   The following flags are now exposed on the project.features after serialization.

   - projects:sample-events
   - projects:servicehooks
   - projects:similarity-indexing
   - projects:custom-inbound-filters
   - projects:minidump