### PR TITLE
fix(events): Make page title clearer

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
@@ -44,7 +44,7 @@ class OrganizationEvents extends AsyncView {
   }
 
   getTitle() {
-    return `${this.props.organization.slug} Events`;
+    return `Events - ${this.props.organization.slug}`;
   }
 
   renderBody() {


### PR DESCRIPTION
per cramer's feedback. this makes the full title `Events - org-slug - Sentry`