### PR TITLE
feat(event search): Support glob patterns for wildcard searching

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -49,7 +49,7 @@ def translate(pat):
                 res = '%s[%s]' % (res, stuff)
         else:
             res = res + re.escape(c)
-    return res
+    return '^' + res + '$'
 
 
 event_search_grammar = Grammar(r"""

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+import re
+import six
+
 from collections import namedtuple
 
 from parsimonious.exceptions import ParseError
@@ -7,6 +10,47 @@ from parsimonious.grammar import Grammar, NodeVisitor
 
 from sentry.search.utils import parse_datetime_string, InvalidQuery
 from sentry.utils.snuba import SENTRY_SNUBA_MAP
+
+WILDCARD_CHARS = re.compile(r'[\*\[\]\?]')
+
+
+def translate(pat):
+    """Translate a shell PATTERN to a regular expression.
+    There is no way to quote meta-characters.
+    modified from: https://github.com/python/cpython/blob/2.7/Lib/fnmatch.py#L85
+    """
+
+    i, n = 0, len(pat)
+    res = ''
+    while i < n:
+        c = pat[i]
+        i = i + 1
+        if c == '*':
+            res = res + '.*'
+        elif c == '?':
+            res = res + '.'
+        elif c == '[':
+            j = i
+            if j < n and pat[j] == '!':
+                j = j + 1
+            if j < n and pat[j] == ']':
+                j = j + 1
+            while j < n and pat[j] != ']':
+                j = j + 1
+            if j >= n:
+                res = res + '\\['
+            else:
+                stuff = pat[i:j].replace('\\', '\\\\')
+                i = j + 1
+                if stuff[0] == '!':
+                    stuff = '^' + stuff[1:]
+                elif stuff[0] == '^':
+                    stuff = '\\' + stuff
+                res = '%s[%s]' % (res, stuff)
+        else:
+            res = res + re.escape(c)
+    return res
+
 
 event_search_grammar = Grammar(r"""
 # raw_search must come at the end, otherwise other
@@ -67,7 +111,17 @@ class SearchKey(namedtuple('SearchKey', 'name')):
 
 
 class SearchValue(namedtuple('SearchValue', 'raw_value')):
-    pass
+
+    @property
+    def value(self):
+        if self.is_wildcard():
+            return translate(self.raw_value)
+        return self.raw_value
+
+    def is_wildcard(self):
+        if not isinstance(self.raw_value, six.string_types):
+            return False
+        return bool(WILDCARD_CHARS.search(self.raw_value))
 
 
 class SearchVisitor(NodeVisitor):
@@ -180,7 +234,7 @@ def get_snuba_query_args(query=None, params=None):
     }
     for _filter in parsed_filters:
         snuba_name = _filter.key.snuba_name
-        value = _filter.value.raw_value
+        value = _filter.value.value
 
         if snuba_name in ('start', 'end'):
             kwargs[snuba_name] = value
@@ -208,10 +262,15 @@ def get_snuba_query_args(query=None, params=None):
             )
 
         else:
-            kwargs['conditions'].append([
-                snuba_name,
-                _filter.operator,
-                value,
-            ])
+            if _filter.value.is_wildcard():
+                kwargs['conditions'].append(
+                    [['match', [snuba_name, "'%s'" % (value,)]], '=', 1]
+                )
+            else:
+                kwargs['conditions'].append([
+                    snuba_name,
+                    _filter.operator,
+                    value,
+                ])
 
     return kwargs

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -233,6 +233,15 @@ class EventSearchTest(TestCase):
             'end': datetime.datetime(2015, 5, 19, 10, 15, 1, tzinfo=timezone.utc),
         }
 
+    def test_get_snuba_query_args_wildcard(self):
+        assert get_snuba_query_args('release:3.1.* user.email:*@example.com') == {
+            'conditions': [
+                [['match', ['tags[sentry:release]', "'3\\.1\\..*'"]], '=', 1],
+                [['match', ['email', "'.*\\@example\\.com'"]], '=', 1],
+            ],
+            'filter_keys': {},
+        }
+
     def test_convert_endpoint_params(self):
         assert convert_endpoint_params({
             'project_id': [1, 2, 3],

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -236,8 +236,8 @@ class EventSearchTest(TestCase):
     def test_get_snuba_query_args_wildcard(self):
         assert get_snuba_query_args('release:3.1.* user.email:*@example.com') == {
             'conditions': [
-                [['match', ['tags[sentry:release]', "'3\\.1\\..*'"]], '=', 1],
-                [['match', ['email', "'.*\\@example\\.com'"]], '=', 1],
+                [['match', ['tags[sentry:release]', "'^3\\.1\\..*$'"]], '=', 1],
+                [['match', ['email', "'^.*\\@example\\.com$'"]], '=', 1],
             ],
             'filter_keys': {},
         }

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -384,6 +384,10 @@ class OrganizationEventsTest(APITestCase, SnubaTestCase):
             'c' * 32, group=group, datetime=self.min_ago, tags={'user': {'email': 'foo@example.com'}}
         )
 
+        self.create_event(
+            'd' * 32, group=group, datetime=self.min_ago, tags={'user': {'email': 'foo@example.commmmmmmm'}}
+        )
+
         base_url = reverse(
             'sentry-api-0-organization-events',
             kwargs={


### PR DESCRIPTION
~~This adds support for doing simple wildcard searches like `*@sentry.io` or `3.0.*`.~~

~~We _could_ support something more complicated using [match](https://clickhouse.yandex/docs/en/query_language/functions/string_search_functions/#matchhaystack-pattern), but I think then we'd probably want to add a specific syntax for the comparison rather than just re-using `key:val` and at that point, maybe it's more complicated than anything anyone will use.~~

~~i also considered putting the logic for this within the grammar, which maybe would be nicer.~~

~~thoughts?~~

talked to matt about this some, and decided to support glob patterns using a modified `fnmatch.translate`