### PR TITLE
ref(ui): Fix pagination for debug symbols

### DIFF
--- a/src/sentry/static/sentry/app/views/projectDebugFiles.jsx
+++ b/src/sentry/static/sentry/app/views/projectDebugFiles.jsx
@@ -45,7 +45,7 @@ const ProjectDebugSymbols = createReactClass({
       loading: true,
       error: false,
       debugFiles: [],
-      query: '',
+      query: {query: ''},
       pageLinks: '',
     };
   },
@@ -64,7 +64,7 @@ const ProjectDebugSymbols = createReactClass({
       const queryParams = nextProps.location.query;
       this.setState(
         {
-          query: queryParams.query,
+          query: queryParams,
         },
         this.fetchData
       );
@@ -73,10 +73,9 @@ const ProjectDebugSymbols = createReactClass({
 
   fetchData() {
     const {orgId, projectId} = this.props.params;
-
     const query = {
       per_page: 20,
-      query: this.state.query,
+      ...this.state.query,
     };
 
     this.setState({
@@ -246,7 +245,7 @@ const ProjectDebugSymbols = createReactClass({
             <SearchBar
               defaultQuery=""
               placeholder={t('Search for a DIF')}
-              query={this.state.query}
+              query={this.state.query.query}
               onSearch={this.onSearch}
             />
           </div>

--- a/src/sentry/static/sentry/app/views/projectDebugFiles.jsx
+++ b/src/sentry/static/sentry/app/views/projectDebugFiles.jsx
@@ -218,7 +218,7 @@ const ProjectDebugSymbols = createReactClass({
     if (this.state.loading) body = this.renderLoading();
     else if (this.state.error) body = <LoadingError onRetry={this.fetchData} />;
     else if (this.state.debugFiles.length > 0) body = this.renderDsyms();
-    else if (this.state.query && this.state.query !== '')
+    else if (this.state.query && this.state.query.query !== '')
       body = this.renderNoQueryResults();
     else body = this.renderEmpty();
 

--- a/tests/js/spec/views/__snapshots__/projectDebugFiles.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectDebugFiles.spec.jsx.snap
@@ -52,11 +52,11 @@ exports[`ProjectDebugFiles renders 1`] = `
       <div
         className="css-1geyb25-TextBlock ec8ep340"
       >
-        
+
           Here you can find all your uploaded debug information files (dSYMs, ProGuard, Breakpad ...).
           This is used to convert addresses and minified function names from crash dumps
           into function names and locations.
-        
+
       </div>
     </Component>
   </TextBlock>
@@ -212,4 +212,64 @@ exports[`ProjectDebugFiles renders 1`] = `
     onCursor={[Function]}
   />
 </ProjectDebugSymbols>
+`;
+
+exports[`ProjectDebugFiles renders empty 1`] = `
+<Fragment>
+  <SettingsPageHeading
+    title="Debug Information Files"
+  />
+  <TextBlock>
+
+          Here you can find all your uploaded debug information files (dSYMs, ProGuard, Breakpad ...).
+          This is used to convert addresses and minified function names from crash dumps
+          into function names and locations.
+
+  </TextBlock>
+  <div
+    className="row m-b-1"
+  >
+    <div
+      className="col-sm-7"
+    />
+    <div
+      className="col-sm-5"
+    >
+      <SearchBar
+        defaultQuery=""
+        onSearch={[Function]}
+        placeholder="Search for a DIF"
+        query=""
+      />
+    </div>
+  </div>
+  <Panel>
+    <PanelHeader>
+      <Box
+        w={0.375}
+      >
+        Debug ID
+      </Box>
+      <Box
+        flex="1"
+      >
+        Name
+      </Box>
+      <Box
+        flex="1"
+      />
+    </PanelHeader>
+    <PanelBody
+      direction="column"
+      disablePadding={true}
+      flex={false}
+    >
+      <LoadingIndicator />
+    </PanelBody>
+  </Panel>
+  <Pagination
+    onCursor={[Function]}
+    pageLinks=""
+  />
+</Fragment>
 `;

--- a/tests/js/spec/views/__snapshots__/projectDebugFiles.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectDebugFiles.spec.jsx.snap
@@ -198,7 +198,7 @@ exports[`ProjectDebugFiles renders 1`] = `
                     />
                   </Icon>
                   <p>
-                    Sorry, no releases match your filters.
+                    There are no debug symbols for this project.
                   </p>
                 </div>
               </EmptyStreamWrapper>

--- a/tests/js/spec/views/__snapshots__/projectDebugFiles.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectDebugFiles.spec.jsx.snap
@@ -52,11 +52,11 @@ exports[`ProjectDebugFiles renders 1`] = `
       <div
         className="css-1geyb25-TextBlock ec8ep340"
       >
-
+        
           Here you can find all your uploaded debug information files (dSYMs, ProGuard, Breakpad ...).
           This is used to convert addresses and minified function names from crash dumps
           into function names and locations.
-
+        
       </div>
     </Component>
   </TextBlock>
@@ -220,11 +220,11 @@ exports[`ProjectDebugFiles renders empty 1`] = `
     title="Debug Information Files"
   />
   <TextBlock>
-
+    
           Here you can find all your uploaded debug information files (dSYMs, ProGuard, Breakpad ...).
           This is used to convert addresses and minified function names from crash dumps
           into function names and locations.
-
+        
   </TextBlock>
   <div
     className="row m-b-1"

--- a/tests/js/spec/views/__snapshots__/projectDebugFiles.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectDebugFiles.spec.jsx.snap
@@ -198,7 +198,7 @@ exports[`ProjectDebugFiles renders 1`] = `
                     />
                   </Icon>
                   <p>
-                    There are no debug symbols for this project.
+                    Sorry, no releases match your filters.
                   </p>
                 </div>
               </EmptyStreamWrapper>
@@ -212,64 +212,4 @@ exports[`ProjectDebugFiles renders 1`] = `
     onCursor={[Function]}
   />
 </ProjectDebugSymbols>
-`;
-
-exports[`ProjectDebugFiles renders empty 1`] = `
-<Fragment>
-  <SettingsPageHeading
-    title="Debug Information Files"
-  />
-  <TextBlock>
-    
-          Here you can find all your uploaded debug information files (dSYMs, ProGuard, Breakpad ...).
-          This is used to convert addresses and minified function names from crash dumps
-          into function names and locations.
-        
-  </TextBlock>
-  <div
-    className="row m-b-1"
-  >
-    <div
-      className="col-sm-7"
-    />
-    <div
-      className="col-sm-5"
-    >
-      <SearchBar
-        defaultQuery=""
-        onSearch={[Function]}
-        placeholder="Search for a DIF"
-        query=""
-      />
-    </div>
-  </div>
-  <Panel>
-    <PanelHeader>
-      <Box
-        w={0.375}
-      >
-        Debug ID
-      </Box>
-      <Box
-        flex="1"
-      >
-        Name
-      </Box>
-      <Box
-        flex="1"
-      />
-    </PanelHeader>
-    <PanelBody
-      direction="column"
-      disablePadding={true}
-      flex={false}
-    >
-      <LoadingIndicator />
-    </PanelBody>
-  </Panel>
-  <Pagination
-    onCursor={[Function]}
-    pageLinks=""
-  />
-</Fragment>
 `;


### PR DESCRIPTION
changes the `query` state from a string to an object so that the `cursor` is used in the api request, not just the search query

