### PR TITLE
feat(discover): Validate aggregate function

### DIFF
--- a/src/sentry/api/endpoints/organization_discover_query.py
+++ b/src/sentry/api/endpoints/organization_discover_query.py
@@ -129,6 +129,15 @@ class DiscoverQuerySerializer(serializers.Serializer):
             attrs[source] = conditions
         return attrs
 
+    def validate_aggregations(self, attrs, source):
+        valid_functions = set(['count()', 'uniq', 'avg'])
+        requested_functions = set(agg[0] for agg in attrs[source])
+
+        if not requested_functions.issubset(valid_functions):
+            raise serializers.ValidationError('Invalid aggregate function')
+
+        return attrs
+
     def get_array_field(self, field):
         pattern = r"^(error|stack)\..+"
         return re.search(pattern, field)

--- a/src/sentry/api/endpoints/organization_discover_query.py
+++ b/src/sentry/api/endpoints/organization_discover_query.py
@@ -134,7 +134,11 @@ class DiscoverQuerySerializer(serializers.Serializer):
         requested_functions = set(agg[0] for agg in attrs[source])
 
         if not requested_functions.issubset(valid_functions):
-            raise serializers.ValidationError('Invalid aggregate function')
+            invalid_functions = ', '.join((requested_functions - valid_functions))
+
+            raise serializers.ValidationError(
+                u'Invalid aggregate function - {}'.format(invalid_functions)
+            )
 
         return attrs
 

--- a/tests/snuba/test_organization_discover_query.py
+++ b/tests/snuba/test_organization_discover_query.py
@@ -114,6 +114,19 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 400, response.content
 
+    def test_invalid_aggregation_function(self):
+        with self.feature('organizations:discover'):
+            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            response = self.client.post(url, {
+                'projects': [self.project.id],
+                'fields': ['message', 'platform'],
+                'aggregations': [['test', 'test', 'test']],
+                'range': '14d',
+                'orderby': '-timestamp',
+            })
+
+        assert response.status_code == 400, response.content
+
     def test_boolean_condition(self):
         with self.feature('organizations:discover'):
             url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])


### PR DESCRIPTION
Only allow users to use count, uniq and avg functions via the Discover
API. Return a proper validation message if any other function is
requested.