### PR TITLE
fix(releases) Filter out empty paths when scoring commits

### DIFF
--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -20,7 +20,9 @@ PATH_SEPERATORS = frozenset(['/', '\\'])
 def tokenize_path(path):
     for sep in PATH_SEPERATORS:
         if sep in path:
-            return reversed(path.split(sep))
+            # Exclude empty path segments as some repository integrations
+            # start their paths with `/` which we want to ignore.
+            return reversed(filter(lambda x: x != '', path.split(sep)))
     else:
         return iter([path])
 

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -20,6 +20,7 @@ def test_tokenize_path():
     assert list(tokenize_path('foo/bar')) == ['bar', 'foo']
     assert list(tokenize_path('foo\\bar')) == ['bar', 'foo']
     assert list(tokenize_path('foo.bar')) == ['foo.bar']
+    assert list(tokenize_path('/foo/bar')) == ['bar', 'foo']
 
 
 class GetPreviousReleasesTestCase(TestCase):


### PR DESCRIPTION
When matching paths between stack frames and VCS modified files we were including empty path segments which resulted in misses. If we filter out empty segments suspect commits will work for VSTS repositories. VSTS includes leading `/` in their commit information. I considered changing VSTS but that wouldn't help existing users, nor would it insulate us against other future VCS integrations from also having the same problem.

Fixes APP-691