### PR TITLE
fix: Force ValuesListQuerySet evaluation in weekly report generation.

### DIFF
--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -166,11 +166,13 @@ def prepare_project_series(start__stop, project, rollup=60 * 60 * 24):
                 clean,
                 tsdb.get_range(
                     tsdb.models.group,
-                    project.group_set.filter(
-                        status=GroupStatus.RESOLVED,
-                        resolved_at__gte=start,
-                        resolved_at__lt=stop,
-                    ).values_list('id', flat=True),
+                    list(
+                        project.group_set.filter(
+                            status=GroupStatus.RESOLVED,
+                            resolved_at__gte=start,
+                            resolved_at__lt=stop,
+                        ).values_list('id', flat=True),
+                    ),
                     start,
                     stop,
                     rollup=rollup,


### PR DESCRIPTION
The Snuba TSDB backend requires [a sequence](https://github.com/getsentry/sentry/blob/a80d980b2b56884dbbe3a7d1ed6e57a1b25b0800/src/sentry/tsdb/snuba.py#L204-L216) here, so this forces evaluation of the queryset by casting it to a list.