### PR TITLE
ref(feature): Do not pass renderDisabled as a render prop

### DIFF
--- a/src/sentry/static/sentry/app/components/acl/feature.jsx
+++ b/src/sentry/static/sentry/app/components/acl/feature.jsx
@@ -75,11 +75,7 @@ class Feature extends React.Component {
      *     project,
      *     features: [],
      *     hasFeature: bool,
-     *     renderDisabled: function,
      *   }
-     *
-     * Remember that the renderDisabled function may have been set by the
-     * hookstore.
      *
      * The other interface is more simple, only show `children` if org/project has
      * all the required feature.
@@ -160,7 +156,6 @@ class Feature extends React.Component {
       project,
       features,
       hasFeature,
-      renderDisabled: customDisabledRender,
     };
 
     if (!hasFeature && renderDisabled !== false) {

--- a/tests/js/spec/components/acl/feature.spec.jsx
+++ b/tests/js/spec/components/acl/feature.spec.jsx
@@ -32,7 +32,6 @@ describe('Feature', function() {
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: true,
-        renderDisabled: false,
         features,
         organization,
         project,
@@ -51,7 +50,6 @@ describe('Feature', function() {
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: true,
-        renderDisabled: false,
         organization,
         project,
         features,
@@ -63,7 +61,6 @@ describe('Feature', function() {
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: false,
-        renderDisabled: false,
         organization,
         project,
         features: ['org-baz'],
@@ -83,7 +80,6 @@ describe('Feature', function() {
       expect(noFeatureRenderer).toHaveBeenCalledWith({
         hasFeature: false,
         children: childrenMock,
-        renderDisabled: noFeatureRenderer,
         organization,
         project,
         features: ['org-baz'],
@@ -101,7 +97,6 @@ describe('Feature', function() {
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: true,
-        renderDisabled: false,
         organization: customOrg,
         project,
         features: ['org-bazar'],
@@ -119,7 +114,6 @@ describe('Feature', function() {
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: true,
-        renderDisabled: false,
         organization,
         project: customProject,
         features: ['project-baz'],
@@ -137,7 +131,6 @@ describe('Feature', function() {
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: false,
-        renderDisabled: false,
         organization: null,
         project: null,
         features,
@@ -152,7 +145,6 @@ describe('Feature', function() {
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: true,
-        renderDisabled: false,
         organization,
         project,
         features: ['organizations:org-bar'],
@@ -162,7 +154,6 @@ describe('Feature', function() {
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: false,
-        renderDisabled: false,
         organization,
         project,
         features: ['projects:bar'],
@@ -180,7 +171,6 @@ describe('Feature', function() {
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasFeature: true,
-        renderDisabled: false,
         organization,
         project,
         features: ['organizations:create'],
@@ -236,7 +226,6 @@ describe('Feature', function() {
       expect(wrapper.find('Feature div')).toHaveLength(0);
       expect(noFeatureRenderer).toHaveBeenCalledWith({
         hasFeature: false,
-        renderDisabled: noFeatureRenderer,
         children,
         organization,
         project,
@@ -272,7 +261,6 @@ describe('Feature', function() {
 
       expect(hookFn).toHaveBeenCalledWith({
         hasFeature: false,
-        renderDisabled: hookFn,
         children,
         organization,
         project,


### PR DESCRIPTION
There isn't really a use case for this.

Originally when the children render prop was always called even if the feature had a renderDisabled function specified it would be passed it, but now since the renderDisabled is always called when it's disabled, there is no reason to pass this.