### PR TITLE
fix(issues) Fix commit link when repository has been deleted

### DIFF
--- a/src/sentry/static/sentry/app/components/commitLink.jsx
+++ b/src/sentry/static/sentry/app/components/commitLink.jsx
@@ -39,9 +39,10 @@ function CommitLink({inline, commitId, repository}) {
 
   const shortId = getShortVersion(commitId);
 
-  const providerData = SUPPORTED_PROVIDERS.find(provider =>
-    provider.providerIds.includes(repository.provider.id)
-  );
+  const providerData = SUPPORTED_PROVIDERS.find(provider => {
+    if (!repository.provider) return false;
+    return provider.providerIds.includes(repository.provider.id);
+  });
 
   if (providerData === undefined) {
     return <span>{shortId}</span>;


### PR DESCRIPTION
If a suspect commit comes from a repository that has been deleted we should not error out. Instead fall into the undefined provider case.

I found this by hacking around locally with integrations & suspect commits.