### PR TITLE
fix(discover): Remove internal property

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/data.jsx
@@ -40,7 +40,6 @@ export const COLUMNS = [
   {name: 'message', type: TYPES.STRING},
   {name: 'primary_hash', type: TYPES.STRING},
   {name: 'timestamp', type: TYPES.DATETIME},
-  {name: 'received', type: TYPES.DATETIME},
 
   {name: 'user.id', type: TYPES.STRING},
   {name: 'user.username', type: TYPES.STRING},

--- a/tests/js/spec/views/organizationDiscover/conditions/utils.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/conditions/utils.spec.jsx
@@ -52,8 +52,8 @@ describe('Conditions', function() {
     });
 
     // datetime fields are expanded
-    const expected = ['received', '=', '2018-05-05T00:00:00'];
-    expect(getExternal('received = 2018-05-05', COLUMNS)).toEqual(expected);
+    const expected = ['timestamp', '=', '2018-05-05T00:00:00'];
+    expect(getExternal('timestamp = 2018-05-05', COLUMNS)).toEqual(expected);
   });
 
   it('getInternal()', function() {


### PR DESCRIPTION
We shouldn't expose received to users, they should just use timestamp