### PR TITLE
fix(discover): Make sure by day values are cleared on refetching query

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/resultManager.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/resultManager.jsx
@@ -54,6 +54,9 @@ export default function createResultManager(queryBuilder) {
       if (hasAggregations) {
         data.byDayQuery.query = byDayQuery;
         data.byDayQuery.data = resp[1];
+      } else {
+        data.byDayQuery.query = null;
+        data.byDayQuery.data = null;
       }
 
       return data;


### PR DESCRIPTION
When we refetch queries, we need to make sure any previous state is properly cleared