### PR TITLE
fix(serializer): Fall back to legacy message

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -109,7 +109,7 @@ class EventSerializer(Serializer):
         meta = get_path(event.data, '_meta', attr)
         return (value, meta_with_chunks(value, meta))
 
-    def _get_message_with_meta(self, event):
+    def _get_legacy_message_with_meta(self, event):
         meta = event.data.get('_meta')
 
         message = get_path(event.data, 'logentry', 'formatted')
@@ -120,8 +120,8 @@ class EventSerializer(Serializer):
             msg_meta = get_path(meta, 'logentry', 'message')
 
         if not message:
-            message = get_path(event.data, 'message')
-            msg_meta = get_path(meta, 'message')
+            message = event.message
+            msg_meta = None
 
         return (message, meta_with_chunks(message, msg_meta))
 
@@ -166,7 +166,7 @@ class EventSerializer(Serializer):
             }
             errors.append(error_result)
 
-        (message, message_meta) = self._get_message_with_meta(obj)
+        (message, message_meta) = self._get_legacy_message_with_meta(obj)
         (tags, tags_meta) = self._get_tags_with_meta(obj)
         (context, context_meta) = self._get_attr_with_meta(obj, 'extra', {})
         (packages, packages_meta) = self._get_attr_with_meta(obj, 'modules', {})

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -87,20 +87,11 @@ class EventSerializerTest(TestCase):
         assert result['_meta']['message'] == {'': {'err': ['some error']}}
 
     def test_message_legacy(self):
-        event = self.create_event(
-            data={
-                'message': 'foo',
-                '_meta': {
-                    'message': {'': {'err': ['some error']}},
-                },
-            }
-        )
-
-        # create_event automatically creates the logentry interface
-        del event.data['logentry']
+        event = self.create_event(data={'logentry': None})
+        event.message = 'search message'
 
         result = serialize(event)
-        assert result['message'] is None
+        assert result['message'] == 'search message'
 
     def test_tags_tuples(self):
         event = self.create_event(


### PR DESCRIPTION
Falls back to the legacy search message for now. This is a huge issue, as we don't know what to render in such a case, similar to Discover and Snuba.

Ref #10747
