### PR TITLE
feat(discover): Display alert if user tries to access invalid project

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/missingProjectWarningModal.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/missingProjectWarningModal.jsx
@@ -13,8 +13,7 @@ export default class MissingProjectWarningModal extends React.Component {
   };
 
   renderProject(id) {
-    id = id.toString();
-    const project = this.props.organization.projects.find(p => p.id === id);
+    const project = this.props.organization.projects.find(p => p.id === id.toString());
     return <li key={id}>{project ? project.slug : t(`Unknown project ${id}`)}</li>;
   }
   render() {

--- a/src/sentry/static/sentry/app/views/organizationDiscover/missingProjectWarningModal.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/missingProjectWarningModal.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Modal, {Header, Body, Footer} from 'react-bootstrap/lib/Modal';
+import Button from 'app/components/button';
+import SentryTypes from 'app/sentryTypes';
+import {t} from 'app/locale';
+
+export default class MissingProjectWarningModal extends React.Component {
+  static propTypes = {
+    organization: SentryTypes.Organization.isRequired,
+    projects: PropTypes.arrayOf(PropTypes.number).isRequired,
+    closeModal: PropTypes.func,
+  };
+
+  renderProject(id) {
+    id = id.toString();
+    const project = this.props.organization.projects.find(p => p.id === id);
+    return <li key={id}>{project ? project.slug : t(`Unknown project ${id}`)}</li>;
+  }
+  render() {
+    return (
+      <Modal show={true}>
+        <Header>{t('Project access')}</Header>
+        <Body>
+          <p>
+            {t(
+              `You are not currently a member of all of the projects specified by
+            this query. As a result, data for the following projects will be
+            omitted from the displayed results:`
+            )}
+          </p>
+          <ul>{this.props.projects.map(id => this.renderProject(id))}</ul>
+        </Body>
+        <Footer>
+          <Button priority="primary" onClick={this.props.closeModal}>
+            {t('View results')}
+          </Button>
+        </Footer>
+      </Modal>
+    );
+  }
+}

--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -1,5 +1,5 @@
 /*eslint no-use-before-define: ["error", { "functions": false }]*/
-
+import React from 'react';
 import {uniq} from 'lodash';
 import moment from 'moment-timezone';
 
@@ -7,6 +7,9 @@ import {Client} from 'app/api';
 import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import {t} from 'app/locale';
 
+import {openModal} from 'app/actionCreators/modal';
+
+import MissingProjectWarningModal from './missingProjectWarningModal';
 import {COLUMNS, PROMOTED_TAGS, SPECIAL_TAGS} from './data';
 import {isValidAggregation} from './aggregations/utils';
 
@@ -245,11 +248,26 @@ export default function createQueryBuilder(initial = {}, organization) {
   }
 
   /**
-   * Resets the query to defaults
+   * Resets the query to defaults or the query provided
+   * Displays a warning if user does not have access to any project in the query
    *
    * @returns {Void}
    */
   function reset(q = {}) {
+    const invalidProjects = (q.projects || []).filter(
+      project => !defaultProjects.includes(project)
+    );
+
+    if (invalidProjects.length) {
+      openModal(deps => (
+        <MissingProjectWarningModal
+          organization={organization}
+          projects={invalidProjects}
+          {...deps}
+        />
+      ));
+    }
+
     query = applyDefaults(q);
   }
 }


### PR DESCRIPTION
Displays an alert if the user tries to access a saved query with any
invalid project or one that they are not a member of. Previously this
was silently dropped from the result set without any notification.