### PR TITLE
feat(gitlab) Move gitlab to an organization feature

### DIFF
--- a/src/sentry/api/endpoints/organization_config_integrations.py
+++ b/src/sentry/api/endpoints/organization_config_integrations.py
@@ -12,11 +12,17 @@ from django.conf import settings
 
 class OrganizationConfigIntegrationsEndpoint(OrganizationEndpoint):
     def get(self, request, organization):
+        has_gitlab = features.has('organizations:gitlab-integration',
+                                  organization,
+                                  actor=request.user)
+
         has_catchall = features.has('organizations:internal-catchall',
                                     organization,
                                     actor=request.user)
         providers = []
         for provider in integrations.all():
+            if not has_gitlab and provider.key == 'gitlab':
+                continue
             if not has_catchall and provider.key in settings.SENTRY_INTERNAL_INTEGRATIONS:
                 continue
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -796,6 +796,9 @@ SENTRY_FEATURES = {
     'organizations:internal-catchall': False,
     # Enable inviting members to organizations.
     'organizations:invite-members': True,
+    # Enable gitlab integration currently available to early adopters only.
+    'organizations:gitlab-integration': False,
+
     # DEPRECATED: pending removal.
     'organizations:js-loader': False,
     # DEPRECATED: pending removal.
@@ -1323,7 +1326,6 @@ SENTRY_DEFAULT_INTEGRATIONS = (
 )
 
 SENTRY_INTERNAL_INTEGRATIONS = (
-    'gitlab',
     'vsts-extension',
 )
 

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -74,6 +74,7 @@ default_manager.add('organizations:sso-rippling', OrganizationFeature)  # NOQA
 default_manager.add('organizations:sso-saml2', OrganizationFeature)  # NOQA
 default_manager.add('organizations:suggested-commits', OrganizationFeature)  # NOQA
 default_manager.add('organizations:unreleased-changes', OrganizationFeature)  # NOQA
+default_manager.add('organizations:gitlab-integration', OrganizationFeature)  # NOQA
 
 # Project scoped features
 default_manager.add('projects:similarity-view', ProjectFeature)  # NOQA

--- a/src/sentry/features/exceptions.py
+++ b/src/sentry/features/exceptions.py
@@ -4,4 +4,8 @@ __all__ = ['FeatureNotRegistered']
 
 
 class FeatureNotRegistered(Exception):
-    pass
+    def __init__(self, name):
+        msg = (
+            u'The "{}" feature has not been registered. '
+            'Ensure that a feature has been added to sentry.features.default_manager')
+        super(Exception, self).__init__(msg.format(name))


### PR DESCRIPTION
Gitlab is pretty much complete so we'd like to move it roll it out to the early adopter group. Before we can do this it needs to be gated by an organization feature switch.

I've made the FeatureNotRegistered exception a bit more verbose as I spent some time trying to decipher why my feature wasn't registered despite having updated several places in getsentry.

Refs APP-728