### PR TITLE
fix: Allow empty stacktraces

### DIFF
--- a/src/sentry/data/samples/empty-exception.json
+++ b/src/sentry/data/samples/empty-exception.json
@@ -16,13 +16,7 @@
     "server_name": "mcbk.local",
     "exception": {
         "values": [
-            null,
-            {},
-            {
-                "stacktrace": {
-                    "frames": []
-                }
-            }
+            null
         ]
     },
     "sdk": {

--- a/src/sentry/data/samples/empty-exception.json
+++ b/src/sentry/data/samples/empty-exception.json
@@ -1,5 +1,4 @@
 {
-    "event_id": "28434de4ccf346c3b9b95f07ec3a3846",
     "level": "error",
     "modules": {
         "certifi": "2018.4.16",

--- a/src/sentry/data/samples/empty-exception.json
+++ b/src/sentry/data/samples/empty-exception.json
@@ -11,7 +11,6 @@
         "wsgiref": "0.1.2"
     },
     "platform": "python",
-    "timestamp": 1539708807,
     "server_name": "mcbk.local",
     "exception": {
         "values": [

--- a/src/sentry/data/samples/empty-exception.json
+++ b/src/sentry/data/samples/empty-exception.json
@@ -1,0 +1,46 @@
+{
+    "event_id": "28434de4ccf346c3b9b95f07ec3a3846",
+    "level": "error",
+    "modules": {
+        "certifi": "2018.4.16",
+        "pip": "18.0",
+        "python": "2.7.15",
+        "sentry-sdk": "0.3.1",
+        "setuptools": "40.0.0",
+        "urllib3": "1.23",
+        "wheel": "0.31.1",
+        "wsgiref": "0.1.2"
+    },
+    "platform": "python",
+    "timestamp": 1539708807,
+    "server_name": "mcbk.local",
+    "exception": {
+        "values": [
+            null,
+            {},
+            {
+                "stacktrace": {
+                    "frames": []
+                }
+            }
+        ]
+    },
+    "sdk": {
+        "name": "sentry.python",
+        "version": "0.1",
+        "integrations": [
+            "logging",
+            "stdlib",
+            "excepthook",
+            "dedupe",
+            "atexit",
+            "modules"
+        ],
+        "packages": [
+            {
+                "name": "pypi:sentry-sdk",
+                "version": "0.1"
+            }
+        ]
+    }
+}

--- a/src/sentry/data/samples/empty-stacktrace.json
+++ b/src/sentry/data/samples/empty-stacktrace.json
@@ -11,7 +11,6 @@
         "wsgiref": "0.1.2"
     },
     "platform": "python",
-    "timestamp": 1539708807,
     "server_name": "mcbk.local",
     "stacktrace": {
         "frames": []

--- a/src/sentry/data/samples/empty-stacktrace.json
+++ b/src/sentry/data/samples/empty-stacktrace.json
@@ -1,5 +1,4 @@
 {
-    "event_id": "28434de4ccf346c3b9b95f07ec3a3846",
     "level": "error",
     "modules": {
         "certifi": "2018.4.16",

--- a/src/sentry/data/samples/empty-stacktrace.json
+++ b/src/sentry/data/samples/empty-stacktrace.json
@@ -14,12 +14,6 @@
     "platform": "python",
     "timestamp": 1539708807,
     "server_name": "mcbk.local",
-    "exception": {
-        "values": [
-            null,
-            {}
-        ]
-    },
     "stacktrace": {
         "frames": []
     },

--- a/src/sentry/data/samples/empty-stacktrace.json
+++ b/src/sentry/data/samples/empty-stacktrace.json
@@ -1,0 +1,44 @@
+{
+    "event_id": "28434de4ccf346c3b9b95f07ec3a3846",
+    "level": "error",
+    "modules": {
+        "certifi": "2018.4.16",
+        "pip": "18.0",
+        "python": "2.7.15",
+        "sentry-sdk": "0.3.1",
+        "setuptools": "40.0.0",
+        "urllib3": "1.23",
+        "wheel": "0.31.1",
+        "wsgiref": "0.1.2"
+    },
+    "platform": "python",
+    "timestamp": 1539708807,
+    "server_name": "mcbk.local",
+    "exception": {
+        "values": [
+            null,
+            {}
+        ]
+    },
+    "stacktrace": {
+        "frames": []
+    },
+    "sdk": {
+        "name": "sentry.python",
+        "version": "0.1",
+        "integrations": [
+            "logging",
+            "stdlib",
+            "excepthook",
+            "dedupe",
+            "atexit",
+            "modules"
+        ],
+        "packages": [
+            {
+                "name": "pypi:sentry-sdk",
+                "version": "0.1"
+            }
+        ]
+    }
+}

--- a/src/sentry/data/samples/pii.json
+++ b/src/sentry/data/samples/pii.json
@@ -12,7 +12,6 @@
         "wsgiref": "0.1.2"
     },
     "platform": "python",
-    "timestamp": 1539708807,
     "server_name": "mcbk.local",
     "exception": {
         "values": [

--- a/src/sentry/data/samples/unity.json
+++ b/src/sentry/data/samples/unity.json
@@ -1,7 +1,6 @@
 {
   "event_id": "ce6ab074ae0d45388af7a1cbb9eb092d",
   "message": "DivideByZeroException",
-  "timestamp": "2018-10-25T13:03:40",
   "logger": "",
   "platform": "csharp",
   "release": "1.1",

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -203,7 +203,7 @@ def generate_culprit(data, platform=None):
     try:
         stacktraces = [
             e['stacktrace'] for e in data['sentry.interfaces.Exception']['values']
-            if e.get('stacktrace')
+            if e and e.get('stacktrace')
         ]
     except KeyError:
         stacktrace = data.get('sentry.interfaces.Stacktrace')
@@ -633,7 +633,7 @@ class EventManager(object):
         if exception:
             sdk_info = get_sdk_from_event(data)
             for ex in exception['values']:
-                if 'mechanism' in ex:
+                if ex is not None and 'mechanism' in ex:
                     normalize_mechanism_meta(ex['mechanism'], sdk_info)
 
         # If there is no User ip_addres, update it either from the Http interface
@@ -689,6 +689,8 @@ class EventManager(object):
         for exception_interface in self._data.get(
             'sentry.interfaces.Exception', {}
         ).get('values', []):
+            if exception_interface is None:
+                continue
             message = u': '.join(
                 filter(None, map(exception_interface.get, ['type', 'value']))
             )

--- a/src/sentry/interfaces/exception.py
+++ b/src/sentry/interfaces/exception.py
@@ -1069,7 +1069,7 @@ class Exception(Interface):
         # while others may not and we ALWAYS want stacktraces over values
         output = []
         for value in self.values:
-            if not value.stacktrace:
+            if not value or not value.stacktrace:
                 continue
             stack_hash = value.stacktrace.get_hash(
                 platform=platform,
@@ -1081,15 +1081,16 @@ class Exception(Interface):
 
         if not output:
             for value in self.values:
-                output.extend(value.get_hash(platform=platform))
+                if value:
+                    output.extend(value.get_hash(platform=platform))
 
         return output
 
     def get_api_context(self, is_public=False):
         return {
-            'values': [v.get_api_context(is_public=is_public) for v in self.values],
+            'values': [v.get_api_context(is_public=is_public) for v in self.values if v],
             'hasSystemFrames':
-            any(v.stacktrace.get_has_system_frames() for v in self.values if v.stacktrace),
+            any(v.stacktrace.get_has_system_frames() for v in self.values if v and v.stacktrace),
             'excOmitted':
             self.exc_omitted,
         }
@@ -1127,7 +1128,7 @@ class Exception(Interface):
         return ''
 
     def iter_tags(self):
-        if not self.values:
+        if not self.values or not self.values[0]:
             return
 
         mechanism = self.values[0].mechanism

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -135,7 +135,6 @@ STACKTRACE_INTERFACE_SCHEMA = {
             'type': 'array',
             # To validate individual frames use FRAME_INTERFACE_SCHEMA
             'items': {},
-            'minItems': 1,
         },
         'frames_omitted': {
             'type': 'array',
@@ -145,7 +144,7 @@ STACKTRACE_INTERFACE_SCHEMA = {
         },
         'registers': {'type': 'object'},
     },
-    'required': ['frames'],
+    'required': [],
     # `additionalProperties: {'not': {}}` forces additional properties to
     # individually fail with errors that identify the key, so they can be deleted.
     'additionalProperties': {'not': {}},
@@ -227,9 +226,6 @@ EXCEPTION_INTERFACE_SCHEMA = {
             # To validate stacktraces use STACKTRACE_INTERFACE_SCHEMA
             'type': 'object',
             'properties': {
-                # The code allows for the possibility of an empty
-                # {"frames":[]} object, this sucks and should go.
-                # STACKTRACE_INTERFACE_SCHEMA enforces at least 1
                 'frames': {'type': 'array'},
             },
         },

--- a/src/sentry/interfaces/sdk.py
+++ b/src/sentry/interfaces/sdk.py
@@ -17,6 +17,9 @@ def get_with_prefix(d, k, default=None, delimiter=":"):
     {"raven-java": "7.0.0"}.
     """
 
+    if k is None:
+        return default
+
     prefix = k.split(delimiter, 1)[0]
     for key in [k, prefix]:
         if key in d:
@@ -74,6 +77,7 @@ class Sdk(Interface):
     def get_api_context(self, is_public=False):
         newest_version = get_with_prefix(settings.SDK_VERSIONS, self.name)
         newest_name = get_with_prefix(settings.DEPRECATED_SDKS, self.name, self.name)
+
         if newest_version is not None:
             try:
                 is_newer = (

--- a/src/sentry/stacktraces.py
+++ b/src/sentry/stacktraces.py
@@ -175,6 +175,8 @@ def find_stacktraces_in_data(data, include_raw=False):
     exc_container = data.get('sentry.interfaces.Exception')
     if exc_container:
         for exc in exc_container['values']:
+            if not exc:
+                continue
             stacktrace = exc.get('stacktrace')
             if stacktrace:
                 _report_stack(stacktrace, exc)

--- a/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
@@ -170,7 +170,7 @@ let GroupEventToolbar = createReactClass({
         <span>
           <Tooltip title={this.getDateTooltip()} tooltipOptions={{html: true}}>
             <span>
-              <DateTime date={evt.dateCreated} style={style} />
+              <DateTime date={process.env.IS_PERCY ? evt.dateCreated : "Dummy timestamp"} style={style} />
               {isOverLatencyThreshold && <span className="icon-alert" />}
             </span>
           </Tooltip>

--- a/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
@@ -7,6 +7,7 @@ import createReactClass from 'create-react-class';
 
 import ConfigStore from 'app/stores/configStore';
 import SentryTypes from 'app/sentryTypes';
+import getDynamicText from 'app/utils/getDynamicText';
 import DateTime from 'app/components/dateTime';
 import FileSize from 'app/components/fileSize';
 import Tooltip from 'app/components/tooltip';
@@ -170,7 +171,10 @@ let GroupEventToolbar = createReactClass({
         <span>
           <Tooltip title={this.getDateTooltip()} tooltipOptions={{html: true}}>
             <span>
-              <DateTime date={process.env.IS_PERCY ? evt.dateCreated : "Dummy timestamp"} style={style} />
+              <DateTime
+                date={getDynamicText({value: evt.dateCreated, fixed: 'Dummy timestamp'})}
+                style={style}
+              />
               {isOverLatencyThreshold && <span className="icon-alert" />}
             </span>
           </Tooltip>

--- a/src/sentry/utils/data_scrubber.py
+++ b/src/sentry/utils/data_scrubber.py
@@ -79,7 +79,7 @@ class SensitiveDataFilter(object):
 
         if 'sentry.interfaces.Exception' in data:
             for exc in data['sentry.interfaces.Exception']['values']:
-                if exc.get('stacktrace'):
+                if exc is not None and exc.get('stacktrace'):
                     self.filter_stacktrace(exc['stacktrace'])
 
         if 'sentry.interfaces.Breadcrumbs' in data:

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -173,9 +173,7 @@ class Browser(object):
 
     def snapshot(self, name):
         """
-        Capture a screenshot of the current state of the page. Screenshots
-        are captured both locally (in ``cls.screenshots_path``) as well as
-        with Percy (when enabled).
+        Capture a screenshot of the current state of the page.
         """
         # TODO(dcramer): ideally this would take the executing test package
         # into account for duplicate names

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -120,6 +120,28 @@ class IssueDetailsTest(AcceptanceTestCase):
         self.browser.wait_until('.entries')
         self.browser.snapshot('issue details pii stripped')
 
+    def test_empty_exception(self):
+        event = self.create_sample_event(
+            platform='empty-exception'
+        )
+
+        self.browser.get(
+            u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
+        )
+        self.browser.wait_until('.entries')
+        self.browser.snapshot('issue details nulled out')
+
+    def test_empty_stacktrace(self):
+        event = self.create_sample_event(
+            platform='empty-stacktrace'
+        )
+
+        self.browser.get(
+            u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
+        )
+        self.browser.wait_until('.entries')
+        self.browser.snapshot('issue details empty stacktrace')
+
     def test_activity_page(self):
         event = self.create_sample_event(
             platform='python',

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -129,7 +129,7 @@ class IssueDetailsTest(AcceptanceTestCase):
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
         self.browser.wait_until('.entries')
-        self.browser.snapshot('issue details nulled out')
+        self.browser.snapshot('issue details empty exception')
 
     def test_empty_stacktrace(self):
         event = self.create_sample_event(

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -26,8 +26,7 @@ class IssueDetailsTest(AcceptanceTestCase):
             platform=platform,
             default=default,
             sample_name=sample_name,
-            event_id='d964fdbd649a4cf8bfc35d18082b6b0e',
-            timestamp=1452683305,
+            event_id='d964fdbd649a4cf8bfc35d18082b6b0e'
         )
         event.group.update(
             first_seen=datetime(2015, 8, 13, 3, 8, 25, tzinfo=timezone.utc),

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -544,6 +544,12 @@ class EventManagerTest(TransactionTestCase):
         assert event1.transaction is None
         assert event1.culprit == 'foobar'
 
+    def test_inferred_culprit_from_empty_stacktrace(self):
+        manager = EventManager(make_event(stacktrace={"frames": []}))
+        manager.normalize()
+        event = manager.save(1)
+        assert event.culprit == ''
+
     def test_transaction_and_culprit(self):
         manager = EventManager(make_event(
             transaction='foobar',

--- a/tests/sentry/interfaces/test_stacktrace.py
+++ b/tests/sentry/interfaces/test_stacktrace.py
@@ -49,6 +49,12 @@ class StacktraceTest(TestCase):
         )
 
     def test_null_values(self):
+        sink = {'frames': [], 'frames_omitted': None, 'registers': None}
+
+        assert Stacktrace.to_python({}).to_json() == sink
+        assert Stacktrace.to_python({'frames': None}).to_json() == sink
+        assert Stacktrace.to_python({'frames': []}).to_json() == sink
+
         # TODO(markus): Should eventually generate frames: [None]
         assert Stacktrace.to_python({'frames': [None]}).to_json() == \
             {'frames': [], 'frames_omitted': None, 'registers': None}


### PR DESCRIPTION
Also fix some unrelated null issues

This reverts commit 2b9fb52ed9b3f87577bdcf8a11008f7baa98cc3e.

fix SENTRY-89B
fix JAVASCRIPT-4M4
fix SENTRY-89C


#sync-getsentry