### PR TITLE
Revert "feat: Include triggering rules in webhook payload"

### DIFF
--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -66,7 +66,7 @@ class NotificationPlugin(Plugin):
 
     def notify(self, notification):
         event = notification.event
-        return self.notify_users(event.group, event, map(lambda r: r.label, notification.rules))
+        return self.notify_users(event.group, event)
 
     def rule_notify(self, event, futures):
         rules = []
@@ -117,7 +117,7 @@ class NotificationPlugin(Plugin):
 
         self.logger.info('notification.%s' % log_event, extra=extra)
 
-    def notify_users(self, group, event, triggering_rules, fail_silently=False):
+    def notify_users(self, group, event, fail_silently=False):
         raise NotImplementedError
 
     def notify_about_activity(self, activity):

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -66,7 +66,7 @@ class NotificationPlugin(Plugin):
 
     def notify(self, notification):
         event = notification.event
-        return self.notify_users(event.group, event, [r.label for r in notification.rules])
+        return self.notify_users(event.group, event, map(lambda r: r.label, notification.rules))
 
     def rule_notify(self, event, futures):
         rules = []

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -66,8 +66,7 @@ class NotificationPlugin(Plugin):
 
     def notify(self, notification):
         event = notification.event
-        return self.notify_users(event.group, event, triggering_rules=[
-                                 r.label for r in notification.rules])
+        return self.notify_users(event.group, event, [r.label for r in notification.rules])
 
     def rule_notify(self, event, futures):
         rules = []
@@ -118,7 +117,7 @@ class NotificationPlugin(Plugin):
 
         self.logger.info('notification.%s' % log_event, extra=extra)
 
-    def notify_users(self, group, event, triggering_rules, fail_silently=False, **kwargs):
+    def notify_users(self, group, event, triggering_rules, fail_silently=False):
         raise NotImplementedError
 
     def notify_about_activity(self, activity):

--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -104,7 +104,7 @@ class WebHooksPlugin(notify.NotificationPlugin):
             verify_ssl=False,
         )
 
-    def notify_users(self, group, event, triggering_rules, fail_silently=False, **kwargs):
+    def notify_users(self, group, event, triggering_rules, fail_silently=False):
         payload = self.get_group_data(group, event, triggering_rules)
         for url in self.get_webhook_urls(group.project):
             safe_execute(self.send_webhook, url, payload, _with_transaction=False)

--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -74,7 +74,7 @@ class WebHooksPlugin(notify.NotificationPlugin):
             }
         ]
 
-    def get_group_data(self, group, event, triggering_rules):
+    def get_group_data(self, group, event):
         data = {
             'id': six.text_type(group.id),
             'project': group.project.slug,
@@ -85,7 +85,6 @@ class WebHooksPlugin(notify.NotificationPlugin):
             'culprit': group.culprit,
             'message': event.get_legacy_message(),
             'url': group.get_absolute_url(),
-            'triggering_rules': triggering_rules,
         }
         data['event'] = dict(event.data or {})
         data['event']['tags'] = event.get_tags()
@@ -104,7 +103,7 @@ class WebHooksPlugin(notify.NotificationPlugin):
             verify_ssl=False,
         )
 
-    def notify_users(self, group, event, triggering_rules, fail_silently=False):
-        payload = self.get_group_data(group, event, triggering_rules)
+    def notify_users(self, group, event, fail_silently=False):
+        payload = self.get_group_data(group, event)
         for url in self.get_webhook_urls(group.project):
             safe_execute(self.send_webhook, url, payload, _with_transaction=False)

--- a/tests/sentry/plugins/sentry_webhooks/test_plugin.py
+++ b/tests/sentry/plugins/sentry_webhooks/test_plugin.py
@@ -40,7 +40,6 @@ class WebHooksPluginTest(TestCase):
         assert payload['message'] == 'Hello world'
         assert payload['event']['id'] == 24
         assert payload['event']['event_id'] == event.event_id
-        assert payload['triggering_rules'] == ['my rule']
 
     def test_webhook_validation(self):
         # Test that you can't sneak a bad domain into the list of webhooks


### PR DESCRIPTION
Reverts getsentry/sentry#10506.

Introduced `SENTRY-89K`, requiring various plugins to be updated to reflect these changes before they are merged.