### PR TITLE
feat(UI): flexible sizing for hovercards

### DIFF
--- a/src/sentry/static/sentry/app/components/hovercard.jsx
+++ b/src/sentry/static/sentry/app/components/hovercard.jsx
@@ -10,10 +10,18 @@ class Hovercard extends React.Component {
     containerClassName: PropTypes.string,
     header: PropTypes.node,
     body: PropTypes.node,
+    minHeight: PropTypes.number,
+    minWidth: PropTypes.number,
+    maxWidth: PropTypes.number,
+    dynamicWidth: PropTypes.bool,
   };
 
   static defaultProps = {
     displayTimeout: 100,
+    minWidth: 295,
+    maxWidth: 295,
+    minHeight: 50,
+    dynamicWidth: false,
   };
 
   constructor(...args) {
@@ -54,6 +62,7 @@ class Hovercard extends React.Component {
 
   positionClasses() {
     if (!this.cardElement || !this.state.visible) return {};
+
     const rect = this.cardElement.getBoundingClientRect();
 
     const classes = {
@@ -68,6 +77,71 @@ class Hovercard extends React.Component {
     const currentClasses = intersection(this.cardElement.classList, Object.keys(classes));
 
     return currentClasses.length > 0 ? currentClasses : classes;
+  }
+
+  // figure out if we're dealing with hovercard-left or hovercard-right (in which case we don't
+  // want to center the hovercard) or hovercard or hovercard-bottom (in which case we do)
+  getMargin(classes) {
+    if (!this.cardElement || !this.state.visible) return {};
+
+    const rect = this.cardElement.getBoundingClientRect();
+
+    const rectWidth = this.isMultipleLines() ? rect.width : this.getSingleLineWidth();
+
+    if (classes.indexOf('left') !== -1 || classes.indexOf('right')) {
+      return -rectWidth / 2;
+    } else {
+      return 0;
+    }
+  }
+
+  isMultipleLines() {
+    if (!this.cardElement || !this.state.visible) return {};
+
+    // spans will create a new bounding box for each line of text
+    // if the text wraps, so this is a way to test for text wrapping
+    return this.cardBodySpan.getClientRects().length > 1;
+  }
+
+  //computed styles come back like "10px", so convert to the int 10
+  stylePxToNum(px) {
+    return parseInt(px.slice(0, -2), 10);
+  }
+
+  //this will be the width of the overall hovercard, based on the
+  //contents of the span in the body and all padding/borders around it
+  getSingleLineWidth() {
+    if (!this.cardElement || !this.state.visible) return {};
+
+    const spanStyle = getComputedStyle(this.cardBodySpan);
+    const spanPadding = 2 * this.stylePxToNum(spanStyle.padding);
+    const spanBorder =
+      this.stylePxToNum(spanStyle['border-left-width']) +
+      this.stylePxToNum(spanStyle['border-right-width']);
+
+    const bodyStyle = getComputedStyle(this.cardBody);
+    const bodyPadding = 2 * this.stylePxToNum(bodyStyle.padding);
+    const bodyBorder =
+      this.stylePxToNum(bodyStyle['border-left-width']) +
+      this.stylePxToNum(bodyStyle['border-right-width']);
+
+    const elementStyle = getComputedStyle(this.cardElement);
+    const elementPadding = 2 * this.stylePxToNum(elementStyle.padding);
+    const elementBorder =
+      this.stylePxToNum(elementStyle['border-left-width']) +
+      this.stylePxToNum(elementStyle['border-right-width']);
+
+    const spanWidth = this.cardBodySpan.getBoundingClientRect().width;
+
+    return (
+      spanWidth +
+      spanPadding +
+      spanBorder +
+      bodyPadding +
+      bodyBorder +
+      elementPadding +
+      elementBorder
+    );
   }
 
   render() {
@@ -93,10 +167,28 @@ class Hovercard extends React.Component {
             ref={e => {
               this.cardElement = e;
             }}
+            style={{
+              //if we're not using dynamicWidth or if we are but have multiple lines of text,
+              //then just use the given minWidth
+              minWidth:
+                !this.props.dynamicWidth || this.isMultipleLines()
+                  ? this.props.minWidth
+                  : this.getSingleLineWidth(),
+              maxWidth: this.props.maxWidth,
+              marginLeft: this.getMargin(cx),
+            }}
           >
             <div className="hovercard-hoverlap" />
             {header && <div className="hovercard-header">{header}</div>}
-            {body && <div className="hovercard-body">{body}</div>}
+            {body && (
+              <div
+                className="hovercard-body"
+                ref={e => (this.cardBody = e)}
+                style={{minHeight: this.props.minHeight}}
+              >
+                <span ref={e => (this.cardBodySpan = e)}>{body}</span>
+              </div>
+            )}
           </div>
         )}
       </span>

--- a/src/sentry/static/sentry/app/components/hovercard.jsx
+++ b/src/sentry/static/sentry/app/components/hovercard.jsx
@@ -60,6 +60,13 @@ class Hovercard extends React.Component {
     this.hoverWait = setTimeout(() => this.setState({visible, rendered}), timeout);
   };
 
+  isOneLine() {
+    if (!this.cardElement || !this.state.visible) return null;
+    // spans will create a new bounding box for each line of text
+    // if the text wraps, so this is a way to test for text wrapping
+    return this.cardBodySpan.getClientRects().length <= 1;
+  }
+
   positionClasses() {
     if (!this.cardElement || !this.state.visible) return {};
 
@@ -151,6 +158,7 @@ class Hovercard extends React.Component {
     const containerCx = classNames('hovercard-container', containerClassName);
     const cx = classNames('hovercard', this.positionClasses(), className, {
       'with-header': header,
+      'one-line': this.isOneLine(),
       visible,
     });
 
@@ -181,11 +189,7 @@ class Hovercard extends React.Component {
             <div className="hovercard-hoverlap" />
             {header && <div className="hovercard-header">{header}</div>}
             {body && (
-              <div
-                className="hovercard-body"
-                ref={e => (this.cardBody = e)}
-                style={{minHeight: this.props.minHeight}}
-              >
+              <div className="hovercard-body">
                 <span ref={e => (this.cardBodySpan = e)}>{body}</span>
               </div>
             )}

--- a/src/sentry/static/sentry/less/sentry-hovercard.less
+++ b/src/sentry/static/sentry/less/sentry-hovercard.less
@@ -29,23 +29,43 @@
   // Default align hovercard top-middle
   bottom: 28px;
   left: 50%;
+  transform: translateY(0) translateX(-50%);
+  width: @hovercard-width;
   visibility: hidden;
 
   @keyframes hovercardSlideUp {
     from {
-      transform: translateY(12px);
+      transform: translateY(12px) translateX(-50%);
     }
     to {
-      transform: translateY(0);
+      transform: translateY(0) translateX(-50%);
+    }
+  }
+
+  @keyframes hovercardSlideUpNoCenter {
+    from {
+      transform: translateY(12px) translateX(0);
+    }
+    to {
+      transform: translateY(0) translateX(0);
     }
   }
 
   @keyframes hovercardSlideDown {
     from {
-      transform: translateY(-12px);
+      transform: translateY(-12px) translateX(-50%);
     }
     to {
-      transform: translateY(0);
+      transform: translateY(0) translateX(-50%);
+    }
+  }
+
+  @keyframes hovercardSlideDownNoCenter {
+    from {
+      transform: translateY(-12px) translateX(0);
+    }
+    to {
+      transform: translateY(0) translateX(0);
     }
   }
 
@@ -66,6 +86,11 @@
   &.visible {
     visibility: visible;
     animation-play-state: running;
+  }
+
+  &.one-line {
+    width: auto;
+    white-space: nowrap;
   }
 
   &.hovercard-bottom {
@@ -95,9 +120,20 @@
     }
   }
 
+  &.hovercard-right,
+  &.hovercard-left {
+    transform: translateY(0) translateX(0);
+    animation: hovercardFadeIn 100ms ease-in-out,
+      hovercardSlideDownNoCenter 100ms ease-in-out;
+
+    &.hovercard-bottom {
+      animation: hovercardFadeIn 100ms ease-in-out,
+        hovercardSlideUpNoCenter 100ms ease-in-out;
+    }
+  }
+
   &.hovercard-left {
     left: 0;
-    margin-left: 0;
 
     &:before,
     &:after {
@@ -109,7 +145,6 @@
   &.hovercard-right {
     left: initial;
     right: 0;
-    margin-left: 0;
 
     &:before,
     &:after {

--- a/src/sentry/static/sentry/less/sentry-hovercard.less
+++ b/src/sentry/static/sentry/less/sentry-hovercard.less
@@ -9,7 +9,6 @@
 
 .hovercard {
   @hovercard-padding: 15px;
-  @hovercard-width: 295px;
   border-radius: 4px;
   background-clip: padding-box;
   background: #fff;
@@ -30,8 +29,6 @@
   // Default align hovercard top-middle
   bottom: 28px;
   left: 50%;
-  margin-left: -@hovercard-width / 2;
-  width: @hovercard-width;
   visibility: hidden;
 
   @keyframes hovercardSlideUp {
@@ -174,7 +171,6 @@
 
   .hovercard-body {
     padding: @hovercard-padding;
-    min-height: 50px;
 
     .commit-heading {
       margin: 10px 0;

--- a/tests/js/spec/components/__snapshots__/issueSyncListElement.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/issueSyncListElement.spec.jsx.snap
@@ -6,6 +6,10 @@ exports[`AlertLink renders 1`] = `
     className="css-17m6soy-hoverCardStyles"
     containerClassName="css-1s8b4pt-hoverCardContainer"
     displayTimeout={100}
+    dynamicWidth={false}
+    maxWidth={295}
+    minHeight={50}
+    minWidth={295}
   >
     <IntegrationIcon
       src="icon-github"

--- a/tests/js/spec/components/events/interfaces/__snapshots__/exceptionMechanism.spec.jsx.snap
+++ b/tests/js/spec/components/events/interfaces/__snapshots__/exceptionMechanism.spec.jsx.snap
@@ -47,6 +47,7 @@ exports[`ExceptionMechanism basic attributes should add the help_link to the des
         body="Nothing to see here."
         containerClassName="pill-icon"
         displayTimeout={100}
+        dynamicWidth={false}
         header={
           <span>
             Details
@@ -61,6 +62,9 @@ exports[`ExceptionMechanism basic attributes should add the help_link to the des
             </a>
           </span>
         }
+        maxWidth={295}
+        minHeight={50}
+        minWidth={295}
       >
         <InlineSvg
           size="14px"
@@ -86,12 +90,16 @@ exports[`ExceptionMechanism basic attributes should render a description hoverca
         body="Nothing to see here."
         containerClassName="pill-icon"
         displayTimeout={100}
+        dynamicWidth={false}
         header={
           <span>
             Details
              
           </span>
         }
+        maxWidth={295}
+        minHeight={50}
+        minWidth={295}
       >
         <InlineSvg
           size="14px"

--- a/tests/js/spec/components/group/__snapshots__/externalIssueActions.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/externalIssueActions.spec.jsx.snap
@@ -75,7 +75,11 @@ exports[`ExternalIssueActions with an external issue linked renders 1`] = `
         className="css-17m6soy-hoverCardStyles"
         containerClassName="css-1s8b4pt-hoverCardContainer"
         displayTimeout={100}
+        dynamicWidth={false}
         header="Linked GitHub Integration"
+        maxWidth={295}
+        minHeight={50}
+        minWidth={295}
       >
         <span
           className="hovercard-container css-1s8b4pt-hoverCardContainer"
@@ -277,7 +281,11 @@ exports[`ExternalIssueActions with no external issues linked renders 1`] = `
           className="css-17m6soy-hoverCardStyles"
           containerClassName="css-1s8b4pt-hoverCardContainer"
           displayTimeout={100}
+          dynamicWidth={false}
           header="Linked GitHub Integration"
+          maxWidth={295}
+          minHeight={50}
+          minWidth={295}
         >
           <span
             className="hovercard-container css-1s8b4pt-hoverCardContainer"

--- a/tests/js/spec/views/__snapshots__/groupSimilarView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/groupSimilarView.spec.jsx.snap
@@ -1056,6 +1056,10 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                         />
                       }
                       displayTimeout={100}
+                      dynamicWidth={false}
+                      maxWidth={295}
+                      minHeight={50}
+                      minWidth={295}
                     >
                       <span
                         className="hovercard-container"
@@ -1162,6 +1166,10 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                     <Hovercard
                       body={0}
                       displayTimeout={100}
+                      dynamicWidth={false}
+                      maxWidth={295}
+                      minHeight={50}
+                      minWidth={295}
                     >
                       <span
                         className="hovercard-container"


### PR DESCRIPTION
- Allow hovercards to have specified min and max width, and min height
- Allow hovercards to shrink-to-fit like a tooltip if they only contain one line of text/stuff

Tests not yet written