### PR TITLE
fix(integrations) Compare migratable repositories as case-insensitive

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
@@ -97,7 +97,13 @@ export default class IntegrationRepos extends AsyncComponent {
 
     this.setState({adding: true});
 
-    let migratableRepo = itemList.filter(item => selection.value === item.name)[0];
+    let migratableRepo = itemList.filter(item => {
+      if (!(selection.value && item.name)) {
+        return false;
+      }
+      return selection.value.toLowerCase() === item.name.toLowerCase();
+    })[0];
+
     let promise;
     if (migratableRepo) {
       promise = migrateRepository(this.api, orgId, migratableRepo.id, integration);

--- a/tests/js/fixtures/repository.js
+++ b/tests/js/fixtures/repository.js
@@ -1,7 +1,7 @@
 export function Repository(params = {}) {
   return {
     id: '4',
-    name: 'repo-name',
+    name: 'example/repo-name',
     provider: 'github',
     url: 'https://github.com/example/repo-name',
     status: 'active',

--- a/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
@@ -10,12 +10,12 @@ describe('IntegrationRepos', function() {
     Client.clearMockResponses();
   });
 
-  describe('Adding repositories', function() {
-    const org = TestStubs.Organization();
-    const integration = TestStubs.GitHubIntegration();
-    const routerContext = TestStubs.routerContext();
+  const org = TestStubs.Organization();
+  const integration = TestStubs.GitHubIntegration();
+  const routerContext = TestStubs.routerContext();
 
-    describe('successful save', async function() {
+  describe('Adding repositories', function() {
+    it('can save successfully', async function() {
       let addRepo = Client.addMockResponse({
         url: `/organizations/${org.slug}/repos/`,
         method: 'POST',
@@ -24,7 +24,7 @@ describe('IntegrationRepos', function() {
       Client.addMockResponse({
         url: `/organizations/${org.slug}/integrations/1/repos/`,
         body: {
-          repos: [{identifier: 'repo-name', name: 'repo-name'}],
+          repos: [{identifier: 'example/repo-name', name: 'repo-name'}],
         },
       });
       Client.addMockResponse({
@@ -49,7 +49,7 @@ describe('IntegrationRepos', function() {
           data: {
             installation: '1',
             provider: 'integrations:github',
-            identifier: 'repo-name',
+            identifier: 'example/repo-name',
           },
         })
       );
@@ -58,10 +58,10 @@ describe('IntegrationRepos', function() {
         .find('strong')
         .first();
       expect(name).toHaveLength(1);
-      expect(name.text()).toEqual('repo-name');
+      expect(name.text()).toEqual('example/repo-name');
     });
 
-    describe('save failure', async function() {
+    it('handles failure during save', async function() {
       let addRepo = Client.addMockResponse({
         url: `/organizations/${org.slug}/repos/`,
         method: 'POST',
@@ -95,48 +95,79 @@ describe('IntegrationRepos', function() {
       expect(addRepo).toHaveBeenCalled();
       expect(wrapper.find('RepoOption')).toHaveLength(0);
     });
+  });
 
-    describe('migratable repo', function() {
+  describe('migratable repo', function() {
+    it('associates repository with integration', () => {
       Client.addMockResponse({
         url: `/organizations/${org.slug}/repos/`,
         body: [
-          {
-            name: 'foo/bar',
-            id: 2,
+          TestStubs.Repository({
             integrationId: null,
             provider: {
-              name: 'GitHub',
               id: 'integrations:github',
+              name: 'GitHub',
               status: 'active',
-              url: 'github.com/foo/bar',
             },
-          },
+          }),
         ],
       });
       Client.addMockResponse({
         url: `/organizations/${org.slug}/integrations/${integration.id}/repos/`,
-        body: {repos: [{identifier: 'foo/bar', name: 'foo'}]},
+        body: {repos: [{identifier: 'example/repo-name', name: 'repo-name'}]},
+      });
+      const updateRepo = Client.addMockResponse({
+        method: 'PUT',
+        url: `/organizations/${org.slug}/repos/4/`,
+        body: {},
       });
       const wrapper = mount(
         <IntegrationRepos integration={integration} />,
         routerContext
       );
 
-      it('associates repository with integration', () => {
-        const updateRepo = Client.addMockResponse({
-          method: 'PUT',
-          url: `/organizations/${org.slug}/repos/${2}/`,
-          body: {},
-        });
-        wrapper.find('DropdownButton').simulate('click');
-        wrapper.find('StyledListElement').simulate('click');
-        expect(updateRepo).toHaveBeenCalledWith(
-          `/organizations/${org.slug}/repos/${2}/`,
-          expect.objectContaining({
-            data: {integrationId: '1'},
-          })
-        );
+      wrapper.find('DropdownButton').simulate('click');
+      wrapper.find('StyledListElement').simulate('click');
+      expect(updateRepo).toHaveBeenCalledWith(
+        `/organizations/${org.slug}/repos/4/`,
+        expect.objectContaining({
+          data: {integrationId: '1'},
+        })
+      );
+    });
+
+    it('compares case-insensitive', () => {
+      Client.addMockResponse({
+        url: `/organizations/${org.slug}/repos/`,
+        method: 'GET',
+        body: [TestStubs.Repository({name: 'Example/repo-name'})],
       });
+      const getItems = Client.addMockResponse({
+        url: `/organizations/${org.slug}/integrations/${integration.id}/repos/`,
+        method: 'GET',
+        body: {
+          repos: [{identifier: 'example/repo-name', name: 'repo-name'}],
+        },
+      });
+      const updateRepo = Client.addMockResponse({
+        method: 'PUT',
+        url: `/organizations/${org.slug}/repos/4/`,
+        body: {},
+      });
+      const wrapper = mount(
+        <IntegrationRepos integration={integration} />,
+        routerContext
+      );
+      wrapper.find('DropdownButton').simulate('click');
+      wrapper.find('StyledListElement').simulate('click');
+
+      expect(getItems).toHaveBeenCalled();
+      expect(updateRepo).toHaveBeenCalledWith(
+        `/organizations/${org.slug}/repos/4/`,
+        expect.objectContaining({
+          data: {integrationId: '1'},
+        })
+      );
     });
   });
 });

--- a/tests/js/spec/views/releases/pullRequestLink.spec.jsx
+++ b/tests/js/spec/views/releases/pullRequestLink.spec.jsx
@@ -12,7 +12,7 @@ describe('PullRequestLink', function() {
     );
 
     expect(wrapper.find('a')).toHaveLength(0);
-    expect(wrapper.find('span').text()).toEqual('repo-name #3: Fix first issue');
+    expect(wrapper.find('span').text()).toEqual('example/repo-name #3: Fix first issue');
   });
 
   it('renders github links for integrations:github repositories', function() {
@@ -32,7 +32,7 @@ describe('PullRequestLink', function() {
 
     let link = wrapper.find('a');
     expect(link).toHaveLength(1);
-    expect(link.text().trim()).toEqual('repo-name #3: Fix first issue');
+    expect(link.text().trim()).toEqual('example/repo-name #3: Fix first issue');
   });
 
   it('renders github links for github repositories', function() {
@@ -52,7 +52,7 @@ describe('PullRequestLink', function() {
 
     let link = wrapper.find('a');
     expect(link).toHaveLength(1);
-    expect(link.text().trim()).toEqual('repo-name #3: Fix first issue');
+    expect(link.text().trim()).toEqual('example/repo-name #3: Fix first issue');
   });
 
   it('renders gitlab links for integrations:gitlab repositories', function() {
@@ -72,7 +72,7 @@ describe('PullRequestLink', function() {
 
     let link = wrapper.find('a');
     expect(link).toHaveLength(1);
-    expect(link.text().trim()).toEqual('repo-name #3: Fix first issue');
+    expect(link.text().trim()).toEqual('example/repo-name #3: Fix first issue');
   });
 
   it('renders github links for gitlab repositories', function() {
@@ -92,6 +92,6 @@ describe('PullRequestLink', function() {
 
     let link = wrapper.find('a');
     expect(link).toHaveLength(1);
-    expect(link.text().trim()).toEqual('repo-name #3: Fix first issue');
+    expect(link.text().trim()).toEqual('example/repo-name #3: Fix first issue');
   });
 });

--- a/tests/js/spec/views/settings/__snapshots__/organizationRepositories.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationRepositories.spec.jsx.snap
@@ -36,7 +36,7 @@ exports[`OrganizationRepositories renders with a repository 1`] = `
           repository={
             Object {
               "id": "4",
-              "name": "repo-name",
+              "name": "example/repo-name",
               "provider": "github",
               "status": "active",
               "url": "https://github.com/example/repo-name",


### PR DESCRIPTION
Old integrations have created repositories with Titlecased organization names. This prevents these repositories from being migrated to the new integrations as the names we have in our database don't match the names from the provider. Instead the frontend tries to create a new repository which creates a unique key conflict with the old repository.

I've checked the various repository integration providers we have and they require repository/project slugs to have unique lower case representations. This makes comparing repository names by lower case reasonably safe and unlikely to cause problems in the future.

Fixes ISSUE-201