### PR TITLE
build(precommit): Fix precommit calling jest directly (APP-716)

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
   "proxyURL": "http://localhost:8000",
   "scripts": {
     "test": "node scripts/test.js",
+    "test-precommit": "yarn test --findRelatedTests --bail",
     "test-ci": "yarn test --runInBand --ci --coverage --testResultsProcessor=jest-junit",
     "test-debug": "node --inspect-brk scripts/test.js --runInBand",
     "test-staged": "yarn test --findRelatedTests $(git diff --name-only --cached)",

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -17,7 +17,7 @@ const jest = require('jest');
 const argv = process.argv.slice(2);
 
 // Watch unless on CI or in coverage mode
-if (!process.env.CI && argv.indexOf('--coverage') < 0) {
+if (!process.env.CI && !process.env.SENTRY_PRECOMMIT && argv.indexOf('--coverage') < 0) {
   argv.push('--watch');
 }
 

--- a/src/sentry/lint/engine.py
+++ b/src/sentry/lint/engine.py
@@ -18,6 +18,7 @@ import json
 from subprocess import check_output, Popen
 
 os.environ['PYFLAKES_NODOCTEST'] = '1'
+os.environ['SENTRY_PRECOMMIT'] = '1'
 
 
 def get_project_root():
@@ -256,7 +257,7 @@ def js_test(file_list=None):
 
     has_errors = False
     if js_file_list:
-        status = Popen([jest_path, '--bail', '--findRelatedTests'] + js_file_list).wait()
+        status = Popen(['yarn', 'test-precommit'] + js_file_list).wait()
         has_errors = status != 0
 
     return has_errors


### PR DESCRIPTION
Changes precommit script to call `yarn test-precommit` script so that we can bootstrap
env variables.