### PR TITLE
fix(discover): Do not send invalid properties with query

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
@@ -81,7 +81,7 @@ const OrganizationDiscoverContainer = createReactClass({
     return fetchSavedQuery(organization, savedQueryId)
       .then(resp => {
         if (this.queryBuilder) {
-          this.queryBuilder.reset(resp);
+          this.queryBuilder.reset(parseSavedQuery(resp));
         } else {
           this.queryBuilder = createQueryBuilder(parseSavedQuery(resp), organization);
         }


### PR DESCRIPTION
Make sure saved search metadata, e.g. id, name, create/update date do
not get sent with the rest of the fields.