### PR TITLE
fix(org-events): Fix absolute date picker and disable previous range

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEvents/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/eventsChart.jsx
@@ -85,6 +85,8 @@ class EventsChart extends React.PureComponent {
       };
     }
 
+    // TODO(billy): For now only include previous period when we use relative time
+
     return (
       <div>
         <EventsRequestWithParams
@@ -93,6 +95,7 @@ class EventsChart extends React.PureComponent {
           showLoading
           query={(location.query && location.query.query) || ''}
           getCategory={() => t('Events')}
+          includePrevious={!!period}
         >
           {({timeseriesData, previousTimeseriesData}) => {
             return (

--- a/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
@@ -1,5 +1,5 @@
 import {Flex} from 'grid-emotion';
-import {isEqual} from 'lodash';
+import {isDate, isEqualWith} from 'lodash';
 import {withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -21,6 +21,16 @@ import withOrganization from 'app/utils/withOrganization';
 
 import {getParams} from './utils/getParams';
 import EventsContext from './utils/eventsContext';
+
+// `lodash.isEqual` does not compare date objects properly?
+const dateComparer = (value, other) => {
+  if (isDate(value) && isDate(other)) {
+    return +value === +other;
+  }
+
+  // returning undefined will use default comparator
+  return undefined;
+};
 
 class OrganizationEventsContainer extends React.Component {
   static propTypes = {
@@ -66,7 +76,7 @@ class OrganizationEventsContainer extends React.Component {
     const values = OrganizationEventsContainer.getStateFromRouter(props);
 
     // Update `queryValues` if URL parameters change
-    if (!isEqual(state.queryValues, values)) {
+    if (!isEqualWith(state.queryValues, values, dateComparer)) {
       return {
         ...values,
         queryValues: values,

--- a/src/sentry/static/sentry/app/views/organizationEvents/utils/eventsRequest.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/utils/eventsRequest.jsx
@@ -182,7 +182,7 @@ class EventsRequestWithParams extends React.Component {
   transformPreviousPeriodData = (current, previous) => {
     // Need the current period data array so we can take the timestamp
     // so we can be sure the data lines up
-    if (!previous) return [];
+    if (!previous) return null;
 
     return {
       seriesName: 'Previous Period',


### PR DESCRIPTION
Disables previous period when absolute date is selected as it can be buggy.