### PR TITLE
fix(stream): Replace browser history on driect hit

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -389,7 +389,7 @@ const Stream = createReactClass({
                 environment: matchingEventEnvironment,
               })}`;
             }
-            return void browserHistory.push(redirect);
+            return void browserHistory.replace(redirect);
           }
         }
 


### PR DESCRIPTION
The back button becomes broken since the search query is stored in the
query string. When going back from the direct hit you are immediately
redirect to it.

This fixes that.