### PR TITLE
fix(ui): Fix DropdownAutoCompleteMenu group headers w/ virtualized rows

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -173,10 +173,19 @@ class DropdownAutoCompleteMenu extends React.Component {
     if (items[0] && items[0].items) {
       //if the first item has children, we assume it is a group
       return _.flatMap(this.filterGroupedItems(items, inputValue), item => {
-        return [
-          {...item, groupLabel: true},
-          ...item.items.map(groupedItem => ({...groupedItem, index: itemCount++})),
-        ];
+        const groupItems = item.items.map(groupedItem => ({
+          ...groupedItem,
+          index: itemCount++,
+        }));
+
+        // Make sure we don't add the group label to list of items
+        // if we try to hide it, otherwise it will render if the list
+        // is using virtualized rows (because of fixed row heights)
+        if (item.hideGroupLabel) {
+          return groupItems;
+        }
+
+        return [{...item, groupLabel: true}, ...groupItems];
       });
     }
 
@@ -231,11 +240,9 @@ class DropdownAutoCompleteMenu extends React.Component {
     const {index} = item;
 
     return item.groupLabel ? (
-      !item.hideGroupLabel && (
-        <LabelWithBorder style={style} key={item.label || item.id}>
-          {item.label && <GroupLabel>{item.label}</GroupLabel>}
-        </LabelWithBorder>
-      )
+      <LabelWithBorder style={style} key={item.label || item.id}>
+        {item.label && <GroupLabel>{item.label}</GroupLabel>}
+      </LabelWithBorder>
     ) : (
       <AutoCompleteItem
         size={itemSize}


### PR DESCRIPTION
Do not add hidden group labels to the dropdown item list. This causes an empty row if
we are using virtualized rows because of fixed row heights per item in list.