### PR TITLE
fix(features): Use organization prop when available

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/index.jsx
@@ -13,12 +13,11 @@ import recreateRoute from 'app/utils/recreateRoute';
 
 class ProjectFilters extends React.Component {
   static contextTypes = {
-    organization: SentryTypes.Organization,
     project: SentryTypes.Project,
   };
 
   render() {
-    let {organization, project} = this.context;
+    let {project} = this.context;
     let {orgId, projectId, filterType} = this.props.params;
     if (!project) return null;
 
@@ -58,7 +57,6 @@ class ProjectFilters extends React.Component {
           ) : (
             <ProjectFiltersSettings
               project={project}
-              organization={organization}
               params={this.props.params}
               features={features}
             />

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.jsx
@@ -156,7 +156,6 @@ class LegacyBrowserFilterRow extends React.Component {
 class ProjectFiltersSettings extends AsyncComponent {
   static propTypes = {
     project: SentryTypes.Project,
-    organization: SentryTypes.Organization,
     params: PropTypes.object,
     features: PropTypes.object,
   };
@@ -196,10 +195,9 @@ class ProjectFiltersSettings extends AsyncComponent {
       renderDisabled={({children, ...props}) =>
         children({...props, renderDisabled: this.renderDisabledCustomFilters})}
     >
-      {({hasFeature, renderDisabled, ...featureProps}) => (
+      {({hasFeature, organization, renderDisabled, ...featureProps}) => (
         <React.Fragment>
-          {!hasFeature &&
-            renderDisabled({organization: this.props.organization, ...featureProps})}
+          {!hasFeature && renderDisabled({organization, ...featureProps})}
 
           {customFilterFields.map(field => (
             <FieldFromConfig key={field.name} field={{...field, disabled: !hasFeature}} />

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
@@ -168,8 +168,6 @@ const KeyStats = createReactClass({
 
 class KeyRateLimitsForm extends React.Component {
   static propTypes = {
-    organization: PropTypes.object.isRequired,
-    project: PropTypes.object.isRequired,
     data: SentryTypes.ProjectKey.isRequired,
   };
 
@@ -192,7 +190,7 @@ class KeyRateLimitsForm extends React.Component {
   };
 
   render() {
-    let {data, project, organization} = this.props;
+    let {data} = this.props;
     let {keyId, orgId, projectId} = this.props.params;
     let apiEndpoint = `/projects/${orgId}/${projectId}/keys/${keyId}/`;
 
@@ -211,7 +209,7 @@ class KeyRateLimitsForm extends React.Component {
           renderDisabled={({children, ...props}) =>
             children({...props, renderDisabled: disabledAlert})}
         >
-          {({hasFeature, features, renderDisabled}) => (
+          {({hasFeature, features, organization, project, renderDisabled}) => (
             <Panel>
               <PanelHeader>{t('Rate Limits')}</PanelHeader>
 
@@ -296,8 +294,6 @@ const KeySettings = createReactClass({
   displayName: 'KeySettings',
 
   propTypes: {
-    organization: PropTypes.object.isRequired,
-    project: PropTypes.object.isRequired,
     data: SentryTypes.ProjectKey.isRequired,
     onRemove: PropTypes.func.isRequired,
   },
@@ -333,7 +329,7 @@ const KeySettings = createReactClass({
 
   render() {
     let {keyId, orgId, projectId} = this.props.params;
-    let {data, organization, project} = this.props;
+    let {data} = this.props;
     let apiEndpoint = `/projects/${orgId}/${projectId}/keys/${keyId}/`;
     const loaderLink = getDynamicText({
       value: data.dsn.cdn,
@@ -372,12 +368,7 @@ const KeySettings = createReactClass({
           </Panel>
         </Form>
 
-        <KeyRateLimitsForm
-          params={this.props.params}
-          data={data}
-          organization={organization}
-          project={project}
-        />
+        <KeyRateLimitsForm params={this.props.params} data={data} />
 
         <Feature features={['organizations:js-loader']}>
           <Form saveOnBlur apiEndpoint={apiEndpoint} apiMethod="PUT" initialData={data}>
@@ -464,11 +455,6 @@ const KeySettings = createReactClass({
 });
 
 export default class ProjectKeyDetails extends AsyncView {
-  static contextTypes = {
-    organization: SentryTypes.Organization,
-    project: SentryTypes.Project,
-  };
-
   getTitle() {
     return t('Key Details');
   }
@@ -486,7 +472,6 @@ export default class ProjectKeyDetails extends AsyncView {
   renderBody() {
     let {data} = this.state;
     let {params} = this.props;
-    let {organization, project} = this.context;
 
     return (
       <div className="ref-key-details">
@@ -494,13 +479,7 @@ export default class ProjectKeyDetails extends AsyncView {
 
         <KeyStats params={params} />
 
-        <KeySettings
-          organization={organization}
-          project={project}
-          params={params}
-          data={data}
-          onRemove={this.handleRemove}
-        />
+        <KeySettings params={params} data={data} onRemove={this.handleRemove} />
       </div>
     );
   }


### PR DESCRIPTION
When rendering Feature component children, use the `organization` prop passed in over organization props from a higher scope.