### PR TITLE
fix(ui): Fix duplicate form values showing up in integration form

### DIFF
--- a/src/sentry/static/sentry/app/components/group/externalIssueActions.jsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueActions.jsx
@@ -179,7 +179,7 @@ class ExternalIssueForm extends AsyncComponent {
       >
         {config.map(field => (
           <FieldFromConfig
-            key={field.default || field.name}
+            key={`${field.name}-${field.default}`}
             field={field}
             inline={false}
             stacked


### PR DESCRIPTION
Fixes ISSUE-190

I think since default is not guaranteed to be unique, this was causing some weird react `key` behavior and this was happening:
![screenshot 2018-11-09 13 51 35](https://user-images.githubusercontent.com/5026776/48290097-a1d85680-e426-11e8-97fa-2758e011cbca.png)

I tested locally, and I don't think this will re-introduce the bug fixed in https://github.com/getsentry/sentry/pull/9665