### PR TITLE
ref(ui): Attempt to fix native stack frame rendering

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -380,34 +380,36 @@ const Frame = createReactClass({
     let hint = this.getFrameHint();
     return (
       <StrictClick onClick={this.isExpandable() ? this.toggleContext : null}>
-        <div className="title as-table">
-          {this.renderLeadHint()}
-          {defined(data.package) ? (
-            <span className="package" title={data.package}>
-              {trimPackage(data.package)}
-            </span>
-          ) : (
-            <span className="package">{'<unknown>'}</span>
-          )}
-          <span className="address">{data.instructionAddr}</span>
-          <span className="symbol">
-            <code>{data.function || '<unknown>'}</code>{' '}
-            {data.filename && (
-              <span className="filename">
-                {data.filename}
-                {data.lineNo ? ':' + data.lineNo : ''}
+        <DefaultLine className="title as-table">
+          <NativeLineContent>
+            {this.renderLeadHint()}
+            {defined(data.package) ? (
+              <span className="package" title={data.package}>
+                {trimPackage(data.package)}
               </span>
+            ) : (
+              <span className="package">{'<unknown>'}</span>
             )}
-            {hint !== null ? (
-              <Tooltip title={_.escape(hint)}>
-                <a key="inline">
-                  <span className="icon-question" />
-                </a>
-              </Tooltip>
-            ) : null}
-            {this.renderExpander()}
-          </span>
-        </div>
+            <span className="address">{data.instructionAddr}</span>
+            <span className="symbol">
+              <code>{data.function || '<unknown>'}</code>{' '}
+              {data.filename && (
+                <span className="filename">
+                  {data.filename}
+                  {data.lineNo ? ':' + data.lineNo : ''}
+                </span>
+              )}
+              {hint !== null ? (
+                <Tooltip title={_.escape(hint)}>
+                  <a key="inline">
+                    <span className="icon-question" />
+                  </a>
+                </Tooltip>
+              ) : null}
+            </span>
+          </NativeLineContent>
+          {this.renderExpander()}
+        </DefaultLine>
       </StrictClick>
     );
   },
@@ -470,6 +472,10 @@ const VertCenterWrapper = styled('div')`
 
 const RepeatedContent = styled(VertCenterWrapper)`
   justify-content: center;
+`;
+
+const NativeLineContent = styled(RepeatedContent)`
+  flex: 1;
 `;
 
 const DefaultLine = styled(VertCenterWrapper)`

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -476,8 +476,9 @@ const RepeatedContent = styled(VertCenterWrapper)`
 
 const NativeLineContent = styled(RepeatedContent)`
   flex: 1;
+  overflow: hidden;
 
-  > span {
+  & > span {
     display: block;
     padding: 0 5px;
   }

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -476,6 +476,11 @@ const RepeatedContent = styled(VertCenterWrapper)`
 
 const NativeLineContent = styled(RepeatedContent)`
   flex: 1;
+
+  > span {
+    display: block;
+    padding: 0 5px;
+  }
 `;
 
 const DefaultLine = styled(VertCenterWrapper)`

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1372,8 +1372,6 @@ div.traceback > ul {
     }
 
     .title.as-table {
-      display: flex;
-      align-items: baseline;
       width: 100%;
       padding-left: 15px;
 

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1375,11 +1375,6 @@ div.traceback > ul {
       width: 100%;
       padding-left: 15px;
 
-      > span {
-        display: block;
-        padding: 0 5px;
-      }
-
       .package {
         width: 15%;
         font-size: 13px;


### PR DESCRIPTION
A similar change was done with default frames, apply this to native frames.

See https://github.com/getsentry/sentry/pull/10352
Example percy snapshot: https://percy.io/getsentry/sentry/builds/1149989?utm_campaign=getsentry&utm_content=sentry&utm_source=github_status