### PR TITLE
fix(jira) Make post-install simpler

### DIFF
--- a/src/sentry/integrations/jira/descriptor.py
+++ b/src/sentry/integrations/jira/descriptor.py
@@ -32,6 +32,13 @@ class JiraDescriptorEndpoint(Endpoint):
                 },
                 'apiVersion': 1,
                 'modules': {
+                    'postInstallPage': {
+                        'url': '/extensions/jira/configure',
+                        'name': {
+                            'value': 'Configure Sentry Add-on'
+                        },
+                        'key': 'post-install-sentry'
+                    },
                     'configurePage': {
                         'url': '/extensions/jira/configure',
                         'name': {


### PR DESCRIPTION
Customers have been getting confused about how to get jira setup as required steps are buried deep inside jira addon configuration. By using a `postInstallPage` we can make it clearer to the user that there is more for them to do.

## New post install prompt

<img width="712" alt="screen shot 2018-11-16 at 9 52 57 am" src="https://user-images.githubusercontent.com/24086/48628695-d21f7800-e985-11e8-856f-550ce99bbb2e.png">


Fixes APP-785