### PR TITLE
fix(discover): Fix datetime field handling in conditions

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/conditions/condition.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/conditions/condition.jsx
@@ -71,17 +71,13 @@ export default class Condition extends React.Component {
     const stringOnlyOperators = new Set(['LIKE', 'NOT LIKE']);
 
     return CONDITION_OPERATORS.filter(operator => {
-      if (colType === 'number') {
+      if (colType === 'number' || colType === 'datetime') {
         return !stringOnlyOperators.has(operator);
       }
 
       // We currently only support = and != on array fields
       if (ARRAY_FIELD_PREFIXES.some(prefix => colName.startsWith(prefix))) {
         return ['=', '!='].includes(operator);
-      }
-
-      if (colType === 'datetime') {
-        return !stringOnlyOperators.has(operator) && !numberOnlyOperators.has(operator);
       }
 
       // Treat everything else like a string

--- a/src/sentry/static/sentry/app/views/organizationDiscover/conditions/condition.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/conditions/condition.jsx
@@ -80,6 +80,10 @@ export default class Condition extends React.Component {
         return ['=', '!='].includes(operator);
       }
 
+      if (colType === 'datetime') {
+        return !stringOnlyOperators.has(operator) && !numberOnlyOperators.has(operator);
+      }
+
       // Treat everything else like a string
       return !numberOnlyOperators.has(operator);
     });

--- a/src/sentry/static/sentry/app/views/organizationDiscover/conditions/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/conditions/utils.jsx
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 import {CONDITION_OPERATORS} from '../data';
 
 const specialConditions = new Set(['IS NULL', 'IS NOT NULL']);
@@ -18,9 +20,12 @@ export function isValidCondition(condition, cols) {
   const isColValid = columns.has(condition[0]);
   const isOperatorValid = allOperators.has(condition[1]);
 
+  const colType = (cols.find(col => col.name === condition[0]) || {}).type;
+
   const isValueValid =
     specialConditions.has(condition[1]) ||
-    typeof condition[2] === (cols.find(col => col.name === condition[0]) || {}).type;
+    (colType === 'datetime' && condition[2] !== null) ||
+    colType === typeof condition[2];
 
   return isColValid && isOperatorValid && isValueValid;
 }
@@ -92,6 +97,11 @@ export function getExternal(internal, columns) {
       if (external[2] === 'false') {
         external[2] = false;
       }
+    }
+
+    if (type === 'datetime') {
+      const date = moment.utc(external[2]);
+      external[2] = date.isValid() ? date.format() : null;
     }
   }
 

--- a/src/sentry/static/sentry/app/views/organizationDiscover/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/data.jsx
@@ -2,6 +2,7 @@ const TYPES = {
   STRING: 'string',
   NUMBER: 'number',
   BOOLEAN: 'boolean',
+  DATETIME: 'datetime',
 };
 
 export const PROMOTED_TAGS = [
@@ -37,8 +38,8 @@ export const COLUMNS = [
   {name: 'platform', type: TYPES.STRING},
   {name: 'message', type: TYPES.STRING},
   {name: 'primary_hash', type: TYPES.STRING},
-  {name: 'timestamp', type: TYPES.STRING}, // TODO: handling datetime as string for now
-  {name: 'received', type: TYPES.STRING}, // TODO: handling datetime as string for now
+  {name: 'timestamp', type: TYPES.DATETIME},
+  {name: 'received', type: TYPES.DATETIME},
 
   {name: 'user_id', type: TYPES.STRING},
   {name: 'username', type: TYPES.STRING},

--- a/tests/js/spec/views/organizationDiscover/conditions/condition.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/conditions/condition.spec.jsx
@@ -30,6 +30,7 @@ describe('Condition', function() {
       const columns = [
         {name: 'col1', type: 'string'},
         {name: 'col2', type: 'number'},
+        {name: 'col3', type: 'datetime'},
         {name: 'exception_stacks.type', type: 'string'},
       ];
       wrapper = mount(
@@ -53,6 +54,15 @@ describe('Condition', function() {
       const options = wrapper.instance().filterOptions([], 'col2');
       expect(options).toHaveLength(8);
       expect(options[0]).toEqual({value: 'col2 >', label: 'col2 >'});
+    });
+
+    it('renders operator options for datetime column', function() {
+      const options = wrapper.instance().filterOptions([], 'col3');
+      expect(options).toHaveLength(4);
+      expect(options[0]).toEqual({value: 'col3 =', label: 'col3 ='});
+      expect(options[1]).toEqual({value: 'col3 !=', label: 'col3 !='});
+      expect(options[2]).toEqual({value: 'col3 IS NULL', label: 'col3 IS NULL'});
+      expect(options[3]).toEqual({value: 'col3 IS NOT NULL', label: 'col3 IS NOT NULL'});
     });
 
     it('limits operators to = and != for array fields', function() {

--- a/tests/js/spec/views/organizationDiscover/conditions/condition.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/conditions/condition.spec.jsx
@@ -58,11 +58,15 @@ describe('Condition', function() {
 
     it('renders operator options for datetime column', function() {
       const options = wrapper.instance().filterOptions([], 'col3');
-      expect(options).toHaveLength(4);
-      expect(options[0]).toEqual({value: 'col3 =', label: 'col3 ='});
-      expect(options[1]).toEqual({value: 'col3 !=', label: 'col3 !='});
-      expect(options[2]).toEqual({value: 'col3 IS NULL', label: 'col3 IS NULL'});
-      expect(options[3]).toEqual({value: 'col3 IS NOT NULL', label: 'col3 IS NOT NULL'});
+      expect(options).toHaveLength(8);
+      expect(options[0]).toEqual({value: 'col3 >', label: 'col3 >'});
+      expect(options[1]).toEqual({value: 'col3 <', label: 'col3 <'});
+      expect(options[2]).toEqual({value: 'col3 >=', label: 'col3 >='});
+      expect(options[3]).toEqual({value: 'col3 <=', label: 'col3 <='});
+      expect(options[4]).toEqual({value: 'col3 =', label: 'col3 ='});
+      expect(options[5]).toEqual({value: 'col3 !=', label: 'col3 !='});
+      expect(options[6]).toEqual({value: 'col3 IS NULL', label: 'col3 IS NULL'});
+      expect(options[7]).toEqual({value: 'col3 IS NOT NULL', label: 'col3 IS NOT NULL'});
     });
 
     it('limits operators to = and != for array fields', function() {

--- a/tests/js/spec/views/organizationDiscover/conditions/utils.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/conditions/utils.spec.jsx
@@ -50,6 +50,10 @@ describe('Conditions', function() {
     conditionList.forEach(({internal, external}) => {
       expect(getExternal(internal, COLUMNS)).toEqual(external);
     });
+
+    // datetime fields are expanded
+    const expected = ['received', '=', '2018-05-05T00:00:00Z'];
+    expect(getExternal('received = 2018-05-05', COLUMNS)).toEqual(expected);
   });
 
   it('getInternal()', function() {


### PR DESCRIPTION
Handle "timestamp" and "received" fields as datetime rather than
strings. Do not allow LIKE and NOT LIKE conditions on these fields,
cast values to date time format.