### PR TITLE
feat(integrations) Add provider method for external id generation

### DIFF
--- a/src/sentry/api/endpoints/organization_integration_repos.py
+++ b/src/sentry/api/endpoints/organization_integration_repos.py
@@ -15,7 +15,16 @@ class OrganizationIntegrationReposEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationIntegrationsPermission, )
 
     def get(self, request, organization, integration_id):
+        """
+        Get the list of repositories available in an integration
+        ````````````````````````````````````````````````````````
 
+        Gets all repositories that an integration makes available,
+        and indicates whether or not you can search repositories
+        by name.
+
+        :qparam string search: Name fragment to search repositories by.
+        """
         try:
             integration = Integration.objects.get(id=integration_id, organizations=organization)
         except Integration.DoesNotExist:

--- a/src/sentry/api/serializers/models/repository.py
+++ b/src/sentry/api/serializers/models/repository.py
@@ -9,7 +9,7 @@ from sentry.models import Repository
 @register(Repository)
 class RepositorySerializer(Serializer):
     def serialize(self, obj, attrs, user):
-        external_id = None
+        external_slug = None
         integration_id = None
         if obj.integration_id:
             integration_id = six.text_type(obj.integration_id)
@@ -19,7 +19,7 @@ class RepositorySerializer(Serializer):
                 'id': obj.provider,
                 'name': repo_provider.name,
             }
-            external_id = repo_provider.repository_external_id(obj)
+            external_slug = repo_provider.repository_external_slug(obj)
         else:
             provider = {
                 'id': 'unknown',
@@ -33,5 +33,5 @@ class RepositorySerializer(Serializer):
             'status': obj.get_status_display(),
             'dateCreated': obj.date_added,
             'integrationId': integration_id,
-            'externalId': external_id
+            'externalSlug': external_slug
         }

--- a/src/sentry/api/serializers/models/repository.py
+++ b/src/sentry/api/serializers/models/repository.py
@@ -9,14 +9,17 @@ from sentry.models import Repository
 @register(Repository)
 class RepositorySerializer(Serializer):
     def serialize(self, obj, attrs, user):
+        external_id = None
         integration_id = None
         if obj.integration_id:
             integration_id = six.text_type(obj.integration_id)
         if obj.provider:
+            repo_provider = obj.get_provider()
             provider = {
                 'id': obj.provider,
-                'name': obj.get_provider().name,
+                'name': repo_provider.name,
             }
+            external_id = repo_provider.repository_external_id(obj)
         else:
             provider = {
                 'id': 'unknown',
@@ -30,4 +33,5 @@ class RepositorySerializer(Serializer):
             'status': obj.get_status_display(),
             'dateCreated': obj.date_added,
             'integrationId': integration_id,
+            'externalId': external_id
         }

--- a/src/sentry/integrations/bitbucket/repository.py
+++ b/src/sentry/integrations/bitbucket/repository.py
@@ -126,3 +126,6 @@ class BitbucketRepositoryProvider(providers.IntegrationRepositoryProvider):
                 installation.raise_error(e)
             else:
                 return self._format_commits(repo, res)
+
+    def repository_external_id(self, repo):
+        return repo.name

--- a/src/sentry/integrations/bitbucket/repository.py
+++ b/src/sentry/integrations/bitbucket/repository.py
@@ -127,5 +127,5 @@ class BitbucketRepositoryProvider(providers.IntegrationRepositoryProvider):
             else:
                 return self._format_commits(repo, res)
 
-    def repository_external_id(self, repo):
+    def repository_external_slug(self, repo):
         return repo.name

--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -143,3 +143,6 @@ class GitHubRepositoryProvider(providers.IntegrationRepositoryProvider):
 
     def pull_request_url(self, repo, pull_request):
         return u'{}/pulls/{}'.format(repo.url, pull_request.key)
+
+    def repository_external_id(self, repo):
+        return repo.name

--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -144,5 +144,5 @@ class GitHubRepositoryProvider(providers.IntegrationRepositoryProvider):
     def pull_request_url(self, repo, pull_request):
         return u'{}/pulls/{}'.format(repo.url, pull_request.key)
 
-    def repository_external_id(self, repo):
+    def repository_external_slug(self, repo):
         return repo.name

--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -142,7 +142,7 @@ class GitHubRepositoryProvider(providers.IntegrationRepositoryProvider):
         return changes
 
     def pull_request_url(self, repo, pull_request):
-        return u'{}/pulls/{}'.format(repo.url, pull_request.key)
+        return u'{}/pull/{}'.format(repo.url, pull_request.key)
 
     def repository_external_slug(self, repo):
         return repo.name

--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -155,5 +155,5 @@ class GitlabRepositoryProvider(providers.IntegrationRepositoryProvider):
     def pull_request_url(self, repo, pull_request):
         return u'{}/merge_requests/{}'.format(repo.url, pull_request.key)
 
-    def repository_external_id(self, repo):
+    def repository_external_slug(self, repo):
         return repo.config['project_id']

--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -154,3 +154,6 @@ class GitlabRepositoryProvider(providers.IntegrationRepositoryProvider):
 
     def pull_request_url(self, repo, pull_request):
         return u'{}/merge_requests/{}'.format(repo.url, pull_request.key)
+
+    def repository_external_id(self, repo):
+        return repo.config['project_id']

--- a/src/sentry/integrations/repositories.py
+++ b/src/sentry/integrations/repositories.py
@@ -23,7 +23,7 @@ class RepositoryMixin(object):
 
         The shape of the `identifier` should match the data
         returned by the integration's
-        IntegrationRepositoryProvider.repository_external_id()
+        IntegrationRepositoryProvider.repository_external_slug()
         """
         raise NotImplementedError
 

--- a/src/sentry/integrations/repositories.py
+++ b/src/sentry/integrations/repositories.py
@@ -20,6 +20,10 @@ class RepositoryMixin(object):
             'name': display_name,
             'identifier': external_repo_id,
         }]
+
+        The shape of the `identifier` should match the data
+        returned by the integration's
+        IntegrationRepositoryProvider.repository_external_id()
         """
         raise NotImplementedError
 

--- a/src/sentry/integrations/vsts/repository.py
+++ b/src/sentry/integrations/vsts/repository.py
@@ -118,3 +118,6 @@ class VstsRepositoryProvider(providers.IntegrationRepositoryProvider):
                 'patch_set': c.get('patch_set'),
             } for c in commit_list
         ]
+
+    def repository_external_id(self, repo):
+        return repo.external_id

--- a/src/sentry/integrations/vsts/repository.py
+++ b/src/sentry/integrations/vsts/repository.py
@@ -119,5 +119,5 @@ class VstsRepositoryProvider(providers.IntegrationRepositoryProvider):
             } for c in commit_list
         ]
 
-    def repository_external_id(self, repo):
+    def repository_external_slug(self, repo):
         return repo.external_id

--- a/src/sentry/plugins/providers/dummy/repository.py
+++ b/src/sentry/plugins/providers/dummy/repository.py
@@ -38,5 +38,5 @@ class DummyRepositoryProvider(RepositoryProvider):
             }
         ]
 
-    def repository_external_id(self, repo):
+    def repository_external_slug(self, repo):
         return repo.external_id

--- a/src/sentry/plugins/providers/dummy/repository.py
+++ b/src/sentry/plugins/providers/dummy/repository.py
@@ -37,3 +37,6 @@ class DummyRepositoryProvider(RepositoryProvider):
                 'repository': repo.name,
             }
         ]
+
+    def repository_external_id(self, repo):
+        return repo.external_id

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -143,6 +143,14 @@ class IntegrationRepositoryProvider(object):
         """
         return None
 
+    def repository_external_id(self, repo):
+        """
+        Generate the public facing 'external_id' for a repository
+        The shape of this id must match the `identifier` returned by
+        the integration's Integration.get_repositories() method
+        """
+        return repo.name
+
     @staticmethod
     def should_ignore_commit(message):
         return '#skipsentry' in message

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -143,9 +143,9 @@ class IntegrationRepositoryProvider(object):
         """
         return None
 
-    def repository_external_id(self, repo):
+    def repository_external_slug(self, repo):
         """
-        Generate the public facing 'external_id' for a repository
+        Generate the public facing 'external_slug' for a repository
         The shape of this id must match the `identifier` returned by
         the integration's Integration.get_repositories() method
         """

--- a/src/sentry/plugins/providers/repository.py
+++ b/src/sentry/plugins/providers/repository.py
@@ -133,9 +133,9 @@ class RepositoryProvider(ProviderMixin):
         """
         return None
 
-    def repository_external_id(self, repo):
+    def repository_external_slug(self, repo):
         """
-        Generate the public facing 'external_id' for a repository
+        Generate the public facing 'external_slug' for a repository
         The shape of this id must match the `identifier` returned by
         the Plugin's get repositories method
         """

--- a/src/sentry/plugins/providers/repository.py
+++ b/src/sentry/plugins/providers/repository.py
@@ -127,6 +127,20 @@ class RepositoryProvider(ProviderMixin):
     def compare_commits(self, repo, start_sha, end_sha, actor=None):
         raise NotImplementedError
 
+    def pull_request_url(self, repo, pull_request):
+        """
+        Generate a URL to a pull request on the repository provider.
+        """
+        return None
+
+    def repository_external_id(self, repo):
+        """
+        Generate the public facing 'external_id' for a repository
+        The shape of this id must match the `identifier` returned by
+        the Plugin's get repositories method
+        """
+        return None
+
     @staticmethod
     def should_ignore_commit(message):
         return '#skipsentry' in message

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
@@ -98,10 +98,10 @@ export default class IntegrationRepos extends AsyncComponent {
     this.setState({adding: true});
 
     let migratableRepo = itemList.filter(item => {
-      if (!(selection.value && item.name)) {
+      if (!(selection.value && item.externalId)) {
         return false;
       }
-      return selection.value.toLowerCase() === item.name.toLowerCase();
+      return selection.value == item.externalId;
     })[0];
 
     let promise;
@@ -133,7 +133,7 @@ export default class IntegrationRepos extends AsyncComponent {
       );
     }
     const repositories = new Set(
-      this.state.itemList.filter(item => item.integrationId).map(i => i.name)
+      this.state.itemList.filter(item => item.integrationId).map(i => i.externalId)
     );
     let repositoryOptions = (this.state.integrationRepos.repos || []).filter(
       repo => !repositories.has(repo.identifier)

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
@@ -98,10 +98,10 @@ export default class IntegrationRepos extends AsyncComponent {
     this.setState({adding: true});
 
     let migratableRepo = itemList.filter(item => {
-      if (!(selection.value && item.externalId)) {
+      if (!(selection.value && item.externalSlug)) {
         return false;
       }
-      return selection.value == item.externalId;
+      return selection.value == item.externalSlug;
     })[0];
 
     let promise;
@@ -133,7 +133,7 @@ export default class IntegrationRepos extends AsyncComponent {
       );
     }
     const repositories = new Set(
-      this.state.itemList.filter(item => item.integrationId).map(i => i.externalId)
+      this.state.itemList.filter(item => item.integrationId).map(i => i.externalSlug)
     );
     let repositoryOptions = (this.state.integrationRepos.repos || []).filter(
       repo => !repositories.has(repo.identifier)

--- a/tests/js/fixtures/repository.js
+++ b/tests/js/fixtures/repository.js
@@ -5,6 +5,7 @@ export function Repository(params = {}) {
     provider: 'github',
     url: 'https://github.com/example/repo-name',
     status: 'active',
+    externalId: 'example/repo-name',
     ...params,
   };
 }

--- a/tests/js/fixtures/repository.js
+++ b/tests/js/fixtures/repository.js
@@ -5,7 +5,7 @@ export function Repository(params = {}) {
     provider: 'github',
     url: 'https://github.com/example/repo-name',
     status: 'active',
-    externalId: 'example/repo-name',
+    externalSlug: 'example/repo-name',
     ...params,
   };
 }

--- a/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
@@ -104,7 +104,7 @@ describe('IntegrationRepos', function() {
         body: [
           TestStubs.Repository({
             integrationId: null,
-            externalId: 'example/repo-name',
+            externalSlug: 'example/repo-name',
             provider: {
               id: 'integrations:github',
               name: 'GitHub',
@@ -137,12 +137,12 @@ describe('IntegrationRepos', function() {
       );
     });
 
-    it('uses externalId not name for comparison', () => {
+    it('uses externalSlug not name for comparison', () => {
       Client.addMockResponse({
         url: `/organizations/${org.slug}/repos/`,
         method: 'GET',
         body: [
-          TestStubs.Repository({name: 'Repo Name', externalId: 'example/repo-name'}),
+          TestStubs.Repository({name: 'Repo Name', externalSlug: 'example/repo-name'}),
         ],
       });
       const getItems = Client.addMockResponse({

--- a/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
@@ -141,15 +141,13 @@ describe('IntegrationRepos', function() {
       Client.addMockResponse({
         url: `/organizations/${org.slug}/repos/`,
         method: 'GET',
-        body: [
-          TestStubs.Repository({name: 'Repo Name', externalSlug: 'example/repo-name'}),
-        ],
+        body: [TestStubs.Repository({name: 'repo-name', externalSlug: 9876})],
       });
       const getItems = Client.addMockResponse({
         url: `/organizations/${org.slug}/integrations/${integration.id}/repos/`,
         method: 'GET',
         body: {
-          repos: [{identifier: 'example/repo-name', name: 'repo-name'}],
+          repos: [{identifier: 9876, name: 'repo-name'}],
         },
       });
       const updateRepo = Client.addMockResponse({

--- a/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
@@ -104,6 +104,7 @@ describe('IntegrationRepos', function() {
         body: [
           TestStubs.Repository({
             integrationId: null,
+            externalId: 'example/repo-name',
             provider: {
               id: 'integrations:github',
               name: 'GitHub',
@@ -136,11 +137,13 @@ describe('IntegrationRepos', function() {
       );
     });
 
-    it('compares case-insensitive', () => {
+    it('uses externalId not name for comparison', () => {
       Client.addMockResponse({
         url: `/organizations/${org.slug}/repos/`,
         method: 'GET',
-        body: [TestStubs.Repository({name: 'Example/repo-name'})],
+        body: [
+          TestStubs.Repository({name: 'Repo Name', externalId: 'example/repo-name'}),
+        ],
       });
       const getItems = Client.addMockResponse({
         url: `/organizations/${org.slug}/integrations/${integration.id}/repos/`,

--- a/tests/js/spec/views/settings/__snapshots__/organizationRepositories.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationRepositories.spec.jsx.snap
@@ -35,6 +35,7 @@ exports[`OrganizationRepositories renders with a repository 1`] = `
           orgId="org-slug"
           repository={
             Object {
+              "externalSlug": "example/repo-name",
               "id": "4",
               "name": "example/repo-name",
               "provider": "github",

--- a/tests/sentry/api/endpoints/test_organization_repositories.py
+++ b/tests/sentry/api/endpoints/test_organization_repositories.py
@@ -35,7 +35,7 @@ class OrganizationRepositoriesListTest(APITestCase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]['id'] == six.text_type(repo.id)
-        assert response.data[0]['externalId'] is None
+        assert response.data[0]['externalSlug'] is None
 
     def test_get_integration_repository(self):
         repo = Repository.objects.create(

--- a/tests/sentry/api/endpoints/test_organization_repositories.py
+++ b/tests/sentry/api/endpoints/test_organization_repositories.py
@@ -56,7 +56,7 @@ class OrganizationRepositoriesListTest(APITestCase):
             'id': 'dummy',
             'name': 'Example'
         }
-        assert first_row['externalId'] == six.text_type(repo.external_id)
+        assert first_row['externalSlug'] == six.text_type(repo.external_id)
 
     def test_status_unmigratable(self):
         self.url = self.url + '?status=unmigratable'

--- a/tests/sentry/api/endpoints/test_organization_repositories.py
+++ b/tests/sentry/api/endpoints/test_organization_repositories.py
@@ -35,6 +35,28 @@ class OrganizationRepositoriesListTest(APITestCase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]['id'] == six.text_type(repo.id)
+        assert response.data[0]['externalId'] is None
+
+    def test_get_integration_repository(self):
+        repo = Repository.objects.create(
+            name='getsentry/example',
+            organization_id=self.org.id,
+            external_id=12345,
+            provider='dummy',
+            config={'name': 'getsentry/example'}
+        )
+
+        response = self.client.get(self.url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        first_row = response.data[0]
+        assert first_row['id'] == six.text_type(repo.id)
+        assert first_row['provider'] == {
+            'id': 'dummy',
+            'name': 'Example'
+        }
+        assert first_row['externalId'] == six.text_type(repo.external_id)
 
     def test_status_unmigratable(self):
         self.url = self.url + '?status=unmigratable'

--- a/tests/sentry/api/serializers/test_pull_request.py
+++ b/tests/sentry/api/serializers/test_pull_request.py
@@ -105,7 +105,7 @@ class PullRequestSerializerTest(TestCase):
 
         result = serialize(pull_request, user)
 
-        assert result['externalUrl'] == 'https://github.com/test/test/pulls/9'
+        assert result['externalUrl'] == 'https://github.com/test/test/pull/9'
         assert result['message'] == 'waddap'
         assert result['title'] == 'cool pr'
         assert result['repository']['name'] == 'test/test'

--- a/tests/sentry/integrations/bitbucket/test_repository.py
+++ b/tests/sentry/integrations/bitbucket/test_repository.py
@@ -125,6 +125,6 @@ class BitbucketRepositoryProviderTest(TestCase):
             }
         }
 
-    def test_repository_external_id(self):
-        result = self.provider.repository_external_id(self.repo)
+    def test_repository_external_slug(self):
+        result = self.provider.repository_external_slug(self.repo)
         assert result == self.repo.name

--- a/tests/sentry/integrations/bitbucket/test_repository.py
+++ b/tests/sentry/integrations/bitbucket/test_repository.py
@@ -124,3 +124,7 @@ class BitbucketRepositoryProviderTest(TestCase):
                 'webhook_id': webhook_id,
             }
         }
+
+    def test_repository_external_id(self):
+        result = self.provider.repository_external_id(self.repo)
+        assert result == self.repo.name

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -42,7 +42,7 @@ class GitHubAppsProviderTest(PluginTestCase):
             external_id='654321',
         )
         return Repository.objects.create(
-            name='example-repo',
+            name='getsentry/example-repo',
             provider='integrations:github',
             organization_id=organization.id,
             integration_id=integration.id,
@@ -156,3 +156,7 @@ class GitHubAppsProviderTest(PluginTestCase):
         pull = PullRequest(key=99)
         result = self.provider.pull_request_url(self.repository, pull)
         assert result == 'https://github.com/getsentry/example-repo/pulls/99'
+
+    def test_repository_external_id(self):
+        result = self.provider.repository_external_id(self.repository)
+        assert result == self.repository.config['name']

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -155,7 +155,7 @@ class GitHubAppsProviderTest(PluginTestCase):
     def test_pull_request_url(self):
         pull = PullRequest(key=99)
         result = self.provider.pull_request_url(self.repository, pull)
-        assert result == 'https://github.com/getsentry/example-repo/pulls/99'
+        assert result == 'https://github.com/getsentry/example-repo/pull/99'
 
     def test_repository_external_slug(self):
         result = self.provider.repository_external_slug(self.repository)

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -157,6 +157,6 @@ class GitHubAppsProviderTest(PluginTestCase):
         result = self.provider.pull_request_url(self.repository, pull)
         assert result == 'https://github.com/getsentry/example-repo/pulls/99'
 
-    def test_repository_external_id(self):
-        result = self.provider.repository_external_id(self.repository)
+    def test_repository_external_slug(self):
+        result = self.provider.repository_external_slug(self.repository)
         assert result == self.repository.config['name']

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -309,9 +309,9 @@ class GitLabRepositoryProviderTest(PluginTestCase):
         assert result == 'https://example.gitlab.com/getsentry/projects/example-repo/merge_requests/99'
 
     @responses.activate
-    def test_repository_external_id(self):
+    def test_repository_external_slug(self):
         response = self.create_repository(self.default_repository_config,
                                           self.integration.id)
         repo = Repository.objects.get(pk=response.data['id'])
-        result = self.provider.repository_external_id(repo)
+        result = self.provider.repository_external_slug(repo)
         assert result == repo.config['project_id']

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -307,3 +307,11 @@ class GitLabRepositoryProviderTest(PluginTestCase):
         pull = PullRequest(key=99)
         result = self.provider.pull_request_url(repo, pull)
         assert result == 'https://example.gitlab.com/getsentry/projects/example-repo/merge_requests/99'
+
+    @responses.activate
+    def test_repository_external_id(self):
+        response = self.create_repository(self.default_repository_config,
+                                          self.integration.id)
+        repo = Repository.objects.get(pk=response.data['id'])
+        result = self.provider.repository_external_id(repo)
+        assert result == repo.config['project_id']

--- a/tests/sentry/integrations/vsts/test_repository.py
+++ b/tests/sentry/integrations/vsts/test_repository.py
@@ -118,10 +118,10 @@ class VisualStudioRepositoryProviderTest(TestCase):
             'integration_id': integration.id,
         }
 
-    def test_repository_external_id(self):
+    def test_repository_external_slug(self):
         repo = Repository(
             name='MyFirstProject',
             url='https://mbittker.visualstudio.com/_git/MyFirstProject/',
             external_id=self.vsts_external_id)
-        result = self.provider.repository_external_id(repo)
+        result = self.provider.repository_external_slug(repo)
         assert result == repo.external_id

--- a/tests/sentry/integrations/vsts/test_repository.py
+++ b/tests/sentry/integrations/vsts/test_repository.py
@@ -117,3 +117,11 @@ class VisualStudioRepositoryProviderTest(TestCase):
             },
             'integration_id': integration.id,
         }
+
+    def test_repository_external_id(self):
+        repo = Repository(
+            name='MyFirstProject',
+            url='https://mbittker.visualstudio.com/_git/MyFirstProject/',
+            external_id=self.vsts_external_id)
+        result = self.provider.repository_external_id(repo)
+        assert result == repo.external_id


### PR DESCRIPTION
Right now the web ui relies on name == identifier to determine if a repository has been connected or not. This only works for a github and bitbucket, other integrations/plugins have other identifiers that they use in their API calls. Exposing this method allows us to expose the provider's ID system to our webui so it can do safer filtering operations.

Refs #10563