### PR TITLE
fix(email) Handle unicode when generating URLs

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -16,8 +16,8 @@ from datetime import timedelta
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils import timezone
+from django.utils.http import urlencode
 from django.utils.translation import ugettext_lazy as _
-from six.moves.urllib.parse import urlencode
 
 from sentry import eventtypes, tagstore
 from sentry.constants import (

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -236,4 +236,6 @@ class GroupTest(TestCase):
         group = self.create_group(project=project)
 
         result = group.get_absolute_url({'environment': u'd\u00E9v'})
-        assert result == 'http://testserver/baz/pumped-quagga/issues/1/?environment=d%C3%A9v'
+        assert result == u'http://testserver/baz/{}/issues/{}/?environment=d%C3%A9v'.format(
+            project.slug,
+            group.id)

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -230,3 +230,10 @@ class GroupTest(TestCase):
         group = self.create_group(project=project)
 
         assert group.get_email_subject() == '%s - %s' % (group.qualified_short_id, group.title)
+
+    def test_get_absolute_url(self):
+        project = self.create_project(name='pumped-quagga')
+        group = self.create_group(project=project)
+
+        result = group.get_absolute_url({'environment': u'd\u00E9v'})
+        assert result == 'http://testserver/baz/pumped-quagga/issues/1/?environment=d%C3%A9v'


### PR DESCRIPTION
Email alerts create absolute URLs to issues with specific environments.
Those environment names can contain unicode and we need to use a unicode
safe urlencode implementation.

Fixes SENTRY-84F
Fixes #10653