### PR TITLE
ref(integrations): Expose 503s to the enduser rather than give a 500 Internal Error.

### DIFF
--- a/src/sentry/api/bases/integration.py
+++ b/src/sentry/api/bases/integration.py
@@ -24,5 +24,4 @@ class IntegrationEndpoint(OrganizationEndpoint):
             response = Response(context, status=503)
             response.exception = True
             return response
-        response = super(IntegrationEndpoint, self).handle_exception(exc)
-        return response
+        return super(IntegrationEndpoint, self).handle_exception(exc)

--- a/src/sentry/api/bases/integration.py
+++ b/src/sentry/api/bases/integration.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import
+
+import six
+
+from rest_framework.response import Response
+
+from sentry.integrations.exceptions import ApiHostError
+from sentry.utils.sdk import capture_exception
+
+from .organization import OrganizationEndpoint, OrganizationPermission
+
+
+class IntegrationEndpoint(OrganizationEndpoint):
+    permission_classes = (OrganizationPermission, )
+
+    def handle_exception(self, request, exc):
+        if isinstance(exc, ApiHostError) or exc.code == 503:
+            import sys
+            import traceback
+            sys.stderr.write(traceback.format_exc())
+            event_id = capture_exception()
+            context = {
+                'detail': six.text_type(exc),
+                'errorId': event_id,
+            }
+            response = Response(context, status=503)
+            response.exception = True
+            return response
+        response = super(IntegrationEndpoint, self).handle_exception(exc)
+        return response

--- a/src/sentry/api/bases/integration.py
+++ b/src/sentry/api/bases/integration.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import
 
 import six
+import sys
+import traceback
 
 from rest_framework.response import Response
-
-from sentry.integrations.exceptions import ApiHostError
 from sentry.utils.sdk import capture_exception
 
 from .organization import OrganizationEndpoint, OrganizationPermission
@@ -14,9 +14,7 @@ class IntegrationEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationPermission, )
 
     def handle_exception(self, request, exc):
-        if isinstance(exc, ApiHostError) or exc.code == 503:
-            import sys
-            import traceback
+        if exc.code == 503:
             sys.stderr.write(traceback.format_exc())
             event_id = capture_exception()
             context = {

--- a/src/sentry/integrations/bitbucket/search.py
+++ b/src/sentry/integrations/bitbucket/search.py
@@ -2,12 +2,11 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
-from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.bases.integration import IntegrationEndpoint
 from sentry.models import Integration
 
 
-class BitbucketSearchEndpoint(OrganizationEndpoint):
-    permission_classes = (OrganizationPermission, )
+class BitbucketSearchEndpoint(IntegrationEndpoint):
 
     def get(self, request, organization, integration_id):
         try:

--- a/src/sentry/integrations/github/search.py
+++ b/src/sentry/integrations/github/search.py
@@ -2,12 +2,11 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
-from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.bases.integration import IntegrationEndpoint
 from sentry.models import Integration
 
 
-class GitHubSearchEndpoint(OrganizationEndpoint):
-    permission_classes = (OrganizationPermission, )
+class GitHubSearchEndpoint(IntegrationEndpoint):
 
     def get(self, request, organization, integration_id):
         try:

--- a/src/sentry/integrations/gitlab/search.py
+++ b/src/sentry/integrations/gitlab/search.py
@@ -2,12 +2,11 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
-from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.bases.integration import IntegrationEndpoint
 from sentry.models import Integration
 
 
-class GitlabIssueSearchEndpoint(OrganizationEndpoint):
-    permission_classes = (OrganizationPermission, )
+class GitlabIssueSearchEndpoint(IntegrationEndpoint):
 
     def get(self, request, organization, integration_id):
         try:

--- a/src/sentry/integrations/jira/search.py
+++ b/src/sentry/integrations/jira/search.py
@@ -4,13 +4,12 @@ from six.moves.urllib.parse import parse_qs, unquote_plus, urlencode, urlsplit, 
 
 from rest_framework.response import Response
 
-from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.bases.integration import IntegrationEndpoint
 from sentry.integrations.exceptions import ApiError, ApiUnauthorized
 from sentry.models import Integration
 
 
-class JiraSearchEndpoint(OrganizationEndpoint):
-    permission_classes = (OrganizationPermission, )
+class JiraSearchEndpoint(IntegrationEndpoint):
 
     def _get_formatted_user(self, user):
         display = '%s %s(%s)' % (

--- a/src/sentry/integrations/vsts/search.py
+++ b/src/sentry/integrations/vsts/search.py
@@ -1,13 +1,12 @@
 from __future__ import absolute_import
 
-from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.bases.integration import IntegrationEndpoint
 from rest_framework.response import Response
 
 from sentry.models import Integration
 
 
-class VstsSearchEndpoint(OrganizationEndpoint):
-    permission_classes = (OrganizationPermission, )
+class VstsSearchEndpoint(IntegrationEndpoint):
 
     def get(self, request, organization, integration_id):
         try:

--- a/tests/sentry/integrations/gitlab/test_search.py
+++ b/tests/sentry/integrations/gitlab/test_search.py
@@ -190,7 +190,7 @@ class GitlabSearchTest(GitLabTestCase):
                 'query': 'GetSentry',
             }
         )
-        assert resp.status_code == 500
+        assert resp.status_code == 503
 
     def test_projects_request_fails(self):
         responses.add(
@@ -204,4 +204,4 @@ class GitlabSearchTest(GitLabTestCase):
                 'query': 'GetSentry',
             }
         )
-        assert resp.status_code == 500
+        assert resp.status_code == 503


### PR DESCRIPTION
Created the `IntegrationEndpoint` class that inherits from `OrganizationEndpoint`, but will expose a `503` rather than throwing an internal error.