### PR TITLE
feat(feedback): Support DSN-based feedback submission

### DIFF
--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -27,7 +27,6 @@ class ProjectPermission(OrganizationPermission):
 
         if not result:
             return result
-
         if project.teams.exists():
             return any(
                 has_team_permission(request, team, self.scope_map) for team in project.teams.all()
@@ -46,6 +45,8 @@ class ProjectPermission(OrganizationPermission):
                 return False
 
             return roles.get(role).is_global
+        elif hasattr(request.auth, 'project_id') and project.id == request.auth.project_id:
+            return True
 
         return False
 

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -37,7 +37,7 @@ class ScopedPermission(permissions.BasePermission):
 
     def has_permission(self, request, view):
         # session-based auth has all scopes for a logged in user
-        if not request.auth:
+        if not getattr(request, 'auth', None):
             return request.user.is_authenticated()
 
         allowed_scopes = set(self.scope_map.get(request.method, []))

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -158,6 +158,14 @@ class ProjectKey(Model):
         )
 
     @property
+    def organization_id(self):
+        return self.project.organization_id
+
+    @property
+    def organization(self):
+        return self.project.organization
+
+    @property
     def dsn_private(self):
         return self.get_dsn(public=False)
 


### PR DESCRIPTION
- Support DSN-based authorization header (Authorization: DSN [dsn])
- Allow POST via DSN authorization to /projects/{project}/user-feedback/