### PR TITLE
fix(ui): Create team sending duplicate requests

### DIFF
--- a/src/sentry/static/sentry/app/components/createTeam/createTeamForm.jsx
+++ b/src/sentry/static/sentry/app/components/createTeam/createTeamForm.jsx
@@ -10,13 +10,19 @@ import slugify from 'app/utils/slugify';
 export default class CreateTeamForm extends React.Component {
   static propTypes = {
     organization: SentryTypes.Organization.isRequired,
-    onSuccess: PropTypes.func.isRequired,
+    onSuccess: PropTypes.func,
     onSubmit: PropTypes.func,
     formProps: PropTypes.object,
   };
 
   handleCreateTeamSuccess = data => {
-    this.props.onSuccess(data);
+    let {onSuccess} = this.props;
+
+    if (typeof onSuccess !== 'function') {
+      return;
+    }
+
+    onSuccess(data);
   };
 
   render() {
@@ -37,6 +43,7 @@ export default class CreateTeamForm extends React.Component {
           onSubmit={this.props.onSubmit}
           onSubmitSuccess={this.handleCreateTeamSuccess}
           requireChanges
+          data-test-id="create-team-form"
           {...this.props.formProps}
         >
           <TextField

--- a/src/sentry/static/sentry/app/components/modals/createTeamModal.jsx
+++ b/src/sentry/static/sentry/app/components/modals/createTeamModal.jsx
@@ -45,11 +45,7 @@ class CreateTeamModal extends React.Component {
           {t('Create Team')}
         </Header>
         <Body>
-          <CreateTeamForm
-            {...props}
-            onSubmit={this.handleSubmit}
-            onSuccess={this.handleSuccess}
-          />
+          <CreateTeamForm {...props} onSubmit={this.handleSubmit} />
         </Body>
       </React.Fragment>
     );

--- a/tests/js/spec/components/modals/createTeamModal.spec.jsx
+++ b/tests/js/spec/components/modals/createTeamModal.spec.jsx
@@ -13,8 +13,12 @@ describe('CreateTeamModal', function() {
   let org = TestStubs.Organization();
   let closeModal = jest.fn();
   let onClose = jest.fn();
+  let onSuccess = jest.fn();
 
-  beforeEach(function() {});
+  beforeEach(function() {
+    onClose.mockReset();
+    onSuccess.mockReset();
+  });
 
   afterEach(function() {});
 
@@ -26,6 +30,7 @@ describe('CreateTeamModal', function() {
         organization={org}
         closeModal={closeModal}
         onClose={onClose}
+        onSuccess={onSuccess}
       />,
       TestStubs.routerContext()
     );
@@ -36,9 +41,10 @@ describe('CreateTeamModal', function() {
 
     wrapper.find('CreateTeamForm Form').simulate('submit');
 
-    expect(createTeam).toHaveBeenCalled();
+    expect(createTeam).toHaveBeenCalledTimes(1);
     await tick();
     expect(onClose).toHaveBeenCalled();
     expect(closeModal).toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
The success handler for "create team" modal was being called twice.

Fixes JAVASCRIPT-4F4 (maybe?)