### PR TITLE
feat(discover): Remove tags_keys and tags_values from selectable columns

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/data.jsx
@@ -48,8 +48,8 @@ export const COLUMNS = [
 
   {name: 'sdk.name', type: TYPES.STRING},
   {name: 'sdk.version', type: TYPES.STRING},
-  {name: 'tags_key', type: TYPES.STRING},
-  {name: 'tags_value', type: TYPES.STRING},
+  // {name: 'tags_key', type: TYPES.STRING},
+  // {name: 'tags_value', type: TYPES.STRING},
   {name: 'contexts.key', type: TYPES.STRING},
   {name: 'contexts.value', type: TYPES.STRING},
   {name: 'http.method', type: TYPES.STRING},


### PR DESCRIPTION
Sometimes causes snuba to run out of memory since it expands every tag.
Commented out for now as it might not be a permanent solution.