### PR TITLE
feat(analytics): Expose functions to track operational metrics

### DIFF
--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -12,6 +12,10 @@ const validHookNames = new Set([
   'analytics:event',
   'analytics:log-experiment',
 
+  // Operational metrics
+  'metrics:gauge',
+  'metrics:increment',
+
   // Specific component customizations
   'component:org-auth-view',
   'component:org-members-view',

--- a/src/sentry/static/sentry/app/utils/analytics.jsx
+++ b/src/sentry/static/sentry/app/utils/analytics.jsx
@@ -4,15 +4,36 @@ import HookStore from 'app/stores/hookStore';
  * If the backend for `analytics` is reload, you will need to add the event `name`
  * to the inclusion list in https://github.com/getsentry/reload/blob/master/reload_app/events.py
  *
+ *
+ * If you are using `gauge` or `increment`, the metric names need to be added to
+ * https://github.com/getsentry/reload/blob/master/reload_app/metrics/__init__.py
+ */
+
+/**
  * @param {String} name The name of the event
  * @param {Object} data Additional event data to record
  */
-function analytics(name, data) {
+export function analytics(name, data) {
   HookStore.get('analytics:event').forEach(cb => cb(name, data));
 }
 
-function amplitude(name, organization_id, data) {
+export function amplitude(name, organization_id, data) {
   HookStore.get('amplitude:event').forEach(cb => cb(name, organization_id, data));
 }
 
-export {amplitude, analytics};
+/**
+ * @param {String} name Metric name
+ * @param {Number} value Value to record for this metric
+ * @param {Object} tags An additional tags object
+ */
+export function gauge(name, value, tags) {
+  HookStore.get('metrics:gauge').forEach(cb => cb(name, value, tags));
+}
+
+/**
+ * @param {String} name Metric name
+ * @param {Object} tags An additional tags object
+ */
+export function increment(name, tags) {
+  HookStore.get('metrics:increment').forEach(cb => cb(name, tags));
+}


### PR DESCRIPTION
e.g. render times, load times, API response times, API responses, etc

Requires https://github.com/getsentry/getsentry/pull/2342 and https://github.com/getsentry/reload/pull/59