### PR TITLE
fix(snuba): Return empty dict for `totals` on early exit from query

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -110,7 +110,8 @@ class SnubaTagStorage(TagStorage):
             orderby='-count', limit=limit, totals=True,
             referrer='tagstore.__get_tag_key_and_top_values'
         )
-        if raise_on_empty and (result is None or totals['count'] == 0):
+
+        if raise_on_empty and (not result or totals.get('count', 0) == 0):
             raise TagKeyNotFound if group_id is None else GroupTagKeyNotFound
         else:
             if group_id is None:
@@ -132,8 +133,8 @@ class SnubaTagStorage(TagStorage):
 
             return key_ctor(
                 key=key,
-                values_seen=totals['values_seen'],
-                count=totals['count'],
+                values_seen=totals.get('values_seen', 0),
+                count=totals.get('count', 0),
                 top_values=top_values
             )
 

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -369,7 +369,10 @@ def query(start, end, groupby, conditions=None, filter_keys=None,
             referrer=referrer, is_grouprelease=is_grouprelease, totals=totals, limitby=limitby
         )
     except (QueryOutsideRetentionError, QueryOutsideGroupActivityError):
-        return OrderedDict()
+        if totals:
+            return OrderedDict(), {}
+        else:
+            return OrderedDict()
 
     # Validate and scrub response, and translate snuba keys back to IDs
     aggregate_cols = [a[2] for a in aggregations]


### PR DESCRIPTION
This was causing an error trying to unpack the `results, totals` tuple: https://github.com/getsentry/sentry/blob/c1c6f315380cdd021538fb4f605253da7d6b675e/src/sentry/tagstore/snuba/backend.py#L108