### PR TITLE
(WIP) lru_cache based memoize

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -108,6 +108,8 @@ class EventSerializer(Serializer):
         return (message, meta_with_chunks(message, msg_meta))
 
     def get_attrs(self, item_list, user, is_public=False):
+        # TODO this forces a reload from nodestore, which is maybe not
+        # required in the case that we have already got this data in the event.
         Event.objects.bind_nodes(item_list, 'data')
 
         results = {}

--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -18,7 +18,6 @@ from django.db import models
 from django.db.models.signals import post_delete
 
 from sentry import nodestore
-from sentry.utils.cache import memoize
 from sentry.utils.compat import pickle
 from sentry.utils.strings import decompress, compress
 from sentry.utils.canonical import CANONICAL_TYPES, CanonicalKeyDict
@@ -98,7 +97,7 @@ class NodeData(collections.MutableMapping):
     def copy(self):
         return self.data.copy()
 
-    @memoize
+    @property
     def data(self):
         if self._node_data is not None:
             return self._node_data

--- a/src/sentry/utils/cache.py
+++ b/src/sentry/utils/cache.py
@@ -27,12 +27,7 @@ def memoize(func):
     >>>     def func(self):
     >>>         return 'foo'
     """
-    @property
-    @lru_cache(maxsize=10)
-    def prop(*args):
-        return func(*args)
-
-    return prop
+    return property(lru_cache(maxsize=10)(func))
 
 
 class cached_for_request(object):

--- a/src/sentry/utils/canonical.py
+++ b/src/sentry/utils/canonical.py
@@ -128,5 +128,8 @@ class CanonicalKeyDict(collections.MutableMapping):
     def __delitem__(self, key):
         del self.data[self._norm_func(key)]
 
+    def __repr__(self):
+        return repr(self.data)
+
 
 CANONICAL_TYPES = (CanonicalKeyDict, CanonicalKeyView)

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -100,6 +100,9 @@ class EventSerializerTest(TestCase):
 
         # create_event automatically creates the logentry interface
         del event.data['logentry']
+        # need to re-save because the serializer forces a re-fetch from
+        # nodestore which will reanmiate the property if we don't save.
+        event.save()
 
         result = serialize(event)
         assert result['message'] == 'foo'


### PR DESCRIPTION
ref: use lru_cache in memoize and return a property

This version of memoize doesn't cache the value on the property's parent
object, so it doesn't pollute the `__dict__` namespace, meaning we don't
have to clean out `__dict__` when we go to pickle/serialize the object.

It also now returns a proper `property` object which can be used to
decorate the property's setter with `@foo.setter`. Invalidating the
cache in the setter is still up to the end user.