### PR TITLE
feat(app-platform): Add sentry app install details endpoint 

### DIFF
--- a/src/sentry/api/endpoints/organization_sentry_app_installation_details.py
+++ b/src/sentry/api/endpoints/organization_sentry_app_installation_details.py
@@ -33,4 +33,4 @@ class OrganizationSentryAppInstallationDetailsEndpoint(OrganizationEndpoint):
             return Response(status=404)
 
         Destroyer.run(install=install)
-        return Response(status=200)
+        return Response(status=204)

--- a/src/sentry/api/endpoints/organization_sentry_app_installation_details.py
+++ b/src/sentry/api/endpoints/organization_sentry_app_installation_details.py
@@ -2,24 +2,35 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
-from api.bases.sentryapps import SentryAppInstallationDetailsEndpoint as BaseEndpoint
+from sentry.api.bases import OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.features.helpers import requires_feature
-from sentry.mediators.sentry_app_installation import Destroyer
+from sentry.mediators.sentry_app_installations import Destroyer
+from sentry.models import SentryAppInstallation
 
 
-class OrganizationSentryAppInstallationDetailsEndpoint(BaseEndpoint):
+class OrganizationSentryAppInstallationDetailsEndpoint(OrganizationEndpoint):
     @requires_feature('organizations:internal-catchall')
-    def get(self, request, organization, install):
-        if install.organization == organization:
-            return Response(serialize(install))
-
-        return Response(status=404)
-
-    @requires_feature('organizations:internal-catchall')
-    def delete(self, request, organization, install):
-        if not install.organization == organization:
+    def get(self, request, organization, uuid):
+        try:
+            install = SentryAppInstallation.objects.get(
+                organization=organization,
+                uuid=uuid,
+            )
+        except SentryAppInstallation.DoesNotExist:
             return Response(status=404)
 
-        Destroyer.run(install)
+        return Response(serialize(install))
+
+    @requires_feature('organizations:internal-catchall')
+    def delete(self, request, organization, uuid):
+        try:
+            install = SentryAppInstallation.objects.get(
+                organization=organization,
+                uuid=uuid,
+            )
+        except SentryAppInstallation.DoesNotExist:
+            return Response(status=404)
+
+        Destroyer.run(install=install)
         return Response(status=200)

--- a/src/sentry/api/endpoints/organization_sentry_app_installation_details.py
+++ b/src/sentry/api/endpoints/organization_sentry_app_installation_details.py
@@ -9,14 +9,14 @@ from sentry.mediators.sentry_app_installation import Destroyer
 
 
 class OrganizationSentryAppInstallationDetailsEndpoint(BaseEndpoint):
-    @requires_feature('organizations:internall-catchall')
+    @requires_feature('organizations:internal-catchall')
     def get(self, request, organization, install):
         if install.organization == organization:
             return Response(serialize(install))
 
         return Response(status=404)
 
-    @requires_feature('organizations:internall-catchall')
+    @requires_feature('organizations:internal-catchall')
     def delete(self, request, organization, install):
         if not install.organization == organization:
             return Response(status=404)

--- a/src/sentry/api/endpoints/organization_sentry_app_installation_details.py
+++ b/src/sentry/api/endpoints/organization_sentry_app_installation_details.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import
+
+from rest_framework.response import Response
+
+from api.bases.sentryapps import SentryAppInstallationDetailsEndpoint as BaseEndpoint
+from sentry.api.serializers import serialize
+from sentry.features.helpers import requires_feature
+from sentry.mediators.sentry_app_installation import Destroyer
+
+
+class OrganizationSentryAppInstallationDetailsEndpoint(BaseEndpoint):
+    @requires_feature('organizations:internall-catchall')
+    def get(self, request, organization, install):
+        if install.organization == organization:
+            return Response(serialize(install))
+
+        return Response(status=404)
+
+    @requires_feature('organizations:internall-catchall')
+    def delete(self, request, organization, install):
+        if not install.organization == organization:
+            return Response(status=404)
+
+        Destroyer.run(install)
+        return Response(status=200)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -614,7 +614,7 @@ urlpatterns = patterns(
         name='sentry-api-0-organization-sentry-app-installations'
     ),
     url(
-        r'^organizations/(?P<organization_slug>[^\/]+)/sentry-app-installations/(?P<uuid>[^/]+)/$',
+        r'^organizations/(?P<organization_slug>[^\/]+)/sentry-app-installations/(?P<uuid>[^\/]+)/$',
         OrganizationSentryAppInstallationDetailsEndpoint.as_view(),
         name='sentry-api-0-organization-sentry-app-installations-details'
     ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -92,11 +92,8 @@ from .endpoints.organization_config_integrations import OrganizationConfigIntegr
 from .endpoints.organization_config_repositories import OrganizationConfigRepositoriesEndpoint
 from .endpoints.organization_repository_commits import OrganizationRepositoryCommitsEndpoint
 from .endpoints.organization_repository_details import OrganizationRepositoryDetailsEndpoint
-<<<<<<< HEAD
 from .endpoints.organization_sentry_app_installations import OrganizationSentryAppInstallationsEndpoint
-=======
-from .endpoints.organizattion_sentry_app_installation_details import OrganizationSentryAppInstallationDetailsEndpoint
->>>>>>> feat(app-platform): Add sentry app install details endpoint
+from .endpoints.organization_sentry_app_installation_details import OrganizationSentryAppInstallationDetailsEndpoint
 from .endpoints.organization_stats import OrganizationStatsEndpoint
 from .endpoints.organization_teams import OrganizationTeamsEndpoint
 from .endpoints.organization_user_issues import OrganizationUserIssuesEndpoint

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -92,7 +92,11 @@ from .endpoints.organization_config_integrations import OrganizationConfigIntegr
 from .endpoints.organization_config_repositories import OrganizationConfigRepositoriesEndpoint
 from .endpoints.organization_repository_commits import OrganizationRepositoryCommitsEndpoint
 from .endpoints.organization_repository_details import OrganizationRepositoryDetailsEndpoint
+<<<<<<< HEAD
 from .endpoints.organization_sentry_app_installations import OrganizationSentryAppInstallationsEndpoint
+=======
+from .endpoints.organizattion_sentry_app_installation_details import OrganizationSentryAppInstallationDetailsEndpoint
+>>>>>>> feat(app-platform): Add sentry app install details endpoint
 from .endpoints.organization_stats import OrganizationStatsEndpoint
 from .endpoints.organization_teams import OrganizationTeamsEndpoint
 from .endpoints.organization_user_issues import OrganizationUserIssuesEndpoint
@@ -611,6 +615,11 @@ urlpatterns = patterns(
         r'^organizations/(?P<organization_slug>[^\/]+)/sentry-app-installations/$',
         OrganizationSentryAppInstallationsEndpoint.as_view(),
         name='sentry-api-0-organization-sentry-app-installations'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/sentry-app-installation/(?P<uuid>[^/]+)/$',
+        OrganizationSentryAppInstallationDetailsEndpoint.as_view(),
+        name='sentry-api-0-organization-sentry-app-installation-details'
     ),
     url(
         r'^organizations/(?P<organization_slug>[^\/]+)/stats/$',

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -614,9 +614,9 @@ urlpatterns = patterns(
         name='sentry-api-0-organization-sentry-app-installations'
     ),
     url(
-        r'^organizations/(?P<organization_slug>[^\/]+)/sentry-app-installation/(?P<uuid>[^/]+)/$',
+        r'^organizations/(?P<organization_slug>[^\/]+)/sentry-app-installations/(?P<uuid>[^/]+)/$',
         OrganizationSentryAppInstallationDetailsEndpoint.as_view(),
-        name='sentry-api-0-organization-sentry-app-installation-details'
+        name='sentry-api-0-organization-sentry-app-installations-details'
     ),
     url(
         r'^organizations/(?P<organization_slug>[^\/]+)/stats/$',

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -1,0 +1,104 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from sentry.constants import SentryAppStatus
+from sentry.testutils import APITestCase
+from sentry.testutils.helpers import with_feature
+from sentry.mediators.sentry_apps import Creator as SentryAppCreator
+from sentry.mediators.sentry_app_installations import Creator
+
+
+class OrganizationSentryAppInstallationDetailsTest(APITestCase):
+    def setUp(self):
+        self.superuser = self.create_user(email='a@example.com', is_superuser=True)
+        self.user = self.create_user(email='boop@example.com')
+        self.org = self.create_organization(owner=self.user)
+        self.super_org = self.create_organization(owner=self.superuser)
+        self.published_app = SentryAppCreator.run(
+            name='Test',
+            organization=self.super_org,
+            scopes=(),
+            webhook_url='https://example.com',
+        )
+        self.published_app.update(status=SentryAppStatus.PUBLISHED)
+        self.installation, _ = Creator.run(
+            slug=self.published_app.slug,
+            organization=self.super_org,
+        )
+        self.unpublished_app = SentryAppCreator.run(
+            name='Testin',
+            organization=self.org,
+            scopes=(),
+            webhook_url='https://example.com',
+        )
+        self.installation2, _ = Creator.run(
+            slug=self.unpublished_app.slug,
+            organization=self.org,
+        )
+        self.url = reverse(
+            'sentry-api-0-organization-sentry-app-installation-details',
+            args=[
+                self.org.slug,
+                self.installation2.uuid,
+            ])
+
+
+class GetOrganizationSentryAppInstallationDetailsTest(OrganizationSentryAppInstallationDetailsTest):
+    @with_feature('organizations:internal-catchall')
+    def test_access_within_installs_organization(self):
+        self.login_as(user=self.user)
+        response = self.client.get(self.url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert response.data == {
+            'app': self.unpublished_app.slug,
+            'organization': self.org.slug,
+            'uuid': self.installation2.uuid,
+        }
+
+    @with_feature('organizations:internal-catchall')
+    def test_no_access_outside_install_organization(self):
+        self.login_as(user=self.user)
+        url = reverse(
+            'sentry-api-0-organization-sentry-app-installation-details',
+            args=[self.org.slug, self.installation.uuid],
+        )
+        response = self.client.get(url, format='json')
+        assert response.status_code == 404
+
+        url = reverse(
+            'sentry-api-0-organization-sentry-app-installation-details',
+            args=[self.super_org.slug, self.installation2.uuid],
+        )
+        response = self.client.get(url, format='json')
+        assert response.status_code == 403
+
+    def test_no_access_without_internal_catchall(self):
+        self.login_as(user=self.user)
+
+        response = self.client.get(self.url, format='json')
+        assert response.status_code == 404
+
+
+class DeleteOrganizationSentryAppInstallationDetailsTest(
+        OrganizationSentryAppInstallationDetailsTest):
+    @with_feature('organizations:internal-catchall')
+    def test_delete_install(self):
+        self.login_as(user=self.user)
+        response = self.client.delete(self.url, format='json')
+
+        assert response.status_code == 200
+
+    @with_feature('organizations:internal-catchall')
+    def test_member_cannot_delete_install(self):
+        user = self.create_user('bar@example.com')
+        self.create_member(
+            organization=self.org,
+            user=user,
+            role='member',
+        )
+        self.login_as(user)
+        response = self.client.delete(self.url, format='json')
+
+        assert response.status_code == 403

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -37,7 +37,7 @@ class OrganizationSentryAppInstallationDetailsTest(APITestCase):
             organization=self.org,
         )
         self.url = reverse(
-            'sentry-api-0-organization-sentry-app-installation-details',
+            'sentry-api-0-organization-sentry-app-installations-details',
             args=[
                 self.org.slug,
                 self.installation2.uuid,
@@ -61,14 +61,14 @@ class GetOrganizationSentryAppInstallationDetailsTest(OrganizationSentryAppInsta
     def test_no_access_outside_install_organization(self):
         self.login_as(user=self.user)
         url = reverse(
-            'sentry-api-0-organization-sentry-app-installation-details',
+            'sentry-api-0-organization-sentry-app-installations-details',
             args=[self.org.slug, self.installation.uuid],
         )
         response = self.client.get(url, format='json')
         assert response.status_code == 404
 
         url = reverse(
-            'sentry-api-0-organization-sentry-app-installation-details',
+            'sentry-api-0-organization-sentry-app-installations-details',
             args=[self.super_org.slug, self.installation2.uuid],
         )
         response = self.client.get(url, format='json')
@@ -88,7 +88,7 @@ class DeleteOrganizationSentryAppInstallationDetailsTest(
         self.login_as(user=self.user)
         response = self.client.delete(self.url, format='json')
 
-        assert response.status_code == 200
+        assert response.status_code == 204
 
     @with_feature('organizations:internal-catchall')
     def test_member_cannot_delete_install(self):


### PR DESCRIPTION
* Adds `GET` and `DELETE` endpoints for a sentry app installation. (Didn't think we need edit yet?)
  * Inherits from `OrganizationEndpoint` so scopes should be the same on who can delete (`owners` only)
