### PR TITLE
feat: Strip surrogates for postgres

### DIFF
--- a/src/sentry/db/postgres/base.py
+++ b/src/sentry/db/postgres/base.py
@@ -19,20 +19,35 @@ __all__ = ('DatabaseWrapper', )
 
 
 def remove_null(value):
-    if not isinstance(value, string_types):
-        return value
+    # In psycopg2 2.7+, behavior was introduced where a
+    # NULL byte in a parameter would start raising a ValueError.
+    # psycopg2 chose to do this rather than let Postgres silently
+    # truncate the data, which is it's behavior when it sees a
+    # NULL byte. But for us, we'd rather remove the null value so it's
+    # somewhat legible rather than error. Considering this is better
+    # behavior than the database truncating, seems good to do this
+    # rather than attempting to sanitize all data inputs now manually.
     return value.replace('\x00', '')
 
 
 def remove_surrogates(value):
-    if not isinstance(value, string_types):
-        return value
+    # Another hack.  postgres does not accept lone surrogates
+    # in utf-8 mode.  If we encounter any lone surrogates in
+    # our string we need to remove it.
     if type(value) is bytes:
         try:
             return strip_lone_surrogates(value.decode('utf-8')).encode('utf-8')
         except UnicodeError:
             return value
     return strip_lone_surrogates(value)
+
+
+def clean_bad_params(params):
+    params = list(params)
+    for idx, param in enumerate(params):
+        if isinstance(param, string_types):
+            params[idx] = remove_null(remove_surrogates(param))
+    return params
 
 
 class CursorWrapper(object):
@@ -56,31 +71,7 @@ class CursorWrapper(object):
     @less_shitty_error_messages
     def execute(self, sql, params=None):
         if params is not None:
-            try:
-                return self.cursor.execute(sql, params)
-            except ValueError as e:
-                # In psycopg2 2.7+, behavior was introduced where a
-                # NULL byte in a parameter would start raising a ValueError.
-                # psycopg2 chose to do this rather than let Postgres silently
-                # truncate the data, which is it's behavior when it sees a
-                # NULL byte. But for us, we'd rather remove the null value so it's
-                # somewhat legible rather than error. Considering this is better
-                # behavior than the database truncating, seems good to do this
-                # rather than attempting to sanitize all data inputs now manually.
-
-                # Note: This message is brittle, but it's currently hardcoded into
-                # psycopg2 for this behavior. If anything changes, we're choosing to
-                # address that later rather than potentially catch incorrect behavior.
-                if e.message != 'A string literal cannot contain NUL (0x00) characters.':
-                    raise
-                return self.cursor.execute(sql, [remove_null(param) for param in params])
-            except Database.DataError as e:
-                # Another hack.  postgres does not accept lone surrogates
-                # in utf-8 mode.  If we encounter any lone surrogates in
-                # our string we need to remove it.
-                if 'invalid byte sequence for encoding' not in e.message:
-                    raise
-                return self.cursor.execute(sql, [remove_surrogates(param) for param in params])
+            return self.cursor.execute(sql, clean_bad_params(params))
         return self.cursor.execute(sql)
 
     @capture_transaction_exceptions

--- a/src/sentry/utils/strings.py
+++ b/src/sentry/utils/strings.py
@@ -37,7 +37,7 @@ _lone_surrogate = re.compile(u"""(?x)
 def strip_lone_surrogates(string):
     """Removes lone surrogates."""
     if six.PY3:
-        return string.encode('utf-8', 'surrogateescape').decode('utf-8', 'ignore')
+        return string.encode('utf-8', 'surrogatepass').decode('utf-8', 'ignore')
     return _lone_surrogate.sub('', string)
 
 

--- a/src/sentry/utils/strings.py
+++ b/src/sentry/utils/strings.py
@@ -24,6 +24,22 @@ _sprintf_placeholder_re = re.compile(
     r'%(?:\d+\$)?[+-]?(?:[ 0]|\'.{1})?-?\d*(?:\.\d+)?[bcdeEufFgGosxX]'
 )
 
+_lone_surrogate = re.compile(u"""(?x)
+    (
+        [\ud800-\udbff](?![\udc00-\udfff])
+    ) | (
+        (?<![\ud800-\udbff])
+        [\udc00-\udfff]
+    )
+""")
+
+
+def strip_lone_surrogates(string):
+    """Removes lone surrogates."""
+    if six.PY3:
+        return string.encode('utf-8', 'surrogateescape').decode('utf-8', 'ignore')
+    return _lone_surrogate.sub('', string)
+
 
 def truncatechars(value, arg, ellipsis='...'):
     # TODO (alex) could use unicode ellipsis: u'\u2026'

--- a/tests/sentry/db/postgres/test_base.py
+++ b/tests/sentry/db/postgres/test_base.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from __future__ import absolute_import
 
 import pytest
@@ -48,3 +49,13 @@ class CursorWrapperTestCase(TestCase):
         long_str_from_db = cursor.fetchone()[0]
         assert long_str_from_db == (u'a' * (MAX_CULPRIT_LENGTH - 1))
         assert len(long_str_from_db) <= MAX_CULPRIT_LENGTH
+
+    def test_lone_surrogates(self):
+        from django.db import connection
+        cursor = connection.cursor()
+
+        bad_str = u'Hello\ud83dWorld🇦🇹!'
+
+        cursor.execute('SELECT %s', [bad_str])
+        bad_str_from_db = cursor.fetchone()[0]
+        assert bad_str_from_db == u'HelloWorld🇦🇹!'

--- a/tests/sentry/db/postgres/test_base.py
+++ b/tests/sentry/db/postgres/test_base.py
@@ -5,6 +5,7 @@ import pytest
 from sentry.utils.db import is_postgres
 from sentry.testutils import TestCase
 from sentry.constants import MAX_CULPRIT_LENGTH
+from django.utils.encoding import force_text
 
 
 def psycopg2_version():
@@ -55,7 +56,6 @@ class CursorWrapperTestCase(TestCase):
         cursor = connection.cursor()
 
         bad_str = u'Hello\ud83dWorld🇦🇹!'
-
         cursor.execute('SELECT %s', [bad_str])
-        bad_str_from_db = cursor.fetchone()[0]
+        bad_str_from_db = force_text(cursor.fetchone()[0])
         assert bad_str_from_db == u'HelloWorld🇦🇹!'


### PR DESCRIPTION
This removes lone surrogates on the way to postgres.  This works around issues
that manifest like this: "invalid byte sequence for encoding "UTF8": 0xed 0xa0 0xbd".

It's similar to how we deal with null values now.