### PR TITLE
ref(hovercard): Use styled components

### DIFF
--- a/src/sentry/static/sentry/app/components/hovercard.jsx
+++ b/src/sentry/static/sentry/app/components/hovercard.jsx
@@ -126,13 +126,16 @@ const slideIn = p => keyframes`
 
 const positionX = offset => p => css`
   right: ${p.position.x === 'right' ? offset : 'inherit'};
-  left: ${{left: offset, right: 'inherit', middle: '50%'}[p.position.x]};
+  left: ${p.position.x === 'middle'
+    ? '50%'
+    : p.position.x === 'left' ? offset : 'inherit'};
+
   transform: ${translateX(p.position.x)};
 `;
 
 const positionY = offset => p => css`
-  bottom: ${{top: offset, bottom: 'inherit'}[p.position.y]};
-  top: ${{top: 'inherit', bottom: offset}[p.position.y]};
+  bottom: ${p.position.y === 'top' ? offset : 'inherit'};
+  top: ${p.position.y === 'bottom' ? offset : 'inherit'};
 `;
 
 const getTipColor = p =>

--- a/src/sentry/static/sentry/app/components/hovercard.jsx
+++ b/src/sentry/static/sentry/app/components/hovercard.jsx
@@ -113,7 +113,7 @@ class Hovercard extends React.Component {
 }
 
 const translateX = x => `translateX(${x === 'middle' ? '-50%' : 0})`;
-const slideTranslateY = y => `translateY(${{top: -1, bottom: 1}[y] * 14}px)`;
+const slideTranslateY = y => `translateY(${(y === 'top' ? 1 : -1) * 14}px)`;
 
 const slideIn = p => keyframes`
   from {

--- a/src/sentry/static/sentry/app/components/hovercard.jsx
+++ b/src/sentry/static/sentry/app/components/hovercard.jsx
@@ -6,7 +6,7 @@ import styled, {css, keyframes} from 'react-emotion';
 import {fadeIn} from 'app/styles/animations';
 import space from 'app/styles/space';
 
-const DEFAULT_POSITION = {x: 'middle', y: 'top'};
+const DEFAULT_POSITION = {x: 'middle', y: 'top', offset: 0};
 
 class Hovercard extends React.Component {
   static propTypes = {
@@ -67,13 +67,17 @@ class Hovercard extends React.Component {
     if (!this.cardElement.current || this.state.visible) return;
     const rect = this.cardElement.current.getBoundingClientRect();
 
-    const y = rect.top < 0 ? 'bottom' : 'top';
+    // Computes the offset that the hovercard should be from the anchor point
+    // of the container (top or bottom absolute position).
+    const offset = this.containerElement.current.offsetHeight;
+
+    const y = rect.top - offset < 0 ? 'bottom' : 'top';
     const x =
       rect.right > window.innerWidth && !(rect.left < 0)
         ? 'right'
         : rect.left < 0 ? 'left' : 'middle';
 
-    this.setState({position: {x, y}});
+    this.setState({position: {x, y, offset}});
   }
 
   render() {
@@ -86,6 +90,7 @@ class Hovercard extends React.Component {
     return (
       <Container
         className={containerClassName}
+        innerRef={this.containerElement}
         onMouseEnter={this.handleToggleOn}
         onMouseLeave={this.handleToggleOff}
       >
@@ -152,7 +157,7 @@ const StyledHovercard = styled('div')`
 
   position: absolute;
   ${positionX('-2px')};
-  ${positionY('28px')};
+  ${p => positionY(`${p.position.offset + 12}px`)};
 
   animation: ${fadeIn} 100ms, ${slideIn} 100ms ease-in-out;
   animation-play-state: ${p => (p.visible ? 'running' : 'paused')};

--- a/src/sentry/static/sentry/app/components/hovercard.jsx
+++ b/src/sentry/static/sentry/app/components/hovercard.jsx
@@ -1,7 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import intersection from 'lodash/intersection';
+import styled, {css, keyframes} from 'react-emotion';
+
+import {fadeIn} from 'app/styles/animations';
+import space from 'app/styles/space';
+
+const DEFAULT_POSITION = {x: 'middle', y: 'top'};
 
 class Hovercard extends React.Component {
   static propTypes = {
@@ -18,13 +23,16 @@ class Hovercard extends React.Component {
 
   constructor(...args) {
     super(...args);
-    this.state = {
-      visible: false,
-      rendered: false,
-    };
     this.hoverWait = null;
-    this.cardElement = null;
+    this.cardElement = React.createRef();
+    this.containerElement = React.createRef();
   }
+
+  state = {
+    visible: false,
+    rendered: false,
+    position: null,
+  };
 
   handleToggleOn = () => this.toggleHovercard(true);
   handleToggleOff = () => this.toggleHovercard(false);
@@ -46,62 +54,150 @@ class Hovercard extends React.Component {
     // after the delay period. This allows us to compute the size of the
     // hovercard to position it before it is made visible.
     if (visible) {
-      this.setState({rendered});
+      this.setState({rendered}, () => this.positionCard());
     }
 
-    this.hoverWait = setTimeout(() => this.setState({visible, rendered}), timeout);
+    this.hoverWait = setTimeout(
+      () => this.setState({visible, rendered, ...(!rendered ? {position: null} : {})}),
+      timeout
+    );
   };
 
-  positionClasses() {
-    if (!this.cardElement || !this.state.visible) return {};
-    const rect = this.cardElement.getBoundingClientRect();
+  positionCard() {
+    if (!this.cardElement.current || this.state.visible) return;
+    const rect = this.cardElement.current.getBoundingClientRect();
 
-    const classes = {
-      'hovercard-bottom': rect.top < 0,
-      'hovercard-left': rect.left < 0,
-      'hovercard-right': rect.right > window.innerWidth && !(rect.left < 0),
-    };
+    const y = rect.top < 0 ? 'bottom' : 'top';
+    const x =
+      rect.right > window.innerWidth && !(rect.left < 0)
+        ? 'right'
+        : rect.left < 0 ? 'left' : 'middle';
 
-    // If it's already been given a positon class do not use the recomputed
-    // position classes, since they will have been computed from it's new
-    // current correct position. Use the previous positions.
-    const currentClasses = intersection(this.cardElement.classList, Object.keys(classes));
-
-    return currentClasses.length > 0 ? currentClasses : classes;
+    this.setState({position: {x, y}});
   }
 
   render() {
     const {containerClassName, className, header, body} = this.props;
-    const {rendered, visible} = this.state;
+    const {rendered, visible, position} = this.state;
 
-    const containerCx = classNames('hovercard-container', containerClassName);
-    const cx = classNames('hovercard', this.positionClasses(), className, {
-      'with-header': header,
-      visible,
-    });
+    // Maintain the hovercard class name for BC with less styles
+    const cx = classNames('hovercard', className);
 
     return (
-      <span
-        className={containerCx}
+      <Container
+        className={containerClassName}
         onMouseEnter={this.handleToggleOn}
         onMouseLeave={this.handleToggleOff}
       >
         {this.props.children}
         {rendered && (
-          <div
+          <StyledHovercard
+            visible={visible}
+            withHeader={!!header}
             className={cx}
-            ref={e => {
-              this.cardElement = e;
-            }}
+            position={position || DEFAULT_POSITION}
+            innerRef={this.cardElement}
           >
-            <div className="hovercard-hoverlap" />
-            {header && <div className="hovercard-header">{header}</div>}
-            {body && <div className="hovercard-body">{body}</div>}
-          </div>
+            {header && <Header>{header}</Header>}
+            {body && <Body>{body}</Body>}
+          </StyledHovercard>
         )}
-      </span>
+      </Container>
     );
   }
 }
+
+const translateX = x => `translateX(${x === 'middle' ? '-50%' : 0})`;
+const slideTranslateY = y => `translateY(${{top: -1, bottom: 1}[y] * 14}px)`;
+
+const slideIn = p => keyframes`
+  from {
+    transform: ${translateX(p.position.x)} ${slideTranslateY(p.position.y)};
+  }
+  to {
+    transform: ${translateX(p.position.x)} translateY(0);
+  }
+`;
+
+const positionX = offset => p => css`
+  right: ${p.position.x === 'right' ? offset : 'inherit'};
+  left: ${{left: offset, right: 'inherit', middle: '50%'}[p.position.x]};
+  transform: ${translateX(p.position.x)};
+`;
+
+const positionY = offset => p => css`
+  bottom: ${{top: offset, bottom: 'inherit'}[p.position.y]};
+  top: ${{top: 'inherit', bottom: offset}[p.position.y]};
+`;
+
+const getTipColor = p =>
+  p.position.y === 'bottom' && p.withHeader ? p.theme.offWhite : '#fff';
+
+const StyledHovercard = styled('div')`
+  border-radius: 4px;
+  text-align: left;
+  padding: 0;
+  line-height: 1;
+  z-index: 1000;
+  white-space: initial;
+  color: ${p => p.theme.gray5};
+  border: 1px solid ${p => p.theme.borderLight};
+  background: #fff;
+  background-clip: padding-box;
+  box-shadow: 0 0 35px 0 rgba(67, 62, 75, 0.2);
+  width: 295px;
+
+  /* The hovercard may appear in different contexts, don't inherit fonts */
+  font-family: ${p => p.theme.text.family};
+
+  position: absolute;
+  ${positionX('-2px')};
+  ${positionY('28px')};
+
+  animation: ${fadeIn} 100ms, ${slideIn} 100ms ease-in-out;
+  animation-play-state: ${p => (p.visible ? 'running' : 'paused')};
+  visibility: ${p => (p.visible ? 'visible' : 'hidden')};
+
+  &:before,
+  &:after {
+    content: '';
+    display: block;
+    position: absolute;
+    z-index: -1;
+    border: 10px solid transparent;
+    /* stylelint-disable-next-line property-no-unknown */
+    border-${p => p.position.y}-color: ${getTipColor};
+    ${positionX('20px')};
+    ${positionY('-20px')};
+  }
+
+  &:before {
+    /* stylelint-disable-next-line property-no-unknown */
+    border-${p => p.position.y}-color: ${p => p.theme.borderLight};
+    ${positionY('-21px')};
+  }
+`;
+
+const Container = styled('span')`
+  position: relative;
+`;
+
+const Header = styled('div')`
+  font-size: 14px;
+  background: ${p => p.theme.offWhite};
+  border-bottom: 1px solid ${p => p.theme.borderLight};
+  border-radius: 4px 4px 0 0;
+  font-weight: 600;
+  word-wrap: break-word;
+
+  /* The font needs a little extra padding. It has funny vert alignment. */
+  padding: ${space(2 * 0.6)} ${space(2 * 0.75)};
+  padding-top: ${space(2 * 0.75)};
+`;
+
+const Body = styled('div')`
+  padding: ${space(2)};
+  min-height: 30px;
+`;
 
 export default Hovercard;

--- a/src/sentry/static/sentry/app/styles/animations.jsx
+++ b/src/sentry/static/sentry/app/styles/animations.jsx
@@ -18,6 +18,15 @@ export const growDown = height => keyframes`
   }
 `;
 
+export const fadeIn = keyframes`
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+`;
+
 export const fadeOut = keyframes`
   0% {
     opacity: 1;

--- a/src/sentry/static/sentry/less/group-similar.less
+++ b/src/sentry/static/sentry/less/group-similar.less
@@ -79,18 +79,6 @@
   display: flex;
   justify-content: center;
   padding: 5px 0;
-
-  .hovercard {
-    &.hovercard-right:before {
-      right: 13px;
-    }
-    &:after {
-      right: 13px;
-    }
-    .hovercard-body {
-      min-height: auto;
-    }
-  }
 }
 
 .similar-items-footer {

--- a/src/sentry/static/sentry/less/sentry-hovercard.less
+++ b/src/sentry/static/sentry/less/sentry-hovercard.less
@@ -3,210 +3,39 @@
  * ============================================================================
  */
 
-.hovercard-container {
-  position: relative;
-}
-
 .hovercard {
-  @hovercard-padding: 15px;
-  @hovercard-width: 295px;
-  border-radius: 4px;
-  background-clip: padding-box;
-  background: #fff;
-  color: @gray-darker;
-  text-align: left;
-  position: absolute;
-  display: block;
-  padding: 0;
-  line-height: 1;
-  z-index: 1000;
-  box-shadow: 0 0 35px 0 rgba(67, 62, 75, 0.2);
-  border: 1px solid @trim;
-  white-space: initial;
+  @hovercard-padding: 16px;
 
-  // The hovercard may appear in different contexts, don't inherit fonts
-  font-family: @font-family-base;
-
-  // Default align hovercard top-middle
-  bottom: 28px;
-  left: 50%;
-  margin-left: -@hovercard-width / 2;
-  width: @hovercard-width;
-  visibility: hidden;
-
-  @keyframes hovercardSlideUp {
-    from {
-      transform: translateY(12px);
-    }
-    to {
-      transform: translateY(0);
-    }
+  .commit-heading {
+    margin: 10px 0;
   }
 
-  @keyframes hovercardSlideDown {
-    from {
-      transform: translateY(-12px);
-    }
-    to {
-      transform: translateY(0);
-    }
-  }
+  .commit {
+    margin-top: 5px;
+    margin-bottom: 0;
+    position: relative;
+    padding: 1px 0 0 25px;
+    font-size: 13px;
 
-  @keyframes hovercardFadeIn {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-  }
+    .commit-avatar {
+      position: absolute;
+      .square(19px);
+      top: 2px;
+      left: 0;
 
-  animation: hovercardFadeIn 100ms ease-in-out, hovercardSlideDown 100ms ease-in-out;
-
-  // Wait for the element to become visible
-  animation-play-state: paused;
-
-  &.visible {
-    visibility: visible;
-    animation-play-state: running;
-  }
-
-  &.hovercard-bottom {
-    bottom: initial;
-    top: 28px;
-
-    animation: hovercardFadeIn 100ms ease-in-out, hovercardSlideUp 100ms ease-in-out;
-
-    .hovercard-hoverlap {
-      top: -16px;
-    }
-
-    &:before,
-    &:after {
-      bottom: initial;
-      top: -20px;
-      // Avoid having
-      transform: rotate(180deg);
-    }
-
-    &:before {
-      top: -21px;
-    }
-
-    &.with-header:after {
-      border-top-color: @white-dark;
-    }
-  }
-
-  &.hovercard-left {
-    left: 0;
-    margin-left: 0;
-
-    &:before,
-    &:after {
-      left: 21px;
-      margin-left: 0;
-    }
-  }
-
-  &.hovercard-right {
-    left: initial;
-    right: 0;
-    margin-left: 0;
-
-    &:before,
-    &:after {
-      left: initial;
-      right: 21px;
-      margin-left: 0;
-    }
-  }
-
-  &:before,
-  &:after {
-    .square(0);
-    content: '';
-    display: block;
-    position: absolute;
-    z-index: -1;
-    bottom: -20px;
-    left: 50%;
-    margin-left: -10px;
-    border: 10px solid transparent;
-    border-top-color: #fff;
-  }
-
-  &:before {
-    bottom: -21px;
-    border-top-color: @trim;
-  }
-
-  .hovercard-hoverlap {
-    position: absolute;
-    bottom: -16px;
-    height: 16px;
-    left: 0;
-    right: 0;
-  }
-
-  .hovercard-header {
-    font-size: 14px;
-    background: @white-dark;
-    border-bottom: 1px solid @trim;
-    border-radius: 4px 4px 0 0;
-    font-weight: 600;
-    word-wrap: break-word;
-
-    // Thhe font needs a little extra padding. It has funny vert alignment.
-    padding: @hovercard-padding * 0.6 @hovercard-padding * 0.75;
-    padding-top: @hovercard-padding * 0.6 + 2px;
-
-    .pull-right {
-      a {
-        color: @50;
-
-        &:hover {
-          color: @70;
-        }
-      }
-    }
-  }
-
-  .hovercard-body {
-    padding: @hovercard-padding;
-    min-height: 50px;
-
-    .commit-heading {
-      margin: 10px 0;
-    }
-
-    .commit {
-      margin-top: 5px;
-      margin-bottom: 0;
-      position: relative;
-      padding: 1px 0 0 25px;
-      font-size: 13px;
-
-      .commit-avatar {
-        position: absolute;
+      .avatar {
         .square(19px);
-        top: 2px;
-        left: 0;
-
-        .avatar {
-          .square(19px);
-        }
       }
+    }
 
-      .commit-message {
-        line-height: 1.4;
-        margin: 2px 0 5px;
-      }
+    .commit-message {
+      line-height: 1.4;
+      margin: 2px 0 5px;
+    }
 
-      .commit-meta {
-        font-size: 12px;
-        color: @70;
-      }
+    .commit-meta {
+      font-size: 12px;
+      color: @70;
     }
   }
 

--- a/tests/js/spec/components/group/__snapshots__/externalIssueActions.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/externalIssueActions.spec.jsx.snap
@@ -79,6 +79,31 @@ exports[`ExternalIssueActions with an external issue linked renders 1`] = `
       >
         <Container
           className="css-1s8b4pt-hoverCardContainer"
+          innerRef={
+            Object {
+              "current": <span
+                class="css-1l5wko0-Container-hoverCardContainer e38w1je1"
+              >
+                <svg
+                  class="e1vaar1z1 css-18jkql6-StyledSvg-IntegrationIcon e2idor0"
+                  height="1em"
+                  viewBox="[object Object]"
+                  width="1em"
+                >
+                  <use
+                    href="#test"
+                    xlink:href="#test"
+                  />
+                </svg>
+                <a
+                  class="css-oytllg-IntegrationLink e1vaar1z2"
+                  href="https://github.com/MeredithAnya/testing/issues/2"
+                >
+                  getsentry/sentry#2
+                </a>
+              </span>,
+            }
+          }
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -287,6 +312,30 @@ exports[`ExternalIssueActions with no external issues linked renders 1`] = `
         >
           <Container
             className="css-1s8b4pt-hoverCardContainer"
+            innerRef={
+              Object {
+                "current": <span
+                  class="css-1l5wko0-Container-hoverCardContainer e38w1je1"
+                >
+                  <svg
+                    class="e1vaar1z1 css-18jkql6-StyledSvg-IntegrationIcon e2idor0"
+                    height="1em"
+                    viewBox="[object Object]"
+                    width="1em"
+                  >
+                    <use
+                      href="#test"
+                      xlink:href="#test"
+                    />
+                  </svg>
+                  <a
+                    class="css-oytllg-IntegrationLink e1vaar1z2"
+                  >
+                    Link GitHub Issue
+                  </a>
+                </span>,
+              }
+            }
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
           >

--- a/tests/js/spec/components/group/__snapshots__/externalIssueActions.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/externalIssueActions.spec.jsx.snap
@@ -77,49 +77,55 @@ exports[`ExternalIssueActions with an external issue linked renders 1`] = `
         displayTimeout={100}
         header="Linked GitHub Integration"
       >
-        <span
-          className="hovercard-container css-1s8b4pt-hoverCardContainer"
+        <Container
+          className="css-1s8b4pt-hoverCardContainer"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
-          <IntegrationIcon
-            src="icon-github"
+          <span
+            className="css-1l5wko0-Container-hoverCardContainer e38w1je1"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
-            <InlineSvg
-              className="css-qf3g6n-IntegrationIcon e1vaar1z1"
+            <IntegrationIcon
               src="icon-github"
             >
-              <StyledSvg
+              <InlineSvg
                 className="css-qf3g6n-IntegrationIcon e1vaar1z1"
-                height="1em"
-                viewBox={Object {}}
-                width="1em"
+                src="icon-github"
               >
-                <svg
-                  className="e1vaar1z1 css-18jkql6-StyledSvg-IntegrationIcon e2idor0"
+                <StyledSvg
+                  className="css-qf3g6n-IntegrationIcon e1vaar1z1"
                   height="1em"
                   viewBox={Object {}}
                   width="1em"
                 >
-                  <use
-                    href="#test"
-                    xlinkHref="#test"
-                  />
-                </svg>
-              </StyledSvg>
-            </InlineSvg>
-          </IntegrationIcon>
-          <IntegrationLink
-            href="https://github.com/MeredithAnya/testing/issues/2"
-          >
-            <a
-              className="css-oytllg-IntegrationLink e1vaar1z2"
+                  <svg
+                    className="e1vaar1z1 css-18jkql6-StyledSvg-IntegrationIcon e2idor0"
+                    height="1em"
+                    viewBox={Object {}}
+                    width="1em"
+                  >
+                    <use
+                      href="#test"
+                      xlinkHref="#test"
+                    />
+                  </svg>
+                </StyledSvg>
+              </InlineSvg>
+            </IntegrationIcon>
+            <IntegrationLink
               href="https://github.com/MeredithAnya/testing/issues/2"
             >
-              getsentry/sentry#2
-            </a>
-          </IntegrationLink>
-        </span>
+              <a
+                className="css-oytllg-IntegrationLink e1vaar1z2"
+                href="https://github.com/MeredithAnya/testing/issues/2"
+              >
+                getsentry/sentry#2
+              </a>
+            </IntegrationLink>
+          </span>
+        </Container>
       </Hovercard>
       <OpenCloseIcon
         isLinked={100}
@@ -279,51 +285,57 @@ exports[`ExternalIssueActions with no external issues linked renders 1`] = `
           displayTimeout={100}
           header="Linked GitHub Integration"
         >
-          <span
-            className="hovercard-container css-1s8b4pt-hoverCardContainer"
+          <Container
+            className="css-1s8b4pt-hoverCardContainer"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
           >
-            <IntegrationIcon
-              src="icon-github"
+            <span
+              className="css-1l5wko0-Container-hoverCardContainer e38w1je1"
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
             >
-              <InlineSvg
-                className="css-qf3g6n-IntegrationIcon e1vaar1z1"
+              <IntegrationIcon
                 src="icon-github"
               >
-                <StyledSvg
+                <InlineSvg
                   className="css-qf3g6n-IntegrationIcon e1vaar1z1"
-                  height="1em"
-                  viewBox={Object {}}
-                  width="1em"
+                  src="icon-github"
                 >
-                  <svg
-                    className="e1vaar1z1 css-18jkql6-StyledSvg-IntegrationIcon e2idor0"
+                  <StyledSvg
+                    className="css-qf3g6n-IntegrationIcon e1vaar1z1"
                     height="1em"
                     viewBox={Object {}}
                     width="1em"
                   >
-                    <use
-                      href="#test"
-                      xlinkHref="#test"
-                    />
-                  </svg>
-                </StyledSvg>
-              </InlineSvg>
-            </IntegrationIcon>
-            <IntegrationLink
-              href={null}
-              onClick={[Function]}
-            >
-              <a
-                className="css-oytllg-IntegrationLink e1vaar1z2"
+                    <svg
+                      className="e1vaar1z1 css-18jkql6-StyledSvg-IntegrationIcon e2idor0"
+                      height="1em"
+                      viewBox={Object {}}
+                      width="1em"
+                    >
+                      <use
+                        href="#test"
+                        xlinkHref="#test"
+                      />
+                    </svg>
+                  </StyledSvg>
+                </InlineSvg>
+              </IntegrationIcon>
+              <IntegrationLink
                 href={null}
                 onClick={[Function]}
               >
-                Link GitHub Issue
-              </a>
-            </IntegrationLink>
-          </span>
+                <a
+                  className="css-oytllg-IntegrationLink e1vaar1z2"
+                  href={null}
+                  onClick={[Function]}
+                >
+                  Link GitHub Issue
+                </a>
+              </IntegrationLink>
+            </span>
+          </Container>
         </Hovercard>
         <OpenCloseIcon
           isLinked={null}

--- a/tests/js/spec/views/__snapshots__/groupSimilarView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/groupSimilarView.spec.jsx.snap
@@ -1058,6 +1058,42 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                       displayTimeout={100}
                     >
                       <Container
+                        innerRef={
+                          Object {
+                            "current": <span
+                              class="css-s35yzd-Container e38w1je1"
+                            >
+                              <div
+                                class="css-omtyju-StyledScoreBar eecxaw40"
+                              >
+                                <div
+                                  class="css-1jrlewc-Bar eecxaw41"
+                                  color="#98b480"
+                                  size="40"
+                                />
+                                <div
+                                  class="css-1jrlewc-Bar eecxaw41"
+                                  color="#98b480"
+                                  size="40"
+                                />
+                                <div
+                                  class="css-1jrlewc-Bar eecxaw41"
+                                  color="#98b480"
+                                  size="40"
+                                />
+                                <div
+                                  class="css-1jrlewc-Bar eecxaw41"
+                                  color="#98b480"
+                                  size="40"
+                                />
+                                <div
+                                  class="css-15vxee-Bar eecxaw41"
+                                  size="40"
+                                />
+                              </div>
+                            </span>,
+                          }
+                        }
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
@@ -1169,6 +1205,38 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                       displayTimeout={100}
                     >
                       <Container
+                        innerRef={
+                          Object {
+                            "current": <span
+                              class="css-s35yzd-Container e38w1je1"
+                            >
+                              <div
+                                class="css-omtyju-StyledScoreBar eecxaw40"
+                              >
+                                <div
+                                  class="css-15vxee-Bar eecxaw41"
+                                  size="40"
+                                />
+                                <div
+                                  class="css-15vxee-Bar eecxaw41"
+                                  size="40"
+                                />
+                                <div
+                                  class="css-15vxee-Bar eecxaw41"
+                                  size="40"
+                                />
+                                <div
+                                  class="css-15vxee-Bar eecxaw41"
+                                  size="40"
+                                />
+                                <div
+                                  class="css-15vxee-Bar eecxaw41"
+                                  size="40"
+                                />
+                              </div>
+                            </span>,
+                          }
+                        }
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >

--- a/tests/js/spec/views/__snapshots__/groupSimilarView.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/groupSimilarView.spec.jsx.snap
@@ -1057,102 +1057,107 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                       }
                       displayTimeout={100}
                     >
-                      <span
-                        className="hovercard-container"
+                      <Container
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <StyledScoreBar
-                          score={4}
-                          vertical={true}
+                        <span
+                          className="css-s35yzd-Container e38w1je1"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                         >
-                          <ScoreBar
-                            className="css-omtyju-StyledScoreBar eecxaw40"
-                            palette={
-                              Array [
-                                "#ec5e44",
-                                "#f38259",
-                                "#f9a66d",
-                                "#98b480",
-                                "#57be8c",
-                              ]
-                            }
+                          <StyledScoreBar
                             score={4}
-                            size={40}
-                            thickness={4}
                             vertical={true}
                           >
-                            <div
+                            <ScoreBar
                               className="css-omtyju-StyledScoreBar eecxaw40"
+                              palette={
+                                Array [
+                                  "#ec5e44",
+                                  "#f38259",
+                                  "#f9a66d",
+                                  "#98b480",
+                                  "#57be8c",
+                                ]
+                              }
+                              score={4}
+                              size={40}
+                              thickness={4}
+                              vertical={true}
                             >
-                              <Bar
-                                color="#98b480"
-                                key="0"
-                                size={40}
-                                thickness={4}
-                                vertical={true}
+                              <div
+                                className="css-omtyju-StyledScoreBar eecxaw40"
                               >
-                                <div
-                                  className="css-1jrlewc-Bar eecxaw41"
+                                <Bar
                                   color="#98b480"
+                                  key="0"
                                   size={40}
-                                />
-                              </Bar>
-                              <Bar
-                                color="#98b480"
-                                key="1"
-                                size={40}
-                                thickness={4}
-                                vertical={true}
-                              >
-                                <div
-                                  className="css-1jrlewc-Bar eecxaw41"
+                                  thickness={4}
+                                  vertical={true}
+                                >
+                                  <div
+                                    className="css-1jrlewc-Bar eecxaw41"
+                                    color="#98b480"
+                                    size={40}
+                                  />
+                                </Bar>
+                                <Bar
                                   color="#98b480"
+                                  key="1"
                                   size={40}
-                                />
-                              </Bar>
-                              <Bar
-                                color="#98b480"
-                                key="2"
-                                size={40}
-                                thickness={4}
-                                vertical={true}
-                              >
-                                <div
-                                  className="css-1jrlewc-Bar eecxaw41"
+                                  thickness={4}
+                                  vertical={true}
+                                >
+                                  <div
+                                    className="css-1jrlewc-Bar eecxaw41"
+                                    color="#98b480"
+                                    size={40}
+                                  />
+                                </Bar>
+                                <Bar
                                   color="#98b480"
+                                  key="2"
                                   size={40}
-                                />
-                              </Bar>
-                              <Bar
-                                color="#98b480"
-                                key="3"
-                                size={40}
-                                thickness={4}
-                                vertical={true}
-                              >
-                                <div
-                                  className="css-1jrlewc-Bar eecxaw41"
+                                  thickness={4}
+                                  vertical={true}
+                                >
+                                  <div
+                                    className="css-1jrlewc-Bar eecxaw41"
+                                    color="#98b480"
+                                    size={40}
+                                  />
+                                </Bar>
+                                <Bar
                                   color="#98b480"
+                                  key="3"
                                   size={40}
-                                />
-                              </Bar>
-                              <Bar
-                                empty={true}
-                                key="empty-0"
-                                size={40}
-                                thickness={4}
-                                vertical={true}
-                              >
-                                <div
-                                  className="css-15vxee-Bar eecxaw41"
+                                  thickness={4}
+                                  vertical={true}
+                                >
+                                  <div
+                                    className="css-1jrlewc-Bar eecxaw41"
+                                    color="#98b480"
+                                    size={40}
+                                  />
+                                </Bar>
+                                <Bar
+                                  empty={true}
+                                  key="empty-0"
                                   size={40}
-                                />
-                              </Bar>
-                            </div>
-                          </ScoreBar>
-                        </StyledScoreBar>
-                      </span>
+                                  thickness={4}
+                                  vertical={true}
+                                >
+                                  <div
+                                    className="css-15vxee-Bar eecxaw41"
+                                    size={40}
+                                  />
+                                </Bar>
+                              </div>
+                            </ScoreBar>
+                          </StyledScoreBar>
+                        </span>
+                      </Container>
                     </Hovercard>
                   </div>
                   <div
@@ -1163,98 +1168,103 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                       body={0}
                       displayTimeout={100}
                     >
-                      <span
-                        className="hovercard-container"
+                      <Container
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <StyledScoreBar
-                          score={0}
-                          vertical={true}
+                        <span
+                          className="css-s35yzd-Container e38w1je1"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                         >
-                          <ScoreBar
-                            className="css-omtyju-StyledScoreBar eecxaw40"
-                            palette={
-                              Array [
-                                "#ec5e44",
-                                "#f38259",
-                                "#f9a66d",
-                                "#98b480",
-                                "#57be8c",
-                              ]
-                            }
+                          <StyledScoreBar
                             score={0}
-                            size={40}
-                            thickness={4}
                             vertical={true}
                           >
-                            <div
+                            <ScoreBar
                               className="css-omtyju-StyledScoreBar eecxaw40"
+                              palette={
+                                Array [
+                                  "#ec5e44",
+                                  "#f38259",
+                                  "#f9a66d",
+                                  "#98b480",
+                                  "#57be8c",
+                                ]
+                              }
+                              score={0}
+                              size={40}
+                              thickness={4}
+                              vertical={true}
                             >
-                              <Bar
-                                empty={true}
-                                key="empty-0"
-                                size={40}
-                                thickness={4}
-                                vertical={true}
+                              <div
+                                className="css-omtyju-StyledScoreBar eecxaw40"
                               >
-                                <div
-                                  className="css-15vxee-Bar eecxaw41"
+                                <Bar
+                                  empty={true}
+                                  key="empty-0"
                                   size={40}
-                                />
-                              </Bar>
-                              <Bar
-                                empty={true}
-                                key="empty-1"
-                                size={40}
-                                thickness={4}
-                                vertical={true}
-                              >
-                                <div
-                                  className="css-15vxee-Bar eecxaw41"
+                                  thickness={4}
+                                  vertical={true}
+                                >
+                                  <div
+                                    className="css-15vxee-Bar eecxaw41"
+                                    size={40}
+                                  />
+                                </Bar>
+                                <Bar
+                                  empty={true}
+                                  key="empty-1"
                                   size={40}
-                                />
-                              </Bar>
-                              <Bar
-                                empty={true}
-                                key="empty-2"
-                                size={40}
-                                thickness={4}
-                                vertical={true}
-                              >
-                                <div
-                                  className="css-15vxee-Bar eecxaw41"
+                                  thickness={4}
+                                  vertical={true}
+                                >
+                                  <div
+                                    className="css-15vxee-Bar eecxaw41"
+                                    size={40}
+                                  />
+                                </Bar>
+                                <Bar
+                                  empty={true}
+                                  key="empty-2"
                                   size={40}
-                                />
-                              </Bar>
-                              <Bar
-                                empty={true}
-                                key="empty-3"
-                                size={40}
-                                thickness={4}
-                                vertical={true}
-                              >
-                                <div
-                                  className="css-15vxee-Bar eecxaw41"
+                                  thickness={4}
+                                  vertical={true}
+                                >
+                                  <div
+                                    className="css-15vxee-Bar eecxaw41"
+                                    size={40}
+                                  />
+                                </Bar>
+                                <Bar
+                                  empty={true}
+                                  key="empty-3"
                                   size={40}
-                                />
-                              </Bar>
-                              <Bar
-                                empty={true}
-                                key="empty-4"
-                                size={40}
-                                thickness={4}
-                                vertical={true}
-                              >
-                                <div
-                                  className="css-15vxee-Bar eecxaw41"
+                                  thickness={4}
+                                  vertical={true}
+                                >
+                                  <div
+                                    className="css-15vxee-Bar eecxaw41"
+                                    size={40}
+                                  />
+                                </Bar>
+                                <Bar
+                                  empty={true}
+                                  key="empty-4"
                                   size={40}
-                                />
-                              </Bar>
-                            </div>
-                          </ScoreBar>
-                        </StyledScoreBar>
-                      </span>
+                                  thickness={4}
+                                  vertical={true}
+                                >
+                                  <div
+                                    className="css-15vxee-Bar eecxaw41"
+                                    size={40}
+                                  />
+                                </Bar>
+                              </div>
+                            </ScoreBar>
+                          </StyledScoreBar>
+                        </span>
+                      </Container>
                     </Hovercard>
                   </div>
                 </div>


### PR DESCRIPTION
Refactors the Hovercard component to be primarily based off of styled components.

There are still various elements used within the hovercard that are *not* styled components, so the rendered element retains it's `hovercard` class so that these styles may still apply.

Converting this to a styled component also comes with the benefits of:

 - Positioning in the middle on the X axis now also correctly handles hovercards of different widths.

 - The hovercard will now correctly position itself and the top and bottom of elements that are taller than ~ 18px.