### PR TITLE
ref(app-platform): Make slug max_length consistent

### DIFF
--- a/src/sentry/api/endpoints/organization_sentry_app_installations.py
+++ b/src/sentry/api/endpoints/organization_sentry_app_installations.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
+from sentry.constants import SENTRY_APP_SLUG_MAX_LENGTH
 from sentry.features.helpers import requires_feature
 from sentry.mediators.sentry_app_installations import Creator
 from sentry.models import SentryAppInstallation
@@ -16,7 +17,7 @@ from sentry.models import SentryAppInstallation
 class OrganizationSentryAppInstallationsSerializer(serializers.Serializer):
     slug = serializers.RegexField(
         r'^[a-z0-9_\-]+$',
-        max_length=64,
+        max_length=SENTRY_APP_SLUG_MAX_LENGTH,
         error_messages={
             'invalid': _('Enter a valid slug consisting of lowercase letters, '
                          'numbers, underscores or hyphens.'),

--- a/src/sentry/api/endpoints/organization_sentry_app_installations.py
+++ b/src/sentry/api/endpoints/organization_sentry_app_installations.py
@@ -16,7 +16,7 @@ from sentry.models import SentryAppInstallation
 class OrganizationSentryAppInstallationsSerializer(serializers.Serializer):
     slug = serializers.RegexField(
         r'^[a-z0-9_\-]+$',
-        max_length=50,
+        max_length=64,
         error_messages={
             'invalid': _('Enter a valid slug consisting of lowercase letters, '
                          'numbers, underscores or hyphens.'),

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -79,6 +79,8 @@ MAX_EMAIL_FIELD_LENGTH = 75
 ENVIRONMENT_NAME_PATTERN = r'^[^\n\r\f\/]*$'
 ENVIRONMENT_NAME_MAX_LENGTH = 64
 
+SENTRY_APP_SLUG_MAX_LENGTH = 64
+
 # Team slugs which may not be used. Generally these are top level URL patterns
 # which we don't want to worry about conflicts on.
 RESERVED_ORGANIZATION_SLUGS = frozenset(

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -7,7 +7,7 @@ from django.db import models
 from django.utils import timezone
 from django.template.defaultfilters import slugify
 
-from sentry.constants import SentryAppStatus
+from sentry.constants import SentryAppStatus, SENTRY_APP_SLUG_MAX_LENGTH
 from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, ParanoidModel
 from sentry.models import Organization
 from sentry.models.apiscopes import HasApiScopes
@@ -42,7 +42,7 @@ class SentryApp(ParanoidModel, HasApiScopes):
                                related_name='owned_sentry_apps')
 
     name = models.TextField()
-    slug = models.CharField(max_length=64, unique=True)
+    slug = models.CharField(max_length=SENTRY_APP_SLUG_MAX_LENGTH, unique=True)
     status = BoundedPositiveIntegerField(
         default=SentryAppStatus.UNPUBLISHED,
         choices=SentryAppStatus.as_choices(),


### PR DESCRIPTION
We have the `max_length` for the sentry app slug [set to 64](https://github.com/getsentry/sentry/blob/master/src/sentry/models/sentryapp.py#L45) so should have the same `max_length` when creating the installation. 