### PR TITLE
ref(snuba): Improve exception hierarchy

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -132,8 +132,11 @@ class QueryMemoryLimitExceeded(QueryExecutionError):
     """
 
 
-class QueryIllegalTypeArgument(QueryExecutionError):
-    pass
+class QueryIllegalTypeOfArgument(QueryExecutionError):
+    """
+    Exception raised when a function in the query is provided an invalid
+    argument type.
+    """
 
 
 class QueryOutsideRetentionError(Exception):
@@ -378,7 +381,7 @@ def raw_query(start, end, groupby=None, conditions=None, filter_keys=None,
                 raise SchemaValidationError(error['message'])
             elif error['type'] == 'clickhouse':
                 if error['code'] == 43:
-                    raise QueryIllegalTypeArgument(error['message'])
+                    raise QueryIllegalTypeOfArgument(error['message'])
                 elif error['code'] == 241:
                     raise QueryMemoryLimitExceeded(error['message'])
                 else:

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -99,7 +99,6 @@ class UnqualifiedQueryError(SnubaError):
     Exception raised when no project_id qualifications were provided in the
     query or could be derived from other filter criteria.
     """
-    pass
 
 
 class UnexpectedResponseError(SnubaError):


### PR DESCRIPTION
This will fix the grouping issues in Sentry, make comparison results more useful for identifying different error classes, and allow the frontend to special case different responses to provide better feedback to the user in some circumstances (e.g. queries that use too much memory)

Requires getsentry/snuba#218