### PR TITLE
fix(docs) Fix missing documentation for service hooks

### DIFF
--- a/api-docs/generator.py
+++ b/api-docs/generator.py
@@ -151,7 +151,8 @@ def cli(output_path, output_format):
         user = utils.create_user('john@interstellar.invalid')
         org = utils.create_org('The Interstellar Jurisdiction',
                                owner=user)
-        api_key = utils.create_api_key(org)
+        report('auth', 'Creating api token')
+        api_token = utils.create_api_token(user)
 
         report('org', 'Creating team')
         team = utils.create_team('Powerful Abolitionist',
@@ -177,7 +178,7 @@ def cli(output_path, output_format):
         vars = {
             'org': org,
             'me': user,
-            'api_key': api_key,
+            'api_token': api_token,
             'teams': [{
                 'team': team,
                 'projects': projects,

--- a/api-docs/generator.py
+++ b/api-docs/generator.py
@@ -157,6 +157,7 @@ def cli(output_path, output_format):
         report('org', 'Creating team')
         team = utils.create_team('Powerful Abolitionist',
                                  org=org)
+        utils.join_team(team, user)
 
         projects = []
         for project_name in 'Pump Station', 'Prime Mover':

--- a/api-docs/sentry.conf.py
+++ b/api-docs/sentry.conf.py
@@ -64,3 +64,6 @@ SENTRY_OPTIONS.update({
     'filestore.backend': 'filesystem',
     'filestore.options': {'location': '/tmp/sentry-files'},
 })
+
+# Enable feature flags so sample responses generate.
+SENTRY_FEATURES['projects:servicehooks'] = True

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -108,6 +108,8 @@ class DebugFilesEndpoint(ProjectEndpoint):
                                           file belongs to.
         :pparam string project_slug: the slug of the project to list the
                                      DIFs of.
+        :qparam string query: If set, this parameter is used to locate DIFs with.
+        :qparam string id: If set, the specified DIF will be sent in the response.
         :auth: required
         """
         query = request.GET.get('query')
@@ -153,6 +155,7 @@ class DebugFilesEndpoint(ProjectEndpoint):
                                           file belongs to.
         :pparam string project_slug: the slug of the project to delete the
                                      DIF.
+        :qparam string id: The id of the DIF to delete.
         :auth: required
         """
 
@@ -259,8 +262,8 @@ class DifAssembleEndpoint(ProjectEndpoint):
 
     def post(self, request, project):
         """
-        Assmble one or multiple chunks (FileBlob) into debug files
-        ``````````````````````````````````````````````````````````
+        Assemble one or multiple chunks (FileBlob) into debug files
+        ````````````````````````````````````````````````````````````
 
         :auth: required
         """

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -59,15 +59,13 @@ def retrieve_organization_scenario(runner):
 @scenario('UpdateOrganization')
 def update_organization_scenario(runner):
     with runner.isolated_org('Badly Misnamed') as org:
-        api_key = runner.utils.create_api_key(org)
         runner.request(
             method='PUT',
             path='/organizations/%s/' % org.slug,
             data={
                 'name': 'Impeccably Designated',
                 'slug': 'impeccably-designated',
-            },
-            api_key=api_key
+            }
         )
 
 

--- a/src/sentry/api/endpoints/project_servicehook_details.py
+++ b/src/sentry/api/endpoints/project_servicehook_details.py
@@ -27,6 +27,7 @@ class ProjectServiceHookDetailsEndpoint(ProjectEndpoint):
         :pparam string project_slug: the slug of the project the client keys
                                      belong to.
         :pparam string hook_id: the guid of the service hook.
+        :auth: required
         """
         try:
             hook = ServiceHook.objects.get(
@@ -49,6 +50,7 @@ class ProjectServiceHookDetailsEndpoint(ProjectEndpoint):
         :pparam string hook_id: the guid of the service hook.
         :param string url: the url for the webhook
         :param array[string] events: the events to subscribe to
+        :auth: required
         """
         if not request.user.is_authenticated():
             return self.respond(status=401)
@@ -102,6 +104,7 @@ class ProjectServiceHookDetailsEndpoint(ProjectEndpoint):
         :pparam string project_slug: the slug of the project the client keys
                                      belong to.
         :pparam string hook_id: the guid of the service hook.
+        :auth: required
         """
         if not request.user.is_authenticated():
             return self.respond(status=401)

--- a/src/sentry/api/endpoints/project_servicehooks.py
+++ b/src/sentry/api/endpoints/project_servicehooks.py
@@ -46,10 +46,14 @@ class ProjectServiceHooksEndpoint(ProjectEndpoint):
 
         Return a list of service hooks bound to a project.
 
+        This endpoint requires the 'servicehooks' feature to
+        be enabled for your project.
+
         :pparam string organization_slug: the slug of the organization the
                                           client keys belong to.
         :pparam string project_slug: the slug of the project the client keys
                                      belong to.
+        :auth: required
         """
         if not self.has_feature(request, project):
             return self.respond({
@@ -92,12 +96,16 @@ class ProjectServiceHooksEndpoint(ProjectEndpoint):
         - event.alert: An alert is generated for an event (via rules).
         - event.created: A new event has been processed.
 
+        This endpoint requires the 'servicehooks' feature to
+        be enabled for your project.
+
         :pparam string organization_slug: the slug of the organization the
                                           client keys belong to.
         :pparam string project_slug: the slug of the project the client keys
                                      belong to.
         :param string url: the url for the webhook
         :param array[string] events: the events to subscribe to
+        :auth: required
         """
         if not request.user.is_authenticated():
             return self.respond(status=401)

--- a/src/sentry/utils/apidocs.py
+++ b/src/sentry/utils/apidocs.py
@@ -375,13 +375,12 @@ class MockUtils(object):
     def create_api_token(self, user):
         from django.conf import settings
         from sentry.models import ApiToken
-        token = ApiToken.objects.create(
+        return ApiToken.objects.create(
             user=user,
             scope_list=settings.SENTRY_SCOPES,
             refresh_token=None,
             expires_at=None,
         )
-        return token
 
     def create_client_key(self, project, label='Default'):
         from sentry.models import ProjectKey

--- a/src/sentry/utils/apidocs.py
+++ b/src/sentry/utils/apidocs.py
@@ -396,10 +396,21 @@ class MockUtils(object):
             },
         )[0]
 
+    def join_team(self, team, user):
+        from sentry.models import OrganizationMember, OrganizationMemberTeam
+        member = OrganizationMember.objects.get(
+            organization_id=team.organization_id,
+            user_id=user.id
+        )
+        return OrganizationMemberTeam.objects.create(
+            team=team,
+            organizationmember=member)
+
     def create_project(self, name, teams, org):
         from sentry.models import Project
         project = Project.objects.get_or_create(
-            name=name, defaults={
+            name=name,
+            defaults={
                 'organization': org,
             }
         )[0]


### PR DESCRIPTION
The sample response for project service hooks was a 401 and it should be a 201. The cause of this was that the user the docs were generated with was a member, and that the servicehooks feature was not enabled. I've resolved both of these problems and switched the API docs generator off
of the deprecated ApiKey to ApiTokens.

Refs #10190