### PR TITLE
fix(ui): Better key for AvatarList items

### DIFF
--- a/src/sentry/static/sentry/app/components/avatar/avatarList.jsx
+++ b/src/sentry/static/sentry/app/components/avatar/avatarList.jsx
@@ -47,7 +47,7 @@ export default class AvatarList extends React.Component {
         {visibleUsers.map(user => {
           return (
             <StyledAvatar
-              key={user.id}
+              key={`${user.id}-${user.email}`}
               user={user}
               size={avatarSize}
               renderTooltip={renderTooltip}

--- a/tests/js/spec/components/avatar/__snapshots__/avatarList.spec.jsx.snap
+++ b/tests/js/spec/components/avatar/__snapshots__/avatarList.spec.jsx.snap
@@ -131,7 +131,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
         </Tooltip>
         <StyledAvatar
           hasTooltip={true}
-          key="1"
+          key="1-foo@example.com"
           size={28}
           user={
             Object {
@@ -280,7 +280,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
         </StyledAvatar>
         <StyledAvatar
           hasTooltip={true}
-          key="2"
+          key="2-foo@example.com"
           size={28}
           user={
             Object {
@@ -429,7 +429,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
         </StyledAvatar>
         <StyledAvatar
           hasTooltip={true}
-          key="3"
+          key="3-foo@example.com"
           size={28}
           user={
             Object {
@@ -578,7 +578,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
         </StyledAvatar>
         <StyledAvatar
           hasTooltip={true}
-          key="4"
+          key="4-foo@example.com"
           size={28}
           user={
             Object {
@@ -727,7 +727,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
         </StyledAvatar>
         <StyledAvatar
           hasTooltip={true}
-          key="5"
+          key="5-foo@example.com"
           size={28}
           user={
             Object {
@@ -931,7 +931,7 @@ exports[`AvatarList renders with user avatars 1`] = `
       >
         <StyledAvatar
           hasTooltip={true}
-          key="1"
+          key="1-foo@example.com"
           size={28}
           user={
             Object {
@@ -1080,7 +1080,7 @@ exports[`AvatarList renders with user avatars 1`] = `
         </StyledAvatar>
         <StyledAvatar
           hasTooltip={true}
-          key="2"
+          key="2-foo@example.com"
           size={28}
           user={
             Object {


### PR DESCRIPTION
Sometimes the id would be unset (mock data or for avatars for non-users) and we would get key errors.