### PR TITLE
fix: Don't strip (possible) NoneType value in Template interface

### DIFF
--- a/src/sentry/interfaces/template.py
+++ b/src/sentry/interfaces/template.py
@@ -82,7 +82,7 @@ class Template(Interface):
             'File "%s", line %s' % (self.filename, self.lineno),
             '',
         ]
-        result.extend([n[1].strip('\n') for n in context])
+        result.extend([n[1].strip('\n') if n[1] else '' for n in context])
 
         return '\n'.join(result)
 


### PR DESCRIPTION
Fixes SENTRY-86F