### PR TITLE
ref(ui) Extract repository add/delete/cancel to action creators

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/integrations.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/integrations.jsx
@@ -56,7 +56,7 @@ export function addIntegrationToProject(orgId, projectId, integration) {
  *
  * @param {Object} client ApiClient
  * @param {String} orgId Organization Slug
- * @param {Number} repositoryId Repository ID
+ * @param {String} repositoryId Repository ID
  */
 export function deleteRepository(client, orgId, repositoryId) {
   addLoadingMessage();
@@ -75,7 +75,7 @@ export function deleteRepository(client, orgId, repositoryId) {
  *
  * @param {Object} client ApiClient
  * @param {String} orgId Organization Slug
- * @param {Number} repositoryId Repository ID
+ * @param {String} repositoryId Repository ID
  */
 export function cancelDeleteRepository(client, orgId, repositoryId) {
   addLoadingMessage();
@@ -113,7 +113,7 @@ function applyRepositoryAddComplete(promise) {
  *
  * @param {Object} client ApiClient
  * @param {String} orgId Organization Slug
- * @param {Number} repositoryId Repository ID
+ * @param {String} repositoryId Repository ID
  * @param {Object} integration Integration provider data.
  */
 export function migrateRepository(client, orgId, repositoryId, integration) {

--- a/src/sentry/static/sentry/app/components/repositoryRow.jsx
+++ b/src/sentry/static/sentry/app/components/repositoryRow.jsx
@@ -3,10 +3,10 @@ import React from 'react';
 import styled from 'react-emotion';
 import PropTypes from 'prop-types';
 
+import {deleteRepository, cancelDeleteRepository} from 'app/actionCreators/integrations';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
 import SpreadLayout from 'app/components/spreadLayout';
-import IndicatorStore from 'app/stores/indicatorStore';
 import {Repository} from 'app/sentryTypes';
 import {t} from 'app/locale';
 
@@ -55,30 +55,22 @@ class RepositoryRow extends React.Component {
 
   cancelDelete = () => {
     let {api, orgId, repository, onRepositoryChange} = this.props;
-    let indicator = IndicatorStore.add(t('Saving changes...'));
-
-    api.request(`/organizations/${orgId}/repos/${repository.id}/`, {
-      method: 'PUT',
-      data: {status: 'visible'},
-      success: data => {
+    cancelDeleteRepository(api, orgId, repository.id).then(
+      data => {
         if (onRepositoryChange) onRepositoryChange(data);
       },
-      error: () => IndicatorStore.addError(t('An error occurred.')),
-      complete: () => IndicatorStore.remove(indicator),
-    });
+      () => {}
+    );
   };
 
   deleteRepo = () => {
     let {api, orgId, repository, onRepositoryChange} = this.props;
-    let indicator = IndicatorStore.add(t('Saving changes..'));
-    api.request(`/organizations/${orgId}/repos/${repository.id}/`, {
-      method: 'DELETE',
-      success: data => {
+    deleteRepository(api, orgId, repository.id).then(
+      data => {
         if (onRepositoryChange) onRepositoryChange(data);
       },
-      error: () => IndicatorStore.addError(t('Unable to delete repository.')),
-      complete: () => IndicatorStore.remove(indicator),
-    });
+      () => {}
+    );
   };
 
   get isActive() {


### PR DESCRIPTION
Move repository related actions to action creators & promises. I've co-located the indicator operations with the API requests so that the react components can be more focused on their state management and have fewer concerns intertwined.