### PR TITLE
feat: Add new reappeared_event event type

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -148,6 +148,7 @@ SENTRY_RULES = (
     'sentry.rules.conditions.every_event.EveryEventCondition',
     'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition',
     'sentry.rules.conditions.regression_event.RegressionEventCondition',
+    'sentry.rules.conditions.reappeared_event.ReappearedEventCondition',
     'sentry.rules.conditions.tagged_event.TaggedEventCondition',
     'sentry.rules.conditions.event_frequency.EventFrequencyCondition',
     'sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition',

--- a/src/sentry/rules/base.py
+++ b/src/sentry/rules/base.py
@@ -101,7 +101,8 @@ class RuleBase(object):
 
 
 class EventState(object):
-    def __init__(self, is_new, is_regression, is_new_group_environment):
+    def __init__(self, is_new, is_regression, is_new_group_environment, has_reappeared):
         self.is_new = is_new
         self.is_regression = is_regression
         self.is_new_group_environment = is_new_group_environment
+        self.has_reappeared = has_reappeared

--- a/src/sentry/rules/conditions/reappeared_event.py
+++ b/src/sentry/rules/conditions/reappeared_event.py
@@ -1,0 +1,18 @@
+"""
+sentry.rules.conditions.reappeared_event
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+
+from __future__ import absolute_import
+
+from sentry.rules.conditions.base import EventCondition
+
+
+class ReappearedEventCondition(EventCondition):
+    label = 'An issue changes state from ignored to unresolved'
+
+    def passes(self, event, state):
+        return state.has_reappeared

--- a/src/sentry/rules/processor.py
+++ b/src/sentry/rules/processor.py
@@ -37,7 +37,7 @@ class EventCompatibilityProxy(object):
 class RuleProcessor(object):
     logger = logging.getLogger('sentry.rules')
 
-    def __init__(self, event, is_new, is_regression, is_new_group_environment):
+    def __init__(self, event, is_new, is_regression, is_new_group_environment, has_reappeared):
         self.event = EventCompatibilityProxy(event)
         self.group = event.group
         self.project = event.project
@@ -45,6 +45,7 @@ class RuleProcessor(object):
         self.is_new = is_new
         self.is_regression = is_regression
         self.is_new_group_environment = is_new_group_environment
+        self.has_reappeared = has_reappeared
 
         self.grouped_futures = {}
 
@@ -76,6 +77,7 @@ class RuleProcessor(object):
             is_new=self.is_new,
             is_regression=self.is_regression,
             is_new_group_environment=self.is_new_group_environment,
+            has_reappeared=self.has_reappeared,
         )
 
     def apply_rule(self, rule):

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -563,6 +563,7 @@ class RuleTestCase(TestCase):
         kwargs.setdefault('is_new', True)
         kwargs.setdefault('is_regression', True)
         kwargs.setdefault('is_new_group_environment', True)
+        kwargs.setdefault('has_reappeared', True)
         return EventState(**kwargs)
 
     def assertPasses(self, rule, event=None, **kwargs):

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -24,4 +24,4 @@ class ProjectRuleConfigurationTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data['actions']) == 3
-        assert len(response.data['conditions']) == 8
+        assert len(response.data['conditions']) == 9

--- a/tests/sentry/rules/conditions/test_reappeared_event.py
+++ b/tests/sentry/rules/conditions/test_reappeared_event.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import
+
+from sentry.testutils.cases import RuleTestCase
+from sentry.rules.conditions.reappeared_event import ReappearedEventCondition
+
+
+class ReappearedEventConditionTest(RuleTestCase):
+    rule_cls = ReappearedEventCondition
+
+    def test_applies_correctly(self):
+        rule = self.get_rule()
+
+        self.assertPasses(rule, self.event, has_reappeared=True)
+
+        self.assertDoesNotPass(rule, self.event, has_reappeared=False)

--- a/tests/sentry/rules/test_processor.py
+++ b/tests/sentry/rules/test_processor.py
@@ -32,7 +32,12 @@ class RuleProcessorTest(TestCase):
             }
         )
 
-        rp = RuleProcessor(event, is_new=True, is_regression=True, is_new_group_environment=True)
+        rp = RuleProcessor(
+            event,
+            is_new=True,
+            is_regression=True,
+            is_new_group_environment=True,
+            has_reappeared=True)
         results = list(rp.apply())
         assert len(results) == 1
         callback, futures = results[0]


### PR DESCRIPTION
At Flexport, we rely heavily on Sentry's webhook notification functionality to perform alert dispatching across teams and through numerous systems. Lately, our error volume has become so high that it's difficult for us to keep up, even though most of the errors are noise. We'd love to leverage Sentry's Ignore functionality, but it is currently not possible to trigger an alert based on an error coming out of Ignored state.

This PR adds a new alert rule that fires an alert when events transition from the "Ignored" state to the "unresolved" state.

Apologies if I missed something obvious when creating this PR! I had a lot of fun diving into your codebase, but it's a lot to take in!

## Screenshot

![image](https://user-images.githubusercontent.com/61138/47169419-506df900-d2b8-11e8-8212-07a289a1e9ca.png)
