### PR TITLE
fix(tests) Reduce flaky test by waiting for external issue panel

### DIFF
--- a/src/sentry/static/sentry/app/components/group/externalIssuesList.jsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssuesList.jsx
@@ -71,7 +71,7 @@ class ExternalIssueList extends AsyncComponent {
     if (!integrationIssues && !pluginIssues && !pluginActions)
       return (
         <React.Fragment>
-          <h6>
+          <h6 data-test-id="linked-issues">
             <span>Linked Issues</span>
           </h6>
           <AlertLink
@@ -87,7 +87,7 @@ class ExternalIssueList extends AsyncComponent {
 
     return (
       <React.Fragment>
-        <h6>
+        <h6 data-test-id="linked-issues">
           <span>Linked Issues</span>
         </h6>
         {integrationIssues && <Box mb={2}>{integrationIssues}</Box>}

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -152,6 +152,7 @@ class IssueDetailsTest(AcceptanceTestCase):
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
         self.browser.wait_until('.entries')
+        self.browser.wait_until('[data-test-id="linked-issues"]')
         self.browser.snapshot('issue details empty stacktrace')
 
     def test_activity_page(self):


### PR DESCRIPTION
The external issue panel has been causing percy tests to be inconsistent. By waiting for that component to render we should get more consistent test results.