### PR TITLE
fix(integrations): Azure DevOps corrected subscription id

### DIFF
--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -408,7 +408,7 @@ class VstsIntegrationProvider(IntegrationProvider):
                 'You do not have sufficent account access to create an integration.\nPlease check with the owner of this account.'
             )
 
-        subscription_id = subscription['publisherInputs']['tfsSubscriptionId']
+        subscription_id = subscription['id']
         return subscription_id, shared_secret
 
     def get_oauth_data(self, payload):

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -39,8 +39,7 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
 
         metadata = integration.metadata
         assert metadata['scopes'] == list(VSTSIdentityProvider.oauth_scopes)
-        assert metadata['subscription']['id'] == \
-            CREATE_SUBSCRIPTION['publisherInputs']['tfsSubscriptionId']
+        assert metadata['subscription']['id'] == CREATE_SUBSCRIPTION['id']
         assert metadata['domain_name'] == self.vsts_base_url
 
     def test_migrate_repositories(self):


### PR DESCRIPTION
We were storing `tfsSubscriptionId` for the  subscription id. The api, however, does not let you look up the subscription by that id. Instead, the `id` field in the response was what we were wanting. This will also need to be corrected in production for all records.

Jira APP-631