### PR TITLE
revert: Temporarily pass bad data to snuba for message

### DIFF
--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -11,7 +11,9 @@ class SnubaEventStream(EventStream):
             'group_id': event.group_id,
             'event_id': event.event_id,
             'project_id': event.project_id,
-            'message': event.real_message,
+            # TODO(mitsuhiko): We do not want to send this incorrect
+            # message but this is what snuba needs at the moment.
+            'message': event.message,
             'platform': event.platform,
             'datetime': event.datetime,
             'data': dict(event.data.items()),


### PR DESCRIPTION
We pass the search message into snuba again because for now snuba otherwise shows empty messages in the UI.