### PR TITLE
fix(ui): Fix large event errors crashing issue details

### DIFF
--- a/src/sentry/static/sentry/app/components/events/errors.jsx
+++ b/src/sentry/static/sentry/app/components/events/errors.jsx
@@ -6,6 +6,8 @@ import EventErrorItem from 'app/components/events/errorItem';
 import SentryTypes from 'app/sentryTypes';
 import {t, tn} from 'app/locale';
 
+const MAX_ERRORS = 100;
+
 class EventErrors extends React.Component {
   static propTypes = {
     group: SentryTypes.Group.isRequired,
@@ -35,7 +37,10 @@ class EventErrors extends React.Component {
   };
 
   render() {
-    let errors = this.uniqueErrors(this.props.event.errors);
+    let eventErrors = this.props.event.errors;
+    // XXX: uniqueErrors is not performant with large datasets
+    let errors =
+      eventErrors.length > MAX_ERRORS ? eventErrors : this.uniqueErrors(eventErrors);
     let numErrors = errors.length;
     let isOpen = this.state.isOpen;
     return (
@@ -51,8 +56,8 @@ class EventErrors extends React.Component {
             {isOpen ? t('Hide') : t('Show')}
           </a>
           {tn(
-            'There was %d error encountered while processing this event',
-            'There were %d errors encountered while processing this event',
+            'There was %s error encountered while processing this event',
+            'There were %s errors encountered while processing this event',
             numErrors
           )}
         </p>


### PR DESCRIPTION
`tn` transforms the count to a locale string which crashes sprintf since it expects an int.
This error also exposed another problem, calling `_.uniqWith` with a large dataset is very slow.
Avoid calling this if there are more than 100 errors, and just use the original dataset.

Fixes JAVASCRIPT-4H6