### PR TITLE
fix(integrations): Show errors when issue config fetching fails due to external apis

### DIFF
--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -54,15 +54,17 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             return Response(
                 {'detail': 'This feature is not supported for this integration.'}, status=400)
 
-        # TODO(jess): add create issue config to serializer
-        return Response(
-            serialize(
-                integration,
-                request.user,
-                IntegrationIssueConfigSerializer(group, action, params=request.GET),
-                organization_id=organization_id
+        try:
+            return Response(
+                serialize(
+                    integration,
+                    request.user,
+                    IntegrationIssueConfigSerializer(group, action, params=request.GET),
+                    organization_id=organization_id
+                )
             )
-        )
+        except IntegrationError as exc:
+            return Response({'detail': exc.message}, status=400)
 
     # was thinking put for link an existing issue, post for create new issue?
     def put(self, request, group, integration_id):

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -397,6 +397,19 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                 'Jira returned: Unauthorized. '
                 'Please check your configuration settings.'
             )
+        except ApiError as exc:
+            logger.info(
+                'error-fetching-issue-config',
+                extra={
+                    'integration_id': self.model.id,
+                    'organization': group.organization.id,
+                    'error': exc.message,
+                }
+            )
+            raise IntegrationError(
+                'There was an error communicating with the Jira API. '
+                'Please try again or contact support.'
+            )
 
         try:
             meta = resp['projects'][0]

--- a/src/sentry/static/sentry/app/components/asyncComponent.jsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.jsx
@@ -50,6 +50,9 @@ export default class AsyncComponent extends React.Component {
   // eslint-disable-next-line react/sort-comp
   shouldReloadOnVisible = false;
 
+  // should `renderError` render the `detail` attribute of a 400 error
+  shouldRenderBadRequests = false;
+
   constructor(props, context) {
     super(props, context);
 
@@ -165,7 +168,6 @@ export default class AsyncComponent extends React.Component {
           if (options.allowError && options.allowError(error)) {
             error = null;
           }
-
           this.handleError(error, [stateKey, endpoint, params, options]);
         },
       });
@@ -299,6 +301,19 @@ export default class AsyncComponent extends React.Component {
 
     if (permissionErrors) {
       return <PermissionDenied />;
+    }
+
+    if (this.shouldRenderBadRequests) {
+      let badRequests = Object.values(this.state.errors)
+        .filter(
+          resp =>
+            resp && resp.status === 400 && resp.responseJSON && resp.responseJSON.detail
+        )
+        .map(resp => resp.responseJSON.detail);
+
+      if (badRequests.length) {
+        return <LoadingError message={badRequests.join('\n')} />;
+      }
     }
 
     return (

--- a/src/sentry/static/sentry/app/components/group/externalIssueActions.jsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueActions.jsx
@@ -36,6 +36,8 @@ class ExternalIssueForm extends AsyncComponent {
     onSubmitSuccess: PropTypes.func.isRequired,
   };
 
+  shouldRenderBadRequests = true;
+
   getEndpoints() {
     let {action, group, integration} = this.props;
     return [

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -101,6 +101,8 @@ jest.mock('echarts-for-react/lib/core', () => {
 });
 
 jest.mock('app/utils/sdk', () => ({
+  captureBreadcrumb: jest.fn(),
+  addBreadcrumb: jest.fn(),
   captureMessage: jest.fn(),
   captureException: jest.fn(),
   showReportDialog: jest.fn(),

--- a/tests/js/spec/components/asyncComponent.spec.jsx
+++ b/tests/js/spec/components/asyncComponent.spec.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import {mount, shallow} from 'enzyme';
+import {Client} from 'app/api';
+
+import AsyncComponent from 'app/components/asyncComponent';
+
+describe('AsyncComponent', function() {
+  class TestAsyncComponent extends AsyncComponent {
+    shouldRenderBadRequests = true;
+
+    constructor(props) {
+      super(props);
+      this.state = {};
+    }
+
+    getEndpoints() {
+      return [['data', '/some/path/to/something/']];
+    }
+
+    renderBody() {
+      return <div>{this.state.data.message}</div>;
+    }
+  }
+
+  it('renders on successful request', function() {
+    Client.clearMockResponses();
+    Client.addMockResponse({
+      url: '/some/path/to/something/',
+      method: 'GET',
+      body: {
+        message: 'hi',
+      },
+    });
+    let wrapper = shallow(<TestAsyncComponent />);
+    expect(wrapper.find('div')).toHaveLength(1);
+    expect(wrapper.find('div').text()).toEqual('hi');
+  });
+
+  it('renders error message', function() {
+    Client.clearMockResponses();
+    Client.addMockResponse({
+      url: '/some/path/to/something/',
+      method: 'GET',
+      body: {
+        detail: 'oops there was a problem',
+      },
+      statusCode: 400,
+    });
+    let wrapper = mount(<TestAsyncComponent />);
+    expect(wrapper.find('LoadingError')).toHaveLength(1);
+    expect(
+      wrapper
+        .find('LoadingError')
+        .find('p')
+        .text()
+    ).toEqual('oops there was a problem');
+  });
+});


### PR DESCRIPTION
for example:
![screenshot 2018-10-24 17 10 15](https://user-images.githubusercontent.com/5026776/47468619-0fdb1780-d7b1-11e8-935d-4546ebb16fc9.png)
