### PR TITLE
fix(environments): Re-request tag values when environment changes

### DIFF
--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -34,7 +34,7 @@ const GroupSidebar = createReactClass({
   mixins: [ApiMixin, ProjectState],
 
   getInitialState() {
-    return {participants: []};
+    return {participants: [], environment: this.props.environment};
   },
 
   componentWillMount() {
@@ -67,11 +67,23 @@ const GroupSidebar = createReactClass({
       },
     });
 
+    this.fetchTagData();
+  },
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.environment !== this.props.environment) {
+      this.setState({environment: nextProps.environment}, this.fetchTagData);
+    }
+  },
+
+  fetchTagData() {
+    let {group} = this.props;
+
     // Fetch the top values for the current group's top tags.
     this.api.request(`/issues/${group.id}/tags/`, {
       query: _.pickBy({
         key: group.tags.map(data => data.key),
-        environment: this.props.environment && this.props.environment.name,
+        environment: this.state.environment && this.state.environment.name,
       }),
       success: data => {
         this.setState({

--- a/tests/js/spec/components/group/sidebar.spec.jsx
+++ b/tests/js/spec/components/group/sidebar.spec.jsx
@@ -108,4 +108,21 @@ describe('GroupSidebar', function() {
       );
     });
   });
+
+  describe('environment toggle', function() {
+    it('re-requests tags with correct environment', function() {
+      const stagingEnv = {name: 'staging', displayName: 'Staging', id: '2'};
+      expect(tagValuesMock).toHaveBeenCalledTimes(1);
+      wrapper.setProps({environment: stagingEnv});
+      expect(tagValuesMock).toHaveBeenCalledTimes(2);
+      expect(tagValuesMock).toHaveBeenCalledWith(
+        '/issues/1/tags/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            environment: 'staging',
+          }),
+        })
+      );
+    });
+  });
 });


### PR DESCRIPTION
Previously this only happened on mount so tag values requested may not
be correct when the environment is toggled from this view.