### PR TITLE
feat(app-platform): OAuth authorization endpoint

### DIFF
--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from sentry.api.authentication import ClientIdSecretAuthentication
 from sentry.api.base import Endpoint, SessionAuthentication
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.permissions import ScopedPermission
@@ -59,12 +60,13 @@ class SentryAppInstallationDetailsEndpoint(Endpoint):
         return (args, kwargs)
 
 
-class SentryAppInstallationAuthorizationPermission(ScopedPermission):
+class SentryAppAuthorizationPermission(ScopedPermission):
     def has_object_permission(self, request, view, install):
         if not request.user.is_sentry_app:
             return False
         return request.user == install.sentry_app.proxy_user
 
 
-class SentryAppInstallationAuthorizationEndpoint(SentryAppInstallationDetailsEndpoint):
-    permission_classes = (SentryAppInstallationAuthorizationPermission, )
+class SentryAppAuthorizationEndpoint(SentryAppInstallationDetailsEndpoint):
+    authentication_classes = (ClientIdSecretAuthentication, )
+    permission_classes = (SentryAppAuthorizationPermission, )

--- a/src/sentry/api/endpoints/sentry_app_authorizations.py
+++ b/src/sentry/api/endpoints/sentry_app_authorizations.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import
+
+from rest_framework.response import Response
+
+from sentry.api.bases import SentryAppAuthorizationEndpoint as BaseEndpoint
+from sentry.coreapi import APIUnauthorized
+from sentry.mediators.sentry_app_installations import Authorizer
+from sentry.api.serializers.models.apitoken import ApiTokenSerializer
+
+
+class SentryAppAuthorizationsEndpoint(BaseEndpoint):
+    def post(self, request, install):
+        try:
+            token = Authorizer.run(
+                grant_type=request.json_body.get('grant_type'),
+                code=request.json_body.get('code'),
+                client_id=request.json_body.get('client_id'),
+                user=request.user,
+                install=install,
+            )
+        except APIUnauthorized:
+            return Response({'error': 'Unauthorized'}, status=403)
+
+        return Response(
+            ApiTokenSerializer().serialize(
+                token,
+                {
+                    'state': request.json_body.get('state'),
+                    'application': None,
+                },
+                request.user,
+            ),
+            status=201
+        )

--- a/src/sentry/api/serializers/models/apitoken.py
+++ b/src/sentry/api/serializers/models/apitoken.py
@@ -28,7 +28,9 @@ class ApiTokenSerializer(Serializer):
             'application': attrs['application'],
             'expiresAt': obj.expires_at,
             'dateCreated': obj.date_added,
+            'state': attrs.get('state'),
         }
         if not attrs['application']:
             data['token'] = obj.token
+            data['refreshToken'] = obj.refresh_token
         return data

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -155,6 +155,7 @@ from .endpoints.debug_files import DebugFilesEndpoint, DifAssembleEndpoint, \
     UnknownDebugFilesEndpoint, AssociateDSymFilesEndpoint
 from .endpoints.sentry_apps import SentryAppsEndpoint
 from .endpoints.sentry_app_details import SentryAppDetailsEndpoint
+from .endpoints.sentry_app_authorizations import SentryAppAuthorizationsEndpoint
 from .endpoints.shared_group_details import SharedGroupDetailsEndpoint
 from .endpoints.system_health import SystemHealthEndpoint
 from .endpoints.system_options import SystemOptionsEndpoint
@@ -1102,6 +1103,12 @@ urlpatterns = patterns(
         r'^sentry-apps/(?P<sentry_app_slug>[^\/]+)/$',
         SentryAppDetailsEndpoint.as_view(),
         name='sentry-api-0-sentry-app-details'
+    ),
+
+    url(
+        r'^sentry-app-installations/(?P<uuid>[^\/]+)/authorizations/$',
+        SentryAppAuthorizationsEndpoint.as_view(),
+        name='sentry-api-0-sentry-app-authorizations'
     ),
 
     # Internal

--- a/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
@@ -1,0 +1,138 @@
+from __future__ import absolute_import
+
+import six
+
+from datetime import datetime, timedelta
+from django.core.urlresolvers import reverse
+from django.utils import timezone
+
+from sentry.mediators.sentry_apps import Creator as SentryAppCreator
+from sentry.mediators.sentry_app_installations import Creator as \
+    SentryAppInstallationCreator
+from sentry.models import ApiApplication, ApiToken
+from sentry.testutils import APITestCase
+
+
+class TestSentryAppAuthorizations(APITestCase):
+    def setUp(self):
+        self.user = self.create_user()
+        self.org = self.create_organization()
+
+        self.sentry_app = SentryAppCreator.run(
+            name='nulldb',
+            organization=self.create_organization(),
+            scopes=('org:read', ),
+            webhook_url='http://example.com',
+        )
+
+        self.other_sentry_app = SentryAppCreator.run(
+            name='slowdb',
+            organization=self.create_organization(),
+            scopes=(),
+            webhook_url='http://example.com',
+        )
+
+        self.install, self.grant = SentryAppInstallationCreator.run(
+            organization=self.org,
+            slug='nulldb',
+        )
+
+        self.url = reverse(
+            'sentry-api-0-sentry-app-authorizations',
+            args=[self.install.uuid],
+        )
+
+    def _run_request(self, *args, **kwargs):
+        data = {
+            'client_id': self.sentry_app.application.client_id,
+            'client_secret': self.sentry_app.application.client_secret,
+            'grant_type': 'authorization_code',
+            'code': self.grant.code,
+        }
+        data.update(**kwargs)
+        return self.client.post(self.url, data, headers={
+            'Content-Type': 'application/json',
+        })
+
+    def test_exchanges_for_token_successfully(self):
+        response = self._run_request()
+
+        token = ApiToken.objects.get(
+            application=self.sentry_app.application
+        )
+
+        assert response.status_code == 201, response.content
+        assert response.data['scopes'] == self.sentry_app.scope_list
+        assert response.data['token'] == token.token
+        assert response.data['refreshToken'] == token.refresh_token
+
+        expires_at = response.data['expiresAt'].replace(
+            second=0,
+            microsecond=0,
+        )
+
+        expected_expires_at = (datetime.now() + timedelta(hours=8)).replace(
+            second=0,
+            microsecond=0,
+        )
+
+        assert expires_at == expected_expires_at
+
+    def test_incorrect_grant_type(self):
+        response = self._run_request(grant_type='notit')
+        assert response.status_code == 403
+
+    def test_invalid_installation(self):
+        self.install, _ = SentryAppInstallationCreator.run(
+            organization=self.org,
+            slug='slowdb',
+        )
+
+        # URL with this new Install's uuid in it
+        self.url = reverse(
+            'sentry-api-0-sentry-app-authorizations',
+            args=[self.install.uuid],
+        )
+
+        response = self._run_request()
+        assert response.status_code == 403
+
+    def test_non_sentry_app_user(self):
+        app = ApiApplication.objects.create(
+            owner=self.create_user()
+        )
+        response = self._run_request(
+            client_id=app.client_id,
+            client_secret=app.client_secret,
+        )
+        assert response.status_code == 401
+
+    def test_invalid_grant(self):
+        response = self._run_request(code='123')
+        assert response.status_code == 403
+
+    def test_expired_grant(self):
+        self.grant.update(expires_at=timezone.now() - timedelta(minutes=2))
+        response = self._run_request()
+        assert response.status_code == 403
+
+    def test_request_with_exchanged_access_token(self):
+        response = self._run_request()
+        token = response.data['token']
+
+        url = reverse(
+            'sentry-api-0-organization-details',
+            args=[self.org.slug],
+        )
+
+        response = self.client.get(
+            url,
+            HTTP_AUTHORIZATION='Bearer {}'.format(token),
+        )
+
+        assert response.status_code == 200
+        assert response.data['id'] == six.binary_type(self.org.id)
+
+    def test_state(self):
+        response = self._run_request(state='abc123')
+        assert response.data['state'] == 'abc123'


### PR DESCRIPTION
Every `SentryApp` will have a Client ID and Secret.

On installation, a request will be made to the App service, including an OAuth Grant Code. The service will use that grant, along with their Client ID and Secret, to exchange for an Access Token and Refresh Token.

This is the endpoint that Apps will use to do that. It uses the work done in https://github.com/getsentry/sentry/pull/9915 for the authentication piece of this.

Each installation will get it's own Access Token. Tokens expire 8 hours after creation.

**Notable Additions:**
- A new endpoint: `/sentry-app-installations/:uuid/authorizations`.
- `refreshToken` added to `ApiToken` serialization.