### PR TITLE
fix(native): Do not compute caches for unsupported legacy DIFs

### DIFF
--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -733,6 +733,12 @@ class DIFCache(object):
             if o is None:
                 return None, None, None
 
+            # Check features from the actual object file, if this is a legacy
+            # DIF where features have not been extracted yet.
+            if (debug_file.data or {}).get('features') is None:
+                if o.features < set(cls.required_features):
+                    return None, None, None
+
             cache = cls.cache_cls.from_object(o)
         except SymbolicError as e:
             if not isinstance(e, cls.ignored_errors):

--- a/tests/sentry/models/test_debugfile.py
+++ b/tests/sentry/models/test_debugfile.py
@@ -550,7 +550,7 @@ class CfiCacheTest(TestCase):
     def test_skip_cficache_without_feature(self):
         debug_id = '67e9247c-814e-392b-a027-dbde6748fcbf'
         self.create_dif_from_path(
-            path=os.path.join(os.path.dirname(__file__), 'fixtures', 'crash.dSYM'),
+            path=os.path.join(os.path.dirname(__file__), 'fixtures', 'crash.dsym'),
             debug_id=debug_id,
             dif_type='macho',
         )

--- a/tests/sentry/models/test_debugfile.py
+++ b/tests/sentry/models/test_debugfile.py
@@ -394,6 +394,17 @@ class SymCacheTest(TestCase):
         assert debug_id in symcaches
         assert symcaches[debug_id].id == debug_id
 
+    def test_skip_symcache_without_feature(self):
+        debug_id = '1ddb3423-950a-3646-b17b-d4360e6acfc9'
+        self.create_dif_from_path(
+            path=os.path.join(os.path.dirname(__file__), 'fixtures', 'crash'),
+            debug_id=debug_id,
+            dif_type='macho',
+        )
+
+        symcaches = ProjectDebugFile.difcache.get_symcaches(self.project, [debug_id])
+        assert not symcaches
+
     def test_update_symcache(self):
         debug_id = '67e9247c-814e-392b-a027-dbde6748fcbf'
         dif = self.create_dif_from_path(
@@ -535,6 +546,17 @@ class CfiCacheTest(TestCase):
 
         cficaches = ProjectDebugFile.difcache.get_cficaches(self.project, [debug_id])
         assert debug_id in cficaches
+
+    def test_skip_cficache_without_feature(self):
+        debug_id = '67e9247c-814e-392b-a027-dbde6748fcbf'
+        self.create_dif_from_path(
+            path=os.path.join(os.path.dirname(__file__), 'fixtures', 'crash.dSYM'),
+            debug_id=debug_id,
+            dif_type='macho',
+        )
+
+        symcaches = ProjectDebugFile.difcache.get_cficaches(self.project, [debug_id])
+        assert not symcaches
 
     def test_update_cficache(self):
         debug_id = '1ddb3423-950a-3646-b17b-d4360e6acfc9'


### PR DESCRIPTION
This should reduce the number of `SymCacheErrorBadDebugFile` and `CfiCacheErrorBadDebugFile`.