### PR TITLE
ref(app-platform): Minor cleanup

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -448,7 +448,7 @@ CELERY_IMPORTS = (
     'sentry.tasks.scheduler', 'sentry.tasks.signals', 'sentry.tasks.store', 'sentry.tasks.unmerge',
     'sentry.tasks.symcache_update', 'sentry.tasks.servicehooks',
     'sentry.tagstore.tasks', 'sentry.tasks.assemble', 'sentry.tasks.integrations',
-    'sentry.tasks.files',
+    'sentry.tasks.files', 'sentry.tasks.app_platform',
 )
 CELERY_QUEUES = [
     Queue('activity.notify', routing_key='activity.notify'),

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/index.jsx
@@ -28,7 +28,7 @@ class SentryApplicationRow extends React.PureComponent {
     installs: PropTypes.array,
   };
 
-  redirectUrl = install => {
+  redirectUser = install => {
     const {orgId, app} = this.props;
     let redirectUrl = `/settings/${orgId}/integrations/`;
 
@@ -52,7 +52,7 @@ class SentryApplicationRow extends React.PureComponent {
 
     const success = install => {
       addSuccessMessage(t(`${app.slug} successfully installed.`));
-      this.redirectUrl(install);
+      this.redirectUser(install);
     };
 
     const error = err => {

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/index.jsx
@@ -41,9 +41,10 @@ class SentryApplicationRow extends React.PureComponent {
       );
       const query = Object.assign(qs.parse(url.query), installQuery);
       redirectUrl = `${url.protocol}//${url.host}${url.pathname}?${qs.stringify(query)}`;
+      window.location.assign(redirectUrl);
     }
 
-    return redirectUrl;
+    browserHistory.push(redirectUrl);
   };
 
   install = () => {
@@ -51,7 +52,7 @@ class SentryApplicationRow extends React.PureComponent {
 
     const success = install => {
       addSuccessMessage(t(`${app.slug} successfully installed.`));
-      browserHistory.push(this.redirectUrl(install));
+      this.redirectUrl(install);
     };
 
     const error = err => {

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
@@ -61,7 +61,7 @@ class SentryApplicationDetails extends AsyncView {
           apiMethod={method}
           apiEndpoint={endpoint}
           allowUndo
-          initialData={{organization: orgId, ...app}}
+          initialData={{organization: orgId, isAlertable: false, ...app}}
           onSubmitSuccess={this.onSubmitSuccess}
           onSubmitError={err => addErrorMessage(t('Unable to save change'))}
         >

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/sentryApplicationDetails.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/sentryApplicationDetails.spec.jsx.snap
@@ -547,6 +547,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                 "snapshots": Array [
                                                                   Map {
                                                                     "organization" => "org-slug",
+                                                                    "isAlertable" => false,
                                                                     "name" => "Sample App",
                                                                     "slug" => "sample-app",
                                                                     "scopes" => Array [
@@ -555,7 +556,6 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "uuid" => "123456123456123456123456",
                                                                     "webhookUrl" => "https://example.com/webhook",
                                                                     "redirectUrl" => "https://example/com/setup",
-                                                                    "isAlertable" => false,
                                                                     "clientId" => "client-id",
                                                                     "clientSecret" => "client-secret",
                                                                     "overview" => "This is an app.",
@@ -865,6 +865,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "snapshots": Array [
                                                                                               Map {
                                                                                                 "organization" => "org-slug",
+                                                                                                "isAlertable" => false,
                                                                                                 "name" => "Sample App",
                                                                                                 "slug" => "sample-app",
                                                                                                 "scopes" => Array [
@@ -873,7 +874,6 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "uuid" => "123456123456123456123456",
                                                                                                 "webhookUrl" => "https://example.com/webhook",
                                                                                                 "redirectUrl" => "https://example/com/setup",
-                                                                                                "isAlertable" => false,
                                                                                                 "clientId" => "client-id",
                                                                                                 "clientSecret" => "client-secret",
                                                                                                 "overview" => "This is an app.",
@@ -1199,6 +1199,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                 "snapshots": Array [
                                                                   Map {
                                                                     "organization" => "org-slug",
+                                                                    "isAlertable" => false,
                                                                     "name" => "Sample App",
                                                                     "slug" => "sample-app",
                                                                     "scopes" => Array [
@@ -1207,7 +1208,6 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "uuid" => "123456123456123456123456",
                                                                     "webhookUrl" => "https://example.com/webhook",
                                                                     "redirectUrl" => "https://example/com/setup",
-                                                                    "isAlertable" => false,
                                                                     "clientId" => "client-id",
                                                                     "clientSecret" => "client-secret",
                                                                     "overview" => "This is an app.",
@@ -1517,6 +1517,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "snapshots": Array [
                                                                                               Map {
                                                                                                 "organization" => "org-slug",
+                                                                                                "isAlertable" => false,
                                                                                                 "name" => "Sample App",
                                                                                                 "slug" => "sample-app",
                                                                                                 "scopes" => Array [
@@ -1525,7 +1526,6 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "uuid" => "123456123456123456123456",
                                                                                                 "webhookUrl" => "https://example.com/webhook",
                                                                                                 "redirectUrl" => "https://example/com/setup",
-                                                                                                "isAlertable" => false,
                                                                                                 "clientId" => "client-id",
                                                                                                 "clientSecret" => "client-secret",
                                                                                                 "overview" => "This is an app.",
@@ -1842,6 +1842,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                 "snapshots": Array [
                                                                   Map {
                                                                     "organization" => "org-slug",
+                                                                    "isAlertable" => false,
                                                                     "name" => "Sample App",
                                                                     "slug" => "sample-app",
                                                                     "scopes" => Array [
@@ -1850,7 +1851,6 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "uuid" => "123456123456123456123456",
                                                                     "webhookUrl" => "https://example.com/webhook",
                                                                     "redirectUrl" => "https://example/com/setup",
-                                                                    "isAlertable" => false,
                                                                     "clientId" => "client-id",
                                                                     "clientSecret" => "client-secret",
                                                                     "overview" => "This is an app.",
@@ -2158,6 +2158,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "snapshots": Array [
                                                                                               Map {
                                                                                                 "organization" => "org-slug",
+                                                                                                "isAlertable" => false,
                                                                                                 "name" => "Sample App",
                                                                                                 "slug" => "sample-app",
                                                                                                 "scopes" => Array [
@@ -2166,7 +2167,6 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "uuid" => "123456123456123456123456",
                                                                                                 "webhookUrl" => "https://example.com/webhook",
                                                                                                 "redirectUrl" => "https://example/com/setup",
-                                                                                                "isAlertable" => false,
                                                                                                 "clientId" => "client-id",
                                                                                                 "clientSecret" => "client-secret",
                                                                                                 "overview" => "This is an app.",
@@ -2583,6 +2583,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                 "snapshots": Array [
                                                                   Map {
                                                                     "organization" => "org-slug",
+                                                                    "isAlertable" => false,
                                                                     "name" => "Sample App",
                                                                     "slug" => "sample-app",
                                                                     "scopes" => Array [
@@ -2591,7 +2592,6 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "uuid" => "123456123456123456123456",
                                                                     "webhookUrl" => "https://example.com/webhook",
                                                                     "redirectUrl" => "https://example/com/setup",
-                                                                    "isAlertable" => false,
                                                                     "clientId" => "client-id",
                                                                     "clientSecret" => "client-secret",
                                                                     "overview" => "This is an app.",
@@ -2933,6 +2933,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "snapshots": Array [
                                                                                               Map {
                                                                                                 "organization" => "org-slug",
+                                                                                                "isAlertable" => false,
                                                                                                 "name" => "Sample App",
                                                                                                 "slug" => "sample-app",
                                                                                                 "scopes" => Array [
@@ -2941,7 +2942,6 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "uuid" => "123456123456123456123456",
                                                                                                 "webhookUrl" => "https://example.com/webhook",
                                                                                                 "redirectUrl" => "https://example/com/setup",
-                                                                                                "isAlertable" => false,
                                                                                                 "clientId" => "client-id",
                                                                                                 "clientSecret" => "client-secret",
                                                                                                 "overview" => "This is an app.",
@@ -3258,6 +3258,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                 "snapshots": Array [
                                                                   Map {
                                                                     "organization" => "org-slug",
+                                                                    "isAlertable" => false,
                                                                     "name" => "Sample App",
                                                                     "slug" => "sample-app",
                                                                     "scopes" => Array [
@@ -3266,7 +3267,6 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "uuid" => "123456123456123456123456",
                                                                     "webhookUrl" => "https://example.com/webhook",
                                                                     "redirectUrl" => "https://example/com/setup",
-                                                                    "isAlertable" => false,
                                                                     "clientId" => "client-id",
                                                                     "clientSecret" => "client-secret",
                                                                     "overview" => "This is an app.",
@@ -3601,6 +3601,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "snapshots": Array [
                                                                                               Map {
                                                                                                 "organization" => "org-slug",
+                                                                                                "isAlertable" => false,
                                                                                                 "name" => "Sample App",
                                                                                                 "slug" => "sample-app",
                                                                                                 "scopes" => Array [
@@ -3609,7 +3610,6 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "uuid" => "123456123456123456123456",
                                                                                                 "webhookUrl" => "https://example.com/webhook",
                                                                                                 "redirectUrl" => "https://example/com/setup",
-                                                                                                "isAlertable" => false,
                                                                                                 "clientId" => "client-id",
                                                                                                 "clientSecret" => "client-secret",
                                                                                                 "overview" => "This is an app.",
@@ -3905,6 +3905,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                 "snapshots": Array [
                                                   Map {
                                                     "organization" => "org-slug",
+                                                    "isAlertable" => false,
                                                     "name" => "Sample App",
                                                     "slug" => "sample-app",
                                                     "scopes" => Array [
@@ -3913,7 +3914,6 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                     "uuid" => "123456123456123456123456",
                                                     "webhookUrl" => "https://example.com/webhook",
                                                     "redirectUrl" => "https://example/com/setup",
-                                                    "isAlertable" => false,
                                                     "clientId" => "client-id",
                                                     "clientSecret" => "client-secret",
                                                     "overview" => "This is an app.",
@@ -5280,6 +5280,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                             "snapshots": Array [
                                                                               Map {
                                                                                 "organization" => "org-slug",
+                                                                                "isAlertable" => false,
                                                                                 "name" => "Sample App",
                                                                                 "slug" => "sample-app",
                                                                                 "scopes" => Array [
@@ -5288,7 +5289,6 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                 "uuid" => "123456123456123456123456",
                                                                                 "webhookUrl" => "https://example.com/webhook",
                                                                                 "redirectUrl" => "https://example/com/setup",
-                                                                                "isAlertable" => false,
                                                                                 "clientId" => "client-id",
                                                                                 "clientSecret" => "client-secret",
                                                                                 "overview" => "This is an app.",
@@ -5600,6 +5600,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                 "snapshots": Array [
                                                   Map {
                                                     "organization" => "org-slug",
+                                                    "isAlertable" => false,
                                                     "name" => "Sample App",
                                                     "slug" => "sample-app",
                                                     "scopes" => Array [
@@ -5608,7 +5609,6 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                     "uuid" => "123456123456123456123456",
                                                     "webhookUrl" => "https://example.com/webhook",
                                                     "redirectUrl" => "https://example/com/setup",
-                                                    "isAlertable" => false,
                                                     "clientId" => "client-id",
                                                     "clientSecret" => "client-secret",
                                                     "overview" => "This is an app.",
@@ -5916,6 +5916,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                             "snapshots": Array [
                                                                               Map {
                                                                                 "organization" => "org-slug",
+                                                                                "isAlertable" => false,
                                                                                 "name" => "Sample App",
                                                                                 "slug" => "sample-app",
                                                                                 "scopes" => Array [
@@ -5924,7 +5925,6 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                 "uuid" => "123456123456123456123456",
                                                                                 "webhookUrl" => "https://example.com/webhook",
                                                                                 "redirectUrl" => "https://example/com/setup",
-                                                                                "isAlertable" => false,
                                                                                 "clientId" => "client-id",
                                                                                 "clientSecret" => "client-secret",
                                                                                 "overview" => "This is an app.",
@@ -6192,6 +6192,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                 "snapshots": Array [
                                                   Map {
                                                     "organization" => "org-slug",
+                                                    "isAlertable" => false,
                                                     "name" => "Sample App",
                                                     "slug" => "sample-app",
                                                     "scopes" => Array [
@@ -6200,7 +6201,6 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                     "uuid" => "123456123456123456123456",
                                                     "webhookUrl" => "https://example.com/webhook",
                                                     "redirectUrl" => "https://example/com/setup",
-                                                    "isAlertable" => false,
                                                     "clientId" => "client-id",
                                                     "clientSecret" => "client-secret",
                                                     "overview" => "This is an app.",
@@ -6508,6 +6508,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                             "snapshots": Array [
                                                                               Map {
                                                                                 "organization" => "org-slug",
+                                                                                "isAlertable" => false,
                                                                                 "name" => "Sample App",
                                                                                 "slug" => "sample-app",
                                                                                 "scopes" => Array [
@@ -6516,7 +6517,6 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                 "uuid" => "123456123456123456123456",
                                                                                 "webhookUrl" => "https://example.com/webhook",
                                                                                 "redirectUrl" => "https://example/com/setup",
-                                                                                "isAlertable" => false,
                                                                                 "clientId" => "client-id",
                                                                                 "clientSecret" => "client-secret",
                                                                                 "overview" => "This is an app.",
@@ -6687,6 +6687,7 @@ exports[`Sentry Application Details new sentry application renders() it shows em
           className="form-stacked"
           initialData={
             Object {
+              "isAlertable": false,
               "organization": "org-slug",
             }
           }
@@ -7103,10 +7104,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                 },
                                                                 "fieldState": Object {},
                                                                 "fields": Object {
+                                                                  "isAlertable": false,
                                                                   "organization": "org-slug",
                                                                 },
                                                                 "formState": undefined,
                                                                 "initialData": Object {
+                                                                  "isAlertable": false,
                                                                   "organization": "org-slug",
                                                                 },
                                                                 "options": Object {
@@ -7122,6 +7125,7 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                 "snapshots": Array [
                                                                   Map {
                                                                     "organization" => "org-slug",
+                                                                    "isAlertable" => false,
                                                                   },
                                                                 ],
                                                               }
@@ -7196,6 +7200,7 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                           id="name"
                                                                                           initialData={
                                                                                             Object {
+                                                                                              "isAlertable": false,
                                                                                               "organization": "org-slug",
                                                                                             }
                                                                                           }
@@ -7357,10 +7362,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                             },
                                                                                             "fieldState": Object {},
                                                                                             "fields": Object {
+                                                                                              "isAlertable": false,
                                                                                               "organization": "org-slug",
                                                                                             },
                                                                                             "formState": undefined,
                                                                                             "initialData": Object {
+                                                                                              "isAlertable": false,
                                                                                               "organization": "org-slug",
                                                                                             },
                                                                                             "options": Object {
@@ -7376,6 +7383,7 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                             "snapshots": Array [
                                                                                               Map {
                                                                                                 "organization" => "org-slug",
+                                                                                                "isAlertable" => false,
                                                                                               },
                                                                                             ],
                                                                                           }
@@ -7639,10 +7647,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                 },
                                                                 "fieldState": Object {},
                                                                 "fields": Object {
+                                                                  "isAlertable": false,
                                                                   "organization": "org-slug",
                                                                 },
                                                                 "formState": undefined,
                                                                 "initialData": Object {
+                                                                  "isAlertable": false,
                                                                   "organization": "org-slug",
                                                                 },
                                                                 "options": Object {
@@ -7658,6 +7668,7 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                 "snapshots": Array [
                                                                   Map {
                                                                     "organization" => "org-slug",
+                                                                    "isAlertable" => false,
                                                                   },
                                                                 ],
                                                               }
@@ -7732,6 +7743,7 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                           id="webhookUrl"
                                                                                           initialData={
                                                                                             Object {
+                                                                                              "isAlertable": false,
                                                                                               "organization": "org-slug",
                                                                                             }
                                                                                           }
@@ -7893,10 +7905,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                             },
                                                                                             "fieldState": Object {},
                                                                                             "fields": Object {
+                                                                                              "isAlertable": false,
                                                                                               "organization": "org-slug",
                                                                                             },
                                                                                             "formState": undefined,
                                                                                             "initialData": Object {
+                                                                                              "isAlertable": false,
                                                                                               "organization": "org-slug",
                                                                                             },
                                                                                             "options": Object {
@@ -7912,6 +7926,7 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                             "snapshots": Array [
                                                                                               Map {
                                                                                                 "organization" => "org-slug",
+                                                                                                "isAlertable" => false,
                                                                                               },
                                                                                             ],
                                                                                           }
@@ -8166,10 +8181,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                 },
                                                                 "fieldState": Object {},
                                                                 "fields": Object {
+                                                                  "isAlertable": false,
                                                                   "organization": "org-slug",
                                                                 },
                                                                 "formState": undefined,
                                                                 "initialData": Object {
+                                                                  "isAlertable": false,
                                                                   "organization": "org-slug",
                                                                 },
                                                                 "options": Object {
@@ -8185,6 +8202,7 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                 "snapshots": Array [
                                                                   Map {
                                                                     "organization" => "org-slug",
+                                                                    "isAlertable" => false,
                                                                   },
                                                                 ],
                                                               }
@@ -8259,6 +8277,7 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                           id="redirectUrl"
                                                                                           initialData={
                                                                                             Object {
+                                                                                              "isAlertable": false,
                                                                                               "organization": "org-slug",
                                                                                             }
                                                                                           }
@@ -8418,10 +8437,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                             },
                                                                                             "fieldState": Object {},
                                                                                             "fields": Object {
+                                                                                              "isAlertable": false,
                                                                                               "organization": "org-slug",
                                                                                             },
                                                                                             "formState": undefined,
                                                                                             "initialData": Object {
+                                                                                              "isAlertable": false,
                                                                                               "organization": "org-slug",
                                                                                             },
                                                                                             "options": Object {
@@ -8437,6 +8458,7 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                             "snapshots": Array [
                                                                                               Map {
                                                                                                 "organization" => "org-slug",
+                                                                                                "isAlertable" => false,
                                                                                               },
                                                                                             ],
                                                                                           }
@@ -8791,10 +8813,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                 },
                                                                 "fieldState": Object {},
                                                                 "fields": Object {
+                                                                  "isAlertable": false,
                                                                   "organization": "org-slug",
                                                                 },
                                                                 "formState": undefined,
                                                                 "initialData": Object {
+                                                                  "isAlertable": false,
                                                                   "organization": "org-slug",
                                                                 },
                                                                 "options": Object {
@@ -8810,6 +8834,7 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                 "snapshots": Array [
                                                                   Map {
                                                                     "organization" => "org-slug",
+                                                                    "isAlertable" => false,
                                                                   },
                                                                 ],
                                                               }
@@ -8899,6 +8924,7 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                           id="isAlertable"
                                                                                           initialData={
                                                                                             Object {
+                                                                                              "isAlertable": false,
                                                                                               "organization": "org-slug",
                                                                                             }
                                                                                           }
@@ -9077,10 +9103,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                             },
                                                                                             "fieldState": Object {},
                                                                                             "fields": Object {
+                                                                                              "isAlertable": false,
                                                                                               "organization": "org-slug",
                                                                                             },
                                                                                             "formState": undefined,
                                                                                             "initialData": Object {
+                                                                                              "isAlertable": false,
                                                                                               "organization": "org-slug",
                                                                                             },
                                                                                             "options": Object {
@@ -9096,6 +9124,7 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                             "snapshots": Array [
                                                                                               Map {
                                                                                                 "organization" => "org-slug",
+                                                                                                "isAlertable" => false,
                                                                                               },
                                                                                             ],
                                                                                           }
@@ -9350,10 +9379,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                 },
                                                                 "fieldState": Object {},
                                                                 "fields": Object {
+                                                                  "isAlertable": false,
                                                                   "organization": "org-slug",
                                                                 },
                                                                 "formState": undefined,
                                                                 "initialData": Object {
+                                                                  "isAlertable": false,
                                                                   "organization": "org-slug",
                                                                 },
                                                                 "options": Object {
@@ -9369,6 +9400,7 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                 "snapshots": Array [
                                                                   Map {
                                                                     "organization" => "org-slug",
+                                                                    "isAlertable" => false,
                                                                   },
                                                                 ],
                                                               }
@@ -9444,6 +9476,7 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                           id="overview"
                                                                                           initialData={
                                                                                             Object {
+                                                                                              "isAlertable": false,
                                                                                               "organization": "org-slug",
                                                                                             }
                                                                                           }
@@ -9629,10 +9662,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                             },
                                                                                             "fieldState": Object {},
                                                                                             "fields": Object {
+                                                                                              "isAlertable": false,
                                                                                               "organization": "org-slug",
                                                                                             },
                                                                                             "formState": undefined,
                                                                                             "initialData": Object {
+                                                                                              "isAlertable": false,
                                                                                               "organization": "org-slug",
                                                                                             },
                                                                                             "options": Object {
@@ -9648,6 +9683,7 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                             "snapshots": Array [
                                                                                               Map {
                                                                                                 "organization" => "org-slug",
+                                                                                                "isAlertable" => false,
                                                                                               },
                                                                                             ],
                                                                                           }
@@ -9881,10 +9917,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                 },
                                                 "fieldState": Object {},
                                                 "fields": Object {
+                                                  "isAlertable": false,
                                                   "organization": "org-slug",
                                                 },
                                                 "formState": undefined,
                                                 "initialData": Object {
+                                                  "isAlertable": false,
                                                   "organization": "org-slug",
                                                 },
                                                 "options": Object {
@@ -9900,6 +9938,7 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                 "snapshots": Array [
                                                   Map {
                                                     "organization" => "org-slug",
+                                                    "isAlertable" => false,
                                                   },
                                                 ],
                                               }
@@ -11200,10 +11239,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                             },
                                                                             "fieldState": Object {},
                                                                             "fields": Object {
+                                                                              "isAlertable": false,
                                                                               "organization": "org-slug",
                                                                             },
                                                                             "formState": undefined,
                                                                             "initialData": Object {
+                                                                              "isAlertable": false,
                                                                               "organization": "org-slug",
                                                                             },
                                                                             "options": Object {
@@ -11219,6 +11260,7 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                             "snapshots": Array [
                                                                               Map {
                                                                                 "organization" => "org-slug",
+                                                                                "isAlertable" => false,
                                                                               },
                                                                             ],
                                                                           }

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
@@ -118,6 +118,7 @@ describe('Organization Developer Settings', function() {
       });
 
       it('redirects the user to the App when a redirectUrl is set', () => {
+        window.location.assign = jest.fn();
         Client.addMockResponse({
           url: `/organizations/${org.slug}/sentry-apps/`,
           body: [sentryApp],
@@ -135,12 +136,13 @@ describe('Organization Developer Settings', function() {
 
         wrapper.find('StyledInstallButton').simulate('click');
 
-        expect(browserHistory.push).toHaveBeenCalledWith(
+        expect(window.location.assign).toHaveBeenCalledWith(
           `${sentryApp.redirectUrl}?code=${install.code}&installationId=${install.uuid}`
         );
       });
 
       it('handles a redirectUrl with pre-existing query params', () => {
+        window.location.assign = jest.fn();
         const sentryAppWithQuery = TestStubs.SentryApp({
           redirectUrl: 'https://example.com/setup?hello=1',
         });
@@ -162,7 +164,7 @@ describe('Organization Developer Settings', function() {
 
         wrapper.find('StyledInstallButton').simulate('click');
 
-        expect(browserHistory.push).toHaveBeenCalledWith(
+        expect(window.location.assign).toHaveBeenCalledWith(
           `https://example.com/setup?code=${install.code}&hello=1&installationId=${install.uuid}`
         );
       });


### PR DESCRIPTION
* Add `sentry.tasks.app_platform` to imports
* Use `window.location.assign` to send users to the `redirectUrl`
* Add default for `isAlertable` so it's not null