### PR TITLE
fix(ui) Improve spacing in jira-config screen

### DIFF
--- a/src/sentry/templates/sentry/integrations/jira-config.html
+++ b/src/sentry/templates/sentry/integrations/jira-config.html
@@ -1,82 +1,86 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script src="{{ ac_js_src }}"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
-    <script src="//aui-cdn.atlassian.com/aui-adg/6.0.9/js/aui.min.js"></script>
-    <link rel="stylesheet" href="//aui-cdn.atlassian.com/aui-adg/6.0.9/css/aui.min.css" media="all">
-    <style>
-    body {
-      background: transparent;
-      margin-left: 10px;
-    }
+  <script src="{{ ac_js_src }}"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+  <script src="//aui-cdn.atlassian.com/aui-adg/6.0.9/js/aui.min.js"></script>
+  <link rel="stylesheet" href="//aui-cdn.atlassian.com/aui-adg/6.0.9/css/aui.min.css" media="all">
+  <style>
+  body {
+    background: transparent;
+  }
+  .container {
+    padding: 30px;
+  }
 
-    form ul {
-      margin: 0;
-      padding: 0;
-    }
+  form ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
 
-    form.aui ul label {
-      color: #333
-    }
+  .aui ul label {
+    color: #333
+  }
 
-    .description {
-      max-width: 400px;
-    }
+  .description {
+    max-width: 400px;
+  }
 
-    div.signin {
-      padding-top: 25px;
-    }
-    </style>
+  .signin {
+    padding-top: 25px;
+  }
+  </style>
 </head>
 <body>
-  <h3>Sentry Integration Configuration</h3>
-
-  {% if login_required %}
-    <div class="aui-message aui-message-info">
-      <p>Please login to your Sentry account to access the Sentry Add-on configuration</p>
-    </div>
-    <div class="signin">
-      <a class="aui-button aui-button-default" href="{{ login_url }}" target="_blank">
-        Sign In to Sentry
-      </a>
-    </div>
-  {% else %}
-    {% if refresh_required %}
+  <div class="container">
+    <h2>Sentry Integration Configuration</h2>
+    {% if login_required %}
       <div class="aui-message aui-message-info">
-        <p>This page has expired, please refresh to configure your Sentry integration</p>
+        <p>Please login to your Sentry account to access the Sentry Add-on configuration</p>
+      </div>
+      <div class="signin">
+        <a class="aui-button aui-button-default" href="{{ login_url }}" target="_blank">
+          Sign In to Sentry
+        </a>
       </div>
     {% else %}
-      {% if completed %}
-      <div class="aui-message aui-message-success">
-        <p class="title">
-          <strong>Saved!</strong>
-        </p>
-        <p>
-          The Sentry Jira integration is now enabled for the selected
-          organizations. Return to your sentry organization to configure the Jira
-          integration for your organization.
-        </p>
-      </div>
-      {% endif %}
-
-      <form class="aui top-label" action="" method="post">
-        {% csrf_token %}
-        {% for field in form %}
-          <div class="field-group top-label">
-            {{ field.errors }}
-            {{ field.label_tag }} {{ field }}
-            <div class="description">{{ field.help_text }}</div>
-          </div>
-        {% endfor %}
-        <div class="field-group">
-          <button class="aui-button aui-button-primary" type="submit">
-              Save Settings
-          </button>
+      {% if refresh_required %}
+        <div class="aui-message aui-message-info">
+          <p>This page has expired, please refresh to configure your Sentry integration</p>
         </div>
-      </form>
+      {% else %}
+        {% if completed %}
+        <div class="aui-message aui-message-success">
+          <p class="title">
+            <strong>Saved!</strong>
+          </p>
+          <p>
+            The Sentry Jira integration is now enabled for the selected
+            organizations. Return to your sentry organization to configure the Jira
+            integration for your organization.
+          </p>
+        </div>
+        {% endif %}
+
+        <form class="aui top-label" action="" method="post">
+          {% csrf_token %}
+          {% for field in form %}
+            <div class="field-group top-label">
+              {{ field.errors }}
+              {{ field.label_tag }} {{ field }}
+              <div class="description">{{ field.help_text }}</div>
+            </div>
+          {% endfor %}
+          <div class="field-group">
+            <button class="aui-button aui-button-primary" type="submit">
+                Save Settings
+            </button>
+          </div>
+        </form>
+      {% endif %}
     {% endif %}
-  {% endif %}
+  </div>
 </body>
 {% if login_required %}
   <script type="text/javascript">


### PR DESCRIPTION
Add padding to the jira config iframe so that the checkbox inputs are clickable and the layout is overall less cramped.

## Before

<img width="909" alt="screen shot 2018-11-16 at 9 45 32 am" src="https://user-images.githubusercontent.com/24086/48628114-62f55400-e984-11e8-8f28-5cc3bbfbbbf0.png">


## After

<img width="901" alt="screen shot 2018-11-16 at 9 45 10 am" src="https://user-images.githubusercontent.com/24086/48628129-6ab4f880-e984-11e8-88a4-af5c9b364c73.png">


Fixes APP-619