### PR TITLE
fix(ui): Add logout to `Create a New Organization` prompt 

### DIFF
--- a/src/sentry/static/sentry/app/components/narrowLayout.jsx
+++ b/src/sentry/static/sentry/app/components/narrowLayout.jsx
@@ -1,14 +1,40 @@
 import jQuery from 'jquery';
 import React from 'react';
+import PropTypes from 'prop-types';
+
+import {t} from 'app/locale';
+import {Client} from 'app/api';
+import styled from 'react-emotion';
+
+const Logout = styled.span`
+  float: right;
+  padding-top: 3px;
+  font-size: 16px;
+`;
 
 class NarrowLayout extends React.Component {
+  static propTypes = {
+    showLogout: PropTypes.bool,
+  };
+
   componentWillMount() {
+    this.api = new Client();
     jQuery(document.body).addClass('narrow');
   }
 
   componentWillUnmount() {
+    this.api.clear();
     jQuery(document.body).removeClass('narrow');
   }
+
+  handleLogout = () => {
+    this.api.request('/auth/', {
+      method: 'DELETE',
+      success: () => {
+        window.location = '/auth/login';
+      },
+    });
+  };
 
   render() {
     return (
@@ -20,6 +46,11 @@ class NarrowLayout extends React.Component {
               <a href="/">
                 <span className="icon-sentry-logo" />
               </a>
+              {this.props.showLogout && (
+                <a className="logout" onClick={this.handleLogout}>
+                  <Logout>{t('Sign out')}</Logout>
+                </a>
+              )}
             </div>
             <div className="box-content with-padding">{this.props.children}</div>
           </div>

--- a/src/sentry/static/sentry/app/components/narrowLayout.jsx
+++ b/src/sentry/static/sentry/app/components/narrowLayout.jsx
@@ -6,12 +6,6 @@ import {t} from 'app/locale';
 import {Client} from 'app/api';
 import styled from 'react-emotion';
 
-const Logout = styled.span`
-  float: right;
-  padding-top: 3px;
-  font-size: 16px;
-`;
-
 class NarrowLayout extends React.Component {
   static propTypes = {
     showLogout: PropTypes.bool,
@@ -47,7 +41,7 @@ class NarrowLayout extends React.Component {
                 <span className="icon-sentry-logo" />
               </a>
               {this.props.showLogout && (
-                <a className="logout" onClick={this.handleLogout}>
+                <a className="logout pull-right" onClick={this.handleLogout}>
                   <Logout>{t('Sign out')}</Logout>
                 </a>
               )}
@@ -59,5 +53,9 @@ class NarrowLayout extends React.Component {
     );
   }
 }
+
+const Logout = styled.span`
+  font-size: 16px;
+`;
 
 export default NarrowLayout;

--- a/src/sentry/static/sentry/app/views/organizationCreate.jsx
+++ b/src/sentry/static/sentry/app/views/organizationCreate.jsx
@@ -26,7 +26,7 @@ export default class OrganizationCreate extends AsyncView {
     let privacyUrl = ConfigStore.get('privacyUrl');
 
     return (
-      <NarrowLayout>
+      <NarrowLayout showLogout={true}>
         <h3>{t('Create a New Organization')}</h3>
 
         <p>

--- a/src/sentry/static/sentry/app/views/organizationCreate.jsx
+++ b/src/sentry/static/sentry/app/views/organizationCreate.jsx
@@ -26,7 +26,7 @@ export default class OrganizationCreate extends AsyncView {
     let privacyUrl = ConfigStore.get('privacyUrl');
 
     return (
-      <NarrowLayout showLogout={true}>
+      <NarrowLayout showLogout>
         <h3>{t('Create a New Organization')}</h3>
 
         <p>

--- a/tests/js/spec/components/narrowLayout.spec.jsx
+++ b/tests/js/spec/components/narrowLayout.spec.jsx
@@ -9,7 +9,7 @@ describe('NarrowLayout', function() {
     expect(wrapper.find('a.logout')).toHaveLength(0);
   });
   it('renders with logout', function() {
-    let wrapper = mount(<NarrowLayout showLogout={true} />);
+    let wrapper = mount(<NarrowLayout showLogout />);
     expect(wrapper.find('a.logout')).toHaveLength(1);
   });
   it('can logout', function() {
@@ -18,7 +18,7 @@ describe('NarrowLayout', function() {
       method: 'DELETE',
       status: 204,
     });
-    let wrapper = mount(<NarrowLayout showLogout={true} />);
+    let wrapper = mount(<NarrowLayout showLogout />);
 
     wrapper.find('a.logout').simulate('click');
     expect(mock).toHaveBeenCalled();

--- a/tests/js/spec/components/narrowLayout.spec.jsx
+++ b/tests/js/spec/components/narrowLayout.spec.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import NarrowLayout from 'app/components/narrowLayout';
+
+describe('NarrowLayout', function() {
+  it('renders without logout', function() {
+    let wrapper = mount(<NarrowLayout />);
+    expect(wrapper.find('a.logout')).toHaveLength(0);
+  });
+  it('renders with logout', function() {
+    let wrapper = mount(<NarrowLayout showLogout={true} />);
+    expect(wrapper.find('a.logout')).toHaveLength(1);
+  });
+  it('can logout', function() {
+    let mock = MockApiClient.addMockResponse({
+      url: '/auth/',
+      method: 'DELETE',
+      status: 204,
+    });
+    let wrapper = mount(<NarrowLayout showLogout={true} />);
+
+    wrapper.find('a.logout').simulate('click');
+    expect(mock).toHaveBeenCalled();
+  });
+});

--- a/tests/js/spec/views/__snapshots__/organizationCreate.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationCreate.spec.jsx.snap
@@ -4,7 +4,9 @@ exports[`OrganizationCreate render() renders with terms 1`] = `
 <SideEffect(DocumentTitle)
   title="Create Organization - Sentry"
 >
-  <NarrowLayout>
+  <NarrowLayout
+    showLogout={true}
+  >
     <h3>
       Create a New Organization
     </h3>
@@ -80,7 +82,9 @@ exports[`OrganizationCreate render() renders without terms 1`] = `
 <SideEffect(DocumentTitle)
   title="Create Organization - Sentry"
 >
-  <NarrowLayout>
+  <NarrowLayout
+    showLogout={true}
+  >
     <h3>
       Create a New Organization
     </h3>


### PR DESCRIPTION
If a user didn't have an organization, they could get stuck on this page without the option to logout.

<img width="837" alt="screen shot 2018-10-21 at 3 18 31 pm" src="https://user-images.githubusercontent.com/16394317/47308531-baeba580-d5e6-11e8-8374-4a86d519491a.png">
