### PR TITLE
feat: Include triggering rules in webhook payload

### DIFF
--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -66,7 +66,8 @@ class NotificationPlugin(Plugin):
 
     def notify(self, notification):
         event = notification.event
-        return self.notify_users(event.group, event, [r.label for r in notification.rules])
+        return self.notify_users(event.group, event, triggering_rules=[
+                                 r.label for r in notification.rules])
 
     def rule_notify(self, event, futures):
         rules = []
@@ -117,7 +118,7 @@ class NotificationPlugin(Plugin):
 
         self.logger.info('notification.%s' % log_event, extra=extra)
 
-    def notify_users(self, group, event, triggering_rules, fail_silently=False):
+    def notify_users(self, group, event, triggering_rules, fail_silently=False, **kwargs):
         raise NotImplementedError
 
     def notify_about_activity(self, activity):

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -66,7 +66,7 @@ class NotificationPlugin(Plugin):
 
     def notify(self, notification):
         event = notification.event
-        return self.notify_users(event.group, event, map(lambda r: r.label, notification.rules))
+        return self.notify_users(event.group, event, [r.label for r in notification.rules])
 
     def rule_notify(self, event, futures):
         rules = []

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -66,7 +66,7 @@ class NotificationPlugin(Plugin):
 
     def notify(self, notification):
         event = notification.event
-        return self.notify_users(event.group, event)
+        return self.notify_users(event.group, event, map(lambda r: r.label, notification.rules))
 
     def rule_notify(self, event, futures):
         rules = []
@@ -117,7 +117,7 @@ class NotificationPlugin(Plugin):
 
         self.logger.info('notification.%s' % log_event, extra=extra)
 
-    def notify_users(self, group, event, fail_silently=False):
+    def notify_users(self, group, event, triggering_rules, fail_silently=False):
         raise NotImplementedError
 
     def notify_about_activity(self, activity):

--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -74,7 +74,7 @@ class WebHooksPlugin(notify.NotificationPlugin):
             }
         ]
 
-    def get_group_data(self, group, event):
+    def get_group_data(self, group, event, triggering_rules):
         data = {
             'id': six.text_type(group.id),
             'project': group.project.slug,
@@ -85,6 +85,7 @@ class WebHooksPlugin(notify.NotificationPlugin):
             'culprit': group.culprit,
             'message': event.get_legacy_message(),
             'url': group.get_absolute_url(),
+            'triggering_rules': triggering_rules,
         }
         data['event'] = dict(event.data or {})
         data['event']['tags'] = event.get_tags()
@@ -103,7 +104,7 @@ class WebHooksPlugin(notify.NotificationPlugin):
             verify_ssl=False,
         )
 
-    def notify_users(self, group, event, fail_silently=False):
-        payload = self.get_group_data(group, event)
+    def notify_users(self, group, event, triggering_rules, fail_silently=False):
+        payload = self.get_group_data(group, event, triggering_rules)
         for url in self.get_webhook_urls(group.project):
             safe_execute(self.send_webhook, url, payload, _with_transaction=False)

--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -104,7 +104,7 @@ class WebHooksPlugin(notify.NotificationPlugin):
             verify_ssl=False,
         )
 
-    def notify_users(self, group, event, triggering_rules, fail_silently=False):
+    def notify_users(self, group, event, triggering_rules, fail_silently=False, **kwargs):
         payload = self.get_group_data(group, event, triggering_rules)
         for url in self.get_webhook_urls(group.project):
             safe_execute(self.send_webhook, url, payload, _with_transaction=False)

--- a/tests/sentry/plugins/sentry_webhooks/test_plugin.py
+++ b/tests/sentry/plugins/sentry_webhooks/test_plugin.py
@@ -40,6 +40,7 @@ class WebHooksPluginTest(TestCase):
         assert payload['message'] == 'Hello world'
         assert payload['event']['id'] == 24
         assert payload['event']['event_id'] == event.event_id
+        assert payload['triggering_rules'] == ['my rule']
 
     def test_webhook_validation(self):
         # Test that you can't sneak a bad domain into the list of webhooks


### PR DESCRIPTION
### Context
At Flexport, we are heavy users of Sentry webhooks. We use these to assign, prioritize and route alerts through various systems. We have a bunch of different "alert rules" in the sentry UI which all fire the same webhook. But in the webhook, we cannot distinguish which particular rule fired. We need this information because it's an important input for prioritization.

### Solution
The solution is pretty simple. I just added code to wire the triggering rule names to the webhook payload.

### Test plan
- Run sentry locally and verify that the payload includes this field
- Update tests