### PR TITLE
feat(jiraserver) Implement issue search and issue link

### DIFF
--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -35,7 +35,7 @@ class JiraCloud(object):
     def cache_prefix(self):
         return 'sentry-jira-2:'
 
-    def request_hook(self, method, path, params, **kwargs):
+    def request_hook(self, method, path, data, params, **kwargs):
         """
         Used by Jira Client to apply the jira-cloud authentication
         """
@@ -56,7 +56,11 @@ class JiraCloud(object):
             **(url_params or {})
         )
         request_spec = kwargs.copy()
-        request_spec.update(dict(method=method, path=path, params=params))
+        request_spec.update(dict(
+            method=method,
+            path=path,
+            data=data,
+            params=params))
         return request_spec
 
 
@@ -88,7 +92,7 @@ class JiraApiClient(ApiClient):
         Use the request_hook method for our specific style of Jira to
         add authentication data and transform parameters.
         """
-        request_spec = self.jira_style.request_hook(method, path, params, **kwargs)
+        request_spec = self.jira_style.request_hook(method, path, data, params, **kwargs)
         return self._request(**request_spec)
 
     def get_cached(self, full_url):

--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -43,6 +43,7 @@ class JiraApiClient(ApiClient):
         super(JiraApiClient, self).__init__(verify_ssl=True)
 
     def request(self, method, path, data=None, params=None, **kwargs):
+        # TODO(mark) make this a method that comes from the client/style
         # handle params that are already part of the path
         url_params = dict(parse_qs(urlsplit(path).query))
         url_params.update(params or {})

--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -77,6 +77,9 @@ class JiraApiClient(ApiClient):
 
     def __init__(self, base_url, jira_style, verify_ssl):
         self.base_url = base_url
+        # `jira_style` encapsulates differences between jira server & jira cloud.
+        # We only support one API version for Jira, but server/cloud require different
+        # authentication mechanisms and caching.
         self.jira_style = jira_style
         super(JiraApiClient, self).__init__(verify_ssl)
 

--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -22,28 +22,23 @@ def md5(*bits):
     return _md5(':'.join((force_bytes(bit, errors='replace') for bit in bits)))
 
 
-class JiraApiClient(ApiClient):
-    COMMENT_URL = '/rest/api/2/issue/%s/comment'
-    STATUS_URL = '/rest/api/2/status'
-    CREATE_URL = '/rest/api/2/issue'
-    ISSUE_URL = '/rest/api/2/issue/%s'
-    META_URL = '/rest/api/2/issue/createmeta'
-    PRIORITIES_URL = '/rest/api/2/priority'
-    PROJECT_URL = '/rest/api/2/project'
-    SEARCH_URL = '/rest/api/2/search/'
-    VERSIONS_URL = '/rest/api/2/project/%s/versions'
-    USERS_URL = '/rest/api/2/user/assignable/search'
-    SERVER_INFO_URL = '/rest/api/2/serverInfo'
-    ASSIGN_URL = '/rest/api/2/issue/%s/assignee'
-    TRANSITION_URL = '/rest/api/2/issue/%s/transitions'
+class JiraCloud(object):
+    """
+    Contains the jira-cloud specifics that a JiraClient needs
+    in order to communicate with jira
+    """
 
-    def __init__(self, base_url, shared_secret):
-        self.base_url = base_url
+    def __init__(self, shared_secret):
         self.shared_secret = shared_secret
-        super(JiraApiClient, self).__init__(verify_ssl=True)
 
-    def request(self, method, path, data=None, params=None, **kwargs):
-        # TODO(mark) make this a method that comes from the client/style
+    @property
+    def cache_prefix(self):
+        return 'sentry-jira-2:'
+
+    def request_hook(self, method, path, params, **kwargs):
+        """
+        Used by Jira Client to apply the jira-cloud authentication
+        """
         # handle params that are already part of the path
         url_params = dict(parse_qs(urlsplit(path).query))
         url_params.update(params or {})
@@ -60,7 +55,38 @@ class JiraApiClient(ApiClient):
             jwt=encoded_jwt,
             **(url_params or {})
         )
-        return self._request(method, path, data=data, params=params, **kwargs)
+        request_spec = kwargs.copy()
+        request_spec.update(dict(method=method, path=path, params=params))
+        return request_spec
+
+
+class JiraApiClient(ApiClient):
+    COMMENT_URL = '/rest/api/2/issue/%s/comment'
+    STATUS_URL = '/rest/api/2/status'
+    CREATE_URL = '/rest/api/2/issue'
+    ISSUE_URL = '/rest/api/2/issue/%s'
+    META_URL = '/rest/api/2/issue/createmeta'
+    PRIORITIES_URL = '/rest/api/2/priority'
+    PROJECT_URL = '/rest/api/2/project'
+    SEARCH_URL = '/rest/api/2/search/'
+    VERSIONS_URL = '/rest/api/2/project/%s/versions'
+    USERS_URL = '/rest/api/2/user/assignable/search'
+    SERVER_INFO_URL = '/rest/api/2/serverInfo'
+    ASSIGN_URL = '/rest/api/2/issue/%s/assignee'
+    TRANSITION_URL = '/rest/api/2/issue/%s/transitions'
+
+    def __init__(self, base_url, jira_style, verify_ssl):
+        self.base_url = base_url
+        self.jira_style = jira_style
+        super(JiraApiClient, self).__init__(verify_ssl)
+
+    def request(self, method, path, data=None, params=None, **kwargs):
+        """
+        Use the request_hook method for our specific style of Jira to
+        add authentication data and transform parameters.
+        """
+        request_spec = self.jira_style.request_hook(method, path, params, **kwargs)
+        return self._request(**request_spec)
 
     def get_cached(self, full_url):
         """
@@ -68,7 +94,7 @@ class JiraApiClient(ApiClient):
         based on URL
         TODO: Implement GET attr in cache as well. (see self.create_meta for example)
         """
-        key = 'sentry-jira-2:' + md5(full_url, self.base_url).hexdigest()
+        key = self.jira_style.cache_prefix + md5(full_url, self.base_url).hexdigest()
         cached_result = cache.get(key)
         if not cached_result:
             cached_result = self.get(full_url)
@@ -80,7 +106,7 @@ class JiraApiClient(ApiClient):
 
     def search_issues(self, query):
         # check if it looks like an issue id
-        if re.search(r'^[A-Za-z]+-\d+$', query):
+        if re.search(r'^[A-Z][A-Z0-9]+-\d+$', query):
             jql = 'id="%s"' % query.replace('"', '\\"')
         else:
             jql = 'text ~ "%s"' % query.replace('"', '\\"')

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -341,6 +341,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         elif field_meta.get('autoCompleteUrl') and \
                 (schema.get('items') == 'user' or schema['type'] == 'user'):
             fieldtype = 'select'
+            # TODO(mark) make this a method that comes from the client/style
             sentry_url = reverse(
                 'sentry-extensions-jira-search', args=[group.organization.slug, self.model.id],
             )

--- a/src/sentry/integrations/jira/search.py
+++ b/src/sentry/integrations/jira/search.py
@@ -10,6 +10,12 @@ from sentry.models import Integration
 
 
 class JiraSearchEndpoint(IntegrationEndpoint):
+    def _get_integration(self, organization, integration_id):
+        return Integration.objects.get(
+            organizations=organization,
+            id=integration_id,
+            provider='jira',
+        )
 
     def _get_formatted_user(self, user):
         display = '%s %s(%s)' % (
@@ -24,11 +30,7 @@ class JiraSearchEndpoint(IntegrationEndpoint):
 
     def get(self, request, organization, integration_id):
         try:
-            integration = Integration.objects.get(
-                organizations=organization,
-                id=integration_id,
-                provider='jira',
-            )
+            integration = self._get_integration(organization, integration_id)
         except Integration.DoesNotExist:
             return Response(status=404)
 

--- a/src/sentry/integrations/jira/search.py
+++ b/src/sentry/integrations/jira/search.py
@@ -10,11 +10,13 @@ from sentry.models import Integration
 
 
 class JiraSearchEndpoint(IntegrationEndpoint):
+    provider = 'jira'
+
     def _get_integration(self, organization, integration_id):
         return Integration.objects.get(
             organizations=organization,
             id=integration_id,
-            provider='jira',
+            provider=self.provider,
         )
 
     def _get_formatted_user(self, user):

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -1,14 +1,22 @@
 from __future__ import absolute_import
 
 import jwt
+import re
 
 from django.core.urlresolvers import reverse
+from django.utils.encoding import force_bytes
+from hashlib import md5 as _md5
 from oauthlib.oauth1 import SIGNATURE_RSA
 from requests_oauthlib import OAuth1
 from six.moves.urllib.parse import parse_qsl
 
 from sentry.integrations.client import ApiClient, ApiError
+from sentry.utils.cache import cache
 from sentry.utils.http import absolute_uri
+
+
+def md5(*bits):
+    return _md5(':'.join((force_bytes(bit, errors='replace') for bit in bits)))
 
 
 class JiraServerSetupClient(ApiClient):
@@ -100,6 +108,12 @@ class JiraServerClient(ApiClient):
     Client for making authenticated requests to JiraServer
     """
 
+    META_URL = '/rest/api/2/issue/createmeta'
+    PRIORITIES_URL = '/rest/api/2/priority'
+    VERSIONS_URL = '/rest/api/2/project/%s/versions'
+    SEARCH_URL = '/rest/api/2/search/'
+    ISSUE_URL = '/rest/api/2/issue/%s'
+
     def __init__(self, installation):
         self.installation = installation
         super(JiraServerClient, self).__init__(self.metadata['verify_ssl'])
@@ -114,6 +128,7 @@ class JiraServerClient(ApiClient):
         return self.installation.model.metadata
 
     def request(self, *args, **kwargs):
+        # TODO(mark) Request hooking could be part of the jira style
         if 'auth' not in kwargs:
             auth_data = self.identity.data
             kwargs['auth'] = OAuth1(
@@ -125,6 +140,19 @@ class JiraServerClient(ApiClient):
                 signature_type='auth_header')
         return self._request(*args, **kwargs)
 
+    def get_cached(self, full_url):
+        """
+        Basic Caching mechanism for requests and responses. It only caches responses
+        based on URL
+        """
+        # TODO(mark) This key needs to come from the 'jira style'
+        key = 'sentry-jira-server:' + md5(full_url, self.base_url).hexdigest()
+        cached_result = cache.get(key)
+        if not cached_result:
+            cached_result = self.get(full_url)
+            cache.set(key, cached_result, 60)
+        return cached_result
+
     def get_valid_statuses(self):
         # TODO Implement this.
         return []
@@ -132,3 +160,29 @@ class JiraServerClient(ApiClient):
     def get_projects_list(self):
         # TODO Implement this
         return []
+
+    def get_create_meta(self, project=None):
+        params = {'expand': 'projects.issuetypes.fields'}
+        if project is not None:
+            params['projectIds'] = project
+        return self.get(
+            self.META_URL,
+            params=params,
+        )
+
+    def get_priorities(self):
+        return self.get_cached(self.PRIORITIES_URL)
+
+    def get_versions(self, project):
+        return self.get_cached(self.VERSIONS_URL % project)
+
+    def search_issues(self, query):
+        # check if it looks like an issue id
+        if re.search(r'^[A-Za-z]+-\d+$', query):
+            jql = 'id="%s"' % query.replace('"', '\\"')
+        else:
+            jql = 'text ~ "%s"' % query.replace('"', '\\"')
+        return self.get(self.SEARCH_URL, params={'jql': jql})
+
+    def get_issue(self, issue_id):
+        return self.get(self.ISSUE_URL % (issue_id,))

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -3,18 +3,12 @@ from __future__ import absolute_import
 import jwt
 
 from django.core.urlresolvers import reverse
-from django.utils.encoding import force_bytes
-from hashlib import md5 as _md5
 from oauthlib.oauth1 import SIGNATURE_RSA
 from requests_oauthlib import OAuth1
 from six.moves.urllib.parse import parse_qsl
 
 from sentry.integrations.client import ApiClient, ApiError
 from sentry.utils.http import absolute_uri
-
-
-def md5(*bits):
-    return _md5(':'.join((force_bytes(bit, errors='replace') for bit in bits)))
 
 
 class JiraServerSetupClient(ApiClient):

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -108,7 +108,7 @@ class JiraServer(object):
     def cache_prefix(self):
         return 'sentry-jira-server:'
 
-    def request_hook(self, method, path, params, **kwargs):
+    def request_hook(self, method, path, data, params, **kwargs):
         """
         Used by Jira Client to apply the jira-server authentication
         Which is RSA signed OAuth1
@@ -123,5 +123,9 @@ class JiraServer(object):
                 signature_type='auth_header')
 
         request_spec = kwargs.copy()
-        request_spec.update(dict(method=method, path=path, params=params))
+        request_spec.update(dict(
+            method=method,
+            path=path,
+            data=data,
+            params=params))
         return request_spec

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -4,6 +4,7 @@ import logging
 import six
 
 from django import forms
+from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_exempt
 from six.moves.urllib.parse import urlparse
@@ -208,6 +209,18 @@ class JiraServerIntegration(JiraIntegration):
             self.default_identity = self.get_default_identity()
 
         return JiraServerClient(self)
+
+    def get_link_issue_config(self, group, **kwargs):
+        fields = super(JiraIntegration, self).get_link_issue_config(group, **kwargs)
+        org = group.organization
+        autocomplete_url = reverse(
+            'sentry-extensions-jiraserver-search', args=[org.slug, self.model.id],
+        )
+        for field in fields:
+            if field['name'] == 'externalIssue':
+                field['url'] = autocomplete_url
+                field['type'] = 'select'
+        return fields
 
 
 class JiraServerIntegrationProvider(IntegrationProvider):

--- a/src/sentry/integrations/jira_server/search.py
+++ b/src/sentry/integrations/jira_server/search.py
@@ -1,14 +1,7 @@
 from __future__ import absolute_import
 
 from sentry.integrations.jira.search import JiraSearchEndpoint
-from sentry.models import Integration
 
 
 class JiraServerSearchEndpoint(JiraSearchEndpoint):
-
-    def _get_integration(self, organization, integration_id):
-        return Integration.objects.get(
-            organizations=organization,
-            id=integration_id,
-            provider='jira_server',
-        )
+    provider = 'jira_server'

--- a/src/sentry/integrations/jira_server/search.py
+++ b/src/sentry/integrations/jira_server/search.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+from sentry.integrations.jira.search import JiraSearchEndpoint
+from sentry.models import Integration
+
+
+class JiraServerSearchEndpoint(JiraSearchEndpoint):
+
+    def _get_integration(self, organization, integration_id):
+        return Integration.objects.get(
+            organizations=organization,
+            id=integration_id,
+            provider='jira_server',
+        )

--- a/src/sentry/integrations/jira_server/urls.py
+++ b/src/sentry/integrations/jira_server/urls.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
+
 from django.conf.urls import patterns, url
 
+from .search import JiraServerSearchEndpoint
 from .webhooks import JiraIssueUpdatedWebhook
 
 urlpatterns = patterns(
@@ -10,4 +12,8 @@ urlpatterns = patterns(
         JiraIssueUpdatedWebhook.as_view(),
         name='sentry-extensions-jiraserver-issue-updated'
     ),
+    url(r'^search/(?P<organization_slug>[^\/]+)/(?P<integration_id>\d+)/$',
+        JiraServerSearchEndpoint.as_view(),
+        name='sentry-extensions-jiraserver-search'
+        ),
 )

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -11,26 +11,9 @@ from sentry.models import (
 )
 from sentry.testutils import IntegrationTestCase
 from sentry.utils import json
+from .testutils import EXAMPLE_PRIVATE_KEY
 
 import responses
-
-PRIVATE_KEY = '''
------BEGIN RSA PRIVATE KEY-----
-MIICWwIBAAKBgQC1cd9t8sA03awggLiX2gjZxyvOVUPJksLly1E662tttTeR3Wm9
-eo6onNeI8HRD+O4wubUp4h4Chc7DtLDmFEPhUZ8Qkwztiifm99Xo3s0nUq4Pygp5
-AU09KXTEPbzHLh1dnXLcxVLmGDE4drh0NWmYsd/Zp7XNIZq2TRQQ3NTdVQIDAQAB
-AoGAFwMyS0eWiR30TssEnn3Q0Y4pSCoYRuCOR4bZ7pcdMPTi72UdnCKHJWt/Cqc0
-l8piq1tiVsWO+NLvvnKUXRoE4cAyrGrpf1F0uP5zYW71SQALc9wwsjDzuj7BZEuK
-fg35JSceLHWE1WtzPDX5Xg20YPnMrA/xe/RwuPjuBH0wSqECQQDizzmKdKCq0ejy
-3OxEto5knqpSEgRcOk0HDsdgjwkwiZJOj5ECV2FKpNHuu2thGy/aDJyLlmUso8j0
-OpvLAzOvAkEAzMwAgGexTxKm8hy3ilvVn9EvhSKjaIakqY4ONK9LZ4zMiDHI0H6C
-FXlwWX7CJM0YVFMubj8SB8rnIuvFDEBMOwJABHtRyMGbNyTktH/XD1iIIcbc2LhQ
-a74fLYeGOws4hEQDpxfBJsmxO3dcSppbedS+slFTepKjNymZW/IYh/9tMwJAEL5E
-9DqGBn7x4y1x2//yESTbC7lvPqZzY+FXS/tg4NBkEGZxkoolPHg3NTnlyXhzGsHK
-M/04DicKipJYA85l7QJAJ3u67qZXecM/oWTtJToBDuyKGHfdY1564+RbyDEjJJRb
-vz4O/8FQQ1sGjdEBMMrRBCHEG8o3/XDTrB97t45TeA==
------END RSA PRIVATE KEY-----
-'''
 
 
 class JiraServerIntegrationTest(IntegrationTestCase):
@@ -68,7 +51,7 @@ class JiraServerIntegrationTest(IntegrationTestCase):
             'url': 'https://jira.example.com/',
             'verify_ssl': False,
             'consumer_key': 'sentry-bot',
-            'private_key': PRIVATE_KEY
+            'private_key': EXAMPLE_PRIVATE_KEY
         }
         resp = self.client.post(self.setup_path, data=data)
         assert resp.status_code == 200
@@ -93,7 +76,7 @@ class JiraServerIntegrationTest(IntegrationTestCase):
             'url': 'https://jira.example.com/',
             'verify_ssl': False,
             'consumer_key': 'sentry-bot',
-            'private_key': PRIVATE_KEY
+            'private_key': EXAMPLE_PRIVATE_KEY
         }
         resp = self.client.post(self.setup_path, data=data)
         assert resp.status_code == 302
@@ -128,7 +111,7 @@ class JiraServerIntegrationTest(IntegrationTestCase):
             'url': 'https://jira.example.com/',
             'verify_ssl': False,
             'consumer_key': 'sentry-bot',
-            'private_key': PRIVATE_KEY
+            'private_key': EXAMPLE_PRIVATE_KEY
         }
         resp = self.client.post(self.setup_path, data=data)
         assert resp.status_code == 302
@@ -153,7 +136,7 @@ class JiraServerIntegrationTest(IntegrationTestCase):
             'url': 'https://jira.example.com/',
             'verify_ssl': False,
             'consumer_key': 'sentry-bot',
-            'private_key': PRIVATE_KEY
+            'private_key': EXAMPLE_PRIVATE_KEY
         }
         resp = self.client.post(self.setup_path, data=data)
         assert resp.status_code == 302
@@ -228,7 +211,7 @@ class JiraServerIntegrationTest(IntegrationTestCase):
         assert identity.data['consumer_key'] == 'sentry-bot'
         assert identity.data['access_token'] == 'valid-token'
         assert identity.data['access_token_secret'] == 'valid-secret'
-        assert identity.data['private_key'] == PRIVATE_KEY
+        assert identity.data['private_key'] == EXAMPLE_PRIVATE_KEY
 
     @responses.activate
     def test_setup_create_webhook(self):

--- a/tests/sentry/integrations/jira_server/test_search.py
+++ b/tests/sentry/integrations/jira_server/test_search.py
@@ -1,0 +1,119 @@
+from __future__ import absolute_import
+
+import responses
+
+from django.core.urlresolvers import reverse
+from exam import fixture
+
+from sentry.models import (
+    Integration,
+    IdentityProvider,
+    Identity,
+    IdentityStatus
+)
+from sentry.testutils import APITestCase
+from .testutils import (
+    EXAMPLE_PRIVATE_KEY,
+    EXAMPLE_ISSUE_SEARCH,
+)
+
+
+class JiraSearchEndpointTest(APITestCase):
+
+    @fixture
+    def integration(self):
+        integration = Integration.objects.create(
+            provider='jira_server',
+            name='Example Jira',
+            metadata={
+                'verify_ssl': False,
+                'base_url': 'https://jira.example.org',
+            }
+        )
+        identity_provider = IdentityProvider.objects.create(
+            external_id='jira.example.org:sentry-test',
+            type='jira_server',
+        )
+        identity = Identity.objects.create(
+            idp=identity_provider,
+            user=self.user,
+            scopes=(),
+            status=IdentityStatus.VALID,
+            data={
+                'consumer_key': 'sentry-test',
+                'private_key': EXAMPLE_PRIVATE_KEY,
+                'access_token': 'access-token',
+                'access_token_secret': 'access-token-secret',
+            }
+        )
+        integration.add_organization(
+            self.organization,
+            self.user,
+            default_auth_id=identity.id)
+        return integration
+
+    @responses.activate
+    def test_get_success_text_search(self):
+        org = self.organization
+        integration = self.integration
+        responses.add(
+            responses.GET,
+            'https://jira.example.org/rest/api/2/search/?jql=text ~ "test"',
+            body=EXAMPLE_ISSUE_SEARCH,
+            content_type='json'
+        )
+
+        self.login_as(self.user)
+        path = reverse('sentry-extensions-jiraserver-search', args=[org.slug, integration.id])
+        resp = self.client.get('%s?field=externalIssue&query=test' % (path,))
+
+        assert resp.status_code == 200
+        assert resp.data == [
+            {'label': '(HSP-1) this is a test issue summary', 'value': 'HSP-1'}
+        ]
+
+    @responses.activate
+    def test_get_success_id_search(self):
+        org = self.organization
+        integration = self.integration
+        responses.add(
+            responses.GET,
+            'https://jira.example.org/rest/api/2/search/?jql=id="HSP-1"',
+            body=EXAMPLE_ISSUE_SEARCH,
+            content_type='json'
+        )
+
+        self.login_as(self.user)
+        path = reverse('sentry-extensions-jiraserver-search', args=[org.slug, integration.id])
+        resp = self.client.get('%s?field=externalIssue&query=HSP-1' % (path,))
+
+        assert resp.status_code == 200
+        assert resp.data == [
+            {'label': '(HSP-1) this is a test issue summary', 'value': 'HSP-1'}
+        ]
+
+    @responses.activate
+    def test_get_network_error(self):
+        org = self.organization
+        integration = self.integration
+        responses.add(
+            responses.GET,
+            'https://jira.example.org/rest/api/2/search/?jql=id="HSP-1"',
+            status=502,
+            body='<p>We are down</p>'
+        )
+
+        self.login_as(self.user)
+        path = reverse('sentry-extensions-jiraserver-search', args=[org.slug, integration.id])
+        resp = self.client.get('%s?field=externalIssue&query=HSP-1' % (path,))
+
+        assert resp.status_code == 400
+
+    def test_get_missing_integration(self):
+        self.login_as(self.user)
+        org = self.organization
+
+        path = reverse('sentry-extensions-jiraserver-search', args=[org.slug, 99])
+        resp = self.client.get('%s?field=externalIssue&query=HSP-1' % (path,))
+
+        assert resp.status_code == 404

--- a/tests/sentry/integrations/jira_server/testutils.py
+++ b/tests/sentry/integrations/jira_server/testutils.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import
+
+EXAMPLE_PRIVATE_KEY = '''
+-----BEGIN RSA PRIVATE KEY-----
+MIICWwIBAAKBgQC1cd9t8sA03awggLiX2gjZxyvOVUPJksLly1E662tttTeR3Wm9
+eo6onNeI8HRD+O4wubUp4h4Chc7DtLDmFEPhUZ8Qkwztiifm99Xo3s0nUq4Pygp5
+AU09KXTEPbzHLh1dnXLcxVLmGDE4drh0NWmYsd/Zp7XNIZq2TRQQ3NTdVQIDAQAB
+AoGAFwMyS0eWiR30TssEnn3Q0Y4pSCoYRuCOR4bZ7pcdMPTi72UdnCKHJWt/Cqc0
+l8piq1tiVsWO+NLvvnKUXRoE4cAyrGrpf1F0uP5zYW71SQALc9wwsjDzuj7BZEuK
+fg35JSceLHWE1WtzPDX5Xg20YPnMrA/xe/RwuPjuBH0wSqECQQDizzmKdKCq0ejy
+3OxEto5knqpSEgRcOk0HDsdgjwkwiZJOj5ECV2FKpNHuu2thGy/aDJyLlmUso8j0
+OpvLAzOvAkEAzMwAgGexTxKm8hy3ilvVn9EvhSKjaIakqY4ONK9LZ4zMiDHI0H6C
+FXlwWX7CJM0YVFMubj8SB8rnIuvFDEBMOwJABHtRyMGbNyTktH/XD1iIIcbc2LhQ
+a74fLYeGOws4hEQDpxfBJsmxO3dcSppbedS+slFTepKjNymZW/IYh/9tMwJAEL5E
+9DqGBn7x4y1x2//yESTbC7lvPqZzY+FXS/tg4NBkEGZxkoolPHg3NTnlyXhzGsHK
+M/04DicKipJYA85l7QJAJ3u67qZXecM/oWTtJToBDuyKGHfdY1564+RbyDEjJJRb
+vz4O/8FQQ1sGjdEBMMrRBCHEG8o3/XDTrB97t45TeA==
+-----END RSA PRIVATE KEY-----
+'''
+
+EXAMPLE_ISSUE_SEARCH = '''
+{
+  "expand": "names,schema",
+  "startAt": 0,
+  "maxResults": 50,
+  "total": 1,
+  "issues": [
+    {
+      "expand": "",
+      "id": "10001",
+      "self": "http://www.example.com/jira/rest/api/2/issue/10001",
+      "key": "HSP-1",
+      "fields": {
+        "summary": "this is a test issue summary"
+      }
+    }
+  ],
+  "warningMessages": [
+    "The value 'splat' does not exist for the field 'Foo'."
+  ]
+}
+'''


### PR DESCRIPTION
By implementing issue search we can enable linking to existing issues for jira-server.

~~There is a bunch of copy-paste right now. I'm planning on refactoring that away in an upcoming pull request. I wanted to keep this and that refactoring separate so that each change is easier to review/grok.~~

I've refactored the Jira-Cloud integration a bit to extract out the bits that vary between server & cloud. The biggest delta is how authentication is handled on each request. Jira cloud uses JWTs while Jira Server uses Oauth1.

Refs APP-574