### PR TITLE
fix(forms): Override default if form-global disabled is set

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/jsonForm.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/jsonForm.jsx
@@ -201,6 +201,12 @@ class FormPanel extends React.Component {
             // eslint-disable-next-line no-unused-vars
             let {defaultValue, ...fieldWithoutDefaultValue} = field;
 
+            // Allow the form panel disabled prop to override the fields
+            // disabled prop, with fallback to the fields disabled state.
+            if (disabled === true) {
+              fieldWithoutDefaultValue.disabled = true;
+            }
+
             return (
               <FieldFromConfig
                 access={access}


### PR DESCRIPTION
When passing disabled down at the top level of a form, previously the field specific `disabled` value would override this.

