### PR TITLE
ref: Coerce log level to integer later

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -620,7 +620,9 @@ class EventManager(object):
             level = data.get('level') or DEFAULT_LOG_LEVEL
             if isinstance(level, int) or (isinstance(level, six.string_types) and level.isdigit()):
                 level = LOG_LEVELS.get(int(level), DEFAULT_LOG_LEVEL)
-            data['level'] = LOG_LEVELS_MAP.get(level, LOG_LEVELS_MAP[DEFAULT_LOG_LEVEL])
+            elif level not in LOG_LEVELS_MAP:
+                level = DEFAULT_LOG_LEVEL
+            data['level'] = level
 
             if data.get('dist') and not data.get('release'):
                 data['dist'] = None
@@ -885,7 +887,7 @@ class EventManager(object):
         # convert this to a dict to ensure we're only storing one value per key
         # as most parts of Sentry dont currently play well with multiple values
         tags = dict(data.get('tags') or [])
-        tags['level'] = LOG_LEVELS[level]
+        tags['level'] = level
         if logger_name:
             tags['logger'] = logger_name
         if server_name:
@@ -979,7 +981,7 @@ class EventManager(object):
             {
                 'culprit': culprit,
                 'logger': logger_name,
-                'level': level,
+                'level': LOG_LEVELS_MAP[level],
                 'last_seen': date,
                 'first_seen': date,
                 'active_at': date,

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -849,6 +849,9 @@ class EventManager(object):
 
         # pull out our top-level (non-data attr) kwargs
         level = data.pop('level')
+        if not isinstance(level, int):
+            level = LOG_LEVELS_MAP[level]
+
         transaction_name = data.pop('transaction', None)
         culprit = data.pop('culprit', None)
         logger_name = data.pop('logger', None)
@@ -981,7 +984,7 @@ class EventManager(object):
             {
                 'culprit': culprit,
                 'logger': logger_name,
-                'level': LOG_LEVELS_MAP[level],
+                'level': level,
                 'last_seen': date,
                 'first_seen': date,
                 'active_at': date,


### PR DESCRIPTION
This matches relay's behavior more closely. At some point we might want
to remove the coercion to integer, but I don't see a reason to take that
risk right now.

#sync-getsentry