### PR TITLE
fix(api): Use ValidationError instead of APIException to fix TypeError

### DIFF
--- a/src/sentry/api/fields/avatar.py
+++ b/src/sentry/api/fields/avatar.py
@@ -47,7 +47,7 @@ class AvatarField(serializers.WritableField):
             with Image.open(BytesIO(data)) as img:
                 width, height = img.size
                 if not self.is_valid_size(width, height):
-                    raise APIException('Invalid image dimensions.', status_code=400)
+                    raise serializers.ValidationError('Invalid image dimensions.')
         except IOError:
             raise serializers.ValidationError('Invalid image format.')
 


### PR DESCRIPTION
`status_code` isn't a valid argument for `APIException`

fixes SENTRY-6RC