### PR TITLE
ref(auth): Map sso auth providers 1 <-> to features

### DIFF
--- a/src/sentry/auth/provider.py
+++ b/src/sentry/auth/provider.py
@@ -25,7 +25,9 @@ class Provider(object):
     including its configuration and basic identity management.
     """
     name = None
-    required_feature = None
+
+    # All auth providers by default require the sso-basic feature
+    required_feature = 'organizations:sso-basic'
 
     def __init__(self, key, **config):
         self.key = key

--- a/src/sentry/web/frontend/organization_auth_settings.py
+++ b/src/sentry/web/frontend/organization_auth_settings.py
@@ -33,6 +33,7 @@ class AuthProviderSettingsForm(forms.Form):
         help_text=_('Require members use a valid linked SSO account to access this organization'),
         required=False,
     )
+
     default_role = forms.ChoiceField(
         label=_('Default Role'),
         choices=roles.get_choices(),
@@ -156,16 +157,6 @@ class OrganizationAuthSettingsView(OrganizationView):
 
     @transaction.atomic
     def handle(self, request, organization):
-        if not features.has('organizations:sso-basic', organization, actor=request.user):
-            messages.add_message(
-                request,
-                messages.ERROR,
-                ERR_NO_SSO,
-            )
-            return HttpResponseRedirect(
-                reverse('sentry-organization-home', args=[organization.slug])
-            )
-
         try:
             auth_provider = AuthProvider.objects.get(
                 organization=organization,
@@ -173,6 +164,20 @@ class OrganizationAuthSettingsView(OrganizationView):
         except AuthProvider.DoesNotExist:
             pass
         else:
+            provider = auth_provider.get_provider()
+            requires_feature = provider.required_feature
+
+            # Provider is not enabled
+            if requires_feature and not features.has(
+                    requires_feature,
+                    organization,
+                    actor=request.user
+            ):
+                home_url = reverse('sentry-organization-home', args=[organization.slug])
+                messages.add_message(request, messages.ERROR, ERR_NO_SSO)
+
+                return HttpResponseRedirect(home_url)
+
             return self.handle_existing_provider(
                 request=request,
                 organization=organization,


### PR DESCRIPTION
Currently all auth providers needed the sso-basic feature to be enabled.  This changes that mapping so that each provider has exactly 1 features that enables the functionality.

sso-basic → github, google, 3rd part providers
sso-saml2 → all SAML providers
sso-rippling → rippling provider (gated differently on sentry.io)

This makes marking each feature as enabled / disabled on sentry and sentry.io simpler.