### PR TITLE
(fix) Weekly Reports Button

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/accountNotificationSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/accountNotificationSettings.jsx
@@ -21,9 +21,12 @@ export const fields = {
     help: t('E.g. changes in issue assignment, resolution status, and comments.'),
   },
   weeklyReports: {
+    // Form is not visible because currently not implemented
     name: 'weeklyReports',
+    // type: 'boolean',
     label: t('Send Me Weekly Reports'),
     help: t("Reports contain a summary of what's happened within your organization."),
+    // disabled: true,
   },
   deployNotifications: {
     name: 'deployNotifications',

--- a/src/sentry/static/sentry/app/data/forms/accountNotificationSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/accountNotificationSettings.jsx
@@ -22,10 +22,8 @@ export const fields = {
   },
   weeklyReports: {
     name: 'weeklyReports',
-    type: 'boolean',
     label: t('Send Me Weekly Reports'),
     help: t("Reports contain a summary of what's happened within your organization."),
-    disabled: true,
   },
   deployNotifications: {
     name: 'deployNotifications',

--- a/src/sentry/static/sentry/app/views/settings/account/accountNotificationFineTuning.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountNotificationFineTuning.jsx
@@ -246,8 +246,6 @@ export default class AccountNotificationFineTuning extends AsyncView {
         <SettingsPageHeader title={title} />
         {description && <TextBlock>{description}</TextBlock>}
 
-        {console.log('field', field)}
-
         {field &&
           field.defaultFieldName &&
             // not implemented yet

--- a/src/sentry/static/sentry/app/views/settings/account/accountNotificationFineTuning.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountNotificationFineTuning.jsx
@@ -246,19 +246,23 @@ export default class AccountNotificationFineTuning extends AsyncView {
         <SettingsPageHeader title={title} />
         {description && <TextBlock>{description}</TextBlock>}
 
+        {console.log('field', field)}
+
         {field &&
-          field.defaultFieldName && (
-            <Form
-              saveOnBlur
-              apiMethod="PUT"
-              apiEndpoint={'/users/me/notifications/'}
-              initialData={this.state.notifications}
-            >
-              <JsonForm
-                title={`Default ${title}`}
-                fields={[fields[field.defaultFieldName]]}
-              />
-            </Form>
+          field.defaultFieldName &&
+            // not implemented yet
+            field.defaultFieldName !== 'weeklyReports' && (
+              <Form
+                saveOnBlur
+                apiMethod="PUT"
+                apiEndpoint={'/users/me/notifications/'}
+                initialData={this.state.notifications}
+              >
+                <JsonForm
+                  title={`Default ${title}`}
+                  fields={[fields[field.defaultFieldName]]}
+                />
+              </Form>
           )}
         <Form
           saveOnBlur


### PR DESCRIPTION
This update removes the confusion of the greyed out button and removes the greyed out Send Me Weekly Reports button.

Fixing this issue because many users are misled by the button and the ability to fine-tune reports. The fine-tune ability is a work in progress. Attached is the commit that has the previous features:

https://github.com/getsentry/sentry/pull/7239

### Before: 
**sentry.io/settings/account/notifications/**
![screen shot 2018-11-19 at 4 48 22 pm](https://user-images.githubusercontent.com/25037561/48744438-1fb51280-ec1c-11e8-9b40-acb00f6a179c.png)
<br>
**sentry.io/settings/account/notifications/reports/**
![screen shot 2018-11-19 at 4 48 32 pm](https://user-images.githubusercontent.com/25037561/48744443-23489980-ec1c-11e8-8e69-97b71e92a958.png)


### After
**sentry.io/settings/account/notifications/**
![screen shot 2018-11-19 at 4 46 56 pm](https://user-images.githubusercontent.com/25037561/48744792-91419080-ec1d-11e8-8f92-8253221c9e2b.png)
<br>
**sentry.io/settings/account/notifications/reports/**
![screen shot 2018-11-19 at 4 47 41 pm](https://user-images.githubusercontent.com/25037561/48744802-9f8fac80-ec1d-11e8-8f07-8fd17a5ecda6.png)
