### PR TITLE
feat(gitlab) Implement compare_commits for Gitlab

### DIFF
--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -99,9 +99,17 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
         )
 
     def get_user(self):
+        """Get a user
+
+        See https://docs.gitlab.com/ee/api/users.html#single-user
+        """
         return self.get(GitLabApiClientPath.user)
 
     def get_group_projects(self, group, query=None, simple=True):
+        """Get projects for a group
+
+        See https://docs.gitlab.com/ee/api/groups.html#list-a-group-s-projects
+        """
         # simple param returns limited fields for the project.
         # Really useful, because we often don't need most of the project information
         return self.get(
@@ -115,11 +123,19 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
         )
 
     def get_project(self, project_id):
+        """Get project
+
+        See https://docs.gitlab.com/ee/api/projects.html#get-single-project
+        """
         return self.get(
             GitLabApiClientPath.project.format(project=project_id)
         )
 
     def get_projects(self, query, simple=True):
+        """Get project list
+
+        See https://docs.gitlab.com/ee/api/projects.html#list-all-projects
+        """
         # simple param returns limited fields for the project.
         # Really useful, because we often don't need most of the project information
         return self.get(
@@ -131,6 +147,10 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
         )
 
     def get_issue(self, project_id, issue_id):
+        """Get an issue
+
+        See https://docs.gitlab.com/ee/api/issues.html#single-issue
+        """
         try:
             return self.get(
                 GitLabApiClientPath.issue.format(project=project_id, issue=issue_id)
@@ -139,6 +159,10 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
             raise ApiError('Issue not found with ID', 404)
 
     def create_issue(self, project, data):
+        """Create an issue
+
+        See https://docs.gitlab.com/ee/api/issues.html#new-issue
+        """
         return self.post(
             GitLabApiClientPath.issues.format(project=project),
             data=data,
@@ -154,17 +178,29 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
         )
 
     def create_note(self, project_id, issue_iid, data):
+        """Create an issue note
+
+        See https://docs.gitlab.com/ee/api/notes.html#create-new-issue-note
+        """
         return self.post(
             GitLabApiClientPath.notes.format(project=project_id, issue=issue_iid),
             data=data,
         )
 
     def list_project_members(self, project_id):
+        """Get project members
+
+        See https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project
+        """
         return self.get(
             GitLabApiClientPath.members.format(project=project_id)
         )
 
     def create_project_webhook(self, project_id):
+        """Create a webhook on a project
+
+        See https://docs.gitlab.com/ee/api/projects.html#add-project-hook
+        """
         path = GitLabApiClientPath.project_hooks.format(project=project_id)
         hook_uri = reverse('sentry-extensions-gitlab-webhook')
         model = self.installation.model
@@ -180,6 +216,10 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
         return resp['id']
 
     def delete_project_webhook(self, project_id, hook_id):
+        """Delete a webhook from a project
+
+        See https://docs.gitlab.com/ee/api/projects.html#delete-project-hook
+        """
         path = GitLabApiClientPath.project_hook.format(project=project_id, hook_id=hook_id)
         return self.delete(path)
 
@@ -189,6 +229,8 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
         Gitlab doesn't give us a good way to do this, so we fetch the end_sha
         and use its date to find the block of commits. We only fetch one page
         of commits to match other implementations (github, bitbucket)
+
+        See https://docs.gitlab.com/ee/api/commits.html#get-the-diff-of-a-commit
         """
         path = GitLabApiClientPath.commit.format(project=project_id, sha=end_sha)
         commit = self.get(path)
@@ -200,10 +242,18 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
         return self.get(path, params={'until': end_date})
 
     def compare_commits(self, project_id, start_sha, end_sha):
+        """Compare commits between two shas
+
+        See https://docs.gitlab.com/ee/api/repositories.html#compare-branches-tags-or-commits
+        """
         path = GitLabApiClientPath.compare.format(project=project_id)
         return self.get(path, params={'from': start_sha, 'to': end_sha})
 
     def get_diff(self, project_id, sha):
+        """Get the diff for a commit
+
+        See https://docs.gitlab.com/ee/api/commits.html#get-the-diff-of-a-commit
+        """
         path = GitLabApiClientPath.diff.format(
             project=project_id,
             sha=sha

--- a/src/sentry/integrations/gitlab/issues.py
+++ b/src/sentry/integrations/gitlab/issues.py
@@ -39,6 +39,7 @@ class GitlabIssueBasic(IssueBasicMixin):
                 'url': autocomplete_url,
                 'updatesForm': True,
                 'required': True,
+                'choices': [],
             }
         ] + fields
 

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -54,6 +54,12 @@ class Webhook(object):
 
 
 class MergeEventWebhook(Webhook):
+    """
+    Handle Merge Request Hook
+
+    See https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#merge-request-events
+    """
+
     def __call__(self, integration, organization, event):
         repo = self.get_repo(integration, organization, event)
         if repo is None:
@@ -102,6 +108,12 @@ class MergeEventWebhook(Webhook):
 
 
 class PushEventWebhook(Webhook):
+    """
+    Handle push hook
+
+    See https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#push-events
+    """
+
     def __call__(self, integration, organization, event):
         repo = self.get_repo(integration, organization, event)
         if repo is None:

--- a/tests/sentry/integrations/gitlab/test_issues.py
+++ b/tests/sentry/integrations/gitlab/test_issues.py
@@ -45,7 +45,8 @@ class GitlabIssuesTest(GitLabTestCase):
                 'name': 'project',
                 'required': True,
                 'type': 'select',
-                'label': 'Gitlab Project'
+                'label': 'Gitlab Project',
+                'choices': [],
             },
             {
                 'name': 'title',

--- a/tests/sentry/integrations/gitlab/testutils.py
+++ b/tests/sentry/integrations/gitlab/testutils.py
@@ -306,3 +306,106 @@ PUSH_EVENT_IGNORED_COMMIT = b"""
   "total_commits_count": 1
 }
 """
+
+
+COMPARE_RESPONSE = r"""
+{
+  "commit": {
+    "id": "12d65c8dd2b2676fa3ac47d955accc085a37a9c1",
+    "short_id": "12d65c8dd2b",
+    "title": "JS fix",
+    "author_name": "Dmitriy",
+    "author_email": "dmitriy@example.com",
+    "created_at": "2014-02-27T10:27:00+02:00"
+  },
+  "commits": [{
+    "id": "12d65c8dd2b2676fa3ac47d955accc085a37a9c1",
+    "short_id": "12d65c8dd2b",
+    "title": "JS fix",
+    "author_name": "Dmitriy",
+    "author_email": "dmitriy@example.com",
+    "created_at": "2014-02-27T10:27:00+02:00"
+  },
+  {
+    "id": "8b090c1b79a14f2bd9e8a738f717824ff53aebad",
+    "short_id": "8b090c1b",
+    "title": "Fix dmitriy mistake",
+    "author_name": "Sally",
+    "author_email": "sally@example.com",
+    "created_at": "2014-02-27T10:27:00+02:00"
+  }],
+  "diffs": [{
+    "old_path": "files/js/application.js",
+    "new_path": "files/js/application.js",
+    "a_mode": null,
+    "b_mode": "100644",
+    "diff": "--- a/files/js/application.js\n+++ b/files/js/application.js\n@@ -24,8 +24,10 @@\n //= require g.raphael-min\n //= require g.bar-min\n //= require branch-graph\n-//= require highlightjs.min\n-//= require ace/ace\n //= require_tree .\n //= require d3\n //= require underscore\n+\n+function fix() { \n+  alert(\"Fixed\")\n+}",
+    "new_file": false,
+    "renamed_file": false,
+    "deleted_file": false
+  }],
+  "compare_timeout": false,
+  "compare_same_ref": false
+}
+"""
+
+
+COMMIT_LIST_RESPONSE = r"""
+[
+  {
+    "id": "ed899a2f4b50b4370feeea94676502b42383c746",
+    "short_id": "ed899a2f4b5",
+    "title": "Replace sanitize with escape once",
+    "author_name": "Dmitriy",
+    "author_email": "dmitriy@example.com",
+    "authored_date": "2018-09-20T11:50:22+03:00",
+    "committer_name": "Administrator",
+    "committer_email": "admin@example.com",
+    "committed_date": "2018-09-20T11:50:22+03:00",
+    "created_at": "2018-09-20T11:50:22+03:00",
+    "message": "Replace sanitize with escape once",
+    "parent_ids": [
+      "6104942438c14ec7bd21c6cd5bd995272b3faff6"
+    ]
+  },
+  {
+    "id": "6104942438c14ec7bd21c6cd5bd995272b3faff6",
+    "short_id": "6104942438c",
+    "title": "Sanitize for network graph",
+    "author_name": "randx",
+    "author_email": "dmitriy@example.com",
+    "committer_name": "Dmitriy",
+    "committer_email": "dmitriy@example.com",
+    "created_at": "2018-09-20T09:06:12+03:00",
+    "message": "Sanitize for network graph",
+    "parent_ids": [
+      "ae1d9fb46aa2b07ee9836d49862ec4e2c46fbbba"
+    ]
+  }
+]
+"""
+
+COMMIT_DIFF_RESPONSE = r"""
+[
+    {
+        "old_path": "files/js/application.js",
+        "new_path": "files/js/application.js",
+        "a_mode": null,
+        "b_mode": "100644",
+        "diff": "--- a/files/js/application.js\n+++ b/files/js/application.js\n@@ -24,8 +24,10 @@\n //= require g.raphael-min\n //= require g.bar-min\n //= require branch-graph\n-//= require highlightjs.min\n-//= require ace/ace\n //= require_tree .\n //= require d3\n //= require underscore\n+\n+function fix() { \n+  alert(\"Fixed\")\n+}",
+        "new_file": false,
+        "renamed_file": false,
+        "deleted_file": false
+    },
+    {
+        "a_mode": "100644",
+        "b_mode": "100644",
+        "deleted_file": false,
+        "diff": "@@ -1 +1,3 @@\n OH HAI\n+OH HAI\n+OH HAI\n",
+        "new_file": false,
+        "new_path": "README.txt",
+        "old_path": "README.txt",
+        "renamed_file": false
+    }
+]
+"""


### PR DESCRIPTION
This enables gitlab repositories to have commits, and changed files recorded when releases are created. This greases the wheels for automatic issue resolution and suspect commit detection machinery as well.

Refs APP-496