### PR TITLE
fix(features): Clean up auth provider component renderers

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationAuth/providerItem.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuth/providerItem.jsx
@@ -28,7 +28,7 @@ export default class ProviderItem extends React.PureComponent {
 
   renderDisabledLock = p => <LockedFeature provider={p.provider} features={p.features} />;
 
-  renderInstallButton = (provider, hasFeature) => (
+  renderInstallButton = ({provider, hasFeature}) => (
     <Button
       type="submit"
       name="provider"
@@ -62,12 +62,10 @@ export default class ProviderItem extends React.PureComponent {
               </Box>
             </Flex>
 
-            <Box flex={1}>
-              {!hasFeature && renderDisabled({organization, provider, features})}
-            </Box>
+            <Box flex={1}>{!hasFeature && renderDisabled({provider, features})}</Box>
 
             <Box>
-              {(renderInstallButton || this.renderInstallButton)(provider, hasFeature)}
+              {(renderInstallButton || this.renderInstallButton)({provider, hasFeature})}
             </Box>
           </PanelItem>
         )}


### PR DESCRIPTION
* `organization` does not need to be passed to the renderDisabled prop of the auth/ProviderItem feature renderer. This will already be available in the upper scope if an overriding feature component needs it.

 * Pass `provider` and `hasFeature` in an object for easier argument use in overriding feature components.

Refs: [JAVASCRIPT-4NH](https://sentry.io/share/issue/fb8541ef18a24e6db82546ba10421776/)