### PR TITLE
feat(charts): Allow local/utc date formatting in charts

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/baseChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/baseChart.jsx
@@ -108,6 +108,9 @@ class BaseChart extends React.Component {
 
     // How is data grouped (affects formatting of axis labels and tooltips)
     interval: PropTypes.oneOf(['hour', 'day']),
+
+    // Formats dates as UTC?
+    utc: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -124,6 +127,7 @@ class BaseChart extends React.Component {
     yAxis: {},
     isGroupedByDate: false,
     interval: 'day',
+    utc: false,
   };
 
   handleChartReady = (...args) => {
@@ -155,6 +159,7 @@ class BaseChart extends React.Component {
       isGroupedByDate,
       interval,
       previousPeriod,
+      utc,
 
       devicePixelRatio,
       height,
@@ -194,7 +199,9 @@ class BaseChart extends React.Component {
           color: colors || this.getColorPalette(),
           grid: Grid(grid),
           tooltip:
-            tooltip !== null ? Tooltip({interval, isGroupedByDate, ...tooltip}) : null,
+            tooltip !== null
+              ? Tooltip({interval, isGroupedByDate, utc, ...tooltip})
+              : null,
           legend: legend ? Legend({...legend}) : null,
           yAxis: yAxis !== null ? YAxis(yAxis) : null,
           xAxis:
@@ -203,6 +210,7 @@ class BaseChart extends React.Component {
                   ...xAxis,
                   interval,
                   isGroupedByDate,
+                  utc,
                 })
               : null,
           series: !previousPeriod

--- a/src/sentry/static/sentry/app/components/charts/baseChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/baseChart.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import ReactEchartsCore from 'echarts-for-react/lib/core';
 import echarts from 'echarts/lib/echarts';
 
+import {DEFAULT_USE_UTC} from 'app/constants';
 import SentryTypes from 'app/sentryTypes';
 import theme from 'app/utils/theme';
 
@@ -127,7 +128,7 @@ class BaseChart extends React.Component {
     yAxis: {},
     isGroupedByDate: false,
     interval: 'day',
-    utc: false,
+    utc: DEFAULT_USE_UTC,
   };
 
   handleChartReady = (...args) => {

--- a/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
@@ -1,16 +1,17 @@
-import moment from 'moment';
 import 'echarts/lib/component/tooltip';
+
+import {getFormattedDate} from 'app/utils/dates';
 import {truncationFormatter} from '../utils';
 
-function formatAxisLabel(value, isTimestamp) {
+function formatAxisLabel(value, isTimestamp, utc) {
   if (!isTimestamp) {
     return value;
   }
 
-  return moment.utc(value).format('MMM D, YYYY');
+  return getFormattedDate(value, 'MMM D, YYYY', utc);
 }
 
-function getFormatter({filter, isGroupedByDate, truncate}) {
+function getFormatter({filter, isGroupedByDate, truncate, utc}) {
   const getFilter = seriesParam => {
     const value = seriesParam.data[1];
     if (typeof filter === 'function') {
@@ -23,7 +24,7 @@ function getFormatter({filter, isGroupedByDate, truncate}) {
   return seriesParams => {
     const label =
       seriesParams.length &&
-      formatAxisLabel(seriesParams[0].axisValueLabel, isGroupedByDate);
+      formatAxisLabel(seriesParams[0].axisValueLabel, isGroupedByDate, utc);
     return [
       `<div>${truncationFormatter(label, truncate)}</div>`,
       seriesParams
@@ -39,9 +40,9 @@ function getFormatter({filter, isGroupedByDate, truncate}) {
 }
 
 export default function Tooltip(
-  {filter, isGroupedByDate, formatter, truncate, ...props} = {}
+  {filter, isGroupedByDate, formatter, truncate, utc, ...props} = {}
 ) {
-  formatter = formatter || getFormatter({filter, isGroupedByDate, truncate});
+  formatter = formatter || getFormatter({filter, isGroupedByDate, truncate, utc});
 
   return {
     show: true,

--- a/src/sentry/static/sentry/app/components/charts/components/xAxis.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/xAxis.jsx
@@ -1,16 +1,12 @@
-import moment from 'moment';
-
+import {getFormattedDate} from 'app/utils/dates';
 import theme from 'app/utils/theme';
 import {truncationFormatter} from '../utils';
 
-export default function XAxis({isGroupedByDate, interval, ...props} = {}) {
+export default function XAxis({isGroupedByDate, interval, utc, ...props} = {}) {
   const axisLabelFormatter = value => {
     if (isGroupedByDate) {
       const format = interval === 'hour' ? 'LT' : 'MMM Do';
-      return moment
-        .utc(value)
-        .local()
-        .format(format);
+      return getFormattedDate(value, format, {local: !utc});
     } else if (props.truncate) {
       return truncationFormatter(value, props.truncate);
     } else {

--- a/src/sentry/static/sentry/app/constants/index.jsx
+++ b/src/sentry/static/sentry/app/constants/index.jsx
@@ -63,6 +63,8 @@ export const MENU_CLOSE_DELAY = 200;
 
 export const DEFAULT_STATS_PERIOD = '14d';
 
+export const DEFAULT_USE_UTC = true;
+
 export const DEFAULT_RELATIVE_PERIODS = {
   '24h': t('Last 24 hours'),
   '7d': t('Last 7 days'),


### PR DESCRIPTION
Adds a `utc` option for charts to format xaxis or tooltips in UTC.