### PR TITLE
fix(ui): Fix stream search bar not autocompleting multiple times

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar.jsx
@@ -420,17 +420,22 @@ class SmartSearchBar extends React.Component {
 
       newQuery = query.slice(0, lastTermIndex); // get text preceding last term
 
-      // if (/:\S+\s/.test(newQuery)) {
+      // if (/:(("[^"]+")|([^"]\S*))\s/.test(newQuery)) {
+      // // Note: this breaks if you have nested quotes
       // newQuery = newQuery.concat(query.slice(lastTermIndex)) + replaceText;
       // } else {
+      // console.log(last);
       // newQuery =
       // last.indexOf(':') > -1
       // ? // tag key present: replace everything after colon with replaceText
-      // newQuery.replace(/\:"[^"]*"?$|\:\S*$/, ':' + replaceText)
+      // newQuery.replace(/\:"[^"]*"?$|\:[^"]\S*$/, ':' + replaceText)
       // : // no tag key present: replace last token with replaceText
       // newQuery.replace(/\S+$/, replaceText);
+
+      // console.log(newQuery);
       // newQuery = newQuery.concat(query.slice(lastTermIndex));
       // }
+
       newQuery =
         last.indexOf(':') > -1
           ? // tag key present: replace everything after colon with replaceText

--- a/src/sentry/static/sentry/app/components/smartSearchBar.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar.jsx
@@ -420,6 +420,17 @@ class SmartSearchBar extends React.Component {
 
       newQuery = query.slice(0, lastTermIndex); // get text preceding last term
 
+      // if (/:\S+\s/.test(newQuery)) {
+      // newQuery = newQuery.concat(query.slice(lastTermIndex)) + replaceText;
+      // } else {
+      // newQuery =
+      // last.indexOf(':') > -1
+      // ? // tag key present: replace everything after colon with replaceText
+      // newQuery.replace(/\:"[^"]*"?$|\:\S*$/, ':' + replaceText)
+      // : // no tag key present: replace last token with replaceText
+      // newQuery.replace(/\S+$/, replaceText);
+      // newQuery = newQuery.concat(query.slice(lastTermIndex));
+      // }
       newQuery =
         last.indexOf(':') > -1
           ? // tag key present: replace everything after colon with replaceText

--- a/src/sentry/static/sentry/app/components/smartSearchBar.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar.jsx
@@ -80,6 +80,10 @@ class SmartSearchBar extends React.Component {
     return query.slice(0, cursor).match(/\S+:"[^"]*"?|\S+/g);
   };
 
+  static isTermCompleted = term => {
+    return /\S+:(("[^"]*")|([^"]\S*))/.test(term);
+  };
+
   static defaultProps = {
     defaultQuery: '',
     query: null,
@@ -254,7 +258,8 @@ class SmartSearchBar extends React.Component {
       !terms || // no terms
       terms.length === 0 || // no terms
       (terms.length === 1 && terms[0] === this.props.defaultQuery) || // default term
-      /^\s+$/.test(query.slice(cursor - 1, cursor + 1))
+      (SearchBar.isTermCompleted(terms[terms.length - 1]) &&
+        /^\s+$/.test(query.slice(cursor - 1, cursor + 1))) // ends with space AND previous term is not finished (e.g. `browser:"Chr `)
     ) {
       let {defaultSearchItems} = this.props;
 
@@ -420,19 +425,18 @@ class SmartSearchBar extends React.Component {
 
       newQuery = query.slice(0, lastTermIndex); // get text preceding last term
 
-      // if (/:(("[^"]+")|([^"]\S*))\s/.test(newQuery)) {
-      // // Note: this breaks if you have nested quotes
-      // newQuery = newQuery.concat(query.slice(lastTermIndex)) + replaceText;
+      // If last term is a finished term e.g. tag:value or tag:"value", then append new text
+      // if (SearchBar.isTermCompleted(last)) {
+      // newQuery = newQuery.concat(query.slice(lastTermIndex)) + newReplaceText;
       // } else {
-      // console.log(last);
       // newQuery =
       // last.indexOf(':') > -1
-      // ? // tag key present: replace everything after colon with replaceText
-      // newQuery.replace(/\:"[^"]*"?$|\:[^"]\S*$/, ':' + replaceText)
-      // : // no tag key present: replace last token with replaceText
-      // newQuery.replace(/\S+$/, replaceText);
+      // ? // tag key present: replace everything after colon with newReplaceText
+      // // newQuery.replace(/\:"[^"]*"?$|\:[^"]\S*$/, ':' + newReplaceText)
+      // newQuery.replace(/\:"[^"]*"?$|\:\S*$/, ':' + newReplaceText)
+      // : // no tag key present: replace last token with newReplaceText
+      // newQuery.replace(/\S+$/, newReplaceText);
 
-      // console.log(newQuery);
       // newQuery = newQuery.concat(query.slice(lastTermIndex));
       // }
 

--- a/tests/js/spec/views/stream/searchBar.spec.jsx
+++ b/tests/js/spec/views/stream/searchBar.spec.jsx
@@ -103,26 +103,50 @@ describe('SearchBar', function() {
     });
   });
 
-  it('can select additional autocomplete terms when last query term is finished and has trailing space', function() {
-    let query = 'timesSeen:1 ';
+  describe('onAutoComplete', function() {
+    let wrapper;
     let props = {
       orgId: '123',
       projectId: '456',
-      query,
     };
-    let wrapper = mount(<SearchBar {...props} />, options);
+    const setQuery = (el, query) => {
+      el.setProps({query});
+      el.update();
 
-    wrapper
-      .find('input')
-      .getDOMNode()
-      .setSelectionRange(query.length, query.length);
-    wrapper.instance().updateAutoCompleteItems();
-    wrapper.find('input').simulate('focus');
-    wrapper
-      .find('.search-autocomplete-item')
-      .first()
-      .simulate('click');
+      el
+        .find('input')
+        .getDOMNode()
+        .setSelectionRange(query.length, query.length);
+      el.instance().updateAutoCompleteItems();
+      el.find('input').simulate('focus');
+      el
+        .find('.search-autocomplete-item')
+        .first()
+        .simulate('click');
+    };
 
-    expect(wrapper.find('input').prop('value')).toBe('timesSeen:1 browser:');
+    beforeEach(function() {
+      wrapper = mount(<SearchBar {...props} />, options);
+    });
+
+    it('adds additional autocomplete terms when last query term is a single character and has trailing space', function() {
+      setQuery(wrapper, 'timesSeen:1 ');
+      expect(wrapper.find('input').prop('value')).toBe('timesSeen:1 browser:');
+    });
+
+    it('adds additional autocomplete terms when last query term is multiple characters and has trailing space', function() {
+      setQuery(wrapper, 'timesSeen:1234 ');
+      expect(wrapper.find('input').prop('value')).toBe('timesSeen:1234 browser:');
+    });
+
+    it('does not modify query if previous tag value begins with a quote and has trailing space', function() {
+      setQuery(wrapper, 'tag:"Chrome ');
+      expect(wrapper.find('input').prop('value')).toBe('tag:"Chrome ');
+    });
+
+    it('adds autocomplete terms if previous value is a valid quoted value', function() {
+      setQuery(wrapper, 'tag:"Chrome 70" ');
+      expect(wrapper.find('input').prop('value')).toBe('tag:"Chrome 70" browser:');
+    });
   });
 });

--- a/tests/js/spec/views/stream/searchBar.spec.jsx
+++ b/tests/js/spec/views/stream/searchBar.spec.jsx
@@ -8,8 +8,13 @@ describe('SearchBar', function() {
   let sandbox;
   let options;
   let urlTagValuesMock;
+<<<<<<< HEAD
   let supportedTags;
   const clickInput = searchBar => searchBar.find('input[name="query"]').simulate('click');
+=======
+  let environmentTagValuesMock;
+  let browserTagValuesMock;
+>>>>>>> 4e143b35ed... fix edgecase bugs
 
   beforeEach(function() {
     TagStore.reset();
@@ -26,6 +31,21 @@ describe('SearchBar', function() {
       url: '/projects/123/456/tags/url/values/',
       body: [],
     });
+<<<<<<< HEAD
+=======
+    environmentTagValuesMock = MockApiClient.addMockResponse({
+      url: '/projects/123/456/tags/environment/values/',
+      body: [],
+    });
+
+    browserTagValuesMock = MockApiClient.addMockResponse({
+      url: '/projects/123/456/tags/browser/values/',
+      body: [
+        {key: 'browser', value: 'Chrome 70', name: 'Chrome 70'},
+        {key: 'browser', value: 'Chrome 71', name: 'Chrome 71'},
+      ],
+    });
+>>>>>>> 4e143b35ed... fix edgecase bugs
   });
 
   afterEach(function() {
@@ -109,20 +129,31 @@ describe('SearchBar', function() {
       orgId: '123',
       projectId: '456',
     };
-    const setQuery = (el, query) => {
-      el.setProps({query});
-      el.update();
 
-      el
-        .find('input')
-        .getDOMNode()
-        .setSelectionRange(query.length, query.length);
+    const selectFirstAutocompleteItem = el => {
       el.instance().updateAutoCompleteItems();
       el.find('input').simulate('focus');
+
       el
         .find('.search-autocomplete-item')
         .first()
         .simulate('click');
+
+      const input = el.find('input');
+
+      input
+        .getDOMNode()
+        .setSelectionRange(input.prop('value').length, input.prop('value').length);
+
+      return el;
+    };
+
+    const setQuery = (el, query) => {
+      el
+        .find('input')
+        .simulate('change', {target: {value: query}})
+        .getDOMNode()
+        .setSelectionRange(query.length, query.length);
     };
 
     beforeEach(function() {
@@ -131,22 +162,45 @@ describe('SearchBar', function() {
 
     it('adds additional autocomplete terms when last query term is a single character and has trailing space', function() {
       setQuery(wrapper, 'timesSeen:1 ');
+      selectFirstAutocompleteItem(wrapper);
       expect(wrapper.find('input').prop('value')).toBe('timesSeen:1 browser:');
+    });
+
+    it('adds additional autocomplete term with existing term', async function() {
+      setQuery(wrapper, 'timesSeen:1 bro');
+      selectFirstAutocompleteItem(wrapper);
+      expect(wrapper.find('input').prop('value')).toBe('timesSeen:1 browser:');
+
+      selectFirstAutocompleteItem(wrapper);
+      expect(browserTagValuesMock).toHaveBeenCalled();
+      expect(wrapper.find('input').prop('value')).toBe(
+        'timesSeen:1 browser:"Chrome 70" '
+      );
     });
 
     it('adds additional autocomplete terms when last query term is multiple characters and has trailing space', function() {
       setQuery(wrapper, 'timesSeen:1234 ');
+      selectFirstAutocompleteItem(wrapper);
       expect(wrapper.find('input').prop('value')).toBe('timesSeen:1234 browser:');
     });
 
+    // This is an existing bug
     it('does not modify query if previous tag value begins with a quote and has trailing space', function() {
-      setQuery(wrapper, 'tag:"Chrome ');
-      expect(wrapper.find('input').prop('value')).toBe('tag:"Chrome ');
+      setQuery(wrapper, 'browser:"Chrome ');
+      selectFirstAutocompleteItem(wrapper);
+      expect(wrapper.find('input').prop('value')).toBe('browser:"Chrome 70" ');
     });
 
     it('adds autocomplete terms if previous value is a valid quoted value', function() {
-      setQuery(wrapper, 'tag:"Chrome 70" ');
-      expect(wrapper.find('input').prop('value')).toBe('tag:"Chrome 70" browser:');
+      setQuery(wrapper, 'browser:"Chrome 70" ');
+      selectFirstAutocompleteItem(wrapper);
+      expect(wrapper.find('input').prop('value')).toBe('browser:"Chrome 70" browser:');
+    });
+
+    it('does not add anything if autocomplete value is empty string', function() {
+      setQuery(wrapper, 'browser:"Chrome 70" ');
+      wrapper.instance().onAutoComplete('');
+      expect(wrapper.find('input').prop('value')).toBe('browser:"Chrome 70" ');
     });
   });
 });

--- a/tests/js/spec/views/stream/searchBar.spec.jsx
+++ b/tests/js/spec/views/stream/searchBar.spec.jsx
@@ -8,13 +8,9 @@ describe('SearchBar', function() {
   let sandbox;
   let options;
   let urlTagValuesMock;
-<<<<<<< HEAD
+  let browserTagValuesMock;
   let supportedTags;
   const clickInput = searchBar => searchBar.find('input[name="query"]').simulate('click');
-=======
-  let environmentTagValuesMock;
-  let browserTagValuesMock;
->>>>>>> 4e143b35ed... fix edgecase bugs
 
   beforeEach(function() {
     TagStore.reset();
@@ -29,25 +25,10 @@ describe('SearchBar', function() {
 
     urlTagValuesMock = MockApiClient.addMockResponse({
       url: '/projects/123/456/tags/url/values/',
-      body: [],
-    });
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
-
-    MockApiClient.addMockResponse({
-      url: '/projects/123/456/tags/tag/values/',
       body: [
         {key: 'tag', value: 'foo', name: 'foo'},
         {key: 'tag', value: 'bar', name: 'bar'},
       ],
-    });
-
->>>>>>> 0c8349f5b8... wip
-    environmentTagValuesMock = MockApiClient.addMockResponse({
-      url: '/projects/123/456/tags/environment/values/',
-      body: [],
     });
 
     browserTagValuesMock = MockApiClient.addMockResponse({
@@ -57,7 +38,6 @@ describe('SearchBar', function() {
         {key: 'browser', value: 'Chrome 71', name: 'Chrome 71'},
       ],
     });
->>>>>>> 4e143b35ed... fix edgecase bugs
   });
 
   afterEach(function() {
@@ -143,8 +123,7 @@ describe('SearchBar', function() {
     };
 
     const selectFirstAutocompleteItem = el => {
-      el.instance().updateAutoCompleteItems();
-      el.find('input').simulate('focus');
+      el.find('input').simulate('click');
 
       el
         .find('.search-autocomplete-item')
@@ -211,7 +190,10 @@ describe('SearchBar', function() {
 
     it('does not add anything if autocomplete value is empty string', function() {
       setQuery(wrapper, 'browser:"Chrome 70" ');
-      wrapper.instance().onAutoComplete('');
+      wrapper
+        .find('SmartSearchBar')
+        .instance()
+        .onAutoComplete('');
       expect(wrapper.find('input').prop('value')).toBe('browser:"Chrome 70" ');
     });
 

--- a/tests/js/spec/views/stream/searchBar.spec.jsx
+++ b/tests/js/spec/views/stream/searchBar.spec.jsx
@@ -32,7 +32,19 @@ describe('SearchBar', function() {
       body: [],
     });
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
+=======
+
+    MockApiClient.addMockResponse({
+      url: '/projects/123/456/tags/tag/values/',
+      body: [
+        {key: 'tag', value: 'foo', name: 'foo'},
+        {key: 'tag', value: 'bar', name: 'bar'},
+      ],
+    });
+
+>>>>>>> 0c8349f5b8... wip
     environmentTagValuesMock = MockApiClient.addMockResponse({
       url: '/projects/123/456/tags/environment/values/',
       body: [],
@@ -201,6 +213,26 @@ describe('SearchBar', function() {
       setQuery(wrapper, 'browser:"Chrome 70" ');
       wrapper.instance().onAutoComplete('');
       expect(wrapper.find('input').prop('value')).toBe('browser:"Chrome 70" ');
+    });
+
+    it('replaces existing tag value (with quoted value)', function() {
+      setQuery(wrapper, 'browser:"Chrome 71" ');
+      wrapper
+        .find('input')
+        .getDOMNode()
+        .setSelectionRange(8, 8);
+      selectFirstAutocompleteItem(wrapper);
+      expect(wrapper.find('input').prop('value')).toBe('browser:"Chrome 70" ');
+    });
+
+    it('replaces existing tag value (without quoted value)', function() {
+      setQuery(wrapper, 'tag:test1 tag:test2 ');
+      wrapper
+        .find('input')
+        .getDOMNode()
+        .setSelectionRange(14, 14);
+      selectFirstAutocompleteItem(wrapper);
+      expect(wrapper.find('input').prop('value')).toBe('tag:test1 tag:foo');
     });
   });
 });

--- a/tests/js/spec/views/stream/searchBar.spec.jsx
+++ b/tests/js/spec/views/stream/searchBar.spec.jsx
@@ -102,4 +102,27 @@ describe('SearchBar', function() {
       expect(mock).not.toHaveBeenCalled();
     });
   });
+
+  it('can select additional autocomplete terms when last query term is finished and has trailing space', function() {
+    let query = 'timesSeen:1 ';
+    let props = {
+      orgId: '123',
+      projectId: '456',
+      query,
+    };
+    let wrapper = mount(<SearchBar {...props} />, options);
+
+    wrapper
+      .find('input')
+      .getDOMNode()
+      .setSelectionRange(query.length, query.length);
+    wrapper.instance().updateAutoCompleteItems();
+    wrapper.find('input').simulate('focus');
+    wrapper
+      .find('.search-autocomplete-item')
+      .first()
+      .simulate('click');
+
+    expect(wrapper.find('input').prop('value')).toBe('timesSeen:1 browser:');
+  });
 });


### PR DESCRIPTION
This fixes the stream search bar so that it continues to work when a search term exists and is completed (has key:value and a trailing space)

Old:
https://cl.ly/a08cb9399087/download/Screen%20Recording%202018-11-01%20at%2011.08%20AM.gif

New:
https://cl.ly/1333474092f2/Screen%20Recording%202018-11-01%20at%2012.57%20PM.gif