### PR TITLE
fix(require-2fa): Generate token when user is removed

### DIFF
--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -119,6 +119,11 @@ class OrganizationMember(Model):
         self.token = None
         self.token_expires_at = None
 
+    def remove_user(self):
+        self.email = self.get_email()
+        self.user = None
+        self.token = self.generate_token()
+
     def regenerate_token(self):
         self.token = self.generate_token()
         self.refresh_expires_at()

--- a/src/sentry/tasks/auth.py
+++ b/src/sentry/tasks/auth.py
@@ -89,8 +89,7 @@ def _remove_2fa_non_compliant_member(member, org, actor=None, actor_key=None, ip
     }
 
     try:
-        member.email = member.get_email()
-        member.user = None
+        member.remove_user()
         member.save()
     except (AssertionError, IntegrityError):
         logger.warning(


### PR DESCRIPTION
Generate a token and expiration for the organization member, when the user is removed due to require 2FA