### PR TITLE
feat(feature): Enhance Feature to check HookStore

### DIFF
--- a/src/sentry/static/sentry/app/components/acl/comingSoon.jsx
+++ b/src/sentry/static/sentry/app/components/acl/comingSoon.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import {t} from 'app/locale';
+import Alert from 'app/components/alert';
+
+const ComingSoon = p => (
+  <Alert type="info" icon="icon-circle-info">
+    {t('This feature is coming soon!')}
+  </Alert>
+);
+
+export default ComingSoon;

--- a/src/sentry/static/sentry/app/utils.jsx
+++ b/src/sentry/static/sentry/app/utils.jsx
@@ -227,6 +227,15 @@ export function sortProjects(projects) {
 export const buildUserId = id => `user:${id}`;
 export const buildTeamId = id => `team:${id}`;
 
+/**
+ * Removes the organization / project scope prefix on feature names.
+ */
+export function descopeFeatureName(feature) {
+  return typeof feature.match !== 'function'
+    ? feature
+    : feature.match(/(?:^(?:project|organization):)?(.*)/).pop();
+}
+
 // re-export under utils
 export {parseLinkHeader, Collection, PendingChangeQueue, CursorPoller};
 
@@ -246,6 +255,7 @@ export default {
   parseLinkHeader,
   buildUserId,
   buildTeamId,
+  descopeFeatureName,
 
   // external imports
   objectToArray,

--- a/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
@@ -136,7 +136,7 @@ class OrganizationEventsContainer extends React.Component {
       organization.projects && organization.projects.filter(({isMember}) => isMember);
 
     return (
-      <Feature features={['events-stream']} renderNoFeatureMessage>
+      <Feature features={['events-stream']} renderDisabled>
         <EventsContext.Provider
           value={{actions: this.actions, ...this.state.queryValues}}
         >

--- a/src/sentry/static/sentry/app/views/organizationHealth/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/index.jsx
@@ -85,7 +85,7 @@ class OrganizationHealth extends React.Component {
       organization.projects && organization.projects.filter(({isMember}) => isMember);
 
     return (
-      <Feature features={['health']} renderNoFeatureMessage>
+      <Feature features={['health']} renderDisabled>
         <HealthContext.Provider value={{actions: this.actions, ...this.state}}>
           <HealthWrapper>
             <HealthNavigationMenu />

--- a/tests/js/spec/components/acl/feature.spec.jsx
+++ b/tests/js/spec/components/acl/feature.spec.jsx
@@ -3,6 +3,7 @@ import {mount} from 'enzyme';
 
 import Feature from 'app/components/acl/feature';
 import ConfigStore from 'app/stores/configStore';
+import HookStore from 'app/stores/hookStore';
 
 describe('Feature', function() {
   const organization = TestStubs.Organization({
@@ -25,19 +26,24 @@ describe('Feature', function() {
     });
 
     it('has features', function() {
-      mount(
-        <Feature features={['org-foo', 'project-foo']}>{childrenMock}</Feature>,
-        routerContext
-      );
+      const features = ['org-foo', 'project-foo'];
+
+      mount(<Feature features={features}>{childrenMock}</Feature>, routerContext);
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: true,
+        renderDisabled: false,
+        features,
+        organization,
+        project,
       });
     });
 
     it('has features when requireAll is false', function() {
+      const features = ['org-foo', 'project-foo', 'apple'];
+
       mount(
-        <Feature features={['org-foo', 'project-foo', 'apple']} requireAll={false}>
+        <Feature features={features} requireAll={false}>
           {childrenMock}
         </Feature>,
         routerContext
@@ -45,6 +51,10 @@ describe('Feature', function() {
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: true,
+        renderDisabled: false,
+        organization,
+        project,
+        features,
       });
     });
 
@@ -53,28 +63,36 @@ describe('Feature', function() {
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: false,
+        renderDisabled: false,
+        organization,
+        project,
+        features: ['org-baz'],
       });
     });
 
     it('calls render function when no features', function() {
       const noFeatureRenderer = jest.fn(() => null);
       mount(
-        <Feature features={['org-baz']} renderNoFeatureMessage={noFeatureRenderer}>
+        <Feature features={['org-baz']} renderDisabled={noFeatureRenderer}>
           {childrenMock}
         </Feature>,
         routerContext
       );
 
-      expect(childrenMock).not.toHaveBeenCalled();
-      expect(noFeatureRenderer).toHaveBeenCalled();
+      expect(noFeatureRenderer).not.toHaveBeenCalled();
+      expect(childrenMock).toHaveBeenCalledWith({
+        hasFeature: false,
+        renderDisabled: noFeatureRenderer,
+        organization,
+        project,
+        features: ['org-baz'],
+      });
     });
 
     it('can specify org from props', function() {
+      const customOrg = TestStubs.Organization({features: ['org-bazar']});
       mount(
-        <Feature
-          organization={TestStubs.Organization({features: ['org-bazar']})}
-          features={['org-bazar']}
-        >
+        <Feature organization={customOrg} features={['org-bazar']}>
           {childrenMock}
         </Feature>,
         routerContext
@@ -82,15 +100,17 @@ describe('Feature', function() {
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: true,
+        renderDisabled: false,
+        organization: customOrg,
+        project,
+        features: ['org-bazar'],
       });
     });
 
     it('can specify project from props', function() {
+      const customProject = TestStubs.Project({features: ['project-baz']});
       mount(
-        <Feature
-          project={TestStubs.Project({features: ['project-baz']})}
-          features={['project-baz']}
-        >
+        <Feature project={customProject} features={['project-baz']}>
           {childrenMock}
         </Feature>,
         routerContext
@@ -98,12 +118,17 @@ describe('Feature', function() {
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: true,
+        renderDisabled: false,
+        organization,
+        project: customProject,
+        features: ['project-baz'],
       });
     });
 
     it('handles no org/project', function() {
+      const features = ['org-foo', 'project-foo'];
       mount(
-        <Feature organization={null} project={null} features={['org-foo', 'project-foo']}>
+        <Feature organization={null} project={null} features={features}>
           {childrenMock}
         </Feature>,
         routerContext
@@ -111,6 +136,10 @@ describe('Feature', function() {
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: false,
+        renderDisabled: false,
+        organization: null,
+        project: null,
+        features,
       });
     });
 
@@ -128,6 +157,10 @@ describe('Feature', function() {
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: true,
+        renderDisabled: false,
+        organization,
+        project,
+        features: ['organization:bar'],
       });
 
       mount(
@@ -139,6 +172,10 @@ describe('Feature', function() {
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: false,
+        renderDisabled: false,
+        organization,
+        project,
+        features: ['project:bar'],
       });
     });
 
@@ -153,15 +190,17 @@ describe('Feature', function() {
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: true,
+        renderDisabled: false,
+        organization,
+        project,
+        features: ['organizations:create'],
       });
     });
   });
 
   describe('as React node', function() {
-    let wrapper;
-
     it('has features', function() {
-      wrapper = mount(
+      const wrapper = mount(
         <Feature features={['org-bar']}>
           <div>The Child</div>
         </Feature>,
@@ -172,7 +211,7 @@ describe('Feature', function() {
     });
 
     it('has no features', function() {
-      wrapper = mount(
+      const wrapper = mount(
         <Feature features={['org-baz']}>
           <div>The Child</div>
         </Feature>,
@@ -180,6 +219,85 @@ describe('Feature', function() {
       );
 
       expect(wrapper.find('Feature div')).toHaveLength(0);
+    });
+
+    it('renders a default disabled component', function() {
+      const wrapper = mount(
+        <Feature features={['org-baz']} renderDisabled>
+          <div>The Child</div>
+        </Feature>,
+        routerContext
+      );
+
+      expect(wrapper.exists('ComingSoon')).toBe(true);
+      expect(wrapper.exists('Feature div[children="The Child"]')).not.toBe(true);
+    });
+
+    it('calls renderDisabled function when no features', function() {
+      const noFeatureRenderer = jest.fn(() => null);
+      const wrapper = mount(
+        <Feature features={['org-baz']} renderDisabled={noFeatureRenderer}>
+          <div>The Child</div>
+        </Feature>,
+        routerContext
+      );
+
+      expect(wrapper.find('Feature div')).toHaveLength(0);
+      expect(noFeatureRenderer).toHaveBeenCalledWith({
+        hasFeature: false,
+        renderDisabled: noFeatureRenderer,
+        organization,
+        project,
+        features: ['org-baz'],
+      });
+    });
+  });
+
+  describe('using HookStore for renderDisabled', function() {
+    let hookFn;
+
+    beforeEach(function() {
+      hookFn = jest.fn(() => null);
+      HookStore.hooks['feature-disabled:org-baz'] = [hookFn];
+    });
+
+    afterEach(function() {
+      delete HookStore.hooks['feature-disabled:org-baz'];
+    });
+
+    it('calls renderDisabled function from HookStore when no features', function() {
+      const noFeatureRenderer = jest.fn(() => null);
+      const wrapper = mount(
+        <Feature features={['org-baz']} renderDisabled={noFeatureRenderer}>
+          <div>The Child</div>
+        </Feature>,
+        routerContext
+      );
+
+      expect(wrapper.find('Feature div')).toHaveLength(0);
+      expect(noFeatureRenderer).not.toHaveBeenCalled();
+
+      expect(hookFn).toHaveBeenCalledWith({
+        hasFeature: false,
+        renderDisabled: hookFn,
+        organization,
+        project,
+        features: ['org-baz'],
+      });
+    });
+
+    it('does not check hook store for multiple features', function() {
+      const noFeatureRenderer = jest.fn(() => null);
+      const wrapper = mount(
+        <Feature features={['org-baz', 'org-bazar']} renderDisabled={noFeatureRenderer}>
+          <div>The Child</div>
+        </Feature>,
+        routerContext
+      );
+
+      expect(wrapper.find('Feature div')).toHaveLength(0);
+      expect(hookFn).not.toHaveBeenCalled();
+      expect(noFeatureRenderer).toHaveBeenCalled();
     });
   });
 });

--- a/tests/js/spec/utils/utils.spec.jsx
+++ b/tests/js/spec/utils/utils.spec.jsx
@@ -4,6 +4,7 @@ import {
   parseRepo,
   explodeSlug,
   sortProjects,
+  descopeFeatureName,
 } from 'app/utils';
 
 describe('utils.valueIsEqual', function() {
@@ -233,4 +234,13 @@ describe('utils.projectDisplayCompare', function() {
       },
     ]);
   });
+});
+
+describe('utils.descopeFeatureName', function() {
+  [
+    ['organization:feature', 'feature'],
+    ['project:feature', 'feature'],
+    ['unknown-scope:feature', 'unknown-scope:feature'],
+    ['', ''],
+  ].map(([input, expected]) => expect(descopeFeatureName(input)).toEqual(expected));
 });


### PR DESCRIPTION
This enhances the Feature component to check HookStore for a render function to used when a feature is disabled. It also makes the API more consistent for when a children function is rendered, what render props are passed, and when the custom disabled function is rendered.

 - `renderNoFeatureMessage` has been renamed to `renderDisabled` to be more consistent with it's intended purpose.

 - If a `children` function is passed, this will now *always* be rendered, even if the renderDisabled prop is set to true or given a render function.

   This allows rendering of the disabled message to be more flexible within context of the children render function. For example, you may want to disable the action button in your rendered component, and also render the renderDisabled component above the content.

 - When a SINGLE FEATURE is passed and renderDisabled is true or set to a function, HookStore will now be checked for that feature using the hook store key `feature-disabled:<unprefixed feature>`. When a hook is registered the first hook for this key will be used as the renderDisabled function.

 - When renderDisabled is called by the Feature (children is not a function), it will be passed all the same render props as children would be passed if it were a function.