### PR TITLE
ref(ui): handle overflowing text in multiproject selector

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/headerItemPosition.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/headerItemPosition.jsx
@@ -7,10 +7,12 @@ const HeaderItemPosition = styled.div`
   flex: 1;
   max-width: 450px;
   height: 100%;
+  min-width: 0;
 
   /* stylelint-disable-next-line no-duplicate-selectors */
   ${AutoCompleteRoot}, ${TimeRangeRoot} {
     flex: 1;
+    min-width: 0;
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -364,7 +364,6 @@ export default class OrganizationDiscover extends React.Component {
                 onUpdate={this.runQuery}
               />
             </HeaderItemPosition>
-            <HeaderSeparator />
           </Header>
           <BodyContent>
             {shouldDisplayResult && (

--- a/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
@@ -201,7 +201,6 @@ class OrganizationEventsContainer extends React.Component {
                   onUpdate={this.handleUpdatePeriod}
                 />
               </HeaderItemPosition>
-              <HeaderSeparator />
             </Header>
             <Body>{children}</Body>
           </OrganizationEventsContent>


### PR DESCRIPTION
<img width="1496" alt="screen shot 2018-11-19 at 1 23 33 pm" src="https://user-images.githubusercontent.com/30713/48735849-5a0fb700-ebfe-11e8-93d3-c54a5561cff5.png">
