### PR TITLE
feat(api): Add OrganizationTagKeyValuesEndpoint

### DIFF
--- a/src/sentry/api/bases/__init__.py
+++ b/src/sentry/api/bases/__init__.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from .group import *  # NOQA
 from .organization import *  # NOQA
+from .organization_events import *  # NOQA
 from .organizationissues import *  # NOQA
 from .organizationmember import *  # NOQA
 from .project import *  # NOQA

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -74,7 +74,9 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
 
         return list(environments)
 
-    def get_snuba_query_args(self, request, organization):
+    def get_filter_params(self, request, organization):
+        # get the top level params -- projects, time range, and environment
+        # from the request
         try:
             start, end = get_date_range_from_params(request.GET)
         except InvalidParams as exc:
@@ -94,6 +96,10 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         if environments:
             params['environment'] = environments
 
+        return params
+
+    def get_snuba_query_args(self, request, organization):
+        params = self.get_filter_params(request, organization)
         try:
             return get_snuba_query_args(query=request.GET.get('query'), params=params)
         except InvalidSearchQuery as exc:

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -1,0 +1,100 @@
+from __future__ import absolute_import
+
+from rest_framework.exceptions import PermissionDenied
+
+from sentry import roles
+from sentry.api.bases import OrganizationEndpoint
+from sentry.api.event_search import get_snuba_query_args, InvalidSearchQuery
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.utils import get_date_range_from_params, InvalidParams
+from sentry.models import (
+    Environment, OrganizationMember, OrganizationMemberTeam, Project, ProjectStatus
+)
+
+
+class OrganizationEventsError(Exception):
+    pass
+
+
+class OrganizationEventsEndpointBase(OrganizationEndpoint):
+
+    def get_project_ids(self, request, organization):
+        project_ids = set(map(int, request.GET.getlist('project')))
+
+        requested_projects = project_ids.copy()
+
+        try:
+            om_role = OrganizationMember.objects.filter(
+                user=request.user,
+                organization=organization,
+            ).values_list('role', flat=True).get()
+        except OrganizationMember.DoesNotExist:
+            om_role = None
+
+        if request.user.is_superuser or (om_role and roles.get(om_role).is_global):
+            qs = Project.objects.filter(
+                organization=organization,
+                status=ProjectStatus.VISIBLE,
+            )
+        else:
+            qs = Project.objects.filter(
+                organization=organization,
+                teams__in=OrganizationMemberTeam.objects.filter(
+                    organizationmember__user=request.user,
+                    organizationmember__organization=organization,
+                ).values_list('team'),
+                status=ProjectStatus.VISIBLE,
+            )
+
+        if project_ids:
+            qs = qs.filter(id__in=project_ids)
+
+        project_ids = set(qs.values_list('id', flat=True))
+
+        if requested_projects and project_ids != requested_projects:
+            raise PermissionDenied
+
+        return list(project_ids)
+
+    def get_environments(self, request, organization):
+        requested_environments = set(request.GET.getlist('environment'))
+
+        if not requested_environments:
+            return []
+
+        environments = set(
+            Environment.objects.filter(
+                organization_id=organization.id,
+                name__in=requested_environments,
+            ).values_list('name', flat=True),
+        )
+
+        if requested_environments != environments:
+            raise ResourceDoesNotExist
+
+        return list(environments)
+
+    def get_snuba_query_args(self, request, organization):
+        try:
+            start, end = get_date_range_from_params(request.GET)
+        except InvalidParams as exc:
+            raise OrganizationEventsError(exc.message)
+
+        try:
+            project_ids = self.get_project_ids(request, organization)
+        except ValueError:
+            raise OrganizationEventsError('Invalid project ids')
+
+        environments = self.get_environments(request, organization)
+        params = {
+            'start': start,
+            'end': end,
+            'project_id': project_ids,
+        }
+        if environments:
+            params['environment'] = environments
+
+        try:
+            return get_snuba_query_args(query=request.GET.get('query'), params=params)
+        except InvalidSearchQuery as exc:
+            raise OrganizationEventsError(exc.message)

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -4,114 +4,18 @@ from collections import namedtuple
 from datetime import timedelta
 from functools32 import partial
 
-from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
-from sentry import roles
-from sentry.api.bases import OrganizationEndpoint
-from sentry.api.event_search import get_snuba_query_args, InvalidSearchQuery
-from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.event import SnubaEvent
 from sentry.api.serializers.snuba import SnubaTSResultSerializer
-from sentry.api.utils import get_date_range_from_params, InvalidParams
-from sentry.models import (
-    Environment, OrganizationMember, OrganizationMemberTeam, Project, ProjectStatus
-)
 from sentry.utils.dates import parse_stats_period
 from sentry.utils.snuba import raw_query
 
 
 SnubaTSResult = namedtuple('SnubaTSResult', ('data', 'start', 'end', 'rollup'))
-
-
-class OrganizationEventsError(Exception):
-    pass
-
-
-class OrganizationEventsEndpointBase(OrganizationEndpoint):
-
-    def get_project_ids(self, request, organization):
-        project_ids = set(map(int, request.GET.getlist('project')))
-
-        requested_projects = project_ids.copy()
-
-        try:
-            om_role = OrganizationMember.objects.filter(
-                user=request.user,
-                organization=organization,
-            ).values_list('role', flat=True).get()
-        except OrganizationMember.DoesNotExist:
-            om_role = None
-
-        if request.user.is_superuser or (om_role and roles.get(om_role).is_global):
-            qs = Project.objects.filter(
-                organization=organization,
-                status=ProjectStatus.VISIBLE,
-            )
-        else:
-            qs = Project.objects.filter(
-                organization=organization,
-                teams__in=OrganizationMemberTeam.objects.filter(
-                    organizationmember__user=request.user,
-                    organizationmember__organization=organization,
-                ).values_list('team'),
-                status=ProjectStatus.VISIBLE,
-            )
-
-        if project_ids:
-            qs = qs.filter(id__in=project_ids)
-
-        project_ids = set(qs.values_list('id', flat=True))
-
-        if requested_projects and project_ids != requested_projects:
-            raise PermissionDenied
-
-        return list(project_ids)
-
-    def get_environments(self, request, organization):
-        requested_environments = set(request.GET.getlist('environment'))
-
-        if not requested_environments:
-            return []
-
-        environments = set(
-            Environment.objects.filter(
-                organization_id=organization.id,
-                name__in=requested_environments,
-            ).values_list('name', flat=True),
-        )
-
-        if requested_environments != environments:
-            raise ResourceDoesNotExist
-
-        return list(environments)
-
-    def get_snuba_query_args(self, request, organization):
-        try:
-            start, end = get_date_range_from_params(request.GET)
-        except InvalidParams as exc:
-            raise OrganizationEventsError(exc.message)
-
-        try:
-            project_ids = self.get_project_ids(request, organization)
-        except ValueError:
-            raise OrganizationEventsError('Invalid project ids')
-
-        environments = self.get_environments(request, organization)
-        params = {
-            'start': start,
-            'end': end,
-            'project_id': project_ids,
-        }
-        if environments:
-            params['environment'] = environments
-
-        try:
-            return get_snuba_query_args(query=request.GET.get('query'), params=params)
-        except InvalidSearchQuery as exc:
-            raise OrganizationEventsError(exc.message)
 
 
 class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):

--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+
+from functools32 import partial
+
+from rest_framework.response import Response
+
+from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError
+from sentry.api.event_search import get_snuba_query_args, InvalidSearchQuery
+from sentry.api.paginator import GenericOffsetPaginator
+from sentry.utils.snuba import raw_query
+from sentry.tagstore.base import TAG_KEY_RE
+
+
+class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
+
+    def get(self, request, organization, key):
+        if not TAG_KEY_RE.match(key):
+            return Response({'detail': 'Invalid tag key format for "%s"' % (key,)}, status=400)
+
+        try:
+            filter_params = self.get_filter_params(request, organization)
+        except OrganizationEventsError as exc:
+            return Response({'detail': exc.message}, status=400)
+
+        query = 'tags_key:%s' % (key,)
+
+        try:
+            snuba_args = get_snuba_query_args(query, params=filter_params)
+        except InvalidSearchQuery as exc:
+            return Response({'detail': exc.message}, status=400)
+
+        data_fn = partial(
+            # extract 'data' from raw_query result
+            lambda *args, **kwargs: raw_query(*args, **kwargs)['data'],
+            aggregations=[
+                ('count()', '', 'count'),
+            ],
+            orderby='-count',
+            groupby=['tags_value'],
+            referrer='api.organization-tags',
+            **snuba_args
+        )
+
+        return self.paginate(
+            request=request,
+            on_results=lambda results: [{
+                'value': row['tags_value'],
+                'count': row['count'],
+            } for row in results],
+            paginator=GenericOffsetPaginator(data_fn=data_fn),
+        )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -93,6 +93,7 @@ from .endpoints.organization_config_repositories import OrganizationConfigReposi
 from .endpoints.organization_repository_commits import OrganizationRepositoryCommitsEndpoint
 from .endpoints.organization_repository_details import OrganizationRepositoryDetailsEndpoint
 from .endpoints.organization_sentry_apps import OrganizationSentryAppsEndpoint
+from .endpoints.organization_tagkey_values import OrganizationTagKeyValuesEndpoint
 from .endpoints.sentry_app_installations import SentryAppInstallationsEndpoint
 from .endpoints.sentry_app_installation_details import SentryAppInstallationDetailsEndpoint
 from .endpoints.organization_stats import OrganizationStatsEndpoint
@@ -645,6 +646,11 @@ urlpatterns = patterns(
         r'^organizations/(?P<organization_slug>[^\/]+)/teams/$',
         OrganizationTeamsEndpoint.as_view(),
         name='sentry-api-0-organization-teams'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/tags/(?P<key>[^/]+)/values/$',
+        OrganizationTagKeyValuesEndpoint.as_view(),
+        name='sentry-api-0-organization-tagkey-values'
     ),
     url(
         r'^organizations/(?P<organization_slug>[^\/]+)/onboarding-tasks/$',

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -1,0 +1,69 @@
+from __future__ import absolute_import
+
+from datetime import timedelta
+from django.utils import timezone
+from django.core.urlresolvers import reverse
+
+from sentry.testutils import APITestCase, SnubaTestCase
+
+
+class OrganizationTagKeyValuesTest(APITestCase, SnubaTestCase):
+    def setUp(self):
+        super(OrganizationTagKeyValuesTest, self).setUp()
+        self.min_ago = timezone.now() - timedelta(minutes=1)
+
+    def test_simple(self):
+        user = self.create_user()
+        org = self.create_organization()
+        team = self.create_team(organization=org)
+        self.create_member(organization=org, user=user, teams=[team])
+
+        self.login_as(user=user)
+
+        project = self.create_project(organization=org, teams=[team])
+        group = self.create_group(project=project)
+
+        self.create_event(
+            'a' * 32, group=group, datetime=self.min_ago, tags={'fruit': 'apple'}
+        )
+        self.create_event(
+            'b' * 32, group=group, datetime=self.min_ago, tags={'fruit': 'orange'}
+        )
+        self.create_event(
+            'c' * 32, group=group, datetime=self.min_ago, tags={'some_tag': 'some_value'}
+        )
+        self.create_event(
+            'd' * 32, group=group, datetime=self.min_ago, tags={'fruit': 'orange'}
+        )
+
+        url = reverse(
+            'sentry-api-0-organization-tagkey-values',
+            kwargs={
+                'organization_slug': org.slug,
+                'key': 'fruit',
+            }
+        )
+
+        response = self.client.get(url, format='json')
+        assert response.status_code == 200, response.content
+        assert response.data == [{'count': 2, 'value': 'orange'}, {'count': 1, 'value': 'apple'}]
+
+    def test_bad_key(self):
+        user = self.create_user()
+        org = self.create_organization()
+        team = self.create_team(organization=org)
+        self.create_member(organization=org, user=user, teams=[team])
+
+        self.login_as(user=user)
+
+        url = reverse(
+            'sentry-api-0-organization-tagkey-values',
+            kwargs={
+                'organization_slug': org.slug,
+                'key': 'fr uit',
+            }
+        )
+
+        response = self.client.get(url, format='json')
+        assert response.status_code == 400, response.content
+        assert response.data == {'detail': 'Invalid tag key format for "fr uit"'}


### PR DESCRIPTION
also did some refactoring to reuse `OrganizationEventsEndpointBase` (so that this endpoint will also use the same top level filter params as org events/org event stats -- project, environment and date range)
