### PR TITLE
feat(ui): Fix obscured errors due to LazyLoad

### DIFF
--- a/src/sentry/static/sentry/app/components/lazyLoad.jsx
+++ b/src/sentry/static/sentry/app/components/lazyLoad.jsx
@@ -2,11 +2,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
-import sdk from 'app/utils/sdk';
+import {isWebpackChunkLoadingError} from 'app/utils';
 import {t} from 'app/locale';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import retryableImport from 'app/utils/retryableImport';
+import sdk from 'app/utils/sdk';
 
 class LazyLoad extends React.Component {
   static propTypes = {
@@ -67,12 +68,7 @@ class LazyLoad extends React.Component {
   getComponentGetter = () => this.props.component || this.props.route.componentPromise;
 
   handleFetchError = error => {
-    const isWebpackLoadingError =
-      error &&
-      typeof error.message === 'string' &&
-      error.message.toLowerCase().includes('loading chunk');
-
-    let options = isWebpackLoadingError
+    let options = isWebpackChunkLoadingError(error)
       ? {fingerprint: ['webpack', 'error loading chunk']}
       : {};
 

--- a/src/sentry/static/sentry/app/utils.jsx
+++ b/src/sentry/static/sentry/app/utils.jsx
@@ -236,6 +236,14 @@ export function descopeFeatureName(feature) {
     : feature.match(/(?:^(?:projects|organizations):)?(.*)/).pop();
 }
 
+export function isWebpackChunkLoadingError(error) {
+  return (
+    error &&
+    typeof error.message === 'string' &&
+    error.message.toLowerCase().includes('loading chunk')
+  );
+}
+
 // re-export under utils
 export {parseLinkHeader, Collection, PendingChangeQueue, CursorPoller};
 

--- a/src/sentry/static/sentry/app/utils/retryableImport.jsx
+++ b/src/sentry/static/sentry/app/utils/retryableImport.jsx
@@ -1,3 +1,5 @@
+import {isWebpackChunkLoadingError} from 'app/utils';
+
 const MAX_RETRIES = 2;
 
 export default async function retryableImport(fn) {
@@ -7,12 +9,7 @@ export default async function retryableImport(fn) {
       const module = await fn();
       return module.default || module;
     } catch (err) {
-      const isWebpackLoadingError =
-        err &&
-        typeof err.message === 'string' &&
-        err.message.toLowerCase().includes('loading chunk');
-
-      if (isWebpackLoadingError && retries < MAX_RETRIES) {
+      if (isWebpackChunkLoadingError(err) && retries < MAX_RETRIES) {
         retries++;
         return tryLoad();
       }

--- a/src/sentry/static/sentry/app/utils/retryableImport.jsx
+++ b/src/sentry/static/sentry/app/utils/retryableImport.jsx
@@ -7,7 +7,12 @@ export default async function retryableImport(fn) {
       const module = await fn();
       return module.default || module;
     } catch (err) {
-      if (retries < MAX_RETRIES) {
+      const isWebpackLoadingError =
+        err &&
+        typeof err.message === 'string' &&
+        err.message.toLowerCase().includes('loading chunk');
+
+      if (isWebpackLoadingError && retries < MAX_RETRIES) {
         retries++;
         return tryLoad();
       }

--- a/tests/js/spec/utils/retryableImport.spec.jsx
+++ b/tests/js/spec/utils/retryableImport.spec.jsx
@@ -22,15 +22,30 @@ describe('retryableImport', function() {
     expect(importMock).toHaveBeenCalledTimes(1);
   });
 
+  it('does not retry if error was not a webpack chunk loading error', async function() {
+    const importMock = jest.fn();
+
+    importMock.mockReturnValueOnce(
+      new Promise((resolve, reject) => reject(new Error('Another error happened')))
+    );
+
+    try {
+      await retryableImport(() => importMock());
+    } catch (err) {
+      // do nothing
+    }
+    expect(importMock).toHaveBeenCalledTimes(1);
+  });
+
   it('can fail 2 dynamic imports and succeed on 3rd try', async function() {
     const importMock = jest.fn();
 
     importMock
       .mockReturnValueOnce(
-        new Promise((resolve, reject) => reject(new Error('Unable to import')))
+        new Promise((resolve, reject) => reject(new Error('Loading chunk 123 failed')))
       )
       .mockReturnValueOnce(
-        new Promise((resolve, reject) => reject(new Error('Unable to import')))
+        new Promise((resolve, reject) => reject(new Error('Loading chunk 123 failed')))
       )
       .mockReturnValue(
         new Promise(resolve =>
@@ -52,10 +67,13 @@ describe('retryableImport', function() {
 
   it('only retries 3 times', async function() {
     const importMock = jest.fn(
-      () => new Promise((resolve, reject) => reject(new Error('Unable to import')))
+      () =>
+        new Promise((resolve, reject) => reject(new Error('Loading chunk 123 failed')))
     );
 
-    await expect(retryableImport(() => importMock())).rejects.toThrow('Unable to import');
+    await expect(retryableImport(() => importMock())).rejects.toThrow(
+      'Loading chunk 123 failed'
+    );
     expect(importMock).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
`retryableImport` was created in an attempt to reduce code split errors due to network problems. However, the `catch` was a bit broad and was obscuring errors that occurred while evaluating a module. In that case, it would retry the dynamic import and would succeed, but imported module would be undefined because the module evaluation failed.