### PR TITLE
test(acceptance): Add a test for invalid interfaces

### DIFF
--- a/src/sentry/data/samples/invalid-interfaces.json
+++ b/src/sentry/data/samples/invalid-interfaces.json
@@ -1,0 +1,105 @@
+{
+    "level": "error",
+    "platform": "python",
+    "server_name": "mcbk.local",
+    "breadcrumbs": {
+        "values": [
+            {
+                "message": "missing timestamp"
+            },
+            {
+                "message": "invalid level",
+                "timestamp": "2017-08-04T07:37:08Z",
+                "level": "invalid",
+                "type": "debug"
+            },
+            {
+                "message": "invalid data",
+                "timestamp": "2017-08-04T07:37:08Z",
+                "data": "must be a mapping"
+            }
+        ]
+    },
+    "debug_meta": {
+        "is_debug_build": "nope",
+        "images": [
+            {
+                "type": ""
+            },
+            {
+                "type": "invalid"
+            },
+            {
+                "type": "symbolic",
+                "name": "missing image_size"
+            },
+            {
+                "type": "symbolic",
+                "image_size": "0xbeef",
+                "name": "missing id"
+            },
+            {
+                "type": "symbolic",
+                "image_size": "invalid",
+                "name": "missing id"
+            }
+        ],
+        "sdk_info": {
+            "dsym_type": "none"
+        }
+    },
+    "exception": {
+        "values": [
+            {},
+            {
+                "type": "",
+                "value": ""
+            },
+            {
+                "type": "ValueError",
+                "mechanism": {
+                    "type": "",
+                    "handled": true
+                }
+            },
+            {
+                "type": "ValueError",
+                "mechanism": {
+                    "type": "generic",
+                    "handled": true,
+                    "description": 42
+                }
+            },
+            {
+                "type": "ValueError",
+                "stacktrace": {
+                    "frames": [
+                        {},
+                        {
+                            "unknown": "unknown attribute"
+                        }
+                    ]
+                }
+            }
+        ],
+        "exc_omitted": [
+            1
+        ]
+    },
+    "logentry": {
+        "formatted": "without message attribute"
+    },
+    "request": {
+        "method": "unknown"
+    },
+    "sdk": {
+        "name": "sentry.python",
+        "version": "0.1",
+        "integrations": "no list",
+        "packages": "no list"
+    },
+    "user": {
+        "email": "B5849C8CC2779009ECA17792D1138D13",
+        "ip_address": "F528764D624DB129B32C21FBCA0CB8D6"
+    }
+}

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -154,6 +154,17 @@ class IssueDetailsTest(AcceptanceTestCase):
         self.browser.wait_until('.entries')
         self.browser.snapshot('issue details empty stacktrace')
 
+    def test_invalid_interfaces(self):
+        event = self.create_sample_event(
+            platform='invalid-interfaces'
+        )
+
+        self.browser.get(
+            u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
+        )
+        self.browser.wait_until('.entries')
+        self.browser.snapshot('issue details invalid interfaces')
+
     def test_activity_page(self):
         event = self.create_sample_event(
             platform='python',


### PR DESCRIPTION
Adds an acceptance test for events with all sorts of invalid interfaces so we can diff it in Percy.