### PR TITLE
ref(integrations): Azure DevOps removed external_id from create subscription

### DIFF
--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -244,7 +244,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
             api_preview=True,
         )
 
-    def create_subscription(self, instance, external_id, shared_secret):
+    def create_subscription(self, instance, shared_secret):
         return self.post(
             VstsApiPath.subscriptions.format(
                 instance=instance

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -388,7 +388,7 @@ class VstsIntegrationProvider(IntegrationProvider):
 
         except (IntegrationModel.DoesNotExist, AssertionError, KeyError):
             subscription_id, subscription_secret = self.create_subscription(
-                base_url, account['accountId'], oauth_data)
+                base_url, oauth_data)
             integration['metadata']['subscription'] = {
                 'id': subscription_id,
                 'secret': subscription_secret,
@@ -396,11 +396,11 @@ class VstsIntegrationProvider(IntegrationProvider):
 
         return integration
 
-    def create_subscription(self, instance, account_id, oauth_data):
+    def create_subscription(self, instance, oauth_data):
         webhook = WorkItemWebhook()
         try:
             subscription, shared_secret = webhook.create_subscription(
-                instance, oauth_data, self.oauth_redirect_url, account_id)
+                instance, oauth_data, self.oauth_redirect_url)
         except ApiError as e:
             if e.code != 400 or 'permission' not in e.message:
                 raise e

--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -172,10 +172,10 @@ class WorkItemWebhook(Endpoint):
         # TODO(lb): hmm... this looks brittle to me
         return EMAIL_PARSER.search(email).group(1)
 
-    def create_subscription(self, instance, identity_data, oauth_redirect_url, external_id):
+    def create_subscription(self, instance, identity_data, oauth_redirect_url):
         client = self.get_client(Identity(data=identity_data), oauth_redirect_url)
         shared_secret = self.create_webhook_secret()
-        return client.create_subscription(instance, external_id, shared_secret), shared_secret
+        return client.create_subscription(instance, shared_secret), shared_secret
 
     def create_webhook_secret(self):
         # following this example


### PR DESCRIPTION
`external_id` never appeared to be used in create subscription. 