### PR TITLE
style(css): Prefer sc-selector over no-duplicate-selectors

### DIFF
--- a/src/sentry/static/sentry/app/components/alertMessage.jsx
+++ b/src/sentry/static/sentry/app/components/alertMessage.jsx
@@ -27,8 +27,7 @@ const StyledCloseButton = styled.button`
   right: ${p => p.theme.grid}px;
   top: 7px;
 
-  /* stylelint-disable-next-line no-duplicate-selectors */
-  ${StyledInlineSvg} {
+  ${/* sc-selector */ StyledInlineSvg} {
     color: ${p => p.theme.gray4};
   }
 

--- a/src/sentry/static/sentry/app/components/assigneeSelector.jsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.jsx
@@ -302,8 +302,7 @@ const AssigneeSelector = styled(AssigneeSelectorComponent)`
   justify-content: flex-end;
 
   /* manually align menu underneath dropdown caret */
-  /* stylelint-disable-next-line no-duplicate-selectors */
-  ${StyledMenu} {
+  ${/* sc-selector */ StyledMenu} {
     right: -14px;
   }
 `;

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarMenuItem.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarMenuItem.jsx
@@ -76,8 +76,7 @@ const MenuItemLink = styled(({to, href, external, ...props}) => {
     color: ${p => p.theme.gray5};
   }
 
-  /* stylelint-disable-next-line no-duplicate-selectors */
-  ${OrgSummary} {
+  ${/* sc-selector */ OrgSummary} {
     padding-left: 0;
     padding-right: 0;
   }

--- a/src/sentry/static/sentry/app/components/text.jsx
+++ b/src/sentry/static/sentry/app/components/text.jsx
@@ -7,8 +7,7 @@ import Panel from 'app/components/panels/panel';
 const Text = styled.div`
   ${textStyles};
 
-  /* stylelint-disable-next-line no-duplicate-selectors */
-  ${Panel} & {
+  ${/* sc-selector */ Panel} & {
     padding-left: ${space(2)};
     padding-right: ${space(2)};
 

--- a/src/sentry/static/sentry/app/views/groupMerged/mergedItem.jsx
+++ b/src/sentry/static/sentry/app/views/groupMerged/mergedItem.jsx
@@ -169,8 +169,7 @@ const Controls = styled(({expanded, ...props}) => (
 const Fingerprint = styled('label')`
   font-family: ${p => p.theme.text.familyMono};
 
-  /* stylelint-disable-next-line no-duplicate-selectors */
-  ${Controls} & {
+  ${/* sc-selector */ Controls} & {
     font-weight: normal;
     margin: 0;
   }

--- a/src/sentry/static/sentry/app/views/organizationDashboard/teamSection.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/teamSection.jsx
@@ -54,13 +54,11 @@ const ProjectCards = styled(Flex)`
 const TeamSectionWrapper = styled.div`
   border-bottom: ${p => (p.showBorder ? '1px solid ' + p.theme.borderLight : 0)};
 
-  /* stylelint-disable no-duplicate-selectors */
   &:last-child {
-    ${ProjectCards} {
+    ${/* sc-selector */ ProjectCards} {
       padding-bottom: 0;
     }
   }
-  /* stylelint-enable */
 `;
 
 const TeamTitleBar = styled(Flex)`


### PR DESCRIPTION
As recommended on the styled-components tooling page https://www.styled-components.com/docs/tooling#interpolation-tagging.

This however does not work with *all* instances of `no-duplicate-selector`. This blcok here does not seem to take to it:

https://github.com/getsentry/sentry/blob/1ede77317a5367dff4a2ef1687f9a5a09a81f518/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx#L218-L226