### PR TITLE
build(jest): Disable "verbose" to see console logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "webpack-profile": "yarn -s webpack --profile --json > stats.json"
   },
   "jest": {
+    "verbose": false,
     "collectCoverageFrom": [
       "tests/js/spec/**/*.{js,jsx}",
       "src/sentry/static/sentry/app/**/*.{js,jsx}"


### PR DESCRIPTION
If you've been writing frontend tests then I'm sure you've noticed your `console.log` output being gobbled up from stdout. It's due to a bug in jest with `verbose` mode enabled. I think this is a good temporary solution since I've seen many complaints about `console.log` output.

See this thread for more information: https://github.com/facebook/jest/issues/2441