### PR TITLE
fix(integrations) Make setup complete modal less empty

### DIFF
--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -17,13 +17,17 @@ from . import default_manager
 
 DIALOG_RESPONSE = """
 <!doctype html>
-<html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Sentry - Integration Setup Complete</title>
+</head>
 <body>
-<script>
-window.opener.postMessage({json}, document.origin);
-window.close();
-</script>
-<noscript>Please wait...</noscript>
+  <script>
+  window.opener.postMessage({json}, document.origin);
+  window.close();
+  </script>
+  <p>You can safely close this window now.</p>
 </body>
 </html>
 """


### PR DESCRIPTION
Make the document displayed at setup complete a valid HTML document, and display a small bit of text so that if the window doesn't auto close the user knows they can close the page.

Fixes APP-598