### PR TITLE
feat: Add FeatureDisabled component

### DIFF
--- a/docs-ui/components/featureDisabled.stories.js
+++ b/docs-ui/components/featureDisabled.stories.js
@@ -8,7 +8,7 @@ storiesOf('UI|FeatureDisabled', module)
   .add(
     'basic style',
     withInfo('A disabled feature component')(() => (
-      <FeatureDisabled name="Example Feature" feature="organizaton:example-feature" />
+      <FeatureDisabled name="Example Feature" feature="organization:example-feature" />
     ))
   )
   .add(

--- a/docs-ui/components/featureDisabled.stories.js
+++ b/docs-ui/components/featureDisabled.stories.js
@@ -16,7 +16,7 @@ storiesOf('UI|FeatureDisabled', module)
     withInfo('A disabled feature wrapped in an alert')(() => (
       <FeatureDisabled
         name="Example Feature"
-        feature="organizaton:example-feature"
+        feature="organization:example-feature"
         alert
       />
     ))

--- a/docs-ui/components/featureDisabled.stories.js
+++ b/docs-ui/components/featureDisabled.stories.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import {storiesOf} from '@storybook/react';
+import {withInfo} from '@storybook/addon-info';
+import FeatureDisabled from 'app/components/acl/featureDisabled';
+
+storiesOf('UI|FeatureDisabled', module)
+  .add(
+    'basic style',
+    withInfo('A disabled feature component')(() => (
+      <FeatureDisabled name="Example Feature" feature="organizaton:example-feature" />
+    ))
+  )
+  .add(
+    'alert style',
+    withInfo('A disabled feature wrapped in an alert')(() => (
+      <FeatureDisabled
+        name="Example Feature"
+        feature="organizaton:example-feature"
+        alert
+      />
+    ))
+  );

--- a/src/sentry/static/sentry/app/components/acl/featureDisabled.jsx
+++ b/src/sentry/static/sentry/app/components/acl/featureDisabled.jsx
@@ -11,7 +11,7 @@ import ExternalLink from 'app/components/externalLink';
 const CONFIG_DOCS_URL = 'https://docs.sentry.io/server/config/';
 
 /**
- * DisabledInfo renders a componet informing that a feature has been disabled.
+ * DisabledInfo renders a component informing that a feature has been disabled.
  *
  * By default this component will render a help button which toggles more
  * information about why the feature is disabled, showing the missing feature

--- a/src/sentry/static/sentry/app/components/acl/featureDisabled.jsx
+++ b/src/sentry/static/sentry/app/components/acl/featureDisabled.jsx
@@ -120,7 +120,8 @@ const HelpDescription = styled(Box)`
 `;
 
 const StyledAlert = styled(Alert)`
-  ${/* sc-selector */ HelpButton} {
+  /* stylelint-disable-next-line no-duplicate-selectors */
+  ${HelpButton} {
     color: #6d6319;
     &:hover {
       color: #88750b;

--- a/src/sentry/static/sentry/app/components/acl/featureDisabled.jsx
+++ b/src/sentry/static/sentry/app/components/acl/featureDisabled.jsx
@@ -44,7 +44,7 @@ class FeatureDisabled extends React.Component {
           {t('This feature is not enabled on your Sentry installation.')}
           {!hideHelpToggle && (
             <HelpButton
-              icon={this.showHelp ? 'icon-chevron-down' : 'icon-circle-info'}
+              icon={showHelp ? 'icon-chevron-down' : 'icon-circle-info'}
               priority="link"
               size="xsmall"
               onClick={this.toggleHelp}

--- a/src/sentry/static/sentry/app/components/acl/featureDisabled.jsx
+++ b/src/sentry/static/sentry/app/components/acl/featureDisabled.jsx
@@ -7,6 +7,7 @@ import {t, tct} from 'app/locale';
 import Alert from 'app/components/alert';
 import Button from 'app/components/button';
 import ExternalLink from 'app/components/externalLink';
+import space from 'app/styles/space';
 
 const CONFIG_DOCS_URL = 'https://docs.sentry.io/server/config/';
 
@@ -71,7 +72,7 @@ class FeatureDisabled extends React.Component {
           )}
         </Flex>
         {showHelp && (
-          <HelpDescription mt={1}>
+          <HelpDescription>
             <p>
               {tct(
                 `Enable this feature on your sentry installation by adding the
@@ -109,6 +110,7 @@ const HelpButton = styled(Button)`
 
 const HelpDescription = styled(Box)`
   font-size: 0.9em;
+  margin-top: ${space(1)};
 
   p {
     line-height: 1.5em;

--- a/src/sentry/static/sentry/app/components/acl/featureDisabled.jsx
+++ b/src/sentry/static/sentry/app/components/acl/featureDisabled.jsx
@@ -31,7 +31,7 @@ class FeatureDisabled extends React.Component {
 
   toggleHelp = e => {
     e.preventDefault();
-    this.setState({showHelp: !this.state.showHelp});
+    this.setState(state => ({showHelp: !state.showHelp}));
   };
 
   render() {

--- a/src/sentry/static/sentry/app/components/acl/featureDisabled.jsx
+++ b/src/sentry/static/sentry/app/components/acl/featureDisabled.jsx
@@ -1,0 +1,119 @@
+import {Box, Flex} from 'grid-emotion';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'react-emotion';
+
+import {t, tct} from 'app/locale';
+import Alert from 'app/components/alert';
+import Button from 'app/components/button';
+import ExternalLink from 'app/components/externalLink';
+
+const CONFIG_DOCS_URL = 'https://docs.sentry.io/server/config/';
+
+/**
+ * DisabledInfo renders a componet informing that a feature has been disabled.
+ *
+ * By default this component will render a help button which toggles more
+ * information about why the feature is disabled, showing the missing feature
+ * flag and linking to documentation for managing sentry server feature flags.
+ */
+class FeatureDisabled extends React.Component {
+  static propTypes = {
+    feature: PropTypes.string,
+    featureName: PropTypes.string,
+    hideHelpToggle: PropTypes.bool,
+    alert: PropTypes.bool,
+  };
+
+  state = {
+    showHelp: false,
+  };
+
+  toggleHelp = e => {
+    e.preventDefault();
+    this.setState({showHelp: !this.state.showHelp});
+  };
+
+  render() {
+    const {showHelp} = this.state;
+    const {feature, featureName, hideHelpToggle, alert} = this.props;
+
+    const featureDisabled = (
+      <React.Fragment>
+        <Flex justify="space-between">
+          {t('This feature is not enabled on your Sentry installation.')}
+          {!hideHelpToggle && (
+            <HelpButton
+              icon={this.showHelp ? 'icon-chevron-down' : 'icon-circle-info'}
+              priority="link"
+              size="xsmall"
+              onClick={this.toggleHelp}
+            >
+              {t('Help')}
+            </HelpButton>
+          )}
+        </Flex>
+        {showHelp && (
+          <HelpDescription mt={1}>
+            <p>
+              {tct(
+                `Enable this feature on your sentry installation by adding the
+                  following configuration into your [configFile:sentry.conf.py].
+                  See [configLink:the configuration documentation] for more
+                  details.`,
+                {
+                  configFile: <code />,
+                  configLink: <ExternalLink href={CONFIG_DOCS_URL} />,
+                }
+              )}
+            </p>
+            <pre>
+              <code
+              >{`# Enables the ${featureName} feature\nSENTRY_FEATURES['${feature}'] = True`}</code>
+            </pre>
+          </HelpDescription>
+        )}
+      </React.Fragment>
+    );
+
+    return !alert ? (
+      featureDisabled
+    ) : (
+      <StyledAlert type="warning" icon="icon-labs">
+        {featureDisabled}
+      </StyledAlert>
+    );
+  }
+}
+
+const HelpButton = styled(Button)`
+  font-size: 0.8em;
+`;
+
+const HelpDescription = styled(Box)`
+  font-size: 0.9em;
+
+  p {
+    line-height: 1.5em;
+  }
+
+  pre {
+    margin-bottom: 0;
+  }
+`;
+
+const StyledAlert = styled(Alert)`
+  ${/* sc-selector */ HelpButton} {
+    color: #6d6319;
+    &:hover {
+      color: #88750b;
+    }
+  }
+
+  pre,
+  code {
+    background: #fbf7e0;
+  }
+`;
+
+export default FeatureDisabled;

--- a/src/sentry/static/sentry/app/components/acl/featureDisabled.jsx
+++ b/src/sentry/static/sentry/app/components/acl/featureDisabled.jsx
@@ -19,10 +19,27 @@ const CONFIG_DOCS_URL = 'https://docs.sentry.io/server/config/';
  */
 class FeatureDisabled extends React.Component {
   static propTypes = {
+    /**
+     * The feature flag key that should be uwed in the code example for
+     * enabling the feature.
+     */
     feature: PropTypes.string,
+    /**
+     * The english name of the feature. This is used in the comment that will
+     * be outputted above the example line of code to enable the feature.
+     */
     featureName: PropTypes.string,
-    hideHelpToggle: PropTypes.bool,
+    /**
+     * Render the disabled message within a warning Alert.
+     *
+     * Attaches additional styles to the FeatureDisabeld component to make it
+     * look nice within the Alert.
+     */
     alert: PropTypes.bool,
+    /**
+     * Do not show the help toggle.
+     */
+    hideHelpToggle: PropTypes.bool,
   };
 
   state = {

--- a/tests/js/spec/components/acl/featureDisabled.spec.jsx
+++ b/tests/js/spec/components/acl/featureDisabled.spec.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import FeatureDisabled from 'app/components/acl/featureDisabled';
+import {mount} from 'enzyme';
+
+describe('FeatureDisabled', function() {
+  const routerContext = TestStubs.routerContext();
+
+  it('renders', function() {
+    const wrapper = mount(
+      <FeatureDisabled feature={'organization:my-feature'} featureName="Some Feature" />,
+      routerContext
+    );
+
+    expect(
+      wrapper
+        .find('Flex')
+        .first()
+        .text()
+    ).toEqual(
+      expect.stringContaining('This feature is not enabled on your Sentry installation.')
+    );
+    expect(wrapper.exists('HelpButton')).toBe(true);
+  });
+
+  it('renders as an Alert', function() {
+    const wrapper = mount(
+      <FeatureDisabled
+        alert
+        feature={'organization:my-feature'}
+        featureName="Some Feature"
+      />,
+      routerContext
+    );
+
+    expect(wrapper.exists('Alert')).toBe(true);
+  });
+
+  it('displays instructions when help is clicked', function() {
+    const wrapper = mount(
+      <FeatureDisabled
+        alert
+        feature={'organization:my-feature'}
+        featureName="Some Feature"
+      />,
+      routerContext
+    );
+
+    wrapper.find('HelpButton').simulate('click');
+    wrapper.update();
+
+    expect(wrapper.exists('HelpDescription')).toBe(true);
+  });
+});


### PR DESCRIPTION
Adds a component that can be used to denote when a feature is disabled.

This is intended to be used with the `Feature`'s `renderDisabled` render prop.

[See it in action here](https://storybook.getsentry.net/branches/feat-add-featuredisabled-component/index.html?selectedKind=UI%7CFeatureDisabled&selectedStory=basic%20style&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Fstories%2Fstories-panel)

![image](https://user-images.githubusercontent.com/1421724/47686468-8c4a6d80-db98-11e8-8ad0-14834aaef154.png)

![image](https://user-images.githubusercontent.com/1421724/47686474-953b3f00-db98-11e8-8770-568d98f7f1d1.png)
