### PR TITLE
analyics(ui): Add metric for app init

### DIFF
--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -25,6 +25,11 @@ import ajaxCsrfSetup from 'app/utils/ajaxCsrfSetup';
 import * as il8n from 'app/locale';
 import plugins from 'app/plugins';
 
+// Used for operational metrics to determine that the application js
+// bundle was loaded by browser
+window.__sentryMetrics = window.__sentryMetrics || {};
+window.__sentryMetrics.sentryAppInit = +new Date();
+
 // setup jquery for CSRF tokens
 jQuery.ajaxSetup({
   //jQuery won't allow using the ajaxCsrfSetup function directly

--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -27,8 +27,9 @@ import plugins from 'app/plugins';
 
 // Used for operational metrics to determine that the application js
 // bundle was loaded by browser
-window.__sentryMetrics = window.__sentryMetrics || {};
-window.__sentryMetrics.sentryAppInit = +new Date();
+if (window.performance) {
+  window.performance.mark('sentry-app-init');
+}
 
 // setup jquery for CSRF tokens
 jQuery.ajaxSetup({


### PR DESCRIPTION
Records time for when app bundle is initialized. This is just a crude metric for determining how long it takes our bundle to load and if it loads at all. We should explore the Performance API for our next set of metrics.