### PR TITLE
feat(discover): Update default fields value

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -10,7 +10,7 @@ import {isValidAggregation} from './aggregations/utils';
 
 const DEFAULTS = {
   projects: [],
-  fields: [],
+  fields: ['event_id', 'project_name', 'platform', 'timestamp'],
   conditions: [],
   aggregations: [],
   range: '14d',

--- a/tests/js/spec/views/organizationDiscover/discover.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/discover.spec.jsx
@@ -177,10 +177,13 @@ describe('Discover', function() {
     });
 
     it('runs basic query', async function() {
+      const query = {...queryBuilder.getExternal()};
+      query.fields = [...queryBuilder.getExternal().fields, 'project_id'];
+
       wrapper.instance().runQuery();
       await tick();
       expect(queryBuilder.fetch).toHaveBeenCalledTimes(1);
-      expect(queryBuilder.fetch).toHaveBeenCalledWith(queryBuilder.getExternal());
+      expect(queryBuilder.fetch).toHaveBeenCalledWith(query);
       expect(wrapper.state().data.baseQuery.data).toEqual(mockResponse);
     });
 
@@ -304,7 +307,8 @@ describe('Discover', function() {
         const fields = wrapper.find('SelectControl[name="fields"]');
         expect(fields.text()).toContain('message');
         wrapper.instance().reset();
-        expect(fields.text()).toContain('No fields selected');
+        expect(fields.text()).not.toContain('message');
+        expect(fields.text()).toContain('event_id');
       });
 
       it('resets "orderby"', function() {

--- a/tests/js/spec/views/organizationDiscover/queryBuilder.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/queryBuilder.spec.jsx
@@ -11,7 +11,7 @@ describe('Query Builder', function() {
 
       expect(external.projects).toEqual([2]);
       expect(external.fields).toEqual(expect.arrayContaining([expect.any(String)]));
-      expect(external.fields).toHaveLength(46);
+      expect(external.fields).toHaveLength(4);
       expect(external.conditions).toHaveLength(0);
       expect(external.aggregations).toHaveLength(0);
       expect(external.orderby).toBe('-timestamp');
@@ -150,6 +150,7 @@ describe('Query Builder', function() {
     });
 
     it('updates orderby if there is an aggregation and value is not a valid field', function() {
+      queryBuilder.updateField('fields', ['event_id']);
       queryBuilder.updateField('aggregations', [['count()', null, 'count']]);
 
       const query = queryBuilder.getInternal();
@@ -157,6 +158,7 @@ describe('Query Builder', function() {
     });
 
     it('updates orderby if there is no aggregation and value is not a valid field', function() {
+      queryBuilder.updateField('fields', ['event_id']);
       queryBuilder.updateField('aggregations', [['count()', null, 'count']]);
       expect(queryBuilder.getInternal().orderby).toBe('-count');
       queryBuilder.updateField('aggregations', []);

--- a/tests/js/spec/views/organizationDiscover/utils.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/utils.spec.jsx
@@ -55,6 +55,7 @@ describe('getOrderByOptions()', function() {
   });
 
   it('allows ordering by aggregations with aggregations and no fields', function() {
+    queryBuilder.updateField('fields', []);
     queryBuilder.updateField('aggregations', [['count()', null, 'count']]);
 
     const options = getOrderByOptions(queryBuilder);


### PR DESCRIPTION
Update the Discover default query to something faster (empty fields value means all columns selected)