### PR TITLE
fix(features): Use featureName not name

### DIFF
--- a/docs-ui/components/featureDisabled.stories.js
+++ b/docs-ui/components/featureDisabled.stories.js
@@ -9,7 +9,7 @@ storiesOf('UI|FeatureDisabled', module)
     'basic style',
     withInfo('A disabled feature component')(() => (
       <FeatureDisabled
-        name="Example Feature"
+        featureName="Example Feature"
         features={['organization:example-feature', 'organization:example-feature-2']}
       />
     ))
@@ -18,7 +18,7 @@ storiesOf('UI|FeatureDisabled', module)
     'alert style',
     withInfo('A disabled feature wrapped in an alert')(() => (
       <FeatureDisabled
-        name="Example Feature"
+        featureName="Example Feature"
         features={['organization:example-feature']}
         alert
       />

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.jsx
@@ -181,9 +181,9 @@ class ProjectFiltersSettings extends AsyncComponent {
 
   renderDisabledCustomFilters = p => (
     <FeatureDisabled
+      featureName={t('Custom Inbound Filters')}
       features={p.features}
       alert={PanelAlert}
-      name={t('Custom Inbound Filters')}
       message={t(
         'Release and Error Message filtering are not enabled on your Sentry installation'
       )}


### PR DESCRIPTION
This was missed in a few places when it was refactored.