### PR TITLE
feat(chunk_upload): Indicate maximum file sizes

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -10,10 +10,11 @@ from rest_framework.response import Response
 from django.core.urlresolvers import reverse
 from django.conf import settings
 
-from sentry import options, quotas
+from sentry import options
 from sentry.models import FileBlob
 from sentry.api.bases.organization import (OrganizationEndpoint,
                                            OrganizationReleasePermission)
+from sentry.utils.files import get_max_file_size
 
 
 # The blob size must be a power of two
@@ -54,7 +55,7 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
                 'url': endpoint,
                 'chunkSize': CHUNK_UPLOAD_BLOB_SIZE,
                 'chunksPerRequest': MAX_CHUNKS_PER_REQUEST,
-                'maxFileSize': quotas.get_maximum_file_size(organization),
+                'maxFileSize': get_max_file_size(organization),
                 'maxRequestSize': MAX_REQUEST_SIZE,
                 'concurrency': MAX_CONCURRENCY,
                 'hashAlgorithm': HASH_ALGORITHM,

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -10,7 +10,7 @@ from rest_framework.response import Response
 from django.core.urlresolvers import reverse
 from django.conf import settings
 
-from sentry import options
+from sentry import options, quotas
 from sentry.models import FileBlob
 from sentry.api.bases.organization import (OrganizationEndpoint,
                                            OrganizationReleasePermission)
@@ -54,6 +54,7 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
                 'url': endpoint,
                 'chunkSize': CHUNK_UPLOAD_BLOB_SIZE,
                 'chunksPerRequest': MAX_CHUNKS_PER_REQUEST,
+                'maxFileSize': quotas.get_maximum_file_size(organization),
                 'maxRequestSize': MAX_REQUEST_SIZE,
                 'concurrency': MAX_CONCURRENCY,
                 'hashAlgorithm': HASH_ALGORITHM,

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -75,6 +75,7 @@ default_manager.add('organizations:suggested-commits', OrganizationFeature)  # N
 default_manager.add('organizations:unreleased-changes', OrganizationFeature)  # NOQA
 default_manager.add('organizations:gitlab-integration', OrganizationFeature)  # NOQA
 default_manager.add('organizations:jira-server-integration', OrganizationFeature)  # NOQA
+default_manager.add('organizations:large-debug-files', OrganizationFeature)  # NOQA
 
 # Project scoped features
 default_manager.add('projects:similarity-view', ProjectFeature)  # NOQA

--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -40,6 +40,7 @@ UPLOAD_RETRY_TIME = 60  # 1min
 DEFAULT_BLOB_SIZE = 1024 * 1024  # one mb
 CHUNK_STATE_HEADER = '__state'
 MULTI_BLOB_UPLOAD_CONCURRENCY = 8
+MAX_FILE_SIZE = 2 ** 31  # 2GB is the maximum offset supported by fileblob
 
 
 def enum(**named_values):
@@ -58,7 +59,7 @@ ChunkFileState = enum(
 def _get_size_and_checksum(fileobj):
     size = 0
     checksum = sha1()
-    while 1:
+    while True:
         chunk = fileobj.read(65536)
         if not chunk:
             break
@@ -156,7 +157,7 @@ class FileBlob(Model):
             _ensure_blob_owned(blob)
 
         def _flush_blobs():
-            while 1:
+            while True:
                 try:
                     blob, lock = blobs_to_save.pop()
                 except IndexError:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -37,6 +37,7 @@ register('system.root-api-key', flags=FLAG_PRIORITIZE_DISK)
 register('system.logging-format', default=LoggingFormat.HUMAN, flags=FLAG_NOSTORE)
 # This is used for the chunk upload endpoint
 register('system.upload-url-prefix', flags=FLAG_PRIORITIZE_DISK)
+register('system.maximum-file-size', default=500 * 1024 * 1024, flags=FLAG_PRIORITIZE_DISK)
 
 # Redis
 register(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -37,7 +37,7 @@ register('system.root-api-key', flags=FLAG_PRIORITIZE_DISK)
 register('system.logging-format', default=LoggingFormat.HUMAN, flags=FLAG_NOSTORE)
 # This is used for the chunk upload endpoint
 register('system.upload-url-prefix', flags=FLAG_PRIORITIZE_DISK)
-register('system.maximum-file-size', default=500 * 1024 * 1024, flags=FLAG_PRIORITIZE_DISK)
+register('system.maximum-file-size', default=2 ** 31, flags=FLAG_PRIORITIZE_DISK)
 
 # Redis
 register(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -37,10 +37,7 @@ register('system.root-api-key', flags=FLAG_PRIORITIZE_DISK)
 register('system.logging-format', default=LoggingFormat.HUMAN, flags=FLAG_NOSTORE)
 # This is used for the chunk upload endpoint
 register('system.upload-url-prefix', flags=FLAG_PRIORITIZE_DISK)
-register(
-    'system.chunk-upload.maximum-file-size',
-    default=500 * 1024 * 1024,
-    flags=FLAG_PRIORITIZE_DISK)
+register('system.maximum-file-size', default=500 * 1024 * 1024, flags=FLAG_PRIORITIZE_DISK)
 
 # Redis
 register(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -37,7 +37,10 @@ register('system.root-api-key', flags=FLAG_PRIORITIZE_DISK)
 register('system.logging-format', default=LoggingFormat.HUMAN, flags=FLAG_NOSTORE)
 # This is used for the chunk upload endpoint
 register('system.upload-url-prefix', flags=FLAG_PRIORITIZE_DISK)
-register('system.maximum-file-size', default=500 * 1024 * 1024, flags=FLAG_PRIORITIZE_DISK)
+register(
+    'system.chunk-upload.maximum-file-size',
+    default=500 * 1024 * 1024,
+    flags=FLAG_PRIORITIZE_DISK)
 
 # Redis
 register(

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -137,3 +137,6 @@ class Quota(Service):
 
     def get_event_retention(self, organization):
         return options.get('system.event-retention-days') or None
+
+    def get_maximum_file_size(self, organization):
+        return options.get('system.maximum-file-size')

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -46,7 +46,7 @@ class Quota(Service):
     """
     __all__ = (
         'get_maximum_quota', 'get_organization_quota', 'get_project_quota', 'is_rate_limited',
-        'translate_quota', 'validate', 'refund', 'get_event_retention', 'get_maximum_file_size',
+        'translate_quota', 'validate', 'refund', 'get_event_retention',
     )
 
     def __init__(self, **options):
@@ -137,6 +137,3 @@ class Quota(Service):
 
     def get_event_retention(self, organization):
         return options.get('system.event-retention-days') or None
-
-    def get_maximum_file_size(self, organization):
-        return options.get('system.chunk-upload.maximum-file-size')

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -46,7 +46,7 @@ class Quota(Service):
     """
     __all__ = (
         'get_maximum_quota', 'get_organization_quota', 'get_project_quota', 'is_rate_limited',
-        'translate_quota', 'validate', 'refund', 'get_event_retention',
+        'translate_quota', 'validate', 'refund', 'get_event_retention', 'get_maximum_file_size',
     )
 
     def __init__(self, **options):
@@ -139,4 +139,4 @@ class Quota(Service):
         return options.get('system.event-retention-days') or None
 
     def get_maximum_file_size(self, organization):
-        return options.get('system.maximum-file-size')
+        return options.get('system.chunk-upload.maximum-file-size')

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import, print_function
 import os
 import logging
 
-from sentry import quotas
 from sentry.tasks.base import instrumented_task
+from sentry.utils.files import get_max_file_size
 from sentry.utils.sdk import configure_scope
 
 logger = logging.getLogger(__name__)
@@ -97,8 +97,7 @@ def assemble_file(project, name, checksum, chunks, file_type):
     # Reject all files that exceed the maximum allowed size for this
     # organization. This value cannot be
     file_size = sum(x[2] for x in file_blobs)
-    max_size = quotas.get_maximum_file_size(project.organization)
-    if file_size > max_size:
+    if file_size > get_max_file_size(project.organization):
         set_assemble_status(project, checksum, ChunkFileState.ERROR,
                             detail='File exceeds maximum size')
         return

--- a/src/sentry/utils/files.py
+++ b/src/sentry/utils/files.py
@@ -9,6 +9,9 @@ from __future__ import absolute_import
 
 import zlib
 
+from sentry import features, options
+from sentry.models import MAX_FILE_SIZE
+
 
 def compress_file(fp, level=6):
     compressor = zlib.compressobj(level)
@@ -18,3 +21,11 @@ def compress_file(fp, level=6):
         chunks.append(chunk)
         z_chunks.append(compressor.compress(chunk))
     return (b''.join(z_chunks) + compressor.flush(), b''.join(chunks))
+
+
+def get_max_file_size(organization):
+    """Returns the maximum allowed debug file size for this organization."""
+    if features.has('organizations:large-debug-files', organization):
+        return MAX_FILE_SIZE
+    else:
+        return options.get('system.maximum-file-size')

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -38,7 +38,7 @@ class ChunkUploadTest(APITestCase):
         assert response.data['chunkSize'] == CHUNK_UPLOAD_BLOB_SIZE
         assert response.data['chunksPerRequest'] == MAX_CHUNKS_PER_REQUEST
         assert response.data['maxRequestSize'] == MAX_REQUEST_SIZE
-        assert response.data['maxFileSize'] == options.get('system.maximum-file-size')
+        assert response.data['maxFileSize'] == options.get('system.chunk-upload.maximum-file-size')
         assert response.data['concurrency'] == MAX_CONCURRENCY
         assert response.data['hashAlgorithm'] == HASH_ALGORITHM
         assert response.data['url'] == options.get('system.url-prefix') + self.url

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -38,6 +38,7 @@ class ChunkUploadTest(APITestCase):
         assert response.data['chunkSize'] == CHUNK_UPLOAD_BLOB_SIZE
         assert response.data['chunksPerRequest'] == MAX_CHUNKS_PER_REQUEST
         assert response.data['maxRequestSize'] == MAX_REQUEST_SIZE
+        assert response.data['maxFileSize'] == options.get('system.maximum-file-size')
         assert response.data['concurrency'] == MAX_CONCURRENCY
         assert response.data['hashAlgorithm'] == HASH_ALGORITHM
         assert response.data['url'] == options.get('system.url-prefix') + self.url

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -6,7 +6,7 @@ from django.core.urlresolvers import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile
 
 from sentry import options
-from sentry.models import ApiToken, FileBlob
+from sentry.models import ApiToken, FileBlob, MAX_FILE_SIZE
 from sentry.testutils import APITestCase
 from sentry.api.endpoints.chunk import (MAX_CHUNKS_PER_REQUEST, MAX_CONCURRENCY,
                                         HASH_ALGORITHM, MAX_REQUEST_SIZE,
@@ -38,7 +38,7 @@ class ChunkUploadTest(APITestCase):
         assert response.data['chunkSize'] == CHUNK_UPLOAD_BLOB_SIZE
         assert response.data['chunksPerRequest'] == MAX_CHUNKS_PER_REQUEST
         assert response.data['maxRequestSize'] == MAX_REQUEST_SIZE
-        assert response.data['maxFileSize'] == options.get('system.chunk-upload.maximum-file-size')
+        assert response.data['maxFileSize'] == options.get('system.maximum-file-size')
         assert response.data['concurrency'] == MAX_CONCURRENCY
         assert response.data['hashAlgorithm'] == HASH_ALGORITHM
         assert response.data['url'] == options.get('system.url-prefix') + self.url
@@ -51,6 +51,16 @@ class ChunkUploadTest(APITestCase):
         )
 
         assert response.data['url'] == options.get('system.upload-url-prefix') + self.url
+
+    def test_large_uploads(self):
+        with self.feature('organizations:large-debug-files'):
+            response = self.client.get(
+                self.url,
+                HTTP_AUTHORIZATION=u'Bearer {}'.format(self.token.token),
+                format='json'
+            )
+
+        assert response.data['maxFileSize'] == MAX_FILE_SIZE
 
     def test_wrong_api_token(self):
         token = ApiToken.objects.create(


### PR DESCRIPTION
This adds a limit of 500MB for all symbol uploads except for organizations flagged with feature `organizations:large-debug-files`.

Refs https://github.com/getsentry/sentry-cli/pull/432