### PR TITLE
fix(ui): Fix closing broadcast modal for IE11

### DIFF
--- a/src/sentry/static/sentry/app/components/broadcastModal.jsx
+++ b/src/sentry/static/sentry/app/components/broadcastModal.jsx
@@ -104,9 +104,11 @@ const BroadcastModal = createReactClass({
   },
 
   handleClick(evt) {
-    if ([].indexOf.call(evt.target.classList, 'modal') !== -1) {
-      this.close();
+    if (!evt.target.classList.contains('modal')) {
+      return;
     }
+
+    this.close();
   },
 
   renderOneModal(message, i, a) {


### PR DESCRIPTION
`classList.contains` should be supported: https://developer.mozilla.org/en-US/docs/Web/API/Element/classList

Fixes JAVASCRIPT-4CA