### PR TITLE
feat(ui): Switch order of Discover and Events sidebar icons

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -200,16 +200,6 @@ class Sidebar extends React.Component {
                   to={`/${organization.slug}/`}
                 />
 
-                <Feature features={['discover']}>
-                  <SidebarItem
-                    {...sidebarItemProps}
-                    onClick={this.hidePanel}
-                    icon={<InlineSvg src="icon-discover" />}
-                    label={t('Discover')}
-                    to={`/organizations/${organization.slug}/discover/`}
-                  />
-                </Feature>
-
                 <Feature features={['events-stream']}>
                   <SidebarItem
                     {...sidebarItemProps}
@@ -217,6 +207,16 @@ class Sidebar extends React.Component {
                     icon={<InlineSvg src="icon-stack" />}
                     label={t('Events')}
                     to={`/organizations/${organization.slug}/events/`}
+                  />
+                </Feature>
+
+                <Feature features={['discover']}>
+                  <SidebarItem
+                    {...sidebarItemProps}
+                    onClick={this.hidePanel}
+                    icon={<InlineSvg src="icon-discover" />}
+                    label={t('Discover')}
+                    to={`/organizations/${organization.slug}/discover/`}
                   />
                 </Feature>
               </SidebarSection>


### PR DESCRIPTION
Projects -> Events -> Discover