### PR TITLE
feat(app-platform): Issue Created Service Hooks

### DIFF
--- a/src/sentry/mediators/service_hooks/creator.py
+++ b/src/sentry/mediators/service_hooks/creator.py
@@ -10,7 +10,7 @@ from sentry.models import ServiceHook
 
 class Creator(Mediator):
     application = Param('sentry.models.ApiApplication', required=False)
-    actor = Param('sentry.models.User')
+    actor = Param('sentry.db.models.BaseModel')
     project = Param('sentry.models.Project')
     events = Param(Iterable)
     url = Param(six.string_types)

--- a/src/sentry/models/servicehook.py
+++ b/src/sentry/models/servicehook.py
@@ -18,10 +18,13 @@ from sentry.db.models import (
     FlexibleForeignKey,
     sane_repr,
 )
+from sentry.models import SentryApp
 
 SERVICE_HOOK_EVENTS = [
     'event.alert',
     'event.created',
+    # 'issue.created', This is only allowed for Sentry Apps, but listing it
+    #                  here for discoverability purposes.
 ]
 
 
@@ -57,6 +60,13 @@ class ServiceHook(Model):
         db_table = 'sentry_servicehook'
 
     __repr__ = sane_repr('guid', 'project_id')
+
+    @property
+    def created_by_sentry_app(self):
+        return self.application_id and \
+            SentryApp.objects.filter(
+                application_id=self.application_id,
+            ).exists()
 
     def __init__(self, *args, **kwargs):
         super(ServiceHook, self).__init__(*args, **kwargs)

--- a/src/sentry/models/signals.py
+++ b/src/sentry/models/signals.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from sentry.models import Group
+
+
+@receiver(post_save, sender=Group)
+def resource_changed(sender, instance, created, **kwargs):
+    from sentry.tasks.servicehooks import process_resource_change
+    process_resource_change.delay(sender, instance.id, created)

--- a/src/sentry/tasks/servicehooks.py
+++ b/src/sentry/tasks/servicehooks.py
@@ -1,12 +1,93 @@
 from __future__ import absolute_import, print_function
 
 import six
+
 from time import time
 
+from sentry.api.serializers import serialize, app_platform_event
 from sentry.http import safe_urlopen
-from sentry.tasks.base import instrumented_task
+from sentry.models import Group, SentryAppInstallation, ServiceHook
+from sentry.tasks.base import instrumented_task, retry
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
+
+# This is an extra, explicit, measure to ensure we only send events for
+# resource changes we deem necessary.
+ALLOWED_ACTIONS = (
+    'issue.created',
+)
+
+# We call some models by a different name, publically, than their class name.
+# For example the model Group is called "Issue" in the UI. We want the Service
+# Hook events to match what we externally call these primitives.
+RESOURCE_RENAMES = {
+    'Group': 'issue',
+}
+
+
+@instrumented_task(
+    'sentry.tasks.process_resource_change',
+    default_retry_delay=60 * 5,
+    max_retries=5,
+)
+@retry()
+def process_resource_change(sender, instance_id, created):
+    model = sender.__name__
+    model = RESOURCE_RENAMES.get(model, model.lower())
+
+    instance = sender.objects.get(id=instance_id)
+
+    event = 'created' if created else 'updated'
+    action = u'{}.{}'.format(model, event)
+
+    if action not in ALLOWED_ACTIONS:
+        return
+
+    project = None
+
+    if isinstance(instance, Group):
+        project = instance.project
+
+    if not project:
+        return
+
+    servicehooks = ServiceHook.objects.filter(
+        project_id=project.id,
+    )
+
+    for servicehook in filter(lambda s: action in s.events, servicehooks):
+        # For now, these ``post_save`` callbacks are only valid for service
+        # hooks created by a Sentry App.
+        if not servicehook.created_by_sentry_app:
+            continue
+
+        payload = app_platform_event(
+            action,
+            SentryAppInstallation.objects.get(id=servicehook.actor_id),
+            serialize(instance),
+        )
+
+        send_request(servicehook, payload)
+
+
+def send_request(servicehook, payload):
+    from sentry import tsdb
+    tsdb.incr(tsdb.models.servicehook_fired, servicehook.id)
+
+    headers = {
+        'Content-Type': 'application/json',
+        'X-ServiceHook-Timestamp': six.text_type(int(time())),
+        'X-ServiceHook-GUID': servicehook.guid,
+        'X-ServiceHook-Signature': servicehook.build_signature(json.dumps(payload)),
+    }
+
+    safe_urlopen(
+        url=servicehook.url,
+        data=json.dumps(payload),
+        headers=headers,
+        timeout=5,
+        verify_ssl=True,
+    )
 
 
 def get_payload_v0(event):
@@ -47,34 +128,14 @@ def get_payload_v0(event):
     name='sentry.tasks.process_service_hook', default_retry_delay=60 * 5, max_retries=5
 )
 def process_service_hook(servicehook_id, event, **kwargs):
-    from sentry import tsdb
-    from sentry.models import ServiceHook
-
     try:
         servicehook = ServiceHook.objects.get(id=servicehook_id)
     except ServiceHook.DoesNotExist:
         return
-
-    tsdb.incr(tsdb.models.servicehook_fired, servicehook.id)
 
     if servicehook.version == 0:
         payload = get_payload_v0(event)
     else:
         raise NotImplementedError
 
-    body = json.dumps(payload)
-
-    headers = {
-        'Content-Type': 'application/json',
-        'X-ServiceHook-Timestamp': six.text_type(int(time())),
-        'X-ServiceHook-GUID': servicehook.guid,
-        'X-ServiceHook-Signature': servicehook.build_signature(body),
-    }
-
-    safe_urlopen(
-        url=servicehook.url,
-        data=body,
-        headers=headers,
-        timeout=5,
-        verify_ssl=False,
-    )
+    send_request(servicehook, payload)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -26,8 +26,7 @@ from uuid import uuid4
 
 from sentry.event_manager import EventManager
 from sentry.constants import SentryAppStatus
-from sentry.mediators.sentry_apps import Creator as SentryAppCreator
-from sentry.mediators.service_hooks import Creator as ServiceHookCreator
+from sentry.mediators import sentry_apps, sentry_app_installations, service_hooks
 from sentry.models import (
     Activity, Environment, Event, EventError, EventMapping, Group, Organization, OrganizationMember,
     OrganizationMemberTeam, Project, Team, User, UserEmail, Release, Commit, ReleaseCommit,
@@ -717,7 +716,7 @@ class Fixtures(object):
         if not webhook_url:
             webhook_url = 'https://example.com/webhook'
 
-        app = SentryAppCreator.run(
+        app = sentry_apps.Creator.run(
             name=name,
             organization=organization,
             scopes=scopes,
@@ -728,6 +727,13 @@ class Fixtures(object):
             app.update(status=SentryAppStatus.PUBLISHED)
 
         return app
+
+    def create_sentry_app_installation(self, organization=None, slug=None, user=None):
+        return sentry_app_installations.Creator.run(
+            slug=(slug or self.create_sentry_app().slug),
+            organization=(organization or self.create_organization()),
+            user=(user or self.create_user()),
+        )
 
     def create_service_hook(self, actor=None, project=None, events=None, url=None, **kwargs):
         if not actor:
@@ -740,7 +746,7 @@ class Fixtures(object):
         if not url:
             url = 'https://example/sentry/webhook'
 
-        return ServiceHookCreator.run(
+        return service_hooks.Creator.run(
             actor=actor,
             project=project,
             events=events,

--- a/tests/sentry/tasks/test_servicehooks.py
+++ b/tests/sentry/tasks/test_servicehooks.py
@@ -1,0 +1,81 @@
+from __future__ import absolute_import
+
+import six
+
+from mock import patch
+
+from sentry.testutils import TestCase
+from sentry.tasks.servicehooks import get_payload_v0, process_service_hook
+from sentry.testutils.helpers.faux import faux
+from sentry.utils import json
+
+
+class DictContaining(object):
+    def __init__(self, *keys):
+        self.keys = keys
+
+    def __eq__(self, other):
+        return all([k in other.keys() for k in self.keys])
+
+
+class Any(object):
+    def __eq__(self, other):
+        return True
+
+
+class TestServiceHooks(TestCase):
+    def setUp(self):
+        self.project = self.create_project()
+
+        self.install, _ = self.create_sentry_app_installation(
+            organization=self.project.organization
+        )
+
+        self.hook = self.create_service_hook(
+            actor=self.install,
+            application=self.install.sentry_app.application,
+            project=self.project,
+            events=('issue.created', ),
+        )
+
+    @patch('sentry.tasks.servicehooks.safe_urlopen')
+    def test_group_created_sends_service_hook(self, safe_urlopen):
+        with self.tasks():
+            issue = self.create_group(project=self.project)
+
+        data = json.loads(faux(safe_urlopen).kwargs['data'])
+        assert data['action'] == 'issue.created'
+        assert data['installation']['uuid'] == self.install.uuid
+        assert data['data']['id'] == six.text_type(issue.id)
+        assert faux(safe_urlopen).kwarg_equals('headers', DictContaining(
+            'Content-Type',
+            'X-ServiceHook-Timestamp',
+            'X-ServiceHook-GUID',
+            'X-ServiceHook-Signature',
+        ))
+
+    @patch('sentry.tasks.servicehooks.safe_urlopen')
+    def test_non_group_events_dont_send_service_hooks(self, safe_urlopen):
+        with self.tasks():
+            self.create_project()
+
+        assert len(safe_urlopen.calls) == 0
+
+    @patch('sentry.tasks.servicehooks.safe_urlopen')
+    def test_event_created_sends_service_hook(self, safe_urlopen):
+        self.hook.update(events=['event.created', 'event.alert'])
+
+        event = self.create_event(project=self.project)
+
+        process_service_hook(self.hook.id, event)
+
+        data = json.loads(faux(safe_urlopen).kwargs['data'])
+
+        assert faux(safe_urlopen).kwarg_equals('url', self.hook.url)
+        assert data == json.loads(json.dumps(get_payload_v0(event)))
+        assert faux(safe_urlopen).kwarg_equals('headers', DictContaining(
+            'Content-Type',
+            'X-ServiceHook-Timestamp',
+            'X-ServiceHook-GUID',
+            'X-ServiceHook-Signature',
+        ))


### PR DESCRIPTION
Sentry Apps will have the option of subscribing to Issue events (only create, for now). This will power apps that function like our current issue tracking ones, where they need to replicate Issues on their end whenever a new one appears in Sentry.

Most important changes are: https://github.com/getsentry/sentry/pull/10614/files#diff-848226385eacc13bb2f468bb4868ac67R1

## Important Changes

### This will create a background job for every `Group` created.
Almost all of them will do nothing, as there will be no Service Hook to deliver, but this will substantially increase the pure _number_ of jobs enqueued. cc @mattrobenolt @JTCunning 

### Changes `ArrayField` to allow operations when using Postgresql
Since Postgresql supports Array column operations, when Sentry is using Postgresql, it'll now allow things like `<column>__contains=`. cc @mattrobenolt 

## Differences with existing Service Hooks

Service Hooks that exist today are more or less _only_ for when an Event is created. More so, the payload is very Event specific.

Payloads for Service Hooks that are to be sent to a Sentry App create a payload different than existing ones. It includes the service hook `action` (eg. `issue.created`), a reference to the Sentry App Installation (this is how apps will correlate a request from us, to an account/org/user/whatever on their side).

The payload for this new event is closer to what I think we need to do in the future for all Service Hooks, but for now they must be backwards compatible, so it only changes for App Platform events.

