### PR TITLE
ref: Remove DSymApps

### DIFF
--- a/src/sentry/api/serializers/models/debug_file.py
+++ b/src/sentry/api/serializers/models/debug_file.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import
 
 import six
 
-from sentry.api.serializers import Serializer, register, serialize
-from sentry.models import (ProjectDebugFile, VersionDSymFile, DSymApp, DIF_PLATFORMS_REVERSE)
+from sentry.api.serializers import Serializer, register
+from sentry.models import ProjectDebugFile
 
 
 @register(ProjectDebugFile)
@@ -21,36 +21,5 @@ class DebugFileSerializer(Serializer):
             'sha1': obj.file.checksum,
             'dateCreated': obj.file.timestamp,
             'data': obj.data or {},
-        }
-        return d
-
-
-@register(VersionDSymFile)
-class VersionDSymFileSerializer(Serializer):
-    def serialize(self, obj, attrs, user):
-        d = {
-            'id': six.text_type(obj.id),
-            'version': obj.version,
-            'build': obj.build,
-            'dateAdded': obj.date_added,
-            'dsymAppId': obj.dsym_app_id,
-            'dsym': serialize(obj.dsym_file)
-        }
-        return d
-
-
-@register(DSymApp)
-class DSymAppSerializer(Serializer):
-    def serialize(self, obj, attrs, user):
-        d = {
-            'id': six.text_type(obj.id),
-            'iconUrl': obj.data.get('icon_url', None),
-            'appId': six.text_type(obj.app_id),
-            'name': obj.data.get('name', None),
-            'platform': DIF_PLATFORMS_REVERSE.get(obj.platform) or 'unknown',
-            # XXX: this should be renamed.  It's currently only used in
-            # the not yet merged itunes connect plugin (ios, tvos etc.)
-            'platforms': ', '.join(obj.data.get('platforms', [])),
-            'lastSync': obj.last_synced,
         }
         return d

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -121,23 +121,6 @@ def cpu_name_from_data(data):
     return unique_cpu_name
 
 
-def version_build_from_data(data):
-    """Returns release and build string from the given data if it exists."""
-    app_context = data.get('contexts', {}).get('app', {})
-    if app_context is not None:
-        if (app_context.get('app_identifier', None) and
-                app_context.get('app_version', None) and
-                app_context.get('app_build', None) and
-                app_context.get('app_name', None)):
-            return AppInfo(
-                app_context.get('app_identifier', None),
-                app_context.get('app_version', None),
-                app_context.get('app_build', None),
-                app_context.get('app_name', None),
-            )
-    return None
-
-
 def rebase_addr(instr_addr, obj):
     return parse_addr(instr_addr) - parse_addr(obj.addr)
 

--- a/tests/sentry/lang/native/test_utils.py
+++ b/tests/sentry/lang/native/test_utils.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import os
 
 from sentry.lang.native.utils import get_sdk_from_event, cpu_name_from_data, \
-    version_build_from_data, merge_minidump_event
+    merge_minidump_event
 
 
 def test_get_sdk_from_event():
@@ -58,77 +58,6 @@ def test_cpu_name_from_data():
     )
 
     assert cpu_name == 'arm64'
-
-
-def test_version_build_from_data():
-
-    app_info = version_build_from_data(
-        {
-            'contexts': {
-                'app': {
-                    'app_build': "2",
-                    'device_app_hash': "18482a73f96d2ed3f4ce8d73fa9942744bff3598",
-                    'app_id': "45BA82DF-F3E3-37F7-9D88-12A1AAB719E7",
-                    'app_version': "1.0",
-                    'app_identifier': "com.rokkincat.SentryExample",
-                    'app_name': "SwiftExample",
-                    'app_start_time': "2017-03-28T15:14:01Z",
-                    'type': "app",
-                    'build_type': "simulator"
-                }
-            }
-        }
-    )
-    assert app_info.version == '1.0'
-    assert app_info.build == '2'
-    assert app_info.name == 'SwiftExample'
-    assert app_info.id == 'com.rokkincat.SentryExample'
-
-    app_info = version_build_from_data(
-        {
-            'contexts': {
-                'app': {
-                    'device_app_hash': "18482a73f96d2ed3f4ce8d73fa9942744bff3598",
-                    'app_id': "45BA82DF-F3E3-37F7-9D88-12A1AAB719E7",
-                    'app_version': "1.0",
-                    'app_identifier': "com.rokkincat.SentryExample",
-                    'app_name': "SwiftExample",
-                    'app_start_time': "2017-03-28T15:14:01Z",
-                    'type': "app",
-                    'build_type': "simulator"
-                }
-            }
-        }
-    )
-    assert app_info is None
-
-    app_info = version_build_from_data(
-        {
-            'contexts': {
-                'app': {
-                    'device_app_hash': "18482a73f96d2ed3f4ce8d73fa9942744bff3598",
-                    'app_id': "45BA82DF-F3E3-37F7-9D88-12A1AAB719E7",
-                    'app_identifier': "com.rokkincat.SentryExample",
-                    'app_name': "SwiftExample",
-                    'app_start_time': "2017-03-28T15:14:01Z",
-                    'type': "app",
-                    'build_type': "simulator"
-                }
-            }
-        }
-    )
-    assert app_info is None
-
-    app_info = version_build_from_data(
-        {
-            'contexts': {
-                'bal': {
-                    'device_app_hash': "18482a73f96d2ed3f4ce8d73fa9942744bff3598",
-                }
-            }
-        }
-    )
-    assert app_info is None
 
 
 def test_cpu_name_from_data_inferred_type():


### PR DESCRIPTION
Removes usages of DSym apps and corresponding models entirely from the code base. A similar construct might be re-introduced in future. The association endpoint remains as a stub and always returns an empty set.

