### PR TITLE
feat(integrations) Use jira logo for Jira-Server

### DIFF
--- a/docs-ui/components/issueSyncListElement.stories.js
+++ b/docs-ui/components/issueSyncListElement.stories.js
@@ -57,6 +57,13 @@ storiesOf('Other|IssueSyncListElement', module)
           onOpen={() => {}}
           onClose={() => {}}
         />
+        <IssueSyncListElement
+          integrationType="jira_server"
+          externalIssueLink="jira.atlassian.net/browse/APP-367"
+          externalIssueId="367"
+          onOpen={() => {}}
+          onClose={() => {}}
+        />
       </StyledIssueSyncList>
     ))
   );

--- a/src/sentry/static/sentry/app/components/issueSyncListElement.jsx
+++ b/src/sentry/static/sentry/app/components/issueSyncListElement.jsx
@@ -49,6 +49,7 @@ class IssueSyncElement extends React.Component {
       case 'github_enterprise':
         return <IntegrationIcon src="icon-github" />;
       case 'jira':
+      case 'jira_server':
         return <IntegrationIcon src="icon-jira" />;
       case 'vsts':
         return <IntegrationIcon src="icon-vsts" />;
@@ -68,6 +69,8 @@ class IssueSyncElement extends React.Component {
         return 'GitHub Enterprise';
       case 'vsts':
         return 'Azure DevOps';
+      case 'jira_server':
+        return 'Jira Server';
       default:
         return capitalize(type);
     }


### PR DESCRIPTION
Use the correct icon & casing for Jira-Server. The logo-icon is the same as jira cloud because they are 1 'product' based on atlassian's marketing 🙃 

![screen shot 2018-11-26 at 4 19 31 pm](https://user-images.githubusercontent.com/24086/49042784-19341700-f197-11e8-8f2e-a325bc840730.png)

Refs APP-824