### PR TITLE
tests(js): Fix ProjectKeyCredentials proptypes warning

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyCredentials.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyCredentials.jsx
@@ -125,15 +125,13 @@ class ProjectKeyCredentials extends React.Component {
         {showUnreal && (
           <Field
             label={t('Unreal Engine 4 Endpoint')}
-            help={t(
-              'Use this endpoint to configure your UE4 Crash Reporter.',
-            )}
+            help={t('Use this endpoint to configure your UE4 Crash Reporter.')}
             inline={false}
             flexibleControlStateSize
           >
             <TextCopyInput>
               {getDynamicText({
-                value: data.dsn.unreal,
+                value: data.dsn.unreal || '',
                 fixed: '__UNREAL_ENDPOINT__',
               })}
             </TextCopyInput>

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
@@ -37,10 +37,9 @@ import SentryTypes from 'app/sentryTypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import StackedBarChart from 'app/components/stackedBarChart';
 import TextBlock from 'app/views/settings/components/text/textBlock';
+import TextCopyInput from 'app/views/settings/components/forms/textCopyInput';
 import TextField from 'app/views/settings/components/forms/textField';
 import getDynamicText from 'app/utils/getDynamicText';
-
-import TextCopyInput from '../../components/forms/textCopyInput';
 
 const RATE_LIMIT_FORMAT_MAP = new Map([
   [0, 'None'],


### PR DESCRIPTION
Use empty string instead of undefined to appease react proptypes.