### PR TITLE
feat(api): Remove weak anonymous fingerprints

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -412,6 +412,13 @@ class Frame(Interface):
         # Safari throws [native code] frames in for calls like ``forEach``
         # whereas Chrome ignores these. Let's remove it from the hashing algo
         # so that they're more likely to group together
+        if self.filename == '<anonymous>':
+            hashable_filename = None
+        elif self.filename:
+            hashable_filename = remove_filename_outliers(self.filename, platform)
+        else:
+            hashable_filename = None
+
         if self.filename == '[native code]':
             return output
 
@@ -420,8 +427,8 @@ class Frame(Interface):
                 output.append('<module>')
             else:
                 output.append(remove_module_outliers(self.module, platform))
-        elif self.filename and not self.is_url() and not self.is_caused_by():
-            output.append(remove_filename_outliers(self.filename, platform))
+        elif hashable_filename and not self.is_url() and not self.is_caused_by():
+            output.append(hashable_filename)
 
         if self.context_line is None:
             can_use_context = False

--- a/tests/sentry/interfaces/test_stacktrace.py
+++ b/tests/sentry/interfaces/test_stacktrace.py
@@ -565,6 +565,28 @@ class StacktraceTest(TestCase):
         result = interface.get_hash(platform='javascript')
         assert result == ['<module>']
 
+    def test_get_hash_ignores_singular_anonymous_frame(self):
+        interface = Stacktrace.to_python({
+            'frames': [
+                {"abs_path": "<anonymous>", "filename": "<anonymous>", "in_app": False},
+                {"function": "c",
+                 "abs_path": "file:///C:/Users/redacted/AppData/Local/redacted/resources/app.asar/dojo/dojo.js",
+                 "in_app": False,
+                 "lineno": 1188,
+                 "colno": 125,
+                 "filename": "/C:/Users/redacted/AppData/Local/redacted/app-2.4.1/resources/app.asar/dojo/dojo.js"},
+                {"function": "Object._createDocumentViewModel",
+                 "abs_path": "file:///C:/Users/redacted/AppData/Local/redacted/app-2.4.1/resources/app.asar/dojo/dojo.js",
+                 "in_app": False,
+                 "lineno": 1184,
+                 "colno": 92,
+                 "filename": "/C:/Users/redacted/AppData/Local/redacted/app-2.4.1/resources/app.asar/dojo/dojo.js"}
+            ]
+        })
+        result = interface.get_hash(platform='javascript')
+
+        assert result == []
+
     def test_collapse_recursion(self):
         interface = Stacktrace.to_python(
             {


### PR DESCRIPTION
Anonymous frames are roughly the same as frames without filenames, so this resolves issues where they were treated as a stronger hashable component when missing source code context.

This is specific to JavaScript.