### PR TITLE
ref(snuba): Use issue API for Snuba search

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -135,7 +135,7 @@ register('vsts.client-id', flags=FLAG_PRIORITIZE_DISK)
 register('vsts.client-secret', flags=FLAG_PRIORITIZE_DISK)
 
 # Snuba
-register('snuba.use_group_id_column', default=True)  # TODO: Set back!
+register('snuba.use_group_id_column', default=True)
 register('snuba.search.max-pre-snuba-candidates', default=500)
 register('snuba.search.chunk-growth-rate', default=1.5)
 register('snuba.search.max-chunk-size', default=2000)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -135,7 +135,7 @@ register('vsts.client-id', flags=FLAG_PRIORITIZE_DISK)
 register('vsts.client-secret', flags=FLAG_PRIORITIZE_DISK)
 
 # Snuba
-register('snuba.use_group_id_column', default=False)
+register('snuba.use_group_id_column', default=True)  # TODO: Set back!
 register('snuba.search.max-pre-snuba-candidates', default=500)
 register('snuba.search.chunk-growth-rate', default=1.5)
 register('snuba.search.max-chunk-size', default=2000)

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -565,6 +565,8 @@ class SnubaSearchTest(SnubaTestCase):
             }
         )
 
+        self.group1.update(last_seen=self.group1.last_seen + timedelta(days=1))
+
         results = self.backend.query(
             self.project,
             environment=self.environments['production'],
@@ -575,9 +577,19 @@ class SnubaSearchTest(SnubaTestCase):
 
         results = self.backend.query(
             self.project,
+            date_to=self.group1.last_seen + timedelta(days=1),
             environment=self.environments['development'],
             last_seen_from=self.group1.last_seen,
             last_seen_from_inclusive=False,
+        )
+        assert set(results) == set()
+
+        results = self.backend.query(
+            self.project,
+            date_to=self.group1.last_seen + timedelta(days=1),
+            environment=self.environments['development'],
+            last_seen_from=self.group1.last_seen,
+            last_seen_from_inclusive=True,
         )
         assert set(results) == set([self.group1])
 
@@ -796,10 +808,10 @@ class SnubaSearchTest(SnubaTestCase):
             'end': Any(datetime),
             'filter_keys': {
                 'project_id': [self.project.id],
-                'primary_hash': [u'513772ee53011ad9f4dc374b2d34d0e9']
+                'issue': [1]
             },
             'referrer': 'search',
-            'groupby': ['primary_hash'],
+            'groupby': ['issue'],
             'conditions': [],
             'limit': limit,
             'offset': 0,

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -808,7 +808,7 @@ class SnubaSearchTest(SnubaTestCase):
             'end': Any(datetime),
             'filter_keys': {
                 'project_id': [self.project.id],
-                'issue': [1]
+                'issue': [self.group1.id]
             },
             'referrer': 'search',
             'groupby': ['issue'],

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -42,7 +42,7 @@ class TagStorageTest(SnubaTestCase):
         data = json.dumps([{
             'event_id': six.text_type(r) * 32,
             'primary_hash': hash1,
-            'group_id': int(hash1[:16], 16),
+            'group_id': self.proj1group1.id,
             'project_id': self.proj1.id,
             'message': 'message 1',
             'platform': 'python',
@@ -64,7 +64,7 @@ class TagStorageTest(SnubaTestCase):
         } for r in [1, 2]] + [{
             'event_id': '3' * 32,
             'primary_hash': hash2,
-            'group_id': int(hash2[:16], 16),
+            'group_id': self.proj1group2.id,
             'project_id': self.proj1.id,
             'message': 'message 2',
             'platform': 'python',

--- a/tests/snuba/test_snuba.py
+++ b/tests/snuba/test_snuba.py
@@ -5,6 +5,7 @@ import pytest
 import time
 import uuid
 
+from sentry import options
 from sentry.models import GroupHash, GroupHashTombstone
 from sentry.testutils import SnubaTestCase
 from sentry.utils import snuba
@@ -86,6 +87,12 @@ class SnubaTest(SnubaTestCase):
         })
 
     def test_project_issues_with_tombstones(self):
+        # Nothing to be done if we're using `group_id`.
+        # When this option is the default we can remove
+        # this test.
+        if options.get('snuba.use_group_id_column'):
+            return
+
         base_time = datetime.utcnow()
         hash = 'a' * 32
 

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -109,7 +109,7 @@ class SnubaTSDBTest(TestCase):
         data = json.dumps([{
             'event_id': (six.text_type(r) * 32)[:32],
             'primary_hash': [hash1, hash2][(r // 600) % 2],  # Switch every 10 mins
-            'group_id': int([hash1, hash2][(r // 600) % 2][:16], 16),
+            'group_id': [self.proj1group1.id, self.proj1group2.id][(r // 600) % 2],
             'project_id': self.proj1.id,
             'message': 'message 1',
             'platform': 'python',


### PR DESCRIPTION
This will take advantage of the `group_id` column in CH. I don't intend to merge it until we've switched to using `group_id` as the default -- it seemed like too much to maintain both styles.

Note that search still does the PG to CH to PG bouncing, because it still has to. But returning `group_id`s instead of hashes reduces the churn and also eliminates the need to hammer `GroupHash` with huge queries.