### PR TITLE
fix(github) Fix proptype warning in github issue link

### DIFF
--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -128,6 +128,7 @@ class GitHubIssueBasic(IssueBasicMixin):
                 'name': 'externalIssue',
                 'label': 'Issue',
                 'default': '',
+                'choices': [],
                 'type': 'select',
                 'url': autocomplete_url,
                 'required': True,


### PR DESCRIPTION
The externaIssue identifier autocomplete had no default choices and React was emitting the following console error:

```
Warning: Failed prop type: The prop `choices` is marked as required in `SelectField`, but its value is `undefined`.
   in SelectField (created by FieldFromConfig)
   in FieldFromConfig (created by ExternalIssueForm)
   in div (created by Form)
```

Setting a default value fixes this problem.