### PR TITLE
fix(discard-groups): Use fully qualified feature

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
@@ -47,7 +47,7 @@ class DeleteActions extends React.Component {
 
   renderDiscardModal = ({Body, closeModal}) => (
     <Feature
-      features={['discard-groups']}
+      features={['projects:discard-groups']}
       organization={this.props.organization}
       renderDisabled={this.renderDiscardDisabled}
     >


### PR DESCRIPTION
The feature must be fully qualified for the FeatureDisabled component to display the correct code to enable the feature.