### PR TITLE
security: Drop top level crossdomain.xml

### DIFF
--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -810,13 +810,6 @@ def robots_txt(request):
     return HttpResponse("User-agent: *\nDisallow: /\n", content_type='text/plain')
 
 
-@cache_control(max_age=3600, public=True)
-def crossdomain_xml_index(request):
-    response = render_to_response('sentry/crossdomain_index.xml')
-    response['Content-Type'] = 'application/xml'
-    return response
-
-
 @cache_control(max_age=60)
 def crossdomain_xml(request, project_id):
     if not project_id.isdigit():

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -503,8 +503,7 @@ urlpatterns += patterns(
     url(r'favicon\.ico$', lambda r: HttpResponse(status=404)),
 
     # crossdomain.xml
-    url(r'^crossdomain\.xml$', api.crossdomain_xml_index,
-        name='sentry-api-crossdomain-xml-index'),
+    url(r'^crossdomain\.xml$', lambda r: HttpResponse(status=404)),
 
     # plugins
     # XXX(dcramer): preferably we'd be able to use 'integrations' as the URL

--- a/tests/sentry/web/api/tests.py
+++ b/tests/sentry/web/api/tests.py
@@ -728,21 +728,6 @@ class CrossDomainXmlTest(TestCase):
         )
 
 
-class CrossDomainXmlIndexTest(TestCase):
-    @fixture
-    def path(self):
-        return reverse('sentry-api-crossdomain-xml-index')
-
-    def test_permits_policies(self):
-        resp = self.client.get(self.path)
-        self.assertEquals(resp.status_code, 200)
-        self.assertEquals(resp['Content-Type'], 'application/xml')
-        self.assertTemplateUsed(resp, 'sentry/crossdomain_index.xml')
-        assert '<site-control permitted-cross-domain-policies="all" />' in resp.content.decode(
-            'utf-8'
-        )
-
-
 class RobotsTxtTest(TestCase):
     @fixture
     def path(self):


### PR DESCRIPTION
This is legacy and isn't being used any anything active, so should be
safe to entirely drop.

Fixes #10350