### PR TITLE
ref(settings): Rename 'data' project settings to 'sdk setup'

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx
@@ -36,10 +36,6 @@ export default function getConfiguration({project}) {
           description: t('Manage environments in a project'),
         },
         {
-          path: `${pathPrefix}/release-tracking/`,
-          title: t('Releases'),
-        },
-        {
           path: `${pathPrefix}/ownership/`,
           title: t('Issue Owners'),
           description: t('Manage issue ownership rules for a project'),
@@ -67,14 +63,30 @@ export default function getConfiguration({project}) {
             return project.processingIssues > 99 ? '99+' : project.processingIssues;
           },
         },
+        {
+          path: `${pathPrefix}/filters/`,
+          title: t('Inbound Filters'),
+          description: t(
+            "Configure a project's inbound filters (e.g. browsers, messages)"
+          ),
+        },
       ],
     },
     {
-      name: t('Data'),
+      name: t('SDK Setup'),
       items: [
         {
           path: `${pathPrefix}/install/`,
           title: t('Error Tracking'),
+        },
+        {
+          path: `${pathPrefix}/keys/`,
+          title: t('Client Keys (DSN)'),
+          description: t("View and manage the project's client keys (DSN)"),
+        },
+        {
+          path: `${pathPrefix}/release-tracking/`,
+          title: t('Releases'),
         },
         {
           path: `${pathPrefix}/security-headers/`,
@@ -84,18 +96,6 @@ export default function getConfiguration({project}) {
           path: `${pathPrefix}/user-feedback/`,
           title: t('User Feedback'),
           description: t('Configure user feedback reporting feature'),
-        },
-        {
-          path: `${pathPrefix}/filters/`,
-          title: t('Inbound Filters'),
-          description: t(
-            "Configure a project's inbound filters (e.g. browsers, messages)"
-          ),
-        },
-        {
-          path: `${pathPrefix}/keys/`,
-          title: t('Client Keys (DSN)'),
-          description: t("View and manage the project's client keys (DSN)"),
         },
       ],
     },


### PR DESCRIPTION
This change comes from a discussion around what the 'Data' settings really mean. We concluded here that 'SDK Setup' Made a lot more sense, thus the rename and regrouping for SDK related configurations.

![image](https://user-images.githubusercontent.com/1421724/48588922-ee6fd600-e8ed-11e8-8dde-ce538c6934e9.png)
