### PR TITLE
fix(ui): Animate hovercard in from the right direction

### DIFF
--- a/src/sentry/static/sentry/app/components/hovercard.jsx
+++ b/src/sentry/static/sentry/app/components/hovercard.jsx
@@ -113,7 +113,7 @@ class Hovercard extends React.Component {
 }
 
 const translateX = x => `translateX(${x === 'middle' ? '-50%' : 0})`;
-const slideTranslateY = y => `translateY(${(y === 'top' ? 1 : -1) * 14}px)`;
+const slideTranslateY = y => `translateY(${(y === 'top' ? -1 : 1) * 14}px)`;
 
 const slideIn = p => keyframes`
   from {


### PR DESCRIPTION
It was animating in from the bottom when it was positioned on the top, and vice versa.