### PR TITLE
fix: Ignore raw events with non-readable body when sending to Kafka

### DIFF
--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -138,14 +138,14 @@ class APIView(BaseView):
                 try:
                     json.dumps([key, value])
                     meta[key] = value
-                except TypeError:
+                except (TypeError, ValueError):
                     pass
 
             meta['SENTRY_API_VIEW_NAME'] = self.__class__.__name__
 
             kafka_publisher.publish(
                 channel=getattr(settings, 'KAFKA_RAW_EVENTS_PUBLISHER_TOPIC', 'raw-store-events'),
-                value=json.dumps([meta, data])
+                value=json.dumps([meta, base64.b64encode(data)])
             )
         except Exception as e:
             logger.debug("Cannot publish event to Kafka: {}".format(e.message))

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -122,7 +122,10 @@ class APIView(BaseView):
         Sends raw event data to Kafka for later offline processing.
         """
         try:
-            if len(request.body) > options.get('kafka-publisher.max-event-size'):
+            # This may fail when we e.g. send a multipart form. We ignore those errors for now.
+            data = request.body
+
+            if not data or len(data) > options.get('kafka-publisher.max-event-size'):
                 return
 
             # Sampling
@@ -141,8 +144,8 @@ class APIView(BaseView):
             meta['SENTRY_API_VIEW_NAME'] = self.__class__.__name__
 
             kafka_publisher.publish(
-                channel=getattr(settings, 'KAFKA_RAW_EVENTS_PUBLISHER_TOPIC', 'raw_store_events'),
-                value=json.dumps([meta, request.body])
+                channel=getattr(settings, 'KAFKA_RAW_EVENTS_PUBLISHER_TOPIC', 'raw-store-events'),
+                value=json.dumps([meta, data])
             )
         except Exception as e:
             logger.debug("Cannot publish event to Kafka: {}".format(e.message))
@@ -157,7 +160,7 @@ class APIView(BaseView):
         )
         origin = None
 
-        if kafka_publisher is not None and request.body is not None:
+        if kafka_publisher is not None:
             self._publish_to_kafka(request)
 
         try:


### PR DESCRIPTION
`request.body` is not readable for some requests, similar to 
https://github.com/getsentry/sentry/blob/872802a7934803ca3e46ca984bf77be2aa16efbd/src/sentry/web/api.py#L337
As a result, we won't have any minidumps events sent to Kafka, which is probably fine for now.