### PR TITLE
fix: Insert legacy search message into kafka

### DIFF
--- a/src/sentry/eventstream/kafka.py
+++ b/src/sentry/eventstream/kafka.py
@@ -130,6 +130,8 @@ class KafkaEventStream(EventStream):
             'event_id': event.event_id,
             'organization_id': project.organization_id,
             'project_id': event.project_id,
+            # TODO(mitsuhiko): We do not want to send this incorrect
+            # message but this is what snuba needs at the moment.
             'message': event.real_message,
             'platform': event.platform,
             'datetime': event.datetime,

--- a/src/sentry/eventstream/kafka.py
+++ b/src/sentry/eventstream/kafka.py
@@ -132,7 +132,7 @@ class KafkaEventStream(EventStream):
             'project_id': event.project_id,
             # TODO(mitsuhiko): We do not want to send this incorrect
             # message but this is what snuba needs at the moment.
-            'message': event.real_message,
+            'message': event.search_message,
             'platform': event.platform,
             'datetime': event.datetime,
             'data': dict(event.data.items()),


### PR DESCRIPTION
#10744 fixed the wrong code path. The real snuba stream is the kafka one.

//EDIT: this broke snuba writes because `search_message` was the wrong attribute.