### PR TITLE
ref: Refactor event hashing to be more reusable

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -182,11 +182,6 @@ class EventSerializer(Serializer):
             except TypeError:
                 received = None
 
-        from sentry.event_manager import (
-            get_hashes_from_fingerprint,
-            md5_from_hash,
-        )
-
         # TODO(dcramer): move release serialization here
         d = {
             'id': six.text_type(obj.id),
@@ -211,10 +206,7 @@ class EventSerializer(Serializer):
             'dateCreated': obj.datetime,
             'dateReceived': received,
             'errors': errors,
-            'fingerprints': [
-                md5_from_hash(h)
-                for h in get_hashes_from_fingerprint(obj, obj.data.get('fingerprint', ['{{ default }}']))
-            ],
+            'fingerprints': obj.get_hashes(),
             '_meta': {
                 'entries': attrs['_meta']['entries'],
                 'message': message_meta,

--- a/src/sentry/event_hashing.py
+++ b/src/sentry/event_hashing.py
@@ -1,0 +1,97 @@
+from __future__ import absolute_import
+
+import re
+import six
+
+from hashlib import md5
+from collections import OrderedDict
+
+from django.utils.encoding import force_bytes
+
+HASH_RE = re.compile(r'^[0-9a-f]{32}$')
+DEFAULT_FINGERPRINT_VALUES = frozenset(['{{ default }}', '{{default}}'])
+
+
+def md5_from_hash(hash_bits):
+    result = md5()
+    for bit in hash_bits:
+        result.update(force_bytes(bit, errors='replace'))
+    return result.hexdigest()
+
+
+def get_fingerprint_for_event(event):
+    fingerprint = event.data.get('fingerprint')
+    if fingerprint is None:
+        return ['{{ default }}']
+    return fingerprint
+
+
+def get_hashes_for_event(event):
+    return get_hashes_for_event_with_reason(event)[1]
+
+
+def get_hashes_for_event_with_reason(event):
+    interfaces = event.get_interfaces()
+    for interface in six.itervalues(interfaces):
+        result = interface.compute_hashes(event.platform)
+        if not result:
+            continue
+        return (interface.path, result)
+
+    return ('no_interfaces', [''])
+
+
+def get_grouping_behavior(event):
+    data = event.data
+    if data.get('checksum') is not None:
+        return ('checksum', data['checksum'])
+    fingerprint = get_fingerprint_for_event(event)
+    return ('fingerprint', get_hashes_from_fingerprint_with_reason(event, fingerprint))
+
+
+def get_hashes_from_fingerprint(event, fingerprint):
+    if any(d in fingerprint for d in DEFAULT_FINGERPRINT_VALUES):
+        default_hashes = get_hashes_for_event(event)
+        hash_count = len(default_hashes)
+    else:
+        hash_count = 1
+
+    hashes = []
+    for idx in range(hash_count):
+        result = []
+        for bit in fingerprint:
+            if bit in DEFAULT_FINGERPRINT_VALUES:
+                result.extend(default_hashes[idx])
+            else:
+                result.append(bit)
+        hashes.append(result)
+    return hashes
+
+
+def get_hashes_from_fingerprint_with_reason(event, fingerprint):
+    if any(d in fingerprint for d in DEFAULT_FINGERPRINT_VALUES):
+        default_hashes = get_hashes_for_event_with_reason(event)
+        hash_count = len(default_hashes[1])
+    else:
+        hash_count = 1
+
+    hashes = OrderedDict((bit, []) for bit in fingerprint)
+    for idx in range(hash_count):
+        for bit in fingerprint:
+            if bit in DEFAULT_FINGERPRINT_VALUES:
+                hashes[bit].append(default_hashes)
+            else:
+                hashes[bit] = bit
+    return list(hashes.items())
+
+
+def get_event_hashes(event, no_fingerprint=False):
+    if not no_fingerprint:
+        fingerprint = event.data.get('fingerprint') or ['{{ default }}']
+        return [md5_from_hash(h) for h in get_hashes_from_fingerprint(event, fingerprint)]
+    checksum = event.data.get('checksum')
+    if checksum:
+        if HASH_RE.match(checksum):
+            return [checksum]
+        return [md5_from_hash([checksum]), checksum]
+    return [md5_from_hash(h) for h in get_hashes_for_event(event)]

--- a/src/sentry/management/commands/diff.py
+++ b/src/sentry/management/commands/diff.py
@@ -32,9 +32,7 @@ def get_event(pk):
 
 def print_unified_diff(left, right):
     from difflib import unified_diff
-    from sentry.event_manager import (
-        get_grouping_behavior,
-    )
+    from sentry.event_hashing import get_grouping_behavior
 
     left_id = left.id
     right_id = right.id

--- a/src/sentry/management/commands/serve_normalize.py
+++ b/src/sentry/management/commands/serve_normalize.py
@@ -53,7 +53,7 @@ def catch_errors(f):
 
 # Here's where the normalization itself happens
 def process_event(data, meta):
-    from sentry.event_manager import EventManager, get_hashes_for_event
+    from sentry.event_manager import EventManager
     from sentry.tasks.store import should_process
 
     event_manager = EventManager(
@@ -70,7 +70,7 @@ def process_event(data, meta):
     group_hash = None
 
     if not should_process(event):
-        group_hash = get_hashes_for_event(event_manager._get_event_instance(project_id=1))
+        group_hash = event_manager._get_event_instance(project_id=1).get_hashes()
     return {
         "event": dict(event),
         "group_hash": group_hash,

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -123,6 +123,22 @@ class Event(Model):
         from sentry.event_manager import get_event_metadata_compat
         return get_event_metadata_compat(self.data, self.message)
 
+    def get_hashes(self, no_fingerprint=False):
+        """
+        Returns the calculated hashes for the event.
+
+        The `no_fingerprint` parameter disables using the fingerprint value.
+        This is a legacy code path that should be removed but matches old
+        event ingestion behavior.  This will make the code consider the
+        legacy checksum as well before falling back to the default fingerprint.
+        """
+        from sentry.event_hashing import get_event_hashes
+        return get_event_hashes(self, no_fingerprint)
+
+    def get_primary_hash(self):
+        # TODO: This *might* need to be protected from an IndexError?
+        return self.get_hashes()[0]
+
     @property
     def title(self):
         et = eventtypes.get(self.get_event_type())(self.data)

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -8,9 +8,7 @@ from django.db import transaction
 from sentry import eventstream, tagstore
 from sentry.app import tsdb
 from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS_MAP
-from sentry.event_manager import (
-    generate_culprit, get_fingerprint_for_event, get_hashes_from_fingerprint, md5_from_hash
-)
+from sentry.event_manager import generate_culprit
 from sentry.models import (
     Activity, Environment, Event, EventMapping, EventUser, Group,
     GroupEnvironment, GroupHash, GroupRelease, Project, Release, UserReport
@@ -144,11 +142,7 @@ def get_group_backfill_attributes(caches, group, events):
 
 def get_fingerprint(event):
     # TODO: This *might* need to be protected from an IndexError?
-    primary_hash = get_hashes_from_fingerprint(
-        event,
-        get_fingerprint_for_event(event),
-    )[0]
-    return md5_from_hash(primary_hash)
+    return event.get_primary_hash()
 
 
 def migrate_events(caches, project, source_id, destination_id,

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -843,9 +843,6 @@ class SnubaTestCase(TestCase):
         doesn't run them through the 'real' event pipeline. In a perfect
         world all test events would go through the full regular pipeline.
         """
-
-        from sentry.event_manager import get_hashes_from_fingerprint, md5_from_hash
-
         event = super(SnubaTestCase, self).create_event(*args, **kwargs)
 
         data = event.data.data
@@ -865,11 +862,7 @@ class SnubaTestCase(TestCase):
                 group_id=event.group_id,
             )
 
-        hashes = get_hashes_from_fingerprint(
-            event,
-            data.get('fingerprint', ['{{ default }}']),
-        )
-        primary_hash = md5_from_hash(hashes[0])
+        primary_hash = event.get_primary_hash()
 
         grouphash, _ = GroupHash.objects.get_or_create(
             project=event.project,

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -14,10 +14,8 @@ from time import time
 
 from sentry.app import tsdb
 from sentry.constants import VERSION_LENGTH
-from sentry.event_manager import (
-    HashDiscarded, EventManager, EventUser,
-    md5_from_hash
-)
+from sentry.event_manager import HashDiscarded, EventManager, EventUser
+from sentry.event_hashing import md5_from_hash
 from sentry.models import (
     Activity, Environment, Event, ExternalIssue, Group, GroupEnvironment,
     GroupHash, GroupLink, GroupRelease, GroupResolution, GroupStatus,

--- a/tests/sentry/event_manager/test_generate_culprit.py
+++ b/tests/sentry/event_manager/test_generate_culprit.py
@@ -3,7 +3,8 @@
 from __future__ import absolute_import
 
 from sentry.constants import MAX_CULPRIT_LENGTH
-from sentry.event_manager import generate_culprit, md5_from_hash
+from sentry.event_manager import generate_culprit
+from sentry.event_hashing import md5_from_hash
 
 
 def test_with_exception_interface():

--- a/tests/sentry/event_manager/test_get_hashes_from_fingerprint.py
+++ b/tests/sentry/event_manager/test_get_hashes_from_fingerprint.py
@@ -4,8 +4,8 @@ from __future__ import absolute_import, print_function
 
 import mock
 
-from sentry.event_manager import get_hashes_for_event
 from sentry.models import Event
+from sentry.event_hashing import md5_from_hash
 
 
 @mock.patch('sentry.interfaces.stacktrace.Stacktrace.compute_hashes')
@@ -29,9 +29,9 @@ def test_stacktrace_wins_over_http(http_comp_hash, stack_comp_hash):
         platform='python',
         message='Foo bar',
     )
-    hashes = get_hashes_for_event(event)
+    hashes = event.get_hashes()
     assert len(hashes) == 1
     hash_one = hashes[0]
     stack_comp_hash.assert_called_once_with('python')
     assert not http_comp_hash.called
-    assert hash_one == ['foo', 'bar']
+    assert hash_one == md5_from_hash(['foo', 'bar'])


### PR DESCRIPTION
This is some experimental code to clean up the event hashing logic.

#sync-getsentry