### PR TITLE
feat(discover): Make panels scroll instead of body

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Flex} from 'grid-emotion';
 import createReactClass from 'create-react-class';
 import {browserHistory} from 'react-router';
+import jQuery from 'jquery';
 import OrganizationState from 'app/mixins/organizationState';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import {t} from 'app/locale';
@@ -39,6 +40,8 @@ const OrganizationDiscoverContainer = createReactClass({
   },
 
   componentDidMount: function() {
+    jQuery(document.body).addClass('body-discover');
+
     const {savedQueryId} = this.props.params;
     const {search} = this.props.location;
     const {organization} = this.context;
@@ -67,6 +70,10 @@ const OrganizationDiscoverContainer = createReactClass({
     if (nextProps.location.query.view !== this.props.location.query.view) {
       this.setState({view: getView(nextProps.location.query.view)});
     }
+  },
+
+  componentWillUnmount: function() {
+    jQuery(document.body).removeClass('body-discover');
   },
 
   loadTags: function() {

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/table.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/table.jsx
@@ -19,7 +19,7 @@ const MIN_COL_WIDTH = 100;
 const MAX_COL_WIDTH = 500;
 const LINK_COL_WIDTH = 40;
 const CELL_PADDING = 20;
-const MIN_VISIBLE_ROWS = 12;
+const MIN_VISIBLE_ROWS = 6;
 const MAX_VISIBLE_ROWS = 24;
 const OTHER_ELEMENTS_HEIGHT = 70; // pagination buttons, query summary
 

--- a/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/queryFields.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/queryFields.jsx
@@ -10,7 +10,7 @@ import SelectControl from 'app/components/forms/selectControl';
 import Aggregations from '../aggregations';
 import Conditions from '../conditions';
 import {getOrderByOptions} from '../utils';
-import {Fieldset, PlaceholderText, SidebarLabel} from '../styles';
+import {Fieldset, PlaceholderText, SidebarLabel, StyledQueryFields} from '../styles';
 
 export default class QueryFields extends React.Component {
   static propTypes = {
@@ -56,7 +56,7 @@ export default class QueryFields extends React.Component {
     }));
 
     return (
-      <React.Fragment>
+      <StyledQueryFields>
         {savedQuery && (
           <Fieldset>
             <React.Fragment>
@@ -123,7 +123,7 @@ export default class QueryFields extends React.Component {
           />
         </Fieldset>
         <Fieldset>{actions}</Fieldset>
-      </React.Fragment>
+      </StyledQueryFields>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/organizationDiscover/styles.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/styles.jsx
@@ -9,10 +9,7 @@ import {Panel, PanelItem} from 'app/components/panels';
 import NavTabs from 'app/components/navTabs';
 import Link from 'app/components/link';
 
-const FOOTER_HEIGHT = 87;
 const HEADER_HEIGHT = 60;
-const TABS_HEIGHT = 55;
-const QUERY_FIELDS_HEIGHT = 592;
 
 export const DiscoverWrapper = styled(Flex)`
   flex: 1;
@@ -20,7 +17,7 @@ export const DiscoverWrapper = styled(Flex)`
 
 export const DiscoverContainer = styled(Flex)`
   width: 100%;
-  min-height: calc(100vh - ${FOOTER_HEIGHT}px);
+  height: 100vh;
 
   margin-bottom: -20px;
 
@@ -58,6 +55,7 @@ export const BodyContent = styled(Flex)`
   flex: 1;
   flex-direction: column;
   padding: ${space(1.5)} 32px 32px 32px;
+  overflow: scroll;
 `;
 
 export const LoadingContainer = styled(Flex)`
@@ -111,6 +109,11 @@ export const SidebarLabel = styled.label`
   text-transform: uppercase;
   font-size: ${p => p.theme.fontSizeSmall};
   color: ${p => p.theme.gray3};
+`;
+
+export const StyledQueryFields = styled('div')`
+  flex: 1;
+  overflow: scroll;
 `;
 
 export const AddText = styled.span`
@@ -176,10 +179,7 @@ export const SavedQueryAction = styled(Link)`
 `;
 
 export const SavedQueryWrapper = styled('div')`
-  height: ${p =>
-    p.isEditing
-      ? `${QUERY_FIELDS_HEIGHT}px`
-      : `calc(100vh - ${FOOTER_HEIGHT + HEADER_HEIGHT + TABS_HEIGHT}px)`};
+  flex: 1;
   overflow: scroll;
 `;
 

--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -45,6 +45,16 @@ body {
       }
     }
   }
+
+  /* Discover has a 100% height based layout with no footer */
+  &.body-discover {
+    padding-top: 0;
+    padding-bottom: 0;
+    overflow: hidden;
+    footer {
+      display: none;
+    }
+  }
 }
 
 #blk_router {


### PR DESCRIPTION
Use flex elements instead of hardcoded values where possible, hides
footer.