### PR TITLE
ref(analytics): Simplify metrics client API

### DIFF
--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -13,8 +13,7 @@ const validHookNames = new Set([
   'analytics:log-experiment',
 
   // Operational metrics
-  'metrics:gauge',
-  'metrics:increment',
+  'metrics:event',
 
   // Specific component customizations
   'component:org-auth-view',

--- a/src/sentry/static/sentry/app/utils/analytics.jsx
+++ b/src/sentry/static/sentry/app/utils/analytics.jsx
@@ -26,14 +26,6 @@ export function amplitude(name, organization_id, data) {
  * @param {Number} value Value to record for this metric
  * @param {Object} tags An additional tags object
  */
-export function gauge(name, value, tags) {
-  HookStore.get('metrics:gauge').forEach(cb => cb(name, value, tags));
-}
-
-/**
- * @param {String} name Metric name
- * @param {Object} tags An additional tags object
- */
-export function increment(name, tags) {
-  HookStore.get('metrics:increment').forEach(cb => cb(name, tags));
+export function metric(name, value, tags) {
+  HookStore.get('metrics:event').forEach(cb => cb(name, value, tags));
 }


### PR DESCRIPTION
Metric types are now mapped to metric name on the backend.


Requires https://github.com/getsentry/getsentry/pull/2357