### PR TITLE
fix(native): Fix a race during debug file deletion

### DIFF
--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -39,7 +39,7 @@ from sentry.models.file import File, ChunkFileState
 from sentry.reprocessing import resolve_processing_issue, \
     bump_reprocessing_revision
 from sentry.utils import metrics
-from sentry.utils.db import set_mysql_foreign_key_checks
+from sentry.utils.db import mysql_disabled_integrity
 from sentry.utils.zip import safe_extract_zip
 from sentry.utils.decorators import classproperty
 
@@ -307,16 +307,11 @@ class ProjectDebugFile(Model):
     def delete(self, *args, **kwargs):
         dif_id = self.id
 
-        try:
-            # MySQL InnoDB always checks foreign key constraints per row and
-            # does not support deferred checking. Disable constraint validation
-            # temporarily for this session to emulate this behavior.
-            set_mysql_foreign_key_checks(False, using=ProjectDebugFile.objects.db)
-
-            # First, delete the debug file entity. This ensures no other worker
-            # can attach caches to it. Integrity checks are deferred within this
-            # transaction, so existing caches stay intact.
+        with mysql_disabled_integrity(db=ProjectDebugFile.objects.db):
             with transaction.atomic():
+                # First, delete the debug file entity. This ensures no other
+                # worker can attach caches to it. Integrity checks are deferred
+                # within this transaction, so existing caches stay intact.
                 super(ProjectDebugFile, self).delete(*args, **kwargs)
 
                 # Explicitly select referencing caches and delete them. Using
@@ -335,8 +330,6 @@ class ProjectDebugFile(Model):
                     .first()
                 if cficache:
                     cficache.delete()
-        finally:
-            set_mysql_foreign_key_checks(True, using=ProjectDebugFile.objects.db)
 
         self.file.delete()
 

--- a/src/sentry/utils/db.py
+++ b/src/sentry/utils/db.py
@@ -104,3 +104,10 @@ def attach_foreignkey(objects, field, related=[], database=None):
 
 def table_exists(name, using=DEFAULT_DB_ALIAS):
     return name in connections[using].introspection.table_names()
+
+
+def set_mysql_foreign_key_checks(flag, using=DEFAULT_DB_ALIAS):
+    if is_mysql():
+        query = 'SET FOREIGN_KEY_CHECKS=%s' % (1 if flag else 0)
+        cursor = connections[using].cursor()
+        cursor.execute(query)

--- a/src/sentry/utils/db.py
+++ b/src/sentry/utils/db.py
@@ -8,6 +8,7 @@ sentry.utils.db
 from __future__ import absolute_import
 
 import six
+from contextlib import contextmanager, closing
 
 from django.conf import settings
 from django.db import connections, DEFAULT_DB_ALIAS
@@ -106,8 +107,17 @@ def table_exists(name, using=DEFAULT_DB_ALIAS):
     return name in connections[using].introspection.table_names()
 
 
-def set_mysql_foreign_key_checks(flag, using=DEFAULT_DB_ALIAS):
+def _set_mysql_foreign_key_checks(flag, using=DEFAULT_DB_ALIAS):
     if is_mysql():
         query = 'SET FOREIGN_KEY_CHECKS=%s' % (1 if flag else 0)
-        cursor = connections[using].cursor()
-        cursor.execute(query)
+        with closing(connections[using].cursor()) as cursor:
+            cursor.execute(query)
+
+
+@contextmanager
+def mysql_disabled_integrity(db=DEFAULT_DB_ALIAS):
+    try:
+        _set_mysql_foreign_key_checks(False, using=db)
+        yield
+    finally:
+        _set_mysql_foreign_key_checks(True, using=db)

--- a/tests/sentry/models/test_debugfile.py
+++ b/tests/sentry/models/test_debugfile.py
@@ -62,9 +62,10 @@ class DebugFileTest(TestCase):
             version=SYMCACHE_LATEST_VERSION,
         )
 
+        dif_id = dif.id
         dif.delete()
 
-        assert not ProjectDebugFile.objects.filter(id=dif.id).exists()
+        assert not ProjectDebugFile.objects.filter(id=dif_id).exists()
         assert not File.objects.filter(id=dif.file.id).exists()
         assert not ProjectSymCacheFile.objects.filter(id=symcache.id).exists()
         assert not File.objects.filter(id=symcache_file.id).exists()


### PR DESCRIPTION
This spawns a transaction to defer referential integrity checks. Then, it first deletes the debug file (removing the possibility to attach another cache to it) and then all eventual caches. 

No loops ;)

Fixes SENTRY-7XW