### PR TITLE
feat(ui): Add icon prop to tag component

### DIFF
--- a/docs-ui/components/tag.stories.js
+++ b/docs-ui/components/tag.stories.js
@@ -38,4 +38,10 @@ storiesOf('UI|Tags', module)
         Development
       </Tag>
     ))
+  )
+  .add(
+    'with icon',
+    withInfo(
+      'A tag-like thing with an icon. Use when you need to represent something'
+    )(() => <Tag icon="icon-lock">Locked</Tag>)
   );

--- a/src/sentry/static/sentry/app/views/settings/components/tag.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/tag.jsx
@@ -1,7 +1,9 @@
+import {Box} from 'grid-emotion';
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
-import PropTypes from 'prop-types';
-import {Box} from 'grid-emotion';
+
+import InlineSvg from 'app/components/inlineSvg';
 
 const getMarginLeft = p => {
   if (!p.inline) return '';
@@ -16,7 +18,7 @@ const getBorder = p =>
     : '';
 
 const TagTextStyled = styled(({priority, size, border, ...props}) => <Box {...props} />)`
-  display: inline;
+  display: inline-flex;
   padding: ${p => (p.size == 'small' ? '0.1em 0.4em 0.2em' : '0.35em 0.8em 0.4em')};
   font-size: 75%;
   line-height: 1;
@@ -33,8 +35,9 @@ const TagTextStyled = styled(({priority, size, border, ...props}) => <Box {...pr
   ${p => getMarginLeft(p)};
 `;
 
-const Tag = ({children, priority, size, border, ...props}) => (
+const Tag = ({children, icon, priority, size, border, ...props}) => (
   <TagTextStyled priority={priority} size={size} border={border} {...props}>
+    {icon && <StyledInlineSvg src={icon} size="12px" />}
     {children}
   </TagTextStyled>
 );
@@ -43,6 +46,11 @@ Tag.propTypes = {
   priority: PropTypes.string,
   size: PropTypes.string,
   border: PropTypes.bool,
+  icon: PropTypes.string,
 };
+
+const StyledInlineSvg = styled(InlineSvg)`
+  margin-right: 4px;
+`;
 
 export default Tag;

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -734,20 +734,20 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                 priority="success"
                               >
                                 <Component
-                                  className="css-ftrjq0-TagTextStyled e6q9yfr0"
+                                  className="css-vkfyy4-TagTextStyled e6q9yfr0"
                                   ml={1}
                                   priority="success"
                                 >
                                   <Box
-                                    className="css-ftrjq0-TagTextStyled e6q9yfr0"
+                                    className="css-vkfyy4-TagTextStyled e6q9yfr0"
                                     ml={1}
                                   >
                                     <Base
-                                      className="e6q9yfr0 css-hqgxmh-TagTextStyled"
+                                      className="e6q9yfr0 css-1kuo0ex-TagTextStyled"
                                       ml={1}
                                     >
                                       <div
-                                        className="e6q9yfr0 css-hqgxmh-TagTextStyled"
+                                        className="e6q9yfr0 css-1kuo0ex-TagTextStyled"
                                         is={null}
                                       >
                                         Default


### PR DESCRIPTION
[Story in storybook](https://storybook.getsentry.net/branches/featui-add-icon-prop-to-tag-component/index.html?selectedKind=UI%7CTags&selectedStory=with%20icon&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Fstories%2Fstories-panel)

![image](https://user-images.githubusercontent.com/1421724/48376454-d4c95700-e67f-11e8-9779-67e8cf86edeb.png)