### PR TITLE
fix(eventstream): Use copies of all mutable inputs

### DIFF
--- a/src/sentry/eventstream/kafka.py
+++ b/src/sentry/eventstream/kafka.py
@@ -151,7 +151,7 @@ class KafkaEventStream(EventStream):
         state = {
             'transaction_id': uuid4().hex,
             'project_id': project_id,
-            'group_ids': group_ids,
+            'group_ids': list(group_ids),
             'datetime': datetime.now(tz=pytz.utc),
         }
 
@@ -181,7 +181,7 @@ class KafkaEventStream(EventStream):
         state = {
             'transaction_id': uuid4().hex,
             'project_id': project_id,
-            'previous_group_ids': previous_group_ids,
+            'previous_group_ids': list(previous_group_ids),
             'new_group_id': new_group_id,
             'datetime': datetime.now(tz=pytz.utc),
         }
@@ -214,7 +214,7 @@ class KafkaEventStream(EventStream):
             'project_id': project_id,
             'previous_group_id': previous_group_id,
             'new_group_id': new_group_id,
-            'hashes': hashes,
+            'hashes': list(hashes),
             'datetime': datetime.now(tz=pytz.utc),
         }
 


### PR DESCRIPTION
Today I learned references survive pickling. :(

```
In [1]: import pickle

In [2]: lst = [1]

In [3]: lst_copy = list(lst)

In [4]: obj = [lst, lst, lst_copy, lst_copy]

In [5]: from_pickle = pickle.loads(pickle.dumps(obj))

In [6]: from_pickle
Out[6]: [[1], [1], [1], [1]]

In [7]: from_pickle[0].append(2)

In [8]: from_pickle
Out[8]: [[1, 2], [1, 2], [1], [1]]
```

We mutate the list inside the tasks, which was mutating `eventstream_state` :(