### PR TITLE
fix(ui): break long frame titles

### DIFF
--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1332,6 +1332,8 @@ div.traceback > ul {
       // line-height: 1.4;
       line-height: 16px;
       background: lighten(@blue-light, 35);
+      overflow-wrap: break-word;
+      word-wrap: break-word;
       word-break: break-word;
 
       code {

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1333,7 +1333,6 @@ div.traceback > ul {
       line-height: 16px;
       background: lighten(@blue-light, 35);
 
-      word-wrap: break-word;
       word-break: break-all; /* for firefox */
       word-break: break-word; /* for chrome */
 

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1332,9 +1332,10 @@ div.traceback > ul {
       // line-height: 1.4;
       line-height: 16px;
       background: lighten(@blue-light, 35);
-      overflow-wrap: break-word;
+
       word-wrap: break-word;
-      word-break: break-word;
+      word-break: break-all; /* for firefox */
+      word-break: break-word; /* for chrome */
 
       code {
         font-family: inherit;

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1332,6 +1332,7 @@ div.traceback > ul {
       // line-height: 1.4;
       line-height: 16px;
       background: lighten(@blue-light, 35);
+      word-break: break-word;
 
       code {
         font-family: inherit;
@@ -1345,7 +1346,6 @@ div.traceback > ul {
 
     &.system-frame .title {
       background: @white-dark;
-      word-break: break-all;
     }
 
     &.missing-frame .title {


### PR DESCRIPTION
this PR:

1. applies this rule to the right selector (it was only targeting system frames before 🤦‍♂️)
2. uses `word-break: break-word` ~instead of~ in addition to `word-break: break-all` in hopes of fixing the finicky  percy diffs related to frame titles.