### PR TITLE
ref(EventManager): Move Event model creation into separate method

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -705,7 +705,7 @@ class EventManager(object):
     def get_data(self):
         return self._data
 
-    def _get_event_model(self, project_id=None):
+    def _get_event_instance(self, project_id=None):
         data = self._data.copy()
         event_id = data.pop('event_id')
         platform = data.pop('platform', None)
@@ -774,7 +774,7 @@ class EventManager(object):
         # unused
         message = data.pop('message', '')
 
-        event = self._get_event_model(project_id=project_id)
+        event = self._get_event_instance(project_id=project_id)
         event._project_cache = project
 
         date = event.datetime

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -729,9 +729,9 @@ class EventManager(object):
     def save(self, project_id, raw=False):
         from sentry.tasks.post_process import index_event_tags
 
-        project = Project.objects.get_from_cache(id=project_id)
-
         data = self._data
+
+        project = Project.objects.get_from_cache(id=project_id)
 
         # Check to make sure we're not about to do a bunch of work that's
         # already been done if we've processed an event with this ID. (This

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -706,7 +706,7 @@ class EventManager(object):
         return self._data
 
     def _get_event_model(self, project_id=None):
-        data = self._data
+        data = self._data.copy()
         event_id = data.pop('event_id')
         platform = data.pop('platform', None)
 
@@ -781,6 +781,7 @@ class EventManager(object):
         platform = event.platform
         event_id = event.event_id
         data = event.data.data
+        self._data = None
 
         if not culprit:
             if transaction_name:

--- a/src/sentry/utils/canonical.py
+++ b/src/sentry/utils/canonical.py
@@ -104,6 +104,7 @@ class CanonicalKeyDict(collections.MutableMapping):
 
     def copy(self):
         rv = object.__new__(self.__class__)
+        rv._norm_func = self._norm_func
         rv.data = copy.copy(self.data)
         return rv
 


### PR DESCRIPTION
How this could be used in the garbage script:

```python
from sentry.event_manager import *
if not should_process(manager.get_data()):
    hashes = get_hashes_for_event(manager._get_event_model())
```

This will miss a lot of normalization happening in `EventManager.save()`, so this might alert us about grouping changes that don't actually occur. As long as the number is manageable I think this is good enough