### PR TITLE
feat(integrations) Add pull request URL to pull request response

### DIFF
--- a/src/sentry/api/serializers/models/pullrequest.py
+++ b/src/sentry/api/serializers/models/pullrequest.py
@@ -27,33 +27,40 @@ def get_users_for_pull_requests(item_list, user=None):
 class PullRequestSerializer(Serializer):
     def get_attrs(self, item_list, user):
         users_by_author = get_users_for_pull_requests(item_list, user)
-
-        repositories = serialize(
-            list(Repository.objects.filter(
-                id__in=[c.repository_id for c in item_list],
-            )), user
-        )
-
-        repository_objs = {repository['id']: repository for repository in repositories}
+        repositories = list(Repository.objects.filter(
+            id__in=[c.repository_id for c in item_list],
+        ))
+        repository_map = {repository.id: repository for repository in repositories}
+        serialized_repos = {r['id']: r for r in serialize(repositories, user)}
 
         result = {}
         for item in item_list:
+            repository_id = six.text_type(item.repository_id)
             result[item] = {
-                'repository': repository_objs.get(six.text_type(item.repository_id), {}),
+                'repository': serialized_repos.get(repository_id, {}),
+                'external_url': self._external_url(repository_map[item.repository_id], item),
                 'user': users_by_author.get(six.text_type(item.author_id), {})
                 if item.author_id else {},
             }
 
         return result
 
+    def _external_url(self, repository, pull):
+        from sentry.plugins import bindings
+        provider_id = repository.provider
+        if not provider_id or not provider_id.startswith('integrations:'):
+            return None
+        provider_cls = bindings.get('integration-repository.provider').get(provider_id)
+        provider = provider_cls(provider_id)
+        return provider.pull_request_url(repository, pull)
+
     def serialize(self, obj, attrs, user):
-        d = {
+        return {
             'id': obj.key,
             'title': obj.title,
             'message': obj.message,
             'dateCreated': obj.date_added,
             'repository': attrs['repository'],
-            'author': attrs['user']
+            'author': attrs['user'],
+            'externalUrl': attrs['external_url']
         }
-
-        return d

--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -140,3 +140,6 @@ class GitHubRepositoryProvider(providers.IntegrationRepositoryProvider):
                     'type': 'A',
                 })
         return changes
+
+    def pull_request_url(self, repo, pull_request):
+        return u'{}/pulls/{}'.format(repo.url, pull_request.key)

--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -151,3 +151,6 @@ class GitlabRepositoryProvider(providers.IntegrationRepositoryProvider):
                 })
 
         return file_changes
+
+    def pull_request_url(self, repo, pull_request):
+        return u'{}/merge_requests/{}'.format(repo.url, pull_request.key)

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -132,7 +132,16 @@ class IntegrationRepositoryProvider(object):
         pass
 
     def compare_commits(self, repo, start_sha, end_sha):
+        """
+        Generate a list of commits between the start & end sha
+        """
         raise NotImplementedError
+
+    def pull_request_url(self, repo, pull_request):
+        """
+        Generate a URL to a pull request on the repository provider.
+        """
+        return None
 
     @staticmethod
     def should_ignore_commit(message):

--- a/src/sentry/static/sentry/app/views/releases/pullRequestLink.jsx
+++ b/src/sentry/static/sentry/app/views/releases/pullRequestLink.jsx
@@ -22,22 +22,9 @@ class PullRequestLink extends React.Component {
     return id;
   }
 
-  get url() {
-    let providerId = this.providerId;
-    if (providerId === 'github') {
-      return this.props.repository.url + '/pull/' + this.props.pullRequest.id;
-    }
-    if (providerId === 'gitlab') {
-      return this.props.repository.url + '/merge_requests/' + this.props.pullRequest.id;
-    }
-    return undefined;
-  }
-
   render() {
-    let url = this.url;
-    let providerId = this.providerId;
-
     let {pullRequest, repository} = this.props;
+    let providerId = this.providerId;
     let displayId = `${repository.name} #${pullRequest.id}: ${pullRequest.title}`;
 
     let icon = '';
@@ -51,10 +38,10 @@ class PullRequestLink extends React.Component {
       );
     }
 
-    return url ? (
+    return pullRequest.externalUrl ? (
       <a
         className={this.props.inline ? 'inline-commit' : 'btn btn-default btn-sm'}
-        href={url}
+        href={pullRequest.externalUrl}
         target="_blank"
       >
         {icon}&nbsp; {this.props.inline ? '' : ' '}

--- a/src/sentry/static/sentry/app/views/releases/pullRequestLink.jsx
+++ b/src/sentry/static/sentry/app/views/releases/pullRequestLink.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import ExternalLink from 'app/components/externalLink';
 import InlineSvg from 'app/components/inlineSvg';
 
 class PullRequestLink extends React.Component {
@@ -39,14 +40,14 @@ class PullRequestLink extends React.Component {
     }
 
     return pullRequest.externalUrl ? (
-      <a
+      <ExternalLink
         className={this.props.inline ? 'inline-commit' : 'btn btn-default btn-sm'}
         href={pullRequest.externalUrl}
         target="_blank"
       >
         {icon}&nbsp; {this.props.inline ? '' : ' '}
         {displayId}
-      </a>
+      </ExternalLink>
     ) : (
       <span>{displayId}</span>
     );

--- a/tests/js/fixtures/pullRequest.js
+++ b/tests/js/fixtures/pullRequest.js
@@ -12,6 +12,7 @@ export function PullRequest(params = {}) {
     message: 'Closes ISSUE-1',
     repository: Repository(),
     title: 'Fix first issue',
+    externalUrl: 'https://example.github.com/example/repo-name/pulls/3',
     ...params,
   };
 }

--- a/tests/js/spec/views/releases/pullRequestLink.spec.jsx
+++ b/tests/js/spec/views/releases/pullRequestLink.spec.jsx
@@ -4,9 +4,12 @@ import {mount} from 'enzyme';
 import PullRequestLink from 'app/views/releases/pullRequestLink';
 
 describe('PullRequestLink', function() {
-  it('renders no url on missing provider', function() {
+  it('renders no url on missing externalUrl', function() {
     let repository = TestStubs.Repository({provider: null});
-    let pullRequest = TestStubs.PullRequest({repository});
+    let pullRequest = TestStubs.PullRequest({
+      repository,
+      externalUrl: null,
+    });
     let wrapper = mount(
       <PullRequestLink repository={repository} pullRequest={pullRequest} />
     );

--- a/tests/sentry/api/serializers/test_pull_request.py
+++ b/tests/sentry/api/serializers/test_pull_request.py
@@ -5,7 +5,9 @@ from __future__ import absolute_import
 from uuid import uuid4
 
 from sentry.api.serializers import serialize
+from sentry.integrations.github.repository import GitHubRepositoryProvider
 from sentry.models import (PullRequest, CommitAuthor, Release, Repository)
+from sentry.plugins import bindings
 from sentry.testutils import TestCase
 
 
@@ -65,3 +67,46 @@ class PullRequestSerializerTest(TestCase):
         result = serialize(pull_requst, user)
 
         assert result['author'] == {}
+
+    def test_integration_repository(self):
+        # Add binding in case they aren't set.
+        bindings.add(
+            'integration-repository.provider',
+            GitHubRepositoryProvider,
+            id='integrations:github',
+        )
+
+        user = self.create_user()
+        project = self.create_project()
+        release = Release.objects.create(
+            organization_id=project.organization_id,
+            version=uuid4().hex,
+        )
+        release.add_project(project)
+        repository = Repository.objects.create(
+            organization_id=project.organization_id,
+            name='test/test',
+            provider='integrations:github',
+            url='https://github.com/test/test'
+        )
+        commit_author = CommitAuthor.objects.create(
+            name='stebe',
+            email='stebe@sentry.io',
+            organization_id=project.organization_id,
+        )
+        pull_request = PullRequest.objects.create(
+            organization_id=project.organization_id,
+            repository_id=repository.id,
+            key='9',
+            author=commit_author,
+            message='waddap',
+            title="cool pr"
+        )
+
+        result = serialize(pull_request, user)
+
+        assert result['externalUrl'] == 'https://github.com/test/test/pulls/9'
+        assert result['message'] == 'waddap'
+        assert result['title'] == 'cool pr'
+        assert result['repository']['name'] == 'test/test'
+        assert result['author'] == {'name': 'stebe', 'email': 'stebe@sentry.io'}

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -6,7 +6,7 @@ import pytest
 
 from exam import fixture
 
-from sentry.models import Integration, Repository
+from sentry.models import Integration, Repository, PullRequest
 from sentry.testutils import PluginTestCase
 from sentry.testutils.asserts import assert_commit_shape
 from sentry.utils import json
@@ -46,6 +46,7 @@ class GitHubAppsProviderTest(PluginTestCase):
             provider='integrations:github',
             organization_id=organization.id,
             integration_id=integration.id,
+            url='https://github.com/getsentry/example-repo',
             config={'name': 'getsentry/example-repo'},
         )
 
@@ -150,3 +151,8 @@ class GitHubAppsProviderTest(PluginTestCase):
         )
         with pytest.raises(IntegrationError):
             self.provider.compare_commits(self.repository, 'xyz123', 'abcdef')
+
+    def test_pull_request_url(self):
+        pull = PullRequest(key=99)
+        result = self.provider.pull_request_url(self.repository, pull)
+        assert result == 'https://github.com/getsentry/example-repo/pulls/99'

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -13,6 +13,7 @@ from sentry.models import (
     Identity,
     IdentityProvider,
     Integration,
+    PullRequest,
     Repository,
 )
 from sentry.testutils import PluginTestCase
@@ -297,3 +298,12 @@ class GitLabRepositoryProviderTest(PluginTestCase):
         repo = Repository.objects.get(pk=response.data['id'])
         with pytest.raises(IntegrationError):
             self.provider.compare_commits(repo, None, 'abc')
+
+    @responses.activate
+    def test_pull_request_url(self):
+        response = self.create_repository(self.default_repository_config,
+                                          self.integration.id)
+        repo = Repository.objects.get(pk=response.data['id'])
+        pull = PullRequest(key=99)
+        result = self.provider.pull_request_url(repo, pull)
+        assert result == 'https://example.gitlab.com/getsentry/projects/example-repo/merge_requests/99'


### PR DESCRIPTION
When serializing pull requests it would be preferable to have the external URL available so that we don't have to add URL generation logic to react. This should make it simpler to add pull request URLs to other integrations as it can be implemented serverside with the rest of the integration repository logic.

Refs APP-730