### PR TITLE
feat(ui): Add route string to "Permission Denied" error messages

### DIFF
--- a/src/sentry/static/sentry/app/views/permissionDenied.jsx
+++ b/src/sentry/static/sentry/app/views/permissionDenied.jsx
@@ -26,7 +26,7 @@ class PermissionDenied extends React.Component {
     let {organization, project} = this.context;
 
     let route = getRouteStringFromRoutes(routes);
-    sdk.captureException(new Error(ERROR_NAME), {
+    sdk.captureException(new Error(`${ERROR_NAME}${route ? ` : ${route}` : ''}`), {
       fingerprint: [ERROR_NAME, route],
       extra: {
         route,


### PR DESCRIPTION
This will make it easier to see what route is getting a 403 in Sentry