### PR TITLE
fix(ui): Fix sidebar padding when no org in context

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -48,7 +48,7 @@ class Sidebar extends React.Component {
   }
 
   componentDidMount() {
-    let {router} = this.props;
+    let {organization, router} = this.props;
     jQuery(document.body).addClass('body-sidebar');
     jQuery(document).on('click', this.documentClickHandler);
 
@@ -62,7 +62,10 @@ class Sidebar extends React.Component {
       router.listen(() => {
         $('.tooltip').tooltip('hide');
       });
-    this.doCollapse(this.props.collapsed);
+
+    // If there is no organization (i.e. no org in context, or error loading org)
+    // then sidebar should default to collapsed state
+    this.doCollapse(!!organization ? this.props.collapsed : true);
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -167,18 +167,21 @@ const OrganizationContext = createReactClass({
   },
 
   renderError() {
+    let errorComponent;
+
     switch (this.state.errorType) {
       case ERROR_TYPES.ORG_NOT_FOUND:
-        return (
-          <OrganizationNotFound>
-            <Alert type="error">
-              {t('The organization you were looking for was not found.')}
-            </Alert>
-          </OrganizationNotFound>
+        errorComponent = (
+          <Alert type="error">
+            {t('The organization you were looking for was not found.')}
+          </Alert>
         );
+        break;
       default:
-        return <LoadingError onRetry={this.remountComponent} />;
+        errorComponent = <LoadingError onRetry={this.remountComponent} />;
     }
+
+    return <ErrorWrapper>{errorComponent}</ErrorWrapper>;
   },
 
   render() {
@@ -215,6 +218,6 @@ const OrganizationContext = createReactClass({
 
 export default OrganizationContext;
 
-const OrganizationNotFound = styled('div')`
-  margin: ${space(3)};
+const ErrorWrapper = styled('div')`
+  padding: ${space(3)};
 `;


### PR DESCRIPTION
In render, if theres no org, default collapsed state is true, but when it mounts, it only uses `collapsed` from props.
Also adds padding around the error message.


Old:
![image](https://user-images.githubusercontent.com/79684/47752969-456d7e00-dc53-11e8-9bb9-f04d58709b26.png)

New:
![image](https://user-images.githubusercontent.com/79684/47752978-4acac880-dc53-11e8-978c-d128101a3dd0.png)
