### PR TITLE
feat(interfaces): Make most interfaces handle nulls gracefully

### DIFF
--- a/src/sentry/interfaces/breadcrumbs.py
+++ b/src/sentry/interfaces/breadcrumbs.py
@@ -14,7 +14,7 @@ import six
 
 from sentry.interfaces.base import Interface, InterfaceValidationError
 from sentry.utils import json
-from sentry.utils.safe import trim
+from sentry.utils.safe import get_path, trim
 from sentry.utils.dates import to_timestamp, to_datetime, parse_timestamp
 
 
@@ -52,9 +52,8 @@ class Breadcrumbs(Interface):
     @classmethod
     def to_python(cls, data):
         values = []
-        for crumb in data.get('values') or ():
-            if crumb is None:
-                continue
+        for index, crumb in enumerate(get_path(data, 'values', filter=True, default=())):
+            # TODO(ja): Handle already invalid and None breadcrumbs
 
             try:
                 values.append(cls.normalize_crumb(crumb))

--- a/src/sentry/interfaces/contexts.py
+++ b/src/sentry/interfaces/contexts.py
@@ -13,9 +13,9 @@ import string
 
 from django.utils.encoding import force_text
 
-from sentry.utils.safe import trim
 from sentry.interfaces.base import Interface
 from sentry.utils.contexts_normalization import normalize_os, normalize_runtime
+from sentry.utils.safe import get_path, trim
 
 __all__ = ('Contexts', )
 
@@ -59,19 +59,18 @@ class ContextType(object):
 
     @classmethod
     def values_for_data(cls, data):
-        contexts = data.get('contexts') or {}
         rv = []
-        for context in six.itervalues(contexts):
-            if context.get('type') == cls.type:
+        for context in six.itervalues(data.get('contexts') or {}):
+            if context and context.get('type') == cls.type:
                 rv.append(context)
         return rv
 
     @classmethod
     def primary_value_for_data(cls, data):
-        contexts = data.get('contexts') or {}
-        val = contexts.get(cls.type)
+        val = get_path(data, 'contexts', cls.type)
         if val and val.get('type') == cls.type:
             return val
+
         rv = cls.values_for_data(data)
         if len(rv) == 1:
             return rv[0]

--- a/src/sentry/utils/contexts_normalization.py
+++ b/src/sentry/utils/contexts_normalization.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import re
 
 from ua_parser.user_agent_parser import Parse
+from sentry.utils.safe import setdefault_path
 
 # Environment.OSVersion (GetVersionEx) or RuntimeInformation.OSDescription, on Windows
 _windows_re = re.compile('^(Microsoft )?Windows (NT )?(?P<version>\d+\.\d+\.\d+).*$')
@@ -107,11 +108,10 @@ def _inject_browser_context(data, user_agent):
     try:
         if ua['family'] == 'Other':
             return
-        if data.get('contexts', {}).get('browser', None) is None:
-            data['contexts']['browser'] = {
-                'name': ua['family'],
-                'version': _get_version(ua),
-            }
+        setdefault_path(data, 'contexts', 'browser', value={
+            'name': ua['family'],
+            'version': _get_version(ua),
+        })
     except KeyError:
         pass
 
@@ -121,11 +121,10 @@ def _inject_os_context(data, user_agent):
     try:
         if ua['family'] == 'Other':
             return
-        if data.get('contexts', {}).get('os', None) is None:
-            data['contexts']['os'] = {
-                'name': ua['family'],
-                'version': _get_version(ua),
-            }
+        setdefault_path(data, 'contexts', 'os', value={
+            'name': ua['family'],
+            'version': _get_version(ua),
+        })
     except KeyError:
         pass
 
@@ -135,12 +134,12 @@ def _inject_device_context(data, user_agent):
     try:
         if ua['family'] == 'Other':
             return
-        if data.get('contexts', {}).get('device', None) is None:
-            data['contexts']['device'] = {
-                'family': ua['family'],
-                'model': ua['model'],
-                'brand': ua['brand'],
-            }
+        setdefault_path(data, 'contexts', 'device', value={
+            'family': ua['family'],
+            'model': ua['model'],
+            'brand': ua['brand'],
+        })
+
     except KeyError:
         pass
 
@@ -150,7 +149,7 @@ def normalize_user_agent(data):
     if not user_agent:
         return
 
-    data.setdefault('contexts', {})
+    setdefault_path(data, 'contexts', value={})
 
     _inject_browser_context(data, user_agent)
     _inject_os_context(data, user_agent)

--- a/tests/sentry/interfaces/test_exception.py
+++ b/tests/sentry/interfaces/test_exception.py
@@ -75,7 +75,7 @@ class ExceptionTest(TestCase):
                 'module': 'foo.bar',
             }])
         )
-        assert type(inst.values[0]) is SingleException
+        assert isinstance(inst.values[0], SingleException)
         assert inst.values[0].type == 'ValueError'
         assert inst.values[0].value == 'hello world'
         assert inst.values[0].module == 'foo.bar'
@@ -88,7 +88,7 @@ class ExceptionTest(TestCase):
                 'module': 'foo.bar',
             }
         )
-        assert type(inst.values[0]) is SingleException
+        assert isinstance(inst.values[0], SingleException)
         assert inst.values[0].type == 'ValueError'
         assert inst.values[0].value == 'hello world'
         assert inst.values[0].module == 'foo.bar'
@@ -327,6 +327,16 @@ ValueError: hello world
         })
         context = inst.get_api_context()
         assert context['values'][0]['mechanism']['type'] == 'generic'
+
+    def test_iteration(self):
+        inst = Exception.to_python({
+            'values': [None, {'type': 'ValueError'}, None]
+        })
+
+        assert len(inst) == 1
+        assert inst[0].type == 'ValueError'
+        for exc in inst:
+            assert exc.type == 'ValueError'
 
 
 class SingleExceptionTest(TestCase):

--- a/tests/sentry/utils/test_contexts_normalization.py
+++ b/tests/sentry/utils/test_contexts_normalization.py
@@ -186,6 +186,14 @@ class NormalizeUserAgentTests(TestCase):
         assert self.data['contexts']['device']['family'] == 'iPhone'
         assert self.data['contexts']['device']['model'] == 'iPhone'
 
+    def test_contexts_none(self):
+        self.data['contexts'] = None
+        normalize_user_agent(self.data)
+        assert self.data['contexts']['browser']['name'] == 'Chrome'
+        assert self.data['contexts']['browser']['version'] == '66.0.3359'
+        assert self.data['contexts']['os']['name'] == 'Mac OS X'
+        assert self.data['contexts']['os']['version'] == '10.13.4'
+
     def test_browser_already_set(self):
         self.data['contexts'] = {'browser': {'name': 'IE', 'version': '6'}}
         normalize_user_agent(self.data)
@@ -194,6 +202,12 @@ class NormalizeUserAgentTests(TestCase):
         assert self.data['contexts']['os']['name'] == 'Mac OS X'
         assert self.data['contexts']['os']['version'] == '10.13.4'
 
+    def test_browser_none(self):
+        self.data['contexts'] = {'browser': None}
+        normalize_user_agent(self.data)
+        assert self.data['contexts']['browser']['name'] == 'Chrome'
+        assert self.data['contexts']['browser']['version'] == '66.0.3359'
+
     def test_os_already_set(self):
         self.data['contexts'] = {'os': {'name': 'C64', 'version': '1337'}}
         normalize_user_agent(self.data)
@@ -201,6 +215,12 @@ class NormalizeUserAgentTests(TestCase):
         assert self.data['contexts']['browser']['version'] == '66.0.3359'
         assert self.data['contexts']['os']['name'] == 'C64'
         assert self.data['contexts']['os']['version'] == '1337'
+
+    def test_os_none(self):
+        self.data['contexts'] = {'os': None}
+        normalize_user_agent(self.data)
+        assert self.data['contexts']['os']['name'] == 'Mac OS X'
+        assert self.data['contexts']['os']['version'] == '10.13.4'
 
     def test_device_already_set(self):
         self.data = {'request':
@@ -218,3 +238,18 @@ class NormalizeUserAgentTests(TestCase):
         assert self.data['contexts']['os']['name'] == 'iOS'
         assert self.data['contexts']['os']['version'] == '12.1'
         assert self.data['contexts']['device']['brand'] == 'TI Calculator'
+
+    def test_device_none(self):
+        self.data = {
+            'request': {
+                'headers': [[
+                    'User-Agent',
+                    'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1',
+                ]],
+            },
+        }
+        self.data['contexts'] = {'device': None}
+        normalize_user_agent(self.data)
+        assert self.data['contexts']['device']['brand'] == 'Apple'
+        assert self.data['contexts']['device']['family'] == 'iPhone'
+        assert self.data['contexts']['device']['model'] == 'iPhone'


### PR DESCRIPTION
This PR is intentionally incomplete. There are two issues with this implementation which will be targeted in a future PR:

 - The exception interface cannot fully handle `"values": [null]`. This will be fixed with the refactor of to_python
 - The breadcrumbs interface skips `null` breadcrumbs but does not adapt meta data yet. This will also be fixed with the to_python refactor.