### PR TITLE
fix(discover): Fix bug in combined time selector

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/combinedSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/combinedSelector.jsx
@@ -81,7 +81,7 @@ export default class CombinedSelector extends React.Component {
             onChange={val => this.handleChange('relative', val.value)}
           />
         </Box>
-        {relative === null && (
+        {!relative && (
           <React.Fragment>
             <Box mb={1}>
               <DateTimeField


### PR DESCRIPTION
Relative value can be undefined when absolute time is used. This caused a bug in a Discover saved query, where the from and to values would not be displayed.