### PR TITLE
feat(discover): Display overlay panel when query is being fetched

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -14,6 +14,7 @@ import SentryTypes from 'app/sentryTypes';
 import TimeRangeSelector from 'app/components/organizations/timeRangeSelector';
 
 import Result from './result';
+import ResultLoading from './result/loading';
 import Intro from './intro';
 import EarlyAdopterMessage from './earlyAdopterMessage';
 import NewQuery from './sidebar/newQuery';
@@ -164,7 +165,10 @@ export default class OrganizationDiscover extends React.Component {
           });
         }
 
-        this.setState({data, isFetchingQuery: false});
+        this.setState({
+          data,
+          isFetchingQuery: false,
+        });
       })
       .catch(err => {
         const message = (err && err.message) || t('An error occurred');
@@ -351,6 +355,7 @@ export default class OrganizationDiscover extends React.Component {
               />
             )}
             {!shouldDisplayResult && <Intro updateQuery={this.updateFields} />}
+            {isFetchingQuery && <ResultLoading />}
             <EarlyAdopterMessage />
           </BodyContent>
         </Body>

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/loading.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/loading.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import styled from 'react-emotion';
+
+import LoadingIndicator from 'app/components/loadingIndicator';
+
+import {LoadingContainer} from '../styles';
+
+export default class Loading extends React.Component {
+  render() {
+    return (
+      <Background>
+        <LoadingContainer>
+          <LoadingIndicator />
+        </LoadingContainer>
+      </Background>
+    );
+  }
+}
+
+export const Background = styled('div')`
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background-color: rgba(250, 249, 251, 0.7);
+`;

--- a/src/sentry/static/sentry/app/views/organizationDiscover/styles.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/styles.jsx
@@ -56,11 +56,13 @@ export const BodyContent = styled(Flex)`
   flex-direction: column;
   padding: ${space(1.5)} 32px 32px 32px;
   overflow: scroll;
+  position: relative;
 `;
 
 export const LoadingContainer = styled(Flex)`
   flex: 1;
   align-items: center;
+  height: 100%;
 `;
 
 export const TopBar = styled(Flex)`


### PR DESCRIPTION
<img width="1262" alt="screen shot 2018-10-26 at 3 54 26 pm" src="https://user-images.githubusercontent.com/1779792/47595890-8275ff80-d937-11e8-9aeb-080ce91d96fe.png">
