### PR TITLE
fix(ui): Prevent Text Overflow in Early Adopter Message

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/earlyAdopterMessage.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/earlyAdopterMessage.jsx
@@ -12,7 +12,9 @@ export default class EarlyAdopterMessage extends React.Component {
     return (
       <StyledAlert type="info" icon="icon-labs">
         <StyledAlertText>
-          {t('Sentry Discover is alpha software. Thanks for being an early adopter.')}&nbsp;
+          {t(
+            'Sentry Discover is alpha software. Thanks for being an early adopter.'
+          )}&nbsp;
           <StyledLink href="mailto:feedback-discover@sentry.io">
             {t('feedback-discover@sentry.io')}
           </StyledLink>
@@ -31,6 +33,7 @@ const StyledAlert = styled(Alert)`
 const StyledAlertText = styled(Flex)`
   justify-content: space-between;
   white-space: nowrap;
+  flex-wrap: wrap;
   @media (max-width: ${theme.breakpoints[2]}) {
     justify-content: flex-start;
     display: inline;


### PR DESCRIPTION
Add flex-wrap to text to prevent overflow from the container