### PR TITLE
fix(ui) Fix clipped descenders on project badge.

### DIFF
--- a/src/sentry/static/sentry/app/components/idBadge/baseBadge.jsx
+++ b/src/sentry/static/sentry/app/components/idBadge/baseBadge.jsx
@@ -105,6 +105,7 @@ const DisplayNameAndDescription = styled(Flex)`
 const DisplayName = styled('span')`
   overflow: hidden;
   text-overflow: ellipsis;
+  line-height: 1.2;
 `;
 
 const Description = styled('div')`

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/teamSelect.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/teamSelect.jsx
@@ -59,7 +59,7 @@ class TeamSelect extends React.Component {
                     onChange={e => {
                       toggleTeam(team.slug);
                     }}
-                    style={{marginTop: '1px'}}
+                    style={{verticalAlign: 'middle'}}
                   />
                   <IdBadge team={team} hideAvatar />
                 </label>

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -488,7 +488,7 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                 onChange={[Function]}
                                 style={
                                   Object {
-                                    "marginTop": "1px",
+                                    "verticalAlign": "middle",
                                   }
                                 }
                               >
@@ -499,7 +499,7 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                   onChange={[Function]}
                                   style={
                                     Object {
-                                      "marginTop": "1px",
+                                      "verticalAlign": "middle",
                                     }
                                   }
                                   type="checkbox"
@@ -641,7 +641,7 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                 onChange={[Function]}
                                 style={
                                   Object {
-                                    "marginTop": "1px",
+                                    "verticalAlign": "middle",
                                   }
                                 }
                               >
@@ -652,7 +652,7 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                   onChange={[Function]}
                                   style={
                                     Object {
-                                      "marginTop": "1px",
+                                      "verticalAlign": "middle",
                                     }
                                   }
                                   type="checkbox"

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -591,7 +591,7 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                                         data-test-id="badge-display-name"
                                                       >
                                                         <span
-                                                          className="css-1wwlq08-DisplayName e165dl3i2"
+                                                          className="css-d0rtl9-DisplayName e165dl3i2"
                                                           data-test-id="badge-display-name"
                                                         >
                                                           <BadgeDisplayName
@@ -744,7 +744,7 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                                         data-test-id="badge-display-name"
                                                       >
                                                         <span
-                                                          className="css-1wwlq08-DisplayName e165dl3i2"
+                                                          className="css-d0rtl9-DisplayName e165dl3i2"
                                                           data-test-id="badge-display-name"
                                                         >
                                                           <BadgeDisplayName

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -382,7 +382,7 @@ exports[`ProjectCard renders 1`] = `
                                           data-test-id="badge-display-name"
                                         >
                                           <span
-                                            className="css-1wwlq08-DisplayName e165dl3i2"
+                                            className="css-d0rtl9-DisplayName e165dl3i2"
                                             data-test-id="badge-display-name"
                                           >
                                             <span>


### PR DESCRIPTION
Add a smidgen more line-height to display clipped descenders.

### Before

![screen shot 2018-11-20 at 1 49 23 pm](https://user-images.githubusercontent.com/24086/48795599-69106b00-eccb-11e8-950a-a9f15e4457e1.png)

### After
![screen shot 2018-11-20 at 1 48 58 pm](https://user-images.githubusercontent.com/24086/48795612-7168a600-eccb-11e8-9399-aa412e4ea2af.png)
