### PR TITLE
feat(auth): Allow superusers to bypass server rendered auth page

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -6,6 +6,7 @@ import createReactClass from 'create-react-class';
 import moment from 'moment';
 import styled from 'react-emotion';
 
+import {openSudo} from 'app/actionCreators/modal';
 import {setActiveOrganization} from 'app/actionCreators/organizations';
 import {t} from 'app/locale';
 import Alert from 'app/components/alert';
@@ -107,7 +108,7 @@ const OrganizationContext = createReactClass({
         });
       },
 
-      error: (_, textStatus, errorThrown) => {
+      error: (err, textStatus, errorThrown) => {
         let errorType = null;
         switch (errorThrown) {
           case 'NOT FOUND':
@@ -115,10 +116,20 @@ const OrganizationContext = createReactClass({
             break;
           default:
         }
+
         this.setState({
           loading: false,
           error: true,
           errorType,
+        });
+
+        // If user is superuser, open sudo window
+        let user = ConfigStore.get('user');
+        if (!user || !user.isSuperuser || err.status !== 403) {
+          return;
+        }
+        openSudo({
+          retryRequest: () => Promise.resolve(this.fetchData()),
         });
       },
     });

--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -38,6 +38,15 @@ class ReactMixin(object):
 # TODO(dcramer): once we implement basic auth hooks in React we can make this
 # generic
 class ReactPageView(OrganizationView, ReactMixin):
+    def handle_auth_required(self, request, *args, **kwargs):
+        # If user is a superuser (but not active, because otherwise this method would never be called)
+        # Then allow client to handle the route and respond to any API request errors
+        if request.user.is_superuser:
+            return self.handle_react(request)
+
+        # For normal users, let parent class handle (e.g. redirect to login page)
+        return super(ReactPageView, self).handle_auth_required(request, *args, **kwargs)
+
     def handle(self, request, organization, **kwargs):
         if 'project_id' in kwargs and request.GET.get('onboarding'):
             project = Project.objects.filter(

--- a/tests/js/spec/views/organizationContext.spec.jsx
+++ b/tests/js/spec/views/organizationContext.spec.jsx
@@ -1,0 +1,114 @@
+import React from 'react';
+
+import {mount} from 'enzyme';
+import {openSudo} from 'app/actionCreators/modal';
+import ConfigStore from 'app/stores/configStore';
+import OrganizationContext from 'app/views/organizationContext';
+import ProjectsStore from 'app/stores/projectsStore';
+import TeamStore from 'app/stores/teamStore';
+
+jest.mock('app/stores/configStore', () => ({
+  get: jest.fn(),
+}));
+jest.mock('app/actionCreators/modal', () => ({
+  openSudo: jest.fn(),
+}));
+
+describe('OrganizationContext', function() {
+  let wrapper;
+  let org = TestStubs.Organization({
+    teams: [TestStubs.Team()],
+    projects: [TestStubs.Project()],
+  });
+  let getOrgMock;
+
+  beforeAll(function() {});
+
+  beforeEach(function() {
+    MockApiClient.clearMockResponses();
+    getOrgMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/',
+      body: org,
+    });
+    jest.spyOn(TeamStore, 'loadInitialData');
+    jest.spyOn(ProjectsStore, 'loadInitialData');
+    wrapper = mount(
+      <OrganizationContext params={{orgId: 'org-slug'}}>{<div />}</OrganizationContext>
+    );
+  });
+
+  afterEach(function() {
+    TeamStore.loadInitialData.mockRestore();
+    ProjectsStore.loadInitialData.mockRestore();
+  });
+
+  it('renders and fetches org', function() {
+    expect(getOrgMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/',
+      expect.anything()
+    );
+
+    expect(wrapper.state('loading')).toBe(false);
+    expect(wrapper.state('error')).toBe(false);
+    expect(wrapper.state('organization')).toEqual(org);
+
+    expect(TeamStore.loadInitialData).toHaveBeenCalledWith(org.teams);
+    expect(ProjectsStore.loadInitialData).toHaveBeenCalledWith(org.projects);
+  });
+
+  it('resets TeamStore when unmounting', function() {
+    jest.spyOn(TeamStore, 'reset');
+    wrapper.unmount();
+    expect(TeamStore.reset).toHaveBeenCalled();
+    TeamStore.reset.mockRestore();
+  });
+
+  it('fetches new org when router params change', function() {
+    let mock = MockApiClient.addMockResponse({
+      url: '/organizations/new-slug/',
+      body: org,
+    });
+    wrapper.setProps({params: {orgId: 'new-slug'}});
+    wrapper.update();
+
+    expect(mock).toHaveBeenLastCalledWith('/organizations/new-slug/', expect.anything());
+  });
+
+  it('fetches new org when router location state is `refresh`', function() {
+    getOrgMock.mockReset();
+    wrapper.setProps({location: {state: 'refresh'}});
+    wrapper.update();
+
+    expect(getOrgMock).toHaveBeenLastCalledWith(
+      '/organizations/org-slug/',
+      expect.anything()
+    );
+  });
+
+  it('shows loading error for non-superusers on 403s', function() {
+    getOrgMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/',
+      statusCode: 403,
+    });
+    wrapper = mount(
+      <OrganizationContext params={{orgId: 'org-slug'}}>{<div />}</OrganizationContext>
+    );
+
+    expect(wrapper.find('LoadingError')).toHaveLength(1);
+  });
+
+  it('opens sudo modal for superusers on 403s', function() {
+    ConfigStore.get.mockImplementation(() => ({
+      isSuperuser: true,
+    }));
+    getOrgMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/',
+      statusCode: 403,
+    });
+    wrapper = mount(
+      <OrganizationContext params={{orgId: 'org-slug'}}>{<div />}</OrganizationContext>
+    );
+
+    expect(openSudo).toHaveBeenCalled();
+  });
+});

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -54,3 +54,18 @@ class ReactPageViewTest(TestCase):
         assert resp.status_code == 200
         self.assertTemplateUsed(resp, 'sentry/bases/react.html')
         assert resp.context['request']
+
+    def test_inactive_superuser_bypasses_server_auth(self):
+        owner = self.create_user('bar@example.com')
+        org = self.create_organization(owner=owner)
+        non_member = self.create_user('foo@example.com', is_superuser=True)
+
+        path = reverse('sentry-organization-home', args=[org.slug])
+
+        self.login_as(non_member)
+
+        resp = self.client.get(path)
+
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, 'sentry/bases/react.html')
+        assert resp.context['request']


### PR DESCRIPTION
For inactive superusers, bypass server rendered login page and allow React frontend
to handle the route. This means if you are trying to access an org you do not have
access to, React will continue to perform the API requests at that route. This will
result in a 403 and open the sudo login modal.