### PR TITLE
fix(discover): Add Truncation to X-Axis Values

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/components/xAxis.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/xAxis.jsx
@@ -2,21 +2,19 @@ import moment from 'moment';
 
 import theme from 'app/utils/theme';
 
-
 export default function XAxis({isGroupedByDate, interval, ...props} = {}) {
-
   const axisLabelFormatter = value => {
-     if(isGroupedByDate){
-       const format = interval === 'hour' ? 'LT' : 'MMM Do';
-       return moment
-         .utc(value)
-         .local()
-         .format(format);
-     } else if(props.truncate){
-       return value.slice(0, props.truncate) + '…';
-     } else {
-       return undefined;
-     }
+    if (isGroupedByDate) {
+      const format = interval === 'hour' ? 'LT' : 'MMM Do';
+      return moment
+        .utc(value)
+        .local()
+        .format(format);
+    } else if (props.truncate) {
+      return value.slice(0, props.truncate) + '…';
+    } else {
+      return undefined;
+    }
   };
 
   return {

--- a/src/sentry/static/sentry/app/components/charts/components/xAxis.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/xAxis.jsx
@@ -2,22 +2,22 @@ import moment from 'moment';
 
 import theme from 'app/utils/theme';
 
-const TRUNCATION_LENGTH = 80;
 
 export default function XAxis({isGroupedByDate, interval, ...props} = {}) {
-  const axisLabelFormatter = isGroupedByDate
-    ? (value, index) => {
-      const format = interval === 'hour' ? 'LT' : 'MMM Do';
-      return moment
-        .utc(value)
-        .local()
-        .format(format);
-    }
-    : props.truncateXAxis
-      ? (value, index) => {
-        return value.slice(0, TRUNCATION_LENGTH) + '…';
-      }
-      : undefined;
+
+  const axisLabelFormatter = value => {
+     if(isGroupedByDate){
+       const format = interval === 'hour' ? 'LT' : 'MMM Do';
+       return moment
+         .utc(value)
+         .local()
+         .format(format);
+     } else if(props.truncate){
+       return value.slice(0, props.truncate) + '…';
+     } else {
+       return undefined;
+     }
+  };
 
   return {
     type: 'category',

--- a/src/sentry/static/sentry/app/components/charts/components/xAxis.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/xAxis.jsx
@@ -10,7 +10,7 @@ export default function XAxis({isGroupedByDate, interval, ...props} = {}) {
         .utc(value)
         .local()
         .format(format);
-    } else if (props.truncate) {
+    } else if (props.truncate && value.length > props.truncate) {
       return value.slice(0, props.truncate) + '…';
     } else {
       return undefined;

--- a/src/sentry/static/sentry/app/components/charts/components/xAxis.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/xAxis.jsx
@@ -2,16 +2,22 @@ import moment from 'moment';
 
 import theme from 'app/utils/theme';
 
+const TRUNCATION_LENGTH = 80;
+
 export default function XAxis({isGroupedByDate, interval, ...props} = {}) {
   const axisLabelFormatter = isGroupedByDate
     ? (value, index) => {
-        const format = interval === 'hour' ? 'LT' : 'MMM Do';
-        return moment
-          .utc(value)
-          .local()
-          .format(format);
+      const format = interval === 'hour' ? 'LT' : 'MMM Do';
+      return moment
+        .utc(value)
+        .local()
+        .format(format);
+    }
+    : props.truncateXAxis
+      ? (value, index) => {
+        return value.slice(0, TRUNCATION_LENGTH) + '…';
       }
-    : undefined;
+      : undefined;
 
   return {
     type: 'category',

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
@@ -193,7 +193,7 @@ export default class Result extends React.Component {
                 height={300}
                 tooltip={tooltipOptions}
                 legend={{data: [baseQuery.query.aggregations[0][2]], truncate: 80}}
-                xAxis={{truncateXAxis: true}}
+                xAxis={{truncate: 80}}
                 renderer="canvas"
               />
             </ChartWrapper>
@@ -205,7 +205,7 @@ export default class Result extends React.Component {
                 height={300}
                 tooltip={tooltipOptions}
                 legend={{data: [baseQuery.query.aggregations[0][2]], truncate: 80}}
-                xAxis={{truncateXAxis: true}}
+                xAxis={{truncate: 80}}
                 renderer="canvas"
               />
             </ChartWrapper>

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
@@ -193,6 +193,7 @@ export default class Result extends React.Component {
                 height={300}
                 tooltip={tooltipOptions}
                 legend={{data: [baseQuery.query.aggregations[0][2]], truncate: 80}}
+                xAxis={{truncateXAxis: true}}
                 renderer="canvas"
               />
             </ChartWrapper>
@@ -204,6 +205,7 @@ export default class Result extends React.Component {
                 height={300}
                 tooltip={tooltipOptions}
                 legend={{data: [baseQuery.query.aggregations[0][2]], truncate: 80}}
+                xAxis={{truncateXAxis: true}}
                 renderer="canvas"
               />
             </ChartWrapper>

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
@@ -9,7 +9,6 @@ import Papa from 'papaparse';
 import {NUMBER_OF_SERIES_BY_DAY} from '../data';
 
 const CHART_KEY = '__CHART_KEY__';
-const TRUNCATION_LENGTH = 80;
 
 /**
  * Returns data formatted for basic line and bar charts, with each aggregation
@@ -21,16 +20,6 @@ const TRUNCATION_LENGTH = 80;
  */
 export function getChartData(data, query) {
   const {fields} = query;
-
-  data.forEach(obj => {
-    fields.forEach(field => {
-      if (obj.hasOwnProperty(field) && typeof obj[field] === 'string') {
-        if (obj[field].length > TRUNCATION_LENGTH) {
-          obj[field] = obj[field].slice(0, TRUNCATION_LENGTH) + '…';
-        }
-      }
-    });
-  });
 
   return query.aggregations.map(aggregation => {
     return {

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
@@ -9,6 +9,7 @@ import Papa from 'papaparse';
 import {NUMBER_OF_SERIES_BY_DAY} from '../data';
 
 const CHART_KEY = '__CHART_KEY__';
+const TRUNCATION_LENGTH = 80;
 
 /**
  * Returns data formatted for basic line and bar charts, with each aggregation
@@ -20,6 +21,16 @@ const CHART_KEY = '__CHART_KEY__';
  */
 export function getChartData(data, query) {
   const {fields} = query;
+
+  data.forEach(obj => {
+    fields.forEach(field => {
+      if (obj.hasOwnProperty(field) && typeof obj[field] === 'string') {
+        if (obj[field].length > TRUNCATION_LENGTH) {
+          obj[field] = obj[field].slice(0, TRUNCATION_LENGTH) + '…';
+        }
+      }
+    });
+  });
 
   return query.aggregations.map(aggregation => {
     return {


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/APP-668

Truncating the x-axis values prevents e-charts from trying to fit all the labels, forcing the chart to be "smushed"/rendered oddly as shown in the ticket. 

Looks like now:
![image](https://user-images.githubusercontent.com/10991288/48290809-13b19f80-e429-11e8-8491-4dd6718cdb4f.png)
