### PR TITLE
fix(integrations) Strip trailing / off of gitlab instances

### DIFF
--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -127,7 +127,8 @@ class InstallationForm(forms.Form):
                     'and request GitLab to verify SSL when it delivers '
                     'webhooks to Sentry.'),
         widget=forms.CheckboxInput(),
-        required=False
+        required=False,
+        initial=True
     )
     client_id = forms.CharField(
         label=_('GitLab Application ID'),
@@ -143,9 +144,9 @@ class InstallationForm(forms.Form):
         )
     )
 
-    def __init__(self, *args, **kwargs):
-        super(InstallationForm, self).__init__(*args, **kwargs)
-        self.fields['verify_ssl'].initial = True
+    def clean_url(self):
+        """Strip off trailing / as they cause invalid URLs downstream"""
+        return self.cleaned_data['url'].rstrip('/')
 
 
 class InstallationConfigView(PipelineView):

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -17,13 +17,16 @@ from sentry.testutils import IntegrationTestCase
 class GitlabIntegrationTest(IntegrationTestCase):
     provider = GitlabIntegrationProvider
     config = {
-        'url': 'https://gitlab.example.com',
+        # Trailing slash is intentional to ensure that valid
+        # URLs are generated even if the user inputs a trailing /
+        'url': 'https://gitlab.example.com/',
         'name': 'Test App',
         'group': 'cool-group',
         'verify_ssl': True,
         'client_id': 'client_id',
         'client_secret': 'client_secret'
     }
+
     default_group_id = 4
 
     def assert_setup_flow(self, user_id='user_id_1', group_id=None):


### PR DESCRIPTION
If a user inputs a trailing `/` it currently causes a 500 against gitlab.com which is not great.

Fixes SENTRY-837