### PR TITLE
ref(discover): Refactor query fields to accept custom actions

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -17,7 +17,7 @@ import TimeRangeSelector from 'app/components/organizations/timeRangeSelector';
 import Result from './result';
 import Intro from './intro';
 import EarlyAdopterMessage from './earlyAdopterMessage';
-import QueryFields from './sidebar/queryFields';
+import NewQuery from './sidebar/newQuery';
 import QueryRead from './sidebar/queryRead';
 import SavedQueryList from './sidebar/savedQueryList';
 
@@ -338,24 +338,12 @@ export default class OrganizationDiscover extends React.Component {
             />
           )}
           {shouldRenderEditMode && (
-            <QueryFields
+            <NewQuery
               queryBuilder={queryBuilder}
               isFetchingQuery={isFetchingQuery}
               onUpdateField={this.updateField}
-              actions={[
-                {
-                  title: t('Run'),
-                  onClick: this.runQuery,
-                  priority: 'primary',
-                  align: 'left',
-                  isBusy: isFetchingQuery,
-                },
-                {
-                  title: t('Reset'),
-                  onClick: this.reset,
-                  align: 'left',
-                },
-              ]}
+              onRunQuery={this.runQuery}
+              onReset={this.reset}
             />
           )}
           {shouldRenderSavedList && <SavedQueryList organization={organization} />}

--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -17,7 +17,7 @@ import TimeRangeSelector from 'app/components/organizations/timeRangeSelector';
 import Result from './result';
 import Intro from './intro';
 import EarlyAdopterMessage from './earlyAdopterMessage';
-import QueryEdit from './sidebar/queryEdit';
+import QueryFields from './sidebar/queryFields';
 import QueryRead from './sidebar/queryRead';
 import SavedQueryList from './sidebar/savedQueryList';
 
@@ -338,12 +338,24 @@ export default class OrganizationDiscover extends React.Component {
             />
           )}
           {shouldRenderEditMode && (
-            <QueryEdit
+            <QueryFields
               queryBuilder={queryBuilder}
               isFetchingQuery={isFetchingQuery}
               onUpdateField={this.updateField}
-              onRunQuery={this.runQuery}
-              reset={this.reset}
+              actions={[
+                {
+                  title: t('Run'),
+                  onClick: this.runQuery,
+                  priority: 'primary',
+                  align: 'left',
+                  isBusy: isFetchingQuery,
+                },
+                {
+                  title: t('Reset'),
+                  onClick: this.reset,
+                  align: 'left',
+                },
+              ]}
             />
           )}
           {shouldRenderSavedList && <SavedQueryList organization={organization} />}

--- a/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/newQuery.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/newQuery.jsx
@@ -1,0 +1,46 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {Flex, Box} from 'grid-emotion';
+
+import Button from 'app/components/button';
+import {t} from 'app/locale';
+
+import QueryFields from './queryFields';
+import {ButtonSpinner} from '../styles';
+
+export default class NewQuery extends React.Component {
+  static propTypes = {
+    onRunQuery: PropTypes.func.isRequired,
+    onReset: PropTypes.func.isRequired,
+    isFetchingQuery: PropTypes.bool.isRequired,
+  };
+
+  render() {
+    const {onRunQuery, onReset, isFetchingQuery, ...props} = this.props;
+    return (
+      <QueryFields
+        {...props}
+        actions={
+          <Flex>
+            <Box mr={1}>
+              <Button
+                size="xsmall"
+                onClick={onRunQuery}
+                priority="primary"
+                busy={isFetchingQuery}
+              >
+                {t('Run Query')}
+                {isFetchingQuery && <ButtonSpinner />}
+              </Button>
+            </Box>
+            <Box>
+              <Button size="xsmall" onClick={onReset}>
+                {t('Reset')}
+              </Button>
+            </Box>
+          </Flex>
+        }
+      />
+    );
+  }
+}

--- a/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/queryFields.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/queryFields.jsx
@@ -12,13 +12,19 @@ import Conditions from '../conditions';
 import {getOrderByOptions} from '../utils';
 import {Fieldset, PlaceholderText, SidebarLabel, ButtonSpinner} from '../styles';
 
-export default class QueryEdit extends React.Component {
+export default class QueryFields extends React.Component {
   static propTypes = {
     queryBuilder: PropTypes.object.isRequired,
-    isFetchingQuery: PropTypes.bool.isRequired,
     onUpdateField: PropTypes.func.isRequired,
-    onRunQuery: PropTypes.func.isRequired,
-    reset: PropTypes.func.isRequired,
+    actions: PropTypes.arrayOf(
+      PropTypes.shape({
+        title: PropTypes.node.isRequired,
+        priority: PropTypes.string,
+        align: PropTypes.oneOf(['left', 'right']).isRequired,
+        onClick: PropTypes.func.isRequired,
+        isBusy: PropTypes.bool,
+      })
+    ).isRequired,
   };
 
   getSummarizePlaceholder = () => {
@@ -31,8 +37,31 @@ export default class QueryEdit extends React.Component {
     return <PlaceholderText>{text}</PlaceholderText>;
   };
 
+  renderAction(direction) {
+    const boxProps = {
+      mr: direction === 'left' ? 1 : 0,
+      ml: direction === 'right' ? 1 : 0,
+    };
+
+    return function renderAction(action, idx) {
+      return (
+        <Box key={idx} {...boxProps}>
+          <Button
+            size="xsmall"
+            onClick={action.onClick}
+            priority={action.priority}
+            busy={action.isBusy}
+          >
+            {action.title}
+            {action.isBusy && <ButtonSpinner />}
+          </Button>
+        </Box>
+      );
+    };
+  }
+
   render() {
-    const {queryBuilder, isFetchingQuery, onUpdateField, onRunQuery, reset} = this.props;
+    const {queryBuilder, onUpdateField, actions} = this.props;
 
     const currentQuery = queryBuilder.getInternal();
     const columns = queryBuilder.getColumns();
@@ -45,6 +74,9 @@ export default class QueryEdit extends React.Component {
       value: name,
       label: name,
     }));
+
+    const leftActions = actions.filter(action => action.align === 'left');
+    const rightActions = actions.filter(action => action.align === 'right');
 
     return (
       <React.Fragment>
@@ -99,21 +131,9 @@ export default class QueryEdit extends React.Component {
           />
         </Fieldset>
         <Fieldset>
-          <Flex>
-            <Button
-              size="xsmall"
-              onClick={onRunQuery}
-              priority="primary"
-              busy={isFetchingQuery}
-            >
-              {t('Run')}
-              {isFetchingQuery && <ButtonSpinner />}
-            </Button>
-            <Box ml={1}>
-              <Button size="xsmall" onClick={reset}>
-                {t('Reset')}
-              </Button>
-            </Box>
+          <Flex justify="space-between">
+            <Flex>{leftActions.map(this.renderAction('left'))}</Flex>
+            <Flex>{rightActions.map(this.renderAction('right'))}</Flex>
           </Flex>
         </Fieldset>
       </React.Fragment>

--- a/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/queryFields.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/queryFields.jsx
@@ -1,30 +1,20 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Flex, Box} from 'grid-emotion';
 
 import {t} from 'app/locale';
-import Button from 'app/components/button';
 import NumberField from 'app/components/forms/numberField';
 import SelectControl from 'app/components/forms/selectControl';
 
 import Aggregations from '../aggregations';
 import Conditions from '../conditions';
 import {getOrderByOptions} from '../utils';
-import {Fieldset, PlaceholderText, SidebarLabel, ButtonSpinner} from '../styles';
+import {Fieldset, PlaceholderText, SidebarLabel} from '../styles';
 
 export default class QueryFields extends React.Component {
   static propTypes = {
     queryBuilder: PropTypes.object.isRequired,
     onUpdateField: PropTypes.func.isRequired,
-    actions: PropTypes.arrayOf(
-      PropTypes.shape({
-        title: PropTypes.node.isRequired,
-        priority: PropTypes.string,
-        align: PropTypes.oneOf(['left', 'right']).isRequired,
-        onClick: PropTypes.func.isRequired,
-        isBusy: PropTypes.bool,
-      })
-    ).isRequired,
+    actions: PropTypes.node.isRequired,
   };
 
   getSummarizePlaceholder = () => {
@@ -36,29 +26,6 @@ export default class QueryFields extends React.Component {
         : t('No fields selected, showing all');
     return <PlaceholderText>{text}</PlaceholderText>;
   };
-
-  renderAction(direction) {
-    const boxProps = {
-      mr: direction === 'left' ? 1 : 0,
-      ml: direction === 'right' ? 1 : 0,
-    };
-
-    return function renderAction(action, idx) {
-      return (
-        <Box key={idx} {...boxProps}>
-          <Button
-            size="xsmall"
-            onClick={action.onClick}
-            priority={action.priority}
-            busy={action.isBusy}
-          >
-            {action.title}
-            {action.isBusy && <ButtonSpinner />}
-          </Button>
-        </Box>
-      );
-    };
-  }
 
   render() {
     const {queryBuilder, onUpdateField, actions} = this.props;
@@ -74,9 +41,6 @@ export default class QueryFields extends React.Component {
       value: name,
       label: name,
     }));
-
-    const leftActions = actions.filter(action => action.align === 'left');
-    const rightActions = actions.filter(action => action.align === 'right');
 
     return (
       <React.Fragment>
@@ -130,12 +94,7 @@ export default class QueryFields extends React.Component {
             onChange={val => onUpdateField('limit', typeof val === 'number' ? val : null)}
           />
         </Fieldset>
-        <Fieldset>
-          <Flex justify="space-between">
-            <Flex>{leftActions.map(this.renderAction('left'))}</Flex>
-            <Flex>{rightActions.map(this.renderAction('right'))}</Flex>
-          </Flex>
-        </Fieldset>
+        <Fieldset>{actions}</Fieldset>
       </React.Fragment>
     );
   }

--- a/tests/js/spec/views/organizationDiscover/discover.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/discover.spec.jsx
@@ -73,13 +73,13 @@ describe('Discover', function() {
         />,
         TestStubs.routerContext([{organization}])
       );
-      expect(wrapper.find('QueryEdit')).toHaveLength(1);
+      expect(wrapper.find('QueryFields')).toHaveLength(1);
       expect(wrapper.find('QueryRead')).toHaveLength(0);
       wrapper.setProps({
         savedQuery: TestStubs.DiscoverSavedQuery(),
       });
       wrapper.update();
-      expect(wrapper.find('QueryEdit')).toHaveLength(0);
+      expect(wrapper.find('QueryFields')).toHaveLength(0);
       expect(wrapper.find('QueryRead')).toHaveLength(1);
     });
   });
@@ -271,13 +271,13 @@ describe('Discover', function() {
 
     it('toggles edit mode', function() {
       expect(wrapper.find('QueryRead')).toHaveLength(1);
-      expect(wrapper.find('QueryEdit')).toHaveLength(0);
+      expect(wrapper.find('QueryFields')).toHaveLength(0);
       wrapper
         .find('SavedQueryTitle')
         .find('a')
         .simulate('click');
       expect(wrapper.find('QueryRead')).toHaveLength(0);
-      expect(wrapper.find('QueryEdit')).toHaveLength(1);
+      expect(wrapper.find('QueryFields')).toHaveLength(1);
     });
 
     it('delete saved query', function() {
@@ -385,14 +385,14 @@ describe('Discover', function() {
     });
 
     it('toggles sidebar', function() {
-      expect(wrapper.find('QueryEdit')).toHaveLength(1);
+      expect(wrapper.find('QueryFields')).toHaveLength(1);
       expect(wrapper.find('SavedQueries')).toHaveLength(0);
       wrapper
         .find('SidebarTabs')
         .find('a')
         .at(1)
         .simulate('click');
-      expect(wrapper.find('QueryEdit')).toHaveLength(0);
+      expect(wrapper.find('QueryFields')).toHaveLength(0);
       expect(wrapper.find('SavedQueries')).toHaveLength(1);
     });
   });


### PR DESCRIPTION
We'll want to make the actions block of query fields  more customizable since we'll want
to render different variants of this for the new saved search design.

Since we won't have the edit vs read versions of the query component
in future, simply rename QueryEdit to QueryFields