### PR TITLE
fix(plugins) Handle HTTP errors in notification plugins

### DIFF
--- a/tests/sentry/plugins/bases/notify/tests.py
+++ b/tests/sentry/plugins/bases/notify/tests.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 
 from sentry.plugins import NotificationPlugin
+from sentry.plugins.base.structs import Notification
 from sentry.testutils import TestCase
+from requests import HTTPError
 
 
 class NotifyPlugin(TestCase):
@@ -22,3 +24,15 @@ class NotifyPlugin(TestCase):
         n.slug = ''
         url = 'https://sentry.io/'
         assert n.add_notification_referrer_param(url) == 'https://sentry.io/'
+
+    def test_notify_failure(self):
+        n = NotificationPlugin()
+        n.slug = 'slack'
+
+        def hook(*a, **kw):
+            raise HTTPError('401 Unauthorized')
+        event = self.create_event()
+        notification = Notification(event)
+
+        n.notify_users = hook
+        assert n.notify(notification) is False


### PR DESCRIPTION
Notification plugins frequently fail due to invalid credentials or expired accounts. We do not need to be alerted of these errors. Instead we can log them and use that to diagnose failures customers may be
having.

Fixes SENTRY-10V