### PR TITLE
feat(org-events): Add UTC to URL params

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/dateRange.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/dateRange.jsx
@@ -55,7 +55,7 @@ class DateRange extends React.Component {
     /**
      * Use UTC
      */
-    useUtc: PropTypes.bool,
+    utc: PropTypes.bool,
 
     /**
      * handle UTC checkbox change
@@ -74,24 +74,24 @@ class DateRange extends React.Component {
     maxPickableDays: MAX_PICKABLE_DAYS,
   };
 
-  static getTimeStringFromDate = (date, useUtc) => {
-    return getFormattedDate(date, 'HH:mm', {local: !useUtc});
+  static getTimeStringFromDate = (date, utc) => {
+    return getFormattedDate(date, 'HH:mm', {local: !utc});
   };
 
   handleSelectDateRange = ({selection}) => {
-    const {useUtc, onChange} = this.props;
+    const {utc, onChange} = this.props;
     const {startDate, endDate} = selection;
 
     let start = startDate;
     let end = endDate;
 
     if (start) {
-      start = setDateToTime(start, DEFAULT_DAY_START_TIME, {local: !useUtc});
+      start = setDateToTime(start, DEFAULT_DAY_START_TIME, {local: !utc});
     }
 
     if (end) {
       end = setDateToTime(end, DEFAULT_DAY_END_TIME, {
-        local: !useUtc,
+        local: !utc,
       });
     }
 
@@ -115,7 +115,7 @@ class DateRange extends React.Component {
     });
 
     onChange({
-      start: setDateToTime(start, startTime, {local: !this.props.useUtc}),
+      start: setDateToTime(start, startTime, {local: !this.props.utc}),
       end,
     });
   };
@@ -131,7 +131,7 @@ class DateRange extends React.Component {
 
     onChange({
       start,
-      end: setDateToTime(end, endTime, {local: !this.props.useUtc}),
+      end: setDateToTime(end, endTime, {local: !this.props.utc}),
     });
   };
 
@@ -139,25 +139,25 @@ class DateRange extends React.Component {
     const {
       className,
       maxPickableDays,
-      useUtc,
+      utc,
       start,
       end,
       showTimePicker,
       onChangeUtc,
     } = this.props;
 
-    const startTime = DateRange.getTimeStringFromDate(new Date(start), useUtc);
-    const endTime = DateRange.getTimeStringFromDate(new Date(end), useUtc);
+    const startTime = DateRange.getTimeStringFromDate(new Date(start), utc);
+    const endTime = DateRange.getTimeStringFromDate(new Date(end), utc);
 
     // Restraints on the time range that you can select
     // Can't select dates in the future b/c we're not fortune tellers (yet)
     const minDate = getCoercedUtcOrLocalDate(
       getStartOfPeriodAgo(maxPickableDays, 'days'),
       {
-        local: !useUtc,
+        local: !utc,
       }
     );
-    const maxDate = getCoercedUtcOrLocalDate(new Date(), {local: !useUtc});
+    const maxDate = getCoercedUtcOrLocalDate(new Date(), {local: !utc});
 
     return (
       <div className={className} data-test-id="date-range">
@@ -165,10 +165,8 @@ class DateRange extends React.Component {
           rangeColors={[theme.purple]}
           ranges={[
             {
-              startDate: start
-                ? getCoercedUtcOrLocalDate(start, {local: !useUtc})
-                : start,
-              endDate: end ? getCoercedUtcOrLocalDate(end, {local: !useUtc}) : end,
+              startDate: start ? getCoercedUtcOrLocalDate(start, {local: !utc}) : start,
+              endDate: end ? getCoercedUtcOrLocalDate(end, {local: !utc}) : end,
               key: 'selection',
             },
           ]}
@@ -188,7 +186,7 @@ class DateRange extends React.Component {
               {t('Use UTC')}
               <Checkbox
                 onChange={onChangeUtc}
-                checked={useUtc}
+                checked={utc}
                 style={{
                   margin: '0 0 0 0.5em',
                 }}

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateSummary.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateSummary.jsx
@@ -33,16 +33,16 @@ class DateSummary extends React.Component {
      */
     end: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
 
-    useUtc: PropTypes.bool,
+    utc: PropTypes.bool,
   };
 
   formatDate(date) {
-    return getFormattedDate(date, 'll', {local: !this.props.useUtc});
+    return getFormattedDate(date, 'll', {local: !this.props.utc});
   }
 
   formatTime(date, withSeconds = false) {
     return getFormattedDate(date, `HH:mm${withSeconds ? ':ss' : ''}`, {
-      local: !this.props.useUtc,
+      local: !this.props.utc,
     });
   }
 

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
-import {DEFAULT_RELATIVE_PERIODS, DEFAULT_STATS_PERIOD} from 'app/constants';
+import {
+  DEFAULT_RELATIVE_PERIODS,
+  DEFAULT_STATS_PERIOD,
+  DEFAULT_USE_UTC,
+} from 'app/constants';
 import {analytics} from 'app/utils/analytics';
 import {getLocalToUtc, getPeriodAgo, getUtcInLocal} from 'app/utils/dates';
 import {parsePeriodToHours} from 'app/utils';
@@ -68,6 +72,7 @@ class TimeRangeSelector extends React.PureComponent {
   static defaultProps = {
     showAbsolute: true,
     showRelative: false,
+    utc: DEFAULT_USE_UTC,
   };
 
   constructor(props) {

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
@@ -52,7 +52,7 @@ class TimeRangeSelector extends React.PureComponent {
     /**
      * Default initial value for using UTC
      */
-    useUtc: PropTypes.bool,
+    utc: PropTypes.bool,
 
     /**
      * Callback when value changes
@@ -73,7 +73,7 @@ class TimeRangeSelector extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      useUtc: props.useUtc,
+      utc: props.utc,
       isOpen: false,
     };
   }
@@ -114,6 +114,7 @@ class TimeRangeSelector extends React.PureComponent {
         'hours'
       ).toDate(),
       end: new Date(),
+      utc: this.state.utc,
     });
   };
 
@@ -123,6 +124,7 @@ class TimeRangeSelector extends React.PureComponent {
       relative: value,
       start: null,
       end: null,
+      utc: this.state.utc,
     });
     this.handleUpdate();
   };
@@ -134,6 +136,7 @@ class TimeRangeSelector extends React.PureComponent {
       relative: null,
       start,
       end,
+      utc: this.state.utc,
     });
   };
 
@@ -141,19 +144,20 @@ class TimeRangeSelector extends React.PureComponent {
     const {onChange, start, end} = this.props;
 
     this.setState(state => {
-      const useUtc = !state.useUtc;
+      const utc = !state.utc;
       analytics('dateselector.utc_changed', {
-        utc: useUtc,
+        utc,
       });
 
       onChange({
         relative: null,
-        start: useUtc ? getLocalToUtc(start) : getUtcInLocal(start),
-        end: useUtc ? getLocalToUtc(end) : getUtcInLocal(end),
+        start: utc ? getLocalToUtc(start) : getUtcInLocal(start),
+        end: utc ? getLocalToUtc(end) : getUtcInLocal(end),
+        utc,
       });
 
       return {
-        useUtc,
+        utc,
       };
     });
   };
@@ -168,7 +172,7 @@ class TimeRangeSelector extends React.PureComponent {
     const summary = relative ? (
       `${DEFAULT_RELATIVE_PERIODS[relative]}`
     ) : (
-      <DateSummary useUtc={this.state.useUtc} start={start} end={end} />
+      <DateSummary utc={this.state.utc} start={start} end={end} />
     );
 
     return (
@@ -215,7 +219,7 @@ class TimeRangeSelector extends React.PureComponent {
                 {isAbsoluteSelected && (
                   <DateRange
                     showTimePicker
-                    useUtc={this.state.useUtc}
+                    utc={this.state.utc}
                     start={start}
                     end={end}
                     onChange={this.handleSelectDateRange}

--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import moment from 'moment';
 import {browserHistory} from 'react-router';
 
-import {DEFAULT_USE_UTC} from 'app/constants';
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {getUtcDateString} from 'app/utils/dates';
 import {t, tct} from 'app/locale';

--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -356,7 +356,6 @@ export default class OrganizationDiscover extends React.Component {
               <TimeRangeSelector
                 showAbsolute={true}
                 showRelative={true}
-                utc={DEFAULT_USE_UTC}
                 start={start}
                 end={end}
                 relative={currentQuery.range}

--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import moment from 'moment';
 import {browserHistory} from 'react-router';
 
+import {DEFAULT_USE_UTC} from 'app/constants';
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {getUtcDateString} from 'app/utils/dates';
 import {t, tct} from 'app/locale';
@@ -356,7 +357,7 @@ export default class OrganizationDiscover extends React.Component {
               <TimeRangeSelector
                 showAbsolute={true}
                 showRelative={true}
-                useUtc={true}
+                utc={DEFAULT_USE_UTC}
                 start={start}
                 end={end}
                 relative={currentQuery.range}

--- a/src/sentry/static/sentry/app/views/organizationEvents/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/eventsChart.jsx
@@ -5,7 +5,7 @@ import moment from 'moment';
 import {HealthRequestWithParams} from 'app/views/organizationHealth/util/healthRequest';
 import {t} from 'app/locale';
 import AreaChart from 'app/components/charts/areaChart';
-import EventsContext from 'app/views/organizationEvents/eventsContext';
+import EventsContext from 'app/views/organizationEvents/utils/eventsContext';
 import SentryTypes from 'app/sentryTypes';
 import withApi from 'app/utils/withApi';
 

--- a/src/sentry/static/sentry/app/views/organizationEvents/eventsTable.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/eventsTable.jsx
@@ -8,12 +8,13 @@ import {t} from 'app/locale';
 import {PanelBody, Panel, PanelHeader} from 'app/components/panels';
 import DateTime from 'app/components/dateTime';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
-import EventsContext from 'app/views/organizationEvents/eventsContext';
 import IdBadge from 'app/components/idBadge';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import SentryTypes from 'app/sentryTypes';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
+
+import EventsContext from './utils/eventsContext';
 
 class EventsTable extends React.Component {
   static propTypes = {

--- a/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
@@ -7,6 +7,8 @@ import styled from 'react-emotion';
 import {DEFAULT_STATS_PERIOD, DEFAULT_USE_UTC} from 'app/constants';
 import {defined} from 'app/utils';
 import {getLocalDateObject, getUtcDateString} from 'app/utils/dates';
+import {getParams} from 'app/views/organizationEvents/utils';
+import EventsContext from 'app/views/organizationEvents/utils/eventsContext';
 import Feature from 'app/components/acl/feature';
 import Header from 'app/components/organizations/header';
 import HeaderSeparator from 'app/components/organizations/headerSeparator';
@@ -17,9 +19,6 @@ import SentryTypes from 'app/sentryTypes';
 import TimeRangeSelector from 'app/components/organizations/timeRangeSelector';
 import space from 'app/styles/space';
 import withOrganization from 'app/utils/withOrganization';
-
-import {getParams} from './utils/getParams';
-import EventsContext from './utils/eventsContext';
 
 class OrganizationEventsContainer extends React.Component {
   static propTypes = {

--- a/src/sentry/static/sentry/app/views/organizationEvents/utils/eventsContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/utils/eventsContext.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 
+import {DEFAULT_STATS_PERIOD, DEFAULT_USE_UTC} from 'app/constants';
+
 const EventsContext = React.createContext({
   project: [],
   environment: [],
-  period: '7d',
+  period: DEFAULT_STATS_PERIOD,
   start: null,
   end: null,
+  utc: DEFAULT_USE_UTC,
 });
 
 export default EventsContext;

--- a/tests/js/spec/components/organizations/timeRangeSelector/__snapshots__/dateSummary.spec.jsx.snap
+++ b/tests/js/spec/components/organizations/timeRangeSelector/__snapshots__/dateSummary.spec.jsx.snap
@@ -4,7 +4,7 @@ exports[`DateSummary renders 1`] = `
 <DateSummary
   end={2017-10-17T02:38:00.000Z}
   start={2017-10-14T02:38:00.000Z}
-  useUtc={true}
+  utc={true}
 >
   <DateGroupWrapper
     align="center"

--- a/tests/js/spec/components/organizations/timeRangeSelector/dateRange.spec.jsx
+++ b/tests/js/spec/components/organizations/timeRangeSelector/dateRange.spec.jsx
@@ -124,7 +124,7 @@ describe('DateRange', function() {
           start={start}
           end={end}
           showTimePicker
-          useUtc
+          utc
           onChange={onChange}
           onChangeUtc={jest.fn()}
         />,

--- a/tests/js/spec/components/organizations/timeRangeSelector/dateSummary.spec.jsx
+++ b/tests/js/spec/components/organizations/timeRangeSelector/dateSummary.spec.jsx
@@ -11,7 +11,7 @@ describe('DateSummary', function() {
   let routerContext = TestStubs.routerContext();
 
   const createWrapper = (props = {}) =>
-    mount(<DateSummary useUtc start={start} end={end} {...props} />, routerContext);
+    mount(<DateSummary utc start={start} end={end} {...props} />, routerContext);
 
   it('renders', async function() {
     wrapper = createWrapper();

--- a/tests/js/spec/components/organizations/timeRangeSelector/index.spec.jsx
+++ b/tests/js/spec/components/organizations/timeRangeSelector/index.spec.jsx
@@ -48,7 +48,7 @@ describe('TimeRangeSelector', function() {
   });
 
   it('selects absolute item with utc enabled', async function() {
-    wrapper = createWrapper({useUtc: true});
+    wrapper = createWrapper({utc: true});
     await wrapper.find('HeaderItem').simulate('click');
 
     expect(wrapper.find('[data-test-id="date-range"]')).toHaveLength(0);
@@ -58,6 +58,7 @@ describe('TimeRangeSelector', function() {
       relative: null,
       start: new Date('2017-10-03T02:41:20.000Z'),
       end: new Date('2017-10-17T02:41:20.000Z'),
+      utc: true,
     };
     expect(onChange).toHaveBeenLastCalledWith(newProps);
     wrapper.setProps(newProps);
@@ -99,7 +100,7 @@ describe('TimeRangeSelector', function() {
   it('switches from relative to absolute while maintaining equivalent date range (in utc)', async function() {
     wrapper = createWrapper({
       relative: '7d',
-      useUtc: true,
+      utc: true,
     });
     await wrapper.find('HeaderItem').simulate('click');
 
@@ -108,6 +109,7 @@ describe('TimeRangeSelector', function() {
       relative: null,
       start: new Date('2017-10-10T02:41:20.000Z'),
       end: new Date('2017-10-17T02:41:20.000Z'),
+      utc: true,
     });
 
     wrapper.find('SelectorItem[value="14d"]').simulate('click');
@@ -115,6 +117,7 @@ describe('TimeRangeSelector', function() {
       relative: '14d',
       start: null,
       end: null,
+      utc: true,
     });
 
     wrapper.setProps({relative: '14d', start: null, end: null});
@@ -124,6 +127,7 @@ describe('TimeRangeSelector', function() {
       relative: null,
       start: new Date('2017-10-03T02:41:20.000Z'),
       end: new Date('2017-10-17T02:41:20.000Z'),
+      utc: true,
     });
   });
 
@@ -133,7 +137,7 @@ describe('TimeRangeSelector', function() {
       relative: null,
       start: new Date('2017-10-10T00:00:00.000Z'),
       end: new Date('2017-10-17T23:59:59.000Z'),
-      useUtc: true,
+      utc: true,
     });
     wrapper.find('HeaderItem').simulate('click');
 
@@ -143,6 +147,7 @@ describe('TimeRangeSelector', function() {
       relative: null,
       start: new Date('2017-10-10T04:00:00.000Z'),
       end: new Date('2017-10-18T03:59:59.000Z'),
+      utc: false,
     };
     expect(onChange).toHaveBeenLastCalledWith(state);
     wrapper.setProps(state);
@@ -153,6 +158,7 @@ describe('TimeRangeSelector', function() {
       relative: null,
       start: new Date('2017-10-10T00:00:00.000Z'),
       end: new Date('2017-10-17T23:59:59.000Z'),
+      utc: true,
     };
     expect(onChange).toHaveBeenLastCalledWith(state);
     wrapper.setProps(state);
@@ -163,6 +169,7 @@ describe('TimeRangeSelector', function() {
       relative: null,
       start: new Date('2017-10-10T04:00:00.000Z'),
       end: new Date('2017-10-18T03:59:59.000Z'),
+      utc: false,
     });
   });
 });

--- a/tests/js/spec/components/organizations/timeRangeSelector/index.spec.jsx
+++ b/tests/js/spec/components/organizations/timeRangeSelector/index.spec.jsx
@@ -39,6 +39,7 @@ describe('TimeRangeSelector', function() {
       relative: null,
       start: new Date('2017-10-03T02:41:20.000Z'),
       end: new Date('2017-10-17T02:41:20.000Z'),
+      utc: true,
     };
     expect(onChange).toHaveBeenLastCalledWith(newProps);
     wrapper.setProps(newProps);
@@ -78,6 +79,7 @@ describe('TimeRangeSelector', function() {
       relative: null,
       start: new Date('2017-10-10T02:41:20.000Z'),
       end: new Date('2017-10-17T02:41:20.000Z'),
+      utc: true,
     });
 
     wrapper.find('SelectorItem[value="14d"]').simulate('click');
@@ -85,6 +87,7 @@ describe('TimeRangeSelector', function() {
       relative: '14d',
       start: null,
       end: null,
+      utc: true,
     });
 
     wrapper.setProps({relative: '14d', start: null, end: null});
@@ -94,6 +97,7 @@ describe('TimeRangeSelector', function() {
       relative: null,
       start: new Date('2017-10-03T02:41:20.000Z'),
       end: new Date('2017-10-17T02:41:20.000Z'),
+      utc: true,
     });
   });
 

--- a/tests/js/spec/views/organizationEvents/index.spec.jsx
+++ b/tests/js/spec/views/organizationEvents/index.spec.jsx
@@ -186,9 +186,9 @@ describe('OrganizationEvents', function() {
     });
   });
 
-  it('changes to absolute time', async function() {
-    const start = new Date('2017-10-01T04:00:00.000Z');
-    const end = new Date('2017-10-02T03:59:59.000Z');
+  it('changes to absolute time (utc is default)', async function() {
+    const start = new Date('2017-10-01T00:00:00.000Z');
+    const end = new Date('2017-10-01T23:59:59.000Z');
 
     wrapper.find('TimeRangeSelector HeaderItem').simulate('click');
 
@@ -209,8 +209,9 @@ describe('OrganizationEvents', function() {
     expect(router.push).toHaveBeenCalledWith({
       pathname: '/organizations/org-slug/events/',
       query: {
-        start: '2017-10-01T04:00:00',
-        end: '2017-10-02T03:59:59',
+        start: '2017-10-01T00:00:00',
+        end: '2017-10-01T23:59:59',
+        utc: true,
       },
     });
   });


### PR DESCRIPTION
Refactors `useUtc` prop name to `utc` to be consistent with URL (and to
compress URL params a bit)