### PR TITLE
feat(settings): Show features of uploaded debug files

### DIFF
--- a/src/sentry/static/sentry/app/views/projectDebugFiles.jsx
+++ b/src/sentry/static/sentry/app/views/projectDebugFiles.jsx
@@ -4,6 +4,7 @@ import createReactClass from 'create-react-class';
 import {browserHistory} from 'react-router';
 import {omit, isEqual} from 'lodash';
 import qs from 'query-string';
+import styled from 'react-emotion';
 
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import {t} from 'app/locale';
@@ -14,6 +15,7 @@ import FileSize from 'app/components/fileSize';
 import InlineSvg from 'app/components/inlineSvg';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
+import Tooltip from 'app/components/tooltip';
 import OrganizationState from 'app/mixins/organizationState';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
@@ -21,6 +23,7 @@ import TimeSince from 'app/components/timeSince';
 import Pagination from 'app/components/pagination';
 import SearchBar from 'app/components/searchBar';
 import LinkWithConfirmation from 'app/components/linkWithConfirmation';
+import Tag from 'app/views/settings/components/tag';
 import space from 'app/styles/space';
 
 function getFileType(dsym) {
@@ -35,6 +38,29 @@ function getFileType(dsym) {
       return null;
   }
 }
+
+function getFeatureTooltip(feature) {
+  switch (feature) {
+    case 'symtab':
+      return t(
+        'Symbol tables are used as a fallback when full debug information is not available'
+      );
+    case 'debug':
+      return t(
+        'Debug information provides function names and resolvese inlined frames during symbolication'
+      );
+    case 'unwind':
+      return t(
+        'Stack unwinding information improves the quality of stack traces extracted from minidumps'
+      );
+    default:
+      return null;
+  }
+}
+
+const DebugSymbolDetails = styled.div`
+  margin-top: 4px;
+`;
 
 const ProjectDebugSymbols = createReactClass({
   displayName: 'ProjectDebugSymbols',
@@ -152,6 +178,7 @@ const ProjectDebugSymbols = createReactClass({
         .baseUrl}/projects/${orgId}/${projectId}/files/dsyms/?id=${dsym.id}`;
       let fileType = getFileType(dsym);
       let symbolType = fileType ? `${dsym.symbolType} ${fileType}` : dsym.symbolType;
+      let features = dsym.data && dsym.data.features;
 
       return (
         <PanelItem key={key} align="center" px={2} py={1}>
@@ -175,35 +202,42 @@ const ProjectDebugSymbols = createReactClass({
             {dsym.symbolType === 'proguard' && dsym.objectName === 'proguard-mapping'
               ? '-'
               : dsym.objectName}
-            <p className="m-b-0 text-light small">
+            <DebugSymbolDetails className="text-light small">
               {dsym.symbolType === 'proguard' && dsym.cpuName === 'any'
                 ? 'proguard mapping'
                 : `${dsym.cpuName} (${symbolType})`}
-            </p>
+
+              {features &&
+                features.map(feature => (
+                  <Tooltip key={feature} title={getFeatureTooltip(feature)}>
+                    <span>
+                      <Tag inline>{feature}</Tag>
+                    </span>
+                  </Tooltip>
+                ))}
+            </DebugSymbolDetails>
           </Box>
 
-          <Box flex="1">
-            <div className="pull-right">
-              <ActionLink
-                onAction={() => (window.location = url)}
-                className="btn btn-default btn-sm"
-                disabled={!access.has('project:write')}
-                css={{
-                  marginRight: space(0.5),
-                }}
-              >
-                <InlineSvg src="icon-download" /> {t('Download')}
-              </ActionLink>
-              <LinkWithConfirmation
-                className="btn btn-danger btn-sm"
-                disabled={!access.has('project:write')}
-                title={t('Delete')}
-                message={t('Are you sure you wish to delete this file?')}
-                onConfirm={() => this.onDelete(dsym.id)}
-              >
-                <InlineSvg src="icon-trash" />
-              </LinkWithConfirmation>
-            </div>
+          <Box className="text-right">
+            <ActionLink
+              onAction={() => (window.location = url)}
+              className="btn btn-default btn-sm"
+              disabled={!access.has('project:write')}
+              css={{
+                marginRight: space(0.5),
+              }}
+            >
+              <InlineSvg src="icon-download" /> {t('Download')}
+            </ActionLink>
+            <LinkWithConfirmation
+              className="btn btn-danger btn-sm"
+              disabled={!access.has('project:write')}
+              title={t('Delete')}
+              message={t('Are you sure you wish to delete this file?')}
+              onConfirm={() => this.onDelete(dsym.id)}
+            >
+              <InlineSvg src="icon-trash" />
+            </LinkWithConfirmation>
           </Box>
         </PanelItem>
       );

--- a/src/sentry/static/sentry/app/views/projectDebugFiles.jsx
+++ b/src/sentry/static/sentry/app/views/projectDebugFiles.jsx
@@ -47,7 +47,7 @@ function getFeatureTooltip(feature) {
       );
     case 'debug':
       return t(
-        'Debug information provides function names and resolvese inlined frames during symbolication'
+        'Debug information provides function names and resolves inlined frames during symbolication'
       );
     case 'unwind':
       return t(

--- a/src/sentry/static/sentry/app/views/settings/components/tag.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/tag.jsx
@@ -17,7 +17,9 @@ const getBorder = p =>
         : p.theme.gray1};`
     : '';
 
-const TagTextStyled = styled(({priority, size, border, ...props}) => <Box {...props} />)`
+const TagTextStyled = styled(({priority, size, border, inline, ...props}) => (
+  <Box {...props} />
+))`
   display: inline-flex;
   padding: ${p => (p.size == 'small' ? '0.1em 0.4em 0.2em' : '0.35em 0.8em 0.4em')};
   font-size: 75%;
@@ -47,6 +49,7 @@ Tag.propTypes = {
   size: PropTypes.string,
   border: PropTypes.bool,
   icon: PropTypes.string,
+  inline: PropTypes.bool,
 };
 
 const StyledInlineSvg = styled(InlineSvg)`


### PR DESCRIPTION
Shows "features" of debug files as tags. On mouseover, they display some information about this feature and how it is used by Sentry. Once documented, this should clear some confusion about why certain files need to be uploaded to Sentry.

This view might deserve some more refactoring, but for now this only includes what was necessary for this feature.

<img width="917" alt="screenshot 2018-11-19 at 09 29 53" src="https://user-images.githubusercontent.com/1433023/48695016-3a689680-ebde-11e8-8b52-4e2ea3712072.png">
