### PR TITLE
fix(interfaces): Add schema validation for the Template interface

### DIFF
--- a/src/sentry/data/samples/invalid-interfaces.json
+++ b/src/sentry/data/samples/invalid-interfaces.json
@@ -98,6 +98,21 @@
         "integrations": "no list",
         "packages": "no list"
     },
+    "template": {
+        "lineno": 0,
+        "context_line": [
+            2,
+            "{% something %} "
+        ],
+        "pre_context": [
+            1,
+            "<!-- printing something --> "
+        ],
+        "post_context": [
+            3,
+            " "
+        ]
+    },
     "user": {
         "email": "B5849C8CC2779009ECA17792D1138D13",
         "ip_address": "F528764D624DB129B32C21FBCA0CB8D6"

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -271,6 +271,7 @@ TEMPLATE_INTERFACE_SCHEMA = {
             'items': {'type': 'string'}
         },
     },
+    'required': ['lineno', 'context_line'],
     'additionalProperties': False,
 }
 MESSAGE_INTERFACE_SCHEMA = {'type': 'object'}

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -252,7 +252,27 @@ GEO_INTERFACE_SCHEMA = {
     'additionalProperties': False,
 }
 
-TEMPLATE_INTERFACE_SCHEMA = {'type': 'object'}  # TODO fill this out
+TEMPLATE_INTERFACE_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'abs_path': {'type': 'string'},
+        'filename': {'type': 'string'},
+        'context_line': {'type': 'string'},
+        'lineno': {
+            'type': 'number',
+            'minimum': 1,
+        },
+        'pre_context': {
+            'type': 'array',
+            'items': {'type': 'string'}
+        },
+        'post_context': {
+            'type': 'array',
+            'items': {'type': 'string'}
+        },
+    },
+    'additionalProperties': False,
+}
 MESSAGE_INTERFACE_SCHEMA = {'type': 'object'}
 
 TAGS_DICT_SCHEMA = {

--- a/src/sentry/interfaces/template.py
+++ b/src/sentry/interfaces/template.py
@@ -9,7 +9,8 @@ from __future__ import absolute_import
 
 __all__ = ('Template', )
 
-from sentry.interfaces.base import Interface
+from sentry.interfaces.base import Interface, InterfaceValidationError
+from sentry.interfaces.schemas import validate_and_default_interface
 from sentry.interfaces.stacktrace import get_context
 from sentry.utils.safe import trim
 
@@ -42,6 +43,10 @@ class Template(Interface):
 
     @classmethod
     def to_python(cls, data):
+        is_valid, errors = validate_and_default_interface(data, cls.path)
+        if not is_valid:
+            raise InterfaceValidationError("Invalid template")
+
         kwargs = {
             'abs_path': trim(data.get('abs_path', None), 256),
             'filename': trim(data.get('filename', None), 256),


### PR DESCRIPTION
Fixes a regression introduced in #10249 which kept unprocessable template interfaces reported by `raven-python` <= _5.21.0_ (see https://github.com/getsentry/raven-python/commit/157630a9bfd2f6e09c1bc074e68206b086f81ba1).

Fixes [SENTRY-8DT](https://sentry.io/sentry/sentry/issues/774719391)