### PR TITLE
fix(org-events): Fix aggregating events by category name

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEvents/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/eventsChart.jsx
@@ -76,7 +76,7 @@ class EventsChart extends React.Component {
           includeTimeseries
           interval="1d"
           showLoading
-          getCategory={() => t('Event')}
+          getCategory={() => t('Events')}
         >
           {({timeseriesData, previousTimeseriesData}) => (
             <AreaChart

--- a/src/sentry/static/sentry/app/views/organizationHealth/util/healthRequest.jsx
+++ b/src/sentry/static/sentry/app/views/organizationHealth/util/healthRequest.jsx
@@ -300,8 +300,17 @@ class HealthRequestWithParams extends React.Component {
       resultsForTimestamp &&
         !!resultsForTimestamp.length &&
         resultsForTimestamp.forEach(({count, [tag]: tagObject}) => {
-          categorySet.add(this.getCategory(tagObject));
-          timestampMap.set(`${timestamp}-${this.getCategory(tagObject)}`, count);
+          const category = this.getCategory(tagObject);
+          const timestampKey = `${timestamp}-${this.getCategory(tagObject)}`;
+          categorySet.add(category);
+
+          // aggregate if exists
+          timestampMap.set(
+            timestampKey,
+            timestampMap.has(timestampKey)
+              ? timestampMap.get(timestampKey) + count
+              : count
+          );
         });
     });
 

--- a/tests/js/spec/views/organizationHealth/util/healthRequest.spec.jsx
+++ b/tests/js/spec/views/organizationHealth/util/healthRequest.spec.jsx
@@ -401,6 +401,49 @@ describe('HealthRequest', function() {
       );
     });
 
+    it('aggregates all counts per timestamp when category name identical', async function() {
+      doHealthRequest.mockImplementation(() =>
+        Promise.resolve({
+          data: [[new Date(), [COUNT_OBJ, {...COUNT_OBJ, count: 100}]]],
+        })
+      );
+
+      wrapper = mount(
+        <HealthRequestWithParams
+          {...DEFAULTS}
+          includeTimeseries={true}
+          getCategory={() => 'static-category'}
+        >
+          {mock}
+        </HealthRequestWithParams>
+      );
+
+      await tick();
+      wrapper.update();
+
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          timeAggregatedData: null,
+        })
+      );
+
+      wrapper.setProps({
+        includeTimeAggregation: true,
+        timeAggregationSeriesName: 'aggregated series',
+      });
+      await tick();
+      wrapper.update();
+
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          timeAggregatedData: {
+            seriesName: 'aggregated series',
+            data: [{name: expect.anything(), value: 223}],
+          },
+        })
+      );
+    });
+
     it('transparently queries for top tags and then queries for timeseries data using only those top tags', async function() {
       doHealthRequest.mockClear();
       doHealthRequest.mockImplementation((api, props) => {


### PR DESCRIPTION
Previously would assume that category would be different within a timestamp