### PR TITLE
Undefined name: from six.moves import xrange

### DIFF
--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -6,6 +6,8 @@ from hashlib import sha1
 
 from django.core.files.base import ContentFile
 
+from six.moves import xrange
+
 from sentry.testutils import TestCase
 from sentry.tasks.assemble import assemble_dif, assemble_file
 from sentry.models import FileBlob, FileBlobOwner


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/getsentry/sentry on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./src/sentry/utils/strings.py:80:39: E999 SyntaxError: invalid syntax
    delimiters = re.compile(ur'([{}]+)'.format(''.join(map(re.escape, ',.$:/+@!?()<>[]{}'))))
                                      ^
./tests/sentry/tasks/test_assemble.py:78:18: F821 undefined name 'xrange'
        for _ in xrange(8):
                 ^
./tests/sentry/integrations/github/testutils.py:224:0: E999 SyntaxError: bytes can only contain ASCII literal characters.
}"""
^
./tests/sentry/integrations/github_enterprise/testutils.py:213:0: E999 SyntaxError: bytes can only contain ASCII literal characters.
}"""
^
3     E999 SyntaxError: invalid syntax
1     F821 undefined name 'xrange'
4
```