### PR TITLE
fix(integrations): Some GH events don't have actions

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -53,7 +53,7 @@ class Webhook(object):
             logger.info(
                 'github.missing-integration',
                 extra={
-                    'action': event['action'],
+                    'action': event.get('action'),
                     'repository': event.get('repository'),
                     'external_id': external_id,
                 }


### PR DESCRIPTION
When trying to log info about GH Integrations we try to get the `action` for the event, which in some cases doesn't exist so we are getting a `KeyError`. 

FIXES SENTRY-7VM