### PR TITLE
feat(api): Add org events stats endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -61,7 +61,7 @@ from .endpoints.organization_details import OrganizationDetailsEndpoint
 from .endpoints.organization_discover_query import OrganizationDiscoverQueryEndpoint
 from .endpoints.organization_discover_saved_queries import OrganizationDiscoverSavedQueriesEndpoint
 from .endpoints.organization_discover_saved_query_detail import OrganizationDiscoverSavedQueryDetailEndpoint
-from .endpoints.organization_events import OrganizationEventsEndpoint
+from .endpoints.organization_events import OrganizationEventsEndpoint, OrganizationEventsStatsEndpoint
 from .endpoints.organization_health import OrganizationHealthTopEndpoint, OrganizationHealthGraphEndpoint
 from .endpoints.organization_shortid import ShortIdLookupEndpoint
 from .endpoints.organization_environments import OrganizationEnvironmentsEndpoint
@@ -493,6 +493,11 @@ urlpatterns = patterns(
         r'^organizations/(?P<organization_slug>[^\/]+)/events/$',
         OrganizationEventsEndpoint.as_view(),
         name='sentry-api-0-organization-events'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/events-stats/$',
+        OrganizationEventsStatsEndpoint.as_view(),
+        name='sentry-api-0-organization-events-stats'
     ),
     url(
         r'^organizations/(?P<organization_slug>[^\/]+)/issues/new/$',


### PR DESCRIPTION
This makes it so the search terms will also be reflected in the stats (not just the top level filters like project, env, date). I pulled what I could from your health serializers, Matt