### PR TITLE
fix(integrations) Gracefully handle oauth provider failures

### DIFF
--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function
 
 __all__ = ['OAuth2Provider', 'OAuth2CallbackView', 'OAuth2LoginView']
 
+import logging
 from six.moves.urllib.parse import parse_qsl, urlencode
 from uuid import uuid4
 from time import time
@@ -18,6 +19,7 @@ from sentry.pipeline import PipelineView
 
 from .base import Provider
 
+logger = logging.getLogger(__name__)
 ERR_INVALID_STATE = 'An error occurred while validating your request.'
 
 
@@ -257,12 +259,19 @@ class OAuth2CallbackView(PipelineView):
                 return dict(parse_qsl(body))
             return json.loads(body)
         except SSLError:
+            logger.info('identity.oauth2.ssl-error', extra={
+                'url': self.access_token_url,
+                'verify_ssl': verify_ssl,
+            })
             url = self.access_token_url
             return {
                 'error': 'Could not verify SSL certificate',
                 'error_description': u'Ensure that {} has a valid SSL certificate'.format(url)
             }
         except JSONDecodeError:
+            logger.info('identity.oauth2.json-error', extra={
+                'url': self.access_token_url,
+            })
             return {
                 'error': 'Could not decode a JSON Response',
                 'error_description': u'We were not able to parse a JSON response, please try again.'

--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -5,8 +5,9 @@ __all__ = ['OAuth2Provider', 'OAuth2CallbackView', 'OAuth2LoginView']
 from six.moves.urllib.parse import parse_qsl, urlencode
 from uuid import uuid4
 from time import time
-from django.views.decorators.csrf import csrf_exempt
 from requests.exceptions import SSLError
+from simplejson import JSONDecodeError
+from django.views.decorators.csrf import csrf_exempt
 
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.http import safe_urlopen, safe_urlread
@@ -260,6 +261,11 @@ class OAuth2CallbackView(PipelineView):
             return {
                 'error': 'Could not verify SSL certificate',
                 'error_description': u'Ensure that {} has a valid SSL certificate'.format(url)
+            }
+        except JSONDecodeError:
+            return {
+                'error': 'Could not decode a JSON Response',
+                'error_description': u'We were not able to parse a JSON response, please try again.'
             }
 
     def dispatch(self, request, pipeline):

--- a/tests/sentry/auth/providers/test_oauth2.py
+++ b/tests/sentry/auth/providers/test_oauth2.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function
 
 import pytest
+from exam import fixture
 
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.auth.providers.oauth2 import OAuth2Provider
@@ -12,15 +13,18 @@ class OAuth2ProviderTest(TestCase):
     def setUp(self):
         self.org = self.create_organization(owner=self.user)
         self.user = self.create_user('foo@example.com')
-        self.auth_provider = AuthProvider.objects.create(
+        super(OAuth2ProviderTest, self).setUp()
+
+    @fixture
+    def auth_provider(self):
+        return AuthProvider.objects.create(
             provider='oauth2',
             organization=self.org,
         )
-        self.provider = self.get_provider()
-        super(OAuth2ProviderTest, self).setUp()
 
-    def get_provider(self):
-        self.provider = OAuth2Provider(key=self.auth_provider.provider)
+    @fixture
+    def provider(self):
+        return OAuth2Provider(key=self.auth_provider.provider)
 
     def test_refresh_identity_without_refresh_token(self):
         auth_identity = AuthIdentity.objects.create(

--- a/tests/sentry/identity/__init__.py
+++ b/tests/sentry/identity/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/identity/test_oauth2.py
+++ b/tests/sentry/identity/test_oauth2.py
@@ -1,0 +1,87 @@
+from __future__ import absolute_import
+
+import responses
+from exam import fixture
+from mock import Mock
+from requests.exceptions import SSLError
+
+import sentry.identity
+from sentry.identity.oauth2 import OAuth2CallbackView
+from sentry.identity.pipeline import IdentityProviderPipeline
+from sentry.identity.providers.dummy import DummyProvider
+from sentry.testutils import TestCase
+
+
+class OAuth2CallbackViewTest(TestCase):
+
+    def setUp(self):
+        self.org = self.create_organization(owner=self.user)
+        self.user = self.create_user('foo@example.com')
+        sentry.identity.register(DummyProvider)
+        super(OAuth2CallbackViewTest, self).setUp()
+
+    def tearDown(self):
+        super(OAuth2CallbackViewTest, self).tearDown()
+        sentry.identity.unregister(DummyProvider)
+
+    @fixture
+    def view(self):
+        return OAuth2CallbackView(
+            access_token_url='https://example.org/oauth/token',
+            client_id=123456,
+            client_secret='secret-value'
+        )
+
+    @responses.activate
+    def test_exchange_token_success(self):
+        responses.add(
+            responses.POST,
+            'https://example.org/oauth/token',
+            json={'token': 'a-fake-token'}
+        )
+        pipeline = IdentityProviderPipeline(
+            request=Mock(),
+            provider_key='dummy'
+        )
+        code = 'auth-code'
+        result = self.view.exchange_token(None, pipeline, code)
+        assert 'token' in result
+        assert 'a-fake-token' == result['token']
+
+    @responses.activate
+    def test_exchange_token_ssl_error(self):
+        def ssl_error(request):
+            raise SSLError('Could not build connection')
+        responses.add_callback(
+            responses.POST,
+            'https://example.org/oauth/token',
+            callback=ssl_error
+        )
+        pipeline = IdentityProviderPipeline(
+            request=Mock(),
+            provider_key='dummy'
+        )
+        code = 'auth-code'
+        result = self.view.exchange_token(None, pipeline, code)
+        assert 'token' not in result
+        assert 'error' in result
+        assert 'error_description' in result
+        assert 'SSL' in result['error_description']
+
+    @responses.activate
+    def test_exchange_token_no_json(self):
+        responses.add(
+            responses.POST,
+            'https://example.org/oauth/token',
+            body=''
+        )
+        pipeline = IdentityProviderPipeline(
+            request=Mock(),
+            provider_key='dummy'
+        )
+        code = 'auth-code'
+        result = self.view.exchange_token(None, pipeline, code)
+        assert 'token' not in result
+        assert 'error' in result
+        assert 'error_description' in result
+        assert 'JSON' in result['error_description']


### PR DESCRIPTION
When an identity provider like GitLab or GitHub sends us garbage JSON we don't need a sentry issue as there isn't much we can do about it. Handle these errors and display user facing errors.

Fixes SENTRY-86W