### PR TITLE
feat(app-platform): Add sentry app test fixture

### DIFF
--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -24,6 +24,9 @@ from hashlib import sha1
 from loremipsum import Generator
 from uuid import uuid4
 
+from sentry.constants import SentryAppStatus
+from sentry.mediators.sentry_apps import Creator as SentryAppCreator
+from sentry.mediators.sentry_app_installations import Creator as SentryAppInstallationCreator
 from sentry.models import (
     Activity, Environment, Event, EventError, EventMapping, Group, Organization, OrganizationMember,
     OrganizationMemberTeam, Project, Team, User, UserEmail, Release, Commit, ReleaseCommit,
@@ -700,3 +703,27 @@ class Fixtures(object):
                 UserPermission.objects.create(user=user, permission=permission)
         except IntegrityError:
             raise
+
+    def create_sentry_app(self, name=None, organization=None, published=False, scopes=(),
+                          webhook_url=None, **kwargs):
+        if not name:
+            name = 'Test App'
+        if not organization:
+            organization = self.organization
+        if not webhook_url:
+            webhook_url = 'https://example.com/webhook'
+
+        app = SentryAppCreator.run(
+            name=name,
+            organization=organization,
+            scopes=scopes,
+            webhook_url=webhook_url,
+            **kwargs
+        )
+        if published:
+            app.update(status=SentryAppStatus.PUBLISHED)
+
+        return app
+
+    def create_sentry_app_install(self, organization=None):
+        return

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -708,7 +708,7 @@ class Fixtures(object):
         if not name:
             name = 'Test App'
         if not organization:
-            organization = self.organization
+            organization = self.create_organization()
         if not webhook_url:
             webhook_url = 'https://example.com/webhook'
 

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -26,7 +26,6 @@ from uuid import uuid4
 
 from sentry.constants import SentryAppStatus
 from sentry.mediators.sentry_apps import Creator as SentryAppCreator
-from sentry.mediators.sentry_app_installations import Creator as SentryAppInstallationCreator
 from sentry.models import (
     Activity, Environment, Event, EventError, EventMapping, Group, Organization, OrganizationMember,
     OrganizationMemberTeam, Project, Team, User, UserEmail, Release, Commit, ReleaseCommit,
@@ -724,6 +723,3 @@ class Fixtures(object):
             app.update(status=SentryAppStatus.PUBLISHED)
 
         return app
-
-    def create_sentry_app_install(self, organization=None):
-        return

--- a/tests/sentry/api/bases/test_sentryapps.py
+++ b/tests/sentry/api/bases/test_sentryapps.py
@@ -10,7 +10,6 @@ from sentry.api.bases.sentryapps import (
     SentryAppInstallationDetailsEndpoint,
 )
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.mediators.sentry_apps import Creator as SentryAppCreator
 from sentry.mediators.sentry_app_installations import Creator as SentryAppInstallationCreator
 
 
@@ -20,11 +19,9 @@ class SentryAppDetailsPermissionTest(TestCase):
         self.user = self.create_user()
         self.org = self.create_organization(owner=self.user)
 
-        self.sentry_app = SentryAppCreator.run(
+        self.sentry_app = self.create_sentry_app(
             name='foo',
             organization=self.org,
-            scopes=(),
-            webhook_url='https://example.com',
         )
 
         self.request = HttpRequest()
@@ -49,11 +46,9 @@ class SentryAppDetailsEndpointTest(TestCase):
         self.request.user = self.user
         self.request.successful_authenticator = True
 
-        self.sentry_app = SentryAppCreator.run(
+        self.sentry_app = self.create_sentry_app(
             name='foo',
             organization=self.org,
-            scopes=(),
-            webhook_url='https://example.com',
         )
 
     def test_retrieves_sentry_app(self):
@@ -73,13 +68,10 @@ class SentryAppInstallationDetailsPermissionTest(TestCase):
         self.member = self.create_user()
         self.org = self.create_organization(owner=self.member)
 
-        self.sentry_app = SentryAppCreator.run(
+        self.sentry_app = self.create_sentry_app(
             name='foo',
             organization=self.org,
-            scopes=(),
-            webhook_url='https://example.com',
         )
-
         self.installation, _ = SentryAppInstallationCreator.run(
             slug=self.sentry_app.slug,
             organization=self.org,
@@ -125,11 +117,9 @@ class SentryAppInstallationDetailsEndpointTest(TestCase):
         self.request.user = self.user
         self.request.successful_authenticator = True
 
-        self.sentry_app = SentryAppCreator.run(
+        self.sentry_app = self.create_sentry_app(
             name='foo',
             organization=self.org,
-            scopes=(),
-            webhook_url='https://example.com',
         )
 
         self.installation, _ = SentryAppInstallationCreator.run(

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -2,10 +2,8 @@ from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
 
-from sentry.constants import SentryAppStatus
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import with_feature
-from sentry.mediators.sentry_apps import Creator as SentryAppCreator
 from sentry.mediators.sentry_app_installations import Creator
 
 
@@ -15,22 +13,18 @@ class OrganizationSentryAppInstallationDetailsTest(APITestCase):
         self.user = self.create_user(email='boop@example.com')
         self.org = self.create_organization(owner=self.user)
         self.super_org = self.create_organization(owner=self.superuser)
-        self.published_app = SentryAppCreator.run(
+        self.published_app = self.create_sentry_app(
             name='Test',
             organization=self.super_org,
-            scopes=(),
-            webhook_url='https://example.com',
+            published=True,
         )
-        self.published_app.update(status=SentryAppStatus.PUBLISHED)
         self.installation, _ = Creator.run(
             slug=self.published_app.slug,
             organization=self.super_org,
         )
-        self.unpublished_app = SentryAppCreator.run(
+        self.unpublished_app = self.create_sentry_app(
             name='Testin',
             organization=self.org,
-            scopes=(),
-            webhook_url='https://example.com',
         )
         self.installation2, _ = Creator.run(
             slug=self.unpublished_app.slug,

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -17,22 +17,18 @@ class OrganizationSentryAppInstallationsTest(APITestCase):
         self.user = self.create_user(email='boop@example.com')
         self.org = self.create_organization(owner=self.user)
         self.super_org = self.create_organization(owner=self.superuser)
-        self.published_app = SentryAppCreator.run(
+        self.published_app = self.create_sentry_app(
             name='Test',
             organization=self.super_org,
-            scopes=(),
-            webhook_url='https://example.com',
+            published=True,
         )
-        self.published_app.update(status=SentryAppStatus.PUBLISHED)
+        self.unpublished_app = self.create_sentry_app(
+            name='Testin',
+            organization=self.org,
+        )
         self.installation, _ = Creator.run(
             slug=self.published_app.slug,
             organization=self.super_org,
-        )
-        self.unpublished_app = SentryAppCreator.run(
-            name='Testin',
-            organization=self.org,
-            scopes=(),
-            webhook_url='https://example.com',
         )
         self.installation2, _ = Creator.run(
             slug=self.unpublished_app.slug,

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -4,10 +4,8 @@ import six
 
 from django.core.urlresolvers import reverse
 
-from sentry.constants import SentryAppStatus
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import with_feature
-from sentry.mediators.sentry_apps import Creator as SentryAppCreator
 from sentry.mediators.sentry_app_installations import Creator
 
 
@@ -95,11 +93,9 @@ class PostOrganizationSentryAppInstallationsTest(OrganizationSentryAppInstallati
     @with_feature('organizations:internal-catchall')
     def test_install_unpublished_app(self):
         self.login_as(user=self.user)
-        app = SentryAppCreator.run(
+        app = self.create_sentry_app(
             name='Sample',
             organization=self.org,
-            scopes=(),
-            webhook_url='https://example.com',
         )
         response = self.client.post(
             self.url,
@@ -117,13 +113,11 @@ class PostOrganizationSentryAppInstallationsTest(OrganizationSentryAppInstallati
     @with_feature('organizations:internal-catchall')
     def test_install_published_app(self):
         self.login_as(user=self.user)
-        app = SentryAppCreator.run(
+        app = self.create_sentry_app(
             name='Sample',
             organization=self.org,
-            scopes=(),
-            webhook_url='https://example.com',
+            published=True,
         )
-        app.update(status=SentryAppStatus.PUBLISHED)
         response = self.client.post(
             self.url,
             data={'slug': app.slug},
@@ -146,13 +140,11 @@ class PostOrganizationSentryAppInstallationsTest(OrganizationSentryAppInstallati
             role='member',
         )
         self.login_as(user)
-        app = SentryAppCreator.run(
+        app = self.create_sentry_app(
             name='Sample',
             organization=self.org,
-            scopes=(),
-            webhook_url='https://example.com',
+            published=True,
         )
-        app.update(status=SentryAppStatus.PUBLISHED)
         response = self.client.post(
             self.url,
             data={'slug': app.slug},

--- a/tests/sentry/api/endpoints/test_organization_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_apps.py
@@ -2,10 +2,8 @@ from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
 
-from sentry.constants import SentryAppStatus
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import with_feature
-from sentry.mediators.sentry_apps import Creator as SentryAppCreator
 
 
 class OrganizationSentryAppsTest(APITestCase):
@@ -14,18 +12,14 @@ class OrganizationSentryAppsTest(APITestCase):
         self.user = self.create_user(email='boop@example.com')
         self.org = self.create_organization(owner=self.user)
         self.super_org = self.create_organization(owner=self.superuser)
-        self.published_app = SentryAppCreator.run(
+        self.published_app = self.create_sentry_app(
             name='Test',
             organization=self.super_org,
-            scopes=(),
-            webhook_url='https://example.com',
+            published=True,
         )
-        self.published_app.update(status=SentryAppStatus.PUBLISHED)
-        self.unpublished_app = SentryAppCreator.run(
+        self.unpublished_app = self.create_sentry_app(
             name='Testin',
             organization=self.org,
-            scopes=(),
-            webhook_url='https://example.com',
         )
         self.url = reverse('sentry-api-0-organization-sentry-apps', args=[self.org.slug])
 

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -6,33 +6,23 @@ from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import with_feature
-from sentry.mediators.sentry_apps import Creator
-from sentry.constants import SentryAppStatus
 
 
 class SentryAppsTest(APITestCase):
     def setUp(self):
         self.superuser = self.create_user(email='a@example.com', is_superuser=True)
-        self.super_org = self.create_organization(owner=self.superuser)
-
         self.user = self.create_user(email='boop@example.com')
         self.org = self.create_organization(owner=self.user)
-
-        self.published_app = Creator.run(
+        self.super_org = self.create_organization(owner=self.superuser)
+        self.published_app = self.create_sentry_app(
             name='Test',
             organization=self.org,
-            scopes=(),
-            webhook_url='https://example.com',
+            published=True,
         )
-        self.published_app.update(status=SentryAppStatus.PUBLISHED)
-
-        self.unpublished_app = Creator.run(
+        self.unpublished_app = self.create_sentry_app(
             name='Testin',
             organization=self.org,
-            scopes=(),
-            webhook_url='https://example.com',
         )
-
         self.url = reverse('sentry-api-0-sentry-apps')
 
 

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -4,7 +4,6 @@ from django.http import HttpRequest
 from rest_framework.exceptions import AuthenticationFailed
 
 from sentry.api.authentication import ClientIdSecretAuthentication
-from sentry.mediators.sentry_apps import Creator
 from sentry.testutils import TestCase
 
 
@@ -15,11 +14,9 @@ class TestClientIdSecretAuthentication(TestCase):
         self.auth = ClientIdSecretAuthentication()
         self.org = self.create_organization(owner=self.user)
 
-        self.sentry_app = Creator.run(
+        self.sentry_app = self.create_sentry_app(
             name="foo",
             organization=self.org,
-            scopes=(),
-            webhook_url='https://example.com',
         )
 
         self.api_app = self.sentry_app.application

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -5,7 +5,6 @@ from mock import Mock
 
 from sentry.auth import access
 from sentry.models import AuthProvider, AuthIdentity, Organization
-from sentry.mediators.sentry_apps import Creator as SentryAppCreator
 from sentry.mediators.sentry_app_installations import Creator as \
     SentryAppInstallationCreator
 from sentry.testutils import TestCase
@@ -172,11 +171,9 @@ class FromSentryAppTest(TestCase):
             organization=self.out_of_scope_org
         )
 
-        self.sentry_app = SentryAppCreator.run(
+        self.sentry_app = self.create_sentry_app(
             name='SlowDB',
             organization=self.org,
-            scopes=(),
-            webhook_url='http://example.com',
         )
 
         self.proxy_user = self.sentry_app.proxy_user

--- a/tests/sentry/mediators/sentry_app_installations/test_authorizer.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_authorizer.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from datetime import datetime, timedelta
 
 from sentry.coreapi import APIUnauthorized
-from sentry.mediators.sentry_apps import Creator as SentryAppCreator
 from sentry.mediators.sentry_app_installations import Authorizer, Creator
 from sentry.testutils import TestCase
 
@@ -13,11 +12,9 @@ class TestAuthorizer(TestCase):
         self.user = self.create_user()
         self.org = self.create_organization()
 
-        self.sentry_app = SentryAppCreator.run(
+        self.sentry_app = self.create_sentry_app(
             name='nulldb',
             organization=self.org,
-            scopes=(),
-            webhook_url='http://example.com',
         )
 
         self.install, self.grant = Creator.run(

--- a/tests/sentry/mediators/sentry_app_installations/test_creator.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_creator.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-from sentry.mediators.sentry_apps import Creator as SentryAppCreator
 from sentry.mediators.sentry_app_installations import Creator
 from sentry.models import ApiAuthorization
 from sentry.testutils import TestCase
@@ -11,11 +10,10 @@ class TestCreator(TestCase):
         self.user = self.create_user()
         self.org = self.create_organization()
 
-        self.sentry_app = SentryAppCreator.run(
+        self.sentry_app = self.create_sentry_app(
             name='nulldb',
             organization=self.org,
             scopes=('project:read',),
-            webhook_url='http://example.com',
         )
 
         self.creator = Creator(organization=self.org, slug='nulldb')

--- a/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 from django.db import connection
 
-from sentry.mediators.sentry_apps import Creator as SentryAppCreator
 from sentry.mediators.sentry_app_installations import Creator, Destroyer
 from sentry.models import ApiAuthorization, ApiGrant, SentryAppInstallation
 from sentry.testutils import TestCase
@@ -13,11 +12,10 @@ class TestDestroyer(TestCase):
         self.user = self.create_user()
         self.org = self.create_organization()
 
-        self.sentry_app = SentryAppCreator.run(
+        self.sentry_app = self.create_sentry_app(
             name='nulldb',
             organization=self.org,
             scopes=('project:read',),
-            webhook_url='https://example.com',
         )
 
         self.install, self.grant = Creator.run(

--- a/tests/sentry/mediators/sentry_apps/test_destroyer.py
+++ b/tests/sentry/mediators/sentry_apps/test_destroyer.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.db import connection
 
-from sentry.mediators.sentry_apps import Creator, Destroyer
+from sentry.mediators.sentry_apps import Destroyer
 from sentry.models import ApiApplication, User, SentryApp
 from sentry.testutils import TestCase
 
@@ -12,11 +12,10 @@ class TestDestroyer(TestCase):
         self.user = self.create_user()
         self.org = self.create_organization()
 
-        self.sentry_app = Creator.run(
+        self.sentry_app = self.create_sentry_app(
             name='blah',
             organization=self.org,
             scopes=('project:read',),
-            webhook_url='https://example.com',
         )
 
         self.destroyer = Destroyer(sentry_app=self.sentry_app)

--- a/tests/sentry/mediators/sentry_apps/test_updater.py
+++ b/tests/sentry/mediators/sentry_apps/test_updater.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
 from sentry.coreapi import APIError
-from sentry.constants import SentryAppStatus
-from sentry.mediators.sentry_apps import Creator, Updater
+from sentry.mediators.sentry_apps import Updater
 from sentry.testutils import TestCase
 
 
@@ -10,11 +9,10 @@ class TestUpdater(TestCase):
     def setUp(self):
         self.user = self.create_user()
         self.org = self.create_organization(owner=self.user)
-        self.sentry_app = Creator.run(
+        self.sentry_app = self.create_sentry_app(
             name='nulldb',
             organization=self.org,
             scopes=('project:read',),
-            webhook_url='http://example.com',
         )
 
         self.updater = Updater(sentry_app=self.sentry_app)
@@ -31,13 +29,12 @@ class TestUpdater(TestCase):
             ['project:read', 'project:write']
 
     def test_doesnt_update_published_app_scopes(self):
-        sentry_app = Creator.run(
+        sentry_app = self.create_sentry_app(
             name='sentry',
             organization=self.org,
             scopes=('project:read',),
-            webhook_url='http://example.com',
+            published=True,
         )
-        sentry_app.update(status=SentryAppStatus.PUBLISHED)
         updater = Updater(sentry_app=sentry_app)
         updater.scopes = ('project:read', 'project:write', )
 


### PR DESCRIPTION
Adds `create_sentry_app` to test fixtures:
* Defaults:
  * `name='Test App'`
  *  `organization=self.create_organization()`
  * `scopes=()`
  * `webhook_url='https://example.com/webhook'`
 
<br/>

 * To make an app published pass `published=True` (default is False)
