### PR TITLE
fix(integrations) Don't call replace on null

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
@@ -286,9 +286,9 @@ export default class IntegrationRepos extends AsyncComponent {
                       </Box>
                       <Box>
                         <small>
-                          <a href={repo.url}>
-                            {repo.url && repo.url.replace('https://', '')}
-                          </a>
+                          {repo.url && (
+                            <a href={repo.url}>{repo.url.replace('https://', '')}</a>
+                          )}
                         </small>
                       </Box>
                     </Flex>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
@@ -286,7 +286,9 @@ export default class IntegrationRepos extends AsyncComponent {
                       </Box>
                       <Box>
                         <small>
-                          <a href={repo.url}>{repo.url.replace('https://', '')}</a>
+                          <a href={repo.url}>
+                            {repo.url && repo.url.replace('https://', '')}
+                          </a>
                         </small>
                       </Box>
                     </Flex>


### PR DESCRIPTION
We have quite a few repository records in production that do not have a URL as they do not come from an integration.

Fixes JAVASCRIPT-4HJ