### PR TITLE
fix(ui): Fix metadata proxy for IE11

### DIFF
--- a/src/sentry/static/sentry/app/components/events/meta/metaProxy.jsx
+++ b/src/sentry/static/sentry/app/components/events/meta/metaProxy.jsx
@@ -49,6 +49,9 @@ export class MetaProxy {
 export function withMeta(event) {
   if (!event) return null;
 
+  // Return unproxied `event` if browser does not support `Proxy`
+  if (typeof window.Proxy === 'undefined') return event;
+
   let _meta = event._meta;
   return new Proxy(event, new MetaProxy(_meta));
 }


### PR DESCRIPTION
Return original object if Proxy is not supported by browser.

Fixes JAVASCRIPT-4GQ