### PR TITLE
Don't call `postMessage` on a possible null

### DIFF
--- a/src/sentry/templates/sentry/integrations/dialog-complete.html
+++ b/src/sentry/templates/sentry/integrations/dialog-complete.html
@@ -9,7 +9,9 @@
 
 {% block main %}
 <script>
-  window.opener.postMessage({{ payload|to_json }}, document.origin);
+  if (window.opener) {
+    window.opener.postMessage({{ payload|to_json }}, document.origin);
+  }
   window.close();
 </script>
 


### PR DESCRIPTION
This has come up a few times in the last day or so. Guard against `window.opener` being null.

Fixes JAVASCRIPT-4J5