### PR TITLE
fix(integrations): Script to address Azure DevOps Webhooks

### DIFF
--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -244,7 +244,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
             api_preview=True,
         )
 
-    def create_subscription(self, instance, external_id, shared_secret):
+    def create_subscription(self, instance, shared_secret):
         return self.post(
             VstsApiPath.subscriptions.format(
                 instance=instance

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -244,7 +244,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
             api_preview=True,
         )
 
-    def create_subscription(self, instance, shared_secret):
+    def create_subscription(self, instance, external_id, shared_secret):
         return self.post(
             VstsApiPath.subscriptions.format(
                 instance=instance

--- a/src/sentry/integrations/vsts/vsts_subscription_script.py
+++ b/src/sentry/integrations/vsts/vsts_subscription_script.py
@@ -6,7 +6,7 @@ from django.core.urlresolvers import reverse
 from uuid import uuid4
 
 from sentry.constants import ObjectStatus
-from sentry.integrations.exceptions import ApiError, ApiUnathorized
+from sentry.integrations.exceptions import ApiError, ApiUnauthorized
 from sentry.models import OrganizationIntegration
 from sentry.utils.http import absolute_uri
 
@@ -56,7 +56,7 @@ def recreate_subscriptions(self):
 
         try:
             create_webhook(integration, org_integration.organization_id)
-        except (ApiError, ApiUnathorized):
+        except (ApiError, ApiUnauthorized):
             # potentially try the integration again with another org (if it exists)
             integration_ids.append(integration.id)
 

--- a/src/sentry/integrations/vsts/vsts_subscription_script.py
+++ b/src/sentry/integrations/vsts/vsts_subscription_script.py
@@ -18,6 +18,7 @@ def create_webhook(integration, organization_id):
 
     resp = client.create_subscription(
         instance=installation.instance,
+        external_id=integration.external_id,
         shared_secret=shared_secret,
     )
 

--- a/src/sentry/integrations/vsts/vsts_subscription_script.py
+++ b/src/sentry/integrations/vsts/vsts_subscription_script.py
@@ -1,0 +1,68 @@
+from __future__ import absolute_import
+
+import logging
+
+from django.core.urlresolvers import reverse
+from uuid import uuid4
+
+from sentry.constants import ObjectStatus
+from sentry.integrations.exceptions import ApiError, ApiUnathorized
+from sentry.models import OrganizationIntegration
+from sentry.utils.http import absolute_uri
+
+VSTS_WEBHOOK_URL = absolute_uri(reverse('sentry-extensions-vsts-issue-updated'))
+
+logger = logging.getLogger('sentry.integrations.vsts_script')
+
+
+def create_webhook(integration, organization_id):
+    installation = integration.get_installation(organization_id)
+    client = installation.get_client()
+    shared_secret = uuid4.hex + uuid4.hex
+
+    resp = client.create_subscription(
+        instance=installation.instance,
+        shared_secret=shared_secret,
+    )
+
+    installation.model.metadata['subscription'] = {
+        'id': resp['id'],
+        'secret': shared_secret,
+    }
+    installation.model.save()
+
+
+def recreate_subscriptions(self):
+    org_integrations = OrganizationIntegration.objects.filter(
+        integration__provider='vsts',
+        integration__status=ObjectStatus.VISIBLE,
+        status=ObjectStatus.VISIBLE,
+    ).select_related('integration')
+
+    # TODO(lb): this looks a little weird to me...
+    # can I run into issues with both values_list and distinct?
+    integration_ids = list(
+        org_integrations.values_list('integration_id', flat=True).distinct('integration_id')
+    )
+
+    for org_integration in org_integrations:
+        # The integration associated with the organizationintegration
+        # has successfully had its subscription re-created; skip it.
+        integration = org_integration.integration
+        if integration.id not in integration_ids:
+            continue
+
+        integration_ids.remove(integration.id)
+
+        try:
+            create_webhook(integration, org_integration.organization_id)
+        except (ApiError, ApiUnathorized):
+            # potentially try the integration again with another org (if it exists)
+            integration_ids.append(integration.id)
+
+    logger.info(
+        'Was unable to re-create subscription',
+        extra={
+            'integrations': integration_ids,
+        }
+    )

--- a/src/sentry/integrations/vsts/vsts_subscription_script.py
+++ b/src/sentry/integrations/vsts/vsts_subscription_script.py
@@ -1,16 +1,11 @@
 from __future__ import absolute_import
 
 import logging
-
-from django.core.urlresolvers import reverse
 from uuid import uuid4
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.exceptions import ApiError, ApiUnauthorized
 from sentry.models import OrganizationIntegration
-from sentry.utils.http import absolute_uri
-
-VSTS_WEBHOOK_URL = absolute_uri(reverse('sentry-extensions-vsts-issue-updated'))
 
 logger = logging.getLogger('sentry.integrations.vsts_script')
 
@@ -41,7 +36,7 @@ def recreate_subscriptions(self):
 
     # TODO(lb): this looks a little weird to me...
     # can I run into issues with both values_list and distinct?
-    integration_ids = list(
+    integration_ids = set(
         org_integrations.values_list('integration_id', flat=True).distinct('integration_id')
     )
 

--- a/tests/sentry/integrations/vsts/test_script.py
+++ b/tests/sentry/integrations/vsts/test_script.py
@@ -1,0 +1,114 @@
+from __future__ import absolute_import
+
+import responses
+from time import time
+
+
+from sentry.integrations.vsts.vsts_subscription_script import recreate_subscriptions
+from sentry.models import (
+    Identity, IdentityProvider, Integration, OrganizationIntegration
+)
+from sentry.testutils import TestCase
+from uuid import uuid4
+
+
+class VSTSScriptTest(TestCase):
+    def setUp(self):
+        self.idp = IdentityProvider.objects.create(
+            type='vsts',
+            config={},
+        )
+        self.integration_1 = self.create_integration(
+            self.create_organization(), 'https://dev.azure.com/integration_1/')
+        self.integration_2 = self.create_integration(
+            self.create_organization(), 'https://dev.azure.com/integration_2/')
+        responses.add(
+            responses.POST,
+            'https://app.vssps.visualstudio.com/oauth2/token',
+            status=401,
+        )
+
+    def create_integration(self, organization, domain_name):
+        user = self.create_user()
+        integration = Integration.objects.create(
+            provider='vsts',
+            name='Example Vsts',
+            external_id=uuid4().hex,
+            metadata={
+                'domain_name': domain_name,
+            }
+        )
+        default_auth = self.create_identity(user)
+        integration.add_organization(organization, None, default_auth.id)
+        return integration
+
+    def create_identity(self, user):
+        default_auth = Identity.objects.create(
+            idp=self.idp,
+            user=user,
+            external_id=uuid4().hex,
+            data={
+                'access_token': '123456789',
+                'expires': int(time()) + 3600,
+                'refresh_token': 'rxxx-xxxx',
+                'token_type': 'jwt-bearer',
+            },
+        )
+        return default_auth
+
+    def assert_subscription(self, integration_id, subscription_id):
+        integration = Integration.objects.get(id=integration_id)
+        assert integration.metadata['subscription']['id'] == subscription_id
+        assert integration.metadata['subscription']['secret']
+
+    def create_integration_with_invalid_id(self, organization, domain_name):
+        integration = self.create_integration(organization, domain_name)
+        org_integration = OrganizationIntegration.objects.get(
+            organization_id=organization.id,
+            integration_id=integration.id
+        )
+        identity = Identity.objects.get(
+            id=org_integration.default_auth_id,
+        )
+
+        # because refreshing auth will fail when it tries.
+        identity.data['expires'] -= 200000
+        identity.save()
+        return integration
+
+    @responses.activate
+    def test_recreate_subscription(self):
+        integration_3 = self.create_integration_with_invalid_id(
+            self.create_organization(), 'https://dev.azure.com/integration_3/')
+        # create a valid id for integration_3
+        integration_3.add_organization(
+            self.create_organization(),
+            None,
+            self.create_identity(
+                self.create_user()).id)
+        subscription_id_1 = 'one'
+        subscription_id_3 = 'two and three'
+        responses.add(
+            responses.POST,
+            'https://dev.azure.com/integration_1/_apis/hooks/subscriptions',
+            json={
+                'id': subscription_id_1,
+            }
+        )
+        responses.add(
+            responses.POST,
+            'https://dev.azure.com/integration_2/_apis/hooks/subscriptions',
+            status=401,
+        )
+        responses.add(
+            responses.POST,
+            'https://dev.azure.com/integration_3/_apis/hooks/subscriptions',
+            json={
+                'id': subscription_id_3,
+            }
+        )
+        recreate_subscriptions()
+
+        self.assert_subscription(self.integration_1.id, subscription_id_1)
+        assert 'subscription' not in self.integration_2.metadata
+        self.assert_subscription(integration_3.id, subscription_id_3)


### PR DESCRIPTION
Webhooks in Azure DevOps suffered from a few difficulties:

- We were storing the wrong id instead of `tfsSubscriptionId` we needed `id` in the response.
- If an integration is installed on multiple organizations, the subscription information will be overwritten.

This PR simply recreates all subscriptions for vsts integration users. Due to the small number of integration users, this shouldn't be an issue performance wise.  