### PR TITLE
feat: Lower the cache time for bad reads from GCS for release artifacts

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -250,7 +250,7 @@ def fetch_release_file(filename, release, dist=None):
                     z_body, body = compress_file(fp)
         except Exception:
             logger.error('sourcemap.compress_read_failed', exc_info=sys.exc_info())
-            cache.set(cache_key, -1, 3600)
+            cache.set(cache_key, -1, 60)
             result = None
         else:
             headers = {k.lower(): v for k, v in releasefile.file.headers.items()}

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -250,7 +250,6 @@ def fetch_release_file(filename, release, dist=None):
                     z_body, body = compress_file(fp)
         except Exception:
             logger.error('sourcemap.compress_read_failed', exc_info=sys.exc_info())
-            cache.set(cache_key, -1, 60)
             result = None
         else:
             headers = {k.lower(): v for k, v in releasefile.file.headers.items()}


### PR DESCRIPTION
The negative cache is around a section where we should never fail, but we fail due to GCS read errors. This proposes to lower the impact of a bad read to 60 seconds.

I'm also thinking of just not caching the failure here at all.