### PR TITLE
feat(event_manager): Add a Meta helper and emit meta data

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -60,6 +60,7 @@ from sentry.utils.data_filters import (
 )
 from sentry.utils.dates import to_timestamp
 from sentry.utils.db import is_postgres, is_mysql
+from sentry.utils.meta import Meta
 from sentry.utils.safe import safe_execute, trim, trim_dict, get_path
 from sentry.utils.strings import truncatechars
 from sentry.utils.geo import rust_geoip
@@ -536,15 +537,19 @@ class EventManager(object):
             'threads': to_values,
         }
 
+        meta = Meta(data.get('_meta'))
+
         for c in casts:
             if c in data:
                 try:
                     data[c] = casts[c](data[c])
                 except InvalidTimestamp as it:
                     errors.append({'type': it.args[0], 'name': c, 'value': data[c]})
+                    meta.enter(c).add_error(it, data[c])
                     del data[c]
                 except Exception as e:
                     errors.append({'type': EventError.INVALID_DATA, 'name': c, 'value': data[c]})
+                    meta.enter(c).add_error(e, data[c])
                     del data[c]
 
         # raw 'message' is coerced to the Message interface.  Longer term
@@ -561,19 +566,14 @@ class EventManager(object):
         msg_str = data.pop('message', None)
         if msg_str:
             msg_if = data.get('logentry')
-            msg_meta = data.get('_meta', {}).get('message')
 
             if not msg_if:
                 msg_if = data['logentry'] = {'message': msg_str}
-                if msg_meta:
-                    data.setdefault('_meta', {}).setdefault('logentry', {})['message'] = msg_meta
+                meta.enter('logentry', 'message').merge(meta.enter('message'))
 
-            if msg_if.get('message') != msg_str:
-                if not msg_if.get('formatted'):
-                    msg_if['formatted'] = msg_str
-                    if msg_meta:
-                        data.setdefault('_meta', {}).setdefault(
-                            'logentry', {})['formatted'] = msg_meta
+            if msg_if.get('message') != msg_str and not msg_if.get('formatted'):
+                msg_if['formatted'] = msg_str
+                meta.enter('logentry', 'formatted').merge(meta.enter('message'))
 
         # Fill in ip addresses marked as {{auto}}
         if self._client_ip:
@@ -624,6 +624,7 @@ class EventManager(object):
                     e, InterfaceValidationError) else logger.error
                 log('Discarded invalid value for interface: %s (%r)', k, value, exc_info=True)
                 errors.append({'type': EventError.INVALID_DATA, 'name': k, 'value': value})
+                meta.enter(k).add_error(e, value)
 
         # Additional data coercion and defaulting we only do for store.
         if self._for_store:
@@ -746,7 +747,12 @@ class EventManager(object):
 
         # Do not add errors unless there are for non store mode
         if not self._for_store and not data.get('errors'):
-            self._data.pop('errors')
+            data.pop('errors')
+
+        if meta.raw():
+            data['_meta'] = meta.raw()
+        elif '_meta' in data:
+            del data['_meta']
 
     def should_filter(self):
         '''

--- a/src/sentry/utils/meta.py
+++ b/src/sentry/utils/meta.py
@@ -1,0 +1,112 @@
+from __future__ import absolute_import
+
+import six
+
+
+class Meta(object):
+    """
+    A lazy view to detached validation and normalization meta data. It allows to
+    safely traverse the meta tree and create a deep path lazily. Use ``enter``
+    to get a view to the meta data inside a specific key.
+
+    The ``Meta`` object is a shallow view onto the top-level meta structure and
+    only traverses data when actually accessing attributes. Thus, constructing
+    Meta or calling ``enter`` is relatively cheap.
+
+    To modify data for a certain path, use ``create`` and modify the returned
+    dict. Alternatively, use the ``merge`` or ``add_error`` convenience methods.
+    """
+
+    def __init__(self, meta=None, path=None):
+        self._meta = {} if meta is None else meta
+        self._path = path or []
+
+    def enter(self, *path):
+        """
+        Enters into sub meta data at the specified path. This always returns a
+        new ``Meta`` object, regardless whether the path already exists.
+        """
+        return Meta(self._meta, path=self._path + map(six.text_type, path))
+
+    def raw(self):
+        """
+        Returns the raw meta tree at the current path, if it exists; otherwise
+        an empty object. This will contain both the meta data of the key ("")
+        and sub meta trees.
+
+        It is not safe to mutate the return value since it might be detached
+        from the actual meta tree.
+        """
+        meta = self._meta
+        for key in self._path:
+            meta = meta.get(key) or {}
+        return meta
+
+    def get(self):
+        """
+        Returns meta data of the item at the current path, or an empty dict.
+
+        It is not safe to mutate the return value since it might be detached
+        from the actual meta tree.
+        """
+        return self.raw().get('') or {}
+
+    def create(self):
+        """
+        Creates an empty meta data entry corresponding to the current path. This
+        recursively creates the entire parent tree.
+        """
+        meta = self._meta
+        for key in self._path + ['']:
+            if key not in meta or meta[key] is None:
+                meta[key] = {}
+            meta = meta[key]
+
+        return meta
+
+    def merge(self, other):
+        """
+        Merges meta data of the given other ``Meta`` object into the current
+        path.
+
+        If no meta data entry exists for the current path, it is created, along
+        with the entire parent tree.
+        """
+        other = other.get()
+        if not other:
+            return
+
+        meta = self.create()
+        err = meta.get('err')
+        meta.update(other)
+
+        if err and other.get('err'):
+            meta['err'] = err + other['err']
+
+        return meta
+
+    def get_errors(self):
+        """
+        Returns meta errors of the item at the current path.
+
+        It is not safe to mutate the return value since it might be detached
+        from the actual meta tree.
+        """
+        return self.get().get('err') or []
+
+    def add_error(self, error, value=None):
+        """
+        Adds an error to the meta data at the current path. The ``error``
+        argument is converted to string. If the optional ``value`` is given, it
+        is attached as original value into the meta data.
+
+        If no meta data entry exists for the current path, it is created, along
+        with the entire parent tree.
+        """
+        meta = self.create()
+        if 'err' not in meta or meta['err'] is None:
+            meta['err'] = []
+        meta['err'].append(six.text_type(error))
+
+        if value is not None:
+            meta['val'] = value

--- a/tests/sentry/utils/test_meta.py
+++ b/tests/sentry/utils/test_meta.py
@@ -1,0 +1,231 @@
+from __future__ import absolute_import
+
+from copy import deepcopy
+
+from sentry.utils.meta import Meta
+from sentry.testutils import TestCase
+
+
+input_meta = {'': {
+    'err': ['existing'],
+    'val': 'original',
+    'rem': [{'type': 'x'}],
+}}
+
+other_meta = {'': {
+    'err': ['additional'],
+    'val': 'changed',
+    'rem': [{'type': 'y'}],
+}}
+
+merged_meta = {'': {
+    'err': ['existing', 'additional'],
+    'val': 'changed',
+    'rem': [{'type': 'y'}],
+}}
+
+
+class MetaTests(TestCase):
+    def test_get_new(self):
+        assert Meta().raw() == {}
+        assert Meta().get() == {}
+        assert Meta().get_errors() == []
+
+    def test_create_new(self):
+        meta = Meta()
+        assert meta.create() == {}
+        assert meta.raw() == {'': {}}
+
+    def test_merge_new(self):
+        meta = Meta()
+        assert meta.merge(Meta(other_meta)) == other_meta['']
+        assert meta.raw() == other_meta
+
+    def test_add_error_new(self):
+        meta = Meta()
+        meta.add_error('additional', 'changed')
+        assert meta.raw() == {'': {
+            'err': ['additional'],
+            'val': 'changed',
+        }}
+
+    def test_get_missing(self):
+        assert Meta({}).raw() == {}
+        assert Meta({}).get() == {}
+        assert Meta({}).get_errors() == []
+
+    def test_create_missing(self):
+        data = {}
+        meta = Meta(data)
+        assert meta.create() == {}
+        assert data == {'': {}}
+
+    def test_merge_missing(self):
+        data = {}
+        meta = Meta(data)
+        assert meta.merge(Meta(other_meta)) == other_meta['']
+        assert data == other_meta
+
+    def test_add_error_missing(self):
+        data = {}
+        meta = Meta(data)
+        meta.add_error('additional', 'changed')
+        assert data == {'': {
+            'err': ['additional'],
+            'val': 'changed',
+        }}
+
+    def test_get_none(self):
+        assert Meta({'': None}).raw() == {'': None}
+        assert Meta({'': None}).get() == {}
+        assert Meta({'': None}).get_errors() == []
+
+    def test_create_none(self):
+        data = {'': None}
+        meta = Meta(data)
+        assert meta.create() == {}
+        assert data == {'': {}}
+
+    def test_merge_none(self):
+        data = {'': None}
+        meta = Meta(data)
+        assert meta.merge(Meta(other_meta)) == other_meta['']
+        assert data == other_meta
+
+    def test_add_error_none(self):
+        data = {'': None}
+        meta = Meta(data)
+        meta.add_error('additional', 'changed')
+        assert data == {'': {
+            'err': ['additional'],
+            'val': 'changed',
+        }}
+
+    def test_get_empty(self):
+        assert Meta({'': {}}).raw() == {'': {}}
+        assert Meta({'': {}}).get() == {}
+        assert Meta({'': {}}).get_errors() == []
+
+    def test_create_empty(self):
+        data = {'': {}}
+        meta = Meta(data)
+        assert meta.create() == {}
+        assert data == {'': {}}
+
+    def test_merge_empty(self):
+        data = {'': {}}
+        meta = Meta(data)
+        assert meta.merge(Meta(other_meta)) == other_meta['']
+        assert data == other_meta
+
+    def test_add_error_empty(self):
+        data = {'': {}}
+        meta = Meta(data)
+        meta.add_error('additional', 'changed')
+        assert data == {'': {
+            'err': ['additional'],
+            'val': 'changed',
+        }}
+
+    def test_get_root(self):
+        assert Meta(input_meta).raw() == input_meta
+        assert Meta(input_meta).get() == input_meta['']
+        assert Meta(input_meta).get_errors() == ['existing']
+
+    def test_create_root(self):
+        changed = deepcopy(input_meta)
+        meta = Meta(changed)
+        # should be idempotent
+        assert meta.create() == input_meta['']
+        assert changed == input_meta
+
+    def test_merge_root(self):
+        changed = deepcopy(input_meta)
+        meta = Meta(changed)
+        assert meta.merge(Meta(other_meta)) == merged_meta['']
+        assert changed == merged_meta
+
+    def test_add_error_root(self):
+        changed = deepcopy(input_meta)
+        meta = Meta(changed)
+        meta.add_error('additional', 'changed')
+        assert meta.get() == {
+            'err': ['existing', 'additional'],
+            'val': 'changed',
+            'rem': [{'type': 'x'}],
+        }
+
+    def test_get_nested_missing(self):
+        data = {}
+        assert Meta(data).enter('field').raw() == {}
+        assert Meta(data).enter('field').get() == {}
+        assert Meta(data).enter('field').get_errors() == []
+
+    def test_create_nested_missing(self):
+        data = {}
+        meta = Meta(data)
+        assert meta.enter('field').create() == {}
+        assert data == {'field': {'': {}}}
+
+    def test_merge_nested_missing(self):
+        data = {}
+        meta = Meta(data)
+        assert meta.enter('field').merge(Meta(other_meta)) == other_meta['']
+        assert data == {'field': other_meta}
+
+    def test_add_error_nested_missing(self):
+        data = {}
+        meta = Meta(data)
+        meta.enter('field').add_error('additional', 'changed')
+        assert meta.enter('field').get() == {
+            'err': ['additional'],
+            'val': 'changed',
+        }
+
+    def test_get_nested_existing(self):
+        data = {'field': input_meta}
+        assert Meta(data).enter('field').raw() == input_meta
+        assert Meta(data).enter('field').get() == input_meta['']
+        assert Meta(data).enter('field').get_errors() == ['existing']
+
+    def test_create_nested_existing(self):
+        data = {'field': input_meta}
+        changed = deepcopy(data)
+        meta = Meta(changed)
+        assert meta.enter('field').create() == input_meta['']
+        assert changed == data
+
+    def test_merge_nested_existing(self):
+        data = {'field': input_meta}
+        changed = deepcopy(data)
+        meta = Meta(changed)
+        assert meta.enter('field').merge(Meta(other_meta)) == merged_meta['']
+        assert changed == {'field': merged_meta}
+
+    def test_add_error_nested_existing(self):
+        data = {'field': input_meta}
+        changed = deepcopy(data)
+        meta = Meta(changed)
+        meta.enter('field').add_error('additional', 'changed')
+        assert meta.enter('field').get() == {
+            'err': ['existing', 'additional'],
+            'val': 'changed',
+            'rem': [{'type': 'x'}],
+        }
+
+    def test_get_nested_index(self):
+        data = {'0': input_meta}
+        assert Meta(data).enter(0).raw() == input_meta
+        assert Meta(data).enter(0).get() == input_meta['']
+        assert Meta(data).enter(0).get_errors() == ['existing']
+
+    def test_create_nested_index(self):
+        data = {}
+        meta = Meta(data)
+        assert meta.enter(0).create() == {}
+        assert data == {'0': {'': {}}}
+
+    def test_stringify_error(self):
+        meta = Meta()
+        meta.add_error(ValueError('invalid stuff'), 'changed')
+        assert meta.get_errors() == ['invalid stuff']


### PR DESCRIPTION
Note that this already starts to emit `_meta` for interface validation errors and timestamp errors in addition to the global `errors` list.