### PR TITLE
feat(app-platform): Add sentry apps to alert rule actions

### DIFF
--- a/src/sentry/rules/actions/notify_event.py
+++ b/src/sentry/rules/actions/notify_event.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 
 from sentry.plugins import plugins
 from sentry.rules.actions.base import EventAction
+from sentry.rules.actions.services import LegacyPluginService
 from sentry.utils import metrics
 from sentry.utils.safe import safe_execute
 
@@ -25,11 +26,11 @@ class NotifyEventAction(EventAction):
         for plugin in plugins.for_project(self.project, version=1):
             if not isinstance(plugin, NotificationPlugin):
                 continue
-            results.append(plugin)
+            results.append(LegacyPluginService(plugin))
 
         for plugin in plugins.for_project(self.project, version=2):
             for notifier in (safe_execute(plugin.get_notifiers, _with_transaction=False) or ()):
-                results.append(notifier)
+                results.append(LegacyPluginService(notifier))
 
         return results
 

--- a/src/sentry/rules/actions/notify_event.py
+++ b/src/sentry/rules/actions/notify_event.py
@@ -38,6 +38,8 @@ class NotifyEventAction(EventAction):
         group = event.group
 
         for plugin in self.get_plugins():
+            # plugin is now wrapped in the LegacyPluginService object
+            plugin = plugin.service
             if not safe_execute(
                 plugin.should_notify, group=group, event=event, _with_transaction=False
             ):

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -18,6 +18,7 @@ from sentry.utils.safe import safe_execute
 from sentry.utils import metrics
 from sentry.tasks.sentry_apps import notify_sentry_app
 
+
 class PluginService(object):
     def __init__(self, obj):
         self.obj = obj
@@ -46,7 +47,6 @@ class NotifyEventServiceForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         service_choices = [(s.slug, s.title) for s in kwargs.pop('services')]
-        # service_choices = [(plugin.slug, plugin.get_title()) for plugin in kwargs.pop('services')]
 
         super(NotifyEventServiceForm, self).__init__(*args, **kwargs)
 
@@ -105,7 +105,7 @@ class NotifyEventServiceAction(EventAction):
     def get_installs(self):
         sentry_app_ids = SentryAppInstallation.objects.filter(
             organization=self.project.organization_id,
-        ).values_list('sentry_app_id',flat=True)
+        ).values_list('sentry_app_id', flat=True)
 
         apps = SentryApp.objects.filter(id__in=sentry_app_ids, is_alertable=True)
         results = [SentryAppService(app) for app in apps]
@@ -127,10 +127,9 @@ class NotifyEventServiceAction(EventAction):
         return results
 
     def get_services(self):
-        results = []
-        results += self.get_plugins()
-        results += self.get_installs()
-        return results
+        services = self.get_plugins()
+        services += self.get_installs()
+        return services
 
     def get_form_instance(self):
         return self.form_cls(

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -13,15 +13,40 @@ from django import forms
 
 from sentry.plugins import plugins
 from sentry.rules.actions.base import EventAction
+from sentry.models import SentryApp, SentryAppInstallation
 from sentry.utils.safe import safe_execute
 from sentry.utils import metrics
+from sentry.tasks.sentry_apps import notify_sentry_app
+
+class PluginService(object):
+    def __init__(self, obj):
+        self.obj = obj
+
+    @property
+    def slug(self):
+        return self.obj.slug
+
+    @property
+    def title(self):
+        return self.obj.get_title()
+
+
+class SentryAppService(PluginService):
+    def __init__(self, obj):
+        super(SentryAppService, self).__init__(obj)
+        self.obj = obj
+
+    @property
+    def title(self):
+        return self.obj.name
 
 
 class NotifyEventServiceForm(forms.Form):
     service = forms.ChoiceField(choices=())
 
     def __init__(self, *args, **kwargs):
-        service_choices = [(plugin.slug, plugin.get_title()) for plugin in kwargs.pop('plugins')]
+        service_choices = [(s.slug, s.title) for s in kwargs.pop('services')]
+        # service_choices = [(plugin.slug, plugin.get_title()) for plugin in kwargs.pop('services')]
 
         super(NotifyEventServiceForm, self).__init__(*args, **kwargs)
 
@@ -38,7 +63,7 @@ class NotifyEventServiceAction(EventAction):
         self.form_fields = {
             'service': {
                 'type': 'choice',
-                'choices': [[i.slug, i.title] for i in self.get_plugins()]
+                'choices': [[i.slug, i.title] for i in self.get_services()]
             }
         }
 
@@ -50,21 +75,41 @@ class NotifyEventServiceAction(EventAction):
             self.logger.info('rules.fail.is_configured', extra=extra)
             return
 
-        plugin = plugins.get(service)
-        if not plugin.is_enabled(self.project):
-            extra['project_id'] = self.project.id
-            self.logger.info('rules.fail.is_enabled', extra=extra)
-            return
+        app = None
+        try:
+            app = SentryApp.objects.get(slug=service)
+        except SentryApp.DoesNotExist:
+            pass
 
-        group = event.group
+        if app:
+            kwargs = {'sentry_app': app}
+            metrics.incr('notifications.sent', instance=app.slug)
+            yield self.future(notify_sentry_app, **kwargs)
+        else:
+            plugin = plugins.get(service)
+            if not plugin.is_enabled(self.project):
+                extra['project_id'] = self.project.id
+                self.logger.info('rules.fail.is_enabled', extra=extra)
+                return
 
-        if not plugin.should_notify(group=group, event=event):
-            extra['group_id'] = group.id
-            self.logger.info('rule.fail.should_notify', extra=extra)
-            return
+            group = event.group
 
-        metrics.incr('notifications.sent', instance=plugin.slug)
-        yield self.future(plugin.rule_notify)
+            if not plugin.should_notify(group=group, event=event):
+                extra['group_id'] = group.id
+                self.logger.info('rule.fail.should_notify', extra=extra)
+                return
+
+            metrics.incr('notifications.sent', instance=plugin.slug)
+            yield self.future(plugin.rule_notify)
+
+    def get_installs(self):
+        sentry_app_ids = SentryAppInstallation.objects.filter(
+            organization=self.project.organization_id,
+        ).values_list('sentry_app_id',flat=True)
+
+        apps = SentryApp.objects.filter(id__in=sentry_app_ids, is_alertable=True)
+        results = [SentryAppService(app) for app in apps]
+        return results
 
     def get_plugins(self):
         from sentry.plugins.bases.notify import NotificationPlugin
@@ -73,16 +118,22 @@ class NotifyEventServiceAction(EventAction):
         for plugin in plugins.for_project(self.project, version=1):
             if not isinstance(plugin, NotificationPlugin):
                 continue
-            results.append(plugin)
+            results.append(PluginService(plugin))
 
         for plugin in plugins.for_project(self.project, version=2):
             for notifier in (safe_execute(plugin.get_notifiers, _with_transaction=False) or ()):
-                results.append(notifier)
+                results.append(PluginService(notifier))
 
+        return results
+
+    def get_services(self):
+        results = []
+        results += self.get_plugins()
+        results += self.get_installs()
         return results
 
     def get_form_instance(self):
         return self.form_cls(
             self.data,
-            plugins=self.get_plugins(),
+            services=self.get_services(),
         )

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -84,7 +84,7 @@ class NotifyEventServiceAction(EventAction):
         apps = SentryApp.objects.filter(
             installations__organization_id=self.project.organization_id,
             is_alertable=True,
-        )
+        ).distinct()
         results = [SentryAppService(app) for app in apps]
         return results
 

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -80,7 +80,7 @@ class NotifyEventServiceAction(EventAction):
             metrics.incr('notifications.sent', instance=plugin.slug)
             yield self.future(plugin.rule_notify)
 
-    def get_installs(self):
+    def get_sentry_app_services(self):
         apps = SentryApp.objects.filter(
             installations__organization_id=self.project.organization_id,
             is_alertable=True,
@@ -105,7 +105,7 @@ class NotifyEventServiceAction(EventAction):
 
     def get_services(self):
         services = self.get_plugins()
-        services += self.get_installs()
+        services += self.get_sentry_app_services()
         return services
 
     def get_form_instance(self):

--- a/src/sentry/rules/actions/services.py
+++ b/src/sentry/rules/actions/services.py
@@ -3,15 +3,15 @@ from __future__ import absolute_import
 
 class PluginService(object):
     def __init__(self, obj):
-        self.obj = obj
+        self.service = obj
 
     @property
     def slug(self):
-        return self.obj.slug
+        return self.service.slug
 
     @property
     def title(self):
-        return self.obj.get_title()
+        return self.service.get_title()
 
     @property
     def service_type(self):
@@ -21,7 +21,7 @@ class PluginService(object):
 class LegacyPluginService(PluginService):
     def __init__(self, obj):
         super(LegacyPluginService, self).__init__(obj)
-        self.obj = obj
+        self.service = obj
 
     @property
     def service_type(self):
@@ -31,11 +31,11 @@ class LegacyPluginService(PluginService):
 class SentryAppService(PluginService):
     def __init__(self, obj):
         super(SentryAppService, self).__init__(obj)
-        self.obj = obj
+        self.service = obj
 
     @property
     def title(self):
-        return self.obj.name
+        return self.service.name
 
     @property
     def service_type(self):

--- a/src/sentry/rules/actions/services.py
+++ b/src/sentry/rules/actions/services.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import
+
+
+class PluginService(object):
+    def __init__(self, obj):
+        self.obj = obj
+
+    @property
+    def slug(self):
+        return self.obj.slug
+
+    @property
+    def title(self):
+        return self.obj.get_title()
+
+    @property
+    def service_type(self):
+        return 'plugin'
+
+
+class LegacyPluginService(PluginService):
+    def __init__(self, obj):
+        super(LegacyPluginService, self).__init__(obj)
+        self.obj = obj
+
+    @property
+    def service_type(self):
+        return 'legacy_plugin'
+
+
+class SentryAppService(PluginService):
+    def __init__(self, obj):
+        super(SentryAppService, self).__init__(obj)
+        self.obj = obj
+
+    @property
+    def title(self):
+        return self.obj.name
+
+    @property
+    def service_type(self):
+        return 'sentry_app'

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/index.jsx
@@ -42,9 +42,9 @@ class SentryApplicationRow extends React.PureComponent {
       const query = Object.assign(qs.parse(url.query), installQuery);
       redirectUrl = `${url.protocol}//${url.host}${url.pathname}?${qs.stringify(query)}`;
       window.location.assign(redirectUrl);
+    } else {
+      browserHistory.push(redirectUrl);
     }
-
-    browserHistory.push(redirectUrl);
   };
 
   install = () => {

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -1,0 +1,61 @@
+from __future__ import absolute_import, print_function
+
+import six
+from time import time
+
+from sentry.http import safe_urlopen
+from sentry.tasks.base import instrumented_task
+from sentry.utils import json
+from sentry.utils.http import absolute_uri
+from sentry.models import SentryAppInstallation
+from sentry.api.serializers import serialize, app_platform_event
+
+def notify_sentry_app(event, futures):
+    group = event.group
+    project = group.project
+    project_url_base = absolute_uri(u'/{}/{}'.format(
+        project.organization.slug,
+        project.slug,
+    ))
+
+    event_context = serialize(event)
+    event_context['url'] = u'{}/issues/{}/events/{}/'.format(
+        project_url_base,
+        group.id,
+        event.id,
+    )
+    data = {'event': event_context}
+    for f in futures:
+        sentry_app = f.kwargs['sentry_app']
+        try:
+            install = SentryAppInstallation.objects.get(
+                organization=event.project.organization_id,
+                sentry_app=sentry_app,
+            )
+        except SentryAppInstallation.DoesNotExist:
+            return
+
+        payload = app_platform_event('alert', install, data)
+        send_alert_event.delay(sentry_app=sentry_app, payload=payload)
+
+
+@instrumented_task(
+    name='sentry.tasks.sentry_apps.send_alert_event', default_retry_delay=60 * 5, max_retries=5
+)
+def send_alert_event(sentry_app, payload):
+
+    body = json.dumps(payload)
+
+    headers = {
+        'Content-Type': 'application/json',
+        'X-ServiceHook-Timestamp': six.text_type(int(time())),
+        'X-ServiceHook-GUID': sentry_app.uuid,
+    }
+
+    safe_urlopen(
+        url=sentry_app.webhook_url,
+        data=body,
+        headers=headers,
+        timeout=5,
+        verify_ssl=False,
+    )

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -10,6 +10,7 @@ from sentry.utils.http import absolute_uri
 from sentry.models import SentryAppInstallation
 from sentry.api.serializers import serialize, app_platform_event
 
+
 def notify_sentry_app(event, futures):
     group = event.group
     project = group.project

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -60,5 +60,4 @@ def send_alert_event(sentry_app, payload):
         data=body,
         headers=headers,
         timeout=5,
-        verify_ssl=False,
     )

--- a/tests/sentry/rules/actions/test_notify_event.py
+++ b/tests/sentry/rules/actions/test_notify_event.py
@@ -4,6 +4,7 @@ from mock import MagicMock
 
 from sentry.testutils.cases import RuleTestCase
 from sentry.rules.actions.notify_event import NotifyEventAction
+from sentry.rules.actions.services import LegacyPluginService
 
 
 class NotifyEventActionTest(RuleTestCase):
@@ -14,7 +15,7 @@ class NotifyEventActionTest(RuleTestCase):
 
         plugin = MagicMock()
         rule = self.get_rule()
-        rule.get_plugins = lambda: (plugin, )
+        rule.get_plugins = lambda: (LegacyPluginService(plugin), )
 
         results = list(rule.after(event=event, state=self.get_state()))
 

--- a/tests/sentry/rules/actions/test_notify_event_service.py
+++ b/tests/sentry/rules/actions/test_notify_event_service.py
@@ -4,12 +4,13 @@ from mock import MagicMock, patch
 
 from sentry.testutils.cases import RuleTestCase
 from sentry.rules.actions.notify_event_service import NotifyEventServiceAction
+from sentry.tasks.sentry_apps import notify_sentry_app
 
 
 class NotifyEventServiceActionTest(RuleTestCase):
     rule_cls = NotifyEventServiceAction
 
-    def test_applies_correctly(self):
+    def test_applies_correctly_for_plugins(self):
         event = self.get_event()
 
         plugin = MagicMock()
@@ -28,3 +29,21 @@ class NotifyEventServiceActionTest(RuleTestCase):
         assert len(results) is 1
         assert plugin.should_notify.call_count is 1
         assert results[0].callback is plugin.rule_notify
+
+    def test_applies_correctly_for_sentry_apps(self):
+        event = self.get_event()
+
+        self.create_sentry_app(
+            organization=event.organization,
+            name='Test Application',
+            is_alertable=True,
+        )
+
+        rule = self.get_rule(data={
+            'service': 'test-application',
+        })
+
+        results = list(rule.after(event=event, state=self.get_state()))
+
+        assert len(results) is 1
+        assert results[0].callback is notify_sentry_app


### PR DESCRIPTION
Modifies `NotifyEventServiceAction` to support sentry applications that have `is_alertable` set to `True` and creates a task -`sentry_apps.send_alert_event`- for sending the event payload to the sentry app service.

> ![screen shot 2018-11-19 at 1 39 13 pm](https://user-images.githubusercontent.com/15368179/48736615-9d6b2500-ec00-11e8-9be8-3b2231c32ccc.png)



We are not using the `event.alert` service hook in this case because we **only** want to send an event to the service when the specific rule action is the service itself:

> ![screen shot 2018-11-19 at 1 39 31 pm](https://user-images.githubusercontent.com/15368179/48736614-98a67100-ec00-11e8-96d4-be3d70844eba.png)
