### PR TITLE
ref(fileblob): Change naming convention for file blobs

### DIFF
--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -58,7 +58,7 @@ ChunkFileState = enum(
 def _get_size_and_checksum(fileobj):
     size = 0
     checksum = sha1()
-    while 1:
+    while True:
         chunk = fileobj.read(65536)
         if not chunk:
             break
@@ -134,7 +134,7 @@ class FileBlob(Model):
 
         def _upload_and_pend_chunk(fileobj, size, checksum, lock):
             blob = cls(size=size, checksum=checksum)
-            blob.path = cls.generate_unique_path(blob.timestamp)
+            blob.path = cls.generate_unique_path()
             storage = get_storage()
             storage.save(blob.path, fileobj)
             blobs_to_save.append((blob, lock))
@@ -156,7 +156,7 @@ class FileBlob(Model):
             _ensure_blob_owned(blob)
 
         def _flush_blobs():
-            while 1:
+            while True:
                 try:
                     blob, lock = blobs_to_save.pop()
                 except IndexError:
@@ -229,7 +229,7 @@ class FileBlob(Model):
                 return existing
 
             blob = cls(size=size, checksum=checksum)
-            blob.path = cls.generate_unique_path(blob.timestamp)
+            blob.path = cls.generate_unique_path()
             storage = get_storage()
             storage.save(blob.path, fileobj)
             blob.save()
@@ -238,9 +238,9 @@ class FileBlob(Model):
         return blob
 
     @classmethod
-    def generate_unique_path(cls, timestamp):
-        pieces = [six.text_type(x) for x in divmod(int(timestamp.strftime('%s')), ONE_DAY)]
-        pieces.append(uuid4().hex)
+    def generate_unique_path(cls):
+        uuid_hex = uuid4().hex
+        pieces = [uuid_hex[:2], uuid_hex[2:6], uuid_hex[6:]]
         return u'/'.join(pieces)
 
     def delete(self, *args, **kwargs):

--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -239,6 +239,8 @@ class FileBlob(Model):
 
     @classmethod
     def generate_unique_path(cls):
+        # We intentionally do not use checksums as path names to avoid concurrency issues
+        # when we attempt concurrent uploads for any reason.
         uuid_hex = uuid4().hex
         pieces = [uuid_hex[:2], uuid_hex[2:6], uuid_hex[6:]]
         return u'/'.join(pieces)

--- a/tests/sentry/models/test_file.py
+++ b/tests/sentry/models/test_file.py
@@ -24,6 +24,18 @@ class FileBlobTest(TestCase):
         assert my_file1.checksum == my_file2.checksum
         assert my_file1.path == my_file2.path
 
+    def test_generate_unique_path(self):
+        path = FileBlob.generate_unique_path()
+        assert path
+
+        parts = path.split('/')
+        assert len(parts) == 3
+        assert map(len, parts) == [2, 4, 26]
+
+        # Check uniqueness
+        path2 = FileBlob.generate_unique_path()
+        assert path != path2
+
 
 class FileTest(TestCase):
     def test_file_handling(self):


### PR DESCRIPTION
Before the change newly generated file names looked like this:
`17858/55997/18b0ec4fa3ea43e78502b7d2758e0ab1`
After the change:
`ab/a27f/fe029b475f83b5f30e3da8b164`

It gives us 256 directories at the top level, with maximum 65536 directories at the second level, and `2**104` leaves.

The main motivation for the change is to achieve more even name distribution for the GCS storage backend.
This shouldn't affect any existing files on any of the supported backends (filesystem, gcs, s3).

#sync-getsentry