### PR TITLE
feat: Updates to releases progress bar

### DIFF
--- a/src/sentry/static/sentry/app/views/projectReleases/progressBar.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/progressBar.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'react-emotion';
+
+class ProgressBarTest extends React.Component {
+  static propTypes = {
+    width: PropTypes.number,
+  };
+
+  render() {
+    return (
+      <StyledBar>
+        <StyledSlider width={this.props.width} />
+      </StyledBar>
+    );
+  }
+}
+
+const StyledBar = styled.div`
+  background: #767676;
+  width: 100%;
+  height: 15px;
+  float: right;
+  margin-right: 0px;
+  margin-bottom: 10px;
+  border-radius: 20px;
+  position: relative;
+`;
+
+const StyledSlider = styled.div`
+  height: 100%;
+  width: ${props => (props.width ? props.width : 50)}%;
+  background: #7ccca5;
+  padding-right: 0;
+  border-radius: inherit;
+  box-shadow: 0 2px 1px rgba(0, 0, 0, 0.08);
+  position: absolute;
+  bottom: 0;
+  left: 0;
+`;
+export default ProgressBarTest;

--- a/src/sentry/static/sentry/app/views/projectReleases/progressBar.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/progressBar.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'react-emotion';
 
-class ProgressBarTest extends React.Component {
+class ProgressBar extends React.Component {
   static propTypes = {
     width: PropTypes.number,
   };
@@ -38,4 +38,4 @@ const StyledSlider = styled.div`
   bottom: 0;
   left: 0;
 `;
-export default ProgressBarTest;
+export default ProgressBar;

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseLanding.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseLanding.jsx
@@ -71,6 +71,14 @@ const ReleaseLanding = withApi(
       };
     }
 
+    componentDidMount() {
+      let {organization, project} = this.context;
+      analytics('releases.landing_card_viewed', {
+        org_id: parseInt(organization.id, 10),
+        project_id: parseInt(project.id, 10),
+      });
+    }
+
     handleClick = () => {
       let {stepId} = this.state;
       let {organization, project} = this.context;
@@ -80,6 +88,7 @@ const ReleaseLanding = withApi(
       this.setState(state => ({
         stepId: state.stepId + 1,
       }));
+
       analytics('releases.landing_card_clicked', {
         org_id: parseInt(organization.id, 10),
         project_id: parseInt(project.id, 10),

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseProgress.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseProgress.jsx
@@ -7,6 +7,7 @@ import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
 import {PanelItem} from 'app/components/panels';
 import {promptsUpdate} from 'app/actionCreators/prompts';
+import ProgressBarTest from 'app/views/projectReleases/progressBar';
 
 const STEPS = {
   tag: t('Tag an error'),
@@ -86,30 +87,47 @@ class ReleaseProgress extends AsyncComponent {
     promptsUpdate(this.api, params).then(this.setState({showBar: false}));
   }
 
+  getWidth() {
+    let {remainingSteps} = this.state;
+    let width =
+      100 *
+      (Object.keys(STEPS).length - remainingSteps.length) /
+      Object.keys(STEPS).length;
+
+    return width === 0 ? 25 : width;
+  }
+
   renderBody() {
     let {remainingSteps, showBar} = this.state;
     if (!remainingSteps || remainingSteps.length === 0 || !showBar) {
       return null;
     }
+
+    let nextStep = remainingSteps[0];
+
     return (
       <PanelItem>
-        <div className="col-sm-6">
+        <div className="col-sm-8">
           <div>
-            <h4 className="text-light"> {t("Releases aren't 100% set up")}</h4>
-            <StyledBar>
-              <StyledSlider />
-            </StyledBar>
-            <a href="https://docs.sentry.io/learn/releases/">{t('Next steps:')}</a>
-
-            <ul>
-              {this.state.remainingSteps.map((step, i) => {
-                return <li key={i}>{step}</li>;
-              })}
-            </ul>
+            <div className="row">
+              <span className="pull-right">
+                {t('Next step:')}
+                <a href="https://docs.sentry.io/learn/releases/">{`${nextStep}`}</a>{' '}
+              </span>
+              <h4 className="text-light"> {t("Releases aren't 100% set up")}</h4>
+            </div>
+            <div className="row">
+              <ProgressBarTest width={this.getWidth()} />
+              <p>
+                {t(
+                  'Saves you time by surfacing when issues are first introduced, suggesting responsible commits and more!'
+                )}{' '}
+              </p>
+            </div>
           </div>
         </div>
 
-        <div className="col-sm-6">
+        <div className="col-sm-4">
           <div className="pull-right">
             <StyledButton
               className="text-light"
@@ -138,26 +156,4 @@ const StyledButton = styled(Button)`
   margin: 5px;
 `;
 
-const StyledBar = styled.div`
-  background: #767676;
-  width: 100%;
-  height: 15px;
-  float: right;
-  margin-right: 0px;
-  margin-bottom: 10px;
-  border-radius: 20px;
-  position: relative;
-`;
-
-const StyledSlider = styled.div`
-  height: 100%;
-  width: 50%;
-  background: #7ccca5;
-  padding-right: 0;
-  border-radius: inherit;
-  box-shadow: 0 2px 1px rgba(0, 0, 0, 0.08);
-  position: absolute;
-  bottom: 0;
-  left: 0;
-`;
 export default ReleaseProgress;

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseProgress.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseProgress.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {t} from 'app/locale';
 import styled from 'react-emotion';
 
+import {analytics} from 'app/utils/analytics';
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
 import {PanelItem} from 'app/components/panels';
@@ -44,6 +45,11 @@ class ReleaseProgress extends AsyncComponent {
     } else if (stateKey === 'setupStatus') {
       this.getRemainingSteps(data);
     }
+    let {organization, project} = this.context;
+    analytics('releases.progress_bar_viewed', {
+      org_id: parseInt(organization.id, 10),
+      project_id: parseInt(project.id, 10),
+    });
   }
 
   getRemainingSteps(setupStatus) {
@@ -121,7 +127,7 @@ class ReleaseProgress extends AsyncComponent {
               <p>
                 {t(
                   'Saves you time by surfacing when issues are first introduced, suggesting responsible commits and more!'
-                )}{' '}
+                )}
               </p>
             </div>
           </div>

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseProgress.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseProgress.jsx
@@ -45,14 +45,10 @@ class ReleaseProgress extends AsyncComponent {
     } else if (stateKey === 'setupStatus') {
       this.getRemainingSteps(data);
     }
-    let {organization, project} = this.context;
-    analytics('releases.progress_bar_viewed', {
-      org_id: parseInt(organization.id, 10),
-      project_id: parseInt(project.id, 10),
-    });
   }
 
   getRemainingSteps(setupStatus) {
+    let {organization, project} = this.context;
     let remainingSteps;
     if (setupStatus) {
       remainingSteps = setupStatus
@@ -61,6 +57,12 @@ class ReleaseProgress extends AsyncComponent {
 
       this.setState({
         remainingSteps,
+      });
+
+      analytics('releases.progress_bar_viewed', {
+        org_id: parseInt(organization.id, 10),
+        project_id: parseInt(project.id, 10),
+        steps: setupStatus,
       });
     }
   }

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseProgress.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseProgress.jsx
@@ -65,7 +65,7 @@ class ReleaseProgress extends AsyncComponent {
 
   buildMessage(remainingSteps) {
     let keys = remainingSteps.map(step => step.step);
-    let message = 'Save time by ';
+    let message = "You're missing out on ";
 
     if (keys.includes('tag')) {
       message += STEPS.tag.msg;
@@ -169,7 +169,9 @@ class ReleaseProgress extends AsyncComponent {
                 <a
                   href={`https://docs.sentry.io/learn/releases/#${nextStep.url}`}
                   onClick={() => this.recordAnalytics('next', {cta: nextStep.desc})}
-                >{`${nextStep.desc}`}</a>
+                >
+                  {t(`${nextStep.desc}`)}
+                </a>
               </span>
               <h4 className="text-light"> {t("Releases aren't 100% set up")}</h4>
             </StyledDiv>

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseProgress.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseProgress.jsx
@@ -14,18 +14,22 @@ const STEPS = {
   tag: {
     desc: t('Tag an error'),
     url: 'tag-errors',
+    msg: 'knowing which errors were introduced in a release, ',
   },
   repo: {
     desc: t('Link to a repo'),
     url: 'link-repository',
+    msg: 'determining which commit caused an error, ',
   },
   commit: {
     desc: t('Associate commits'),
     url: 'b-associate-commits-with-a-release',
+    msg: 'determining which commit caused an error, ',
   },
   deploy: {
     desc: t('Tell sentry about a deploy'),
     url: 'create-deploy',
+    msg: 'receiving notifications when your code gets deployed, ',
   },
 };
 
@@ -59,12 +63,31 @@ class ReleaseProgress extends AsyncComponent {
     }
   }
 
+  buildMessage(remainingSteps) {
+    let keys = remainingSteps.map(step => step.step);
+    let message = 'Save time by ';
+
+    if (keys.includes('tag')) {
+      message += STEPS.tag.msg;
+    }
+    if (keys.includes('repo') || keys.includes('commit')) {
+      message += STEPS.repo.msg;
+    }
+    if (keys.includes('deploy')) {
+      message += STEPS.deploy.msg;
+    }
+
+    message += 'and more!';
+
+    this.setState({message});
+  }
+
   getRemainingSteps(setupStatus) {
     let {organization, project} = this.context;
     let remainingSteps;
     if (setupStatus) {
       remainingSteps = setupStatus.filter(step => step.complete === false);
-
+      this.buildMessage(remainingSteps);
       this.setState({
         remainingSteps: Object.keys(remainingSteps).length,
         nextStep: remainingSteps[0] && STEPS[remainingSteps[0].step],
@@ -130,13 +153,11 @@ class ReleaseProgress extends AsyncComponent {
   }
 
   renderBody() {
-    let {remainingSteps, showBar} = this.state;
+    let {remainingSteps, showBar, nextStep, message} = this.state;
 
     if (!remainingSteps || remainingSteps === 0 || !showBar) {
       return null;
     }
-
-    let {nextStep} = this.state;
 
     return (
       <PanelItem>
@@ -154,11 +175,7 @@ class ReleaseProgress extends AsyncComponent {
             </StyledDiv>
             <div className="row">
               <ProgressBar width={this.getWidth()} />
-              <p>
-                {t(
-                  'Save time by surfacing when issues are first introduced, what commits are responsible, and more!'
-                )}
-              </p>
+              <p>{t(`${message}`)}</p>
             </div>
           </div>
         </div>

--- a/src/sentry/static/sentry/app/views/projectReleases/releaseProgress.jsx
+++ b/src/sentry/static/sentry/app/views/projectReleases/releaseProgress.jsx
@@ -8,13 +8,25 @@ import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
 import {PanelItem} from 'app/components/panels';
 import {promptsUpdate} from 'app/actionCreators/prompts';
-import ProgressBarTest from 'app/views/projectReleases/progressBar';
+import ProgressBar from 'app/views/projectReleases/progressBar';
 
 const STEPS = {
-  tag: t('Tag an error'),
-  repo: t('Link to a repo'),
-  commit: t('Associate commits'),
-  deploy: t('Tell sentry about a deploy'),
+  tag: {
+    desc: t('Tag an error'),
+    url: 'tag-errors',
+  },
+  repo: {
+    desc: t('Link to a repo'),
+    url: 'link-repository',
+  },
+  commit: {
+    desc: t('Associate commits'),
+    url: 'b-associate-commits-with-a-release',
+  },
+  deploy: {
+    desc: t('Tell sentry about a deploy'),
+    url: 'create-deploy',
+  },
 };
 
 class ReleaseProgress extends AsyncComponent {
@@ -51,15 +63,14 @@ class ReleaseProgress extends AsyncComponent {
     let {organization, project} = this.context;
     let remainingSteps;
     if (setupStatus) {
-      remainingSteps = setupStatus
-        .filter(step => step.complete === false)
-        .map(displayStep => STEPS[displayStep.step]);
+      remainingSteps = setupStatus.filter(step => step.complete === false);
 
       this.setState({
-        remainingSteps,
+        remainingSteps: Object.keys(remainingSteps).length,
+        nextStep: remainingSteps[0] && STEPS[remainingSteps[0].step],
       });
 
-      analytics('releases.progress_bar_viewed', {
+      this.recordAnalytics('viewed', {
         org_id: parseInt(organization.id, 10),
         project_id: parseInt(project.id, 10),
         steps: setupStatus,
@@ -93,42 +104,59 @@ class ReleaseProgress extends AsyncComponent {
       status: action,
     };
     promptsUpdate(this.api, params).then(this.setState({showBar: false}));
+    this.recordAnalytics('closed', {
+      org_id: parseInt(organization.id, 10),
+      project_id: parseInt(project.id, 10),
+      action,
+    });
+  }
+
+  recordAnalytics(action, data) {
+    if (action === 'next') {
+      analytics('releases.progress_bar_clicked_next', data);
+    } else if (action === 'closed') {
+      analytics('releases.progress_bar_closed', data);
+    } else if (action === 'viewed') {
+      analytics('releases.progress_bar_viewed', data);
+    }
   }
 
   getWidth() {
     let {remainingSteps} = this.state;
     let width =
-      100 *
-      (Object.keys(STEPS).length - remainingSteps.length) /
-      Object.keys(STEPS).length;
+      100 * (Object.keys(STEPS).length - remainingSteps) / Object.keys(STEPS).length;
 
     return width === 0 ? 25 : width;
   }
 
   renderBody() {
     let {remainingSteps, showBar} = this.state;
-    if (!remainingSteps || remainingSteps.length === 0 || !showBar) {
+
+    if (!remainingSteps || remainingSteps === 0 || !showBar) {
       return null;
     }
 
-    let nextStep = remainingSteps[0];
+    let {nextStep} = this.state;
 
     return (
       <PanelItem>
         <div className="col-sm-8">
           <div>
-            <div className="row">
+            <StyledDiv className="row">
               <span className="pull-right">
-                {t('Next step:')}
-                <a href="https://docs.sentry.io/learn/releases/">{`${nextStep}`}</a>{' '}
+                {t('Next step: ')}
+                <a
+                  href={`https://docs.sentry.io/learn/releases/#${nextStep.url}`}
+                  onClick={() => this.recordAnalytics('next', {cta: nextStep.desc})}
+                >{`${nextStep.desc}`}</a>
               </span>
               <h4 className="text-light"> {t("Releases aren't 100% set up")}</h4>
-            </div>
+            </StyledDiv>
             <div className="row">
-              <ProgressBarTest width={this.getWidth()} />
+              <ProgressBar width={this.getWidth()} />
               <p>
                 {t(
-                  'Saves you time by surfacing when issues are first introduced, suggesting responsible commits and more!'
+                  'Save time by surfacing when issues are first introduced, what commits are responsible, and more!'
                 )}
               </p>
             </div>
@@ -162,6 +190,10 @@ class ReleaseProgress extends AsyncComponent {
 
 const StyledButton = styled(Button)`
   margin: 5px;
+`;
+
+const StyledDiv = styled('div')`
+  margin-bottom: 10px;
 `;
 
 export default ReleaseProgress;

--- a/tests/js/spec/views/projectReleasesProgress.spec.jsx
+++ b/tests/js/spec/views/projectReleasesProgress.spec.jsx
@@ -50,7 +50,7 @@ describe('ReleaseProgress', function() {
     expect(wrapper.find('PanelItem')).toHaveLength(0);
   });
 
-  it('renders with three steps', async function() {
+  it('renders with next step suggestion', async function() {
     Client.addMockResponse({
       url: '/projects/org-slug/project-slug/releases/completion/',
       body: [
@@ -64,8 +64,14 @@ describe('ReleaseProgress', function() {
       <ReleaseProgress orgId={organization.id} projectId={project.id} />,
       routerContext
     );
+
+    expect(
+      wrapper
+        .find('span')
+        .first()
+        .text()
+    ).toBe('Next step:Link to a repo ');
     expect(getPromptsMock).toHaveBeenCalled();
-    expect(wrapper.find('li')).toHaveLength(3);
   });
 
   it('hides when snoozed', async function() {
@@ -82,7 +88,12 @@ describe('ReleaseProgress', function() {
       <ReleaseProgress orgId={organization.id} projectId={project.id} />,
       routerContext
     );
-    expect(wrapper.find('li')).toHaveLength(3);
+    expect(
+      wrapper
+        .find('span')
+        .first()
+        .text()
+    ).toBe('Next step:Link to a repo ');
     expect(wrapper.find('PanelItem')).toHaveLength(1);
 
     //Snooze the bar

--- a/tests/js/spec/views/projectReleasesProgress.spec.jsx
+++ b/tests/js/spec/views/projectReleasesProgress.spec.jsx
@@ -45,7 +45,7 @@ describe('ReleaseProgress', function() {
       <ReleaseProgress orgId={organization.id} projectId={project.id} />,
       routerContext
     );
-    expect(wrapper.state('remainingSteps')).toHaveLength(0);
+    expect(wrapper.state('remainingSteps')).toBe(0);
     expect(wrapper.find('ReleaseProgress')).toHaveLength(1);
     expect(wrapper.find('PanelItem')).toHaveLength(0);
   });
@@ -70,7 +70,7 @@ describe('ReleaseProgress', function() {
         .find('span')
         .first()
         .text()
-    ).toBe('Next step:Link to a repo ');
+    ).toBe('Next step: Link to a repo');
     expect(getPromptsMock).toHaveBeenCalled();
   });
 
@@ -93,7 +93,7 @@ describe('ReleaseProgress', function() {
         .find('span')
         .first()
         .text()
-    ).toBe('Next step:Link to a repo ');
+    ).toBe('Next step: Link to a repo');
     expect(wrapper.find('PanelItem')).toHaveLength(1);
 
     //Snooze the bar


### PR DESCRIPTION
This adds:
- Dynamicness to the bar depending on how many steps are complete
- A single cta for what needs to be done next
- A statement on why they should even bother setting it up

At it's longest:
<img width="1078" alt="screen shot 2018-11-07 at 4 30 28 pm" src="https://user-images.githubusercontent.com/16228317/48170027-98c27a80-e2aa-11e8-9100-963d0e420528.png">

To Do:
- [x] fix padding :woman_facepalming:
- [x] add specific url for each step 

