### PR TITLE
ref(releases) Remove unused PullRequestCommit class

### DIFF
--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function
 
-from django.db import models, transaction
+from django.db import models
 from django.utils import timezone
 
 from sentry.db.models import (BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr)
@@ -33,32 +33,3 @@ class PullRequest(Model):
     def find_referenced_groups(self):
         text = u'{} {}'.format(self.message, self.title)
         return find_referenced_groups(text, self.organization_id)
-
-    def set_commits(self, commit_list):
-        with transaction.atomic():
-            PullRequestCommit.objects.filter(
-                pull_request=self,
-            ).exclude(
-                commit__in=commit_list,
-            ).delete()
-            existing = set(PullRequestCommit.objects.filter(
-                pull_request=self,
-            ).values_list('commit', flat=True))
-            commits_missing = [c for c in commit_list if c.id not in existing]
-            for commit in commits_missing:
-                PullRequestCommit.objects.create(
-                    pull_request=self,
-                    commit=commit,
-                )
-
-
-class PullRequestCommit(Model):
-    __core__ = False
-
-    pull_request = FlexibleForeignKey('sentry.PullRequest')
-    commit = FlexibleForeignKey('sentry.Commit')
-
-    class Meta:
-        app_label = 'sentry'
-        db_table = 'sentry_pullrequest_commit'
-        unique_together = (('pull_request', 'commit'), )

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -33,3 +33,14 @@ class PullRequest(Model):
     def find_referenced_groups(self):
         text = u'{} {}'.format(self.message, self.title)
         return find_referenced_groups(text, self.organization_id)
+
+
+class PullRequestCommit(Model):
+    __core__ = False
+    pull_request = FlexibleForeignKey('sentry.PullRequest')
+    commit = FlexibleForeignKey('sentry.Commit')
+
+    class Meta:
+        app_label = 'sentry'
+        db_table = 'sentry_pullrequest_commit'
+        unique_together = (('pull_request', 'commit'), )

--- a/tests/sentry/models/test_pullrequest.py
+++ b/tests/sentry/models/test_pullrequest.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from hashlib import sha1
 from uuid import uuid4
 
-from sentry.models import Commit, Repository, PullRequest, PullRequestCommit
+from sentry.models import Commit, Repository, PullRequest
 from sentry.testutils import TestCase
 
 
@@ -43,69 +43,3 @@ class FindReferencedGroupsTest(TestCase):
         groups = pr.find_referenced_groups()
         assert len(groups) == 1
         assert group2 in groups
-
-
-class SetCommitsTest(TestCase):
-    def test_simple(self):
-        org = self.organization
-
-        repo = Repository.objects.create(
-            name='example',
-            organization_id=org.id,
-        )
-
-        commit = Commit.objects.create(
-            key=sha1(uuid4().hex).hexdigest(),
-            repository_id=repo.id,
-            organization_id=org.id,
-            message='',
-        )
-        commit2 = Commit.objects.create(
-            key=sha1(uuid4().hex).hexdigest(),
-            repository_id=repo.id,
-            organization_id=org.id,
-            message='',
-        )
-        commit3 = Commit.objects.create(
-            key=sha1(uuid4().hex).hexdigest(),
-            repository_id=repo.id,
-            organization_id=org.id,
-            message='',
-        )
-
-        pr = PullRequest.objects.create(
-            key='1',
-            repository_id=repo.id,
-            organization_id=org.id,
-            title='',
-            message=''
-        )
-
-        # add initial commits
-        pr.set_commits([commit, commit2])
-
-        pr_commits = set(PullRequestCommit.objects.filter(
-            pull_request=pr,
-        ).values_list('commit', flat=True))
-        assert len(pr_commits) == 2
-        assert commit.id in pr_commits
-        assert commit2.id in pr_commits
-
-        # add a commit
-        pr.set_commits([commit, commit2, commit3])
-        pr_commits = set(PullRequestCommit.objects.filter(
-            pull_request=pr,
-        ).values_list('commit', flat=True))
-        assert len(pr_commits) == 3
-        assert commit.id in pr_commits
-        assert commit2.id in pr_commits
-        assert commit3.id in pr_commits
-
-        # remove a commit
-        pr.set_commits([commit2, commit3])
-        pr_commits = set(PullRequestCommit.objects.filter(
-            pull_request=pr,
-        ).values_list('commit', flat=True))
-        assert len(pr_commits) == 2
-        assert commit2.id in pr_commits
-        assert commit3.id in pr_commits


### PR DESCRIPTION
This class was added several months back but is *never* called in the application code. The table contains 0 rows in production making me pretty confident that this is an unused code path.