### PR TITLE
test(js): Fix jsdom window.performance.mark

### DIFF
--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -26,8 +26,10 @@ import * as il8n from 'app/locale';
 import plugins from 'app/plugins';
 
 // Used for operational metrics to determine that the application js
-// bundle was loaded by browser
-if (window.performance) {
+// bundle was loaded by browser.
+//
+// JSDOM implements window.performance but not window.performance.mark
+if (window.performance && typeof window.performance.mark === 'function') {
   window.performance.mark('sentry-app-init');
 }
 


### PR DESCRIPTION
JSDOM implements window.performance, but not the full API.

See: https://github.com/jsdom/jsdom/issues/2136

I wasn't about to stub this out, so just gonna add this additional type check for now.