### PR TITLE
fix(integrations) Use get() as Content-Type may not be set

### DIFF
--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -250,7 +250,7 @@ class OAuth2CallbackView(PipelineView):
         verify_ssl = pipeline.config.get('verify_ssl', True)
         req = safe_urlopen(self.access_token_url, data=data, verify_ssl=verify_ssl)
         body = safe_urlread(req)
-        if req.headers['Content-Type'].startswith('application/x-www-form-urlencoded'):
+        if req.headers.get('Content-Type', '').startswith('application/x-www-form-urlencoded'):
             return dict(parse_qsl(body))
         return json.loads(body)
 


### PR DESCRIPTION
During a demo we had an OAuth token exchange response not include a content-type header which resulted in a 500. We can work around that by using get()

Fixes SENTRY-827
Fixes APP-686