### PR TITLE
fix(integrations) Add pull request links for gitlab

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/pullRequestLink.jsx
+++ b/src/sentry/static/sentry/app/views/releases/pullRequestLink.jsx
@@ -35,9 +35,21 @@ class PullRequestLink extends React.Component {
 
   render() {
     let url = this.url;
-    let displayId = `${this.props.repository.name} #${this.props.pullRequest.id}: ${this
-      .props.pullRequest.title}`;
     let providerId = this.providerId;
+
+    let {pullRequest, repository} = this.props;
+    let displayId = `${repository.name} #${pullRequest.id}: ${pullRequest.title}`;
+
+    let icon = '';
+    if (['github', 'gitlab', 'bitbucket'].indexOf(providerId) > -1) {
+      icon = (
+        <InlineSvg
+          src={`icon-${providerId}`}
+          style={{verticalAlign: 'text-top'}}
+          size="14px"
+        />
+      );
+    }
 
     return url ? (
       <a
@@ -45,21 +57,7 @@ class PullRequestLink extends React.Component {
         href={url}
         target="_blank"
       >
-        {providerId == 'github' && (
-          <InlineSvg src="icon-github" style={{verticalAlign: 'text-top'}} size="14px" />
-        )}
-        {providerId == 'bitbucket' && (
-          <InlineSvg
-            src="icon-bitbucket"
-            style={{verticalAlign: 'text-top'}}
-            size="14px"
-          />
-        )}
-        {providerId == 'gitlab' && (
-          <InlineSvg src="icon-gitlab" style={{verticalAlign: 'text-top'}} size="14px" />
-        )}
-        &nbsp;
-        {this.props.inline ? '' : ' '}
+        {icon}&nbsp; {this.props.inline ? '' : ' '}
         {displayId}
       </a>
     ) : (

--- a/src/sentry/static/sentry/app/views/releases/pullRequestLink.jsx
+++ b/src/sentry/static/sentry/app/views/releases/pullRequestLink.jsx
@@ -10,17 +10,34 @@ class PullRequestLink extends React.Component {
     inline: PropTypes.bool,
   };
 
-  getUrl = () => {
-    if (this.props.repository.provider.id === 'github') {
+  get providerId() {
+    if (!this.props.repository.provider) {
+      return null;
+    }
+
+    let id = this.props.repository.provider.id;
+    if (id.indexOf(':') > -1) {
+      return id.split(':').pop();
+    }
+    return id;
+  }
+
+  get url() {
+    let providerId = this.providerId;
+    if (providerId === 'github') {
       return this.props.repository.url + '/pull/' + this.props.pullRequest.id;
     }
+    if (providerId === 'gitlab') {
+      return this.props.repository.url + '/merge_requests/' + this.props.pullRequest.id;
+    }
     return undefined;
-  };
+  }
 
   render() {
-    let url = this.getUrl();
+    let url = this.url;
     let displayId = `${this.props.repository.name} #${this.props.pullRequest.id}: ${this
       .props.pullRequest.title}`;
+    let providerId = this.providerId;
 
     return url ? (
       <a
@@ -28,15 +45,18 @@ class PullRequestLink extends React.Component {
         href={url}
         target="_blank"
       >
-        {this.props.repository.provider.id == 'github' && (
+        {providerId == 'github' && (
           <InlineSvg src="icon-github" style={{verticalAlign: 'text-top'}} size="14px" />
         )}
-        {this.props.repository.provider.id == 'bitbucket' && (
+        {providerId == 'bitbucket' && (
           <InlineSvg
             src="icon-bitbucket"
             style={{verticalAlign: 'text-top'}}
             size="14px"
           />
+        )}
+        {providerId == 'gitlab' && (
+          <InlineSvg src="icon-gitlab" style={{verticalAlign: 'text-top'}} size="14px" />
         )}
         &nbsp;
         {this.props.inline ? '' : ' '}

--- a/tests/js/fixtures/pullRequest.js
+++ b/tests/js/fixtures/pullRequest.js
@@ -1,0 +1,17 @@
+import {Repository} from './repository';
+
+export function PullRequest(params = {}) {
+  return {
+    id: '3',
+    author: {
+      username: 'jill@example.org',
+      lastLogin: '2018-11-01T20:09:19.483Z',
+      isSuperuser: false,
+    },
+    dateCreated: '2018-11-05T15:53:24Z',
+    message: 'Closes ISSUE-1',
+    repository: Repository(),
+    title: 'Fix first issue',
+    ...params,
+  };
+}

--- a/tests/js/spec/views/releases/pullRequestLink.spec.jsx
+++ b/tests/js/spec/views/releases/pullRequestLink.spec.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import PullRequestLink from 'app/views/releases/pullRequestLink';
+
+describe('PullRequestLink', function() {
+  it('renders no url on missing provider', function() {
+    let repository = TestStubs.Repository({provider: null});
+    let pullRequest = TestStubs.PullRequest({repository});
+    let wrapper = mount(
+      <PullRequestLink repository={repository} pullRequest={pullRequest} />
+    );
+
+    expect(wrapper.find('a')).toHaveLength(0);
+    expect(wrapper.find('span').text()).toEqual('repo-name #3: Fix first issue');
+  });
+
+  it('renders github links for integrations:github repositories', function() {
+    let repository = TestStubs.Repository({
+      provider: {
+        id: 'integrations:github',
+      },
+    });
+    let pullRequest = TestStubs.PullRequest({repository});
+    let wrapper = mount(
+      <PullRequestLink repository={repository} pullRequest={pullRequest} />
+    );
+
+    let icon = wrapper.find('InlineSvg');
+    expect(icon).toHaveLength(1);
+    expect(icon.props().src).toEqual('icon-github');
+
+    let link = wrapper.find('a');
+    expect(link).toHaveLength(1);
+    expect(link.text().trim()).toEqual('repo-name #3: Fix first issue');
+  });
+
+  it('renders github links for github repositories', function() {
+    let repository = TestStubs.Repository({
+      provider: {
+        id: 'github',
+      },
+    });
+    let pullRequest = TestStubs.PullRequest({repository});
+    let wrapper = mount(
+      <PullRequestLink repository={repository} pullRequest={pullRequest} />
+    );
+
+    let icon = wrapper.find('InlineSvg');
+    expect(icon).toHaveLength(1);
+    expect(icon.props().src).toEqual('icon-github');
+
+    let link = wrapper.find('a');
+    expect(link).toHaveLength(1);
+    expect(link.text().trim()).toEqual('repo-name #3: Fix first issue');
+  });
+
+  it('renders gitlab links for integrations:gitlab repositories', function() {
+    let repository = TestStubs.Repository({
+      provider: {
+        id: 'integrations:gitlab',
+      },
+    });
+    let pullRequest = TestStubs.PullRequest({repository});
+    let wrapper = mount(
+      <PullRequestLink repository={repository} pullRequest={pullRequest} />
+    );
+
+    let icon = wrapper.find('InlineSvg');
+    expect(icon).toHaveLength(1);
+    expect(icon.props().src).toEqual('icon-gitlab');
+
+    let link = wrapper.find('a');
+    expect(link).toHaveLength(1);
+    expect(link.text().trim()).toEqual('repo-name #3: Fix first issue');
+  });
+
+  it('renders github links for gitlab repositories', function() {
+    let repository = TestStubs.Repository({
+      provider: {
+        id: 'gitlab',
+      },
+    });
+    let pullRequest = TestStubs.PullRequest({repository});
+    let wrapper = mount(
+      <PullRequestLink repository={repository} pullRequest={pullRequest} />
+    );
+
+    let icon = wrapper.find('InlineSvg');
+    expect(icon).toHaveLength(1);
+    expect(icon.props().src).toEqual('icon-gitlab');
+
+    let link = wrapper.find('a');
+    expect(link).toHaveLength(1);
+    expect(link.text().trim()).toEqual('repo-name #3: Fix first issue');
+  });
+});


### PR DESCRIPTION
Add pull request links for gitlab. There are existing code paths to show icons for bitbucket, but it doesn't work as there is no code to generate a URL. VSTS is entirely absent from this component as
well. I'll address those gaps separately.

### Screenshot

![screen shot 2018-11-05 at 11 19 58 am](https://user-images.githubusercontent.com/24086/48012269-a7186700-e0ef-11e8-895e-5818ddfde211.png)

Fixes APP-726