### PR TITLE
ref(releases): Change search to use contains

### DIFF
--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -72,7 +72,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
 
         if query:
             queryset = queryset.filter(
-                version__istartswith=query,
+                version__icontains=query,
             )
 
         queryset = queryset.extra(select={

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -88,10 +88,22 @@ class ProjectReleaseListTest(APITestCase):
         assert len(response.data) == 1
         assert response.data[0]['version'] == release.version
 
-        response = self.client.get(url + '?query=bar', format='json')
+        response = self.client.get(url + '?query=baz', format='json')
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 0
+
+        release = Release.objects.create(
+            organization_id=project.organization_id,
+            version='foo.bar-1.0.0',
+            date_added=datetime(2013, 8, 14, 3, 8, 24, 880386),
+        )
+        release.add_project(project)
+
+        response = self.client.get(url + '?query=1', format='json')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
 
 
 class ProjectReleaseListEnvironmentsTest(APITestCase):


### PR DESCRIPTION
**Problem:**
If we have a release with version `foo.bar-1.1.0` we surface `1.1.0` in the UI. 
When someone tries to search `1.1.0`, no results show because we use `startswith` on the full version. 

If there is a better option than using `contains` here to solve the problem, it wasn't immediately clear to me (am obviously open to suggestions).

cc @LSSangha 
