### PR TITLE
fix(discover): Always use the same querybuilder instance

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
@@ -76,7 +76,12 @@ const OrganizationDiscoverContainer = createReactClass({
 
     fetchSavedQuery(organization, savedQueryId)
       .then(resp => {
-        this.queryBuilder = createQueryBuilder(parseSavedQuery(resp), organization);
+        if (this.queryBuilder) {
+          this.queryBuilder.reset(resp);
+        } else {
+          this.queryBuilder = createQueryBuilder(parseSavedQuery(resp), organization);
+        }
+
         this.setState({isLoading: false, savedQuery: resp, view: 'saved'});
       })
       .catch(() => {


### PR DESCRIPTION
This code was previously creating another instance of querybuilder when
navigating to a saved search. This caused a bug where queries run might
not reflect the saved search. We should always use the same querybuilder
otherwise we might get into unpredictable states.