### PR TITLE
feat(discover): Display disabled version of query builder on load

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/aggregations/aggregation.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/aggregations/aggregation.jsx
@@ -13,6 +13,7 @@ export default class Aggregation extends React.Component {
     value: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
     columns: PropTypes.array.isRequired,
+    disabled: PropTypes.bool,
   };
 
   constructor(props) {
@@ -123,6 +124,7 @@ export default class Aggregation extends React.Component {
           inputRenderer={this.inputRenderer}
           valueRenderer={this.valueRenderer}
           onInputChange={this.handleInputChange}
+          disabled={this.props.disabled}
         />
       </Box>
     );

--- a/src/sentry/static/sentry/app/views/organizationDiscover/aggregations/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/aggregations/index.jsx
@@ -14,6 +14,7 @@ export default class Aggregations extends React.Component {
     value: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
     columns: PropTypes.array,
+    disabled: PropTypes.bool,
   };
 
   addRow() {
@@ -35,15 +36,17 @@ export default class Aggregations extends React.Component {
   }
 
   render() {
-    const {value, columns} = this.props;
+    const {value, columns, disabled} = this.props;
 
     return (
       <div>
         <div>
           <SidebarLabel>{t('Aggregation')}</SidebarLabel>
-          <AddText>
-            (<Link onClick={() => this.addRow()}>{t('Add')}</Link>)
-          </AddText>
+          {!disabled && (
+            <AddText>
+              (<Link onClick={() => this.addRow()}>{t('Add')}</Link>)
+            </AddText>
+          )}
         </div>
         {!value.length && (
           <PlaceholderText>{t('None, showing raw event data')}</PlaceholderText>
@@ -54,6 +57,7 @@ export default class Aggregations extends React.Component {
               value={aggregation}
               onChange={val => this.handleChange(val, idx)}
               columns={columns}
+              disabled={disabled}
             />
             <Box ml={1}>
               <a onClick={() => this.removeRow(idx)}>

--- a/src/sentry/static/sentry/app/views/organizationDiscover/conditions/condition.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/conditions/condition.jsx
@@ -15,6 +15,7 @@ export default class Condition extends React.Component {
     columns: PropTypes.arrayOf(
       PropTypes.shape({name: PropTypes.string, type: PropTypes.string})
     ).isRequired,
+    disabled: PropTypes.bool,
   };
 
   constructor(props) {
@@ -177,6 +178,7 @@ export default class Condition extends React.Component {
           creatable={true}
           promptTextCreator={text => text}
           shouldKeyDownEventCreateNewOption={this.shouldKeyDownEventCreateNewOption}
+          disabled={this.props.disabled}
         />
       </Box>
     );

--- a/src/sentry/static/sentry/app/views/organizationDiscover/conditions/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/conditions/index.jsx
@@ -14,6 +14,7 @@ export default class Conditions extends React.Component {
     value: PropTypes.arrayOf(PropTypes.array).isRequired,
     onChange: PropTypes.func.isRequired,
     columns: PropTypes.array.isRequired,
+    disabled: PropTypes.bool,
   };
 
   addRow() {
@@ -35,15 +36,17 @@ export default class Conditions extends React.Component {
   }
 
   render() {
-    const {value, columns} = this.props;
+    const {value, columns, disabled} = this.props;
 
     return (
       <div>
         <div>
           <SidebarLabel>{t('Conditions')}</SidebarLabel>
-          <AddText>
-            (<Link onClick={() => this.addRow()}>{t('Add')}</Link>)
-          </AddText>
+          {!disabled && (
+            <AddText>
+              (<Link onClick={() => this.addRow()}>{t('Add')}</Link>)
+            </AddText>
+          )}
         </div>
         {!value.length && (
           <PlaceholderText>{t('None, showing all events')}</PlaceholderText>
@@ -54,6 +57,7 @@ export default class Conditions extends React.Component {
               value={condition}
               onChange={val => this.handleChange(val, idx)}
               columns={columns}
+              disabled={disabled}
             />
             <Box ml={1}>
               <a onClick={() => this.removeRow(idx)}>

--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -52,6 +52,7 @@ export default class OrganizationDiscover extends React.Component {
     updateSavedQueryData: PropTypes.func.isRequired,
     view: PropTypes.oneOf(['query', 'saved']),
     toggleEditMode: PropTypes.func.isRequired,
+    isLoading: PropTypes.bool.isRequired,
   };
 
   constructor(props) {
@@ -278,7 +279,13 @@ export default class OrganizationDiscover extends React.Component {
   render() {
     const {data, isFetchingQuery, view, resultManager, isEditingSavedQuery} = this.state;
 
-    const {queryBuilder, organization, savedQuery, toggleEditMode} = this.props;
+    const {
+      queryBuilder,
+      organization,
+      savedQuery,
+      toggleEditMode,
+      isLoading,
+    } = this.props;
 
     const currentQuery = queryBuilder.getInternal();
 
@@ -298,7 +305,7 @@ export default class OrganizationDiscover extends React.Component {
           <PageTitle>{t('Discover')}</PageTitle>
           {this.renderSidebarNav()}
           {view === 'saved' && (
-            <SavedQueryWrapper isEditing={isEditingSavedQuery}>
+            <SavedQueryWrapper>
               <SavedQueryList organization={organization} savedQuery={savedQuery} />
             </SavedQueryWrapper>
           )}
@@ -306,10 +313,11 @@ export default class OrganizationDiscover extends React.Component {
             <NewQuery
               organization={organization}
               queryBuilder={queryBuilder}
-              isFetchingQuery={isFetchingQuery}
+              isFetchingQuery={isFetchingQuery || isLoading}
               onUpdateField={this.updateField}
               onRunQuery={this.runQuery}
               onReset={this.reset}
+              isLoading={isLoading}
             />
           )}
           {isEditingSavedQuery &&
@@ -324,6 +332,7 @@ export default class OrganizationDiscover extends React.Component {
                   onReset={this.reset}
                   onDeleteQuery={this.deleteSavedQuery}
                   onSaveQuery={this.updateSavedQuery}
+                  isLoading={isLoading}
                 />
               </QueryPanel>
             )}

--- a/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
@@ -3,8 +3,6 @@ import {Flex} from 'grid-emotion';
 import {browserHistory} from 'react-router';
 import DocumentTitle from 'react-document-title';
 import jQuery from 'jquery';
-import LoadingIndicator from 'app/components/loadingIndicator';
-import {t} from 'app/locale';
 import SentryTypes from 'app/sentryTypes';
 
 import Discover from './discover';
@@ -17,44 +15,36 @@ import {
   getView,
 } from './utils';
 
-import {
-  DiscoverWrapper,
-  DiscoverContainer,
-  Sidebar,
-  Body,
-  PageTitle,
-  TopBar,
-  LoadingContainer,
-} from './styles';
+import {DiscoverWrapper} from './styles';
 
 export default class OrganizationDiscoverContainer extends React.Component {
   static contextTypes = {
     organization: SentryTypes.Organization,
   };
 
-  constructor(props) {
-    super(props);
+  constructor(props, context) {
+    super(props, context);
+
     this.state = {
       isLoading: true,
       savedQuery: null,
-      view: getView(props.location.query.view),
+      view: getView(props.params, props.location.query.view),
     };
+
+    const {search} = props.location;
+    const {organization} = context;
+
+    this.queryBuilder = createQueryBuilder(getQueryFromQueryString(search), organization);
   }
 
   componentDidMount() {
     jQuery(document.body).addClass('body-discover');
 
     const {savedQueryId} = this.props.params;
-    const {search} = this.props.location;
-    const {organization} = this.context;
 
     if (savedQueryId) {
       this.fetchSavedQuery(savedQueryId).then(this.loadTags);
     } else {
-      this.queryBuilder = createQueryBuilder(
-        getQueryFromQueryString(search),
-        organization
-      );
       this.loadTags();
     }
   }
@@ -70,7 +60,7 @@ export default class OrganizationDiscoverContainer extends React.Component {
     }
 
     if (nextProps.location.query.view !== this.props.location.query.view) {
-      this.setState({view: getView(nextProps.location.query.view)});
+      this.setState({view: getView(nextProps.params, nextProps.location.query.view)});
     }
   }
 
@@ -136,22 +126,6 @@ export default class OrganizationDiscoverContainer extends React.Component {
     );
   }
 
-  renderLoading() {
-    return (
-      <DiscoverContainer>
-        <Sidebar>
-          <PageTitle>{t('Discover')}</PageTitle>
-        </Sidebar>
-        <Body>
-          <TopBar />
-          <LoadingContainer>
-            <LoadingIndicator />
-          </LoadingContainer>
-        </Body>
-      </DiscoverContainer>
-    );
-  }
-
   render() {
     const {isLoading, savedQuery, view} = this.state;
 
@@ -165,21 +139,18 @@ export default class OrganizationDiscoverContainer extends React.Component {
     return (
       <DocumentTitle title={`Discover - ${organization.slug} - Sentry`}>
         <DiscoverWrapper>
-          {isLoading ? (
-            this.renderLoading()
-          ) : (
-            <Discover
-              organization={organization}
-              queryBuilder={this.queryBuilder}
-              location={location}
-              params={params}
-              savedQuery={savedQuery}
-              isEditingSavedQuery={this.props.location.query.editing === 'true'}
-              updateSavedQueryData={this.updateSavedQuery}
-              view={view}
-              toggleEditMode={this.toggleEditMode}
-            />
-          )}
+          <Discover
+            isLoading={isLoading}
+            organization={organization}
+            queryBuilder={this.queryBuilder}
+            location={location}
+            params={params}
+            savedQuery={savedQuery}
+            isEditingSavedQuery={this.props.location.query.editing === 'true'}
+            updateSavedQueryData={this.updateSavedQuery}
+            view={view}
+            toggleEditMode={this.toggleEditMode}
+          />
         </DiscoverWrapper>
       </DocumentTitle>
     );

--- a/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/editSavedQuery.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/editSavedQuery.jsx
@@ -21,6 +21,7 @@ export default class EditSavedQuery extends React.Component {
     onDeleteQuery: PropTypes.func.isRequired,
     onSaveQuery: PropTypes.func.isRequired,
     isFetchingQuery: PropTypes.bool.isRequired,
+    isLoading: PropTypes.bool.isRequired,
   };
 
   constructor(props) {
@@ -52,6 +53,7 @@ export default class EditSavedQuery extends React.Component {
       onRunQuery,
       onDeleteQuery,
       onSaveQuery,
+      isLoading,
     } = this.props;
 
     const {savedQueryName} = this.state;
@@ -60,6 +62,7 @@ export default class EditSavedQuery extends React.Component {
       <QueryFields
         queryBuilder={queryBuilder}
         onUpdateField={onUpdateField}
+        isLoading={isLoading}
         savedQuery={savedQuery}
         savedQueryName={this.state.savedQueryName}
         onUpdateName={name => this.handleUpdateName(name)}

--- a/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/newQuery.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/newQuery.jsx
@@ -20,6 +20,7 @@ export default class NewQuery extends React.Component {
     onReset: PropTypes.func.isRequired,
     onUpdateField: PropTypes.func.isRequired,
     isFetchingQuery: PropTypes.bool.isRequired,
+    isLoading: PropTypes.bool.isRequired,
   };
 
   saveQuery() {
@@ -48,12 +49,14 @@ export default class NewQuery extends React.Component {
       onReset,
       isFetchingQuery,
       onUpdateField,
+      isLoading,
     } = this.props;
     return (
       <QueryFieldsContainer>
         <QueryFields
           queryBuilder={queryBuilder}
           onUpdateField={onUpdateField}
+          isLoading={isLoading}
           actions={
             <Flex justify="space-between">
               <Flex>

--- a/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/queryFields.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/queryFields.jsx
@@ -17,6 +17,7 @@ export default class QueryFields extends React.Component {
     queryBuilder: PropTypes.object.isRequired,
     onUpdateField: PropTypes.func.isRequired,
     actions: PropTypes.node.isRequired,
+    isLoading: PropTypes.bool.isRequired,
     // savedQuery, savedQueryName, and onUpdateName are provided only when it's a saved search
     savedQuery: SentryTypes.DiscoverSavedQuery,
     savedQueryName: PropTypes.string,
@@ -38,6 +39,7 @@ export default class QueryFields extends React.Component {
       queryBuilder,
       onUpdateField,
       actions,
+      isLoading,
       savedQuery,
       savedQueryName,
       onUpdateName,
@@ -60,7 +62,7 @@ export default class QueryFields extends React.Component {
         {savedQuery && (
           <Fieldset>
             <React.Fragment>
-              <SidebarLabel htmlFor="name" className="control-label">
+              <SidebarLabel htmlFor="name" className="ciontrol-label">
                 {t('Name')}
               </SidebarLabel>
               <TextField
@@ -84,6 +86,7 @@ export default class QueryFields extends React.Component {
             value={currentQuery.fields}
             onChange={val => onUpdateField('fields', val.map(({value}) => value))}
             clearable={true}
+            disabled={isLoading}
           />
         </Fieldset>
         <Fieldset>
@@ -91,6 +94,7 @@ export default class QueryFields extends React.Component {
             value={currentQuery.aggregations}
             columns={columns}
             onChange={val => onUpdateField('aggregations', val)}
+            disabled={isLoading}
           />
         </Fieldset>
         <Fieldset>
@@ -98,6 +102,7 @@ export default class QueryFields extends React.Component {
             value={currentQuery.conditions}
             columns={columnsForConditions}
             onChange={val => onUpdateField('conditions', val)}
+            disabled={isLoading}
           />
         </Fieldset>
         <Fieldset>
@@ -111,6 +116,7 @@ export default class QueryFields extends React.Component {
             options={getOrderByOptions(queryBuilder)}
             value={currentQuery.orderby}
             onChange={val => onUpdateField('orderby', val.value)}
+            disabled={isLoading}
           />
         </Fieldset>
         <Fieldset>
@@ -120,6 +126,7 @@ export default class QueryFields extends React.Component {
             placeholder="#"
             value={currentQuery.limit}
             onChange={val => onUpdateField('limit', typeof val === 'number' ? val : null)}
+            disabled={isLoading}
           />
         </Fieldset>
         <Fieldset>{actions}</Fieldset>

--- a/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/queryFields.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/queryFields.jsx
@@ -62,7 +62,7 @@ export default class QueryFields extends React.Component {
         {savedQuery && (
           <Fieldset>
             <React.Fragment>
-              <SidebarLabel htmlFor="name" className="ciontrol-label">
+              <SidebarLabel htmlFor="name" className="control-label">
                 {t('Name')}
               </SidebarLabel>
               <TextField

--- a/src/sentry/static/sentry/app/views/organizationDiscover/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/utils.jsx
@@ -85,7 +85,19 @@ export function getOrderByOptions(queryBuilder) {
   return [...columnOptions, ...aggregationOptions];
 }
 
-export function getView(requestedView) {
+/**
+ * Takes the params object and the requested view querystring and returns the
+ * correct view to be displayed
+ *
+ * @param {Object} params
+ * @param {String} reqeustedView
+ * @returns {String} View
+ */
+export function getView(params, requestedView) {
+  if (typeof params.savedQueryId !== 'undefined') {
+    requestedView = 'saved';
+  }
+
   switch (requestedView) {
     case 'saved':
       return 'saved';

--- a/tests/js/spec/views/organizationDiscover/discover.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/discover.spec.jsx
@@ -36,6 +36,7 @@ describe('Discover', function() {
           savedQuery={TestStubs.DiscoverSavedQuery()}
           updateSavedQueryData={jest.fn()}
           toggleEditMode={jest.fn()}
+          isLoading={false}
         />,
         TestStubs.routerContext([{organization}])
       );
@@ -53,6 +54,7 @@ describe('Discover', function() {
           organization={organization}
           updateSavedQueryData={jest.fn()}
           toggleEditMode={jest.fn()}
+          isLoading={false}
         />,
         TestStubs.routerContext([{organization}])
       );
@@ -71,6 +73,7 @@ describe('Discover', function() {
           updateSavedQueryData={jest.fn()}
           location={{search: ''}}
           toggleEditMode={jest.fn()}
+          isLoading={false}
         />,
         TestStubs.routerContext([{organization}])
       );
@@ -113,6 +116,7 @@ describe('Discover', function() {
           params={{}}
           updateSavedQueryData={jest.fn()}
           toggleEditMode={jest.fn()}
+          isLoading={false}
         />,
         TestStubs.routerContext()
       );
@@ -171,6 +175,7 @@ describe('Discover', function() {
           organization={organization}
           updateSavedQueryData={jest.fn()}
           toggleEditMode={jest.fn()}
+          isLoading={false}
         />,
         TestStubs.routerContext()
       );
@@ -239,6 +244,7 @@ describe('Discover', function() {
           organization={organization}
           updateSavedQueryData={jest.fn()}
           toggleEditMode={jest.fn()}
+          isLoading={false}
         />,
         TestStubs.routerContext()
       );
@@ -281,6 +287,7 @@ describe('Discover', function() {
             location={{location: '?fields=something'}}
             updateSavedQueryData={jest.fn()}
             toggleEditMode={jest.fn()}
+            isLoading={false}
           />,
           TestStubs.routerContext()
         );
@@ -351,6 +358,7 @@ describe('Discover', function() {
           view="saved"
           location={{search: ''}}
           toggleEditMode={jest.fn()}
+          isLoading={false}
         />,
         TestStubs.routerContext()
       );
@@ -431,6 +439,7 @@ describe('Discover', function() {
           location={{location: '?fields=something'}}
           updateSavedQueryData={jest.fn()}
           toggleEditMode={jest.fn()}
+          isLoading={false}
         />,
         TestStubs.routerContext()
       );
@@ -472,6 +481,7 @@ describe('Discover', function() {
           location={{location: ''}}
           updateSavedQueryData={jest.fn()}
           toggleEditMode={jest.fn()}
+          isLoading={false}
         />,
         TestStubs.routerContext()
       );
@@ -506,6 +516,7 @@ describe('Discover', function() {
           organization={organization}
           updateSavedQueryData={jest.fn()}
           toggleEditMode={jest.fn()}
+          isLoading={false}
         />,
         TestStubs.routerContext([{organization}])
       );


### PR DESCRIPTION
Avoid displaying a loading view with no content on the page, instead
we'll render as much content as possible and disable fields while
discover tags and saved queries are loading.