### PR TITLE
feat(api): Add inCommit resolution mutation on issues

### DIFF
--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -22,15 +22,15 @@ from sentry.api.serializers.models.group import (
 from sentry.constants import DEFAULT_SORT_OPTION
 from sentry.db.models.query import create_or_update
 from sentry.models import (
-    Activity, Environment, Group, GroupAssignee, GroupBookmark, GroupHash, GroupResolution,
+    Activity, Commit, Environment, Group, GroupAssignee, GroupBookmark, GroupLink, GroupHash, GroupResolution,
     GroupSeen, GroupShare, GroupSnooze, GroupStatus, GroupSubscription, GroupSubscriptionReason,
-    GroupTombstone, Release, TOMBSTONE_FIELDS_FROM_GROUP, UserOption, User, Team
+    GroupTombstone, Release, Repository, TOMBSTONE_FIELDS_FROM_GROUP, UserOption, User, Team
 )
 from sentry.models.event import Event
 from sentry.models.group import looks_like_short_id
 from sentry.receivers import DEFAULT_SAVED_SEARCHES
 from sentry.search.utils import InvalidQuery, parse_query
-from sentry.signals import advanced_search, issue_ignored, issue_resolved_in_release, issue_deleted
+from sentry.signals import advanced_search, issue_ignored, issue_resolved_in_release, issue_deleted, resolved_with_commit
 from sentry.tasks.deletion import delete_groups
 from sentry.tasks.integrations import kick_off_status_syncs
 from sentry.tasks.merge import merge_groups
@@ -93,9 +93,43 @@ class ValidationError(Exception):
     pass
 
 
+class InCommitValidator(serializers.Serializer):
+    commit = serializers.CharField()
+    repository = serializers.CharField()
+
+    def validate_repository(self, attrs, source):
+        value = attrs[source]
+        project = self.context['project']
+        try:
+            attrs[source] = Repository.objects.get(
+                organization_id=project.organization_id,
+                name=value,
+            )
+        except Repository.DoesNotExist:
+            raise serializers.ValidationError(
+                'Unable to find the given repository.'
+            )
+        return attrs
+
+    def validate(self, attrs):
+        repository = attrs['repository']
+        try:
+            commit = Commit.objects.get(
+                repository_id=repository.id,
+                key=attrs['commit'],
+            )
+            attrs['commit'] = commit
+        except Commit.DoesNotExist:
+            raise serializers.ValidationError({
+                'commit': 'Unable to find the given commit.',
+            })
+        return attrs
+
+
 class StatusDetailsValidator(serializers.Serializer):
     inNextRelease = serializers.BooleanField()
     inRelease = serializers.CharField()
+    inCommit = InCommitValidator()
     ignoreDuration = serializers.IntegerField()
     ignoreCount = serializers.IntegerField()
     # in minutes, max of one week
@@ -134,10 +168,14 @@ class StatusDetailsValidator(serializers.Serializer):
 
     def validate_inNextRelease(self, attrs, source):
         project = self.context['project']
-        if not Release.objects.filter(
-            projects=project,
-            organization_id=project.organization_id,
-        ).exists():
+        try:
+            attrs[source] = Release.objects.filter(
+                projects=project,
+                organization_id=project.organization_id,
+            ).extra(select={
+                'sort': 'COALESCE(date_released, date_added)',
+            }).order_by('-sort')[0]
+        except IndexError:
             raise serializers.ValidationError(
                 'No release data present in the system to form a basis for \'Next Release\''
             )
@@ -418,6 +456,11 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
         :param string status: the new status for the issues.  Valid values
                               are ``"resolved"``, ``"resolvedInNextRelease"``,
                               ``"unresolved"``, and ``"ignored"``.
+        :param map statusDetails: additional details about the resolution.
+                                  Valid values are ``"inRelease"``, ``"inNextRelease"``,
+                                  ``"inCommit"``,  ``"ignoreDuration"``, ``"ignoreCount"``,
+                                  ``"ignoreWindow"``, ``"ignoreUserCount"``, and
+                                  ``"ignoreUserWindow"``.
         :param int ignoreDuration: the number of minutes to ignore this issue.
         :param boolean isPublic: sets the issue to public or private.
         :param boolean merge: allows to merge or unmerge different issues.
@@ -512,9 +555,14 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
 
         statusDetails = result.pop('statusDetails', result)
         status = result.get('status')
+        release = None
+        commit = None
+
         if status in ('resolved', 'resolvedInNextRelease'):
             if status == 'resolvedInNextRelease' or statusDetails.get('inNextRelease'):
-                release = Release.objects.filter(
+                # XXX(dcramer): this code is copied between the inNextRelease validator
+                # due to the status vs statusDetails field
+                release = statusDetails.get('inNextRelease') or Release.objects.filter(
                     projects=project,
                     organization_id=project.organization_id,
                 ).extra(select={
@@ -546,8 +594,22 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                 res_type = GroupResolution.Type.in_release
                 res_type_str = 'in_release'
                 res_status = GroupResolution.Status.resolved
+            elif statusDetails.get('inCommit'):
+                in_commit = statusDetails['inCommit']
+                commit = in_commit['commit']
+                activity_type = Activity.SET_RESOLVED_IN_COMMIT
+                activity_data = {
+                    'commit': in_commit['commit'].id,
+                }
+                status_details = {
+                    'inCommit': {
+                        'commit': in_commit['commit'].key,
+                        'repository': in_commit['repository'].name,
+                    },
+                    'actor': serialize(extract_lazy_object(request.user), request.user),
+                }
+                res_type_str = 'in_commit'
             else:
-                release = None
                 res_type_str = 'now'
                 activity_type = Activity.SET_RESOLVED
                 activity_data = {}
@@ -555,8 +617,29 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
 
             now = timezone.now()
 
+            # if we've specified a commit, let's see if its already been released
+            # this will allow us to associate the resolution to a release as if we
+            # were simply using 'inRelease' above
+            # Note: this is different than the way commit resolution works on deploy
+            # creation, as a given deploy is connected to an explicit release, and
+            # in this case we're simply choosing the most recent release which contains
+            # the commit.
+            if commit and not release:
+                try:
+                    release = Release.objects.filter(
+                        projects=project,
+                        releasecommit__commit=commit,
+                    ).extra(select={
+                        'sort': 'COALESCE(date_released, date_added)',
+                    }).order_by('-sort')[0]
+                    res_type = GroupResolution.Type.in_release
+                    res_status = GroupResolution.Status.resolved
+                except IndexError:
+                    release = None
+
             for group in group_list:
                 with transaction.atomic():
+                    resolution = None
                     if release:
                         resolution_params = {
                             'release': release,
@@ -572,24 +655,35 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                         if not created:
                             resolution.update(
                                 datetime=timezone.now(), **resolution_params)
+
+                    if commit:
+                        GroupLink.objects.create(
+                            group_id=group.id,
+                            project_id=group.project_id,
+                            linked_type=GroupLink.LinkedType.commit,
+                            relationship=GroupLink.Relationship.resolves,
+                            linked_id=commit.id,
+                        )
+
+                    # TODO(dcramer): we'd like this to mark things as resolved, but the current
+                    # behavior does not yet do this due to some issues with 'resolved in commit'
+                    if not commit or release:
+                        affected = Group.objects.filter(
+                            id=group.id,
+                        ).update(
+                            status=GroupStatus.RESOLVED,
+                            resolved_at=now,
+                        )
+                        if not resolution:
+                            created = affected
+
+                        group.status = GroupStatus.RESOLVED
+                        group.resolved_at = now
                     else:
-                        resolution = None
-
-                    affected = Group.objects.filter(
-                        id=group.id,
-                    ).update(
-                        status=GroupStatus.RESOLVED,
-                        resolved_at=now,
-                    )
-                    if not resolution:
-                        created = affected
-
-                    group.status = GroupStatus.RESOLVED
-                    group.resolved_at = now
+                        created = True
 
                     self._subscribe_and_assign_issue(
                         acting_user, group, result)
-
                     if created:
                         activity = Activity.objects.create(
                             project=group.project,
@@ -604,13 +698,21 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                         if not is_bulk:
                             activity.send_notification()
 
-                issue_resolved_in_release.send_robust(
-                    group=group,
-                    project=project,
-                    user=acting_user,
-                    resolution_type=res_type_str,
-                    sender=self.__class__,
-                )
+                if release:
+                    issue_resolved_in_release.send_robust(
+                        group=group,
+                        project=project,
+                        user=acting_user,
+                        resolution_type=res_type_str,
+                        sender=type(self),
+                    )
+                elif commit:
+                    resolved_with_commit.send_robust(
+                        organization_id=group.project.organization_id,
+                        user=request.user,
+                        group=group,
+                        sender=type(self),
+                    )
 
                 kick_off_status_syncs.apply_async(kwargs={
                     'project_id': group.project_id,

--- a/tests/sentry/api/endpoints/test_project_group_index.py
+++ b/tests/sentry/api/endpoints/test_project_group_index.py
@@ -13,7 +13,7 @@ from sentry import tagstore
 from sentry.models import (
     Activity, ApiToken, EventMapping, Group, GroupAssignee, GroupBookmark, GroupHash,
     GroupLink, GroupResolution, GroupSeen, GroupShare, GroupSnooze, GroupStatus, GroupSubscription,
-    GroupTombstone, ExternalIssue, Integration, Release, UserOption, OrganizationIntegration
+    GroupTombstone, ExternalIssue, Integration, Release, OrganizationIntegration, UserOption
 )
 from sentry.models.event import Event
 from sentry.testutils import APITestCase
@@ -957,6 +957,174 @@ class GroupUpdateTest(APITestCase):
             type=Activity.SET_RESOLVED_IN_RELEASE,
         )
         assert activity.data['version'] == ''
+
+    def test_set_resolved_in_explicit_commit_unreleased(self):
+        repo = self.create_repo(
+            project=self.project,
+            name=self.project.name,
+        )
+        commit = self.create_commit(
+            project=self.project,
+            repo=repo,
+        )
+        group = self.create_group(
+            checksum='a' * 32,
+            status=GroupStatus.UNRESOLVED,
+        )
+
+        self.login_as(user=self.user)
+
+        url = u'{url}?id={group.id}'.format(
+            url=self.path,
+            group=group,
+        )
+        response = self.client.put(
+            url,
+            data={
+                'status': 'resolved',
+                'statusDetails': {
+                    'inCommit': {
+                        'commit': commit.key,
+                        'repository': repo.name,
+                    },
+                },
+            },
+            format='json'
+        )
+        assert response.status_code == 200
+        assert response.data['status'] == 'resolved'
+        assert response.data['statusDetails']['inCommit'] == {
+            'commit': commit.key,
+            'repository': repo.name,
+        }
+        assert response.data['statusDetails']['actor']['id'] == six.text_type(self.user.id)
+
+        group = Group.objects.get(id=group.id)
+        # TODO(dcramer): we'd like this to mark things as resolved, but the current
+        # behavior does not yet do this due to some issues with 'resolved in commit'
+        assert group.status != GroupStatus.RESOLVED
+
+        link = GroupLink.objects.get(group_id=group.id)
+        assert link.linked_type == GroupLink.LinkedType.commit
+        assert link.relationship == GroupLink.Relationship.resolves
+        assert link.linked_id == commit.id
+
+        assert GroupSubscription.objects.filter(
+            user=self.user,
+            group=group,
+            is_active=True,
+        ).exists()
+
+        activity = Activity.objects.get(
+            group=group,
+            type=Activity.SET_RESOLVED_IN_COMMIT,
+        )
+        assert activity.data['commit'] == commit.id
+
+    def test_set_resolved_in_explicit_commit_released(self):
+        release = self.create_release(
+            project=self.project,
+        )
+        repo = self.create_repo(
+            project=self.project,
+            name=self.project.name,
+        )
+        commit = self.create_commit(
+            project=self.project,
+            repo=repo,
+            release=release,
+        )
+
+        group = self.create_group(
+            checksum='a' * 32,
+            status=GroupStatus.UNRESOLVED,
+        )
+
+        self.login_as(user=self.user)
+
+        url = u'{url}?id={group.id}'.format(
+            url=self.path,
+            group=group,
+        )
+        response = self.client.put(
+            url,
+            data={
+                'status': 'resolved',
+                'statusDetails': {
+                    'inCommit': {
+                        'commit': commit.key,
+                        'repository': repo.name,
+                    },
+                },
+            },
+            format='json'
+        )
+        assert response.status_code == 200
+        assert response.data['status'] == 'resolved'
+        assert response.data['statusDetails']['inCommit'] == {
+            'commit': commit.key,
+            'repository': repo.name,
+        }
+        assert response.data['statusDetails']['actor']['id'] == six.text_type(self.user.id)
+
+        group = Group.objects.get(id=group.id)
+        assert group.status == GroupStatus.RESOLVED
+
+        link = GroupLink.objects.get(group_id=group.id)
+        assert link.project_id == self.project.id
+        assert link.linked_type == GroupLink.LinkedType.commit
+        assert link.relationship == GroupLink.Relationship.resolves
+        assert link.linked_id == commit.id
+
+        assert GroupSubscription.objects.filter(
+            user=self.user,
+            group=group,
+            is_active=True,
+        ).exists()
+
+        activity = Activity.objects.get(
+            group=group,
+            type=Activity.SET_RESOLVED_IN_COMMIT,
+        )
+        assert activity.data['commit'] == commit.id
+
+        resolution = GroupResolution.objects.get(
+            group=group,
+        )
+        assert resolution.type == GroupResolution.Type.in_release
+        assert resolution.status == GroupResolution.Status.resolved
+
+    def test_set_resolved_in_explicit_commit_missing(self):
+        repo = self.create_repo(
+            project=self.project,
+            name=self.project.name,
+        )
+        group = self.create_group(
+            checksum='a' * 32,
+            status=GroupStatus.UNRESOLVED,
+        )
+
+        self.login_as(user=self.user)
+
+        url = u'{url}?id={group.id}'.format(
+            url=self.path,
+            group=group,
+        )
+        response = self.client.put(
+            url,
+            data={
+                'status': 'resolved',
+                'statusDetails': {
+                    'inCommit': {
+                        'commit': 'a' * 40,
+                        'repository': repo.name,
+                    },
+                },
+            },
+            format='json'
+        )
+        assert response.status_code == 400
+        assert response.data['statusDetails'][0]['inCommit'][0]['commit']
 
     def test_set_unresolved(self):
         release = self.create_release(project=self.project, version='abc')


### PR DESCRIPTION
This adds the ability to bulk mutate issues with a "resolved in commit" status. It's
identical to marking it as such via a commit message, which means its limitations are
also identical.

```
{
  "status": "resolved",
  "statusDetails": {
    "inCommit": {
      "commit": "abcdefg",
      "repository": "repo/name"
    }
  }
}
```