### PR TITLE
fix(environments): Fix environment filtering on group events page

### DIFF
--- a/src/sentry/static/sentry/app/views/groupEvents.jsx
+++ b/src/sentry/static/sentry/app/views/groupEvents.jsx
@@ -118,10 +118,13 @@ const GroupEvents = createReactClass({
       loading: true,
       error: false,
     });
-    const query = {limit: 50, query: this.state.query};
+
+    const query = {...this.props.location.query, limit: 50, query: this.state.query};
 
     if (this.state.environment) {
       query.environment = this.state.environment.name;
+    } else {
+      delete query.environment;
     }
 
     this.api.request(`/issues/${this.props.params.groupId}/events/`, {

--- a/tests/js/spec/views/groupEvents.spec.jsx
+++ b/tests/js/spec/views/groupEvents.spec.jsx
@@ -62,7 +62,7 @@ describe('groupEvents', function() {
     });
   });
 
-  fdescribe('changing environment', function() {
+  describe('changing environment', function() {
     let component, eventsMock;
     beforeEach(function() {
       component = shallow(

--- a/tests/js/spec/views/groupEvents.spec.jsx
+++ b/tests/js/spec/views/groupEvents.spec.jsx
@@ -62,20 +62,35 @@ describe('groupEvents', function() {
     });
   });
 
-  it('can change environment', function() {
-    const component = shallow(
-      <GroupEvents
-        params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
-        location={{query: {}}}
-        environment={TestStubs.Environments()[0]}
-      />,
-      {
-        context: {...TestStubs.router(), group: TestStubs.Group()},
-        childContextTypes: {
-          router: PropTypes.object,
-        },
-      }
-    );
-    component.setProps({environment: TestStubs.Environments()[1]});
+  fdescribe('changing environment', function() {
+    let component, eventsMock;
+    beforeEach(function() {
+      component = shallow(
+        <GroupEvents
+          params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
+          location={{query: {}}}
+          environment={TestStubs.Environments()[0]}
+        />,
+        {
+          context: {...TestStubs.router(), group: TestStubs.Group()},
+          childContextTypes: {
+            router: PropTypes.object,
+          },
+        }
+      );
+
+      eventsMock = MockApiClient.addMockResponse({
+        url: '/issues/1/events/',
+      });
+    });
+    it('select environment', function() {
+      component.setProps({environment: TestStubs.Environments()[1]});
+      expect(eventsMock.mock.calls[0][1].query.environment).toEqual('staging');
+    });
+
+    it('select all environments', function() {
+      component.setProps({environment: null});
+      expect(eventsMock.mock.calls[0][1].query.environment).toEqual(undefined);
+    });
   });
 });


### PR DESCRIPTION
Another attempt to fix environment filtering on this page.
Fix refetching data on environment changes, but ignore for other
non-environment querystring changes. Also properly handle changing
environment if one is specified via the search field.

Fixes ISSUE-169 and ISSUE-177