### PR TITLE
ref(ui): empty message polish

### DIFF
--- a/docs-ui/components/emptyMessage.stories.js
+++ b/docs-ui/components/emptyMessage.stories.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Flex, Box} from 'grid-emotion';
 
 import {Panel, PanelHeader} from 'app/components/panels';
 import {storiesOf} from '@storybook/react';
@@ -50,13 +51,36 @@ storiesOf('UI|EmptyMessage', module)
     ))
   )
   .add(
-    'in panel with sub-description',
+    'in panel with title and description',
     withInfo('Put this in a panel for maximum effect')(() => (
       <Panel>
         <PanelHeader>Members</PanelHeader>
         <EmptyMessage
           title="Sentry is better with Friends"
           description="When you use sentry with friends, you'll find your world of possibilities expands!"
+        />
+      </Panel>
+    ))
+  )
+  .add(
+    'in panel with everything',
+    withInfo('Put this in a panel for maximum effect')(() => (
+      <Panel>
+        <PanelHeader>Members</PanelHeader>
+        <EmptyMessage
+          icon="icon-user"
+          title="Sentry is better with friends!"
+          description="When you use sentry with friends, you'll find your world of possibilities expands!"
+          action={
+            <Flex justify="center">
+              <Box mr={1}>
+                <Button priority="primary">Invite Members</Button>
+              </Box>
+              <Box>
+                <Button>Learn More</Button>
+              </Box>
+            </Flex>
+          }
         />
       </Panel>
     ))

--- a/docs-ui/components/emptyMessage.stories.js
+++ b/docs-ui/components/emptyMessage.stories.js
@@ -84,4 +84,26 @@ storiesOf('UI|EmptyMessage', module)
         />
       </Panel>
     ))
+  )
+  .add(
+    'in onboarding/missing functionality panel',
+    withInfo('Put this in a panel for maximum effect')(() => (
+      <Panel dottedBorder>
+        <EmptyMessage
+          icon="icon-discover"
+          title="You're missing out on crucial functionality!"
+          description="Enable this feature now to get the most out of Sentry. What are you waiting for? Do it!"
+          action={
+            <Flex justify="center">
+              <Box mr={1}>
+                <Button priority="primary">Enable it!</Button>
+              </Box>
+              <Box>
+                <Button>Learn More</Button>
+              </Box>
+            </Flex>
+          }
+        />
+      </Panel>
+    ))
   );

--- a/src/sentry/static/sentry/app/components/panels/panel.jsx
+++ b/src/sentry/static/sentry/app/components/panels/panel.jsx
@@ -6,7 +6,7 @@ import PanelBody from 'app/components/panels/panelBody';
 import PanelHeader from 'app/components/panels/panelHeader';
 import space from 'app/styles/space';
 
-const Panel = styled(({title, body, ...props}) => {
+const Panel = styled(({title, body, dottedBorder, ...props}) => {
   let hasHeaderAndBody = !!title && !!body;
 
   return !hasHeaderAndBody ? (
@@ -18,10 +18,11 @@ const Panel = styled(({title, body, ...props}) => {
     </div>
   );
 })`
-  background: #fff;
+  background: ${p => (p.dottedBorder ? p.theme.offWhite : '#fff')};
   border-radius: ${p => p.theme.borderRadius};
-  border: 1px solid ${p => p.theme.borderDark};
-  box-shadow: ${p => p.theme.dropShadowLight};
+  border: 1px
+    ${p => (p.dottedBorder ? 'dotted' + p.theme.gray2 : 'solid ' + p.theme.borderDark)};
+  box-shadow: ${p => (p.dottedBorder ? 'none' : p.theme.dropShadowLight)};
   margin-bottom: ${space(3)};
   position: relative;
 `;
@@ -33,6 +34,7 @@ Panel.propTypes = {
    */
   title: PropTypes.node,
   body: PropTypes.node,
+  dottedBorder: PropTypes.bool,
 };
 
 export default Panel;

--- a/src/sentry/static/sentry/app/views/settings/components/emptyMessage.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/emptyMessage.jsx
@@ -46,7 +46,6 @@ const StyledInlineSvg = styled(InlineSvg)`
 `;
 
 const Action = styled.div`
-  display: block;
   ${MarginStyles};
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/components/emptyMessage.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/emptyMessage.jsx
@@ -12,43 +12,44 @@ const Wrapper = styled.div`
   align-items: center;
   flex-direction: column;
   color: ${p => p.theme.gray4};
-  padding: ${p => p.theme.grid * 3}px;
-  font-size: ${p => (p.theme.large ? p.theme.fontSizeExtraLarge : p.theme.fontSizeLarge)};
-  font-weight: bold;
+  padding: ${p => p.theme.grid * 4}px 15%;
+  line-height: 1;
+  font-size: ${p =>
+    p.size && p.size.large ? p.theme.fontSizeExtraLarge : p.theme.fontSizeLarge};
 `;
 
 const StyledInlineSvg = styled(InlineSvg)`
   display: block;
   color: ${p => p.theme.gray1};
-  width: 2em;
-  height: 2em;
-  margin-bottom: 0.75em;
+  margin-bottom: ${space(2)};
 `;
 
 const Action = styled.div`
   display: block;
-  margin-top: 0.75em;
 `;
 
-const EmptyHeader = styled.div`
+const Title = styled.div`
+  font-weight: bold;
+  font-size: 20px;
   margin-bottom: ${space(2)};
+  line-height: 1.2;
 `;
 
-const EmptyDescription = styled(TextBlock)`
-  font-size: 0.9em;
-  font-weight: normal;
+const Description = styled(TextBlock)`
+  margin-top: -${space(0.5)}; /* Remove the illusion of bad padding by offsetting line-height */
+  margin-bottom: ${space(2)};
 `;
 
 const EmptyMessage = ({title, description, icon, children, action, size}) => {
   return (
     <Wrapper size={size}>
-      {icon && <StyledInlineSvg src={icon} />}
+      {icon && <StyledInlineSvg src={icon} size="36px" />}
       <div className="ref-message">
-        {title && <EmptyHeader>{title}</EmptyHeader>}
-        {description && <EmptyDescription noMargin>{description}</EmptyDescription>}
-        {children}
+        {title && <Title>{title}</Title>}
+        {description && <Description noMargin>{description}</Description>}
+        {children && <Description noMargin>{children}</Description>}
+        {action && <Action>{action}</Action>}
       </div>
-      {action && <Action>{action}</Action>}
     </Wrapper>
   );
 };

--- a/src/sentry/static/sentry/app/views/settings/components/emptyMessage.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/emptyMessage.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import styled from 'react-emotion';
+import styled, {css} from 'react-emotion';
 
 import InlineSvg from 'app/components/inlineSvg';
 import TextBlock from 'app/views/settings/components/text/textBlock';
@@ -13,43 +13,51 @@ const Wrapper = styled.div`
   flex-direction: column;
   color: ${p => p.theme.gray4};
   padding: ${p => p.theme.grid * 4}px 15%;
-  line-height: 1;
   font-size: ${p =>
     p.size && p.size.large ? p.theme.fontSizeExtraLarge : p.theme.fontSizeLarge};
 `;
 
-const StyledInlineSvg = styled(InlineSvg)`
-  display: block;
-  color: ${p => p.theme.gray1};
+const MarginStyles = css`
   margin-bottom: ${space(2)};
+  &:last-child {
+    margin: 0;
+  }
 `;
 
-const Action = styled.div`
-  display: block;
+const Description = styled(TextBlock)`
+  ${MarginStyles};
 `;
 
 const Title = styled.div`
   font-weight: bold;
   font-size: 20px;
-  margin-bottom: ${space(2)};
   line-height: 1.2;
+  ${MarginStyles};
+
+  & + ${Description} {
+    margin-top: -${space(0.5)}; /* Remove the illusion of bad padding by offsetting line-height */
+  }
 `;
 
-const Description = styled(TextBlock)`
-  margin-top: -${space(0.5)}; /* Remove the illusion of bad padding by offsetting line-height */
-  margin-bottom: ${space(2)};
+const StyledInlineSvg = styled(InlineSvg)`
+  display: block;
+  color: ${p => p.theme.gray1};
+  ${MarginStyles};
+`;
+
+const Action = styled.div`
+  display: block;
+  ${MarginStyles};
 `;
 
 const EmptyMessage = ({title, description, icon, children, action, size}) => {
   return (
     <Wrapper size={size}>
       {icon && <StyledInlineSvg src={icon} size="36px" />}
-      <div className="ref-message">
-        {title && <Title>{title}</Title>}
-        {description && <Description noMargin>{description}</Description>}
-        {children && <Description noMargin>{children}</Description>}
-        {action && <Action>{action}</Action>}
-      </div>
+      {title && <Title>{title}</Title>}
+      {description && <Description>{description}</Description>}
+      {children && <Description noMargin>{children}</Description>}
+      {action && <Action>{action}</Action>}
     </Wrapper>
   );
 };

--- a/tests/js/spec/views/__snapshots__/accountSubscriptions.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/accountSubscriptions.spec.jsx.snap
@@ -104,10 +104,10 @@ exports[`AccountSubscriptions renders list and can toggle 1`] = `
         </TextBlock>
         <Panel>
           <Component
-            className="css-103l06k-Panel e1laxa7d0"
+            className="css-1jn7ahh-Panel e1laxa7d0"
           >
             <div
-              className="css-103l06k-Panel e1laxa7d0"
+              className="css-1jn7ahh-Panel e1laxa7d0"
             >
               <div>
                 <PanelHeader>

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -11,10 +11,10 @@ exports[`OrganizationTeamProjects Should render 1`] = `
 >
   <Panel>
     <Component
-      className="css-10qfvek-Panel e1laxa7d0"
+      className="css-yahxlu-Panel e1laxa7d0"
     >
       <div
-        className="css-10qfvek-Panel e1laxa7d0"
+        className="css-yahxlu-Panel e1laxa7d0"
       >
         <PanelHeader
           hasButtons={true}

--- a/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
@@ -190,10 +190,10 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
             className="rule-detail"
           >
             <Component
-              className="rule-detail css-10qfvek-Panel e1laxa7d0"
+              className="rule-detail css-yahxlu-Panel e1laxa7d0"
             >
               <div
-                className="rule-detail css-10qfvek-Panel e1laxa7d0"
+                className="rule-detail css-yahxlu-Panel e1laxa7d0"
               >
                 <PanelHeader>
                   <Component
@@ -2721,10 +2721,10 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
             className="rule-detail"
           >
             <Component
-              className="rule-detail css-10qfvek-Panel e1laxa7d0"
+              className="rule-detail css-yahxlu-Panel e1laxa7d0"
             >
               <div
-                className="rule-detail css-10qfvek-Panel e1laxa7d0"
+                className="rule-detail css-yahxlu-Panel e1laxa7d0"
               >
                 <PanelHeader>
                   <Component

--- a/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
@@ -322,10 +322,10 @@ exports[`projectAlertRules renders 1`] = `
         >
           <Panel>
             <Component
-              className="css-10qfvek-Panel e1laxa7d0"
+              className="css-yahxlu-Panel e1laxa7d0"
             >
               <div
-                className="css-10qfvek-Panel e1laxa7d0"
+                className="css-yahxlu-Panel e1laxa7d0"
               >
                 <PanelHeader
                   align="center"

--- a/tests/js/spec/views/__snapshots__/projectDebugFiles.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectDebugFiles.spec.jsx.snap
@@ -104,10 +104,10 @@ exports[`ProjectDebugFiles renders 1`] = `
   </div>
   <Panel>
     <Component
-      className="css-10qfvek-Panel e1laxa7d0"
+      className="css-yahxlu-Panel e1laxa7d0"
     >
       <div
-        className="css-10qfvek-Panel e1laxa7d0"
+        className="css-yahxlu-Panel e1laxa7d0"
       >
         <PanelHeader>
           <Component

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -155,10 +155,10 @@ exports[`ProjectEnvironments render active renders empty message 1`] = `
     </SettingsPageHeading>
     <Panel>
       <Component
-        className="css-10qfvek-Panel e1laxa7d0"
+        className="css-yahxlu-Panel e1laxa7d0"
       >
         <div
-          className="css-10qfvek-Panel e1laxa7d0"
+          className="css-yahxlu-Panel e1laxa7d0"
         >
           <PanelHeader>
             <Component
@@ -378,10 +378,10 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
     </SettingsPageHeading>
     <Panel>
       <Component
-        className="css-10qfvek-Panel e1laxa7d0"
+        className="css-yahxlu-Panel e1laxa7d0"
       >
         <div
-          className="css-10qfvek-Panel e1laxa7d0"
+          className="css-yahxlu-Panel e1laxa7d0"
         >
           <PanelHeader>
             <Component
@@ -983,10 +983,10 @@ exports[`ProjectEnvironments render hidden renders empty message 1`] = `
     </SettingsPageHeading>
     <Panel>
       <Component
-        className="css-10qfvek-Panel e1laxa7d0"
+        className="css-yahxlu-Panel e1laxa7d0"
       >
         <div
-          className="css-10qfvek-Panel e1laxa7d0"
+          className="css-yahxlu-Panel e1laxa7d0"
         >
           <PanelHeader>
             <Component
@@ -1206,10 +1206,10 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
     </SettingsPageHeading>
     <Panel>
       <Component
-        className="css-10qfvek-Panel e1laxa7d0"
+        className="css-yahxlu-Panel e1laxa7d0"
       >
         <div
-          className="css-10qfvek-Panel e1laxa7d0"
+          className="css-yahxlu-Panel e1laxa7d0"
         >
           <PanelHeader>
             <Component

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -195,26 +195,22 @@ exports[`ProjectEnvironments render active renders empty message 1`] = `
               <EmptyMessage>
                 <Wrapper>
                   <div
-                    className="css-gvii4q-Wrapper eh488yo0"
+                    className="css-ev9qm0-Wrapper eh488yo0"
                   >
-                    <div
-                      className="ref-message"
+                    <Description
+                      noMargin={true}
                     >
-                      <Description
+                      <Component
+                        className="css-pwn5v-TextBlock-Description-MarginStyles eh488yo1"
                         noMargin={true}
                       >
-                        <Component
-                          className="css-vc38z-TextBlock-Description eh488yo4"
-                          noMargin={true}
+                        <div
+                          className="css-pwn5v-TextBlock-Description-MarginStyles eh488yo1"
                         >
-                          <div
-                            className="css-vc38z-TextBlock-Description eh488yo4"
-                          >
-                            You don't have any environments yet.
-                          </div>
-                        </Component>
-                      </Description>
-                    </div>
+                          You don't have any environments yet.
+                        </div>
+                      </Component>
+                    </Description>
                   </div>
                 </Wrapper>
               </EmptyMessage>
@@ -1027,26 +1023,22 @@ exports[`ProjectEnvironments render hidden renders empty message 1`] = `
               <EmptyMessage>
                 <Wrapper>
                   <div
-                    className="css-gvii4q-Wrapper eh488yo0"
+                    className="css-ev9qm0-Wrapper eh488yo0"
                   >
-                    <div
-                      className="ref-message"
+                    <Description
+                      noMargin={true}
                     >
-                      <Description
+                      <Component
+                        className="css-pwn5v-TextBlock-Description-MarginStyles eh488yo1"
                         noMargin={true}
                       >
-                        <Component
-                          className="css-vc38z-TextBlock-Description eh488yo4"
-                          noMargin={true}
+                        <div
+                          className="css-pwn5v-TextBlock-Description-MarginStyles eh488yo1"
                         >
-                          <div
-                            className="css-vc38z-TextBlock-Description eh488yo4"
-                          >
-                            You don't have any hidden environments.
-                          </div>
-                        </Component>
-                      </Description>
-                    </div>
+                          You don't have any hidden environments.
+                        </div>
+                      </Component>
+                    </Description>
                   </div>
                 </Wrapper>
               </EmptyMessage>

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -195,12 +195,25 @@ exports[`ProjectEnvironments render active renders empty message 1`] = `
               <EmptyMessage>
                 <Wrapper>
                   <div
-                    className="css-1ykemxy-Wrapper eh488yo0"
+                    className="css-gvii4q-Wrapper eh488yo0"
                   >
                     <div
                       className="ref-message"
                     >
-                      You don't have any environments yet.
+                      <Description
+                        noMargin={true}
+                      >
+                        <Component
+                          className="css-vc38z-TextBlock-Description eh488yo4"
+                          noMargin={true}
+                        >
+                          <div
+                            className="css-vc38z-TextBlock-Description eh488yo4"
+                          >
+                            You don't have any environments yet.
+                          </div>
+                        </Component>
+                      </Description>
                     </div>
                   </div>
                 </Wrapper>
@@ -1014,12 +1027,25 @@ exports[`ProjectEnvironments render hidden renders empty message 1`] = `
               <EmptyMessage>
                 <Wrapper>
                   <div
-                    className="css-1ykemxy-Wrapper eh488yo0"
+                    className="css-gvii4q-Wrapper eh488yo0"
                   >
                     <div
                       className="ref-message"
                     >
-                      You don't have any hidden environments.
+                      <Description
+                        noMargin={true}
+                      >
+                        <Component
+                          className="css-vc38z-TextBlock-Description eh488yo4"
+                          noMargin={true}
+                        >
+                          <div
+                            className="css-vc38z-TextBlock-Description eh488yo4"
+                          >
+                            You don't have any hidden environments.
+                          </div>
+                        </Component>
+                      </Description>
                     </div>
                   </div>
                 </Wrapper>

--- a/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
@@ -369,10 +369,10 @@ exports[`ProjectPluginDetails renders 1`] = `
                   className="plugin-config ref-plugin-config-amazon-sqs"
                 >
                   <Component
-                    className="plugin-config ref-plugin-config-amazon-sqs css-10qfvek-Panel e1laxa7d0"
+                    className="plugin-config ref-plugin-config-amazon-sqs css-yahxlu-Panel e1laxa7d0"
                   >
                     <div
-                      className="plugin-config ref-plugin-config-amazon-sqs css-10qfvek-Panel e1laxa7d0"
+                      className="plugin-config ref-plugin-config-amazon-sqs css-yahxlu-Panel e1laxa7d0"
                     >
                       <PanelHeader
                         hasButtons={true}

--- a/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
@@ -54,10 +54,10 @@ exports[`ProjectSavedSearches renders 1`] = `
         </SettingsPageHeading>
         <Panel>
           <Component
-            className="css-10qfvek-Panel e1laxa7d0"
+            className="css-yahxlu-Panel e1laxa7d0"
           >
             <div
-              className="css-10qfvek-Panel e1laxa7d0"
+              className="css-yahxlu-Panel e1laxa7d0"
             >
               <PanelHeader
                 disablePadding={true}
@@ -882,10 +882,10 @@ exports[`ProjectSavedSearches renders empty 1`] = `
         </SettingsPageHeading>
         <Panel>
           <Component
-            className="css-10qfvek-Panel e1laxa7d0"
+            className="css-yahxlu-Panel e1laxa7d0"
           >
             <div
-              className="css-10qfvek-Panel e1laxa7d0"
+              className="css-yahxlu-Panel e1laxa7d0"
             >
               <PanelHeader
                 disablePadding={true}

--- a/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
@@ -97,10 +97,10 @@ exports[`ProjectTags renders 1`] = `
         </TextBlock>
         <Panel>
           <Component
-            className="css-10qfvek-Panel e1laxa7d0"
+            className="css-yahxlu-Panel e1laxa7d0"
           >
             <div
-              className="css-10qfvek-Panel e1laxa7d0"
+              className="css-yahxlu-Panel e1laxa7d0"
             >
               <PanelHeader>
                 <Component

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -140,10 +140,10 @@ exports[`CreateProject should render roles when available and allowed, and handl
           className="new-invite-team"
         >
           <Component
-            className="new-invite-team css-10qfvek-Panel e1laxa7d0"
+            className="new-invite-team css-yahxlu-Panel e1laxa7d0"
           >
             <div
-              className="new-invite-team css-10qfvek-Panel e1laxa7d0"
+              className="new-invite-team css-yahxlu-Panel e1laxa7d0"
             >
               <PanelHeader>
                 <Component
@@ -365,10 +365,10 @@ exports[`CreateProject should render roles when available and allowed, and handl
           className="new-invite-team"
         >
           <Component
-            className="new-invite-team css-10qfvek-Panel e1laxa7d0"
+            className="new-invite-team css-yahxlu-Panel e1laxa7d0"
           >
             <div
-              className="new-invite-team css-10qfvek-Panel e1laxa7d0"
+              className="new-invite-team css-yahxlu-Panel e1laxa7d0"
             >
               <PanelHeader>
                 <Component

--- a/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
@@ -216,10 +216,10 @@ exports[`Configure should render correctly render() should render platform docs 
                   >
                     <Panel>
                       <Component
-                        className="css-10qfvek-Panel e1laxa7d0"
+                        className="css-yahxlu-Panel e1laxa7d0"
                       >
                         <div
-                          className="css-10qfvek-Panel e1laxa7d0"
+                          className="css-yahxlu-Panel e1laxa7d0"
                         >
                           <PanelHeader
                             hasButtons={true}

--- a/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -273,10 +273,10 @@ exports[`OrganizationApiKeysList renders 1`] = `
     </div>
     <Panel>
       <Component
-        className="css-10qfvek-Panel e1laxa7d0"
+        className="css-yahxlu-Panel e1laxa7d0"
       >
         <div
-          className="css-10qfvek-Panel e1laxa7d0"
+          className="css-yahxlu-Panel e1laxa7d0"
         >
           <PanelHeader
             align="center"

--- a/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
@@ -180,10 +180,10 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
         </SettingsPageHeading>
         <Panel>
           <Component
-            className="css-10qfvek-Panel e1laxa7d0"
+            className="css-yahxlu-Panel e1laxa7d0"
           >
             <div
-              className="css-10qfvek-Panel e1laxa7d0"
+              className="css-yahxlu-Panel e1laxa7d0"
             >
               <PanelHeader
                 hasButtons={true}

--- a/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
@@ -176,10 +176,10 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
   />
   <Panel>
     <Component
-      className="css-10qfvek-Panel e1laxa7d0"
+      className="css-yahxlu-Panel e1laxa7d0"
     >
       <div
-        className="css-10qfvek-Panel e1laxa7d0"
+        className="css-yahxlu-Panel e1laxa7d0"
       >
         <PanelHeader
           disablePadding={true}
@@ -3064,10 +3064,10 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
   />
   <Panel>
     <Component
-      className="css-10qfvek-Panel e1laxa7d0"
+      className="css-yahxlu-Panel e1laxa7d0"
     >
       <div
-        className="css-10qfvek-Panel e1laxa7d0"
+        className="css-yahxlu-Panel e1laxa7d0"
       >
         <PanelHeader
           disablePadding={true}


### PR DESCRIPTION
General emptyMessage padding, margin, and line-height fixes:

Before:

<img width="741" alt="screen shot 2018-10-23 at 3 29 28 pm" src="https://user-images.githubusercontent.com/30713/47394651-7c361800-d6d8-11e8-9715-f69f8bd47601.png">

After:

<img width="740" alt="screen shot 2018-10-23 at 3 26 48 pm" src="https://user-images.githubusercontent.com/30713/47394552-311c0500-d6d8-11e8-9ac8-6304a3f61b59.png">
