### PR TITLE
fix(2fa): Handle already enrolled

### DIFF
--- a/src/sentry/static/sentry/app/components/asyncComponent.jsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.jsx
@@ -161,6 +161,7 @@ export default class AsyncComponent extends React.Component {
         },
         error: error => {
           // Allow endpoints to fail
+          // allowError can have side effects to handle the error
           if (options.allowError && options.allowError(error)) {
             error = null;
           }

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.jsx
@@ -122,17 +122,32 @@ class AccountSecurityEnroll extends AsyncView {
   }
 
   getEndpoints() {
-    return [];
+    return [
+      [
+        'authenticator',
+        `${ENDPOINT}${this.props.params.authId}/enroll/`,
+        {},
+        {
+          allowError: err => {
+            let alreadyEnrolled =
+              err &&
+              err.status === 400 &&
+              err.responseJSON &&
+              err.responseJSON.details === 'Already enrolled';
+
+            if (alreadyEnrolled) {
+              this.props.router.push('/settings/account/security/');
+              addErrorMessage(t('Already enrolled'));
+              return true;
+            } else return false;
+          },
+        },
+      ],
+    ];
   }
 
   componentWillMount() {
     super.componentWillMount();
-
-    this.api.request(ENDPOINT, {
-      method: 'GET',
-      success: data => this.getAuthenticator(data),
-    });
-
     // If 2FA is required, a pending organization invite
     // can be accepted once the user enrolls in 2FA
     let invite = Cookies.get(PENDING_INVITE);
@@ -145,33 +160,6 @@ class AccountSecurityEnroll extends AsyncView {
       };
     }
   }
-
-  getAuthenticator = authenticators => {
-    let authId = this.props.params.authId;
-    let current = authenticators.find(auth => auth.id == authId);
-    let alreadyEnrolled = current && current.isEnrolled && !current.allowMultiEnrollment;
-
-    if (alreadyEnrolled) {
-      // Redirect to the details page if already enrolled in a 2FA method
-      // that doesn't allow multi enrollment
-      this.props.router.push(`/settings/account/security/mfa/${current.authId}/`);
-    } else {
-      this.api.request(`${ENDPOINT}${authId}/enroll/`, {
-        method: 'GET',
-        success: data => {
-          this.setState({
-            authenticator: data,
-          });
-        },
-        error: () => {
-          // Potentially trying to enroll in an authenticator
-          // the user doesn't have access to
-          this.props.router.push('/settings/account/security/');
-          addErrorMessage(t('Error adding authenticator'));
-        },
-      });
-    }
-  };
 
   loadOrganizationContext = () => {
     if (this.invite && this.invite.memberId) {

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.jsx
@@ -139,7 +139,8 @@ class AccountSecurityEnroll extends AsyncView {
               this.props.router.push('/settings/account/security/');
               addErrorMessage(t('Already enrolled'));
               return true;
-            } else return false;
+            }
+            return false;
           },
         },
       ],

--- a/tests/js/spec/views/accountSecurityEnroll.spec.jsx
+++ b/tests/js/spec/views/accountSecurityEnroll.spec.jsx
@@ -25,6 +25,10 @@ describe('AccountSecurityEnroll', function() {
 
     beforeAll(function() {
       Client.addMockResponse({
+        url: ENDPOINT,
+        body: TestStubs.AllAuthenticators(),
+      });
+      Client.addMockResponse({
         url: `${ENDPOINT}${authenticator.authId}/enroll/`,
         body: authenticator,
       });

--- a/tests/js/spec/views/accountSecurityEnroll.spec.jsx
+++ b/tests/js/spec/views/accountSecurityEnroll.spec.jsx
@@ -25,10 +25,6 @@ describe('AccountSecurityEnroll', function() {
 
     beforeAll(function() {
       Client.addMockResponse({
-        url: ENDPOINT,
-        body: TestStubs.AllAuthenticators(),
-      });
-      Client.addMockResponse({
         url: `${ENDPOINT}${authenticator.authId}/enroll/`,
         body: authenticator,
       });
@@ -73,6 +69,32 @@ describe('AccountSecurityEnroll', function() {
           }),
         })
       );
+    });
+
+    it('can redirect with already enrolled error', function() {
+      Client.addMockResponse({
+        url: `${ENDPOINT}${authenticator.authId}/enroll/`,
+        body: {details: 'Already enrolled'},
+        statusCode: 400,
+      });
+
+      let pushMock = jest.fn();
+      wrapper = mount(
+        <AccountSecurityEnroll />,
+        TestStubs.routerContext([
+          {
+            router: {
+              ...TestStubs.router({
+                push: pushMock,
+              }),
+              params: {
+                authId: authenticator.authId,
+              },
+            },
+          },
+        ])
+      );
+      expect(pushMock).toHaveBeenCalledWith('/settings/account/security/');
     });
   });
 });


### PR DESCRIPTION
An unhandled 400 was being hit when trying to enroll in a 2FA method that was already enrolled in and doesn't have multi enrollment

Fixes JAVASCRIPT-4F9