### PR TITLE
fix(minidump): Fix invalid caching of CFI stack traces

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -62,7 +62,7 @@ sqlparse>=0.1.16,<0.2.0
 statsd>=3.1.0,<3.2.0
 strict-rfc3339>=0.7
 structlog==16.1.0
-symbolic>=5.5.5,<6.0.0
+symbolic>=5.5.6,<6.0.0
 toronado>=0.0.11,<0.1.0
 ua-parser>=0.6.1,<0.8.0
 # for bitbucket client

--- a/src/sentry/lang/native/cfi.py
+++ b/src/sentry/lang/native/cfi.py
@@ -34,6 +34,7 @@ class ThreadRef(object):
         self.raw_frames = frames
         self.modules = modules
         self.resolved_frames = None
+        self._cache_key = self._get_cache_key()
 
     def _get_frame_key(self, frame):
         module = self.modules.find_object(frame['instruction_addr'])
@@ -49,8 +50,7 @@ class ThreadRef(object):
             rebase_addr(frame['instruction_addr'], module)
         )
 
-    @property
-    def _cache_key(self):
+    def _get_cache_key(self):
         values = [self._get_frame_key(f) for f in self.raw_frames]
         # XXX: The seed is hard coded for a future refactor
         return 'st:%s' % hash_values(values, seed='MinidumpCfiProcessor')


### PR DESCRIPTION
The actual fix was https://github.com/getsentry/symbolic/pull/103, this bumps the symbolic requirement and updates the tests.

**Requires to update symbolic in getsentry.**