### PR TITLE
feat: Add retry and timeout workaround for GCS failures

### DIFF
--- a/src/sentry/filestore/gcs.py
+++ b/src/sentry/filestore/gcs.py
@@ -16,8 +16,12 @@ from google.cloud.storage.client import Client
 from google.cloud.storage.blob import Blob
 from google.cloud.storage.bucket import Bucket
 from google.cloud.exceptions import NotFound
+from google.auth.transport.requests import AuthorizedSession
+from google.resumable_media.common import DataCorruption
 
 from sentry.utils import metrics
+from sentry.net.http import TimeoutAdapter
+from requests.exceptions import ConnectionError
 
 
 # _client cache is a 3-tuple of project_id, credentials, Client
@@ -26,15 +30,35 @@ from sentry.utils import metrics
 _client = None, None, None
 
 
+def try_repeated(func):
+    """Runs a function a few times ignoring errors we see from GCS
+    due to what appears to be network issues.  This is a temporary workaround
+    until we can find the root cause.
+    """
+    idx = 0
+    while 1:
+        try:
+            return func()
+        except (DataCorruption, ConnectionError):
+            if idx >= 3:
+                raise
+        idx += 1
+
+
 def get_client(project_id, credentials):
     global _client
     if _client[2] is None or (project_id, credentials) != (_client[0], _client[1]):
+        session = AuthorizedSession(credentials=credentials)
+        adapter = TimeoutAdapter(timeout=10.0)
+        session.mount('http://', adapter)
+        session.mount('https://', adapter)
         _client = (
             project_id,
             credentials,
             Client(
                 project=project_id,
                 credentials=credentials,
+                session=session,
             )
         )
     return _client[2]
@@ -131,6 +155,10 @@ class GoogleCloudFile(File):
         return self.blob.size
 
     def _get_file(self):
+        def _try_download():
+            self.blob.download_to_file(self._file)
+            self.file.seek(0)
+
         if self._file is None:
             with metrics.timer('filestore.read', instance='gcs'):
                 self._file = SpooledTemporaryFile(
@@ -140,8 +168,7 @@ class GoogleCloudFile(File):
                 )
                 if 'r' in self._mode:
                     self._is_dirty = False
-                    self.blob.download_to_file(self._file)
-                    self._file.seek(0)
+                    try_repeated(_try_download)
         return self._file
 
     def _set_file(self, value):
@@ -165,10 +192,13 @@ class GoogleCloudFile(File):
         return super(GoogleCloudFile, self).write(force_bytes(content))
 
     def close(self):
+        def _try_upload():
+            self.file.seek(0)
+            self.blob.upload_from_file(self.file, content_type=self.mime_type)
+
         if self._file is not None:
             if self._is_dirty:
-                self.file.seek(0)
-                self.blob.upload_from_file(self.file, content_type=self.mime_type)
+                try_repeated(_try_upload)
             self._file.close()
             self._file = None
 

--- a/src/sentry/filestore/gcs.py
+++ b/src/sentry/filestore/gcs.py
@@ -58,7 +58,7 @@ def get_client(project_id, credentials):
             Client(
                 project=project_id,
                 credentials=credentials,
-                session=session,
+                _http=session,
             )
         )
     return _client[2]

--- a/src/sentry/net/http.py
+++ b/src/sentry/net/http.py
@@ -128,6 +128,21 @@ class BlacklistAdapter(HTTPAdapter):
             **pool_kwargs)
 
 
+class TimeoutAdapter(HTTPAdapter):
+
+    def __init__(self, *args, **kwargs):
+        timeout = kwargs.pop('timeout', None)
+        HTTPAdapter.__init__(self, *args, **kwargs)
+        if timeout is None:
+            timeout = 10.0
+        self.default_timeout = timeout
+
+    def send(self, *args, **kwargs):
+        if kwargs.get('timeout') is None:
+            kwargs['timeout'] = self.default_timeout
+        return HTTPAdapter.send(self, *args, **kwargs)
+
+
 USER_AGENT = u'sentry/{version} (https://sentry.io)'.format(
     version=SENTRY_VERSION,
 )


### PR DESCRIPTION
Right now we run into a few issues with GCS where we encounter 50 second timeouts which then eventually result in partial reads (corrupted data) or connection resets.  There is a lot that is very weird and unexplained about it but until we can get to the root of the issue this is an attempt to work around it.

#sync-getsentry