### PR TITLE
fix(ui) Remove blur from modal backdrop

### DIFF
--- a/src/sentry/static/sentry/less/select2.less
+++ b/src/sentry/static/sentry/less/select2.less
@@ -131,7 +131,6 @@ html[dir='rtl'] .select2-container .select2-choice > .select2-chosen {
   z-index: 9998;
   /* styles required for IE to work */
   background-color: #fff;
-  filter: alpha(opacity=0);
 }
 
 .select2-drop {

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -2347,11 +2347,6 @@ ul.radio-inputs {
 * Modal
 * ============================================================================
 */
-
-.modal-open .app > * {
-  -webkit-filter: ~'blur(3px) grayscale(25%)';
-}
-
 .modal-backdrop {
   background-color: @gray-dark;
 }


### PR DESCRIPTION
A few customers have mailed in saying that the blur effect causes noticeable UI jank for them. I was unable to reproduce this on my machines, but it seems to acutely effect machines without dedicated GPU hardware. I'd like to try removing the blur to see if it noticeably improves the effected customer's experience.

I've increased the opacity on the shade to help increase contrast with the modal. I've also removed filter() expressions that were targeting IE8 as we don't support that browser anymore.

Refs ISSUE-192