### PR TITLE
fix(ui): Batch requests for stats on org dashboard (ISSUE-197)

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/projects.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/projects.jsx
@@ -1,4 +1,4 @@
-import {debounce} from 'lodash';
+import {chunk, debounce} from 'lodash';
 
 import {
   addLoadingMessage,
@@ -76,16 +76,11 @@ export const _debouncedLoadStats = debounce((api, projectSet, params) => {
     return;
   }
 
-  const queries = [
-    ...Array(Math.ceil(projects.length / MAX_PROJECTS_TO_FETCH)),
-  ].map((val, index) => {
-    const start = index * MAX_PROJECTS_TO_FETCH;
-    return _queryForStats(
-      api,
-      projects.slice(start, start + MAX_PROJECTS_TO_FETCH),
-      params.orgId
-    );
-  });
+  // Split projects into more manageable chunks to query, otherwise we can
+  // potentially face server timeouts
+  const queries = chunk(projects, MAX_PROJECTS_TO_FETCH).map(chunkedProjects =>
+    _queryForStats(api, chunkedProjects, params.orgId)
+  );
 
   Promise.all(queries)
     .then(results => {

--- a/src/sentry/static/sentry/app/actionCreators/projects.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/projects.jsx
@@ -90,7 +90,7 @@ export const _debouncedLoadStats = debounce((api, projectSet, params) => {
   Promise.all(queries)
     .then(results => {
       ProjectActions.loadStatsForProjectSuccess(
-        results.reduce((acc, result) => [...acc, ...result], [])
+        results.reduce((acc, result) => acc.concat(result), [])
       );
     })
     .catch(err => {

--- a/tests/js/spec/actionCreators/projects.spec.jsx
+++ b/tests/js/spec/actionCreators/projects.spec.jsx
@@ -1,0 +1,31 @@
+import {Client} from 'app/api';
+import {_debouncedLoadStats} from 'app/actionCreators/projects';
+
+describe('Projects ActionCreators', function() {
+  const api = new Client();
+  const organization = TestStubs.Organization();
+  let mock;
+
+  it('loadStatsForProject', function() {
+    jest.useFakeTimers();
+    mock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+    });
+    expect(mock).not.toHaveBeenCalled();
+
+    _debouncedLoadStats(api, new Set([...Array(50)].map((_, i) => i)), {
+      orgId: organization.slug,
+    });
+
+    expect(mock).toHaveBeenCalledTimes(5);
+    expect(mock).toHaveBeenLastCalledWith(
+      '/organizations/org-slug/projects/',
+      expect.objectContaining({
+        query: {
+          statsPeriod: '24h',
+          query: 'id:40 id:41 id:42 id:43 id:44 id:45 id:46 id:47 id:48 id:49',
+        },
+      })
+    );
+  });
+});

--- a/tests/js/spec/views/organizationDashboard/index.spec.jsx
+++ b/tests/js/spec/views/organizationDashboard/index.spec.jsx
@@ -337,6 +337,7 @@ describe('OrganizationDashboard', function() {
       );
       jest.useRealTimers();
       await tick();
+      await tick();
       wrapper.update();
       expect(wrapper.find('LoadingCard')).toHaveLength(0);
       expect(wrapper.find('Chart')).toHaveLength(9);

--- a/tests/js/spec/views/organizationDashboard/index.spec.jsx
+++ b/tests/js/spec/views/organizationDashboard/index.spec.jsx
@@ -95,10 +95,12 @@ describe('OrganizationDashboard', function() {
     beforeEach(function() {});
 
     it('renders TeamSection', function() {
-      const projects = [TestStubs.Project({
-        teams,
-        firstEvent: true,
-      })];
+      const projects = [
+        TestStubs.Project({
+          teams,
+          firstEvent: true,
+        }),
+      ];
 
       const wrapper = shallow(
         <Dashboard
@@ -118,11 +120,13 @@ describe('OrganizationDashboard', function() {
     });
 
     it('renders favorited project in favorites section ', function() {
-      const projects = [TestStubs.Project({
-        teams,
-        isBookmarked: true,
-        firstEvent: true,
-      })];
+      const projects = [
+        TestStubs.Project({
+          teams,
+          isBookmarked: true,
+          firstEvent: true,
+        }),
+      ];
 
       const wrapper = shallow(
         <Dashboard
@@ -204,6 +208,7 @@ describe('OrganizationDashboard', function() {
       );
 
       jest.runAllTimers();
+      jest.useRealTimers();
 
       const projectCards = wrapper.find('LazyLoadMock ProjectCard');
       expect(projectCards.at(0).prop('data-test-id')).toBe('a-fave');
@@ -288,7 +293,7 @@ describe('OrganizationDashboard', function() {
       }),
     ];
 
-    it('uses ProjectsStatsStore to load stats', function() {
+    it('uses ProjectsStatsStore to load stats', async function() {
       jest.useFakeTimers();
       ProjectsStatsStore.onStatsLoadSuccess([{...projects[0], stats: [[1517281200, 2]]}]);
       const loadStatsSpy = jest.spyOn(projectsActions, 'loadStatsForProject');
@@ -319,7 +324,6 @@ describe('OrganizationDashboard', function() {
 
       // Advance timers so that batched request fires
       jest.advanceTimersByTime(51);
-
       expect(mock).toHaveBeenCalledTimes(1);
       // query ids = 3, 2, 4 = bookmarked
       // 1 - already loaded in store so shouldn't be in query
@@ -331,10 +335,11 @@ describe('OrganizationDashboard', function() {
           }),
         })
       );
+      jest.useRealTimers();
+      await tick();
       wrapper.update();
       expect(wrapper.find('LoadingCard')).toHaveLength(0);
       expect(wrapper.find('Chart')).toHaveLength(9);
-      jest.useRealTimers();
 
       // Resets store when it unmounts
       wrapper.unmount();


### PR DESCRIPTION
The org dashboard attempts to load stats for all projects within a team. This PR batches the request so we only request up to 10 projects at a time.