### PR TITLE
ref(integrations): Remove vsts-extension from internal integrations list.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1323,7 +1323,7 @@ SENTRY_DEFAULT_INTEGRATIONS = (
 )
 
 SENTRY_INTERNAL_INTEGRATIONS = (
-    'vsts-extension',
+    'jira_server',
 )
 
 


### PR DESCRIPTION
Vsts Extension has an attribute called `visible`. And does not belong in internal integrations (integrations that can only be seen by organizations with the internal catchall flag).