### PR TITLE
fix(ui) Fix clipped descenders in integration hovercards

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationItem.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationItem.jsx
@@ -63,6 +63,7 @@ const DomainName = styled('div')`
   margin-left: ${p => (p.compact ? space(1) : 'inherit')};
   margin-top: ${p => (!p.compact ? space(0.25) : 'inherit')};
   font-size: 1.4rem;
+  line-height: 1.2;
   overflow: hidden;
   text-overflow: ellipsis;
 `;

--- a/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
@@ -1360,7 +1360,7 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                                     compact={true}
                                                   >
                                                     <div
-                                                      className="css-zo2wxu-DomainName ettpo132"
+                                                      className="css-equk2k-DomainName ettpo132"
                                                     >
                                                       github.com/test-integration
                                                     </div>
@@ -2672,7 +2672,7 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                                     compact={true}
                                                   >
                                                     <div
-                                                      className="css-zo2wxu-DomainName ettpo132"
+                                                      className="css-equk2k-DomainName ettpo132"
                                                     >
                                                       jira.com/test-integration
                                                     </div>


### PR DESCRIPTION
I noticed that the overflow changed I did resulted in descenders being clipped off. Add a smidge more line-height to prevent that.

## Bad

![screen shot 2018-11-08 at 5 16 58 pm](https://user-images.githubusercontent.com/24086/48231181-4dc46800-e37b-11e8-8b8b-8c59c9e6d64a.png)

## Better
![screen shot 2018-11-09 at 12 34 53 pm](https://user-images.githubusercontent.com/24086/48278641-1eb20300-e41c-11e8-9cea-1b3857fc1d92.png)