### PR TITLE
Service hook mediators 

### DIFF
--- a/src/sentry/mediators/sentry_apps/destroyer.py
+++ b/src/sentry/mediators/sentry_apps/destroyer.py
@@ -4,7 +4,7 @@ from sentry.mediators import Mediator, Param
 
 
 class Destroyer(Mediator):
-    sentry_app = Param('sentry.models.sentryapp.SentryApp')
+    sentry_app = Param('sentry.models.SentryApp')
 
     def call(self):
         self._destroy_api_application()

--- a/src/sentry/mediators/service_hooks/__init__.py
+++ b/src/sentry/mediators/service_hooks/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import
+
+from .creator import Creator  # NOQA
+from .updater import Updater  # NOQA
+from .destroyer import Destroyer  # NOQA

--- a/src/sentry/mediators/service_hooks/creator.py
+++ b/src/sentry/mediators/service_hooks/creator.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import
+
+import six
+
+from collections import Iterable
+
+from sentry.mediators import Mediator, Param
+from sentry.models import ServiceHook
+
+
+class Creator(Mediator):
+    application = Param('sentry.models.ApiApplication', required=False)
+    actor = Param('sentry.models.User')
+    project = Param('sentry.models.Project')
+    events = Param(Iterable)
+    url = Param(six.string_types)
+
+    def call(self):
+        self.hook = self._create_service_hook()
+        return self.hook
+
+    def _create_service_hook(self):
+        return ServiceHook.objects.create(
+            application=self.application,
+            actor_id=self.actor.id,
+            project_id=self.project.id,
+            events=self.events,
+            url=self.url,
+        )

--- a/src/sentry/mediators/service_hooks/destroyer.py
+++ b/src/sentry/mediators/service_hooks/destroyer.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+from sentry.mediators import Mediator, Param
+
+
+class Destroyer(Mediator):
+    service_hook = Param('sentry.models.ServiceHook')
+
+    def call(self):
+        self._destroy_service_hook()
+        return self.service_hook
+
+    def _destroy_service_hook(self):
+        self.service_hook.delete()

--- a/src/sentry/mediators/service_hooks/updater.py
+++ b/src/sentry/mediators/service_hooks/updater.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import
+
+import six
+
+from collections import Iterable
+
+from sentry.mediators import Mediator, Param
+from sentry.mediators.param import if_param
+
+
+class Updater(Mediator):
+    service_hook = Param('sentry.models.ServiceHook')
+    application = Param('sentry.models.ApiApplication', required=False)
+    actor = Param('sentry.models.User', required=False)
+    project = Param('sentry.models.Project', required=False)
+    events = Param(Iterable, required=False)
+    url = Param(six.string_types, required=False)
+
+    def call(self):
+        self._update_application()
+        self._update_actor()
+        self._update_project()
+        self._update_events()
+        self._update_url()
+        return self.hook
+
+    @if_param('application')
+    def _update_name(self):
+        # not sure if we want to allow this
+        self.service_hook.application = self.application
+
+    @if_param('actor')
+    def _update_actor(self):
+        self.service_hook.actor_id = self.actor.id
+
+    @if_param('project')
+    def _update_project(self):
+        self.service_hook.project_id = self.project.id
+
+    @if_param('events')
+    def _update_events(self):
+        self.service_hook.events = self.events
+
+    @if_param('url')
+    def _update_url(self):
+        self.service_hook.url = self.url

--- a/src/sentry/mediators/service_hooks/updater.py
+++ b/src/sentry/mediators/service_hooks/updater.py
@@ -22,11 +22,10 @@ class Updater(Mediator):
         self._update_project()
         self._update_events()
         self._update_url()
-        return self.hook
+        return self.service_hook
 
     @if_param('application')
-    def _update_name(self):
-        # not sure if we want to allow this
+    def _update_application(self):
         self.service_hook.application = self.application
 
     @if_param('actor')

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -26,6 +26,7 @@ from uuid import uuid4
 
 from sentry.constants import SentryAppStatus
 from sentry.mediators.sentry_apps import Creator as SentryAppCreator
+from sentry.mediators.service_hooks import Creator as ServiceHookCreator
 from sentry.models import (
     Activity, Environment, Event, EventError, EventMapping, Group, Organization, OrganizationMember,
     OrganizationMemberTeam, Project, Team, User, UserEmail, Release, Commit, ReleaseCommit,
@@ -723,3 +724,22 @@ class Fixtures(object):
             app.update(status=SentryAppStatus.PUBLISHED)
 
         return app
+
+    def create_service_hook(self, actor=None, project=None, events=None, url=None, **kwargs):
+        if not actor:
+            actor = self.create_user()
+        if not project:
+            org = self.create_organization(owner=actor)
+            project = self.create_project(organization=org)
+        if not events:
+            events = ('event.created',)
+        if not url:
+            url = 'https://example/sentry/webhook'
+
+        return ServiceHookCreator.run(
+            actor=actor,
+            project=project,
+            events=events,
+            url=url,
+            **kwargs
+        )

--- a/tests/sentry/mediators/service_hooks/__init__.py
+++ b/tests/sentry/mediators/service_hooks/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/mediators/service_hooks/test_creator.py
+++ b/tests/sentry/mediators/service_hooks/test_creator.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import
+
+from sentry.mediators.service_hooks import Creator
+from sentry.models import ServiceHook
+from sentry.testutils import TestCase
+
+
+class TestCreator(TestCase):
+    def setUp(self):
+        self.user = self.create_user()
+        self.org = self.create_organization(owner=self.user)
+        self.project = self.create_project(name='foo', organization=self.org)
+        self.sentry_app = self.create_sentry_app(owner=self.org)
+        self.creator = Creator(application=self.sentry_app.application,
+                               actor=self.sentry_app.proxy_user,
+                               project=self.project,
+                               events=('event.created',),
+                               url=self.sentry_app.webhook_url)
+
+    def test_creates_service_hook(self):
+        self.creator.call()
+
+        service_hook = ServiceHook.objects.get(
+            application=self.sentry_app.application,
+            actor_id=self.sentry_app.proxy_user.id,
+            project_id=self.project.id,
+            url=self.sentry_app.webhook_url,
+        )
+
+        assert service_hook
+        assert service_hook.events == ['event.created']

--- a/tests/sentry/mediators/service_hooks/test_destroyer.py
+++ b/tests/sentry/mediators/service_hooks/test_destroyer.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import
+
+from sentry.mediators.service_hooks import Destroyer
+from sentry.models import ServiceHook
+from sentry.testutils import TestCase
+
+
+class TestDestroyer(TestCase):
+    def setUp(self):
+        self.sentry_app = self.create_sentry_app()
+        self.service_hook = self.create_service_hook(
+            application=self.sentry_app.application
+        )
+        self.destroyer = Destroyer(service_hook=self.service_hook)
+
+    def test_deletes_service_hook(self):
+        service_hook = self.service_hook
+
+        self.destroyer.call()
+
+        assert not ServiceHook.objects.filter(pk=service_hook.id).exists()

--- a/tests/sentry/mediators/service_hooks/test_updater.py
+++ b/tests/sentry/mediators/service_hooks/test_updater.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import
+
+from sentry.mediators.service_hooks import Updater
+from sentry.testutils import TestCase
+
+
+class TestUpdater(TestCase):
+    def setUp(self):
+        self.sentry_app = self.create_sentry_app()
+        self.service_hook = self.create_service_hook(
+            application=self.sentry_app.application
+        )
+
+        self.updater = Updater(service_hook=self.service_hook)
+
+    def test_updates_application(self):
+        app = self.create_sentry_app(name='Blah').application
+        self.updater.application = app
+        self.updater.call()
+        assert self.service_hook.application == app
+
+    def test_updates_actor(self):
+        actor = self.create_user(email='hello@yahoo.com')
+        self.updater.actor = actor
+        self.updater.call()
+        assert self.service_hook.actor_id == actor.id
+
+    def test_updates_project(self):
+        project = self.create_project()
+        self.updater.project = project
+        self.updater.call()
+        assert self.service_hook.project_id == project.id
+
+    def test_updates_events(self):
+        self.updater.events = ('event.alert', )
+        self.updater.call()
+        assert self.service_hook.events == ['event.alert']
+
+    def test_updates_url(self):
+        self.updater.url = 'http://example.com/hooks'
+        self.updater.call()
+        assert self.service_hook.url == 'http://example.com/hooks'


### PR DESCRIPTION
Adds the following mediators for service hooks:
* Creator
* Updater
* Destroyer 

For now these will used for subscribing sentry apps to events i.e. `event.alert, event.created`