### PR TITLE
ref(ui): Rename dottedBorder to dashedBorder for panel

### DIFF
--- a/docs-ui/components/emptyMessage.stories.js
+++ b/docs-ui/components/emptyMessage.stories.js
@@ -88,7 +88,7 @@ storiesOf('UI|EmptyMessage', module)
   .add(
     'in onboarding/missing functionality panel',
     withInfo('Put this in a panel for maximum effect')(() => (
-      <Panel dottedBorder>
+      <Panel dashedBorder>
         <EmptyMessage
           icon="icon-discover"
           title="You're missing out on crucial functionality!"

--- a/src/sentry/static/sentry/app/components/panels/panel.jsx
+++ b/src/sentry/static/sentry/app/components/panels/panel.jsx
@@ -6,7 +6,7 @@ import PanelBody from 'app/components/panels/panelBody';
 import PanelHeader from 'app/components/panels/panelHeader';
 import space from 'app/styles/space';
 
-const Panel = styled(({title, body, dottedBorder, ...props}) => {
+const Panel = styled(({title, body, dashedBorder, ...props}) => {
   let hasHeaderAndBody = !!title && !!body;
 
   return !hasHeaderAndBody ? (
@@ -18,11 +18,11 @@ const Panel = styled(({title, body, dottedBorder, ...props}) => {
     </div>
   );
 })`
-  background: ${p => (p.dottedBorder ? p.theme.offWhite : '#fff')};
+  background: ${p => (p.dashedBorder ? p.theme.offWhite : '#fff')};
   border-radius: ${p => p.theme.borderRadius};
   border: 1px
-    ${p => (p.dottedBorder ? 'dotted' + p.theme.gray2 : 'solid ' + p.theme.borderDark)};
-  box-shadow: ${p => (p.dottedBorder ? 'none' : p.theme.dropShadowLight)};
+    ${p => (p.dashedBorder ? 'dashed' + p.theme.gray2 : 'solid ' + p.theme.borderDark)};
+  box-shadow: ${p => (p.dashedBorder ? 'none' : p.theme.dropShadowLight)};
   margin-bottom: ${space(3)};
   position: relative;
 `;
@@ -34,7 +34,7 @@ Panel.propTypes = {
    */
   title: PropTypes.node,
   body: PropTypes.node,
-  dottedBorder: PropTypes.bool,
+  dashedBorder: PropTypes.bool,
 };
 
 export default Panel;


### PR DESCRIPTION
A dashed border is more visible and follows what was done for the
link issue UI.