### PR TITLE
feat: Use user_agent parsing for all events

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -693,7 +693,7 @@ class EventManager(object):
                 if ex is not None and 'mechanism' in ex:
                     normalize_mechanism_meta(ex['mechanism'], sdk_info)
 
-        # Please not that we eventually remove this check after we validated that it
+        # Please note that we eventually remove this check after we validated that it
         # doesn't impact the load. Ultimately all events should be parsed for a UA.
         # The check if `SENTRY_PARSE_USER_AGENT` is set needs to be there to not
         # trigger a query by trying to fetch the sample rate from the options / db.

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -693,7 +693,13 @@ class EventManager(object):
                 if ex is not None and 'mechanism' in ex:
                     normalize_mechanism_meta(ex['mechanism'], sdk_info)
 
-        if random.random() < options.get('event-normalization.parse-user-agent-sample-rate'):
+        # Please not that we eventually remove this check after we validated that it
+        # doesn't impact the load. Ultimately all events should be parsed for a UA.
+        # The check if `SENTRY_PARSE_USER_AGENT` is set needs to be there to not
+        # trigger a query by trying to fetch the sample rate from the options / db.
+        if (getattr(settings, 'SENTRY_PARSE_USER_AGENT', False) and
+                random.random() <
+                options.get('event-normalization.parse-user-agent-sample-rate')):
             start_time = time.time()
             normalize_user_agent(data)
             ms = int((time.time() - start_time) * 1000)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -151,3 +151,6 @@ register('kafka-publisher.max-event-size', default=100000)
 
 # Event Stream
 register('eventstream.kafka.send-post_process-task', type=Bool, default=True)
+
+# Event Normalization
+register('event-normalization.parse-user-agent-sample-rate', default=0.0)

--- a/src/sentry/utils/contexts_normalization.py
+++ b/src/sentry/utils/contexts_normalization.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 import re
 
+from ua_parser.user_agent_parser import Parse
+
 # Environment.OSVersion (GetVersionEx) or RuntimeInformation.OSDescription, on Windows
 _windows_re = re.compile('^(Microsoft )?Windows (NT )?(?P<version>\d+\.\d+\.\d+).*$')
 # Environment.OSVersion or RuntimeInformation.OSDescription (uname)
@@ -66,3 +68,87 @@ def normalize_runtime(data):
             version = version_map.get(build, None)
             if version is not None:
                 data['version'] = version
+
+
+def _get_version(user_agent):
+    return '.'.join(
+        value for value in [
+            user_agent['major'],
+            user_agent['minor'],
+            user_agent.get('patch'),
+        ] if value
+    ) or None
+
+
+def _parse_user_agent(data):
+    http = data.get('request')
+    if not http:
+        return None
+
+    headers = http.get('headers')
+    if not headers:
+        return None
+
+    for key, value in headers:
+        if key != 'User-Agent':
+            continue
+        ua = Parse(value)
+        if not ua:
+            continue
+        return ua
+    return None
+
+
+def _inject_browser_context(data, user_agent):
+    ua = user_agent['user_agent']
+    try:
+        if ua['family'] == 'Other':
+            return
+        if data.get('contexts', {}).get('browser', None) is None:
+            data['contexts']['browser'] = {
+                'name': ua['family'],
+                'version': _get_version(ua),
+            }
+    except KeyError:
+        pass
+
+
+def _inject_os_context(data, user_agent):
+    ua = user_agent['os']
+    try:
+        if ua['family'] == 'Other':
+            return
+        if data.get('contexts', {}).get('os', None) is None:
+            data['contexts']['os'] = {
+                'name': ua['family'],
+                'version': _get_version(ua),
+            }
+    except KeyError:
+        pass
+
+
+def _inject_device_context(data, user_agent):
+    ua = user_agent['device']
+    try:
+        if ua['family'] == 'Other':
+            return
+        if data.get('contexts', {}).get('device', None) is None:
+            data['contexts']['device'] = {
+                'family': ua['family'],
+                'model': ua['model'],
+                'brand': ua['brand'],
+            }
+    except KeyError:
+        pass
+
+
+def normalize_user_agent(data):
+    user_agent = _parse_user_agent(data)
+    if not user_agent:
+        return
+
+    data.setdefault('contexts', {})
+
+    _inject_browser_context(data, user_agent)
+    _inject_os_context(data, user_agent)
+    _inject_device_context(data, user_agent)

--- a/src/sentry/utils/contexts_normalization.py
+++ b/src/sentry/utils/contexts_normalization.py
@@ -89,13 +89,16 @@ def _parse_user_agent(data):
     if not headers:
         return None
 
-    for key, value in headers:
-        if key != 'User-Agent':
-            continue
-        ua = Parse(value)
-        if not ua:
-            continue
-        return ua
+    try:
+        for key, value in headers:
+            if key != 'User-Agent':
+                continue
+            ua = Parse(value)
+            if not ua:
+                continue
+            return ua
+    except ValueError:
+        pass
     return None
 
 

--- a/tests/sentry/utils/test_contexts_normalization.py
+++ b/tests/sentry/utils/test_contexts_normalization.py
@@ -126,6 +126,48 @@ class NormalizeUserAgentTests(TestCase):
                      ]}
                      }
 
+    def test_no_headers(self):
+        self.data = {'request': {}}
+        normalize_user_agent(self.data)
+        assert 'contexts' not in self.data
+
+    def test_headers_but_no_ua(self):
+        self.data = {'request': {'headers': [['UA', 'a']]}}
+        normalize_user_agent(self.data)
+        assert 'contexts' not in self.data
+
+    def test_headers_wrong_format(self):
+        self.data = {'request': {'headers': ['UA', 'a']}}
+        normalize_user_agent(self.data)
+        assert 'contexts' not in self.data
+
+    def test_broken_ua(self):
+        self.data = {'request':
+                     {'headers': [
+                         [
+                             'User-Agent',
+                             'xx'
+                         ]
+                     ]}
+                     }
+        normalize_user_agent(self.data)
+        assert self.data['contexts'] == {}
+
+    def test_partial_browser_ua(self):
+        self.data = {'request':
+                     {'headers': [
+                         [
+                             'User-Agent',
+                             'Mozilla/5.0  Version/12.0 Mobile/15E148 Safari/604.1'
+                         ]
+                     ]}
+                     }
+        normalize_user_agent(self.data)
+        assert self.data['contexts']['browser']['name'] == 'Safari'
+        assert self.data['contexts']['browser']['version'] == '12.0'
+        assert 'os' not in self.data['contexts']
+        assert 'device' not in self.data['contexts']
+
     def test_browser_device_os_parsed(self):
         self.data = {'request':
                      {'headers': [


### PR DESCRIPTION
***Important***

We need to add `event-normalization.parse-user-agent-sample-rate` to the database as a sentry option

---


This refactors the existing code from `lang/javascript/plugin.py` into `context_normalization.py`.
Additionally, this adds `normalize_user_agent` to EventManager `normalize` function with timing metrics.

We also added a dynamic setting to gradually increase this to 100% of events ingested.

Please note I've changed it so if there is already a `browser`, `os` or `device` context we no longer overwrite it, also for javascript events.

e.g: This is for a php event with correct user-agent header:

![screenshot 2018-11-20 12 01 18](https://user-images.githubusercontent.com/363802/48769498-18454600-ecbc-11e8-8859-ceca085f8b97.png)
![screenshot 2018-11-20 12 01 31](https://user-images.githubusercontent.com/363802/48769504-1a0f0980-ecbc-11e8-98b0-dfc30f6e7190.png)

*Before*
![screenshot 2018-11-20 12 02 29](https://user-images.githubusercontent.com/363802/48769530-2bf0ac80-ecbc-11e8-889f-7bf550083ec3.png)

To enable, merge: https://github.com/getsentry/getsentry/pull/2380

Fixes https://github.com/getsentry/sentry-php/issues/700
Fixes https://github.com/getsentry/sentry/issues/8555