### PR TITLE
feat(ui): Change avatar loading placeholder to be dark bg friendly

### DIFF
--- a/src/sentry/static/sentry/app/components/avatar/baseAvatar.jsx
+++ b/src/sentry/static/sentry/app/components/avatar/baseAvatar.jsx
@@ -62,6 +62,7 @@ class BaseAvatar extends React.Component {
 
     this.state = {
       showBackupAvatar: false,
+      hasLoaded: props.type !== 'upload',
       loadError: false,
     };
   }
@@ -87,11 +88,11 @@ class BaseAvatar extends React.Component {
   };
 
   handleLoad = () => {
-    this.setState({showBackupAvatar: false});
+    this.setState({showBackupAvatar: false, hasLoaded: true});
   };
 
   handleError = () => {
-    this.setState({showBackupAvatar: true, loadError: true});
+    this.setState({showBackupAvatar: true, loadError: true, hasLoaded: true});
   };
 
   renderImg = () => {
@@ -144,6 +145,7 @@ class BaseAvatar extends React.Component {
     return (
       <Tooltip title={tooltip} tooltipOptions={tooltipOptions} disabled={!hasTooltip}>
         <StyledBaseAvatar
+          loaded={this.state.hasLoaded}
           className={classNames('avatar', className)}
           round={round}
           style={{
@@ -165,7 +167,7 @@ export default BaseAvatar;
 // sensible default.
 const StyledBaseAvatar = styled('span')`
   flex-shrink: 0;
-  background-color: ${p => p.theme.whiteDark};
+  ${p => !p.loaded && 'background-color: rgba(200, 200, 200, 0.1);'};
   ${p => p.round && 'border-radius: 100%;'};
 `;
 

--- a/tests/js/spec/components/avatar/__snapshots__/avatarList.spec.jsx.snap
+++ b/tests/js/spec/components/avatar/__snapshots__/avatarList.spec.jsx.snap
@@ -212,6 +212,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                 >
                   <StyledBaseAvatar
                     className="tip avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                    loaded={true}
                     round={true}
                     style={
                       Object {
@@ -222,7 +223,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                     title="Foo Bar (foo@example.com)"
                   >
                     <span
-                      className="tip avatar e1axh4r50 css-1t1vzng-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                      className="tip avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
                       style={
                         Object {
                           "height": "28px",
@@ -360,6 +361,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                 >
                   <StyledBaseAvatar
                     className="tip avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                    loaded={true}
                     round={true}
                     style={
                       Object {
@@ -370,7 +372,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                     title="Foo Bar (foo@example.com)"
                   >
                     <span
-                      className="tip avatar e1axh4r50 css-1t1vzng-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                      className="tip avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
                       style={
                         Object {
                           "height": "28px",
@@ -508,6 +510,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                 >
                   <StyledBaseAvatar
                     className="tip avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                    loaded={true}
                     round={true}
                     style={
                       Object {
@@ -518,7 +521,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                     title="Foo Bar (foo@example.com)"
                   >
                     <span
-                      className="tip avatar e1axh4r50 css-1t1vzng-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                      className="tip avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
                       style={
                         Object {
                           "height": "28px",
@@ -656,6 +659,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                 >
                   <StyledBaseAvatar
                     className="tip avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                    loaded={true}
                     round={true}
                     style={
                       Object {
@@ -666,7 +670,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                     title="Foo Bar (foo@example.com)"
                   >
                     <span
-                      className="tip avatar e1axh4r50 css-1t1vzng-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                      className="tip avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
                       style={
                         Object {
                           "height": "28px",
@@ -804,6 +808,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                 >
                   <StyledBaseAvatar
                     className="tip avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                    loaded={true}
                     round={true}
                     style={
                       Object {
@@ -814,7 +819,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                     title="Foo Bar (foo@example.com)"
                   >
                     <span
-                      className="tip avatar e1axh4r50 css-1t1vzng-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                      className="tip avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
                       style={
                         Object {
                           "height": "28px",
@@ -1007,6 +1012,7 @@ exports[`AvatarList renders with user avatars 1`] = `
                 >
                   <StyledBaseAvatar
                     className="tip avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                    loaded={true}
                     round={true}
                     style={
                       Object {
@@ -1017,7 +1023,7 @@ exports[`AvatarList renders with user avatars 1`] = `
                     title="Foo Bar (foo@example.com)"
                   >
                     <span
-                      className="tip avatar e1axh4r50 css-1t1vzng-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                      className="tip avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
                       style={
                         Object {
                           "height": "28px",
@@ -1155,6 +1161,7 @@ exports[`AvatarList renders with user avatars 1`] = `
                 >
                   <StyledBaseAvatar
                     className="tip avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                    loaded={true}
                     round={true}
                     style={
                       Object {
@@ -1165,7 +1172,7 @@ exports[`AvatarList renders with user avatars 1`] = `
                     title="Foo Bar (foo@example.com)"
                   >
                     <span
-                      className="tip avatar e1axh4r50 css-1t1vzng-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                      className="tip avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
                       style={
                         Object {
                           "height": "28px",

--- a/tests/js/spec/components/group/__snapshots__/suggestedOwners.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/suggestedOwners.spec.jsx.snap
@@ -106,11 +106,12 @@ exports[`SuggestedOwners render() should not show owners committers without feat
                   >
                     <StyledBaseAvatar
                       className="avatar tip"
+                      loaded={true}
                       round={true}
                       style={Object {}}
                     >
                       <span
-                        className="avatar tip css-1ttlt2k-StyledBaseAvatar e1z0ohzl0"
+                        className="avatar tip css-3f9bmx-StyledBaseAvatar e1z0ohzl0"
                         style={Object {}}
                       >
                         <LetterAvatar
@@ -316,11 +317,12 @@ exports[`SuggestedOwners render() should show owners when enable 1`] = `
                   >
                     <StyledBaseAvatar
                       className="avatar tip"
+                      loaded={true}
                       round={true}
                       style={Object {}}
                     >
                       <span
-                        className="avatar tip css-1ttlt2k-StyledBaseAvatar e1z0ohzl0"
+                        className="avatar tip css-3f9bmx-StyledBaseAvatar e1z0ohzl0"
                         style={Object {}}
                       >
                         <LetterAvatar

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -287,6 +287,7 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                 >
                   <StyledBaseAvatar
                     className="avatar css-6su6fj"
+                    loaded={true}
                     style={
                       Object {
                         "height": "36px",
@@ -295,7 +296,7 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                     }
                   >
                     <span
-                      className="avatar css-1muke4e-StyledBaseAvatar e1z0ohzl0"
+                      className="avatar css-1ezk8y8-StyledBaseAvatar e1z0ohzl0"
                       style={
                         Object {
                           "height": "36px",
@@ -742,6 +743,7 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                                     >
                                       <StyledBaseAvatar
                                         className="avatar css-1u6j7yz-StyledAvatar ev46mzr4"
+                                        loaded={true}
                                         round={true}
                                         style={
                                           Object {
@@ -751,7 +753,7 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                                         }
                                       >
                                         <span
-                                          className="avatar ev46mzr4 css-l5crk4-StyledBaseAvatar-StyledAvatar e1z0ohzl0"
+                                          className="avatar ev46mzr4 css-wxw9er-StyledBaseAvatar-StyledAvatar e1z0ohzl0"
                                           style={
                                             Object {
                                               "height": "32px",
@@ -1905,6 +1907,7 @@ exports[`Sidebar renders without org and router 1`] = `
                                     >
                                       <StyledBaseAvatar
                                         className="avatar css-1u6j7yz-StyledAvatar ev46mzr4"
+                                        loaded={true}
                                         round={true}
                                         style={
                                           Object {
@@ -1914,7 +1917,7 @@ exports[`Sidebar renders without org and router 1`] = `
                                         }
                                       >
                                         <span
-                                          className="avatar ev46mzr4 css-l5crk4-StyledBaseAvatar-StyledAvatar e1z0ohzl0"
+                                          className="avatar ev46mzr4 css-wxw9er-StyledBaseAvatar-StyledAvatar e1z0ohzl0"
                                           style={
                                             Object {
                                               "height": "32px",

--- a/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
@@ -24,7 +24,7 @@ exports[`OrganizationDetails render() deletion in progress should render a delet
               style="display:flex;align-items:flex-start"
             >
               <span
-                class="avatar e1fowdfw8 css-yd0wz3-StyledBaseAvatar-StyledAvatar e1z0ohzl0"
+                class="avatar e1fowdfw8 css-tmrp5m-StyledBaseAvatar-StyledAvatar e1z0ohzl0"
                 style="width:32px;height:32px"
               >
                 <svg
@@ -461,7 +461,7 @@ exports[`OrganizationDetails render() pending deletion should render a restorati
               style="display:flex;align-items:flex-start"
             >
               <span
-                class="avatar e1fowdfw8 css-yd0wz3-StyledBaseAvatar-StyledAvatar e1z0ohzl0"
+                class="avatar e1fowdfw8 css-tmrp5m-StyledBaseAvatar-StyledAvatar e1z0ohzl0"
                 style="width:32px;height:32px"
               >
                 <svg
@@ -925,7 +925,7 @@ exports[`OrganizationDetails render() pending deletion should render a restorati
               style="display:flex;align-items:flex-start"
             >
               <span
-                class="avatar e1fowdfw8 css-yd0wz3-StyledBaseAvatar-StyledAvatar e1z0ohzl0"
+                class="avatar e1fowdfw8 css-tmrp5m-StyledBaseAvatar-StyledAvatar e1z0ohzl0"
                 style="width:32px;height:32px"
               >
                 <svg

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -2614,6 +2614,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                               >
                                                 <StyledBaseAvatar
                                                   className="tip avatar"
+                                                  loaded={true}
                                                   round={true}
                                                   style={
                                                     Object {
@@ -2624,7 +2625,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                                   title="Jane Doe (janedoe@example.com)"
                                                 >
                                                   <span
-                                                    className="tip avatar css-1ttlt2k-StyledBaseAvatar e1z0ohzl0"
+                                                    className="tip avatar css-3f9bmx-StyledBaseAvatar e1z0ohzl0"
                                                     style={
                                                       Object {
                                                         "height": "28px",


### PR DESCRIPTION
Previously the placeholder was a solid white-ish. Now it has transparency so it blends better into darker backgrounds.

Old:
https://cl.ly/b82abd8887c0

New:
https://cl.ly/7fc1da5200d0

WhiteBG:
https://cl.ly/cb40cbcc9cb0