### PR TITLE
fix: Get key counts again in group_tag_keys_and_top_values

### DIFF
--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -96,12 +96,12 @@ class TagStorageTest(SnubaTestCase):
         result.sort(key=lambda r: r.key)
         assert result[0].key == 'baz'
         assert result[0].top_values[0].value == 'quux'
-        # assert result[0].values_seen == 1
-        # assert result[0].count == 2
+        assert result[0].values_seen == 1
+        assert result[0].count == 2
 
         assert result[3].key == 'sentry:release'
-        # assert result[3].values_seen == 2
-        # assert result[3].count == 2
+        assert result[3].values_seen == 2
+        assert result[3].count == 2
         top_release_values = result[3].top_values
         assert len(top_release_values) == 2
         assert set(v.value for v in top_release_values) == set(['100', '200'])


### PR DESCRIPTION
Omitting the key counts was ok for the tags sidebar, but broke the
group tags page, and leads to poor comparison results. Even though
adding the counts back requires another query, it's probably better
than the complexity of having to deal with all the different cases
where we may or may not need the counts.

Although I can always make it so that we don't do the extra query for
just the tags sidebar case if we want that component to keep loading
as fast as possible.