### PR TITLE
feat(discover): Prevent Early Flex-Wrap of View Options in Results

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
@@ -16,8 +16,10 @@ import {getChartData, getChartDataByDay, downloadAsCsv, getRowsPageRange} from '
 import Table from './table';
 import Pagination from './pagination';
 import {
+  ResultTitle,
   Heading,
   ResultSummary,
+  ResultViewButtons,
   ResultContainer,
   ResultInnerContainer,
   ChartWrapper,
@@ -84,8 +86,8 @@ export default class Result extends React.Component {
     const linkClasses = 'btn btn-default btn-sm';
 
     return (
-      <Flex flex="1" justify="flex-end">
-        <div className="btn-group">
+      <Flex justify="flex-end">
+        <ResultViewButtons className="btn-group">
           {options.map(opt => {
             const active = opt.id === this.state.view;
             return (
@@ -100,7 +102,7 @@ export default class Result extends React.Component {
               </a>
             );
           })}
-        </div>
+        </ResultViewButtons>
         <Box ml={1}>
           <Link className={linkClasses} onClick={() => downloadAsCsv(baseQuery.data)}>
             {t('Export CSV')}
@@ -178,9 +180,9 @@ export default class Result extends React.Component {
     return (
       <ResultContainer>
         <Flex align="center" mb={space(2)}>
-          <Box flex="1">
+          <ResultTitle>
             {savedQuery ? this.renderSavedQueryHeader() : this.renderQueryResultHeader()}
-          </Box>
+          </ResultTitle>
           {this.renderToggle()}
         </Flex>
         <ResultInnerContainer innerRef={ref => (this.container = ref)}>

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
@@ -19,7 +19,6 @@ import {
   ResultTitle,
   Heading,
   ResultSummary,
-  ResultViewButtons,
   ResultContainer,
   ResultInnerContainer,
   ChartWrapper,
@@ -87,7 +86,7 @@ export default class Result extends React.Component {
 
     return (
       <Flex justify="flex-end">
-        <ResultViewButtons className="btn-group">
+        <Flex className="btn-group">
           {options.map(opt => {
             const active = opt.id === this.state.view;
             return (
@@ -102,7 +101,7 @@ export default class Result extends React.Component {
               </a>
             );
           })}
-        </ResultViewButtons>
+        </Flex>
         <Box ml={1}>
           <Link className={linkClasses} onClick={() => downloadAsCsv(baseQuery.data)}>
             {t('Export CSV')}

--- a/src/sentry/static/sentry/app/views/organizationDiscover/styles.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/styles.jsx
@@ -38,14 +38,9 @@ export const PageTitle = styled.h2`
   height: ${HEADER_HEIGHT}px;
 `;
 
-export const ResultTitle = styled(Flex)`
+export const ResultTitle = styled(Box)`
   flex: 1;
   min-width: 70px;
-`;
-
-//TODO: Add @media for responsiveness
-export const ResultViewButtons = styled(Flex)`
-  justify-content: flex-end;
 `;
 
 export const Sidebar = styled(props => (

--- a/src/sentry/static/sentry/app/views/organizationDiscover/styles.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/styles.jsx
@@ -44,8 +44,8 @@ export const ResultTitle = styled(Flex)`
 `;
 
 //TODO: Add @media for responsiveness
-export const ResultViewButtons = styled('div')`
-  flex: flex-end;
+export const ResultViewButtons = styled(Flex)`
+  justify-content: flex-end;
 `;
 
 export const Sidebar = styled(props => (

--- a/src/sentry/static/sentry/app/views/organizationDiscover/styles.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/styles.jsx
@@ -38,6 +38,16 @@ export const PageTitle = styled.h2`
   height: ${HEADER_HEIGHT}px;
 `;
 
+export const ResultTitle = styled(Flex)`
+  flex: 1;
+  min-width: 70px;
+`;
+
+//TODO: Add @media for responsiveness
+export const ResultViewButtons = styled('div')`
+  flex: flex-end;
+`;
+
 export const Sidebar = styled(props => (
   <Flex {...props} direction="column" w={[320, 320, 320, 380]} />
 ))`


### PR DESCRIPTION
Previously, the views "table", "Line by Day", etc. would wrap too early, even though there is enough room to flex. 
This sets it up so it flexes appropriately and does not wrap the buttons, which changes the height too.
Will have a follow-up PR replacing with a dropdown selector in smaller viewports ~900px.

before at 940 px:
![image](https://user-images.githubusercontent.com/10991288/48384715-6f399280-e6a0-11e8-89c3-53d94ecb4dc3.png)


now 940px: 
![image](https://user-images.githubusercontent.com/10991288/48384647-27b30680-e6a0-11e8-9431-1331946ae50d.png)
