### PR TITLE
fix(integrations): Removed internal feature flag to Outbound Assignee Sync

### DIFF
--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -195,7 +195,7 @@ class GroupAssigneeManager(BaseManager):
             activity.send_notification()
             # sync Sentry assignee to external issues
             if assignee_type == 'user' and features.has(
-                    'organizations:internal-catchall', group.organization, actor=acting_user):
+                    'organizations:integrations-issue-sync', group.organization, actor=acting_user):
                 sync_group_assignee_outbound(group, assigned_to.id, assign=True)
 
     def deassign(self, group, acting_user=None):
@@ -216,7 +216,7 @@ class GroupAssigneeManager(BaseManager):
             )
             activity.send_notification()
             # sync Sentry assignee to external issues
-            if features.has('organizations:internal-catchall',
+            if features.has('organizations:integrations-issue-sync',
                             group.organization, actor=acting_user):
                 sync_group_assignee_outbound(group, None, assign=False)
 

--- a/tests/sentry/models/test_groupassignee.py
+++ b/tests/sentry/models/test_groupassignee.py
@@ -143,7 +143,6 @@ class GroupAssigneeTestCase(TestCase):
 
         with self.feature({
             'organizations:integrations-issue-sync': True,
-            'organizations:internal-catchall': True,
         }):
             with self.tasks():
                 GroupAssignee.objects.assign(self.group, self.user)
@@ -208,7 +207,6 @@ class GroupAssigneeTestCase(TestCase):
 
         with self.feature({
             'organizations:integrations-issue-sync': True,
-            'organizations:internal-catchall': True,
         }):
             with self.tasks():
                 GroupAssignee.objects.deassign(self.group)


### PR DESCRIPTION
Assignee Sync was not working for anyone who is not covered by the internal feature flag. This will change the flag to anyone with access to issue sync.