### PR TITLE
fix(integrations) Include more context in logs when commit fetch fails

### DIFF
--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -134,6 +134,8 @@ def fetch_commits(release_id, user_id, refs, prev_release_id=None, **kwargs):
                     'organization_id': repo.organization_id,
                     'user_id': user_id,
                     'repository': repo.name,
+                    'provider': provider.name,
+                    'error': six.text_type(exc),
                     'end_sha': end_sha,
                     'start_sha': start_sha,
                 }

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -134,7 +134,7 @@ def fetch_commits(release_id, user_id, refs, prev_release_id=None, **kwargs):
                     'organization_id': repo.organization_id,
                     'user_id': user_id,
                     'repository': repo.name,
-                    'provider': provider.name,
+                    'provider': provider.id,
                     'error': six.text_type(exc),
                     'end_sha': end_sha,
                     'start_sha': start_sha,


### PR DESCRIPTION
Having this context will allow us to visualize failure by integration provider.