### PR TITLE
fix(minidump): Correctly offset addresses of cached stack traces

### DIFF
--- a/src/sentry/lang/native/cfi.py
+++ b/src/sentry/lang/native/cfi.py
@@ -63,10 +63,10 @@ class ThreadRef(object):
         # was missing, the stored offset was absolute as well. Otherwise, we
         # have no choice but to assume an absolute address. In practice, the
         # latter hopefully never happens.
-        addr = module.addr + offset if module else offset
+        addr = module.addr + parse_addr(offset) if module else parse_addr(offset)
 
         return module, {
-            'instruction_addr': '0x%x' % parse_addr(addr),
+            'instruction_addr': '0x%x' % addr,
             'function': '<unknown>',  # Required by interface
             'module': module.name if module else None,
             'trust': trust,

--- a/tests/sentry/lang/native/test_cfi.py
+++ b/tests/sentry/lang/native/test_cfi.py
@@ -181,6 +181,24 @@ class CfiReprocessingTest(TestCase):
 
     @mock.patch('sentry.attachments.base.BaseAttachmentCache.get', return_value=None)
     @mock.patch('sentry.utils.cache.cache.get', return_value=None)
+    def test_cfi_missing_stacktrace(self, mock_cache_get, mock_attachment_get):
+        data = {
+            'exception': {
+                'values': [
+                    {
+                        'stacktrace': None,
+                    }
+                ]
+            },
+        }
+        result = reprocess_minidump_with_cfi(data)
+
+        assert mock_cache_get.call_count == 0
+        assert mock_attachment_get.call_count == 0
+        assert result is None
+
+    @mock.patch('sentry.attachments.base.BaseAttachmentCache.get', return_value=None)
+    @mock.patch('sentry.utils.cache.cache.get', return_value=None)
     def test_cfi_reprocessing(self, mock_cache_get, mock_attachment_get):
         dif = self.create_dif_file(
             debug_id='c0bcc3f1-9827-fe65-3058-404b2831d9e6',

--- a/tests/sentry/lang/native/test_cfi.py
+++ b/tests/sentry/lang/native/test_cfi.py
@@ -154,10 +154,10 @@ class CfiReprocessingTest(TestCase):
     @mock.patch('sentry.utils.cache.cache.get', return_value=None)
     def test_cfi_reprocessing_cached(self, mock_cache_get, mock_attachment_get):
         mock_cache_get.return_value = [
-            (None, 0x7f5140cdc000, 'scan'),
-            (None, 0x7fff5aef1000, 'scan'),
-            ('451a38b5-0679-79d2-0738-22a5ceb24c4b', 0x20830, 'cfi'),
-            ('c0bcc3f1-9827-fe65-3058-404b2831d9e6', 0x1d72, 'context'),
+            (None, '0x7f5140cdc000', 'scan'),
+            (None, '0x7fff5aef1000', 'scan'),
+            ('451a38b5-0679-79d2-0738-22a5ceb24c4b', '0x20830', 'cfi'),
+            ('c0bcc3f1-9827-fe65-3058-404b2831d9e6', '0x1d72', 'context'),
         ]
 
         data = self.get_mock_event(reprocessed=False)


### PR DESCRIPTION
Fixes [SENTRY-82N](https://sentry.io/sentry/sentry/issues/747674885/)