### PR TITLE
ref: Refactor and fix next/previous event selection.

### DIFF
--- a/src/sentry/api/endpoints/event_details.py
+++ b/src/sentry/api/endpoints/event_details.py
@@ -8,7 +8,6 @@ from sentry.api.base import Endpoint
 from sentry.api.bases.group import GroupPermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import DetailedEventSerializer, serialize
-from sentry.constants import EVENT_ORDERING_KEY
 from sentry.models import Event
 
 
@@ -33,63 +32,11 @@ class EventDetailsEndpoint(Endpoint):
 
         Event.objects.bind_nodes([event], 'data')
 
-        # HACK(dcramer): work around lack of unique sorting on datetime
-        base_qs = Event.objects.filter(
-            group_id=event.group_id,
-        ).exclude(id=event.id)
-
-        # First, we collect 5 leading/trailing events
-        next_events = sorted(
-            base_qs.filter(
-                datetime__gte=event.datetime,
-            ).order_by('datetime')[0:5],
-            key=EVENT_ORDERING_KEY,
-        )
-        prev_events = sorted(
-            base_qs.filter(
-                datetime__lte=event.datetime,
-            ).order_by('-datetime')[0:5],
-            key=EVENT_ORDERING_KEY,
-            reverse=True,
-        )
-
-        # Now, try and find the real next event.
-        # "next" means:
-        #  * If identical timestamps, greater of the ids
-        #  * else greater of the timestamps
-        next_event = None
-        for e in next_events:
-            if e.datetime == event.datetime and e.id > event.id:
-                next_event = e
-                break
-
-            if e.datetime > event.datetime:
-                next_event = e
-                break
-
-        # Last, pick the previous event
-        # "previous" means:
-        #  * If identical timestamps, lesser of the ids
-        #  * else lesser of the timestamps
-        prev_event = None
-        for e in prev_events:
-            if e.datetime == event.datetime and e.id < event.id:
-                prev_event = e
-                break
-
-            if e.datetime < event.datetime:
-                prev_event = e
-                break
-
         data = serialize(event, request.user, DetailedEventSerializer())
 
-        if next_event:
-            data['nextEventID'] = six.text_type(next_event.id)
-        else:
-            data['nextEventID'] = None
-        if prev_event:
-            data['previousEventID'] = six.text_type(prev_event.id)
-        else:
-            data['previousEventID'] = None
+        next_event = event.next_event
+        prev_event = event.prev_event
+        data['nextEventID'] = next_event and six.text_type(next_event.id)
+        data['previousEventID'] = prev_event and six.text_type(prev_event.id)
 
         return Response(data)

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -67,38 +67,13 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
 
         Event.objects.bind_nodes([event], 'data')
 
-        # HACK(dcramer): work around lack of unique sorting on datetime
-        base_qs = Event.objects.filter(
-            group_id=event.group_id,
-        ).exclude(id=event.id)
-        try:
-            next_event = sorted(
-                base_qs.filter(datetime__gte=event.datetime).order_by('datetime')[0:5],
-                key=lambda x: (x.datetime, x.id)
-            )[0]
-        except IndexError:
-            next_event = None
-
-        try:
-            prev_event = sorted(
-                base_qs.filter(
-                    datetime__lte=event.datetime,
-                ).order_by('-datetime')[0:5],
-                key=lambda x: (x.datetime, x.id),
-                reverse=True
-            )[0]
-        except IndexError:
-            prev_event = None
-
         data = serialize(event, request.user, DetailedEventSerializer())
 
-        if next_event:
-            data['nextEventID'] = six.text_type(next_event.event_id)
-        else:
-            data['nextEventID'] = None
-        if prev_event:
-            data['previousEventID'] = six.text_type(prev_event.event_id)
-        else:
-            data['previousEventID'] = None
+        next_event = event.next_event
+        prev_event = event.prev_event
+        # TODO this is inconsistent with the event_details API which uses the
+        # `id` instead of the `event_id`
+        data['nextEventID'] = next_event and six.text_type(next_event.event_id)
+        data['previousEventID'] = prev_event and six.text_type(prev_event.event_id)
 
         return Response(data)

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -13,11 +13,13 @@ import warnings
 
 from collections import OrderedDict
 from django.db import models
+from django.db.models import Q
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 from hashlib import md5
 
 from sentry import eventtypes
+from sentry.constants import EVENT_ORDERING_KEY
 from sentry.db.models import (
     BoundedBigIntegerField, BoundedIntegerField, Model, NodeField, sane_repr
 )
@@ -323,6 +325,46 @@ class Event(Model):
             )
 
         return self._environment_cache
+
+    # Find next and previous events based on datetime and id. We cannot
+    # simply `ORDER BY (datetime, id)` as this is too slow (no index), so
+    # we grab the next 5 / prev 5 events by datetime, and sort locally to
+    # get the next/prev events. Given that timestamps only have 1-second
+    # granularity, this will be inaccurate if there are more than 5 events
+    # in a given second.
+    @property
+    def next_event(self):
+        qs = self.__class__.objects.filter(
+            # To be 'after', an event needs either a higher datetime,
+            # or the same datetime and a higher id.
+            (
+                Q(datetime__gt=self.datetime) |
+                (Q(datetime=self.datetime) & Q(id__gt=self.id))
+            ),
+            group_id=self.group_id,
+        ).exclude(id=self.id).order_by('datetime')
+
+        try:
+            return sorted(qs[0:5], key=EVENT_ORDERING_KEY)[0]
+        except IndexError:
+            return None
+
+    @property
+    def prev_event(self):
+        qs = self.__class__.objects.filter(
+            # To be 'before', an event needs either a lower datetime,
+            # or the same datetime and a lower id.
+            (
+                Q(datetime__lt=self.datetime) |
+                (Q(datetime=self.datetime) & Q(id__lt=self.id))
+            ),
+            group_id=self.group_id,
+        ).exclude(id=self.id).order_by('-datetime')
+
+        try:
+            return sorted(qs[0:5], key=EVENT_ORDERING_KEY, reverse=True)[0]
+        except IndexError:
+            return None
 
 
 class EventSubjectTemplate(string.Template):

--- a/tests/sentry/api/endpoints/test_project_event_details.py
+++ b/tests/sentry/api/endpoints/test_project_event_details.py
@@ -61,3 +61,37 @@ class ProjectEventDetailsTest(APITestCase):
         assert response.data['nextEventID'] == six.text_type(next_event.event_id)
         assert response.data['previousEventID'] == six.text_type(prev_event.event_id)
         assert response.data['groupID'] == six.text_type(group.id)
+
+    def test_prev_has_no_prev(self):
+        # Test that the "previous" event does not itself have a "previousEventID"
+        # pointing back to the current event. i.e. test that there is not a redirect
+        # loop between next and previous events that occur within the same second.
+        self.login_as(user=self.user)
+
+        group = self.create_group()
+        prev_event = self.create_event(
+            event_id='a' * 32,
+            group=group,
+            datetime=datetime(2013, 8, 13, 3, 8, 24),
+        )
+        cur_event = self.create_event(
+            event_id='b' * 32,
+            group=group,
+            datetime=datetime(2013, 8, 13, 3, 8, 24),
+        )
+
+        url = reverse(
+            'sentry-api-0-project-event-details',
+            kwargs={
+                'event_id': prev_event.event_id,
+                'project_slug': prev_event.project.slug,
+                'organization_slug': prev_event.project.organization.slug,
+            }
+        )
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert response.data['id'] == six.text_type(prev_event.id)
+        assert response.data['previousEventID'] is None
+        assert response.data['nextEventID'] == cur_event.event_id
+        assert response.data['groupID'] == six.text_type(group.id)


### PR DESCRIPTION
Document the reasoning behind, and provide a consistent implementation of
the current "hack" for fetching the next and prev events.

Also fix a bug in one of the implementations where an event could show
up as prev when it should actually be next, and vice versa.