### PR TITLE
ref(eventstream): Enable turning off post-processing task dispatch in Kafka backend

### DIFF
--- a/src/sentry/eventstream/kafka.py
+++ b/src/sentry/eventstream/kafka.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 from confluent_kafka import Producer
 from django.utils.functional import cached_property
 
-from sentry import quotas
+from sentry import options, quotas
 from sentry.models import Organization
 from sentry.eventstream.base import EventStream
 from sentry.utils import json
@@ -113,13 +113,12 @@ class KafkaEventStream(EventStream):
 
     def insert(self, group, event, is_new, is_sample, is_regression,
                is_new_group_environment, primary_hash, skip_consume=False):
-        # ensure the superclass's insert() is called, regardless of what happens
-        # attempting to send to Kafka
-        super(KafkaEventStream, self).insert(
-            group, event, is_new, is_sample,
-            is_regression, is_new_group_environment,
-            primary_hash, skip_consume
-        )
+        if options.get('eventstream.kafka.send-post_process-task'):
+            super(KafkaEventStream, self).insert(
+                group, event, is_new, is_sample,
+                is_regression, is_new_group_environment,
+                primary_hash, skip_consume
+            )
 
         project = event.project
         retention_days = quotas.get_event_retention(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -144,3 +144,6 @@ register('snuba.search.max-total-chunk-time-seconds', default=30.0)
 # Kafka Publisher
 register('kafka-publisher.raw-event-sample-rate', default=0.0)
 register('kafka-publisher.max-event-size', default=100000)
+
+# Event Stream
+register('eventstream.kafka.send-post_process-task', type=Bool, default=True)


### PR DESCRIPTION
This simplifies the migration path for GH-9159 (and provides a reasonably quick escape hatch without requiring a redeploy.)