### PR TITLE
feat: Log sourcemap compression errors on cache set

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -4,6 +4,7 @@ __all__ = ['JavaScriptStacktraceProcessor']
 
 import logging
 import re
+import sys
 import base64
 import six
 import zlib
@@ -247,8 +248,8 @@ def fetch_release_file(filename, release, dist=None):
             with metrics.timer('sourcemaps.release_file_read'):
                 with releasefile.file.getfile() as fp:
                     z_body, body = compress_file(fp)
-        except Exception as e:
-            logger.exception(six.text_type(e))
+        except Exception:
+            logger.error('sourcemap.compress_read_failed', exc_info=sys.exc_info())
             cache.set(cache_key, -1, 3600)
             result = None
         else:


### PR DESCRIPTION
I'm suspecting this is masking some errors and it would be good to know if this is the root of some users not getting their artifacts used.