### PR TITLE
Add Google Translate extension error to filter list

### DIFF
--- a/src/sentry/filters/browser_extensions.py
+++ b/src/sentry/filters/browser_extensions.py
@@ -41,6 +41,9 @@ EXTENSION_EXC_VALUES = re.compile(
                 # Dragon Web Extension from Nuance Communications
                 # See: https://forum.sentry.io/t/error-in-raven-js-plugin-setsuspendstate/481/
                 'plugin.setSuspendState is not a function',
+                # Google Translate extension
+                # See: https://medium.com/@amir.harel/a-b-target-classname-indexof-is-not-a-function-at-least-not-mine-8e52f7be64ca
+                'a[b].target.className.indexOf is not a function',
             )
         )
     ),


### PR DESCRIPTION
Error thrown is:
`a[b].target.className.indexOf is not a function`

We're seeing a bunch of these in our production logs. I can't imagine anyone needing to see these...

This person tracked it down and wrote up their findings:
https://medium.com/@amir.harel/a-b-target-classname-indexof-is-not-a-function-at-least-not-mine-8e52f7be64ca