### PR TITLE
fix(integrations) Record CommitFileChange records for GitHub releases

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -34,19 +34,14 @@ class GitHubClientMixin(ApiClient):
             end_sha,
         ))
 
-    def get_pr_commits(self, repo, num):
-        # see https://developer.github.com/v3/pulls/#list-commits-on-a-pull-request
-        # Max: 250 Commits
-        return self.get(u'/repos/{}/pulls/{}/commits'.format(
-            repo,
-            num
-        ))
-
     def repo_hooks(self, repo):
         return self.get(u'/repos/{}/hooks'.format(repo))
 
     def get_commits(self, repo):
         return self.get(u'/repos/{}/commits'.format(repo))
+
+    def get_commit(self, repo, sha):
+        return self.get(u'/repos/{}/commits/{}'.format(repo, sha))
 
     def get_repo(self, repo):
         return self.get(u'/repos/{}'.format(repo))

--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -58,20 +58,6 @@ class GitHubRepositoryProvider(providers.IntegrationRepositoryProvider):
             'integration_id': data['integration_id']
         }
 
-    def _format_commits(self, repo, commit_list):
-        return [
-            {
-                'id': c['sha'],
-                'repository': repo.name,
-                'author_email': c['commit']['author'].get('email'),
-                'author_name': c['commit']['author'].get('name'),
-                'message': c['commit']['message'],
-                'timestamp': dateutil.parser.parse(
-                    c['commit']['author'].get('date'),
-                ).astimezone(timezone.utc) if c['commit']['author'].get('date') else None,
-            } for c in commit_list
-        ]
-
     def compare_commits(self, repo, start_sha, end_sha):
         integration_id = repo.integration_id
         if integration_id is None:
@@ -82,35 +68,75 @@ class GitHubRepositoryProvider(providers.IntegrationRepositoryProvider):
 
         # use config name because that is kept in sync via webhooks
         name = repo.config['name']
-        if start_sha is None:
-            try:
+        try:
+            if start_sha is None:
                 res = client.get_last_commits(name, end_sha)
-            except Exception as e:
-                installation.raise_error(e)
+                return self._format_commits(client, name, res[:20])
             else:
-                return self._format_commits(repo, res[:10])
-        else:
-            try:
                 res = client.compare_commits(name, start_sha, end_sha)
-            except Exception as e:
-                installation.raise_error(e)
-            else:
-                return self._format_commits(repo, res['commits'])
+                return self._format_commits(client, name, res['commits'])
+        except Exception as e:
+            installation.raise_error(e)
 
-        def get_pr_commits(self, repo, number, actor=None):
-            # (not currently used by sentry)
-            integration_id = repo.integration_id
-            if integration_id is None:
-                raise NotImplementedError('GitHub apps requires an integration id to fetch commits')
-            integration = Integration.objects.get(id=integration_id)
-            installation = integration.get_installation(repo.organization_id)
-            client = installation.get_client()
+    def _format_commits(self, client, repo_name, commit_list):
+        """Convert GitHub commits into our internal format
 
-            # use config name because that is kept in sync via webhooks
-            name = repo.config['name']
-            try:
-                res = client.get_pr_commits(name, number)
-            except Exception as e:
-                installation.raise_error(e)
-            else:
-                return self._format_commits(repo, res)
+        For each commit in the list we have to fetch patch data, as the
+        compare API gives us all of the files changed in the commit
+        range but not which files changed in each commit. Without this
+        we cannot know which specific commit changed a given file.
+
+        See sentry.models.Release.set_commits
+        """
+        return [
+            {
+                'id': c['sha'],
+                'repository': repo_name,
+                'author_email': c['commit']['author'].get('email'),
+                'author_name': c['commit']['author'].get('name'),
+                'message': c['commit']['message'],
+                'timestamp': dateutil.parser.parse(
+                    c['commit']['author'].get('date'),
+                ).astimezone(timezone.utc) if c['commit']['author'].get('date') else None,
+                'patch_set': self._get_patchset(client, repo_name, c['sha'])
+            } for c in commit_list
+        ]
+
+    def _get_patchset(self, client, repo_name, sha):
+        """Get the modified files for a commit
+        """
+        commit = client.get_commit(repo_name, sha)
+        return self._transform_patchset(commit['files'])
+
+    def _transform_patchset(self, diff):
+        """Convert the patch data from GitHub into our internal format
+
+        See sentry.models.Release.set_commits
+        """
+        changes = []
+        for change in diff:
+            if change['status'] == 'modified':
+                changes.append({
+                    'path': change['filename'],
+                    'type': 'M',
+                })
+            if change['status'] == 'added':
+                changes.append({
+                    'path': change['filename'],
+                    'type': 'A',
+                })
+            if change['status'] == 'removed':
+                changes.append({
+                    'path': change['filename'],
+                    'type': 'D',
+                })
+            if change['status'] == 'renamed':
+                changes.append({
+                    'path': change['previous_filename'],
+                    'type': 'D',
+                })
+                changes.append({
+                    'path': change['filename'],
+                    'type': 'A',
+                })
+        return changes

--- a/src/sentry/integrations/github/testutils.py
+++ b/src/sentry/integrations/github/testutils.py
@@ -2288,3 +2288,132 @@ PULL_REQUEST_CLOSED_EVENT_EXAMPLE = b"""{
     "id": 234
   }
 }"""
+
+GET_COMMIT_EXAMPLE = r"""
+{
+  "url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+  "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+  "node_id": "MDY6Q29tbWl0NmRjYjA5YjViNTc4NzVmMzM0ZjYxYWViZWQ2OTVlMmU0MTkzZGI1ZQ==",
+  "html_url": "https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+  "comments_url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e/comments",
+  "commit": {
+    "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+    "author": {
+      "name": "Monalisa Octocat",
+      "email": "support@github.com",
+      "date": "2011-04-14T16:00:49Z"
+    },
+    "committer": {
+      "name": "Monalisa Octocat",
+      "email": "support@github.com",
+      "date": "2011-04-14T16:00:49Z"
+    },
+    "message": "Fix all the bugs",
+    "tree": {
+      "url": "https://api.github.com/repos/octocat/Hello-World/tree/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+      "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+    },
+    "comment_count": 0,
+    "verification": {
+      "verified": false,
+      "reason": "unsigned",
+      "signature": null,
+      "payload": null
+    }
+  },
+  "author": {
+    "login": "octocat",
+    "id": 1,
+    "node_id": "MDQ6VXNlcjE=",
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/octocat",
+    "html_url": "https://github.com/octocat",
+    "followers_url": "https://api.github.com/users/octocat/followers",
+    "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+    "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+    "organizations_url": "https://api.github.com/users/octocat/orgs",
+    "repos_url": "https://api.github.com/users/octocat/repos",
+    "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/octocat/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "committer": {
+    "login": "octocat",
+    "id": 1,
+    "node_id": "MDQ6VXNlcjE=",
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/octocat",
+    "html_url": "https://github.com/octocat",
+    "followers_url": "https://api.github.com/users/octocat/followers",
+    "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+    "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+    "organizations_url": "https://api.github.com/users/octocat/orgs",
+    "repos_url": "https://api.github.com/users/octocat/repos",
+    "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/octocat/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "parents": [
+    {
+      "url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+      "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+    }
+  ],
+  "stats": {
+    "additions": 104,
+    "deletions": 4,
+    "total": 108
+  },
+  "files": [
+    {
+      "filename": "file1.txt",
+      "additions": 10,
+      "deletions": 2,
+      "changes": 12,
+      "status": "modified",
+      "raw_url": "https://github.com/octocat/Hello-World/raw/7ca483543807a51b6079e54ac4cc392bc29ae284/file1.txt",
+      "blob_url": "https://github.com/octocat/Hello-World/blob/7ca483543807a51b6079e54ac4cc392bc29ae284/file1.txt",
+      "patch": "@@ -29,7 +29,7 @@\n....."
+    },
+    {
+      "filename": "added.txt",
+      "additions": 10,
+      "deletions": 0,
+      "changes": 0,
+      "status": "added",
+      "raw_url": "https://github.com/octocat/Hello-World/raw/7ca483543807a51b6079e54ac4cc392bc29ae284/added.txt",
+      "blob_url": "https://github.com/octocat/Hello-World/blob/7ca483543807a51b6079e54ac4cc392bc29ae284/added.txt",
+      "patch": "@@ -29,7 +29,7 @@\n....."
+    },
+    {
+      "filename": "removed.txt",
+      "additions": 0,
+      "deletions": 10,
+      "changes": 0,
+      "status": "removed",
+      "raw_url": "https://github.com/octocat/Hello-World/raw/7ca483543807a51b6079e54ac4cc392bc29ae284/added.txt",
+      "blob_url": "https://github.com/octocat/Hello-World/blob/7ca483543807a51b6079e54ac4cc392bc29ae284/added.txt",
+      "patch": "@@ -29,7 +29,7 @@\n....."
+    },
+    {
+      "filename": "renamed.txt",
+      "previous_filename": "old_name.txt",
+      "additions": 0,
+      "deletions": 0,
+      "changes": 0,
+      "status": "renamed",
+      "raw_url": "https://github.com/octocat/Hello-World/raw/7ca483543807a51b6079e54ac4cc392bc29ae284/added.txt",
+      "blob_url": "https://github.com/octocat/Hello-World/blob/7ca483543807a51b6079e54ac4cc392bc29ae284/added.txt",
+      "patch": "@@ -29,7 +29,7 @@\n....."
+    }
+  ]
+}
+"""

--- a/src/sentry/testutils/asserts.py
+++ b/src/sentry/testutils/asserts.py
@@ -6,6 +6,7 @@ sentry.testutils.asserts
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import
+from sentry.models import CommitFileChange
 
 
 def assert_date_resembles(one, two):
@@ -24,3 +25,20 @@ def assert_mock_called_once_with_partial(mock, *args, **kwargs):
         assert m_args[i] == arg
     for kwarg in kwargs:
         assert m_kwargs[kwarg] == kwargs[kwarg]
+
+
+commit_file_type_choices = {c[0] for c in CommitFileChange._meta.get_field('type').choices}
+
+
+def assert_commit_shape(commit):
+    assert commit['id']
+    assert commit['repository']
+    assert commit['author_email']
+    assert commit['author_name']
+    assert commit['message']
+    assert commit['timestamp']
+    assert commit['patch_set']
+    patches = commit['patch_set']
+    for patch in patches:
+        assert patch['type'] in commit_file_type_choices
+        assert patch['path']

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -2,24 +2,52 @@ from __future__ import absolute_import
 
 import datetime
 import responses
+import pytest
 
 from exam import fixture
-from mock import patch
 
-from django.utils import timezone
 from sentry.models import Integration, Repository
 from sentry.testutils import PluginTestCase
+from sentry.testutils.asserts import assert_commit_shape
 from sentry.utils import json
 
-from sentry.integrations.github.client import GitHubAppsClient
+from sentry.integrations.exceptions import IntegrationError
 from sentry.integrations.github.repository import GitHubRepositoryProvider
-from sentry.integrations.github.testutils import COMPARE_COMMITS_EXAMPLE
+from sentry.integrations.github.testutils import (
+    COMPARE_COMMITS_EXAMPLE,
+    GET_LAST_COMMITS_EXAMPLE,
+    GET_COMMIT_EXAMPLE
+)
+
+
+def stub_installation_token():
+    ten_hours = datetime.datetime.utcnow() + datetime.timedelta(hours=10)
+    responses.add(
+        responses.POST,
+        'https://api.github.com/installations/654321/access_tokens',
+        json={'token': 'v1.install-token', 'expires_at': ten_hours.strftime('%Y-%m-%dT%H:%M:%SZ')}
+    )
 
 
 class GitHubAppsProviderTest(PluginTestCase):
     @fixture
     def provider(self):
         return GitHubRepositoryProvider('integrations:github')
+
+    @fixture
+    def repository(self):
+        organization = self.create_organization()
+        integration = Integration.objects.create(
+            provider='github',
+            external_id='654321',
+        )
+        return Repository.objects.create(
+            name='example-repo',
+            provider='integrations:github',
+            organization_id=organization.id,
+            integration_id=integration.id,
+            config={'name': 'getsentry/example-repo'},
+        )
 
     @responses.activate
     def test_build_repository_config(self):
@@ -45,61 +73,80 @@ class GitHubAppsProviderTest(PluginTestCase):
             'url': 'https://github.com/getsentry/example-repo',
         }
 
-    @patch.object(
-        GitHubAppsClient,
-        'get_last_commits',
-        return_value=[]
-    )
-    def test_compare_commits_no_start(self, mock_get_last_commits):
-        organization = self.create_organization()
-        integration = Integration.objects.create(
-            provider='github',
-            external_id='1',
+    @responses.activate
+    def test_compare_commits_no_start(self):
+        stub_installation_token()
+        responses.add(
+            responses.GET,
+            'https://api.github.com/repos/getsentry/example-repo/commits?sha=abcdef',
+            json=json.loads(GET_LAST_COMMITS_EXAMPLE)
         )
-        repo = Repository.objects.create(
-            name='example-repo',
-            provider='integrations:github',
-            organization_id=organization.id,
-            integration_id=integration.id,
-            config={'name': 'example-repo'},
+        responses.add(
+            responses.GET,
+            'https://api.github.com/repos/getsentry/example-repo/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e',
+            json=json.loads(GET_COMMIT_EXAMPLE)
         )
+        result = self.provider.compare_commits(self.repository, None, 'abcdef')
+        for commit in result:
+            assert_commit_shape(commit)
 
-        self.provider.compare_commits(repo, None, 'a' * 40)
-
-        assert mock_get_last_commits.called
-
-    @patch.object(
-        GitHubAppsClient,
-        'compare_commits',
-        return_value={'commits': []}
-    )
-    def test_compare_commits(self, mock_compare_commits):
-        organization = self.create_organization()
-        integration = Integration.objects.create(
-            provider='github',
-            external_id='1',
+    @responses.activate
+    def test_compare_commits_no_start_failure(self):
+        stub_installation_token()
+        responses.add(
+            responses.GET,
+            'https://api.github.com/repos/getsentry/example-repo/commits?sha=abcdef',
+            status=502
         )
-        repo = Repository.objects.create(
-            name='example-repo',
-            provider='integrations:github',
-            organization_id=organization.id,
-            integration_id=integration.id,
-            config={'name': 'example-repo'},
+        with pytest.raises(IntegrationError):
+            self.provider.compare_commits(self.repository, None, 'abcdef')
+
+    @responses.activate
+    def test_compare_commits(self):
+        stub_installation_token()
+        responses.add(
+            responses.GET,
+            'https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef',
+            json=json.loads(COMPARE_COMMITS_EXAMPLE)
         )
+        responses.add(
+            responses.GET,
+            'https://api.github.com/repos/getsentry/example-repo/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e',
+            json=json.loads(GET_COMMIT_EXAMPLE)
+        )
+        result = self.provider.compare_commits(self.repository, 'xyz123', 'abcdef')
+        for commit in result:
+            assert_commit_shape(commit)
 
-        res = self.provider._format_commits(repo, json.loads(COMPARE_COMMITS_EXAMPLE)['commits'])
+    @responses.activate
+    def test_compare_commits_patchset_handling(self):
+        stub_installation_token()
+        responses.add(
+            responses.GET,
+            'https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef',
+            json=json.loads(COMPARE_COMMITS_EXAMPLE)
+        )
+        responses.add(
+            responses.GET,
+            'https://api.github.com/repos/getsentry/example-repo/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e',
+            json=json.loads(GET_COMMIT_EXAMPLE)
+        )
+        result = self.provider.compare_commits(self.repository, 'xyz123', 'abcdef')
 
-        assert res == [
-            {
-                'author_email': 'support@github.com',
-                'author_name': 'Monalisa Octocat',
-                'message': 'Fix all the bugs',
-                'id': '6dcb09b5b57875f334f61aebed695e2e4193db5e',
-                'repository': 'example-repo',
-                'timestamp': datetime.datetime(2011, 4, 14, 16, 0, 49, tzinfo=timezone.utc),
-            }
-        ]
+        patchset = result[0]['patch_set']
+        assert patchset[0] == {'path': 'file1.txt', 'type': 'M'}
+        assert patchset[1] == {'path': 'added.txt', 'type': 'A'}
+        assert patchset[2] == {'path': 'removed.txt', 'type': 'D'}
+        assert patchset[3] == {'path': 'old_name.txt', 'type': 'D'}
+        assert patchset[4] == {'path': 'renamed.txt', 'type': 'A'}
 
-        self.provider.compare_commits(repo, 'b' * 40, 'a' * 40)
-
-        assert mock_compare_commits.called
+    @responses.activate
+    def test_compare_commits_failure(self):
+        stub_installation_token()
+        responses.add(
+            responses.GET,
+            'https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef',
+            status=502
+        )
+        with pytest.raises(IntegrationError):
+            self.provider.compare_commits(self.repository, 'xyz123', 'abcdef')

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -14,9 +14,9 @@ from sentry.models import (
     IdentityProvider,
     Integration,
     Repository,
-    CommitFileChange
 )
 from sentry.testutils import PluginTestCase
+from sentry.testutils.asserts import assert_commit_shape
 from sentry.utils import json
 
 from .testutils import (
@@ -24,8 +24,6 @@ from .testutils import (
     COMMIT_LIST_RESPONSE,
     COMMIT_DIFF_RESPONSE
 )
-
-commit_file_type_choices = {c[0] for c in CommitFileChange._meta.get_field('type').choices}
 
 
 class GitLabRepositoryProviderTest(PluginTestCase):
@@ -299,17 +297,3 @@ class GitLabRepositoryProviderTest(PluginTestCase):
         repo = Repository.objects.get(pk=response.data['id'])
         with pytest.raises(IntegrationError):
             self.provider.compare_commits(repo, None, 'abc')
-
-
-def assert_commit_shape(commit):
-    assert commit['id']
-    assert commit['repository']
-    assert commit['author_email']
-    assert commit['author_name']
-    assert commit['message']
-    assert commit['timestamp']
-    assert commit['patch_set']
-    patches = commit['patch_set']
-    for patch in patches:
-        assert patch['type'] in commit_file_type_choices
-        assert patch['path']


### PR DESCRIPTION
Releases that use commits from github repositories were not creating CommitFileChange records for commits that were net new. We need to record this data so that we can locate suspect commits in 'squash merge' and 'rebase merge' workflows.

This will add more network requests to the post-release task but GitHub doesn't give us another way to get changed files on an individual commit level. :cry:

Refs APP-635