### PR TITLE
fix(locale): Handle undefined first argument for plurals

### DIFF
--- a/src/sentry/static/sentry/app/locale.jsx
+++ b/src/sentry/static/sentry/app/locale.jsx
@@ -211,7 +211,7 @@ export function gettext(string, ...args) {
 export function ngettext(singular, plural, ...args) {
   let countArg;
   if (args.length > 0) {
-    countArg = args[0];
+    countArg = args[0] || 0;
     args = [countArg.toLocaleString(), ...args.slice(1)];
   } else {
     countArg = 0;


### PR DESCRIPTION
Fixes JAVASCRIPT-4H6