### PR TITLE
feat: Add Jetbrains Artifact to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ example/db.sqlite
 /test_cli/
 Gemfile.lock
 .idea/
+*.iml
 .pytest_cache/
 .vscode/tags
 coverage.xml


### PR DESCRIPTION
Jetbrains (Intellij/Webstorm) uses .iml artifacts for project structure. 