### PR TITLE
docs: Link to new Python and JavaScript SDKs in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,11 +26,10 @@ language, in any application.
 
 Official Sentry SDKs
 ~~~~~~~~~~~~~~~~~~~~
-* `JavaScript <https://github.com/getsentry/raven-js>`_
+* `JavaScript <https://github.com/getsentry/sentry-javascript>`_
 * `React-Native <https://github.com/getsentry/react-native-sentry>`_
-* `Python <https://github.com/getsentry/raven-python>`_
+* `Python <https://github.com/getsentry/sentry-python>`_
 * `Ruby <https://github.com/getsentry/raven-ruby>`_
-* `Node <https://github.com/getsentry/raven-node>`_
 * `PHP <https://github.com/getsentry/sentry-php>`_
 * `Go <https://github.com/getsentry/raven-go>`_
 * `Java <https://github.com/getsentry/sentry-java>`_


### PR DESCRIPTION
I took a look at the README and wondered why the linked SDKs for JavaScript (, Node) and Python were the legacy ones. (If there's a reason, please let me know.)

I changed two links and removed the Node link because it would be redundant.