### PR TITLE
feat(integration) Add webhook to Jira-Server on integration create

### DIFF
--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -283,6 +283,7 @@ class JiraServerIntegrationProvider(IntegrationProvider):
             client.create_issue_webhook(external_id, webhook_secret, credentials)
         except ApiError as err:
             logger.info('jira-server.webhook.failed', extra={
-                'error': six.text_type(err)
+                'error': six.text_type(err),
+                'external_id': external_id,
             })
             raise IntegrationError('Could not create issue webhook in Jira')

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import logging
+import six
 
 from django import forms
 from django.utils.translation import ugettext as _
@@ -14,8 +15,10 @@ from sentry.integrations import (
     FeatureDescription,
 )
 from sentry.integrations.client import ApiError
+from sentry.integrations.exceptions import IntegrationError
 from sentry.integrations.jira import JiraIntegration
 from sentry.pipeline import PipelineView
+from sentry.utils.hashlib import sha1_text
 from sentry.web.helpers import render_to_response
 from .client import JiraServerClient, JiraServerSetupClient
 
@@ -195,6 +198,9 @@ class OAuthCallbackView(PipelineView):
 
 
 class JiraServerIntegration(JiraIntegration):
+    """
+    IntegrationInstallation implementation for Jira-Server
+    """
     default_identity = None
 
     def get_client(self):
@@ -235,24 +241,48 @@ class JiraServerIntegrationProvider(IntegrationProvider):
     def build_integration(self, state):
         install = state['installation_data']
         access_token = state['access_token']
-        hostname = urlparse(install['url']).netloc
+
+        external_id = '%s:%s' % (urlparse(install['url']).netloc, install['consumer_key'])
+        webhook_secret = sha1_text(install['private_key']).hexdigest()
+
+        credentials = {
+            'consumer_key': install['consumer_key'],
+            'private_key': install['private_key'],
+            'access_token': access_token['oauth_token'],
+            'access_token_secret': access_token['oauth_token_secret'],
+        }
+        # Create the webhook before the integration record exists
+        # so that if it fails we don't persist a broken integration.
+        self.create_webhook(external_id, webhook_secret, install, credentials)
+
         return {
             'name': install['consumer_key'],
             'provider': 'jira_server',
-            'external_id': '%s:%s' % (hostname, install['consumer_key']),
+            'external_id': external_id,
             'metadata': {
                 'base_url': install['url'],
                 'verify_ssl': install['verify_ssl'],
+                'webhook_secret': webhook_secret,
             },
             'user_identity': {
                 'type': 'jira_server',
-                'external_id': '%s:%s' % (hostname, install['consumer_key']),
+                'external_id': external_id,
                 'scopes': (),
-                'data': {
-                    'consumer_key': install['consumer_key'],
-                    'private_key': install['private_key'],
-                    'access_token': access_token['oauth_token'],
-                    'access_token_secret': access_token['oauth_token_secret'],
-                }
+                'data': credentials
             }
         }
+
+    def create_webhook(self, external_id, webhook_secret, install, credentials):
+        client = JiraServerSetupClient(
+            install['url'],
+            install['consumer_key'],
+            install['private_key'],
+            install['verify_ssl']
+        )
+        try:
+            client.create_issue_webhook(external_id, webhook_secret, credentials)
+        except ApiError as err:
+            logger.info('jira-server.webhook.failed', extra={
+                'error': six.text_type(err)
+            })
+            raise IntegrationError('Could not create issue webhook in Jira')

--- a/src/sentry/integrations/jira_server/urls.py
+++ b/src/sentry/integrations/jira_server/urls.py
@@ -1,5 +1,13 @@
 from __future__ import absolute_import
-from django.conf.urls import patterns  # , url
+from django.conf.urls import patterns, url
+
+from .webhooks import JiraIssueUpdatedWebhook
+
 urlpatterns = patterns(
     '',
+    url(
+        r'^issue-updated/(?P<token>[^\/]+)/$',
+        JiraIssueUpdatedWebhook.as_view(),
+        name='sentry-extensions-jiraserver-issue-updated'
+    ),
 )

--- a/src/sentry/integrations/jira_server/webhooks.py
+++ b/src/sentry/integrations/jira_server/webhooks.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+from django.views.decorators.csrf import csrf_exempt
+
+from sentry.api.base import Endpoint
+
+
+class JiraIssueUpdatedWebhook(Endpoint):
+    authentication_classes = ()
+    permission_classes = ()
+
+    @csrf_exempt
+    def dispatch(self, request, *args, **kwargs):
+        return super(JiraIssueUpdatedWebhook, self).dispatch(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        # TODO implement.
+        pass

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import jwt
+
 from sentry.integrations.jira_server import JiraServerIntegrationProvider
 from sentry.models import (
     Identity,
@@ -8,6 +10,8 @@ from sentry.models import (
     OrganizationIntegration
 )
 from sentry.testutils import IntegrationTestCase
+from sentry.utils import json
+
 import responses
 
 PRIVATE_KEY = '''
@@ -135,58 +139,7 @@ class JiraServerIntegrationTest(IntegrationTestCase):
         self.assertContains(resp, 'Setup Error')
         self.assertContains(resp, 'access token from Jira')
 
-    @responses.activate
-    def test_authentication_verifier_expired(self):
-        responses.add(
-            responses.POST,
-            'https://jira.example.com/plugins/servlet/oauth/request-token',
-            status=200,
-            content_type='text/plain',
-            body='oauth_token=abc123&oauth_token_secret=def456')
-        responses.add(
-            responses.POST,
-            'https://jira.example.com/plugins/servlet/oauth/access-token',
-            status=404,
-            content_type='text/plain',
-            body='oauth_error=token+expired')
-
-        # Get guide page
-        self.client.get(self.init_path)
-
-        # Get config page
-        self.client.get(self.setup_path + '?completed_guide')
-
-        # Submit credentials
-        data = {
-            'url': 'https://jira.example.com/',
-            'verify_ssl': False,
-            'consumer_key': 'sentry-bot',
-            'private_key': PRIVATE_KEY
-        }
-        self.client.post(self.setup_path, data=data)
-
-        # Try getting the token but it has expired for some reason,
-        # perhaps a stale reload/history navigate.
-        resp = self.client.get(self.setup_path + '?oauth_token=xyz789')
-        assert resp.status_code == 200
-        self.assertContains(resp, 'Setup Error')
-        self.assertContains(resp, 'access token from Jira')
-
-    @responses.activate
-    def test_authentication_success(self):
-        responses.add(
-            responses.POST,
-            'https://jira.example.com/plugins/servlet/oauth/request-token',
-            status=200,
-            content_type='text/plain',
-            body='oauth_token=abc123&oauth_token_secret=def456')
-        responses.add(
-            responses.POST,
-            'https://jira.example.com/plugins/servlet/oauth/access-token',
-            status=200,
-            content_type='text/plain',
-            body='oauth_token=valid-token&oauth_token_secret=valid-secret')
-
+    def install_integration(self):
         # Get guide page
         resp = self.client.get(self.init_path)
         assert resp.status_code == 200
@@ -209,10 +162,57 @@ class JiraServerIntegrationTest(IntegrationTestCase):
         resp = self.client.get(self.setup_path + '?oauth_token=xyz789')
         assert resp.status_code == 200
 
+        return resp
+
+    @responses.activate
+    def test_authentication_verifier_expired(self):
+        responses.add(
+            responses.POST,
+            'https://jira.example.com/plugins/servlet/oauth/request-token',
+            status=200,
+            content_type='text/plain',
+            body='oauth_token=abc123&oauth_token_secret=def456')
+        responses.add(
+            responses.POST,
+            'https://jira.example.com/plugins/servlet/oauth/access-token',
+            status=404,
+            content_type='text/plain',
+            body='oauth_error=token+expired')
+
+        # Try getting the token but it has expired for some reason,
+        # perhaps a stale reload/history navigate.
+        resp = self.install_integration()
+
+        self.assertContains(resp, 'Setup Error')
+        self.assertContains(resp, 'access token from Jira')
+
+    @responses.activate
+    def test_authentication_success(self):
+        responses.add(
+            responses.POST,
+            'https://jira.example.com/plugins/servlet/oauth/request-token',
+            status=200,
+            content_type='text/plain',
+            body='oauth_token=abc123&oauth_token_secret=def456')
+        responses.add(
+            responses.POST,
+            'https://jira.example.com/plugins/servlet/oauth/access-token',
+            status=200,
+            content_type='text/plain',
+            body='oauth_token=valid-token&oauth_token_secret=valid-secret')
+        responses.add(
+            responses.POST,
+            'https://jira.example.com/rest/webhooks/1.0/webhook',
+            status=204,
+            body='')
+
+        self.install_integration()
+
         integration = Integration.objects.get()
         assert integration.name == 'sentry-bot'
         assert integration.metadata['base_url'] == 'https://jira.example.com'
         assert integration.metadata['verify_ssl'] is False
+        assert integration.metadata['webhook_secret']
 
         org_integration = OrganizationIntegration.objects.get(
             integration=integration,
@@ -229,3 +229,66 @@ class JiraServerIntegrationTest(IntegrationTestCase):
         assert identity.data['access_token'] == 'valid-token'
         assert identity.data['access_token_secret'] == 'valid-secret'
         assert identity.data['private_key'] == PRIVATE_KEY
+
+    @responses.activate
+    def test_setup_create_webhook(self):
+        responses.add(
+            responses.POST,
+            'https://jira.example.com/plugins/servlet/oauth/request-token',
+            status=200,
+            content_type='text/plain',
+            body='oauth_token=abc123&oauth_token_secret=def456')
+        responses.add(
+            responses.POST,
+            'https://jira.example.com/plugins/servlet/oauth/access-token',
+            status=200,
+            content_type='text/plain',
+            body='oauth_token=valid-token&oauth_token_secret=valid-secret')
+
+        expected_id = 'jira.example.com:sentry-bot'
+
+        def webhook_response(request):
+            # Ensure the webhook token contains our integration
+            # external id
+            data = json.loads(request.body)
+            url = data['url']
+            token = url.split('/')[-2]
+            token_data = jwt.decode(token, verify=False)
+            assert 'id' in token_data
+            assert token_data['id'] == expected_id
+
+            return (204, {}, '')
+
+        responses.add_callback(
+            responses.POST,
+            'https://jira.example.com/rest/webhooks/1.0/webhook',
+            callback=webhook_response)
+        self.install_integration()
+
+        integration = Integration.objects.get()
+        assert integration.external_id == expected_id
+
+    @responses.activate
+    def test_setup_create_webhook_failure(self):
+        responses.add(
+            responses.POST,
+            'https://jira.example.com/plugins/servlet/oauth/request-token',
+            status=200,
+            content_type='text/plain',
+            body='oauth_token=abc123&oauth_token_secret=def456')
+        responses.add(
+            responses.POST,
+            'https://jira.example.com/plugins/servlet/oauth/access-token',
+            status=200,
+            content_type='text/plain',
+            body='oauth_token=valid-token&oauth_token_secret=valid-secret')
+        responses.add(
+            responses.POST,
+            'https://jira.example.com/rest/webhooks/1.0/webhook',
+            status=502,
+            body='Bad things')
+
+        resp = self.install_integration()
+        self.assertContains(resp, 'webhook')
+
+        assert Integration.objects.count() == 0


### PR DESCRIPTION
Add a webhook to a jira-server instance when creating an integration. This webhook is required to afford the issue-sync features we have planned for jira-server.

Refs APP-803