### PR TITLE
feat(org-events): Use reusable search bar (APP-766)

### DIFF
--- a/src/sentry/static/sentry/app/components/searchBar.jsx
+++ b/src/sentry/static/sentry/app/components/searchBar.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import {cx} from 'react-emotion';
 
 class SearchBar extends React.PureComponent {
   static propTypes = {
@@ -61,8 +62,9 @@ class SearchBar extends React.PureComponent {
   };
 
   render() {
+    let {className} = this.props;
     return (
-      <div className="search">
+      <div className={cx('search', className)}>
         <form className="form-horizontal" onSubmit={this.onSubmit}>
           <div>
             <input

--- a/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
@@ -72,14 +72,14 @@ class OrganizationEvents extends AsyncView {
     router.push({
       pathname: location.pathname,
       query: {
-        ...this.state.query,
+        ...(location.query || {}),
         query,
       },
     });
   };
 
   renderBody() {
-    const {organization} = this.props;
+    const {organization, location} = this.props;
     const {reloading, events, eventsPageLinks} = this.state;
 
     return (
@@ -87,6 +87,7 @@ class OrganizationEvents extends AsyncView {
         <Flex align="center" justify="space-between" mb={2}>
           <HeaderTitle>{t('Events')}</HeaderTitle>
           <StyledSearchBar
+            query={location.query && location.query.query}
             placeholder={t('Search for events, users, tags, and everything else.')}
             onSearch={this.handleSearch}
           />

--- a/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
@@ -1,7 +1,7 @@
+import {Flex} from 'grid-emotion';
 import {isEqual} from 'lodash';
 import React from 'react';
 import styled from 'react-emotion';
-import {Flex} from 'grid-emotion';
 
 import {Panel} from 'app/components/panels';
 import {getParams} from 'app/views/organizationEvents/utils';
@@ -10,9 +10,10 @@ import AsyncView from 'app/views/asyncView';
 import EventsChart from 'app/views/organizationEvents/eventsChart';
 import EventsTable from 'app/views/organizationEvents/eventsTable';
 import Pagination from 'app/components/pagination';
+import PreviewFeature from 'app/components/previewFeature';
+import SearchBar from 'app/components/searchBar';
 import SentryTypes from 'app/sentryTypes';
 import withOrganization from 'app/utils/withOrganization';
-import PreviewFeature from 'app/components/previewFeature';
 
 class OrganizationEvents extends AsyncView {
   static propTypes = {
@@ -54,7 +55,7 @@ class OrganizationEvents extends AsyncView {
         `/organizations/${organization.slug}/events/`,
         {
           query: getParams({
-            period: statsPeriod,
+            statsPeriod,
             ...query,
           }),
         },
@@ -66,6 +67,17 @@ class OrganizationEvents extends AsyncView {
     return `Events - ${this.props.organization.slug}`;
   }
 
+  handleSearch = query => {
+    let {router, location} = this.props;
+    router.push({
+      pathname: location.pathname,
+      query: {
+        ...this.state.query,
+        query,
+      },
+    });
+  };
+
   renderBody() {
     const {organization} = this.props;
     const {reloading, events, eventsPageLinks} = this.state;
@@ -74,7 +86,10 @@ class OrganizationEvents extends AsyncView {
       <React.Fragment>
         <Flex align="center" justify="space-between" mb={2}>
           <HeaderTitle>{t('Events')}</HeaderTitle>
-          {this.renderSearchInput({debounceWait: 1000})}
+          <StyledSearchBar
+            placeholder={t('Search for events, users, tags, and everything else.')}
+            onSearch={this.handleSearch}
+          />
         </Flex>
 
         <PreviewFeature type="info" />
@@ -92,7 +107,12 @@ class OrganizationEvents extends AsyncView {
 }
 
 const HeaderTitle = styled('h4')`
+  flex: 1;
   margin: 0;
+`;
+
+const StyledSearchBar = styled(SearchBar)`
+  flex: 1;
 `;
 
 export default withOrganization(OrganizationEvents);


### PR DESCRIPTION
Use the search bar in `app/components/searchBar` for Events search.
Requires "enter" to search.

Also fixes stats period being removed on search

Fixes APP-766