### PR TITLE
fix: Add extra safety Sample Event experiment analytics

### DIFF
--- a/src/sentry/static/sentry/app/components/createSampleEvent.jsx
+++ b/src/sentry/static/sentry/app/components/createSampleEvent.jsx
@@ -9,6 +9,7 @@ import ApiMixin from 'app/mixins/apiMixin';
 import Button from 'app/components/button';
 import IndicatorStore from 'app/stores/indicatorStore';
 import sdk from 'app/utils/sdk';
+import SentryTypes from 'app/sentryTypes';
 
 const CreateSampleEvent = createReactClass({
   displayName: 'createSampleEvent',
@@ -19,7 +20,7 @@ const CreateSampleEvent = createReactClass({
   },
 
   contextTypes: {
-    organization: PropTypes.object,
+    organization: SentryTypes.Organization.isRequired,
   },
 
   mixins: [ApiMixin],
@@ -28,11 +29,18 @@ const CreateSampleEvent = createReactClass({
     let {projectId} = this.props.params;
     let {organization} = this.context;
     let project = organization.projects.find(proj => proj.slug === projectId);
-    analytics('sample_event.button_viewed', {
+    let data = {
       org_id: parseInt(organization.id, 10),
-      project_id: parseInt(project.id, 10),
       source: this.props.source,
-    });
+    };
+
+    if (!project) {
+      data.project_slug = projectId;
+      analytics('sample_event.button_viewed2', data);
+    } else {
+      data.project_id = parseInt(project.id, 10);
+      analytics('sample_event.button_viewed', data);
+    }
   },
 
   createSampleEvent() {


### PR DESCRIPTION
Fixes-JAVASCRIPT-4N8

Reason: component was mounting, unmounting and remounting. Analytics sent in `componentDidMount` does not have that project in the initial mount so it throws the error. As a safety measure i'm adding a second analytics event juuuust in cases to cover all my bases.

Related [reload-PR](https://github.com/getsentry/reload/pull/65)