### PR TITLE
fix(integrations) Fix repository add not working with integers

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
@@ -97,11 +97,18 @@ export default class IntegrationRepos extends AsyncComponent {
 
     this.setState({adding: true});
 
-    let migratableRepo = itemList.filter(item => {
-      if (!(selection.value && item.name)) {
-        return false;
+    let normalize = function(value) {
+      if (!value) {
+        return '';
       }
-      return selection.value.toLowerCase() === item.name.toLowerCase();
+      if (value.toLowerCase) {
+        return value.toLowerCase();
+      }
+      return value;
+    };
+
+    let migratableRepo = itemList.filter(item => {
+      return normalize(selection.value) === normalize(item.name);
     })[0];
 
     let promise;

--- a/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
@@ -95,6 +95,34 @@ describe('IntegrationRepos', function() {
       expect(addRepo).toHaveBeenCalled();
       expect(wrapper.find('RepoOption')).toHaveLength(0);
     });
+
+    it('uses numeric identifier', () => {
+      Client.addMockResponse({
+        url: `/organizations/${org.slug}/repos/`,
+        method: 'GET',
+        body: [TestStubs.Repository({name: 'Example/repo-name'})],
+      });
+      Client.addMockResponse({
+        url: `/organizations/${org.slug}/integrations/${integration.id}/repos/`,
+        method: 'GET',
+        body: {
+          repos: [{identifier: 123456, name: 'repo-name'}],
+        },
+      });
+      const createRepo = Client.addMockResponse({
+        method: 'POST',
+        url: `/organizations/${org.slug}/repos/`,
+        body: TestStubs.Repository({integrationId: '1'}),
+      });
+      const wrapper = mount(
+        <IntegrationRepos integration={integration} />,
+        routerContext
+      );
+      wrapper.find('DropdownButton').simulate('click');
+      wrapper.find('StyledListElement').simulate('click');
+
+      expect(createRepo).toHaveBeenCalled();
+    });
   });
 
   describe('migratable repo', function() {
@@ -146,7 +174,7 @@ describe('IntegrationRepos', function() {
         url: `/organizations/${org.slug}/integrations/${integration.id}/repos/`,
         method: 'GET',
         body: {
-          repos: [{identifier: 'example/repo-name', name: 'repo-name'}],
+          repos: [{identifier: 'example/Repo-name', name: 'repo-name'}],
         },
       });
       const updateRepo = Client.addMockResponse({


### PR DESCRIPTION
GitLab uses integer ids for its repository identifiers so that repository related operations with GitLab can use simple primary key values. When deciding if a repository can be migrated we need to account
for more than just string types.

Fixes JAVASCRIPT-4MD
Fixes #10565