### PR TITLE
Revert "deps: Bump confluent-kafka to 0.11.6 (#10764)"

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,4 +1,4 @@
-confluent-kafka==0.11.6
+confluent-kafka==0.11.5
 GeoIP==1.3.2
 google-cloud-pubsub>=0.35.4,<0.36.0
 google-cloud-storage>=1.10.0,<1.11.0


### PR DESCRIPTION
This reverts commit 6cec10428236cfbc4ae726c06ad4df6210511143.

The producer in the newer version isn't binding the offset in the delivery callback, which breaks the tests for GH-9159. I'll open an issue in that repository if I can track down the commit that introduced the issue and make sure it wasn't intentional. If it was intentional, I should be able to change the test to accommodate that change (but the test will be slower, which is why I'm avoiding that if possible.)