### PR TITLE
fix(ui) Improve display of release files

### DIFF
--- a/src/sentry/static/sentry/app/components/fileChange.jsx
+++ b/src/sentry/static/sentry/app/components/fileChange.jsx
@@ -1,38 +1,31 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import Avatar from 'app/components/avatar';
 import IconFileGeneric from 'app/icons/icon-file-generic';
 import Tooltip from 'app/components/tooltip';
-import ApiMixin from 'app/mixins/apiMixin';
 
-const FileChange = createReactClass({
-  displayName: 'FileChange',
-
-  propTypes: {
+class FileChange extends React.PureComponent {
+  static propTypes = {
     filename: PropTypes.string.isRequired,
     authors: PropTypes.array.isRequired,
-  },
-
-  mixins: [ApiMixin],
+  };
 
   getInitialState() {
     return {
       loading: true,
     };
-  },
+  }
 
   render() {
     let {filename, authors} = this.props;
-    // types = Array.from(types);
     return (
       <li className="list-group-item list-group-item-sm release-file-change">
         <div className="row row-flex row-center-vertically">
-          <div className="col-sm-9 truncate">
+          <div className="col-sm-10 truncate file-name">
             <IconFileGeneric className="icon-file-generic" size={15} />
-            <span className="file-name">{filename}</span>
+            {filename}
           </div>
-          <div className="col-sm-3 avatar-grid align-right">
+          <div className="col-sm-2 avatar-grid align-right">
             {authors.map((author, i) => {
               return (
                 <Tooltip key={i} title={`${author.name} ${author.email}`}>
@@ -43,23 +36,10 @@ const FileChange = createReactClass({
               );
             })}
           </div>
-          {/* <div className="col-sm-3">
-          {types.map(type => {
-            if (type ===  'A') {
-              return (<span key={type}>{t('Added')} </span>);
-            }
-            else if (type === 'D') {
-              return (<span key={type}>{t('Deleted')} </span>);
-            }
-            else if (type === 'M') {
-              return (<span key={type}>{t('Modified')} </span>);
-            }
-          })}
-          </div> */}
         </div>
       </li>
     );
-  },
-});
+  }
+}
 
 export default FileChange;

--- a/src/sentry/static/sentry/app/components/fileChange.jsx
+++ b/src/sentry/static/sentry/app/components/fileChange.jsx
@@ -10,8 +10,9 @@ class FileChange extends React.PureComponent {
     authors: PropTypes.array.isRequired,
   };
 
-  getInitialState() {
-    return {
+  constructor(props) {
+    super(props);
+    this.state = {
       loading: true,
     };
   }


### PR DESCRIPTION
The additional span causes files to be trucated to 0 width if they would overflow. By removing the span out `truncate` class can do its job. I've made the file column wider as commits can only have a single author, and we don't need all that space for a single icon.

I've also converted this component to an es6 class and removed the commented out code as it was simple to do.

### Old

![screen shot 2018-11-09 at 11 25 32 am](https://user-images.githubusercontent.com/24086/48275975-e1964280-e414-11e8-807c-bff63f15d288.png)

### New

![screen shot 2018-11-09 at 11 45 35 am](https://user-images.githubusercontent.com/24086/48276032-012d6b00-e415-11e8-8610-974e614d08d8.png)
