### PR TITLE
feat(analytics): Add tracking param to sentry issue links

### DIFF
--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -24,6 +24,7 @@ class BitbucketIssueBasicMixin(IssueBasicMixin):
         return ['repo']
 
     def get_create_issue_config(self, group, **kwargs):
+        kwargs['link_referrer'] = 'bitbucket_integration'
         fields = super(BitbucketIssueBasicMixin, self).get_create_issue_config(group, **kwargs)
         default_repo, repo_choices = self.get_repository_choices(group, **kwargs)
 

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -72,6 +72,7 @@ class ExampleIntegration(IntegrationInstallation, IssueSyncMixin):
         return ['project']
 
     def get_create_issue_config(self, group, **kwargs):
+        kwargs['link_referrer'] = 'example_integration'
         fields = super(ExampleIntegration, self).get_create_issue_config(group, **kwargs)
         default = self.get_project_defaults(group.project_id)
         example_project_field = self.generate_example_project_field(default)

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -46,6 +46,7 @@ class GitHubIssueBasic(IssueBasicMixin):
         return (default_repo, default_repo.split('/')[1])
 
     def get_create_issue_config(self, group, **kwargs):
+        kwargs['link_referrer'] = 'github_integration'
         fields = super(GitHubIssueBasic, self).get_create_issue_config(group, **kwargs)
         default_repo, repo_choices = self.get_repository_choices(group, **kwargs)
 
@@ -137,7 +138,7 @@ class GitHubIssueBasic(IssueBasicMixin):
                 'name': 'comment',
                 'label': 'Comment',
                 'default': u'Sentry issue: [{issue_id}]({url})'.format(
-                    url=absolute_uri(group.get_absolute_url()),
+                    url=absolute_uri(group.get_absolute_url(referrer='github_integration')),
                     issue_id=group.qualified_short_id,
                 ),
                 'type': 'textarea',

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -138,7 +138,10 @@ class GitHubIssueBasic(IssueBasicMixin):
                 'name': 'comment',
                 'label': 'Comment',
                 'default': u'Sentry issue: [{issue_id}]({url})'.format(
-                    url=absolute_uri(group.get_absolute_url(referrer='github_integration')),
+                    url=absolute_uri(
+                        group.get_absolute_url(
+                            params={
+                                'referrer': 'github_integration'})),
                     issue_id=group.qualified_short_id,
                 ),
                 'type': 'textarea',

--- a/src/sentry/integrations/gitlab/issues.py
+++ b/src/sentry/integrations/gitlab/issues.py
@@ -45,6 +45,7 @@ class GitlabIssueBasic(IssueBasicMixin):
 
     def get_create_issue_config(self, group, **kwargs):
         default_project, project_choices = self.get_projects_and_default(group, **kwargs)
+        kwargs['link_referrer'] = 'gitlab_integration'
         fields = super(GitlabIssueBasic, self).get_create_issue_config(group, **kwargs)
 
         org = group.organization

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -35,10 +35,13 @@ class IssueBasicMixin(object):
         return '\n\n'.join(result)
 
     def get_group_description(self, group, event, **kwargs):
+        params = {}
+        if kwargs.get('link_referrer'):
+            params['referrer'] = kwargs.get('link_referrer')
         output = [
             u'Sentry Issue: [{}]({})'.format(
                 group.qualified_short_id,
-                absolute_uri(group.get_absolute_url(referrer=kwargs.get('link_referrer'))),
+                absolute_uri(group.get_absolute_url(params=params)),
             )
         ]
         body = self.get_group_body(group, event)

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -38,7 +38,7 @@ class IssueBasicMixin(object):
         output = [
             u'Sentry Issue: [{}]({})'.format(
                 group.qualified_short_id,
-                absolute_uri(group.get_absolute_url()),
+                absolute_uri(group.get_absolute_url(referrer=kwargs.get('link_referrer'))),
             )
         ]
         body = self.get_group_body(group, event)

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -260,7 +260,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         output = [
             u'Sentry Issue: [{}|{}]'.format(
                 group.qualified_short_id,
-                absolute_uri(group.get_absolute_url()),
+                absolute_uri(group.get_absolute_url(referrer='jira_integration')),
             )
         ]
         body = self.get_group_body(group, event)
@@ -386,6 +386,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         return issue_type_meta
 
     def get_create_issue_config(self, group, **kwargs):
+        kwargs['link_referrer'] = 'jira_integration'
         fields = super(JiraIntegration, self).get_create_issue_config(group, **kwargs)
         params = kwargs.get('params', {})
         defaults = self.get_project_defaults(group.project_id)

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -260,7 +260,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         output = [
             u'Sentry Issue: [{}|{}]'.format(
                 group.qualified_short_id,
-                absolute_uri(group.get_absolute_url(referrer='jira_integration')),
+                absolute_uri(group.get_absolute_url(params={'referrer': 'jira_integration'})),
             )
         ]
         body = self.get_group_body(group, event)

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 
 import logging
 
-from six.moves.urllib.parse import parse_qs, urlencode, urlparse, urlunparse
-
 from sentry import tagstore
 from sentry.api.fields.actor import Actor
 from sentry.utils import json
@@ -63,16 +61,6 @@ def get_assignee(group):
         return format_actor_option(assigned_actor.resolve())
     except assigned_actor.type.DoesNotExist:
         return None
-
-
-# TODO(adhiraj): Remove after updating plugins repo.
-def add_notification_referrer_param(url, provider):
-    parsed_url = urlparse(url)
-    query = parse_qs(parsed_url.query)
-    query['referrer'] = provider
-    url_list = list(parsed_url)
-    url_list[4] = urlencode(query, doseq=True)
-    return urlunparse(url_list)
 
 
 def build_attachment_title(group, event=None):
@@ -278,7 +266,7 @@ def build_attachment(group, event=None, tags=None, identity=None, actions=None, 
     return {
         'fallback': u'[{}] {}'.format(group.project.slug, group.title),
         'title': build_attachment_title(group, event),
-        'title_link': group.get_absolute_url(referrer='slack'),
+        'title_link': group.get_absolute_url(params={'referrer': 'slack'}),
         'text': text,
         'fields': fields,
         'mrkdwn_in': ['text'],

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -65,6 +65,7 @@ def get_assignee(group):
         return None
 
 
+# TODO(adhiraj): Remove after updating plugins repo.
 def add_notification_referrer_param(url, provider):
     parsed_url = urlparse(url)
     query = parse_qs(parsed_url.query)
@@ -277,7 +278,7 @@ def build_attachment(group, event=None, tags=None, identity=None, actions=None, 
     return {
         'fallback': u'[{}] {}'.format(group.project.slug, group.title),
         'title': build_attachment_title(group, event),
-        'title_link': add_notification_referrer_param(group.get_absolute_url(), 'slack'),
+        'title_link': group.get_absolute_url(referrer='slack'),
         'text': text,
         'fields': fields,
         'mrkdwn_in': ['text'],

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -59,6 +59,7 @@ class VstsIssueSync(IssueSyncMixin):
         return default_project, project_choices
 
     def get_create_issue_config(self, group, **kwargs):
+        kwargs['link_referrer'] = 'vsts_integration'
         fields = super(VstsIssueSync, self).get_create_issue_config(group, **kwargs)
         # Azure/VSTS has BOTH projects and repositories. A project can have many repositories.
         # Workitems (issues) are associated with the project not the repository.

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -17,6 +17,7 @@ from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
+from six.moves.urllib.parse import urlencode
 
 from sentry import eventtypes, tagstore
 from sentry.constants import (
@@ -262,10 +263,10 @@ class Group(Model):
         )
         super(Group, self).save(*args, **kwargs)
 
-    def get_absolute_url(self, referrer=None):
+    def get_absolute_url(self, params=None):
         url = reverse('sentry-group', args=[self.organization.slug, self.project.slug, self.id])
-        if referrer:
-            url = url + '?referrer=%s' % referrer
+        if params:
+            url = url + '?' + urlencode(params)
         return absolute_uri(url)
 
     @property

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -262,10 +262,11 @@ class Group(Model):
         )
         super(Group, self).save(*args, **kwargs)
 
-    def get_absolute_url(self):
-        return absolute_uri(
-            reverse('sentry-group', args=[self.organization.slug, self.project.slug, self.id])
-        )
+    def get_absolute_url(self, referrer=None):
+        url = reverse('sentry-group', args=[self.organization.slug, self.project.slug, self.id])
+        if referrer:
+            url = url + '?referrer=%s' % referrer
+        return absolute_uri(url)
 
     @property
     def qualified_short_id(self):

--- a/src/sentry/plugins/bases/issue.py
+++ b/src/sentry/plugins/bases/issue.py
@@ -55,8 +55,9 @@ class IssueTrackingPlugin(Plugin):
         return '\n\n'.join(result)
 
     def _get_group_description(self, request, group, event):
+        referrer = self.get_conf_key() + '_plugin'
         output = [
-            absolute_uri(group.get_absolute_url()),
+            absolute_uri(group.get_absolute_url(referrer=referrer)),
         ]
         body = self._get_group_body(request, group, event)
         if body:

--- a/src/sentry/plugins/bases/issue.py
+++ b/src/sentry/plugins/bases/issue.py
@@ -57,7 +57,7 @@ class IssueTrackingPlugin(Plugin):
     def _get_group_description(self, request, group, event):
         referrer = self.get_conf_key() + '_plugin'
         output = [
-            absolute_uri(group.get_absolute_url(referrer=referrer)),
+            absolute_uri(group.get_absolute_url(params={'referrer': referrer})),
         ]
         body = self._get_group_body(request, group, event)
         if body:

--- a/src/sentry/plugins/bases/issue2.py
+++ b/src/sentry/plugins/bases/issue2.py
@@ -62,8 +62,9 @@ class IssueTrackingPlugin2(Plugin):
         return '\n\n'.join(result)
 
     def get_group_description(self, request, group, event):
+        referrer = self.get_conf_key() + '_plugin'
         output = [
-            absolute_uri(group.get_absolute_url()),
+            absolute_uri(group.get_absolute_url(referrer=referrer)),
         ]
         body = self.get_group_body(request, group, event)
         if body:

--- a/src/sentry/plugins/bases/issue2.py
+++ b/src/sentry/plugins/bases/issue2.py
@@ -64,7 +64,7 @@ class IssueTrackingPlugin2(Plugin):
     def get_group_description(self, request, group, event):
         referrer = self.get_conf_key() + '_plugin'
         output = [
-            absolute_uri(group.get_absolute_url(referrer=referrer)),
+            absolute_uri(group.get_absolute_url(params={'referrer': referrer})),
         ]
         body = self.get_group_body(request, group, event)
         if body:

--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -34,8 +34,6 @@ from sentry.utils.linksign import generate_signed_link
 
 from .activity import emails
 
-from six.moves.urllib.parse import urlencode
-
 NOTSET = object()
 
 logger = logging.getLogger(__name__)
@@ -206,13 +204,10 @@ class MailPlugin(NotificationPlugin):
 
         subject = event.get_email_subject()
 
-        link = group.get_absolute_url()
-
         query_params = {'referrer': 'alert_email'}
         if environment:
             query_params['environment'] = environment
-
-        link = link + '?' + urlencode(query_params)
+        link = group.get_absolute_url(params=query_params)
 
         template = 'sentry/emails/error.txt'
         html_template = 'sentry/emails/error.html'

--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -84,7 +84,7 @@ class WebHooksPlugin(notify.NotificationPlugin):
             'level': event.get_tag('level'),
             'culprit': group.culprit,
             'message': event.get_legacy_message(),
-            'url': group.get_absolute_url(),
+            'url': group.get_absolute_url(referrer='webhooks_plugin'),
             'triggering_rules': triggering_rules,
         }
         data['event'] = dict(event.data or {})

--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -84,7 +84,7 @@ class WebHooksPlugin(notify.NotificationPlugin):
             'level': event.get_tag('level'),
             'culprit': group.culprit,
             'message': event.get_legacy_message(),
-            'url': group.get_absolute_url(referrer='webhooks_plugin'),
+            'url': group.get_absolute_url(params={'referrer': 'webhooks_plugin'}),
             'triggering_rules': triggering_rules,
         }
         data['event'] = dict(event.data or {})

--- a/tests/sentry/api/endpoints/test_group_integration_details.py
+++ b/tests/sentry/api/endpoints/test_group_integration_details.py
@@ -102,7 +102,7 @@ class GroupIntegrationDetailsTest(APITestCase):
                                     'Stacktrace (most recent call last):\n\n  '
                                     'File "sentry/models/foo.py", line 29, in build_msg\n    '
                                     'string_max_length=self.string_max_length)\n\nmessage\n```'
-                                    ) % (group.qualified_short_id, absolute_uri(group.get_absolute_url())),
+                                    ) % (group.qualified_short_id, absolute_uri(group.get_absolute_url(referrer='example_integration'))),
                         'type': 'textarea',
                         'name': 'description',
                         'label': 'Description',

--- a/tests/sentry/api/endpoints/test_group_integration_details.py
+++ b/tests/sentry/api/endpoints/test_group_integration_details.py
@@ -102,7 +102,7 @@ class GroupIntegrationDetailsTest(APITestCase):
                                     'Stacktrace (most recent call last):\n\n  '
                                     'File "sentry/models/foo.py", line 29, in build_msg\n    '
                                     'string_max_length=self.string_max_length)\n\nmessage\n```'
-                                    ) % (group.qualified_short_id, absolute_uri(group.get_absolute_url(referrer='example_integration'))),
+                                    ) % (group.qualified_short_id, absolute_uri(group.get_absolute_url(params={'referrer': 'example_integration'}))),
                         'type': 'textarea',
                         'name': 'description',
                         'label': 'Description',

--- a/tests/sentry/integrations/bitbucket/test_issues.py
+++ b/tests/sentry/integrations/bitbucket/test_issues.py
@@ -168,7 +168,7 @@ class BitbucketIssueTest(APITestCase):
             }, {
                 'name': 'description',
                 'label': 'Description',
-                'default': u'Sentry Issue: [BAR-1](http://testserver/baz/bar/issues/%d/)\n\n```\nStacktrace (most recent call last):\n\n  File "sentry/models/foo.py", line 29, in build_msg\n    string_max_length=self.string_max_length)\n\nmessage\n```' % self.group.id,
+                'default': u'Sentry Issue: [BAR-1](http://testserver/baz/bar/issues/%d/?referrer=bitbucket_integration)\n\n```\nStacktrace (most recent call last):\n\n  File "sentry/models/foo.py", line 29, in build_msg\n    string_max_length=self.string_max_length)\n\nmessage\n```' % self.group.id,
                 'type': 'textarea',
                 'autosize': True,
                 'maxRows': 10,

--- a/tests/sentry/integrations/gitlab/test_issues.py
+++ b/tests/sentry/integrations/gitlab/test_issues.py
@@ -38,7 +38,7 @@ class GitlabIssuesTest(GitLabTestCase):
             '    string_max_length=self.string_max_length)\n\nmessage\n```'
         ) % (
             self.group.qualified_short_id,
-            absolute_uri(self.group.get_absolute_url(referrer='gitlab_integration')),
+            absolute_uri(self.group.get_absolute_url(params={'referrer': 'gitlab_integration'})),
         )
         responses.add(
             responses.GET,
@@ -179,7 +179,7 @@ class GitlabIssuesTest(GitLabTestCase):
             '    string_max_length=self.string_max_length)\n\nmessage\n```'
         ) % (
             self.group.qualified_short_id,
-            absolute_uri(self.group.get_absolute_url(referrer='gitlab_integration')),
+            absolute_uri(self.group.get_absolute_url(params={'referrer': 'gitlab_integration'})),
         )
         project_id = 10
         project_name = 'This_is / a_project'
@@ -243,7 +243,7 @@ class GitlabIssuesTest(GitLabTestCase):
             '    string_max_length=self.string_max_length)\n\nmessage\n```'
         ) % (
             self.group.qualified_short_id,
-            absolute_uri(self.group.get_absolute_url(referrer='gitlab_integration')),
+            absolute_uri(self.group.get_absolute_url(params={'referrer': 'gitlab_integration'})),
         )
         project_id = 10
         project_name = 'This_is / a_project'

--- a/tests/sentry/integrations/gitlab/test_issues.py
+++ b/tests/sentry/integrations/gitlab/test_issues.py
@@ -38,7 +38,7 @@ class GitlabIssuesTest(GitLabTestCase):
             '    string_max_length=self.string_max_length)\n\nmessage\n```'
         ) % (
             self.group.qualified_short_id,
-            absolute_uri(self.group.get_absolute_url()),
+            absolute_uri(self.group.get_absolute_url(referrer='gitlab_integration')),
         )
         responses.add(
             responses.GET,
@@ -179,7 +179,7 @@ class GitlabIssuesTest(GitLabTestCase):
             '    string_max_length=self.string_max_length)\n\nmessage\n```'
         ) % (
             self.group.qualified_short_id,
-            absolute_uri(self.group.get_absolute_url()),
+            absolute_uri(self.group.get_absolute_url(referrer='gitlab_integration')),
         )
         project_id = 10
         project_name = 'This_is / a_project'
@@ -243,7 +243,7 @@ class GitlabIssuesTest(GitLabTestCase):
             '    string_max_length=self.string_max_length)\n\nmessage\n```'
         ) % (
             self.group.qualified_short_id,
-            absolute_uri(self.group.get_absolute_url()),
+            absolute_uri(self.group.get_absolute_url(referrer='gitlab_integration')),
         )
         project_id = 10
         project_name = 'This_is / a_project'

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -406,7 +406,7 @@ class JiraIntegrationTest(APITestCase):
                             'string_max_length=self.string_max_length)\n\nmessage\n{code}'
                             ) % (
                                 group.qualified_short_id,
-                                absolute_uri(group.get_absolute_url()),
+                                absolute_uri(group.get_absolute_url(referrer='jira_integration')),
                 ),
                 'type': 'textarea',
                 'name': 'description',

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -406,7 +406,10 @@ class JiraIntegrationTest(APITestCase):
                             'string_max_length=self.string_max_length)\n\nmessage\n{code}'
                             ) % (
                                 group.qualified_short_id,
-                                absolute_uri(group.get_absolute_url(referrer='jira_integration')),
+                                absolute_uri(
+                                    group.get_absolute_url(
+                                        params={
+                                            'referrer': 'jira_integration'})),
                 ),
                 'type': 'textarea',
                 'name': 'description',


### PR DESCRIPTION
We have no idea where people are coming from when they view a sentry issue. This adds a referrer=X query param to issue links we post on external properties.

Will require some changes to plugins repo as well, doing it in a bit.