### PR TITLE
fix(ui) Don't load data we don't use in project owners

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/index.jsx
@@ -29,10 +29,7 @@ class ProjectOwnership extends AsyncView {
 
   getEndpoints() {
     let {organization, project} = this.props;
-    return [
-      ['project', `/projects/${organization.slug}/${project.slug}/`],
-      ['ownership', `/projects/${organization.slug}/${project.slug}/ownership/`],
-    ];
+    return [['ownership', `/projects/${organization.slug}/${project.slug}/ownership/`]];
   }
 
   renderBody() {


### PR DESCRIPTION
When rendering we use this.props.project not this.state.project, so we don't need to re-fetch the project.