### PR TITLE
fix(require-2fa): Fix load organization context

### DIFF
--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -132,6 +132,12 @@ class OrganizationIndexEndpoint(Endpoint):
                         ])
                     except KeyError:
                         queryset = queryset.none()
+                elif key == 'member_id':
+                    queryset = queryset.filter(
+                        id__in=OrganizationMember.objects.filter(
+                            id__in=value,
+                        ).values('organization'),
+                    )
                 else:
                     queryset = queryset.none()
 

--- a/src/sentry/static/sentry/app/actionCreators/organizations.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/organizations.jsx
@@ -60,15 +60,15 @@ export function updateOrganization(org) {
   OrganizationsActions.update(org);
 }
 
-export function fetchOrganizationsByMember(memberId, {setActive}) {
+export function fetchOrganizationByMember(memberId, {loadOrg, setActive}) {
   let api = new Client();
-  let request = api.requestPromise('/organizations/', {
-    query: {
-      member: memberId,
-    },
-  });
+  let request = api.requestPromise(`/organizations/?query=member_id:${memberId}`);
 
   request.then(data => {
+    if (data.length && loadOrg) {
+      OrganizationsStore.add(data[0]);
+    }
+
     if (data.length && setActive) {
       setActiveOrganization(data[0]);
     }

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.jsx
@@ -12,7 +12,7 @@ import {
 } from 'app/actionCreators/indicator';
 import {t} from 'app/locale';
 import {openRecoveryOptions} from 'app/actionCreators/modal';
-import {fetchOrganizationsByMember} from 'app/actionCreators/organizations';
+import {fetchOrganizationByMember} from 'app/actionCreators/organizations';
 import AsyncView from 'app/views/asyncView';
 import Button from 'app/components/button';
 import CircleIndicator from 'app/components/circleIndicator';
@@ -142,7 +142,8 @@ class AccountSecurityEnroll extends AsyncView {
 
   loadOrganizationContext = () => {
     if (this.invite && this.invite.memberId) {
-      fetchOrganizationsByMember(this.invite.memberId, {
+      fetchOrganizationByMember(this.invite.memberId, {
+        loadOrg: true,
         setActive: true,
       });
     }


### PR DESCRIPTION
Added a member_id query to the organizations endpoint, so after a pending invite is accepted the organization can be loaded into context and set as active. Fix from #10069 