### PR TITLE
fix(settings): Fix inaccurate CSP help text

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/cspReports.jsx
+++ b/src/sentry/static/sentry/app/data/forms/cspReports.jsx
@@ -26,10 +26,10 @@ const formGroups = [
         name: 'sentry:csp_ignored_sources',
         type: 'string',
         multiline: true,
-        placeholder: 'e.g. file://*, *.example.com, example.com, etc...',
+        placeholder: 'e.g.\nfile://*\n*.example.com\nexample.com\netc',
         label: t('Additional ignored sources'),
         help: t(
-          'Additional field names to match against when scrubbing data for all projects. Separate multiple entries with a newline.'
+          'Discard reports about requests from the given sources. Separate multiple entries with a newline.'
         ),
         extraHelp: t('Separate multiple entries with a newline.'),
         getData: data => ({

--- a/src/sentry/static/sentry/app/data/forms/cspReports.jsx
+++ b/src/sentry/static/sentry/app/data/forms/cspReports.jsx
@@ -26,7 +26,8 @@ const formGroups = [
         name: 'sentry:csp_ignored_sources',
         type: 'string',
         multiline: true,
-        placeholder: 'e.g.\nfile://*\n*.example.com\nexample.com\netc',
+        autosize: true,
+        placeholder: 'e.g.\nfile://*\n*.example.com\nexample.com',
         label: t('Additional ignored sources'),
         help: t(
           'Discard reports about requests from the given sources. Separate multiple entries with a newline.'

--- a/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectCspReports.spec.jsx.snap
+++ b/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectCspReports.spec.jsx.snap
@@ -49,11 +49,15 @@ exports[`ProjectCspReports renders 1`] = `
                 Object {
                   "extraHelp": "Separate multiple entries with a newline.",
                   "getData": [Function],
-                  "help": "Additional field names to match against when scrubbing data for all projects. Separate multiple entries with a newline.",
+                  "help": "Discard reports about requests from the given sources. Separate multiple entries with a newline.",
                   "label": "Additional ignored sources",
                   "multiline": true,
                   "name": "sentry:csp_ignored_sources",
-                  "placeholder": "e.g. file://*, *.example.com, example.com, etc...",
+                  "placeholder": "e.g.
+file://*
+*.example.com
+example.com
+etc",
                   "type": "string",
                 },
               ],

--- a/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectCspReports.spec.jsx.snap
+++ b/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectCspReports.spec.jsx.snap
@@ -47,6 +47,7 @@ exports[`ProjectCspReports renders 1`] = `
                   "type": "boolean",
                 },
                 Object {
+                  "autosize": true,
                   "extraHelp": "Separate multiple entries with a newline.",
                   "getData": [Function],
                   "help": "Discard reports about requests from the given sources. Separate multiple entries with a newline.",
@@ -56,8 +57,7 @@ exports[`ProjectCspReports renders 1`] = `
                   "placeholder": "e.g.
 file://*
 *.example.com
-example.com
-etc",
+example.com",
                   "type": "string",
                 },
               ],


### PR DESCRIPTION
Currently, on this page: https://sentry.io/settings/sentry/sentry/security-headers/csp/ the help text for "Additional ignored sources" is copied over from "Additional Sensitive Fields" on this page: https://sentry.io/settings/sentry/sentry/, which is something totally different.

Also, the example doesn't match what we say we need (newlines instead of commas).

Before:
![image](https://user-images.githubusercontent.com/14812505/47593751-62d9d980-d92d-11e8-87b8-e41375573872.png)


After:
![image](https://user-images.githubusercontent.com/14812505/47593740-52c1fa00-d92d-11e8-8323-e452110e7051.png)
