### PR TITLE
test: Fix a flaky test test_updates_group

### DIFF
--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -155,7 +155,7 @@ class EventManagerTest(TransactionTestCase):
         group = Group.objects.get(id=event.group_id)
 
         assert group.times_seen == 2
-        assert group.last_seen.replace(microsecond=0) == event.datetime.replace(microsecond=0)
+        assert group.last_seen.replace(microsecond=0) == event2.datetime.replace(microsecond=0)
         assert group.message == event2.message
         assert group.data.get('type') == 'default'
         assert group.data.get('metadata') == {

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -130,11 +130,13 @@ class EventManagerTest(TransactionTestCase):
         assert Event.objects.count() == 1
 
     def test_updates_group(self):
+        timestamp = time() - 300
         manager = EventManager(
             make_event(
                 message='foo',
                 event_id='a' * 32,
                 checksum='a' * 32,
+                timestamp=timestamp,
             )
         )
         manager.normalize()
@@ -145,6 +147,7 @@ class EventManagerTest(TransactionTestCase):
                 message='foo bar',
                 event_id='b' * 32,
                 checksum='a' * 32,
+                timestamp=timestamp + 2.0,
             )
         )
         manager.normalize()


### PR DESCRIPTION
Honestly very puzzled how this test passed before.  We must have fixed a bug somewhere
or changed some behavior.  It compared against event1 and not event2 so if there was a
drift in between they would desync.

Maybe the code assumed different groups but they have the same checksum.