### PR TITLE
fix(integrations): Add shouldReload to the panel

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
@@ -18,6 +18,7 @@ import withOrganization from 'app/utils/withOrganization';
 class OrganizationIntegrations extends AsyncComponent {
   // Some integrations require visiting a different website to add them. When
   // we come back to the tab we want to show our integrations as soon as we can.
+  shouldReload = true;
   reloadOnVisible = true;
   shouldReloadOnVisible = true;
 


### PR DESCRIPTION
This allows the loading spinner to show up on the organization integrations panel when it's reloaded via clicking back from the page.