### PR TITLE
fix(eventtypes): Restore old event message behavior and add tests

### DIFF
--- a/src/sentry/eventtypes/base.py
+++ b/src/sentry/eventtypes/base.py
@@ -28,13 +28,13 @@ class DefaultEvent(BaseEvent):
         return True
 
     def get_metadata(self):
-        message = get_path(self.data, 'logentry', 'formatted') \
-            or get_path(self.data, 'logentry', 'message')
+        message = strip(get_path(self.data, 'logentry', 'formatted') or
+                        get_path(self.data, 'logentry', 'message'))
 
-        if not message:
-            title = '<unlabeled event>'
+        if message:
+            title = truncatechars(message.splitlines()[0], 100)
         else:
-            title = truncatechars(strip(message).splitlines()[0], 100)
+            title = '<unlabeled event>'
 
         return {
             'title': title,

--- a/tests/sentry/eventtypes/test_default.py
+++ b/tests/sentry/eventtypes/test_default.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import
+
+from sentry.eventtypes import DefaultEvent
+from sentry.testutils import TestCase
+
+
+class DefaultEventTest(TestCase):
+    def test_get_metadata(self):
+        inst = DefaultEvent({})
+        assert inst.get_metadata() == {
+            'title': '<unlabeled event>'
+        }
+
+        inst = DefaultEvent({
+            'logentry': {
+                'formatted': '  ',
+            }
+        })
+        assert inst.get_metadata() == {
+            'title': '<unlabeled event>'
+        }
+
+        inst = DefaultEvent({
+            'logentry': {
+                'formatted': 'foo',
+                'message': 'bar',
+            }
+        })
+        assert inst.get_metadata() == {
+            'title': 'foo'
+        }
+
+        inst = DefaultEvent({
+            'logentry': {
+                'message': 'foo',
+            }
+        })
+        assert inst.get_metadata() == {
+            'title': 'foo'
+        }


### PR DESCRIPTION
Fixes [SENTRY-8DR](https://sentry.io/sentry/sentry/issues/774625996)