### PR TITLE
fix(integrations): Don't bork on invalid plugins

### DIFF
--- a/src/sentry/api/endpoints/organization_plugins.py
+++ b/src/sentry/api/endpoints/organization_plugins.py
@@ -11,7 +11,6 @@ from sentry.models import ProjectOption
 
 class OrganizationPluginsEndpoint(OrganizationEndpoint):
     def get(self, request, organization):
-        # Just load all Plugins once.
         all_plugins = dict([
             (p.slug, p) for p in plugins.all()
         ])
@@ -21,8 +20,8 @@ class OrganizationPluginsEndpoint(OrganizationEndpoint):
         else:
             desired_plugins = set(all_plugins.keys())
 
-        if not desired_plugins.issubset(set(all_plugins.keys())):
-            return Response({'detail': 'Invalid plugins'}, status=422)
+        # Ignore plugins that are not available to this Sentry install.
+        desired_plugins = desired_plugins & set(all_plugins.keys())
 
         # Each tuple represents an enabled Plugin (of only the ones we care
         # about) and its corresponding Project.


### PR DESCRIPTION
Previously, if a Sentry installation didn't have sentry-plugins installed, the Org Integrations page would totally fail. It failed because it was checking to ensure the list of plugins passed to the endpoint was a subset of all plugins. That list of plugins, by default, included ones that are in sentry-plugins.

Instead, we now just filter any plugins that are not installed out of the list of ones we search for. The page will now load for everyone and work as intended for those with sentry-plugins installed.