### PR TITLE
fix(ui) Fix stars reverting state

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/settingsProjectItem.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsProjectItem.jsx
@@ -33,14 +33,6 @@ const ProjectItem = createReactClass({
     };
   },
 
-  componentWillReceiveProps(nextProps) {
-    // Local bookmarked state should be unset when the project data changes
-    // Local state is used for optimistic UI update
-    if (this.state.isBookmarked !== nextProps.project.isBookmarked) {
-      this.setState({isBookmarked: nextProps.project.isBookmarked});
-    }
-  },
-
   handleToggleBookmark() {
     let {project, organization} = this.props;
     let {isBookmarked} = this.state;


### PR DESCRIPTION
Because updates are being done via reflux, but the project list page is not using reflux the ProjectItem re-render would see the props from the initial page load, and revert itself.

Given that we don't have a way to display errors if/when starring a project fails I felt it was best to rely on the optimisitic state updates.

Refs APP-657