### PR TITLE
fix(ui) Don't stick a DOMEvent in the URL

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegration.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegration.jsx
@@ -46,12 +46,12 @@ export default class AddIntegration extends React.Component {
     return {left, top};
   }
 
-  openDialog = event => {
+  openDialog = urlParams => {
     const name = 'sentryAddIntegration';
     const {url, width, height} = this.props.provider.setupDialog;
     const {left, top} = this.computeCenteredWindow(width, height);
 
-    const query = {};
+    const query = {...urlParams};
 
     if (this.props.reinstallId) {
       query.reinstall_id = this.props.reinstallId;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegration.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegration.jsx
@@ -46,12 +46,12 @@ export default class AddIntegration extends React.Component {
     return {left, top};
   }
 
-  openDialog = urlParams => {
+  openDialog = event => {
     const name = 'sentryAddIntegration';
     const {url, width, height} = this.props.provider.setupDialog;
     const {left, top} = this.computeCenteredWindow(width, height);
 
-    const query = {...urlParams};
+    const query = {};
 
     if (this.props.reinstallId) {
       query.reinstall_id = this.props.reinstallId;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegrationButton.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegrationButton.jsx
@@ -34,7 +34,7 @@ export default class AddIntegrationButton extends React.Component {
         <span>
           <AddIntegration provider={provider} onInstall={onAddIntegration}>
             {onClick => (
-              <Button disabled={!provider.canAdd} {...buttonProps} onClick={onClick}>
+              <Button disabled={!provider.canAdd} {...buttonProps} onClick={() => onClick()}>
                 {label}
               </Button>
             )}

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/migrationWarnings.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/migrationWarnings.jsx
@@ -43,7 +43,7 @@ export default class MigrationWarnings extends AsyncComponent {
           onInstall={this.props.onInstall}
         >
           {onClick => (
-            <AlertLink onClick={onClick} href="#">
+            <AlertLink onClick={() => onClick()} href="#">
               {tct(
                 "Your [orgName] repositories can't send commit data to Sentry. Add a [orgName] [providerName] instance here.",
                 {


### PR DESCRIPTION
The `openDialog` method is used as an event handler by the `AddIntegrationButton` component. Splatting it into an Object results in a huge crufty URL in the integration popup window.

See https://github.com/getsentry/sentry/blob/b489f0ddef83a13ecd445de3c46471ab46ea75a1/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegrationButton.jsx#L35-L41

Fixes APP-586