### PR TITLE
fix(integrations): Azure DevOps fix subscription check.

### DIFF
--- a/src/sentry/integrations/bitbucket/repository.py
+++ b/src/sentry/integrations/bitbucket/repository.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-from uuid import uuid4
 import six
 from sentry.app import locks
 from sentry.models import OrganizationOption
@@ -9,6 +8,7 @@ from sentry.models import Integration
 from sentry.utils.http import absolute_uri
 
 from sentry.integrations.exceptions import ApiError
+from sentry.integrations.repository import generate_secret
 
 from .webhook import parse_raw_user_email, parse_raw_user_name
 
@@ -48,7 +48,7 @@ class BitbucketRepositoryProvider(providers.IntegrationRepositoryProvider):
                 key='bitbucket:webhook_secret',
             )
             if secret is None:
-                secret = uuid4().hex + uuid4().hex
+                secret = generate_secret()
                 OrganizationOption.objects.set_value(
                     organization=organization,
                     key='bitbucket:webhook_secret',

--- a/src/sentry/integrations/bitbucket/repository.py
+++ b/src/sentry/integrations/bitbucket/repository.py
@@ -8,7 +8,7 @@ from sentry.models import Integration
 from sentry.utils.http import absolute_uri
 
 from sentry.integrations.exceptions import ApiError
-from sentry.integrations.repository import generate_secret
+from sentry.models.apitoken import generate_token
 
 from .webhook import parse_raw_user_email, parse_raw_user_name
 
@@ -48,7 +48,7 @@ class BitbucketRepositoryProvider(providers.IntegrationRepositoryProvider):
                 key='bitbucket:webhook_secret',
             )
             if secret is None:
-                secret = generate_secret()
+                secret = generate_token()
                 OrganizationOption.objects.set_value(
                     organization=organization,
                     key='bitbucket:webhook_secret',

--- a/src/sentry/integrations/repositories.py
+++ b/src/sentry/integrations/repositories.py
@@ -12,8 +12,8 @@ def generate_secret():
 
 
 class RepositoryMixin(object):
-        # whether or not integration has the ability to search through Repositories
-        # dynamically given a search query
+    # whether or not integration has the ability to search through Repositories
+    # dynamically given a search query
     repo_search = False
 
     def get_repositories(self, query=None):

--- a/src/sentry/integrations/repositories.py
+++ b/src/sentry/integrations/repositories.py
@@ -2,11 +2,18 @@ from __future__ import absolute_import
 
 from sentry.constants import ObjectStatus
 from sentry.models import Repository
+from uuid import uuid4
+
+
+def generate_secret():
+    # following this example
+    # https://github.com/getsentry/sentry-plugins/blob/master/src/sentry_plugins/github/plugin.py#L305
+    return uuid4().hex + uuid4().hex
 
 
 class RepositoryMixin(object):
-    # whether or not integration has the ability to search through Repositories
-    # dynamically given a search query
+        # whether or not integration has the ability to search through Repositories
+        # dynamically given a search query
     repo_search = False
 
     def get_repositories(self, query=None):

--- a/src/sentry/integrations/repositories.py
+++ b/src/sentry/integrations/repositories.py
@@ -2,13 +2,6 @@ from __future__ import absolute_import
 
 from sentry.constants import ObjectStatus
 from sentry.models import Repository
-from uuid import uuid4
-
-
-def generate_secret():
-    # following this example
-    # https://github.com/getsentry/sentry-plugins/blob/master/src/sentry_plugins/github/plugin.py#L305
-    return uuid4().hex + uuid4().hex
 
 
 class RepositoryMixin(object):

--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -5,8 +5,9 @@ import logging
 import six
 
 from sentry.models import Identity, Integration, OrganizationIntegration, sync_group_assignee_inbound
+from sentry.integrations.repositories import generate_secret
 from sentry.api.base import Endpoint
-from uuid import uuid4
+
 from django.views.decorators.csrf import csrf_exempt
 from django.utils.crypto import constant_time_compare
 
@@ -175,10 +176,5 @@ class WorkItemWebhook(Endpoint):
 
     def create_subscription(self, instance, identity_data, oauth_redirect_url):
         client = self.get_client(Identity(data=identity_data), oauth_redirect_url)
-        shared_secret = self.create_webhook_secret()
+        shared_secret = generate_secret()
         return client.create_subscription(instance, shared_secret), shared_secret
-
-    def create_webhook_secret(self):
-        # following this example
-        # https://github.com/getsentry/sentry-plugins/blob/master/src/sentry_plugins/github/plugin.py#L305
-        return uuid4().hex + uuid4().hex

--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -5,7 +5,7 @@ import logging
 import six
 
 from sentry.models import Identity, Integration, OrganizationIntegration, sync_group_assignee_inbound
-from sentry.integrations.repositories import generate_secret
+from sentry.models.apitoken import generate_token
 from sentry.api.base import Endpoint
 
 from django.views.decorators.csrf import csrf_exempt
@@ -176,5 +176,5 @@ class WorkItemWebhook(Endpoint):
 
     def create_subscription(self, instance, identity_data, oauth_redirect_url):
         client = self.get_client(Identity(data=identity_data), oauth_redirect_url)
-        shared_secret = generate_secret()
+        shared_secret = generate_token()
         return client.create_subscription(instance, shared_secret), shared_secret

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -287,7 +287,6 @@ def vsts_subscription_check(integration_id, organization_id, **kwargs):
             )
 
         try:
-            # TODO(lb): Move this to a common area in integrations and make it a function
             secret = generate_secret()
             subscription = client.create_subscription(
                 instance=installation.instance,

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -310,7 +310,6 @@ def vsts_subscription_check(integration_id, organization_id, **kwargs):
                     'integration_id': integration_id,
                     'organization_id': organization_id,
                     'subscription_id': subscription_id,
-                    'error': six.text_type(e),
                 }
             )
 

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -13,7 +13,7 @@ from sentry.models import (
 )
 
 from sentry.integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
-from sentry.integrations.repositories import generate_secret
+from sentry.models.apitoken import generate_token
 from sentry.tasks.base import instrumented_task, retry
 
 logger = logging.getLogger('sentry.tasks.integrations')
@@ -300,7 +300,7 @@ def vsts_subscription_check(integration_id, organization_id, **kwargs):
                 )
 
         try:
-            secret = generate_secret()
+            secret = generate_token()
             subscription = client.create_subscription(
                 instance=installation.instance,
                 shared_secret=secret,

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -288,7 +288,7 @@ def vsts_subscription_check(integration_id, organization_id, **kwargs):
                     instance=installation.instance,
                     subscription_id=subscription_id,
                 )
-            except (ApiError, ApiUnauthorized) as e:
+            except ApiError as e:
                 logger.info(
                     'vsts_subscription_check.failed_to_delete_subscription',
                     extra={
@@ -305,7 +305,7 @@ def vsts_subscription_check(integration_id, organization_id, **kwargs):
                 instance=installation.instance,
                 shared_secret=secret,
             )
-        except (ApiError, ApiUnauthorized) as e:
+        except ApiError as e:
             logger.info(
                 'vsts_subscription_check.failed_to_create_subscription',
                 extra={

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -259,32 +259,45 @@ def vsts_subscription_check(integration_id, organization_id, **kwargs):
     integration = Integration.objects.get(id=integration_id)
     installation = integration.get_installation(organization_id=organization_id)
     client = installation.get_client()
-    subscription_id = integration.metadata['subscription']['id']
-    subscription = client.get_subscription(
-        instance=installation.instance,
-        subscription_id=subscription_id,
-    )
+
+    try:
+        subscription_id = integration.metadata['subscription']['id']
+        subscription = client.get_subscription(
+            instance=installation.instance,
+            subscription_id=subscription_id,
+        )
+    except (KeyError, ApiError) as e:
+        logger.info(
+            'vsts_subscription_check.failed_to_get_subscription',
+            extra={
+                'integration_id': integration_id,
+                'organization_id': organization_id,
+                'error': six.text_type(e),
+            }
+        )
+        subscription = None
 
     # https://docs.microsoft.com/en-us/rest/api/vsts/hooks/subscriptions/replace%20subscription?view=vsts-rest-4.1#subscriptionstatus
-    if subscription['status'] == 'disabledBySystem':
+    if not subscription or subscription['status'] == 'disabledBySystem':
         # Update subscription does not work for disabled subscriptions
         # We instead will try to delete and then create a new one.
 
-        try:
-            client.delete_subscription(
-                instance=installation.instance,
-                subscription_id=subscription_id,
-            )
-        except (ApiError, ApiUnauthorized) as e:
-            logger.info(
-                'vsts_subscription_check.failed_to_delete_subscription',
-                extra={
-                    'integration_id': integration_id,
-                    'organization_id': organization_id,
-                    'subscription_id': subscription_id,
-                    'error': six.text_type(e),
-                }
-            )
+        if subscription:
+            try:
+                client.delete_subscription(
+                    instance=installation.instance,
+                    subscription_id=subscription_id,
+                )
+            except (ApiError, ApiUnauthorized) as e:
+                logger.info(
+                    'vsts_subscription_check.failed_to_delete_subscription',
+                    extra={
+                        'integration_id': integration_id,
+                        'organization_id': organization_id,
+                        'subscription_id': subscription_id,
+                        'error': six.text_type(e),
+                    }
+                )
 
         try:
             secret = generate_secret()

--- a/tests/sentry/tasks/test_integrations.py
+++ b/tests/sentry/tasks/test_integrations.py
@@ -45,16 +45,10 @@ class VstsSubscriptionCheckTest(TestCase):
             }
         )
 
-    def assert_subscription(self, subscription_data, subscription_id, check=True, secret=True):
+    def assert_subscription(self, subscription_data, subscription_id):
         assert subscription_data['id'] == subscription_id
-        if check:
-            assert subscription_data['check']
-        else:
-            assert 'check' not in subscription_data
-        if secret:
-            assert subscription_data['secret']
-        else:
-            assert 'secret' not in subscription_data
+        assert subscription_data['check']
+        assert subscription_data['secret']
 
     @responses.activate
     def test_kickoff_subscription(self):


### PR DESCRIPTION
Because  Azure DevOps's update subscription does not appear to work for subscriptions that have been disabled by the system, we will attempt to delete, then recreate the subscriptions instead. Added logging to help us see what's happening with this task.

Fixes SENTRY-84T