### PR TITLE
feat(saml): Enable metadata endpoint before IDP is configured

### DIFF
--- a/src/sentry/auth/providers/saml2.py
+++ b/src/sentry/auth/providers/saml2.py
@@ -185,11 +185,9 @@ class SAML2SLSView(BaseView):
 class SAML2MetadataView(BaseView):
     def dispatch(self, request, organization_slug):
         provider = get_provider(organization_slug)
-        if provider is None:
-            messages.add_message(request, messages.ERROR, ERR_NO_SAML_SSO)
-            return self.redirect('/')
+        config = provider.config if provider else {}
 
-        saml_config = build_saml_config(provider.config, organization_slug)
+        saml_config = build_saml_config(config, organization_slug)
         saml_settings = OneLogin_Saml2_Settings(settings=saml_config, sp_validation_only=True)
         metadata = saml_settings.get_sp_metadata()
         errors = saml_settings.validate_metadata(metadata)
@@ -337,8 +335,6 @@ def build_saml_config(provider_config, org):
         'wantNameId': False,
     }
 
-    idp = provider_config['idp']
-
     # TODO(epurkhiser): This is also available in the helper and should probably come from there.
     acs_url = absolute_uri(reverse('sentry-auth-organization-saml-acs', args=[org]))
     sls_url = absolute_uri(reverse('sentry-auth-organization-saml-sls', args=[org]))
@@ -346,12 +342,6 @@ def build_saml_config(provider_config, org):
 
     saml_config = {
         'strict': True,
-        'idp': {
-            'entityId': idp['entity_id'],
-            'x509cert': idp['x509cert'],
-            'singleSignOnService': {'url': idp['sso_url']},
-            'singleLogoutService': {'url': idp['slo_url']},
-        },
         'sp': {
             'entityId': metadata_url,
             'assertionConsumerService': {
@@ -365,6 +355,16 @@ def build_saml_config(provider_config, org):
         },
         'security': security_config,
     }
+
+    idp = provider_config.get('idp')
+
+    if idp is not None:
+        saml_config['idp'] = {
+            'entityId': idp['entity_id'],
+            'x509cert': idp['x509cert'],
+            'singleSignOnService': {'url': idp['sso_url']},
+            'singleLogoutService': {'url': idp['slo_url']},
+        }
 
     if avd.get('x509cert') is not None:
         saml_config['sp']['x509cert'] = avd['x509cert']


### PR DESCRIPTION
We've seen a lot of people request to have a service provider metadata endpoint they can use to configure their IDP. Prior to this we were only making our metadata endpoint available after the IDP was configured on our end, however to confgiure the IDP on our end means having already confgiured the SP in the users IDP.