### PR TITLE
fix(deletions): Perform manual transaction management

### DIFF
--- a/src/sentry/db/deletion.py
+++ b/src/sentry/db/deletion.py
@@ -203,7 +203,7 @@ class BulkDeleteQuery(object):
                     if i < batch_size:
                         completed = True
 
-                    conn.commit()
+                conn.commit()
 
             if chunk:
                 yield tuple(chunk)

--- a/src/sentry/db/deletion.py
+++ b/src/sentry/db/deletion.py
@@ -132,6 +132,8 @@ class BulkDeleteQuery(object):
         cutoff = timezone.now() - timedelta(days=self.days)
 
         with dbc.get_new_connection(dbc.get_connection_params()) as conn:
+            conn.autocommit = False
+
             chunk = []
 
             completed = False
@@ -200,6 +202,8 @@ class BulkDeleteQuery(object):
                     # loop.
                     if i < batch_size:
                         completed = True
+
+                    conn.commit()
 
             if chunk:
                 yield tuple(chunk)


### PR DESCRIPTION
This connection isn't opened in autocommit mode by default (and can't be, since it uses named cursors, which have to be used within a transaction block.) We weren't doing any explicit transaction management, so the entire lifecycle of this iterator was performed in a single transaction.

To keep the benefits of named cursors (mainly, executing large queries and being able to iterate the results, rather than allocate memory for the entire result set at once), this explicitly commits the transaction after each iteration of the loop to ensure that the transaction is closed, freeing up rows that were just deleted to potentially be vacuumed.

For context, see GH-6407.