### PR TITLE
fix: Set NULL on Release.owner when deleting User

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -74,7 +74,7 @@ class Release(Model):
     data = JSONField(default={})
     new_groups = BoundedPositiveIntegerField(default=0)
     # generally the release manager, or the person initiating the process
-    owner = FlexibleForeignKey('sentry.User', null=True, blank=True)
+    owner = FlexibleForeignKey('sentry.User', null=True, blank=True, on_delete=models.SET_NULL)
 
     # materialized stats
     commit_count = BoundedPositiveIntegerField(null=True, default=0)


### PR DESCRIPTION
Fixes SENTRY-85W