### PR TITLE
fix(org events): Show project slug instead of name

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEvents/eventsTable.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/eventsTable.jsx
@@ -72,7 +72,7 @@ class EventsTable extends React.PureComponent {
                       <IdBadge
                         project={project}
                         avatarSize={16}
-                        displayName={<span>{project.name}</span>}
+                        displayName={<span>{project.slug}</span>}
                         avatarProps={{consistentWidth: true}}
                       />
                     </Project>


### PR DESCRIPTION
![screenshot 2018-11-05 14 40 39](https://user-images.githubusercontent.com/5026776/48031358-c7a0eb00-e108-11e8-8b73-99076a972550.png)
