### PR TITLE
refactor(api): Move sample event creation to action creator

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/projects.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/projects.jsx
@@ -233,3 +233,18 @@ export function removeTeamFromProject(api, orgSlug, projectSlug, teamSlug) {
 export function changeProjectSlug(prev, next) {
   ProjectActions.changeSlug(prev, next);
 }
+
+/**
+ * Send a sample event
+ *
+ * @param {Client} api API Client
+ * @param {String} orgSlug Organization Slug
+ * @param {String} projectSlug Project Slug
+ */
+export function sendSampleEvent(api, orgSlug, projectSlug) {
+  let endpoint = `/projects/${orgSlug}/${projectSlug}/create-sample/`;
+
+  return api.requestPromise(endpoint, {
+    method: 'POST',
+  });
+}

--- a/src/sentry/static/sentry/app/components/errorRobot.jsx
+++ b/src/sentry/static/sentry/app/components/errorRobot.jsx
@@ -7,6 +7,7 @@ import styled from 'react-emotion';
 import {analytics} from 'app/utils/analytics';
 import ApiMixin from 'app/mixins/apiMixin';
 import {t} from 'app/locale';
+import {sendSampleEvent} from 'app/actionCreators/projects';
 
 const ErrorRobot = createReactClass({
   displayName: 'ErrorRobot',
@@ -67,18 +68,15 @@ const ErrorRobot = createReactClass({
 
   createSampleEvent() {
     let {org, project} = this.props;
-    let url = `/projects/${org.slug}/${project.slug}/create-sample/`;
 
     analytics('sample_event.created', {
       org_id: parseInt(org.id, 10),
       project_id: parseInt(project.id, 10),
       source: 'robot',
     });
-    this.api.request(url, {
-      method: 'POST',
-      success: data => {
-        browserHistory.push(`/${org.slug}/${project.slug}/issues/${data.groupID}/`);
-      },
+
+    sendSampleEvent(this.api, org.slug, project.slug).then(data => {
+      browserHistory.push(`/${org.slug}/${project.slug}/issues/${data.groupID}/`);
     });
   },
 


### PR DESCRIPTION
Making this call elsewhere - this refactor will make it easier and follows new pattern of generally moving API calls to action creators.