### PR TITLE
fix(tagstore): Fix merging when corresponding GroupTagValue row doesn…

### DIFF
--- a/src/sentry/tagstore/legacy/models/grouptagvalue.py
+++ b/src/sentry/tagstore/legacy/models/grouptagvalue.py
@@ -50,7 +50,7 @@ class GroupTagValue(Model):
     def merge_counts(self, new_group):
         try:
             with transaction.atomic(using=router.db_for_write(GroupTagValue)):
-                new_obj = GroupTagValue.objects.get(
+                new_obj, _ = GroupTagValue.objects.get_or_create(
                     group_id=new_group.id,
                     key=self.key,
                     value=self.value,

--- a/src/sentry/tagstore/v2/models/grouptagvalue.py
+++ b/src/sentry/tagstore/v2/models/grouptagvalue.py
@@ -124,7 +124,7 @@ class GroupTagValue(Model):
     def merge_counts(self, new_group):
         try:
             with transaction.atomic(using=router.db_for_write(GroupTagValue)):
-                new_obj = GroupTagValue.objects.get(
+                new_obj, _ = GroupTagValue.objects.get_or_create(
                     group_id=new_group.id,
                     project_id=new_group.project_id,
                     _key_id=self._key_id,


### PR DESCRIPTION
…'t already exist

Fixes SENTRY-84V

https://sentry.io/sentry/sentry/issues/753585356/

I didn't go wild on tests because v2 is going away soon.