### PR TITLE
feat(custom-filters): Use feature component w/ hook

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.jsx
@@ -3,14 +3,22 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
+import {
+  Panel,
+  PanelAlert,
+  PanelBody,
+  PanelHeader,
+  PanelItem,
+} from 'app/components/panels';
 import {t} from 'app/locale';
 import AsyncComponent from 'app/components/asyncComponent';
+import Feature from 'app/components/acl/feature';
+import FeatureDisabled from 'app/components/acl/featureDisabled';
 import FieldFromConfig from 'app/views/settings/components/forms/fieldFromConfig';
 import Form from 'app/views/settings/components/forms/form';
 import FormField from 'app/views/settings/components/forms/formField';
 import HookStore from 'app/stores/hookStore';
 import JsonForm from 'app/views/settings/components/forms/jsonForm';
-import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import SentryTypes from 'app/sentryTypes';
 import Switch from 'app/components/switch';
 import filterGroups, {customFilterFields} from 'app/data/forms/inboundFilters';
@@ -171,21 +179,46 @@ class ProjectFiltersSettings extends AsyncComponent {
     onBlur(subfilters, e);
   };
 
-  renderDisabledFeature(fields) {
-    let {project, organization} = this.props;
-    return this.state.hooksDisabled.map(hook =>
-      hook(organization, project, null, fields)
-    );
-  }
-
   renderBody() {
-    let {features, params} = this.props;
+    let {organization, features, params} = this.props;
     let {orgId, projectId} = params;
     let {project} = this.state;
 
     if (!project) return null;
     let projectEndpoint = `/projects/${orgId}/${projectId}/`;
     let filtersEndpoint = `${projectEndpoint}filters/`;
+
+    let disabledAdvFilters = p => (
+      <FeatureDisabled
+        feature={p.features[0]}
+        alert={PanelAlert}
+        name={t('Custom Inbound Filters')}
+        message={t(
+          'Release and Error Message filtering are not enabled on your Sentry installation'
+        )}
+      />
+    );
+
+    let advCustomFilters = (
+      <Feature
+        features={['projects:custom-inbound-filters']}
+        renderDisabled={({children, ...props}) =>
+          children({...props, renderDisabled: disabledAdvFilters})}
+      >
+        {({hasFeature, renderDisabled, ...featureProps}) => (
+          <React.Fragment>
+            {!hasFeature && renderDisabled({organization, ...featureProps})}
+
+            {customFilterFields.map(field => (
+              <FieldFromConfig
+                key={field.name}
+                field={{...field, disabled: !hasFeature}}
+              />
+            ))}
+          </React.Fragment>
+        )}
+      </Feature>
+    );
 
     return (
       <React.Fragment>
@@ -255,16 +288,7 @@ class ProjectFiltersSettings extends AsyncComponent {
           <JsonForm
             features={features}
             forms={filterGroups}
-            renderFooter={() => {
-              // Render additional fields that are behind a feature flag
-              let customFilters = customFilterFields.map(field => (
-                <FieldFromConfig key={field.name} field={field} />
-              ));
-
-              return features.has('custom-inbound-filters')
-                ? customFilters
-                : this.renderDisabledFeature(customFilters);
-            }}
+            renderFooter={() => advCustomFilters}
           />
         </Form>
       </React.Fragment>

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.jsx
@@ -179,46 +179,44 @@ class ProjectFiltersSettings extends AsyncComponent {
     onBlur(subfilters, e);
   };
 
+  renderDisabledCustomFilters = p => (
+    <FeatureDisabled
+      feature={p.features[0]}
+      alert={PanelAlert}
+      name={t('Custom Inbound Filters')}
+      message={t(
+        'Release and Error Message filtering are not enabled on your Sentry installation'
+      )}
+    />
+  );
+
+  renderCustomFilters = () => (
+    <Feature
+      features={['projects:custom-inbound-filters']}
+      renderDisabled={({children, ...props}) =>
+        children({...props, renderDisabled: this.renderDisabledCustomFilters})}
+    >
+      {({hasFeature, renderDisabled, ...featureProps}) => (
+        <React.Fragment>
+          {!hasFeature &&
+            renderDisabled({organization: this.props.organization, ...featureProps})}
+
+          {customFilterFields.map(field => (
+            <FieldFromConfig key={field.name} field={{...field, disabled: !hasFeature}} />
+          ))}
+        </React.Fragment>
+      )}
+    </Feature>
+  );
+
   renderBody() {
-    let {organization, features, params} = this.props;
+    let {features, params} = this.props;
     let {orgId, projectId} = params;
     let {project} = this.state;
 
     if (!project) return null;
     let projectEndpoint = `/projects/${orgId}/${projectId}/`;
     let filtersEndpoint = `${projectEndpoint}filters/`;
-
-    let disabledAdvFilters = p => (
-      <FeatureDisabled
-        feature={p.features[0]}
-        alert={PanelAlert}
-        name={t('Custom Inbound Filters')}
-        message={t(
-          'Release and Error Message filtering are not enabled on your Sentry installation'
-        )}
-      />
-    );
-
-    let advCustomFilters = (
-      <Feature
-        features={['projects:custom-inbound-filters']}
-        renderDisabled={({children, ...props}) =>
-          children({...props, renderDisabled: disabledAdvFilters})}
-      >
-        {({hasFeature, renderDisabled, ...featureProps}) => (
-          <React.Fragment>
-            {!hasFeature && renderDisabled({organization, ...featureProps})}
-
-            {customFilterFields.map(field => (
-              <FieldFromConfig
-                key={field.name}
-                field={{...field, disabled: !hasFeature}}
-              />
-            ))}
-          </React.Fragment>
-        )}
-      </Feature>
-    );
 
     return (
       <React.Fragment>
@@ -288,7 +286,7 @@ class ProjectFiltersSettings extends AsyncComponent {
           <JsonForm
             features={features}
             forms={filterGroups}
-            renderFooter={() => advCustomFilters}
+            renderFooter={this.renderCustomFilters}
           />
         </Form>
       </React.Fragment>

--- a/tests/js/spec/views/projectFilters.spec.jsx
+++ b/tests/js/spec/views/projectFilters.spec.jsx
@@ -206,9 +206,11 @@ describe('ProjectFilters', function() {
     );
   });
 
-  it('does not have filter by release/error message because no hooks store', function() {
-    expect(wrapper.find('TextArea[id="filters:releases"]')).toHaveLength(0);
-    expect(wrapper.find('TextArea[id="filters:error_messages"]')).toHaveLength(0);
+  it('filter by release/error message are not enabled', function() {
+    expect(wrapper.find('TextArea[id="filters:releases"][disabled]')).toHaveLength(1);
+    expect(wrapper.find('TextArea[id="filters:error_messages"][disabled]')).toHaveLength(
+      1
+    );
   });
 
   it('has custom inbound filters with flag + can change', function() {


### PR DESCRIPTION
Refactors the advanced custom filters to use the Feature component, allowing the getsentry disabled hook to be rendered in place easily.
![tunnel evanpurkhiser com_settings_evanpurkhiser_evanpurkhiser_filters_data-filters_](https://user-images.githubusercontent.com/1421724/47818745-dd33a080-dd15-11e8-88b8-2269ff00f00b.png)
