### PR TITLE
feat: Discover and event stream share multi project selection

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/globalSelection.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/globalSelection.jsx
@@ -2,6 +2,7 @@
 
 import {isInteger} from 'lodash';
 import GlobalSelectionActions from 'app/actions/globalSelectionActions';
+import sdk from 'app/utils/sdk';
 
 /**
  * Updates global project selection
@@ -10,6 +11,9 @@ import GlobalSelectionActions from 'app/actions/globalSelectionActions';
  */
 export function updateProjects(projects) {
   if (!isProjectsValid(projects)) {
+    sdk.captureException('Invalid projects selected', {
+      extra: {projects},
+    });
     return;
   }
 

--- a/src/sentry/static/sentry/app/actionCreators/globalSelection.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/globalSelection.jsx
@@ -11,7 +11,7 @@ import sdk from 'app/utils/sdk';
  */
 export function updateProjects(projects) {
   if (!isProjectsValid(projects)) {
-    sdk.captureException('Invalid projects selected', {
+    sdk.captureException(new Error('Invalid projects selected'), {
       extra: {projects},
     });
     return;

--- a/src/sentry/static/sentry/app/actionCreators/globalSelection.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/globalSelection.jsx
@@ -1,0 +1,21 @@
+/*eslint no-use-before-define: ["error", { "functions": false }]*/
+
+import {isInteger} from 'lodash';
+import GlobalSelectionActions from 'app/actions/globalSelectionActions';
+
+/**
+ * Updates global project selection
+ *
+ * @param {Number[]} projects List of project ids
+ */
+export function updateProjects(projects) {
+  if (!isProjectsValid(projects)) {
+    return;
+  }
+
+  GlobalSelectionActions.updateProjects(projects);
+}
+
+function isProjectsValid(projects) {
+  return Array.isArray(projects) && projects.every(project => isInteger(project));
+}

--- a/src/sentry/static/sentry/app/actions/globalSelectionActions.jsx
+++ b/src/sentry/static/sentry/app/actions/globalSelectionActions.jsx
@@ -1,0 +1,3 @@
+import Reflux from 'reflux';
+
+export default Reflux.createActions(['updateProjects']);

--- a/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
+++ b/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
@@ -1,0 +1,27 @@
+import Reflux from 'reflux';
+
+import GlobalSelectionActions from 'app/actions/globalSelectionActions';
+
+/**
+ * Store for global selections
+ * Currently stores active project ids for Discover and EventStream
+ */
+const GlobalSelectionStore = Reflux.createStore({
+  init() {
+    this.selection = {
+      projects: [],
+    };
+    this.listenTo(GlobalSelectionActions.updateProjects, this.updateProjects);
+  },
+
+  get() {
+    return this.selection;
+  },
+
+  updateProjects(projects = []) {
+    this.selection.projects = projects;
+    this.trigger(this.selection);
+  },
+});
+
+export default GlobalSelectionStore;

--- a/src/sentry/static/sentry/app/utils/withGlobalSelection.jsx
+++ b/src/sentry/static/sentry/app/utils/withGlobalSelection.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import Reflux from 'reflux';
+import createReactClass from 'create-react-class';
+
+import getDisplayName from 'app/utils/getDisplayName';
+import GlobalSelectionStore from 'app/stores/globalSelectionStore';
+
+/**
+ * Higher order component that uses GlobalSelectionStore and provides the
+ * active project
+ */
+const withGlobalSelection = WrappedComponent =>
+  createReactClass({
+    displayName: `withGlobalSelection(${getDisplayName(WrappedComponent)})`,
+    mixins: [Reflux.listenTo(GlobalSelectionStore, 'onUpdate')],
+    getInitialState() {
+      return {
+        selection: GlobalSelectionStore.get(),
+      };
+    },
+
+    onUpdate() {
+      this.setState({
+        selection: GlobalSelectionStore.get(),
+      });
+    },
+    render() {
+      return <WrappedComponent {...this.props} selection={this.state.selection} />;
+    },
+  });
+
+export default withGlobalSelection;

--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -5,7 +5,9 @@ import {browserHistory} from 'react-router';
 
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {getUtcDateString} from 'app/utils/dates';
+import {updateProjects} from 'app/actionCreators/globalSelection';
 import {t, tct} from 'app/locale';
+
 import HeaderItemPosition from 'app/components/organizations/headerItemPosition';
 import HeaderSeparator from 'app/components/organizations/headerSeparator';
 import MultipleProjectSelector from 'app/components/organizations/multipleProjectSelector';
@@ -77,7 +79,13 @@ export default class OrganizationDiscover extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const {queryBuilder, location: {search}, savedQuery, isEditingSavedQuery} = nextProps;
+    const {
+      queryBuilder,
+      location: {search},
+      savedQuery,
+      isEditingSavedQuery,
+      params,
+    } = nextProps;
     const currentSearch = this.props.location.search;
     const {resultManager} = this.state;
 
@@ -96,7 +104,7 @@ export default class OrganizationDiscover extends React.Component {
     }
 
     // Clear data only if location.search is empty (reset has been called)
-    if (!search) {
+    if (!search && !params.savedQueryId) {
       const newQuery = getQueryFromQueryString(search);
       queryBuilder.reset(newQuery);
       resultManager.reset();
@@ -105,6 +113,11 @@ export default class OrganizationDiscover extends React.Component {
       });
     }
   }
+
+  updateProjects = val => {
+    this.updateField('projects', val);
+    updateProjects(val);
+  };
 
   updateField = (field, value) => {
     this.props.queryBuilder.updateField(field, value);
@@ -344,7 +357,7 @@ export default class OrganizationDiscover extends React.Component {
               value={currentQuery.projects}
               organization={organization}
               projects={projects}
-              onChange={val => this.updateField('projects', val)}
+              onChange={this.updateProjects}
               onUpdate={this.runQuery}
             />
           </HeaderItemPosition>
@@ -378,7 +391,7 @@ export default class OrganizationDiscover extends React.Component {
                 <div>
                   <HeadingContainer>
                     <Heading>
-                      {t('Discover')}  <BetaTag />
+                      {t('Discover')} <BetaTag />
                     </Heading>
                   </HeadingContainer>
                 </div>

--- a/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {Flex} from 'grid-emotion';
 import {browserHistory} from 'react-router';
 import DocumentTitle from 'react-document-title';
 import jQuery from 'jquery';
 import SentryTypes from 'app/sentryTypes';
+
+import {updateProjects} from 'app/actionCreators/globalSelection';
+import withGlobalSelection from 'app/utils/withGlobalSelection';
 
 import Discover from './discover';
 import createQueryBuilder from './queryBuilder';
@@ -17,9 +21,13 @@ import {
 
 import {DiscoverWrapper} from './styles';
 
-export default class OrganizationDiscoverContainer extends React.Component {
+class OrganizationDiscoverContainer extends React.Component {
   static contextTypes = {
     organization: SentryTypes.Organization,
+  };
+
+  static propTypes = {
+    selection: PropTypes.object.isRequired,
   };
 
   constructor(props, context) {
@@ -34,7 +42,16 @@ export default class OrganizationDiscoverContainer extends React.Component {
     const {search} = props.location;
     const {organization} = context;
 
-    this.queryBuilder = createQueryBuilder(getQueryFromQueryString(search), organization);
+    const query = getQueryFromQueryString(search);
+    if (query.hasOwnProperty('projects')) {
+      // Update global store with projects from querystring
+      updateProjects(query.projects);
+    } else {
+      // Update query with global projects
+      query.projects = props.selection.projects;
+    }
+
+    this.queryBuilder = createQueryBuilder(query, organization);
   }
 
   componentDidMount() {
@@ -52,6 +69,11 @@ export default class OrganizationDiscoverContainer extends React.Component {
   componentWillReceiveProps(nextProps) {
     if (!nextProps.params.savedQueryId) {
       this.setState({savedQuery: null});
+      // Reset querybuilder if we're switching from a saved query
+      if (this.props.params.savedQueryId) {
+        const projects = nextProps.selection.projects;
+        this.queryBuilder.reset({projects});
+      }
       return;
     }
 
@@ -156,3 +178,6 @@ export default class OrganizationDiscoverContainer extends React.Component {
     );
   }
 }
+
+export default withGlobalSelection(OrganizationDiscoverContainer);
+export {OrganizationDiscoverContainer};

--- a/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
@@ -17,6 +17,8 @@ import MultipleProjectSelector from 'app/components/organizations/multipleProjec
 import SentryTypes from 'app/sentryTypes';
 import TimeRangeSelector from 'app/components/organizations/timeRangeSelector';
 import space from 'app/styles/space';
+import {updateProjects} from 'app/actionCreators/globalSelection';
+import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 
 import {getParams} from './utils/getParams';
@@ -59,7 +61,7 @@ class OrganizationEventsContainer extends React.Component {
   static getStateFromRouter(props) {
     const {query} = props.router.location;
     const hasAbsolute = !!query.start && !!query.end;
-    let project = [];
+    let project = props.selection.projects;
     let environment = query.environment || [];
 
     if (defined(query.project) && Array.isArray(query.project)) {
@@ -115,6 +117,10 @@ class OrganizationEventsContainer extends React.Component {
     this.state = {};
   }
 
+  componentDidMount() {
+    this.handleUpdateProjects();
+  }
+
   updateParams = obj => {
     const {router} = this.props;
     // Reset cursor when changing parameters
@@ -150,6 +156,7 @@ class OrganizationEventsContainer extends React.Component {
     this.setState({
       project: projects,
     });
+    updateProjects(projects);
   };
 
   handleChangeEnvironments = environments => {
@@ -234,7 +241,9 @@ class OrganizationEventsContainer extends React.Component {
     );
   }
 }
-export default withRouter(withOrganization(OrganizationEventsContainer));
+export default withRouter(
+  withOrganization(withGlobalSelection(OrganizationEventsContainer))
+);
 export {OrganizationEventsContainer};
 
 const OrganizationEventsContent = styled(Flex)`

--- a/tests/js/spec/actionCreators/globalSelection.spec.jsx
+++ b/tests/js/spec/actionCreators/globalSelection.spec.jsx
@@ -1,0 +1,21 @@
+import {updateProjects} from 'app/actionCreators/globalSelection';
+import GlobalSelectionActions from 'app/actions/globalSelectionActions';
+
+describe('GlobalSelection ActionCreators', function() {
+  let updateProjectsMock;
+  beforeEach(function() {
+    updateProjectsMock = GlobalSelectionActions.updateProjects = jest.fn();
+  });
+
+  describe('updateProjects()', function() {
+    it('updates', function() {
+      updateProjects([1, 2]);
+      expect(updateProjectsMock).toHaveBeenCalledWith([1, 2]);
+    });
+
+    it('does not update invalid projects', function() {
+      updateProjects(['1']);
+      expect(updateProjectsMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/js/spec/stores/globalSelectionStore.spec.jsx
+++ b/tests/js/spec/stores/globalSelectionStore.spec.jsx
@@ -1,0 +1,13 @@
+import GlobalSelectionStore from 'app/stores/globalSelectionStore';
+
+describe('GlobalSelectionStore', function() {
+  it('get()', function() {
+    expect(GlobalSelectionStore.get()).toEqual({projects: []});
+  });
+
+  it('updateProjects()', function() {
+    expect(GlobalSelectionStore.get().projects).toEqual([]);
+    GlobalSelectionStore.updateProjects([1]);
+    expect(GlobalSelectionStore.get().projects).toEqual([1]);
+  });
+});

--- a/tests/js/spec/stores/globalSelectionStore.spec.jsx
+++ b/tests/js/spec/stores/globalSelectionStore.spec.jsx
@@ -1,13 +1,15 @@
 import GlobalSelectionStore from 'app/stores/globalSelectionStore';
+import {updateProjects} from 'app/actionCreators/globalSelection';
 
 describe('GlobalSelectionStore', function() {
   it('get()', function() {
     expect(GlobalSelectionStore.get()).toEqual({projects: []});
   });
 
-  it('updateProjects()', function() {
+  it('updateProjects()', async function() {
     expect(GlobalSelectionStore.get().projects).toEqual([]);
-    GlobalSelectionStore.updateProjects([1]);
+    updateProjects([1]);
+    await tick();
     expect(GlobalSelectionStore.get().projects).toEqual([1]);
   });
 });

--- a/tests/js/spec/utils/withGlobalSelection.spec.jsx
+++ b/tests/js/spec/utils/withGlobalSelection.spec.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import GlobalSelectionStore from 'app/stores/globalSelectionStore';
+import withGlobalSelection from 'app/utils/withGlobalSelection';
+
+describe('withGlobalSelection HoC', function() {
+  beforeEach(() => {
+    GlobalSelectionStore.init();
+  });
+
+  it('works', function() {
+    const MyComponent = () => null;
+    let Container = withGlobalSelection(MyComponent);
+    let wrapper = mount(<Container />);
+
+    expect(wrapper.find('MyComponent').prop('selection')).toEqual({projects: []});
+
+    // Update projects in store
+    GlobalSelectionStore.updateProjects([1]);
+
+    expect(wrapper.find('MyComponent').prop('selection')).toEqual({projects: [1]});
+  });
+});

--- a/tests/js/spec/views/organizationDiscover/discover.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/discover.spec.jsx
@@ -29,11 +29,13 @@ describe('Discover', function() {
     });
 
     it('auto-runs saved query', async function() {
+      const savedQuery = TestStubs.DiscoverSavedQuery();
       wrapper = mount(
         <Discover
           queryBuilder={queryBuilder}
           organization={organization}
-          savedQuery={TestStubs.DiscoverSavedQuery()}
+          savedQuery={savedQuery}
+          params={{savedQueryId: savedQuery.id}}
           updateSavedQueryData={jest.fn()}
           toggleEditMode={jest.fn()}
           isLoading={false}
@@ -72,6 +74,7 @@ describe('Discover', function() {
           organization={organization}
           updateSavedQueryData={jest.fn()}
           location={{search: ''}}
+          params={{}}
           toggleEditMode={jest.fn()}
           isLoading={false}
         />,
@@ -79,8 +82,10 @@ describe('Discover', function() {
       );
       expect(wrapper.find('NewQuery')).toHaveLength(1);
       expect(wrapper.find('EditSavedQuery')).toHaveLength(0);
+      const savedQuery = TestStubs.DiscoverSavedQuery();
       wrapper.setProps({
-        savedQuery: TestStubs.DiscoverSavedQuery(),
+        savedQuery,
+        params: {savedQueryId: savedQuery.id},
         isEditingSavedQuery: true,
       });
       wrapper.update();
@@ -285,6 +290,7 @@ describe('Discover', function() {
             queryBuilder={queryBuilder}
             organization={organization}
             location={{location: '?fields=something'}}
+            params={{}}
             updateSavedQueryData={jest.fn()}
             toggleEditMode={jest.fn()}
             isLoading={false}
@@ -349,11 +355,13 @@ describe('Discover', function() {
   describe('Saved query', function() {
     let wrapper, deleteMock, updateMock;
     beforeEach(function() {
+      const savedQuery = TestStubs.DiscoverSavedQuery();
       wrapper = mount(
         <Discover
           queryBuilder={queryBuilder}
           organization={organization}
-          savedQuery={TestStubs.DiscoverSavedQuery()}
+          savedQuery={savedQuery}
+          params={{savedQueryId: savedQuery.id}}
           updateSavedQueryData={jest.fn()}
           view="saved"
           location={{search: ''}}

--- a/tests/js/spec/views/organizationDiscover/index.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/index.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {mount} from 'enzyme';
 
-import OrganizationDiscoverContainer from 'app/views/organizationDiscover';
+import {OrganizationDiscoverContainer} from 'app/views/organizationDiscover';
 
 describe('OrganizationDiscoverContainer', function() {
   afterEach(function() {
@@ -24,7 +24,11 @@ describe('OrganizationDiscoverContainer', function() {
         },
       });
       wrapper = mount(
-        <OrganizationDiscoverContainer location={{query: {}, search: ''}} params={{}} />,
+        <OrganizationDiscoverContainer
+          location={{query: {}, search: ''}}
+          params={{}}
+          selection={{}}
+        />,
         TestStubs.routerContext([{organization}])
       );
       await tick();
@@ -64,6 +68,7 @@ describe('OrganizationDiscoverContainer', function() {
         <OrganizationDiscoverContainer
           location={{query: {}, search: ''}}
           params={{savedQueryId: 1}}
+          selection={{}}
         />,
         {
           ...TestStubs.routerContext([{organization}, {organization: PropTypes.object}]),
@@ -99,7 +104,11 @@ describe('OrganizationDiscoverContainer', function() {
     it('display coming soon message', async function() {
       const organization = TestStubs.Organization({projects: [TestStubs.Project()]});
       const wrapper = mount(
-        <OrganizationDiscoverContainer location={{query: {}, search: ''}} params={{}} />,
+        <OrganizationDiscoverContainer
+          location={{query: {}, search: ''}}
+          params={{}}
+          selection={{}}
+        />,
         TestStubs.routerContext([{organization}])
       );
       expect(wrapper.text()).toBe('something is happening here soon :)');

--- a/tests/js/spec/views/organizationDiscover/index.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/index.spec.jsx
@@ -12,7 +12,7 @@ describe('OrganizationDiscoverContainer', function() {
   describe('new query', function() {
     let wrapper;
     const organization = TestStubs.Organization({
-      projects: [TestStubs.Project()],
+      projects: [TestStubs.Project({id: '1', slug: 'test-project'})],
       features: ['discover'],
     });
     beforeEach(async function() {
@@ -39,6 +39,18 @@ describe('OrganizationDiscoverContainer', function() {
       expect(wrapper.state().isLoading).toBe(false);
       expect(queryBuilder.getColumns().some(column => column.name === 'tag1')).toBe(true);
       expect(queryBuilder.getColumns().some(column => column.name === 'tag2')).toBe(true);
+    });
+
+    it('sets active projects from global selection', function() {
+      wrapper = mount(
+        <OrganizationDiscoverContainer
+          location={{query: {}, search: ''}}
+          params={{}}
+          selection={{projects: [1]}}
+        />,
+        TestStubs.routerContext([{organization}])
+      );
+      expect(wrapper.find('MultipleProjectSelector').text()).toBe('test-project');
     });
   });
 

--- a/tests/js/spec/views/organizationEvents/index.spec.jsx
+++ b/tests/js/spec/views/organizationEvents/index.spec.jsx
@@ -32,7 +32,11 @@ describe('OrganizationEvents', function() {
     });
 
     wrapper = mount(
-      <OrganizationEventsContainer router={router} organization={organization}>
+      <OrganizationEventsContainer
+        router={router}
+        organization={organization}
+        selection={{projects: []}}
+      >
         <div />
       </OrganizationEventsContainer>,
       TestStubs.routerContext([
@@ -248,6 +252,8 @@ describe('OrganizationEvents', function() {
   });
 
   it('does not update router when toggling environment selector without changes', async function() {
+    expect(router.push).toHaveBeenCalledTimes(1);
+
     wrapper.setProps({
       router: {
         ...router,
@@ -267,6 +273,6 @@ describe('OrganizationEvents', function() {
     wrapper
       .find('MultipleEnvironmentSelector StyledInput')
       .simulate('keyDown', {key: 'Escape'});
-    expect(router.push).not.toHaveBeenCalled();
+    expect(router.push).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Add a global selection store for multi project selection that is used by Discover and event stream