### PR TITLE
ref(event_manager): Use meta for validation errors

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -181,6 +181,7 @@ def plugin_is_regression(group, event):
 
 
 def process_timestamp(value, meta, current_datetime=None):
+    original_value = value
     if value is None:
         return None
 
@@ -188,7 +189,7 @@ def process_timestamp(value, meta, current_datetime=None):
         try:
             value = datetime.fromtimestamp(float(value))
         except Exception:
-            meta.add_error(EventError.INVALID_DATA, value)
+            meta.add_error(EventError.INVALID_DATA, original_value)
             return None
     elif not isinstance(value, datetime):
         # all timestamps are in UTC, but the marker is optional
@@ -205,18 +206,18 @@ def process_timestamp(value, meta, current_datetime=None):
         try:
             value = datetime.strptime(value, fmt)
         except Exception:
-            meta.add_error(EventError.INVALID_DATA, value)
+            meta.add_error(EventError.INVALID_DATA, original_value)
             return None
 
     if current_datetime is None:
         current_datetime = datetime.now()
 
     if value > current_datetime + ALLOWED_FUTURE_DELTA:
-        meta.add_error(EventError.FUTURE_TIMESTAMP, value.isoformat())
+        meta.add_error(EventError.FUTURE_TIMESTAMP, original_value)
         return None
 
     if value < current_datetime - timedelta(days=30):
-        meta.add_error(EventError.PAST_TIMESTAMP, value.isoformat())
+        meta.add_error(EventError.PAST_TIMESTAMP, original_value)
         return None
 
     return float(value.strftime('%s'))

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -212,11 +212,11 @@ def process_timestamp(value, meta, current_datetime=None):
         current_datetime = datetime.now()
 
     if value > current_datetime + ALLOWED_FUTURE_DELTA:
-        meta.add_error(EventError.FUTURE_TIMESTAMP)
+        meta.add_error(EventError.FUTURE_TIMESTAMP, value.isoformat())
         return None
 
     if value < current_datetime - timedelta(days=30):
-        meta.add_error(EventError.PAST_TIMESTAMP)
+        meta.add_error(EventError.PAST_TIMESTAMP, value.isoformat())
         return None
 
     return float(value.strftime('%s'))

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -774,7 +774,7 @@ def validate_and_default_interface(data, interface, name=None, meta=None,
                     default = schema['properties'][p]['default']
                     data[p] = default() if callable(default) else default
                 else:
-                    meta.add_error("missing required field '%s'" % p)
+                    meta.add_error(EventError.MISSING_ATTRIBUTE, data={'name': p})
                     errors.append({'type': EventError.MISSING_ATTRIBUTE, 'name': p})
 
     validator_errors = list(validator.iter_errors(data))
@@ -788,14 +788,11 @@ def validate_and_default_interface(data, interface, name=None, meta=None,
         is_max = ve.validator.startswith('max')
         if is_max:
             error_type = EventError.VALUE_TOO_LONG
-            error_msg = 'value too long'
         elif key == 'environment':
             error_type = EventError.INVALID_ENVIRONMENT
-            error_msg = 'value cannot contain / or newlines'
         else:
             error_type = EventError.INVALID_DATA
-            error_msg = 'invalid value'
-        meta.enter(key).add_error(error_msg, data[key])
+        meta.enter(key).add_error(error_type, data[key])
         errors.append({'type': error_type, 'name': name or key, 'value': data[key]})
 
         if 'default' in ve.schema:

--- a/src/sentry/utils/meta.py
+++ b/src/sentry/utils/meta.py
@@ -29,6 +29,13 @@ class Meta(object):
         """
         return Meta(self._meta, path=self._path + map(six.text_type, path))
 
+    @property
+    def path(self):
+        """
+        Returns the full path of this meta instance, joined with dots (".").
+        """
+        return '.'.join(self._path)
+
     def raw(self):
         """
         Returns the raw meta tree at the current path, if it exists; otherwise
@@ -147,3 +154,11 @@ class Meta(object):
 
         if value is not None:
             meta['val'] = value
+
+    def __iter__(self):
+        """
+        Iterates all child meta entries that potentially have errors set.
+        """
+        for key in self.raw():
+            if key != '':
+                yield self.enter(key)

--- a/tests/sentry/event_manager/test_process_timestamp.py
+++ b/tests/sentry/event_manager/test_process_timestamp.py
@@ -1,50 +1,52 @@
 from __future__ import absolute_import
 
-import pytest
-
 from datetime import datetime
 
-from sentry.event_manager import InvalidTimestamp, process_timestamp
+from sentry.event_manager import process_timestamp
+from sentry.utils.meta import Meta
+from sentry.testutils import TestCase
 
 
-def test_iso_timestamp():
-    assert process_timestamp(
-        '2012-01-01T10:30:45',
-        current_datetime=datetime(2012, 1, 1, 10, 30, 45),
-    ) == 1325413845.0
+class ProcessTimestampTest(TestCase):
+    def setUp(self):
+        self.meta = Meta()
 
+    def test_iso_timestamp(self):
+        assert process_timestamp(
+            '2012-01-01T10:30:45',
+            self.meta,
+            current_datetime=datetime(2012, 1, 1, 10, 30, 45),
+        ) == 1325413845.0
 
-def test_iso_timestamp_with_ms():
-    assert process_timestamp(
-        '2012-01-01T10:30:45.434',
-        current_datetime=datetime(2012, 1, 1, 10, 30, 45, 434000),
-    ) == 1325413845.0
+    def test_iso_timestamp_with_ms(self):
+        assert process_timestamp(
+            '2012-01-01T10:30:45.434',
+            self.meta,
+            current_datetime=datetime(2012, 1, 1, 10, 30, 45, 434000),
+        ) == 1325413845.0
 
+    def test_timestamp_iso_timestamp_with_Z(self):
+        assert process_timestamp(
+            '2012-01-01T10:30:45Z',
+            self.meta,
+            current_datetime=datetime(2012, 1, 1, 10, 30, 45),
+        ) == 1325413845.0
 
-def test_timestamp_iso_timestamp_with_Z():
-    assert process_timestamp(
-        '2012-01-01T10:30:45Z',
-        current_datetime=datetime(2012, 1, 1, 10, 30, 45),
-    ) == 1325413845.0
+    def test_invalid_timestamp(self):
+        assert process_timestamp('foo', self.meta) is None
+        assert len(self.meta.get_errors()) == 1
 
+    def test_invalid_numeric_timestamp(self):
+        assert process_timestamp('100000000000000000000.0', self.meta) is None
+        assert len(self.meta.get_errors()) == 1
 
-def test_invalid_timestamp():
-    with pytest.raises(InvalidTimestamp):
-        process_timestamp('foo')
+    def test_future_timestamp(self):
+        assert process_timestamp('2052-01-01T10:30:45Z', self.meta) is None
+        assert len(self.meta.get_errors()) == 1
 
-
-def test_invalid_numeric_timestamp():
-    with pytest.raises(InvalidTimestamp):
-        process_timestamp('100000000000000000000.0')
-
-
-def test_future_timestamp():
-    with pytest.raises(InvalidTimestamp):
-        process_timestamp('2052-01-01T10:30:45Z')
-
-
-def test_long_microseconds_value():
-    assert process_timestamp(
-        '2012-01-01T10:30:45.341324Z',
-        current_datetime=datetime(2012, 1, 1, 10, 30, 45),
-    ) == 1325413845.0
+    def test_long_microseconds_value(self):
+        assert process_timestamp(
+            '2012-01-01T10:30:45.341324Z',
+            self.meta,
+            current_datetime=datetime(2012, 1, 1, 10, 30, 45),
+        ) == 1325413845.0

--- a/tests/sentry/event_manager/test_process_timestamp.py
+++ b/tests/sentry/event_manager/test_process_timestamp.py
@@ -34,15 +34,15 @@ class ProcessTimestampTest(TestCase):
 
     def test_invalid_timestamp(self):
         assert process_timestamp('foo', self.meta) is None
-        assert len(self.meta.get_errors()) == 1
+        assert len(list(self.meta.iter_errors())) == 1
 
     def test_invalid_numeric_timestamp(self):
         assert process_timestamp('100000000000000000000.0', self.meta) is None
-        assert len(self.meta.get_errors()) == 1
+        assert len(list(self.meta.iter_errors())) == 1
 
     def test_future_timestamp(self):
         assert process_timestamp('2052-01-01T10:30:45Z', self.meta) is None
-        assert len(self.meta.get_errors()) == 1
+        assert len(list(self.meta.iter_errors())) == 1
 
     def test_long_microseconds_value(self):
         assert process_timestamp(

--- a/tests/sentry/event_manager/test_validate_data.py
+++ b/tests/sentry/event_manager/test_validate_data.py
@@ -169,7 +169,7 @@ def test_reserved_tags():
     assert data["tags"] == [("foo", "bar")]
     assert len(data["errors"]) == 1
     assert data["errors"][0]["type"] == "invalid_data"
-    assert data["errors"][0]["name"] == "tags"
+    assert data["errors"][0]["name"] == "tags.0"
     assert data["errors"][0]["value"] == ("release", "abc123")
 
 
@@ -180,7 +180,7 @@ def test_tag_value():
     assert data["tags"] == [("biz", "baz")]
     assert len(data["errors"]) == 1
     assert data["errors"][0]["type"] == "invalid_data"
-    assert data["errors"][0]["name"] == "tags"
+    assert data["errors"][0]["name"] == "tags.0"
     assert data["errors"][0]["value"] == ("foo", "b\nar")
 
 


### PR DESCRIPTION
Introduces a new `Interface::normalize` class method that is used by `EventManager` to validate and normalize interface payloads. Errors are reported via a `Meta` object that is passed in addition to the actual data. On error, this method always returns `None`. 

```python
meta = Meta(data.get('_meta'))
data['exception'] = Exception.normalize(data.get('exception'), meta=meta.enter('exception'))
```

The contract for `normalize` is:
 - If the input data is `None` or an empty dict, it returns `None` without an error
 - If the input data is not a mapping (dict), it adds an error to meta and returns `None`
 - Otherwise, it returns what ever `_normalize` returns, which defaults to identity

To ease transitioning from `to_python` to `normalize`, it now calls `cls.to_python(data).to_json()` internally. To refactor interfaces, we should:

 - Move normalization logic from `to_python` into `_normalize`
 - Move empty key pruning from `to_json` into `_normalize`
 - Remove overrides of `to_python` and `to_json`

Replaces #10558
#sync-getsentry
