### PR TITLE
feat(org-events): Use `events-stats` endpoint for charts

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/events.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/events.jsx
@@ -1,0 +1,121 @@
+import moment from 'moment';
+
+import {DEFAULT_STATS_PERIOD} from 'app/constants';
+import {getUtcDateString} from 'app/utils/dates';
+
+const BASE_URL = org => `/organizations/${org.slug}/events-stats/`;
+
+// Gets the period to query with if we need to double the initial period in order
+// to get data for the previous period
+const getPeriod = ({period, start, end}, {shouldDoublePeriod}) => {
+  if (!period && !start && !end) {
+    period = DEFAULT_STATS_PERIOD;
+  }
+
+  // you can not specify both relative and absolute periods
+  // relative period takes precendence
+  if (period) {
+    if (!shouldDoublePeriod) return {statsPeriod: period};
+    const [, periodNumber, periodLength] = period.match(/([0-9]+)([mhdw])/);
+
+    return {statsPeriod: `${parseInt(periodNumber, 10) * 2}${periodLength}`};
+  }
+
+  if (!start || !end) {
+    throw new Error('start and end required');
+  }
+
+  const formattedStart = getUtcDateString(start);
+  const formattedEnd = getUtcDateString(end);
+
+  if (shouldDoublePeriod) {
+    // get duration of end - start and double
+    const diff = moment(end).diff(moment(start));
+
+    const previousPeriodStart = moment(start).subtract(diff);
+
+    return [
+      {
+        start: getUtcDateString(previousPeriodStart),
+        end: formattedStart,
+      },
+      {
+        start: formattedStart,
+        end: formattedEnd,
+      },
+    ];
+  }
+
+  return {
+    start: formattedStart,
+    end: formattedEnd,
+  };
+};
+
+/**
+ * Make requests to `health` endpoint
+ *
+ * @param {Object} api API client instance
+ * @param {Object} options Request parameters
+ * @param {Object} options.organization Organization object
+ * @param {Number[]} options.projects List of project ids
+ * @param {String[]} options.environments List of environments to query for
+ * @param {String} options.period Time period to query for, in the format: <integer><units> where units are "d" or "h"
+ * @param {String} options.interval Time interval to group results in, in the format: <integer><units> where units are "d", "h", "m", "s"
+ * @param {Boolean} options.includePrevious Should request also return reqsults for previous period?
+ * @param {Number} options.limit The number of rows to return
+ * @param {String} options.query Search query
+ */
+export const doEventsRequest = (
+  api,
+  {
+    organization,
+    projects,
+    environments,
+    period,
+    start,
+    end,
+    interval,
+    includePrevious,
+    limit,
+    query,
+  }
+) => {
+  if (!api) return Promise.reject(new Error('API client not available'));
+
+  const shouldDoublePeriod = includePrevious;
+  const urlQuery = {
+    interval,
+    project: projects,
+    environment: environments,
+    query,
+  };
+
+  // Need to treat absolute dates differently, need to perform 2 requests in
+  // order to guarantee a previous period that matches up to current period
+  if (period || !shouldDoublePeriod) {
+    const periodObj = getPeriod({period, start, end}, {shouldDoublePeriod});
+
+    return api.requestPromise(`${BASE_URL(organization)}`, {
+      query: {
+        ...urlQuery,
+        ...periodObj,
+      },
+    });
+  }
+
+  const absolutePeriods = getPeriod({start, end}, {shouldDoublePeriod});
+
+  return Promise.all(
+    absolutePeriods.filter(i => !!i).map(absolutePeriod =>
+      api.requestPromise(`${BASE_URL(organization)}`, {
+        query: {
+          ...urlQuery,
+          ...absolutePeriod,
+        },
+      })
+    )
+  ).then(results => ({
+    data: results.reduce((acc, {data}) => acc.concat(data), []),
+  }));
+};

--- a/src/sentry/static/sentry/app/actionCreators/events.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/events.jsx
@@ -81,8 +81,6 @@ export const doEventsRequest = (
     query,
   }
 ) => {
-  if (!api) return Promise.reject(new Error('API client not available'));
-
   const shouldDoublePeriod = includePrevious;
   const urlQuery = {
     interval,

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateSummary.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateSummary.jsx
@@ -1,8 +1,6 @@
 /**
  * Displays and formats absolute DateTime ranges
  */
-
-import {Flex} from 'grid-emotion';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
@@ -57,7 +55,7 @@ class DateSummary extends React.Component {
       endTimeFormatted !== DEFAULT_DAY_END_TIME;
 
     return (
-      <DateGroupWrapper className={className} align="center" hasTime={shouldShowTimes}>
+      <DateGroupWrapper className={className} hasTime={shouldShowTimes}>
         <DateGroup>
           <Date hasTime={shouldShowTimes}>
             {this.formatDate(start)}
@@ -79,7 +77,9 @@ class DateSummary extends React.Component {
   }
 }
 
-const DateGroupWrapper = styled(Flex)`
+const DateGroupWrapper = styled('div')`
+  display: flex;
+  align-items: center;
   transform: translateY(${p => (p.hasTime ? '-5px' : '0')});
 `;
 

--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import moment from 'moment';
 import {browserHistory} from 'react-router';
 
+import {DEFAULT_USE_UTC} from 'app/constants';
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {getUtcDateString} from 'app/utils/dates';
 import {t, tct} from 'app/locale';

--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import moment from 'moment';
 import {browserHistory} from 'react-router';
 
-import {DEFAULT_USE_UTC} from 'app/constants';
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {getUtcDateString} from 'app/utils/dates';
 import {t, tct} from 'app/locale';

--- a/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
@@ -4,16 +4,17 @@ import React from 'react';
 import styled from 'react-emotion';
 
 import {Panel} from 'app/components/panels';
-import {getParams} from 'app/views/organizationEvents/utils';
 import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
-import EventsChart from 'app/views/organizationEvents/eventsChart';
-import EventsTable from 'app/views/organizationEvents/eventsTable';
 import Pagination from 'app/components/pagination';
 import PreviewFeature from 'app/components/previewFeature';
 import SearchBar from 'app/components/searchBar';
 import SentryTypes from 'app/sentryTypes';
 import withOrganization from 'app/utils/withOrganization';
+
+import {getParams} from './utils/getParams';
+import EventsChart from './eventsChart';
+import EventsTable from './eventsTable';
 
 class OrganizationEvents extends AsyncView {
   static propTypes = {

--- a/src/sentry/static/sentry/app/views/organizationEvents/eventsTable.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/eventsTable.jsx
@@ -21,6 +21,7 @@ class EventsTable extends React.Component {
     reloading: PropTypes.bool,
     events: PropTypes.array,
     organization: SentryTypes.Organization,
+    utc: PropTypes.bool,
   };
 
   constructor(props) {
@@ -62,7 +63,7 @@ class EventsTable extends React.Component {
   }
 
   render() {
-    const {events, organization, reloading} = this.props;
+    const {events, organization, reloading, utc} = this.props;
     const hasEvents = events && !!events.length;
 
     return (
@@ -103,7 +104,7 @@ class EventsTable extends React.Component {
                   </TableData>
 
                   <TableData>
-                    <StyledDateTime date={new Date(event.dateCreated)} />
+                    <StyledDateTime utc={utc} date={new Date(event.dateCreated)} />
                   </TableData>
                 </TableRow>
               );

--- a/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
@@ -7,8 +7,6 @@ import styled from 'react-emotion';
 import {DEFAULT_STATS_PERIOD, DEFAULT_USE_UTC} from 'app/constants';
 import {defined} from 'app/utils';
 import {getLocalDateObject, getUtcDateString} from 'app/utils/dates';
-import {getParams} from 'app/views/organizationEvents/utils';
-import EventsContext from 'app/views/organizationEvents/utils/eventsContext';
 import Feature from 'app/components/acl/feature';
 import Header from 'app/components/organizations/header';
 import HeaderSeparator from 'app/components/organizations/headerSeparator';
@@ -19,6 +17,9 @@ import SentryTypes from 'app/sentryTypes';
 import TimeRangeSelector from 'app/components/organizations/timeRangeSelector';
 import space from 'app/styles/space';
 import withOrganization from 'app/utils/withOrganization';
+
+import {getParams} from './utils/getParams';
+import EventsContext from './utils/eventsContext';
 
 class OrganizationEventsContainer extends React.Component {
   static propTypes = {

--- a/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
@@ -1,4 +1,5 @@
 import {Flex} from 'grid-emotion';
+import {isEqual} from 'lodash';
 import {withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -61,32 +62,27 @@ class OrganizationEventsContainer extends React.Component {
     };
   }
 
+  static getDerivedStateFromProps(props, state) {
+    const values = OrganizationEventsContainer.getStateFromRouter(props);
+
+    // Update `queryValues` if URL parameters change
+    if (!isEqual(state.queryValues, values)) {
+      return {
+        ...values,
+        queryValues: values,
+      };
+    }
+
+    return null;
+  }
+
   constructor(props) {
     super(props);
 
     this.actions = {
       updateParams: this.updateParams,
     };
-
-    const values = OrganizationEventsContainer.getStateFromRouter(props);
-    this.state = {
-      ...values,
-      queryValues: {
-        ...values,
-      },
-    };
-  }
-
-  componentWillReceiveProps(nextProps, nextState) {
-    if (this.props.location !== nextProps.location) {
-      const values = OrganizationEventsContainer.getStateFromRouter(nextProps);
-
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({
-        ...values,
-        queryValues: {...values},
-      });
-    }
+    this.state = {};
   }
 
   updateParams = obj => {
@@ -116,15 +112,15 @@ class OrganizationEventsContainer extends React.Component {
   };
 
   handleChangeProjects = projects => {
-    this.setState(state => ({
+    this.setState({
       project: projects,
-    }));
+    });
   };
 
   handleChangeEnvironments = environments => {
-    this.setState(state => ({
+    this.setState({
       environment: environments,
-    }));
+    });
   };
 
   handleChangeTime = ({start, end, relative, utc}) => {

--- a/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
@@ -7,6 +7,8 @@ import styled from 'react-emotion';
 import {DEFAULT_STATS_PERIOD, DEFAULT_USE_UTC} from 'app/constants';
 import {defined} from 'app/utils';
 import {getLocalDateObject, getUtcDateString} from 'app/utils/dates';
+import {getParams} from 'app/views/organizationEvents/utils';
+import EventsContext from 'app/views/organizationEvents/utils/eventsContext';
 import Feature from 'app/components/acl/feature';
 import Header from 'app/components/organizations/header';
 import HeaderSeparator from 'app/components/organizations/headerSeparator';
@@ -17,9 +19,6 @@ import SentryTypes from 'app/sentryTypes';
 import TimeRangeSelector from 'app/components/organizations/timeRangeSelector';
 import space from 'app/styles/space';
 import withOrganization from 'app/utils/withOrganization';
-
-import {getParams} from './utils/getParams';
-import EventsContext from './utils/eventsContext';
 
 class OrganizationEventsContainer extends React.Component {
   static propTypes = {

--- a/src/sentry/static/sentry/app/views/organizationEvents/utils/eventsRequest.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/utils/eventsRequest.jsx
@@ -1,0 +1,324 @@
+import {isEqual, omitBy} from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import {doEventsRequest} from 'app/actionCreators/events';
+import LoadingPanel from 'app/views/organizationHealth/loadingPanel';
+import SentryTypes from 'app/sentryTypes';
+import withApi from 'app/utils/withApi';
+import withLatestContext from 'app/utils/withLatestContext';
+
+import EventsContext from './eventsContext';
+
+class EventsRequestWithParams extends React.Component {
+  static propTypes = {
+    /**
+     * API client instance
+     */
+    api: PropTypes.object.isRequired,
+
+    organization: SentryTypes.Organization.isRequired,
+
+    /**
+     * List of project ids to query
+     */
+    projects: PropTypes.arrayOf(PropTypes.number),
+
+    /**
+     * List of environments to query
+     */
+    environments: PropTypes.arrayOf(PropTypes.string),
+
+    /**
+     * Relative time period for query.
+     *
+     * Use `start` and `end` for absolute dates.
+     *
+     * e.g. 24h, 7d, 30d
+     */
+    period: PropTypes.string,
+
+    /**
+     * Absolute start date for query
+     */
+    start: PropTypes.instanceOf(Date),
+    /**
+     * Absolute end date for query
+     */
+    end: PropTypes.instanceOf(Date),
+
+    /**
+     * Interval to group results in
+     *
+     * e.g. 1d, 1h, 1m, 1s
+     */
+    interval: PropTypes.string,
+
+    /**
+     * Include data for previous period
+     */
+    includePrevious: PropTypes.bool,
+
+    /**
+     * number of rows to return
+     */
+    limit: PropTypes.number,
+
+    /**
+     * Transform the response data to be something ingestible by charts
+     */
+    includeTransformedData: PropTypes.bool,
+
+    /**
+     * Include a dataset transform that will aggregate count values for each timestamp.
+     * Be sure to supply a name to `timeAggregationSeriesName`
+     */
+    includeTimeAggregation: PropTypes.bool,
+
+    /**
+     * Name of series of aggregated timeseries
+     */
+    timeAggregationSeriesName: PropTypes.string,
+
+    showLoading: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    period: null,
+    start: null,
+    end: null,
+    interval: '1d',
+    limit: 15,
+    getCategory: i => i,
+    query: '',
+
+    includePrevious: true,
+    includeTransformedData: true,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      reloading: false,
+      timeseriesData: null,
+    };
+  }
+
+  componentDidMount() {
+    this.fetchData();
+  }
+
+  componentDidUpdate(prevProps) {
+    const propNamesToIgnore = ['api', 'children', 'organizations', 'project'];
+
+    const prevPropsToCheck = omitBy(prevProps, (value, key) =>
+      propNamesToIgnore.includes(key)
+    );
+
+    const propsToCheck = omitBy(this.props, (value, key) =>
+      propNamesToIgnore.includes(key)
+    );
+
+    if (isEqual(prevPropsToCheck, propsToCheck)) return;
+
+    this.fetchData();
+  }
+
+  componentWillUnmount() {
+    this.unmounting = true;
+  }
+
+  fetchData = async () => {
+    const {api, ...props} = this.props;
+
+    this.setState(state => ({
+      reloading: state.timeseriesData !== null,
+    }));
+
+    const timeseriesData = await doEventsRequest(api, props);
+
+    if (this.unmounting) return;
+
+    this.setState({
+      reloading: false,
+      timeseriesData,
+    });
+  };
+
+  /**
+   * Retrieves data set for the current period (since data can potentially contain previous period's data), as
+   * well as the previous period if possible.
+   *
+   * Returns `null` if data does not exist
+   */
+  getData = data => {
+    const {includePrevious} = this.props;
+
+    if (!data) {
+      return {
+        previous: null,
+        current: null,
+      };
+    }
+
+    const hasPreviousPeriod = includePrevious;
+    // Take the floor just in case, but data should always be divisible by 2
+    const dataMiddleIndex = Math.floor(data.length / 2);
+
+    return {
+      previous: hasPreviousPeriod ? data.slice(0, dataMiddleIndex) : null,
+      current: hasPreviousPeriod ? data.slice(dataMiddleIndex) : data,
+    };
+  };
+
+  // This aggregates all values per `timestamp`
+  calculateTotalsPerTimestamp = (data, getName = timestamp => timestamp * 1000) => {
+    return data.map(([timestamp, countArray], i) => ({
+      name: getName(timestamp, countArray, i),
+      value: countArray.reduce((acc, {count}) => acc + count, 0),
+    }));
+  };
+
+  /**
+   * Get previous period data, but transform timestampts so that data fits unto the current period's data axis
+   */
+  transformPreviousPeriodData = (current, previous) => {
+    // Need the current period data array so we can take the timestamp
+    // so we can be sure the data lines up
+    if (!previous) return [];
+
+    return {
+      seriesName: 'Previous Period',
+      data: this.calculateTotalsPerTimestamp(
+        previous,
+        (timestamp, countArray, i) => current[i][0] * 1000
+      ),
+    };
+  };
+
+  /**
+   * Aggregate all counts for each time stamp
+   */
+  transformAggregatedTimeseries = (data, seriesName) => {
+    if (!data) return null;
+
+    return {
+      seriesName,
+      data: this.calculateTotalsPerTimestamp(data),
+    };
+  };
+
+  /**
+   * Transforms query response into timeseries data to be used in a chart
+   */
+  transformTimeseriesData = data => {
+    return [
+      {
+        seriesName: 'Events',
+        data: data.map(([timestamp, countsForTimestamp]) => ({
+          name: timestamp * 1000,
+          value: countsForTimestamp.reduce((acc, {count}) => acc + count, 0),
+        })),
+      },
+    ];
+  };
+
+  transformData = data => {
+    if (!data) return null;
+
+    return this.transformTimeseriesData(data);
+  };
+
+  processData({data, totals} = {}) {
+    const {
+      includeTransformedData,
+      includeTimeAggregation,
+      timeAggregationSeriesName,
+    } = this.props;
+    const {current, previous} = this.getData(data);
+    const transformedData = includeTransformedData ? this.transformData(current) : null;
+
+    const previousData = includeTransformedData
+      ? this.transformPreviousPeriodData(current, previous)
+      : null;
+
+    const timeAggregatedData = includeTimeAggregation
+      ? this.transformAggregatedTimeseries(current, timeAggregationSeriesName)
+      : null;
+
+    return {
+      data: transformedData,
+      allData: data,
+      originalData: current,
+      totals,
+      originalPreviousData: previous,
+      previousData,
+      timeAggregatedData,
+    };
+  }
+
+  render() {
+    const {children, showLoading, ...props} = this.props;
+
+    const {timeseriesData, reloading} = this.state;
+
+    // Is "loading" if data is null
+    const loading = reloading || timeseriesData === null;
+
+    if (showLoading && loading) {
+      return <LoadingPanel />;
+    }
+
+    const {
+      data: transformedTimeseriesData,
+      allData: allTimeseriesData,
+      originalData: originalTimeseriesData,
+      totals: timeseriesTotals,
+      originalPreviousData: originalPreviousTimeseriesData,
+      previousData: previousTimeseriesData,
+      timeAggregatedData,
+    } =
+      (timeseriesData && this.processData(timeseriesData, true)) || {};
+
+    return children({
+      loading,
+
+      // timeseries data
+      timeseriesData: transformedTimeseriesData,
+      allTimeseriesData,
+      originalTimeseriesData,
+      timeseriesTotals,
+      originalPreviousTimeseriesData,
+      previousTimeseriesData,
+      timeAggregatedData,
+
+      // sometimes we want to reference props that were given to EventsRequest
+      ...props,
+    });
+  }
+}
+
+const EventsRequest = withLatestContext(
+  withApi(
+    class EventsRequest extends React.Component {
+      render() {
+        return (
+          <EventsContext.Consumer>
+            {({projects, environments, period, filters}) => (
+              <EventsRequestWithParams
+                projects={projects}
+                environments={environments}
+                period={period}
+                filters={filters}
+                {...this.props}
+              />
+            )}
+          </EventsContext.Consumer>
+        );
+      }
+    }
+  )
+);
+
+export default EventsRequest;
+export {EventsRequestWithParams};

--- a/src/sentry/static/sentry/app/views/organizationEvents/utils/eventsRequest.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/utils/eventsRequest.jsx
@@ -111,15 +111,12 @@ class EventsRequestWithParams extends React.Component {
   componentDidUpdate(prevProps) {
     const propNamesToIgnore = ['api', 'children', 'organizations', 'project'];
 
-    const prevPropsToCheck = omitBy(prevProps, (value, key) =>
-      propNamesToIgnore.includes(key)
-    );
+    const omitIgnoredProps = props =>
+      omitBy(props, (value, key) => propNamesToIgnore.includes(key));
 
-    const propsToCheck = omitBy(this.props, (value, key) =>
-      propNamesToIgnore.includes(key)
-    );
-
-    if (isEqual(prevPropsToCheck, propsToCheck)) return;
+    if (isEqual(omitIgnoredProps(prevProps), omitIgnoredProps(this.props))) {
+      return;
+    }
 
     this.fetchData();
   }

--- a/src/sentry/static/sentry/app/views/organizationEvents/utils/getParams.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/utils/getParams.jsx
@@ -1,0 +1,35 @@
+import {DEFAULT_STATS_PERIOD} from 'app/constants';
+import {defined} from 'app/utils';
+
+// Filters out params with null values and returns a default
+// `statsPeriod` when necessary.
+//
+// Accepts `period` and `statsPeriod` but will only return `statsPeriod`
+//
+// TODO(billy): Make period parameter name consistent
+export function getParams(params = {}) {
+  let {start, end, period, statsPeriod, ...otherParams} = params;
+
+  // `statsPeriod` takes precendence for now
+  period = statsPeriod || period;
+
+  if (!start && !end && !period) {
+    period = DEFAULT_STATS_PERIOD;
+  }
+
+  // Filter null values
+  return Object.entries({
+    statsPeriod: period,
+    start: period ? null : start,
+    end: period ? null : end,
+    ...otherParams,
+  })
+    .filter(([key, value]) => defined(value))
+    .reduce(
+      (acc, [key, value]) => ({
+        ...acc,
+        [key]: value,
+      }),
+      {}
+    );
+}

--- a/tests/js/spec/actionCreators/events.spec.jsx
+++ b/tests/js/spec/actionCreators/events.spec.jsx
@@ -1,0 +1,126 @@
+import {Client} from 'app/api';
+import {doEventsRequest} from 'app/actionCreators/events';
+
+describe('Events ActionCreator', function() {
+  const api = new Client();
+  const organization = TestStubs.Organization();
+  const project = TestStubs.Project();
+  const opts = {
+    organization,
+    projects: [project.id],
+    environments: [],
+  };
+
+  let mock;
+
+  beforeEach(function() {
+    MockApiClient.clearMockResponses();
+    mock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {data: [[123, []], [123, []], [123, []], [123, []], [123, []], [123, []]]},
+    });
+  });
+
+  it('requests events stats with relative period', function() {
+    doEventsRequest(api, {
+      ...opts,
+      includePrevious: false,
+      period: '7d',
+    });
+
+    expect(mock).toHaveBeenLastCalledWith(
+      '/organizations/org-slug/events-stats/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          project: [project.id],
+          environment: [],
+          statsPeriod: '7d',
+        }),
+      })
+    );
+  });
+
+  it('requests events stats with relative period including previous period', function() {
+    doEventsRequest(api, {
+      ...opts,
+      includePrevious: true,
+      period: '7d',
+    });
+
+    expect(mock).toHaveBeenLastCalledWith(
+      '/organizations/org-slug/events-stats/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          project: [project.id],
+          environment: [],
+          statsPeriod: '14d',
+        }),
+      })
+    );
+  });
+
+  it('requests events stats with absolute period', async function() {
+    const start = new Date('2017-10-12T12:00:00.000Z');
+    const end = new Date('2017-10-17T00:00:00.000Z');
+    doEventsRequest(api, {
+      ...opts,
+      includePrevious: false,
+      start,
+      end,
+    });
+
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock).toHaveBeenLastCalledWith(
+      '/organizations/org-slug/events-stats/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          project: [project.id],
+          environment: [],
+          start: '2017-10-12T12:00:00',
+          end: '2017-10-17T00:00:00',
+        }),
+      })
+    );
+  });
+
+  it('requests events stats with absolute period including previous period', async function() {
+    const start = new Date('2017-10-12T12:00:00.000Z');
+    const end = new Date('2017-10-17T00:00:00.000Z');
+    const result = await doEventsRequest(api, {
+      ...opts,
+      includePrevious: true,
+      start,
+      end,
+    });
+
+    expect(mock).toHaveBeenCalledTimes(2);
+
+    // Previous period call
+    expect(mock).toHaveBeenNthCalledWith(
+      1,
+      '/organizations/org-slug/events-stats/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          project: [project.id],
+          environment: [],
+          start: '2017-10-08T00:00:00',
+          end: '2017-10-12T12:00:00',
+        }),
+      })
+    );
+
+    expect(mock).toHaveBeenLastCalledWith(
+      '/organizations/org-slug/events-stats/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          project: [project.id],
+          environment: [],
+          start: '2017-10-12T12:00:00',
+          end: '2017-10-17T00:00:00',
+        }),
+      })
+    );
+
+    expect(result.data).toHaveLength(12);
+  });
+});

--- a/tests/js/spec/components/organizations/timeRangeSelector/__snapshots__/dateSummary.spec.jsx.snap
+++ b/tests/js/spec/components/organizations/timeRangeSelector/__snapshots__/dateSummary.spec.jsx.snap
@@ -7,72 +7,63 @@ exports[`DateSummary renders 1`] = `
   utc={true}
 >
   <DateGroupWrapper
-    align="center"
     hasTime={true}
   >
-    <Base
-      align="center"
-      className="css-1vodv3z-DateGroupWrapper eyxmd2r0"
-      hasTime={true}
+    <div
+      className="css-1eqyixq-DateGroupWrapper eyxmd2r0"
     >
-      <div
-        className="css-1vodv3z-DateGroupWrapper eyxmd2r0"
-        hasTime={true}
-        is={null}
-      >
-        <DateGroup>
-          <div
-            className="css-8ah8mg-DateGroup eyxmd2r1"
+      <DateGroup>
+        <div
+          className="css-8ah8mg-DateGroup eyxmd2r1"
+        >
+          <Date
+            hasTime={true}
           >
-            <Date
-              hasTime={true}
+            <div
+              className="css-1gi0kmy-Date eyxmd2r2"
             >
-              <div
-                className="css-1gi0kmy-Date eyxmd2r2"
-              >
-                Oct 14, 2017
-                <Time>
-                  <div
-                    className="css-ul1hyh-Time eyxmd2r3"
-                  >
-                    02:38
-                  </div>
-                </Time>
-              </div>
-            </Date>
-          </div>
-        </DateGroup>
-        <DateRangeDivider>
-          <span
-            className="css-1qowu2b-DateRangeDivider eyxmd2r4"
+              Oct 14, 2017
+              <Time>
+                <div
+                  className="css-ul1hyh-Time eyxmd2r3"
+                >
+                  02:38
+                </div>
+              </Time>
+            </div>
+          </Date>
+        </div>
+      </DateGroup>
+      <DateRangeDivider>
+        <span
+          className="css-1qowu2b-DateRangeDivider eyxmd2r4"
+        >
+          to
+        </span>
+      </DateRangeDivider>
+      <DateGroup>
+        <div
+          className="css-8ah8mg-DateGroup eyxmd2r1"
+        >
+          <Date
+            hasTime={true}
           >
-            to
-          </span>
-        </DateRangeDivider>
-        <DateGroup>
-          <div
-            className="css-8ah8mg-DateGroup eyxmd2r1"
-          >
-            <Date
-              hasTime={true}
+            <div
+              className="css-1gi0kmy-Date eyxmd2r2"
             >
-              <div
-                className="css-1gi0kmy-Date eyxmd2r2"
-              >
-                Oct 17, 2017
-                <Time>
-                  <div
-                    className="css-ul1hyh-Time eyxmd2r3"
-                  >
-                    02:38
-                  </div>
-                </Time>
-              </div>
-            </Date>
-          </div>
-        </DateGroup>
-      </div>
-    </Base>
+              Oct 17, 2017
+              <Time>
+                <div
+                  className="css-ul1hyh-Time eyxmd2r3"
+                >
+                  02:38
+                </div>
+              </Time>
+            </div>
+          </Date>
+        </div>
+      </DateGroup>
+    </div>
   </DateGroupWrapper>
 </DateSummary>
 `;

--- a/tests/js/spec/views/organizationEvents/events.spec.jsx
+++ b/tests/js/spec/views/organizationEvents/events.spec.jsx
@@ -9,15 +9,15 @@ describe('OrganizationEventsErrors', function() {
   const project = TestStubs.Project({isMember: true});
   const org = TestStubs.Organization({projects: [project]});
   let eventsMock;
-  let healthGraphMock;
+  let eventsStatsMock;
 
   beforeEach(function() {
     eventsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
       body: (url, opts) => [TestStubs.OrganizationEvent(opts.query)],
     });
-    healthGraphMock = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/health/graph/',
+    eventsStatsMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
       body: (url, opts) => {
         return TestStubs.HealthGraph(opts.query);
       },
@@ -31,7 +31,7 @@ describe('OrganizationEventsErrors', function() {
     );
     await tick();
     wrapper.update();
-    expect(healthGraphMock).toHaveBeenCalled();
+    expect(eventsStatsMock).toHaveBeenCalled();
     expect(wrapper.find('LoadingIndicator')).toHaveLength(0);
     expect(wrapper.find('IdBadge')).toHaveLength(2);
   });

--- a/tests/js/spec/views/organizationEvents/index.spec.jsx
+++ b/tests/js/spec/views/organizationEvents/index.spec.jsx
@@ -58,8 +58,6 @@ describe('OrganizationEvents', function() {
       .find('EnvironmentSelectorItem')
       .at(0)
       .simulate('click');
-    // This should update state, but not route or context
-    expect(wrapper.state('environment')).toEqual(['production']);
 
     expect(router.push).toHaveBeenCalledWith({
       pathname: '/organizations/org-slug/events/',
@@ -68,6 +66,20 @@ describe('OrganizationEvents', function() {
         statsPeriod: '14d',
       },
     });
+
+    wrapper.setProps({
+      router: {
+        ...router,
+        location: {
+          ...router.location,
+          query: {
+            environment: ['production'],
+            statsPeriod: '14d',
+          },
+        },
+      },
+    });
+
     expect(wrapper.state('queryValues')).toEqual(
       expect.objectContaining({environment: ['production']})
     );
@@ -96,6 +108,20 @@ describe('OrganizationEvents', function() {
         statsPeriod: '14d',
       },
     });
+
+    wrapper.setProps({
+      router: {
+        ...router,
+        location: {
+          ...router.location,
+          query: {
+            environment: ['production', 'staging'],
+            statsPeriod: '14d',
+          },
+        },
+      },
+    });
+
     expect(wrapper.state('queryValues')).toEqual(
       expect.objectContaining({environment: ['production', 'staging']})
     );
@@ -105,7 +131,19 @@ describe('OrganizationEvents', function() {
     await tick();
     wrapper.update();
     wrapper.find('MultipleEnvironmentSelector HeaderItem StyledClose').simulate('click');
-    expect(wrapper.state('environment')).toEqual([]);
+
+    wrapper.setProps({
+      router: {
+        ...router,
+        location: {
+          ...router.location,
+          query: {
+            environment: [],
+            statsPeriod: '14d',
+          },
+        },
+      },
+    });
 
     expect(wrapper.state('queryValues')).toEqual(
       expect.objectContaining({environment: []})
@@ -119,25 +157,6 @@ describe('OrganizationEvents', function() {
     });
   });
 
-  it('does not update component state when router is changed', async function() {
-    expect(wrapper.state('environment')).toEqual([]);
-
-    // This shouldn't happen, we only use URL params for initial state
-    wrapper.setProps({
-      router: {
-        ...router,
-        location: {
-          pathname: '/organizations/org-slug/events/',
-          query: {
-            environment: ['production'],
-            statsPeriod: '14d',
-          },
-        },
-      },
-    });
-    expect(wrapper.state('environment')).toEqual([]);
-  });
-
   it('updates router when changing projects', function() {
     expect(wrapper.state('project')).toEqual([]);
 
@@ -147,7 +166,6 @@ describe('OrganizationEvents', function() {
       .find('MultipleProjectSelector AutoCompleteItem')
       .at(0)
       .simulate('click');
-    expect(wrapper.state('project')).toEqual([2]);
 
     expect(router.push).toHaveBeenCalledWith({
       pathname: '/organizations/org-slug/events/',
@@ -156,6 +174,21 @@ describe('OrganizationEvents', function() {
         statsPeriod: '14d',
       },
     });
+
+    wrapper.setProps({
+      router: {
+        ...router,
+        location: {
+          pathname: '/organizations/org-slug/events/',
+          query: {
+            project: [2],
+            statsPeriod: '14d',
+          },
+        },
+      },
+    });
+
+    expect(wrapper.state('queryValues')).toEqual(expect.objectContaining({project: [2]}));
   });
 
   it('selects multiple projects', async function() {

--- a/tests/js/spec/views/organizationEvents/utils/eventsRequest.spec.jsx
+++ b/tests/js/spec/views/organizationEvents/utils/eventsRequest.spec.jsx
@@ -1,0 +1,282 @@
+import {mount} from 'enzyme';
+import React from 'react';
+
+import {doEventsRequest} from 'app/actionCreators/events';
+import {EventsRequestWithParams} from 'app/views/organizationEvents/utils/eventsRequest';
+
+const COUNT_OBJ = {
+  count: 123,
+};
+
+jest.mock('app/actionCreators/events', () => {
+  return {
+    doEventsRequest: jest.fn(),
+  };
+});
+
+describe('EventsRequest', function() {
+  const project = TestStubs.Project();
+  const organization = TestStubs.Organization();
+  const mock = jest.fn(() => null);
+  const DEFAULTS = {
+    api: {},
+    projects: [parseInt(project.id, 10)],
+    environments: [],
+    period: '24h',
+    organization,
+    tag: 'release',
+    includePrevious: false,
+    includeTimeseries: true,
+  };
+
+  let wrapper;
+
+  describe('with props changes', function() {
+    beforeAll(function() {
+      doEventsRequest.mockImplementation(() =>
+        Promise.resolve({
+          data: [[new Date(), [COUNT_OBJ]]],
+        })
+      );
+      wrapper = mount(
+        <EventsRequestWithParams {...DEFAULTS}>{mock}</EventsRequestWithParams>
+      );
+    });
+
+    it('makes requests', async function() {
+      expect(mock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          loading: true,
+        })
+      );
+
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          loading: false,
+          timeseriesData: [
+            {
+              seriesName: expect.anything(),
+              data: [
+                expect.objectContaining({
+                  name: expect.any(Number),
+                  value: 123,
+                }),
+              ],
+            },
+          ],
+          originalTimeseriesData: [[expect.anything(), expect.anything()]],
+        })
+      );
+
+      expect(doEventsRequest).toHaveBeenCalled();
+    });
+
+    it('makes a new request if projects prop changes', async function() {
+      doEventsRequest.mockClear();
+
+      wrapper.setProps({projects: [123]});
+      await tick();
+      wrapper.update();
+      expect(doEventsRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          projects: [123],
+        })
+      );
+    });
+
+    it('makes a new request if environments prop changes', async function() {
+      doEventsRequest.mockClear();
+
+      wrapper.setProps({environments: ['dev']});
+      await tick();
+      wrapper.update();
+      expect(doEventsRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          environments: ['dev'],
+        })
+      );
+    });
+
+    it('makes a new request if period prop changes', async function() {
+      doEventsRequest.mockClear();
+
+      wrapper.setProps({period: '7d'});
+      await tick();
+      wrapper.update();
+      expect(doEventsRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          period: '7d',
+        })
+      );
+    });
+  });
+
+  describe('transforms', function() {
+    beforeEach(function() {
+      doEventsRequest.mockClear();
+    });
+
+    it('expands period in query if `includePrevious`', async function() {
+      doEventsRequest.mockImplementation(() =>
+        Promise.resolve({
+          data: [
+            [new Date(), [{...COUNT_OBJ, count: 321}, {...COUNT_OBJ, count: 79}]],
+            [new Date(), [COUNT_OBJ]],
+          ],
+        })
+      );
+      wrapper = mount(
+        <EventsRequestWithParams {...DEFAULTS} includePrevious={true}>
+          {mock}
+        </EventsRequestWithParams>
+      );
+
+      await tick();
+      wrapper.update();
+
+      // actionCreator handles expanding the period when calling the API
+      expect(doEventsRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          period: '24h',
+        })
+      );
+
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          loading: false,
+          allTimeseriesData: [
+            [
+              expect.anything(),
+              [
+                expect.objectContaining({count: 321}),
+                expect.objectContaining({count: 79}),
+              ],
+            ],
+            [expect.anything(), [expect.objectContaining({count: 123})]],
+          ],
+          timeseriesData: [
+            {
+              seriesName: expect.anything(),
+              data: [
+                expect.objectContaining({
+                  name: expect.anything(),
+                  value: 123,
+                }),
+              ],
+            },
+          ],
+          previousTimeseriesData: {
+            seriesName: 'Previous Period',
+            data: [
+              expect.objectContaining({
+                name: expect.anything(),
+                value: 400,
+              }),
+            ],
+          },
+
+          originalTimeseriesData: [
+            [expect.anything(), [expect.objectContaining({count: 123})]],
+          ],
+
+          originalPreviousTimeseriesData: [
+            [
+              expect.anything(),
+              [
+                expect.objectContaining({count: 321}),
+                expect.objectContaining({count: 79}),
+              ],
+            ],
+          ],
+        })
+      );
+    });
+
+    it('aggregates counts per timestamp only when `includeTimeAggregation` prop is true', async function() {
+      doEventsRequest.mockImplementation(() =>
+        Promise.resolve({
+          data: [[new Date(), [COUNT_OBJ, {...COUNT_OBJ, count: 100}]]],
+        })
+      );
+
+      wrapper = mount(
+        <EventsRequestWithParams {...DEFAULTS} includeTimeseries={true}>
+          {mock}
+        </EventsRequestWithParams>
+      );
+
+      await tick();
+      wrapper.update();
+
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          timeAggregatedData: null,
+        })
+      );
+
+      wrapper.setProps({
+        includeTimeAggregation: true,
+        timeAggregationSeriesName: 'aggregated series',
+      });
+      await tick();
+      wrapper.update();
+
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          timeAggregatedData: {
+            seriesName: 'aggregated series',
+            data: [{name: expect.anything(), value: 223}],
+          },
+        })
+      );
+    });
+
+    it('aggregates all counts per timestamp when category name identical', async function() {
+      doEventsRequest.mockImplementation(() =>
+        Promise.resolve({
+          data: [[new Date(), [COUNT_OBJ, {...COUNT_OBJ, count: 100}]]],
+        })
+      );
+
+      wrapper = mount(
+        <EventsRequestWithParams
+          {...DEFAULTS}
+          includeTimeseries={true}
+          getCategory={() => 'static-category'}
+        >
+          {mock}
+        </EventsRequestWithParams>
+      );
+
+      await tick();
+      wrapper.update();
+
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          timeAggregatedData: null,
+        })
+      );
+
+      wrapper.setProps({
+        includeTimeAggregation: true,
+        timeAggregationSeriesName: 'aggregated series',
+      });
+      await tick();
+      wrapper.update();
+
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          timeAggregatedData: {
+            seriesName: 'aggregated series',
+            data: [{name: expect.anything(), value: 223}],
+          },
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
This uses the new `events-stats` API endpoint to query for data for charts.
Additionally, charts will now reflect search terms.

Requires:
- [x] https://github.com/getsentry/sentry/pull/10629
- [x] https://github.com/getsentry/sentry/pull/10628
- [x] https://github.com/getsentry/sentry/pull/10631