### PR TITLE
feat(ui): Show the debug symbol type along with the kind

### DIFF
--- a/src/sentry/static/sentry/app/views/projectDebugFiles.jsx
+++ b/src/sentry/static/sentry/app/views/projectDebugFiles.jsx
@@ -23,6 +23,19 @@ import SearchBar from 'app/components/searchBar';
 import LinkWithConfirmation from 'app/components/linkWithConfirmation';
 import space from 'app/styles/space';
 
+function getFileType(dsym) {
+  switch (dsym.data && dsym.data.type) {
+    case 'exe':
+      return t('executable');
+    case 'dbg':
+      return t('debug companion');
+    case 'lib':
+      return t('dynamic library');
+    default:
+      return null;
+  }
+}
+
 const ProjectDebugSymbols = createReactClass({
   displayName: 'ProjectDebugSymbols',
   mixins: [ApiMixin, OrganizationState],
@@ -135,9 +148,12 @@ const ProjectDebugSymbols = createReactClass({
     let {orgId, projectId} = this.props.params;
     let access = this.getAccess();
 
-    const rows = this.state.debugFiles.map((dsym, key) => {
-      const url = `${this.api
+    let rows = this.state.debugFiles.map((dsym, key) => {
+      let url = `${this.api
         .baseUrl}/projects/${orgId}/${projectId}/files/dsyms/?id=${dsym.id}`;
+      let fileType = getFileType(dsym);
+      let symbolType = fileType ? `${dsym.symbolType} ${fileType}` : dsym.symbolType;
+
       return (
         <PanelItem key={key} align="center" px={2} py={1}>
           <Box w={4.5 / 12}>
@@ -162,8 +178,8 @@ const ProjectDebugSymbols = createReactClass({
               : dsym.objectName}
             <p className="m-b-0 text-light small">
               {dsym.symbolType === 'proguard' && dsym.cpuName === 'any'
-                ? 'proguard'
-                : `${dsym.cpuName} (${dsym.symbolType})`}
+                ? 'proguard mapping'
+                : `${dsym.cpuName} (${symbolType})`}
             </p>
           </Box>
 


### PR DESCRIPTION
Adds additional text to distinguish the types of debug files in the UI (_executable_, _debug companion_ or _dynamic library_):

<img width="924" alt="screenshot 2018-10-18 at 16 49 38" src="https://user-images.githubusercontent.com/1433023/47168203-9949a000-d300-11e8-83be-4325a8741cd1.png">
