### PR TITLE
ref(ui) Move broadcast fetching to actionCreators

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/broadcasts.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/broadcasts.jsx
@@ -1,0 +1,11 @@
+export function getAll(api) {
+  return api.requestPromise('/broadcasts/', {method: 'GET'});
+}
+
+export function markAsSeen(api, idList) {
+  return api.requestPromise('/broadcasts/', {
+    method: 'PUT',
+    query: {id: idList},
+    data: {hasSeen: '1'},
+  });
+}

--- a/src/sentry/static/sentry/app/actionCreators/broadcasts.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/broadcasts.jsx
@@ -1,8 +1,8 @@
-export function getAll(api) {
+export function getAllBroadcasts(api) {
   return api.requestPromise('/broadcasts/', {method: 'GET'});
 }
 
-export function markAsSeen(api, idList) {
+export function markBroadcastsAsSeen(api, idList) {
   return api.requestPromise('/broadcasts/', {
     method: 'PUT',
     query: {id: idList},

--- a/src/sentry/static/sentry/app/components/sidebar/broadcasts.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/broadcasts.jsx
@@ -124,13 +124,12 @@ const Broadcasts = createReactClass({
     if (unseenBroadcastIds.length === 0) return;
 
     markBroadcastsAsSeen(this.api, unseenBroadcastIds).then(data => {
-      this.setState(state => {
-        let broadcasts = state.broadcasts.map(item => {
+      this.setState(state => ({
+        broadcasts: state.broadcasts.map(item => {
           item.hasSeen = true;
           return item;
-        });
-        return {broadcasts};
-      });
+        }),
+      }));
     });
   },
 

--- a/src/sentry/static/sentry/app/components/sidebar/broadcasts.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/broadcasts.jsx
@@ -10,7 +10,7 @@ import SidebarItem from 'app/components/sidebar/sidebarItem';
 import SidebarPanel from 'app/components/sidebar/sidebarPanel';
 import SidebarPanelEmpty from 'app/components/sidebar/sidebarPanelEmpty';
 import SidebarPanelItem from 'app/components/sidebar/sidebarPanelItem';
-import * as broadcastActions from 'app/actionCreators/broadcasts';
+import {getAllBroadcasts, markBroadcastsAsSeen} from 'app/actionCreators/broadcasts';
 
 const MARK_SEEN_DELAY = 1000;
 const POLLER_DELAY = 600000; // 10 minute poll (60 * 10 * 1000)
@@ -64,8 +64,7 @@ const Broadcasts = createReactClass({
       this.stopPoll();
     }
 
-    return broadcastActions
-      .getAll(this.api)
+    return getAllBroadcasts(this.api)
       .then(data => {
         this.setState({
           broadcasts: data || [],
@@ -124,12 +123,13 @@ const Broadcasts = createReactClass({
     let unseenBroadcastIds = this.getUnseenIds();
     if (unseenBroadcastIds.length === 0) return;
 
-    broadcastActions.markAsSeen(this.api, unseenBroadcastIds).then(data => {
-      this.setState({
-        broadcasts: this.state.broadcasts.map(item => {
+    markBroadcastsAsSeen(this.api, unseenBroadcastIds).then(data => {
+      this.setState(state => {
+        let broadcasts = state.broadcasts.map(item => {
           item.hasSeen = true;
           return item;
-        }),
+        });
+        return {broadcasts};
       });
     });
   },

--- a/src/sentry/static/sentry/app/components/sidebar/broadcasts.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/broadcasts.jsx
@@ -10,6 +10,7 @@ import SidebarItem from 'app/components/sidebar/sidebarItem';
 import SidebarPanel from 'app/components/sidebar/sidebarPanel';
 import SidebarPanelEmpty from 'app/components/sidebar/sidebarPanelEmpty';
 import SidebarPanelItem from 'app/components/sidebar/sidebarPanelItem';
+import * as broadcastActions from 'app/actionCreators/broadcasts';
 
 const MARK_SEEN_DELAY = 1000;
 const POLLER_DELAY = 600000; // 10 minute poll (60 * 10 * 1000)
@@ -63,23 +64,22 @@ const Broadcasts = createReactClass({
       this.stopPoll();
     }
 
-    this.api.request('/broadcasts/', {
-      method: 'GET',
-      success: data => {
+    return broadcastActions
+      .getAll(this.api)
+      .then(data => {
         this.setState({
           broadcasts: data || [],
           loading: false,
         });
         this.startPoll();
-      },
-      error: () => {
+      })
+      .catch(() => {
         this.setState({
           loading: false,
           error: true,
         });
         this.startPoll();
-      },
-    });
+      });
   },
 
   startPoll() {
@@ -124,20 +124,13 @@ const Broadcasts = createReactClass({
     let unseenBroadcastIds = this.getUnseenIds();
     if (unseenBroadcastIds.length === 0) return;
 
-    this.api.request('/broadcasts/', {
-      method: 'PUT',
-      query: {id: unseenBroadcastIds},
-      data: {
-        hasSeen: '1',
-      },
-      success: () => {
-        this.setState({
-          broadcasts: this.state.broadcasts.map(item => {
-            item.hasSeen = true;
-            return item;
-          }),
-        });
-      },
+    broadcastActions.markAsSeen(this.api, unseenBroadcastIds).then(data => {
+      this.setState({
+        broadcasts: this.state.broadcasts.map(item => {
+          item.hasSeen = true;
+          return item;
+        }),
+      });
     });
   },
 

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -166,14 +166,15 @@ describe('Sidebar', function() {
   });
 
   describe('SidebarPanel', function() {
-    it('displays empty panel when there are no Broadcasts', function() {
+    it('displays empty panel when there are no Broadcasts', async function() {
       MockApiClient.addMockResponse({
         url: '/broadcasts/',
         body: [],
       });
       wrapper = createWrapper();
 
-      wrapper.find('Broadcasts SidebarItem').simulate('click');
+      await wrapper.find('Broadcasts SidebarItem').simulate('click');
+
       wrapper.update();
       expect(wrapper.find('SidebarPanel')).toHaveLength(1);
 
@@ -181,12 +182,12 @@ describe('Sidebar', function() {
       expect(wrapper.find('SidebarPanelEmpty')).toHaveLength(1);
     });
 
-    it('can display Broadcasts panel and mark as seen', function() {
+    it('can display Broadcasts panel and mark as seen', async function() {
       jest.useFakeTimers();
       wrapper = createWrapper();
       expect(apiMocks.broadcasts).toHaveBeenCalled();
 
-      wrapper.find('Broadcasts SidebarItem').simulate('click');
+      await wrapper.find('Broadcasts SidebarItem').simulate('click');
       wrapper.update();
       expect(wrapper.find('SidebarPanel')).toHaveLength(1);
 
@@ -225,13 +226,13 @@ describe('Sidebar', function() {
       expect(wrapper.find('SidebarPanel')).toHaveLength(0);
     });
 
-    it('can unmount Sidebar (and Broadcasts) and kills Broadcast timers', function() {
+    it('can unmount Sidebar (and Broadcasts) and kills Broadcast timers', async function() {
       jest.useFakeTimers();
       wrapper = createWrapper();
       let broadcasts = wrapper.find('Broadcasts').instance();
 
       // This will start timer to mark as seen
-      wrapper.find('Broadcasts SidebarItem').simulate('click');
+      await wrapper.find('Broadcasts SidebarItem').simulate('click');
       wrapper.update();
 
       jest.advanceTimersByTime(500);


### PR DESCRIPTION
Move more API calls to actionCreator patterns. This approach lets components focus on UI rendering logic and delegate API request logic to other modules.

This would be a perfect fit for Promise.prototype.finally() but node doesn't support it yet.