### PR TITLE
feat(ui): Allow FeatureDisabled to accept a custom alert

### DIFF
--- a/src/sentry/static/sentry/app/components/acl/featureDisabled.jsx
+++ b/src/sentry/static/sentry/app/components/acl/featureDisabled.jsx
@@ -31,12 +31,13 @@ class FeatureDisabled extends React.Component {
      */
     featureName: PropTypes.string,
     /**
-     * Render the disabled message within a warning Alert.
+     * Render the disabled message within a warning Alert. A custom Alert
+     * component may be provided.
      *
-     * Attaches additional styles to the FeatureDisabeld component to make it
-     * look nice within the Alert.
+     * Attaches additional styles to the FeatureDisabled component to make it
+     * look consistent within the Alert.
      */
-    alert: PropTypes.bool,
+    alert: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
     /**
      * Do not show the help toggle.
      */
@@ -94,12 +95,14 @@ class FeatureDisabled extends React.Component {
       </React.Fragment>
     );
 
+    const AlertComponent = alert === true ? Alert : alert;
+
     return !alert ? (
       featureDisabled
     ) : (
-      <StyledAlert type="warning" icon="icon-labs">
-        {featureDisabled}
-      </StyledAlert>
+      <AlertComponent type="warning" icon="icon-labs">
+        <AlertWrapper>{featureDisabled}</AlertWrapper>
+      </AlertComponent>
     );
   }
 }
@@ -121,7 +124,7 @@ const HelpDescription = styled(Box)`
   }
 `;
 
-const StyledAlert = styled(Alert)`
+const AlertWrapper = styled('div')`
   /* stylelint-disable-next-line no-duplicate-selectors */
   ${HelpButton} {
     color: #6d6319;

--- a/tests/js/spec/components/acl/featureDisabled.spec.jsx
+++ b/tests/js/spec/components/acl/featureDisabled.spec.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import FeatureDisabled from 'app/components/acl/featureDisabled';
+import {PanelAlert} from 'app/components/panels';
 import {mount} from 'enzyme';
+import FeatureDisabled from 'app/components/acl/featureDisabled';
 
 describe('FeatureDisabled', function() {
   const routerContext = TestStubs.routerContext();
@@ -34,6 +35,19 @@ describe('FeatureDisabled', function() {
     );
 
     expect(wrapper.exists('Alert')).toBe(true);
+  });
+
+  it('renders with custom alert component', function() {
+    const wrapper = mount(
+      <FeatureDisabled
+        alert={PanelAlert}
+        feature={'organization:my-feature'}
+        featureName="Some Feature"
+      />,
+      routerContext
+    );
+
+    expect(wrapper.exists('PanelAlert')).toBe(true);
   });
 
   it('displays instructions when help is clicked', function() {


### PR DESCRIPTION
The primary use case here is to be able to pass a `PanelAlert`.