### PR TITLE
fix(integrations) Make webhook signature optional for github:e

### DIFF
--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -81,14 +81,12 @@ class GitHubEnterpriseWebhookBase(View):
         return self._handlers.get(event_type)
 
     def is_valid_signature(self, method, body, secret, signature):
-        if method == 'sha1':
-            mod = hashlib.sha1
-        else:
+        if method != 'sha1':
             raise NotImplementedError('signature method %s is not supported' % (method, ))
         expected = hmac.new(
             key=secret.encode('utf-8'),
             msg=body,
-            digestmod=mod,
+            digestmod=hashlib.sha1,
         ).hexdigest()
         return constant_time_compare(expected, signature)
 
@@ -112,7 +110,7 @@ class GitHubEnterpriseWebhookBase(View):
     def handle(self, request):
         body = six.binary_type(request.body)
         if not body:
-            logger.error(
+            logger.warning(
                 'github_enterprise.webhook.missing-body',
                 extra=self.get_logging_data(),
             )
@@ -121,7 +119,7 @@ class GitHubEnterpriseWebhookBase(View):
         try:
             handler = self.get_handler(request.META['HTTP_X_GITHUB_EVENT'])
         except KeyError:
-            logger.error(
+            logger.warning(
                 'github_enterprise.webhook.missing-event',
                 extra=self.get_logging_data(),
             )
@@ -131,18 +129,9 @@ class GitHubEnterpriseWebhookBase(View):
             return HttpResponse(status=204)
 
         try:
-            method, signature = request.META['HTTP_X_HUB_SIGNATURE'].split('=', 1)
-        except (KeyError, IndexError):
-            logger.error(
-                'github_enterprise.webhook.missing-signature',
-                extra=self.get_logging_data(),
-            )
-            return HttpResponse(status=400)
-
-        try:
             event = json.loads(body.decode('utf-8'))
         except JSONDecodeError:
-            logger.error(
+            logger.warning(
                 'github_enterprise.webhook.invalid-json',
                 extra=self.get_logging_data(),
                 exc_info=True,
@@ -152,23 +141,32 @@ class GitHubEnterpriseWebhookBase(View):
         try:
             host = request.META['HTTP_X_GITHUB_ENTERPRISE_HOST']
         except KeyError:
-            return HttpResponse(status=401)
+            logger.warning('github_enterprise.webhook.missing-enterprise-host')
+            return HttpResponse(status=400)
 
         secret = self.get_secret(event, host)
-        if secret is None:
-            logger.error(
-                'github_enterprise.webhook.missing-secret',
-                extra=self.get_logging_data(),
+        if not secret:
+            logger.warning(
+                'github_enterprise.webhook.missing-integration',
+                extra={'host': host}
             )
-            return HttpResponse(status=401)
+            return HttpResponse(status=400)
 
-        if not self.is_valid_signature(method, body, self.get_secret(event, host), signature):
-            logger.error(
-                'github_enterprise.webhook.invalid-signature',
-                extra=self.get_logging_data(),
+        try:
+            # Attempt to validate the signature. Older versions of
+            # GitHub Enterprise do not send the signature so this is an optional step.
+            method, signature = request.META['HTTP_X_HUB_SIGNATURE'].split('=', 1)
+            if not self.is_valid_signature(method, body, secret, signature):
+                logger.warning(
+                    'github_enterprise.webhook.invalid-signature',
+                    extra=self.get_logging_data(),
+                )
+                return HttpResponse(status=401)
+        except (KeyError, IndexError) as e:
+            logger.info(
+                'github_enterprise.webhook.missing-signature',
+                extra={'host': host, 'error': six.text_type(e)}
             )
-            return HttpResponse(status=401)
-
         handler()(event, host)
         return HttpResponse(status=204)
 

--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -26,12 +26,25 @@ from mock import patch
 
 class WebhookTest(APITestCase):
     def test_get(self):
-
         url = '/extensions/github-enterprise/webhook/'
 
         response = self.client.get(url)
-
         assert response.status_code == 405
+
+    def test_unknown_host_event(self):
+        # No integration defined in the database, so event should be rejected
+        # because we can't find metadata and secret for it
+        url = '/extensions/github-enterprise/webhook/'
+
+        response = self.client.post(
+            path=url,
+            data=PUSH_EVENT_EXAMPLE_INSTALLATION,
+            content_type='application/json',
+            HTTP_X_GITHUB_EVENT='push',
+            HTTP_X_GITHUB_ENTERPRISE_HOST='99.99.99.99',
+            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
+        )
+        assert response.status_code == 400
 
     def test_unregistered_event(self):
         project = self.project  # force creation
@@ -48,11 +61,18 @@ class WebhookTest(APITestCase):
             HTTP_X_HUB_SIGNATURE='sha1=56a3df597e02adbc17fb617502c70e19d96a6136',
             HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
         )
-
         assert response.status_code == 204
 
-    def test_invalid_signature_event(self):
-
+    @patch('sentry.integrations.github_enterprise.webhook.get_installation_metadata')
+    def test_invalid_signature_event(self, mock_installation):
+        mock_installation.return_value = {
+            'url': '35.232.149.196',
+            'id': '2',
+            'name': 'test-app',
+            'webhook_secret': 'b3002c3e321d4b7880360d397db2ccfd',
+            'private_key': 'private_key',
+            'verify_ssl': True,
+        }
         url = '/extensions/github-enterprise/webhook/'
 
         response = self.client.post(
@@ -64,8 +84,30 @@ class WebhookTest(APITestCase):
             HTTP_X_HUB_SIGNATURE='sha1=33521abeaaf9a57c2abf486e0ccd54d23cf36fec',
             HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
         )
-
         assert response.status_code == 401
+
+    @patch('sentry.integrations.github_enterprise.webhook.get_installation_metadata')
+    def test_missing_signature_ok(self, mock_installation):
+        # Old Github:e doesn't send a signature, so we have to accept that.
+        mock_installation.return_value = {
+            'url': '35.232.149.196',
+            'id': '2',
+            'name': 'test-app',
+            'webhook_secret': 'b3002c3e321d4b7880360d397db2ccfd',
+            'private_key': 'private_key',
+            'verify_ssl': True,
+        }
+        url = '/extensions/github-enterprise/webhook/'
+
+        response = self.client.post(
+            path=url,
+            data=PUSH_EVENT_EXAMPLE_INSTALLATION,
+            content_type='application/json',
+            HTTP_X_GITHUB_EVENT='push',
+            HTTP_X_GITHUB_ENTERPRISE_HOST='35.232.149.196',
+            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
+        )
+        assert response.status_code == 204
 
 
 class PushEventWebhookTest(APITestCase):


### PR DESCRIPTION
Some customers are using older versions of github:e that do not send webhook signatures. We should accept those webhooks, and only validate the signature if it is provided.

I've downgraded all the request validation faults to 'warning' as there isn't much we can do internally when a customer's GitHub is misbehaving.

Fixes SENTRY-7XN
Refs ISSUE-202