### PR TITLE
fix(integrations) Fetch full commit messages for Azure

### DIFF
--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -17,6 +17,7 @@ INVALID_ACCESS_TOKEN = 'HTTP 400 (invalid_request): The access token is not vali
 
 
 class VstsApiPath(object):
+    commit = u'{instance}_apis/git/repositories/{repo_id}/commits/{commit_id}'
     commits = u'{instance}_apis/git/repositories/{repo_id}/commits'
     commits_batch = u'{instance}_apis/git/repositories/{repo_id}/commitsBatch'
     commits_changes = u'{instance}_apis/git/repositories/{repo_id}/commits/{commit_id}/changes'
@@ -197,8 +198,16 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
             },
         )
 
-    def get_commit_filechanges(self, instance, repo_id, commit):
+    def get_commit(self, instance, repo_id, commit):
+        return self.get(
+            VstsApiPath.commit.format(
+                instance=instance,
+                repo_id=repo_id,
+                commit_id=commit
+            )
+        )
 
+    def get_commit_filechanges(self, instance, repo_id, commit):
         resp = self.get(
             VstsApiPath.commits_changes.format(
                 instance=instance,

--- a/tests/sentry/integrations/vsts/test_repository.py
+++ b/tests/sentry/integrations/vsts/test_repository.py
@@ -10,7 +10,9 @@ from sentry.models import Identity, IdentityProvider, Integration, Repository
 from sentry.integrations.vsts.repository import VstsRepositoryProvider
 
 from .testutils import (
-    COMPARE_COMMITS_EXAMPLE, FILE_CHANGES_EXAMPLE
+    COMPARE_COMMITS_EXAMPLE,
+    COMMIT_DETAILS_EXAMPLE,
+    FILE_CHANGES_EXAMPLE
 )
 
 
@@ -25,7 +27,6 @@ class VisualStudioRepositoryProviderTest(TestCase):
 
     @responses.activate
     def test_compare_commits(self):
-
         responses.add(
             responses.POST,
             'https://visualstudio.com/_apis/git/repositories/None/commitsBatch',
@@ -36,6 +37,12 @@ class VisualStudioRepositoryProviderTest(TestCase):
             'https://visualstudio.com/_apis/git/repositories/None/commits/6c36052c58bde5e57040ebe6bdb9f6a52c906fff/changes',
             body=FILE_CHANGES_EXAMPLE,
         )
+        responses.add(
+            responses.GET,
+            'https://visualstudio.com/_apis/git/repositories/None/commits/6c36052c58bde5e57040ebe6bdb9f6a52c906fff',
+            body=COMMIT_DETAILS_EXAMPLE,
+        )
+
         integration = Integration.objects.create(
             provider='vsts',
             external_id=self.vsts_external_id,
@@ -78,7 +85,7 @@ class VisualStudioRepositoryProviderTest(TestCase):
                            'type': 'M'}],
             'author_email': 'max@sentry.io',
             'author_name': 'max bittker',
-            'message': 'Updated README.md',
+            'message': 'Updated README.md\n\nSecond line\n\nFixes SENTRY-1',
             'id': '6c36052c58bde5e57040ebe6bdb9f6a52c906fff',
             'repository': 'example'
         }]

--- a/tests/sentry/integrations/vsts/testutils.py
+++ b/tests/sentry/integrations/vsts/testutils.py
@@ -237,6 +237,7 @@ COMPARE_COMMITS_EXAMPLE = b"""
         "date": "2018-04-24T00:03:18Z"
       },
       "comment": "Updated README.md",
+      "commentTruncated": true,
       "changeCounts": {"Add": 0, "Edit": 1, "Delete": 0},
       "url":
         "https://mbittker.visualstudio.com/_apis/git/repositories/b1e25999-c080-4ea1-8c61-597c4ec41f06/commits/6c36052c58bde5e57040ebe6bdb9f6a52c906fff",
@@ -244,6 +245,62 @@ COMPARE_COMMITS_EXAMPLE = b"""
         "https://mbittker.visualstudio.com/_git/MyFirstProject/commit/6c36052c58bde5e57040ebe6bdb9f6a52c906fff"
     }
   ]
+}
+"""
+
+COMMIT_DETAILS_EXAMPLE = r"""
+{
+    "_links": {
+        "changes": {
+            "href": "https://mbittker.visualstudio.com/_apis/git/repositories/666ffcce-8ffa-46ec-bccf-b93b55bb2320/commits/6c36052c58bde5e57040ebe6bdb9f6a52c906fff/changes"
+        },
+        "repository": {
+            "href": "https://mbittker.visualstudio.com/_apis/git/repositories/666ffcce-8ffa-46ec-bccf-b93b55bb2320"
+        },
+        "self": {
+            "href": "https://mbittker.visualstudio.com/_apis/git/repositories/666ffcce-8ffa-46ec-bccf-b93b55bb2320/commits/6c36052c58bde5e57040ebe6bdb9f6a52c906fff"
+        },
+        "web": {
+            "href": "https://mbittker.visualstudio.com/_git/MyFirstProject/commit/6c36052c58bde5e57040ebe6bdb9f6a52c906fff"
+        }
+    },
+    "author": {
+        "date": "2018-11-23T15:59:19Z",
+        "email": "max@sentry.io",
+        "imageUrl": "https://www.gravatar.com/avatar/1cee8d752bcad4c172d60e56bb398c11?r=g&d=mm",
+        "name": "max bitker"
+    },
+    "comment": "Updated README.md\n\nSecond line\n\nFixes SENTRY-1",
+    "commitId": "6c36052c58bde5e57040ebe6bdb9f6a52c906fff",
+    "committer": {
+        "date": "2018-11-23T15:59:19Z",
+        "email": "max@sentry.io",
+        "imageUrl": "https://www.gravatar.com/avatar/1cee8d752bcad4c172d60e56bb398c11?r=g&d=mm",
+        "name": "max bittker"
+    },
+    "parents": [
+        "641e82ce0ed14f3cf3670b0bf5f669d7fbd40a68"
+    ],
+    "push": {
+        "date": "2018-11-23T16:01:10.7246278Z",
+        "pushId": 2,
+        "pushedBy": {
+            "_links": {
+                "avatar": {
+                    "href": "https://mbittker.visualstudio.com/_apis/GraphProfile/MemberAvatars/msa.NjI0ZGRhOWMtODgyZC03ZmRhLTk3OWItZTdhMjI5MWMzMzBk"
+                }
+            },
+            "descriptor": "msa.NjI0ZGRhOWMtODgyZC03ZmRhLTk3OWItZTdhMjI5MWMzMzBk",
+            "displayName": "Mark Story",
+            "id": "624dda9c-882d-6fda-979b-e7a2291c330d",
+            "imageUrl": "https://mbittker.visualstudio.com/_api/_common/identityImage?id=624dda9c-882d-6fda-979b-e7a2291c330d",
+            "uniqueName": "mark@mark-story.com",
+            "url": "https://mbittker.visualstudio.com/Aa365971d-9897-47eb-becf-c5142d33db08/_apis/Identities/624dda9c-882d-6fda-979b-e7a2291c330d"
+        }
+    },
+    "remoteUrl": "https://mbittker.visualstudio.com/MyFirstProject/_git/box-of-things/commit/6c36052c58bde5e57040ebe6bdb9f6a52c906fff",
+    "treeId": "026257a5e53eb923497c0217ef76e567f3a60088",
+    "url": "https://mbittker.visualstudio.com/_apis/git/repositories/666ffcce-8ffa-46ec-bccf-b93b55bb2320/commits/6c36052c58bde5e57040ebe6bdb9f6a52c906fff"
 }
 """
 
@@ -267,6 +324,7 @@ FILE_CHANGES_EXAMPLE = b"""
   ]
 }
 """
+
 WORK_ITEM_RESPONSE = """{
   "id": 309,
   "rev": 1,
@@ -401,6 +459,7 @@ GET_USERS_RESPONSE = b"""{
   ]
 }
 """
+
 CREATE_SUBSCRIPTION = {
     'id': 'fd672255-8b6b-4769-9260-beea83d752ce',
     'url': 'https://fabrikam.visualstudio.com/_apis/hooks/subscriptions/fd672255-8b6b-4769-9260-beea83d752ce',


### PR DESCRIPTION
Azure Devops' batch commit API only gives us the first line of a commit message. In order to get the full commit message we need to do a individual commit GET request. This adds those API calls when we know that the commit message has been truncated.

Refs APP-712