### PR TITLE
ref(feature): Update semantics of Feature component usage

### DIFF
--- a/src/sentry/static/sentry/app/components/acl/feature.jsx
+++ b/src/sentry/static/sentry/app/components/acl/feature.jsx
@@ -48,7 +48,8 @@ class Feature extends React.Component {
      *  - Provide a custom render function to customize the rendered component.
      *
      * When a custom render function is used, the same object that would be
-     * passed to `children` if a func is provided there, will be used here.
+     * passed to `children` if a func is provided there, will be used here,
+     * aditionally `children` will also be passed.
      *
      * NOTE: HookStore capability.
      *
@@ -160,13 +161,15 @@ class Feature extends React.Component {
       renderDisabled: customDisabledRender,
     };
 
+    if (!hasFeature && renderDisabled !== false) {
+      return customDisabledRender({children, ...renderProps});
+    }
+
     if (typeof children === 'function') {
       return children(renderProps);
     }
 
-    return hasFeature
-      ? children
-      : renderDisabled !== false ? customDisabledRender(renderProps) : null;
+    return hasFeature ? children : null;
   }
 }
 

--- a/tests/js/spec/components/acl/feature.spec.jsx
+++ b/tests/js/spec/components/acl/feature.spec.jsx
@@ -79,9 +79,10 @@ describe('Feature', function() {
         routerContext
       );
 
-      expect(noFeatureRenderer).not.toHaveBeenCalled();
-      expect(childrenMock).toHaveBeenCalledWith({
+      expect(childrenMock).not.toHaveBeenCalled();
+      expect(noFeatureRenderer).toHaveBeenCalledWith({
         hasFeature: false,
+        children: childrenMock,
         renderDisabled: noFeatureRenderer,
         organization,
         project,
@@ -235,9 +236,10 @@ describe('Feature', function() {
 
     it('calls renderDisabled function when no features', function() {
       const noFeatureRenderer = jest.fn(() => null);
+      const children = <div>The Child</div>;
       const wrapper = mount(
         <Feature features={['org-baz']} renderDisabled={noFeatureRenderer}>
-          <div>The Child</div>
+          {children}
         </Feature>,
         routerContext
       );
@@ -246,6 +248,7 @@ describe('Feature', function() {
       expect(noFeatureRenderer).toHaveBeenCalledWith({
         hasFeature: false,
         renderDisabled: noFeatureRenderer,
+        children,
         organization,
         project,
         features: ['org-baz'],
@@ -267,9 +270,10 @@ describe('Feature', function() {
 
     it('calls renderDisabled function from HookStore when no features', function() {
       const noFeatureRenderer = jest.fn(() => null);
+      const children = <div>The Child</div>;
       const wrapper = mount(
         <Feature features={['org-baz']} renderDisabled={noFeatureRenderer}>
-          <div>The Child</div>
+          {children}
         </Feature>,
         routerContext
       );
@@ -280,6 +284,7 @@ describe('Feature', function() {
       expect(hookFn).toHaveBeenCalledWith({
         hasFeature: false,
         renderDisabled: hookFn,
+        children,
         organization,
         project,
         features: ['org-baz'],


### PR DESCRIPTION
The Feature component will now _always_ render the renderDisabled render-prop when it is set, regardless of if the children of the Feature is passed a function. renderDisabled is now also passed the `children`.