### PR TITLE
perf(ui): Add `shouldComponentUpdate` to Sidebar

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -1,3 +1,4 @@
+import {isEqual} from 'lodash';
 import {withRouter} from 'react-router';
 import {ThemeProvider} from 'emotion-theming';
 import $ from 'jquery';
@@ -38,6 +39,8 @@ class Sidebar extends React.Component {
     super(props);
     this.state = {
       horizontal: false,
+      currentPanel: '',
+      showPanel: false,
     };
 
     if (!window.matchMedia) return;
@@ -80,6 +83,21 @@ class Sidebar extends React.Component {
     if (collapsed === nextProps.collapsed) return;
 
     this.doCollapse(nextProps.collapsed);
+  }
+
+  // Sidebar doesn't use children, so don't use it to compare
+  // Also ignore location, will re-render when routes change (instead of query params)
+  shouldComponentUpdate({children, location, ...nextPropsToCompare}, nextState) {
+    const {
+      children: _children, // eslint-disable-line no-unused-vars
+      location: _location, // eslint-disable-line no-unused-vars
+      ...currentPropsToCompare
+    } = this.props;
+
+    return (
+      !isEqual(currentPropsToCompare, nextPropsToCompare) ||
+      !isEqual(this.state, nextState)
+    );
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Ignore `location` from router when deciding to re-render, it only needs to re-render when
route changes (instead of, for example, a query param changing).