### PR TITLE
fix(gitlab) Improve gitlab issue/project search

### DIFF
--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -16,6 +16,7 @@ class GitLabApiClientPath(object):
     compare = u'/projects/{project}/repository/compare'
     diff = u'/projects/{project}/repository/commits/{sha}/diff'
     group = u'/groups/{group}'
+    group_issues = u'/groups/{group}/issues'
     group_projects = u'/groups/{group}/projects'
     hooks = u'/hooks'
     issue = u'/projects/{project}/issues/{issue}'
@@ -131,21 +132,6 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
             GitLabApiClientPath.project.format(project=project_id)
         )
 
-    def get_projects(self, query, simple=True):
-        """Get project list
-
-        See https://docs.gitlab.com/ee/api/projects.html#list-all-projects
-        """
-        # simple param returns limited fields for the project.
-        # Really useful, because we often don't need most of the project information
-        return self.get(
-            GitLabApiClientPath.projects,
-            params={
-                'search': query,
-                'simple': simple,
-            }
-        )
-
     def get_issue(self, project_id, issue_id):
         """Get an issue
 
@@ -168,14 +154,17 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
             data=data,
         )
 
-    def search_issues(self, query):
-        return self.get(
-            GitLabApiClientPath.issues_search,
-            params={
-                'scope': 'all',
-                'search': query
-            }
-        )
+    def search_group_issues(self, group_id, query):
+        """Search issues in a group
+
+        See https://docs.gitlab.com/ee/api/issues.html#list-group-issues
+        """
+        path = GitLabApiClientPath.group_issues.format(group=group_id)
+
+        return self.get(path, params={
+            'scope': 'all',
+            'search': query
+        })
 
     def create_note(self, project_id, issue_iid, data):
         """Create an issue note

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -21,13 +21,11 @@ class GitLabApiClientPath(object):
     hooks = u'/hooks'
     issue = u'/projects/{project}/issues/{issue}'
     issues = u'/projects/{project}/issues'
-    issues_search = u'/issues'
     members = u'/projects/{project}/members'
     notes = u'/projects/{project}/issues/{issue}/notes'
     project = u'/projects/{project}'
     project_hooks = u'/projects/{project}/hooks'
     project_hook = u'/projects/{project}/hooks/{hook_id}'
-    projects = u'/projects'
     user = u'/user'
 
     @staticmethod
@@ -106,7 +104,7 @@ class GitLabApiClient(ApiClient, OAuth2RefreshMixin):
         """
         return self.get(GitLabApiClientPath.user)
 
-    def get_group_projects(self, group, query=None, simple=True):
+    def search_group_projects(self, group, query=None, simple=True):
         """Get projects for a group
 
         See https://docs.gitlab.com/ee/api/groups.html#list-a-group-s-projects

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -106,7 +106,7 @@ class GitlabIntegration(IntegrationInstallation, GitlabIssueBasic, RepositoryMix
 
 class InstallationForm(forms.Form):
     url = forms.CharField(
-        label=_("Installation Url"),
+        label=_('Installation Url'),
         help_text=_('The "base URL" for your GitLab instance, '
                     'includes the host and protocol.'),
         widget=forms.TextInput(
@@ -114,13 +114,13 @@ class InstallationForm(forms.Form):
         ),
     )
     group = forms.CharField(
-        label=_("GitLab Group Name"),
+        label=_('GitLab Group Name'),
         widget=forms.TextInput(
             attrs={'placeholder': _('example-co')}
         )
     )
     verify_ssl = forms.BooleanField(
-        label=_("Verify SSL"),
+        label=_('Verify SSL'),
         help_text=_('By default, we verify SSL certificates '
                     'when delivering payloads to your GitLab instance, '
                     'and request GitLab to verify SSL when it delivers '
@@ -129,14 +129,14 @@ class InstallationForm(forms.Form):
         required=False
     )
     client_id = forms.CharField(
-        label=_("GitLab Application ID"),
+        label=_('GitLab Application ID'),
         widget=forms.TextInput(
             attrs={'placeholder': _(
                 '5832fc6e14300a0d962240a8144466eef4ee93ef0d218477e55f11cf12fc3737')}
         )
     )
     client_secret = forms.CharField(
-        label=_("GitLab Application Secret"),
+        label=_('GitLab Application Secret'),
         widget=forms.TextInput(
             attrs={'placeholder': _('XXXXXXXXXXXXXXXXXXXXXXXXXXX')}
         )

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -87,7 +87,7 @@ class GitlabIntegration(IntegrationInstallation, GitlabIssueBasic, RepositoryMix
     def get_repositories(self, query=None):
         # Note: gitlab projects are the same things as repos everywhere else
         group = self.get_group_id()
-        resp = self.get_client().get_group_projects(group, query)
+        resp = self.get_client().search_group_projects(group, query)
         return [{
             'identifier': repo['id'],
             'name': repo['name_with_namespace'],
@@ -96,7 +96,7 @@ class GitlabIntegration(IntegrationInstallation, GitlabIssueBasic, RepositoryMix
     def search_projects(self, query):
         client = self.get_client()
         group_id = self.get_group_id()
-        return client.get_group_projects(group_id, query)
+        return client.search_group_projects(group_id, query)
 
     def search_issues(self, query):
         client = self.get_client()

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -93,6 +93,16 @@ class GitlabIntegration(IntegrationInstallation, GitlabIssueBasic, RepositoryMix
             'name': repo['name_with_namespace'],
         } for repo in resp]
 
+    def search_projects(self, query):
+        client = self.get_client()
+        group_id = self.get_group_id()
+        return client.get_group_projects(group_id, query)
+
+    def search_issues(self, query):
+        client = self.get_client()
+        group_id = self.get_group_id()
+        return client.search_group_issues(group_id, query)
+
 
 class InstallationForm(forms.Form):
     url = forms.CharField(
@@ -106,7 +116,7 @@ class InstallationForm(forms.Form):
     group = forms.CharField(
         label=_("GitLab Group Name"),
         widget=forms.TextInput(
-            attrs={'placeholder': _('my-awesome-group')}
+            attrs={'placeholder': _('example-co')}
         )
     )
     verify_ssl = forms.BooleanField(

--- a/src/sentry/integrations/gitlab/search.py
+++ b/src/sentry/integrations/gitlab/search.py
@@ -29,14 +29,14 @@ class GitlabIssueSearchEndpoint(OrganizationEndpoint):
         installation = integration.get_installation(organization.id)
 
         if field == 'externalIssue':
-            response = installation.get_client().search_issues(query)
+            response = installation.search_issues(query)
             return Response([{
                 'label': '(#%s) %s' % (i['iid'], i['title']),
                 'value': '%s#%s' % (i['project_id'], i['iid'])
             } for i in response])
 
         if field == 'project':
-            response = installation.get_client().get_projects(query=query)
+            response = installation.search_projects(query)
             return Response([{
                 'label': project['name_with_namespace'],
                 'value': project['id'],

--- a/tests/sentry/integrations/gitlab/test_search.py
+++ b/tests/sentry/integrations/gitlab/test_search.py
@@ -24,7 +24,7 @@ class GitlabSearchTest(GitLabTestCase):
     def test_finds_external_issue_results(self):
         responses.add(
             responses.GET,
-            'https://example.gitlab.com/api/v4/groups/42/issues?scope=all&search=AEIOU',
+            'https://example.gitlab.com/api/v4/groups/1/issues?scope=all&search=AEIOU',
             json=[
                 {'iid': 25, 'title': 'AEIOU Error', 'project_id': '1'},
                 {'iid': 45, 'title': 'AEIOU Error', 'project_id': '2'}
@@ -48,7 +48,7 @@ class GitlabSearchTest(GitLabTestCase):
     def test_finds_project_results(self):
         responses.add(
             responses.GET,
-            'https://example.gitlab.com/api/v4/groups/42/projects?query=GetSentry&simple=True',
+            'https://example.gitlab.com/api/v4/groups/1/projects?query=GetSentry&simple=True',
             json=[
                 {
                     'id': '1',
@@ -80,7 +80,7 @@ class GitlabSearchTest(GitLabTestCase):
     def test_finds_no_external_issues_results(self):
         responses.add(
             responses.GET,
-            'https://example.gitlab.com/api/v4/groups/42/issues?scope=all&search=XYZ',
+            'https://example.gitlab.com/api/v4/groups/1/issues?scope=all&search=XYZ',
             json=[]
         )
         resp = self.client.get(
@@ -98,7 +98,7 @@ class GitlabSearchTest(GitLabTestCase):
     def test_finds_no_project_results(self):
         responses.add(
             responses.GET,
-            'https://example.gitlab.com/api/v4/groups/42/projects?query=GetSentry&simple=True',
+            'https://example.gitlab.com/api/v4/groups/1/projects?query=GetSentry&simple=True',
             json=[]
         )
         resp = self.client.get(

--- a/tests/sentry/integrations/gitlab/testutils.py
+++ b/tests/sentry/integrations/gitlab/testutils.py
@@ -25,6 +25,7 @@ class GitLabTestCase(APITestCase):
             name='Example Gitlab',
             external_id=EXTERNAL_ID,
             metadata={
+                'group_id': 42,
                 'instance': 'example.gitlab.com',
                 'base_url': 'https://example.gitlab.com',
                 'domain_name': 'example.gitlab.com/group-x',

--- a/tests/sentry/integrations/gitlab/testutils.py
+++ b/tests/sentry/integrations/gitlab/testutils.py
@@ -25,7 +25,6 @@ class GitLabTestCase(APITestCase):
             name='Example Gitlab',
             external_id=EXTERNAL_ID,
             metadata={
-                'group_id': 42,
                 'instance': 'example.gitlab.com',
                 'base_url': 'https://example.gitlab.com',
                 'domain_name': 'example.gitlab.com/group-x',


### PR DESCRIPTION
Instead of searching all of gitlab which can be slow on gitlab.com, we should only search the group the sentry integration installation is attached to. This lets the user sift through less data as the results are always relevant to the linked group.

Refs APP-640