### PR TITLE
fix(feature): Correct logic bugs

### DIFF
--- a/src/sentry/static/sentry/app/components/acl/feature.jsx
+++ b/src/sentry/static/sentry/app/components/acl/feature.jsx
@@ -28,7 +28,7 @@ class Feature extends React.Component {
      * On the backend end, feature tags have a scope prefix string that is stripped out on the
      * frontend (since feature tags are attached to a context object).
      *
-     * Use `organization:` or `project:` prefix strings to specify a feature with context.
+     * Use `organizations:` or `projects:` prefix strings to specify a feature with context.
      */
     features: PropTypes.arrayOf(PropTypes.string).isRequired,
 
@@ -102,11 +102,17 @@ class Feature extends React.Component {
   }
 
   hasFeature(feature, features) {
-    let shouldMatchOnlyProject = feature.match(/^project:(\w+)/);
-    let shouldMatchOnlyOrg = feature.match(/^organization:(\w+)/);
+    let shouldMatchOnlyProject = feature.match(/^projects:(.+)/);
+    let shouldMatchOnlyOrg = feature.match(/^organizations:(.+)/);
 
     // Array of feature strings
     let {configFeatures, organization, project} = features;
+
+    // Check config store first as this ovverides features scopped to org or
+    // project contexts.
+    if (configFeatures.includes(feature)) {
+      return true;
+    }
 
     if (shouldMatchOnlyProject) {
       return project.includes(shouldMatchOnlyProject[1]);
@@ -117,11 +123,7 @@ class Feature extends React.Component {
     }
 
     // default, check all feature arrays
-    return (
-      configFeatures.includes(feature) ||
-      organization.includes(feature) ||
-      project.includes(feature)
-    );
+    return organization.includes(feature) || project.includes(feature);
   }
 
   render() {

--- a/src/sentry/static/sentry/app/components/acl/feature.jsx
+++ b/src/sentry/static/sentry/app/components/acl/feature.jsx
@@ -108,7 +108,7 @@ class Feature extends React.Component {
     // Array of feature strings
     let {configFeatures, organization, project} = features;
 
-    // Check config store first as this ovverides features scopped to org or
+    // Check config store first as this overrides features scoped to org or
     // project contexts.
     if (configFeatures.includes(feature)) {
       return true;

--- a/src/sentry/static/sentry/app/utils.jsx
+++ b/src/sentry/static/sentry/app/utils.jsx
@@ -233,7 +233,7 @@ export const buildTeamId = id => `team:${id}`;
 export function descopeFeatureName(feature) {
   return typeof feature.match !== 'function'
     ? feature
-    : feature.match(/(?:^(?:project|organization):)?(.*)/).pop();
+    : feature.match(/(?:^(?:projects|organizations):)?(.*)/).pop();
 }
 
 // re-export under utils

--- a/tests/js/spec/components/acl/feature.spec.jsx
+++ b/tests/js/spec/components/acl/feature.spec.jsx
@@ -146,13 +146,7 @@ describe('Feature', function() {
 
     it('handles features prefixed with org/project', function() {
       mount(
-        <Feature
-          organization={organization}
-          project={project}
-          features={['organization:bar']}
-        >
-          {childrenMock}
-        </Feature>,
+        <Feature features={['organizations:org-bar']}>{childrenMock}</Feature>,
         routerContext
       );
 
@@ -161,22 +155,17 @@ describe('Feature', function() {
         renderDisabled: false,
         organization,
         project,
-        features: ['organization:bar'],
+        features: ['organizations:org-bar'],
       });
 
-      mount(
-        <Feature organization={organization} project={project} features={['project:bar']}>
-          {childrenMock}
-        </Feature>,
-        routerContext
-      );
+      mount(<Feature features={['projects:bar']}>{childrenMock}</Feature>, routerContext);
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: false,
         renderDisabled: false,
         organization,
         project,
-        features: ['project:bar'],
+        features: ['projects:bar'],
       });
     });
 

--- a/tests/js/spec/utils/utils.spec.jsx
+++ b/tests/js/spec/utils/utils.spec.jsx
@@ -238,8 +238,8 @@ describe('utils.projectDisplayCompare', function() {
 
 describe('utils.descopeFeatureName', function() {
   [
-    ['organization:feature', 'feature'],
-    ['project:feature', 'feature'],
+    ['organizations:feature', 'feature'],
+    ['projects:feature', 'feature'],
     ['unknown-scope:feature', 'unknown-scope:feature'],
     ['', ''],
   ].map(([input, expected]) => expect(descopeFeatureName(input)).toEqual(expected));


### PR DESCRIPTION
- The scope prefix for organization and project should be plural, strictly because this is consistent with how the features are declared in the feature manager on the backend.

 - Because they are now plural a bug was exposed with retrieving from the ConfigStore, it should take presidency since it may declare projects: or organizations: flags.

 - Fixes descopeFeatureName to be consistent as well