### PR TITLE
fix(native): Clean scanned stack frames with mixed CFI

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -62,7 +62,7 @@ sqlparse>=0.1.16,<0.2.0
 statsd>=3.1.0,<3.2.0
 strict-rfc3339>=0.7
 structlog==16.1.0
-symbolic>=5.5.3,<6.0.0
+symbolic>=5.5.5,<6.0.0
 toronado>=0.0.11,<0.1.0
 ua-parser>=0.6.1,<0.8.0
 # for bitbucket client

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -209,10 +209,14 @@ class NativeStacktraceProcessor(StacktraceProcessor):
                 symbolicated_frames = self.sym.symbolize_frame(
                     instruction_addr,
                     self.sdk_info,
-                    symbolserver_match=processable_frame.data['symbolserver_match']
+                    symbolserver_match=processable_frame.data['symbolserver_match'],
+                    trust=raw_frame.get('trust'),
                 )
                 if not symbolicated_frames:
-                    return None, [raw_frame], []
+                    if raw_frame.get('trust') == 'scan':
+                        return [], [raw_frame], []
+                    else:
+                        return None, [raw_frame], []
             except SymbolicationFailed as e:
                 # User fixable but fatal errors are reported as processing
                 # issues

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -277,6 +277,8 @@ class Symbolizer(object):
     def symbolize_frame(self, instruction_addr, sdk_info=None, symbolserver_match=None, trust=None):
         obj = self.object_lookup.find_object(instruction_addr)
         if obj is None:
+            if trust == 'scan':
+                return []
             raise SymbolicationFailed(type=EventError.NATIVE_UNKNOWN_IMAGE)
 
         # Try to always prefer the images from the application storage.

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -221,7 +221,7 @@ class Symbolizer(object):
     def _is_simulator_frame(self, frame, obj):
         return obj.name and _sim_platform_re.search(obj.name) is not None
 
-    def _symbolize_app_frame(self, instruction_addr, obj, sdk_info=None):
+    def _symbolize_app_frame(self, instruction_addr, obj, sdk_info=None, trust=None):
         symcache = self.symcaches.get(obj.id)
         if symcache is None:
             # In case we know what error happened on symcache conversion
@@ -247,8 +247,9 @@ class Symbolizer(object):
 
         if not rv:
             # For some frameworks we are willing to ignore missing symbol
-            # errors.
-            if self._is_optional_dif(obj, sdk_info=sdk_info):
+            # errors. Also, ignore scanned stack frames when symbols are
+            # available to complete breakpad's stack scanning heuristics.
+            if trust == 'scan' or self._is_optional_dif(obj, sdk_info=sdk_info):
                 return []
             raise SymbolicationFailed(
                 type=EventError.NATIVE_MISSING_SYMBOL, obj=obj)
@@ -273,7 +274,7 @@ class Symbolizer(object):
             ), obj, package=symbolserver_match['object_name'])
         ]
 
-    def symbolize_frame(self, instruction_addr, sdk_info=None, symbolserver_match=None):
+    def symbolize_frame(self, instruction_addr, sdk_info=None, symbolserver_match=None, trust=None):
         obj = self.object_lookup.find_object(instruction_addr)
         if obj is None:
             raise SymbolicationFailed(type=EventError.NATIVE_UNKNOWN_IMAGE)
@@ -282,7 +283,7 @@ class Symbolizer(object):
         # If the symbolication fails we keep the error for later
         app_err = None
         try:
-            match = self._symbolize_app_frame(instruction_addr, obj, sdk_info=sdk_info)
+            match = self._symbolize_app_frame(instruction_addr, obj, sdk_info=sdk_info, trust=trust)
             if match:
                 return match
         except SymbolicationFailed as err:

--- a/tests/sentry/lang/native/test_cfi.py
+++ b/tests/sentry/lang/native/test_cfi.py
@@ -35,29 +35,83 @@ RAW_STACKTRACE = [
 
 CFI_STACKTRACE = [
     {
-        'function': "<unknown>",
-        'instruction_addr': "0x7f5140cdc000",
+        'function': '<unknown>',
+        'instruction_addr': '0x401dc0',
+        'package': u'/work/linux/build/crash',
+        'trust': 'scan'
+    },
+    {
+        'function': '<unknown>',
+        'instruction_addr': '0x7f5140cdc000',
         'package': None,
-        'trust': "scan",
+        'trust': 'scan'
     },
     {
-        'function': "<unknown>",
-        'instruction_addr': "0x7fff5aef1000",
+        'function': '<unknown>',
+        'instruction_addr': '0x400040',
+        'package': u'/work/linux/build/crash',
+        'trust': 'scan'
+    },
+    {
+        'function': '<unknown>',
+        'instruction_addr': '0x7fff5aef1000',
         'package': None,
-        'trust': "scan",
+        'trust': 'scan'
     },
     {
-        'function': "<unknown>",
-        'instruction_addr': "0x7f514017d830",
-        'package': "/lib/x86_64-linux-gnu/libc-2.23.so",
-        'trust': "cfi",
+        'function': '<unknown>',
+        'instruction_addr': '0x7fff5ae4ac88',
+        'package': None,
+        'trust': 'cfi'
     },
     {
-        'function': "<unknown>",
-        'instruction_addr': "0x401d72",
-        'package': "/work/linux/build/crash",
-        'trust': "context",
+        'function': '<unknown>',
+        'instruction_addr': '0x401de9',
+        'package': u'/work/linux/build/crash',
+        'trust': 'scan'
     },
+    {
+        'function': '<unknown>',
+        'instruction_addr': '0x401dc0',
+        'package': u'/work/linux/build/crash',
+        'trust': 'scan'
+    },
+    {
+        'function': '<unknown>',
+        'instruction_addr': '0x414ca0',
+        'package': u'/work/linux/build/crash',
+        'trust': 'scan'
+    },
+    {
+        'function': '<unknown>',
+        'instruction_addr': '0x401c70',
+        'package': u'/work/linux/build/crash',
+        'trust': 'scan'
+    },
+    {
+        'function': '<unknown>',
+        'instruction_addr': '0x401dc0',
+        'package': u'/work/linux/build/crash',
+        'trust': 'scan'
+    },
+    {
+        'function': '<unknown>',
+        'instruction_addr': '0x401c70',
+        'package': u'/work/linux/build/crash',
+        'trust': 'scan'
+    },
+    {
+        'function': '<unknown>',
+        'instruction_addr': '0x7f514017d830',
+        'package': u'/lib/x86_64-linux-gnu/libc-2.23.so',
+        'trust': 'cfi'
+    },
+    {
+        'function': '<unknown>',
+        'instruction_addr': '0x401d72',
+        'package': u'/work/linux/build/crash',
+        'trust': 'context',
+    }
 ]
 
 
@@ -154,8 +208,17 @@ class CfiReprocessingTest(TestCase):
     @mock.patch('sentry.utils.cache.cache.get', return_value=None)
     def test_cfi_reprocessing_cached(self, mock_cache_get, mock_attachment_get):
         mock_cache_get.return_value = [
+            ('c0bcc3f1-9827-fe65-3058-404b2831d9e6', '0x1dc0', 'scan'),
             (None, '0x7f5140cdc000', 'scan'),
+            ('c0bcc3f1-9827-fe65-3058-404b2831d9e6', '0x0040', 'scan'),
             (None, '0x7fff5aef1000', 'scan'),
+            (None, '0x7fff5ae4ac88', 'cfi'),
+            ('c0bcc3f1-9827-fe65-3058-404b2831d9e6', '0x1de9', 'scan'),
+            ('c0bcc3f1-9827-fe65-3058-404b2831d9e6', '0x1dc0', 'scan'),
+            ('c0bcc3f1-9827-fe65-3058-404b2831d9e6', '0x14ca0', 'scan'),
+            ('c0bcc3f1-9827-fe65-3058-404b2831d9e6', '0x1c70', 'scan'),
+            ('c0bcc3f1-9827-fe65-3058-404b2831d9e6', '0x1dc0', 'scan'),
+            ('c0bcc3f1-9827-fe65-3058-404b2831d9e6', '0x1c70', 'scan'),
             ('451a38b5-0679-79d2-0738-22a5ceb24c4b', '0x20830', 'cfi'),
             ('c0bcc3f1-9827-fe65-3058-404b2831d9e6', '0x1d72', 'context'),
         ]
@@ -163,7 +226,7 @@ class CfiReprocessingTest(TestCase):
         data = self.get_mock_event(reprocessed=False)
         result = reprocess_minidump_with_cfi(data)
 
-        mock_cache_get.assert_called_once_with('st:80d8fdd07a3fb9639403afa33b0e930e')
+        mock_cache_get.assert_called_once_with('st:a996085d85a6793c0f4c377630965675')
         assert mock_attachment_get.call_count == 0
         assert result == self.get_mock_event(reprocessed=True)
 
@@ -175,7 +238,7 @@ class CfiReprocessingTest(TestCase):
         data = self.get_mock_event(reprocessed=False)
         result = reprocess_minidump_with_cfi(data)
 
-        mock_cache_get.assert_called_once_with('st:80d8fdd07a3fb9639403afa33b0e930e')
+        mock_cache_get.assert_called_once_with('st:a996085d85a6793c0f4c377630965675')
         assert mock_attachment_get.call_count == 0
         assert result is None
 

--- a/tests/sentry/lang/native/test_minidump.py
+++ b/tests/sentry/lang/native/test_minidump.py
@@ -268,8 +268,8 @@ def test_minidump_linux():
                 }
             },
             'thread_id': 1304,
-            'type': u'SIGSEGV',
-            'value': u'Fatal Error: SIGSEGV'
+            'type': u'SIGSEGV /0x00000000',
+            'value': u'Fatal Error: SIGSEGV /0x00000000'
         },
         'level': 'fatal',
         'platform': 'native',

--- a/tests/sentry/lang/native/test_plugin.py
+++ b/tests/sentry/lang/native/test_plugin.py
@@ -213,7 +213,7 @@ class BasicResolvingIntegrationTest(TestCase):
 
         assert len(event.interfaces['threads'].values) == 1
 
-    def sym_app_frame(self, instruction_addr, img, sdk_info=None):
+    def sym_app_frame(self, instruction_addr, img, sdk_info=None, trust=None):
         object_name = (
             "/var/containers/Bundle/Application/"
             "B33C37A8-F933-4B6B-9FFA-152282BFDF13/"
@@ -569,7 +569,7 @@ class InAppHonoringResolvingIntegrationTest(TestCase):
 
         assert len(event.interfaces['threads'].values) == 1
 
-    def sym_app_frame(self, instruction_addr, img, sdk_info=None):
+    def sym_app_frame(self, instruction_addr, img, sdk_info=None, trust=None):
         object_name = (
             "/var/containers/Bundle/Application/"
             "B33C37A8-F933-4B6B-9FFA-152282BFDF13/"
@@ -900,7 +900,7 @@ class InAppHonoringResolvingIntegrationTest(TestCase):
         assert frames[5].in_app
         assert frames[6].in_app
 
-    def sym_mac_app_frame(self, instruction_addr, img, sdk_info=None):
+    def sym_mac_app_frame(self, instruction_addr, img, sdk_info=None, trust=None):
         object_name = (
             "/Users/haza/Library/Developer/Xcode/Archives/2017-06-19/"
             "CrashProbe 19-06-2017, 08.53.xcarchive/Products/Applications/"

--- a/tests/sentry/lang/native/test_processor.py
+++ b/tests/sentry/lang/native/test_processor.py
@@ -26,7 +26,7 @@ SDK_INFO = {"sdk_name": "iOS", "version_major": 9,
             "version_minor": 3, "version_patchlevel": 0}
 
 
-def patched_symbolize_app_frame(self, instruction_addr, img, sdk_info=None):
+def patched_symbolize_app_frame(self, instruction_addr, img, sdk_info=None, trust=None):
     if instruction_addr != 4295123756:
         return []
     return [


### PR DESCRIPTION
This fixes our use of the breakpad stack scanner in connection with CFI.

**Issue Description**

Minidump stack traces sometimes only show a single frame or stop in the middle of a stack trace. This happens particularly on Windows and UE4, where the initial frame comes from kernelbase.dll

This behavior comes from Breakpad's stack scanning algorithm. After a frame without FP and CFI, it starts to scan the stack memory for values that look like a memory address. For these candidates, it checks whether they are in the address range of a loaded module. If symbols for that module are available, it also checks whether it can symbolicate a name for that address and otherwise discards the frame. If symbols are not available for the module, the frame is always returned (least precision).

Our implementation generates Breakpad symbols that only contain CFI but no function addresses. Since we supply these symbols to stack walking, Breakpad's stack scanner will find symbols for these modules but cannot resolve function names inside. Therefore, it throws away all frames from modules with our CFI supplied.

This happens everytime when crossing from a frame of a module without FP/CFI (thus stack scanning) to a module with CFI.

**Applied Patch**

This patchees breakpad to not check for function names while stack scanning. In our own symbolication, we can clean frames with `"scan"` trust in modules with debug information.

**Requires to bump symbolic in getsentry.**