### PR TITLE
feat: Prioritize checksum over fingerprints

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -167,7 +167,7 @@ CLIENT_RESERVED_ATTRS = (
     'project', 'errors', 'event_id', 'message', 'checksum', 'culprit', 'fingerprint', 'level',
     'time_spent', 'logger', 'server_name', 'site', 'received', 'timestamp', 'extra', 'modules',
     'tags', 'platform', 'release', 'dist', 'environment', 'transaction', 'key_id', '_meta',
-    'applecrashreport', 'device', 'repos', 'query', 'type',
+    'applecrashreport', 'device', 'repos', 'query', 'type', 'hashes',
 )
 
 # XXX: Must be all lowercase

--- a/src/sentry/event_hashing.py
+++ b/src/sentry/event_hashing.py
@@ -85,13 +85,14 @@ def get_hashes_from_fingerprint_with_reason(event, fingerprint):
     return list(hashes.items())
 
 
-def get_event_hashes(event, no_fingerprint=False):
-    if not no_fingerprint:
-        fingerprint = event.data.get('fingerprint') or ['{{ default }}']
-        return [md5_from_hash(h) for h in get_hashes_from_fingerprint(event, fingerprint)]
+def get_event_hashes(event):
+    # If a checksum is set, use that one.
     checksum = event.data.get('checksum')
     if checksum:
         if HASH_RE.match(checksum):
             return [checksum]
         return [md5_from_hash([checksum]), checksum]
-    return [md5_from_hash(h) for h in get_hashes_for_event(event)]
+
+    # Otherwise go with the new style fingerprint code
+    fingerprint = event.data.get('fingerprint') or ['{{ default }}']
+    return [md5_from_hash(h) for h in get_hashes_from_fingerprint(event, fingerprint)]

--- a/src/sentry/event_hashing.py
+++ b/src/sentry/event_hashing.py
@@ -85,7 +85,7 @@ def get_hashes_from_fingerprint_with_reason(event, fingerprint):
     return list(hashes.items())
 
 
-def get_event_hashes(event):
+def calculate_event_hashes(event):
     # If a checksum is set, use that one.
     checksum = event.data.get('checksum')
     if checksum:

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -913,6 +913,7 @@ class EventManager(object):
 
         data['type'] = event_type.key
         data['metadata'] = event_metadata
+        data['hashes'] = hashes
 
         # index components into ``Event.message``
         # See GH-3248

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -820,7 +820,7 @@ class EventManager(object):
 
         transaction_name = data.get('transaction')
         logger_name = data.get('logger')
-        fingerprint = data.get('fingerprint')
+        fingerprint = data.get('fingerprint') or ['{{ default }}']
         release = data.get('release')
         dist = data.get('dist')
         environment = data.get('environment')
@@ -902,10 +902,13 @@ class EventManager(object):
         # tags are stored as a tuple
         tags = tags.items()
 
-        data['tags'] = tags
-        data['fingerprint'] = fingerprint or ['{{ default }}']
+        # use the default fingerprint if not set
+        fingerprint = fingerprint or ['{{ default }}']
 
-        hashes = event.get_hashes(no_fingerprint=fingerprint is None)
+        data['tags'] = tags
+        data['fingerprint'] = fingerprint
+
+        hashes = event.get_hashes()
 
         event_type = self.get_event_type()
         event_metadata = event_type.get_metadata()

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -902,9 +902,7 @@ class EventManager(object):
         # tags are stored as a tuple
         tags = tags.items()
 
-        # use the default fingerprint if not set
-        fingerprint = fingerprint or ['{{ default }}']
-
+        # Put the actual tags and fingerprint back
         data['tags'] = tags
         data['fingerprint'] = fingerprint
 

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -127,8 +127,13 @@ class Event(Model):
         """
         Returns the calculated hashes for the event.
         """
-        from sentry.event_hashing import get_event_hashes
-        return get_event_hashes(self)
+        from sentry.event_hashing import calculate_event_hashes
+        # If we have hashes stored in the data we use them, otherwise we
+        # fall back to generating new ones from the data
+        hashes = self.data.get('hashes')
+        if hashes is not None:
+            return hashes
+        return calculate_event_hashes(self)
 
     def get_primary_hash(self):
         # TODO: This *might* need to be protected from an IndexError?

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -123,17 +123,12 @@ class Event(Model):
         from sentry.event_manager import get_event_metadata_compat
         return get_event_metadata_compat(self.data, self.message)
 
-    def get_hashes(self, no_fingerprint=False):
+    def get_hashes(self):
         """
         Returns the calculated hashes for the event.
-
-        The `no_fingerprint` parameter disables using the fingerprint value.
-        This is a legacy code path that should be removed but matches old
-        event ingestion behavior.  This will make the code consider the
-        legacy checksum as well before falling back to the default fingerprint.
         """
         from sentry.event_hashing import get_event_hashes
-        return get_event_hashes(self, no_fingerprint)
+        return get_event_hashes(self)
 
     def get_primary_hash(self):
         # TODO: This *might* need to be protected from an IndexError?

--- a/tests/sentry/models/test_event.py
+++ b/tests/sentry/models/test_event.py
@@ -208,13 +208,13 @@ class EventGetLegacyMessageTest(TestCase):
         # Have hashes by default
         hashes = event.get_hashes()
         assert hashes == ['ed076287532e86365e841e92bfc50d8c']
-        event.data.data['hashes'] == ['ed076287532e86365e841e92bfc50d8c']
+        assert event.data.data['hashes'] == ['ed076287532e86365e841e92bfc50d8c']
 
         # if hashes are reset, generate new ones
         event.data.data['hashes'] = None
         hashes = event.get_hashes()
         assert hashes == ['ed076287532e86365e841e92bfc50d8c']
-        event.data.data['hashes'] is None
+        assert event.data.data['hashes'] is None
 
         # Use stored hashes
         event.data.data['hashes'] = ['x']

--- a/tests/sentry/models/test_event.py
+++ b/tests/sentry/models/test_event.py
@@ -208,7 +208,6 @@ class EventGetLegacyMessageTest(TestCase):
         # Have hashes by default
         hashes = event.get_hashes()
         assert hashes == ['ed076287532e86365e841e92bfc50d8c']
-        print(dict(event.data.data))
         event.data.data['hashes'] == ['ed076287532e86365e841e92bfc50d8c']
 
         # if hashes are reset, generate new ones

--- a/tests/sentry/models/test_event.py
+++ b/tests/sentry/models/test_event.py
@@ -5,6 +5,7 @@ import pickle
 from sentry.models import Environment
 from sentry.testutils import TestCase
 from sentry.db.models.fields.node import NodeData
+from sentry.event_manager import EventManager
 
 
 class EventTest(TestCase):
@@ -198,3 +199,24 @@ class EventGetLegacyMessageTest(TestCase):
             }},
         )
         assert event.get_legacy_message() == '<unlabeled event>'
+
+    def test_get_hashes(self):
+        manager = EventManager({'message': 'Hello World!'})
+        manager.normalize()
+        event = manager.save(1)
+
+        # Have hashes by default
+        hashes = event.get_hashes()
+        assert hashes == ['ed076287532e86365e841e92bfc50d8c']
+        print(dict(event.data.data))
+        event.data.data['hashes'] == ['ed076287532e86365e841e92bfc50d8c']
+
+        # if hashes are reset, generate new ones
+        event.data.data['hashes'] = None
+        hashes = event.get_hashes()
+        assert hashes == ['ed076287532e86365e841e92bfc50d8c']
+        event.data.data['hashes'] is None
+
+        # Use stored hashes
+        event.data.data['hashes'] = ['x']
+        assert event.get_hashes() == ['x']


### PR DESCRIPTION
The current code handles `fingerprint` set to `null` and `fingerprint`
set to `{{ default }}` different on event ingestions.  However after
persisting it always stores a fingerprint of `{{ default }}` which means
that both the UI code, snuna and merge/unmerge calculate the wrong
hashes.

This changes the logic to always prefer the checksum if it's set.  We
have seen 11 in 25.000 events to actually send a checksum.  Their
grouping is going to change but this should not have a huge impact on
the overall user experience.