### PR TITLE
feat(app-platform): Add update to sentry app details endpoint 

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_details.py
+++ b/src/sentry/api/endpoints/sentry_app_details.py
@@ -18,3 +18,21 @@ class SentryAppDetailsEndpoint(BaseEndpoint):
             return Response(serialize(sentry_app, request.user))
 
         return Response(status=404)
+
+    def put(self, request, sentry_app):
+        serializer = SentryAppSerializer(data=request.DATA, partial=True)
+        if serializer.is_valid():
+            result = serializer.object
+            kwargs = {}
+            if 'webhook_url' in result:
+                kwargs['webhook_url'] = result['webhook_url']
+            if 'name' in result:
+                kwargs['name'] = result['name']
+
+            updated_app = Updater.run(
+                sentry_app=sentry_app,
+                **kwargs,
+            )
+            return Response(serialize(updated_app, request.user))
+
+        return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/sentry_app_details.py
+++ b/src/sentry/api/endpoints/sentry_app_details.py
@@ -19,6 +19,7 @@ class SentryAppDetailsEndpoint(BaseEndpoint):
 
         return Response(status=404)
 
+    @requires_feature('organizations:internal-catchall', any_org=True)
     def put(self, request, sentry_app):
         serializer = SentryAppSerializer(data=request.DATA, partial=True)
         if serializer.is_valid():

--- a/src/sentry/mediators/sentry_apps/updater.py
+++ b/src/sentry/mediators/sentry_apps/updater.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import six
 
 from collections import Iterable
-from rest_framework.serializers import ValidationError
+from sentry.coreapi import APIError
 
 from sentry.constants import SentryAppStatus
 from sentry.mediators import Mediator, Param
@@ -30,7 +30,7 @@ class Updater(Mediator):
     @if_param('scopes')
     def _update_scopes(self):
         if self.sentry_app.status == SentryAppStatus.PUBLISHED:
-            raise ValidationError('Cannot update scopes on published App.')
+            raise APIError('Cannot update scopes on published App.')
         self.sentry_app.scope_list = self.scopes
 
     @if_param('webhook_url')

--- a/src/sentry/mediators/sentry_apps/updater.py
+++ b/src/sentry/mediators/sentry_apps/updater.py
@@ -5,6 +5,7 @@ import six
 from collections import Iterable
 from rest_framework.serializers import ValidationError
 
+from sentry.constants import SentryAppStatus
 from sentry.mediators import Mediator, Param
 from sentry.mediators.param import if_param
 
@@ -28,17 +29,10 @@ class Updater(Mediator):
 
     @if_param('scopes')
     def _update_scopes(self):
-        self._validate_only_added_scopes()
+        if self.sentry_app.status == SentryAppStatus.PUBLISHED:
+            raise ValidationError('Cannot update scopes on published App.')
         self.sentry_app.scope_list = self.scopes
 
     @if_param('webhook_url')
     def _update_webhook_url(self):
         self.sentry_app.webhook_url = self.webhook_url
-
-    def _validate_only_added_scopes(self):
-        if any(self._scopes_removed):
-            raise ValidationError('Cannot remove `scopes` already in use.')
-
-    @property
-    def _scopes_removed(self):
-        return [s for s in self.sentry_app.scope_list if s not in self.scopes]

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -138,3 +138,23 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             format='json',
         )
         assert response.status_code == 500
+
+    @with_feature('organizations:internal-catchall')
+    def test_cannot_update_non_owned_apps(self):
+        self.login_as(user=self.user)
+        app = Creator.run(
+            name='SampleApp',
+            organization=self.super_org,
+            scopes=(),
+            webhook_url='https://sample.com',
+        )
+        url = reverse('sentry-api-0-sentry-app-details', args=[app.slug])
+        response = self.client.put(
+            url,
+            data={
+                'name': 'NewName',
+                'webhook_url': 'https://newurl.com',
+            },
+            format='json',
+        )
+        assert response.status_code == 403

--- a/tests/sentry/mediators/sentry_apps/test_updater.py
+++ b/tests/sentry/mediators/sentry_apps/test_updater.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
-from rest_framework.serializers import ValidationError
-
+from sentry.coreapi import APIError
 from sentry.constants import SentryAppStatus
 from sentry.mediators.sentry_apps import Creator, Updater
 from sentry.testutils import TestCase
@@ -42,7 +41,7 @@ class TestUpdater(TestCase):
         updater = Updater(sentry_app=sentry_app)
         updater.scopes = ('project:read', 'project:write', )
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(APIError):
             updater.call()
 
     def test_updates_webhook_url(self):

--- a/tests/sentry/mediators/sentry_apps/test_updater.py
+++ b/tests/sentry/mediators/sentry_apps/test_updater.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from rest_framework.serializers import ValidationError
 
+from sentry.constants import SentryAppStatus
 from sentry.mediators.sentry_apps import Creator, Updater
 from sentry.testutils import TestCase
 
@@ -24,17 +25,25 @@ class TestUpdater(TestCase):
         self.updater.call()
         assert self.sentry_app.name == 'A New Thing'
 
-    def test_updates_scopes(self):
+    def test_updates_unpublished_app_scopes(self):
         self.updater.scopes = ('project:read', 'project:write', )
         self.updater.call()
         assert self.sentry_app.get_scopes() == \
             ['project:read', 'project:write']
 
-    def test_rejects_scope_subtractions(self):
-        self.updater.scopes = (None, )
+    def test_doesnt_update_published_app_scopes(self):
+        sentry_app = Creator.run(
+            name='sentry',
+            organization=self.org,
+            scopes=('project:read',),
+            webhook_url='http://example.com',
+        )
+        sentry_app.update(status=SentryAppStatus.PUBLISHED)
+        updater = Updater(sentry_app=sentry_app)
+        updater.scopes = ('project:read', 'project:write', )
 
         with self.assertRaises(ValidationError):
-            self.updater.call()
+            updater.call()
 
     def test_updates_webhook_url(self):
         self.updater.webhook_url = 'http://example.com/hooks'


### PR DESCRIPTION
* Adds `PUT` to sentry app details endpoint
  * only allowing updates for `name` and `webhook_url` for Unpublished Apps, will figure out updating of `scopes` later




**ToDos**
* ~Tests~
* ~`SentryAppSerializer` (from https://github.com/getsentry/sentry/pull/10130)~
* Will want to add in `redirect_url` once that is added to the model 
