### PR TITLE
fix(snuba): Do not use Environment.project_id for project_id filtering

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -434,7 +434,6 @@ def get_related_project_ids(column, ids):
     Get the project_ids from a model that has a foreign key to project.
     """
     mappings = {
-        'environment': (Environment, 'id', 'project_id'),
         'issue': (Group, 'id', 'project_id'),
         'tags[sentry:release]': (ReleaseProject, 'release_id', 'project_id'),
     }


### PR DESCRIPTION
This column (`Environment.project_id`) is no longer set/updated by the application, and using it's value as a query filter can result in an incorrect query by either filtering by the incorrect project ID, or attempting to filter by a project no longer exists in the database: https://github.com/getsentry/sentry/blob/bca953f2a8babfaf0d265171dbf3a14b7337fea9/src/sentry/models/environment.py#L43-L44