### PR TITLE
fix(integrations) Give better messaging to jira users

### DIFF
--- a/src/sentry/integrations/jira/configure.py
+++ b/src/sentry/integrations/jira/configure.py
@@ -76,7 +76,7 @@ class JiraConfigureView(View):
             ).values_list('organization_id', flat=True)
 
             form = JiraConfigForm(organizations, initial={'organizations': active_orgs})
-            return self.get_response({'form': form})
+            return self.get_response({'form': form, 'organizations': organizations})
 
         enabled_orgs = [o for o in organizations if o.id in form.cleaned_data['organizations']]
         disabled_orgs = list(set(organizations) - set(enabled_orgs))

--- a/src/sentry/templates/sentry/integrations/jira-config.html
+++ b/src/sentry/templates/sentry/integrations/jira-config.html
@@ -81,7 +81,7 @@
           </form>
         {% else %}
           <div class="aui-message aui-message-warning">
-            <p>You do not have Manager or Owner access to any organizations in Sentry.</p>
+            <p>You must have Owner or Manager permissions in Sentry to complete setup.</p>
           </div>
         {% endif %}
 

--- a/src/sentry/templates/sentry/integrations/jira-config.html
+++ b/src/sentry/templates/sentry/integrations/jira-config.html
@@ -51,33 +51,40 @@
         </div>
       {% else %}
         {% if completed %}
-        <div class="aui-message aui-message-success">
-          <p class="title">
-            <strong>Saved!</strong>
-          </p>
-          <p>
-            The Sentry Jira integration is now enabled for the selected
-            organizations. Return to your sentry organization to configure the Jira
-            integration for your organization.
-          </p>
-        </div>
+          <div class="aui-message aui-message-success">
+            <p class="title">
+              <strong>Saved!</strong>
+            </p>
+            <p>
+              The Sentry Jira integration is now enabled for the selected
+              organizations. Return to your sentry organization to configure the Jira
+              integration for your organization.
+            </p>
+          </div>
         {% endif %}
 
-        <form class="aui top-label" action="" method="post">
-          {% csrf_token %}
-          {% for field in form %}
-            <div class="field-group top-label">
-              {{ field.errors }}
-              {{ field.label_tag }} {{ field }}
-              <div class="description">{{ field.help_text }}</div>
+        {% if organizations|length %}
+          <form class="aui top-label" action="" method="post">
+            {% csrf_token %}
+            {% for field in form %}
+              <div class="field-group top-label">
+                {{ field.errors }}
+                {{ field.label_tag }} {{ field }}
+                <div class="description">{{ field.help_text }}</div>
+              </div>
+            {% endfor %}
+            <div class="field-group">
+              <button class="aui-button aui-button-primary" type="submit">
+                  Save Settings
+              </button>
             </div>
-          {% endfor %}
-          <div class="field-group">
-            <button class="aui-button aui-button-primary" type="submit">
-                Save Settings
-            </button>
+          </form>
+        {% else %}
+          <div class="aui-message aui-message-warning">
+            <p>You do not have Manager or Owner access to any organizations in Sentry.</p>
           </div>
-        </form>
+        {% endif %}
+
       {% endif %}
     {% endif %}
   </div>


### PR DESCRIPTION
When a user has jira-admin but not manager/owner access in sentry we currently display a broken looking page to them. This communicates that they cannot proceed more clearly and hints at how they can move forwards.

![screen shot 2018-11-21 at 11 24 52 am](https://user-images.githubusercontent.com/24086/48854532-2361aa00-ed80-11e8-8fce-2df303190531.png)

Refs APP-784