### PR TITLE
fix: Upgrade requests

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -51,7 +51,7 @@ querystring_parser>=1.2.3,<2.0.0
 rb>=1.7.0,<2.0.0
 redis-py-cluster==1.3.4
 redis>=2.10.3,<2.10.6
-requests[security]>=2.18.4,<2.19.0
+requests[security]>=2.20.0,<2.21.0
 selenium==3.11.0
 semaphore>=0.2.0,<0.3.0
 sentry-sdk>=0.5.0,<0.6


### PR DESCRIPTION
Scan report:

```
╞════════════════════════════╤═══════════╤══════════════════════════╤══════════╡
│ package                    │ installed │ affected                 │ ID       │
╞════════════════════════════╧═══════════╧══════════════════════════╧══════════╡
│ requests                   │ 2.18.4    │ <2.19.1                  │ 36546    │
╞══════════════════════════════════════════════════════════════════════════════╡
│ The Requests package before 2.19.1 sends an HTTP Authorization header to an  │
│ http URI upon receiving a same-hostname https-to-http redirect, which makes  │
│ it easier for remote attackers to discover credentials by sniffing the netwo │
│ rk.                                                                          │
╘══════════════════════════════════════════════════════════════════════════════╛
```