### PR TITLE
fix(api): Fix issue where favourites aren't showing in the Project List

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -82,6 +82,18 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
                 organization=organization,
             ).prefetch_related('teams')
 
+        if request.user.is_authenticated():
+            queryset = queryset.extra(
+                select={
+                    'is_bookmarked': """exists (
+                        select *
+                        from sentry_projectbookmark spb
+                        where spb.project_id = sentry_project.id and spb.user_id = %s
+                    )""",
+                },
+                select_params=(request.user.id,),
+            )
+
         query = request.GET.get('query')
         if query:
             tokens = tokenize_query(query)
@@ -99,7 +111,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
         return self.paginate(
             request=request,
             queryset=queryset,
-            order_by='slug',
+            order_by=('-is_bookmarked', 'slug'),
             on_results=lambda x: serialize(x, request.user, ProjectSummarySerializer(
                 environment_id=self._get_environment_id_from_request(
                     request,

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -210,7 +210,14 @@ class DateTimePaginator(BasePaginator):
 # TODO(dcramer): previous cursors are too complex at the moment for many things
 # and are only useful for polling situations. The OffsetPaginator ignores them
 # entirely and uses standard paging
-class OffsetPaginator(BasePaginator):
+class OffsetPaginator(object):
+    def __init__(self, queryset, order_by=None, max_limit=MAX_LIMIT, on_results=None):
+        self.key = order_by if order_by is None or isinstance(
+            order_by, (list, tuple, set)) else (order_by, )
+        self.queryset = queryset
+        self.max_limit = max_limit
+        self.on_results = on_results
+
     def get_result(self, limit=100, cursor=None):
         # offset is page #
         # value is page limit
@@ -221,10 +228,7 @@ class OffsetPaginator(BasePaginator):
 
         queryset = self.queryset
         if self.key:
-            if self.desc:
-                queryset = queryset.order_by(u'-{}'.format(self.key))
-            else:
-                queryset = queryset.order_by(self.key)
+            queryset = queryset.order_by(*self.key)
 
         page = cursor.offset
         offset = cursor.offset * cursor.value

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -29,7 +29,7 @@ from sentry.constants import SentryAppStatus
 from sentry.mediators import sentry_apps, sentry_app_installations, service_hooks
 from sentry.models import (
     Activity, Environment, Event, EventError, EventMapping, Group, Organization, OrganizationMember,
-    OrganizationMemberTeam, Project, Team, User, UserEmail, Release, Commit, ReleaseCommit,
+    OrganizationMemberTeam, Project, ProjectBookmark, Team, User, UserEmail, Release, Commit, ReleaseCommit,
     CommitAuthor, Repository, CommitFileChange, ProjectDebugFile, File, UserPermission, EventAttachment
 )
 from sentry.utils.canonical import CanonicalKeyDict
@@ -324,6 +324,9 @@ class Fixtures(object):
         for team in teams:
             project.add_team(team)
         return project
+
+    def create_project_bookmark(self, project, user):
+        return ProjectBookmark.objects.create(project_id=project.id, user=user)
 
     def create_project_key(self, project):
         return project.key_set.get_or_create()[0]

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -1,92 +1,107 @@
 from __future__ import absolute_import
 
-import six
+from exam import fixture
 
 from sentry.testutils import APITestCase
 
 
 class OrganizationProjectsTest(APITestCase):
+
+    @fixture
+    def org(self):
+        return self.create_organization(owner=self.user, name='baz')
+
+    @fixture
+    def team(self):
+        return self.create_team(organization=self.org)
+
+    @fixture
+    def path(self):
+        return u'/api/0/organizations/{}/projects/'.format(self.org.slug)
+
+    def check_valid_response(self, response, expected_projects):
+        assert response.status_code == 200, response.content
+        assert [project.id for project in expected_projects] == [
+            int(project_resp['id']) for project_resp in response.data]
+
     def test_simple(self):
         self.login_as(user=self.user)
+        project = self.create_project(teams=[self.team])
 
-        org = self.create_organization(owner=self.user, name='baz')
-        team = self.create_team(organization=org)
-        project = self.create_project(teams=[team])
-
-        path = u'/api/0/organizations/{}/projects/'.format(org.slug)
-        response = self.client.get(path)
-
-        assert response.status_code == 200, response.content
-        assert len(response.data) == 1
-        assert response.data[0]['id'] == six.text_type(project.id)
-        assert self.client.session['activeorg'] == org.slug
+        response = self.client.get(self.path)
+        self.check_valid_response(response, [project])
+        assert self.client.session['activeorg'] == self.org.slug
 
     def test_with_stats(self):
         self.login_as(user=self.user)
 
-        org = self.create_organization(owner=self.user, name='baz')
-        team = self.create_team(organization=org)
-        self.create_project(teams=[team])
+        projects = [self.create_project(teams=[self.team])]
 
-        path = u'/api/0/organizations/{}/projects/'.format(org.slug)
-
-        response = self.client.get(u'{}?statsPeriod=24h'.format(path), format='json')
-        assert response.status_code == 200
-        assert len(response.data) == 1
+        response = self.client.get(u'{}?statsPeriod=24h'.format(self.path), format='json')
+        self.check_valid_response(response, projects)
         assert response.data[0]['stats']
 
-        response = self.client.get(u'{}?statsPeriod=14d'.format(path), format='json')
-        assert response.status_code == 200
-        assert len(response.data) == 1
+        response = self.client.get(u'{}?statsPeriod=14d'.format(self.path), format='json')
+        self.check_valid_response(response, projects)
         assert response.data[0]['stats']
 
-        response = self.client.get(u'{}?statsPeriod='.format(path), format='json')
-        assert response.status_code == 200
-        assert len(response.data) == 1
+        response = self.client.get(u'{}?statsPeriod='.format(self.path), format='json')
+        self.check_valid_response(response, projects)
         assert 'stats' not in response.data[0]
 
-        response = self.client.get(u'{}?statsPeriod=48h'.format(path), format='json')
+        response = self.client.get(u'{}?statsPeriod=48h'.format(self.path), format='json')
         assert response.status_code == 400
 
     def test_search(self):
         self.login_as(user=self.user)
+        project = self.create_project(teams=[self.team], name='bar', slug='bar')
 
-        org = self.create_organization(owner=self.user, name='baz')
-        team = self.create_team(organization=org)
-        project = self.create_project(teams=[team], name='bar', slug='bar')
+        response = self.client.get(u'{}?query=bar'.format(self.path))
+        self.check_valid_response(response, [project])
 
-        path = u'/api/0/organizations/{}/projects/?query=bar'.format(org.slug)
-        response = self.client.get(path)
-
-        assert response.status_code == 200, response.content
-        assert len(response.data) == 1
-        assert response.data[0]['id'] == six.text_type(project.id)
-
-        path = u'/api/0/organizations/{}/projects/?query=baz'.format(org.slug)
-        response = self.client.get(path)
-
-        assert response.status_code == 200, response.content
-        assert len(response.data) == 0
+        response = self.client.get(u'{}?query=baz'.format(self.path))
+        self.check_valid_response(response, [])
 
     def test_search_by_ids(self):
         self.login_as(user=self.user)
 
-        org = self.create_organization(owner=self.user, name='baz')
-        team = self.create_team(organization=org)
-        project_bar = self.create_project(teams=[team], name='bar', slug='bar')
-        project_foo = self.create_project(teams=[team], name='foo', slug='foo')
-        self.create_project(teams=[team], name='baz', slug='baz')
+        project_bar = self.create_project(teams=[self.team], name='bar', slug='bar')
+        project_foo = self.create_project(teams=[self.team], name='foo', slug='foo')
+        self.create_project(teams=[self.team], name='baz', slug='baz')
 
-        path = u'/api/0/organizations/{}/projects/?query=id:{}'.format(org.slug, project_foo.id)
+        path = u'{}?query=id:{}'.format(self.path, project_foo.id)
+        response = self.client.get(path)
+        self.check_valid_response(response, [project_foo])
+
+        path = u'{}?query=id:{} id:{}'.format(self.path, project_bar.id, project_foo.id)
         response = self.client.get(path)
 
-        assert response.status_code == 200, response.content
-        assert len(response.data) == 1
-        assert response.data[0]['id'] == six.text_type(project_foo.id)
+        self.check_valid_response(response, [project_bar, project_foo])
 
-        path = u'/api/0/organizations/{}/projects/?query=id:{} id:{}'.format(
-            org.slug, project_bar.id, project_foo.id)
-        response = self.client.get(path)
+    def test_bookmarks_appear_first_across_pages(self):
+        self.login_as(user=self.user)
 
-        assert response.status_code == 200, response.content
-        assert len(response.data) == 2
+        projects = [self.create_project(teams=[self.team], name=i, slug=i) for i in range(3)]
+        projects.sort(key=lambda project: project.slug)
+
+        response = self.client.get(self.path)
+        self.check_valid_response(response, [project for project in projects])
+
+        response = self.client.get(self.path + '?per_page=2')
+        self.check_valid_response(response, [project for project in projects[:2]])
+
+        self.create_project_bookmark(projects[-1], user=self.user)
+        # Move the bookmarked project to the front
+        projects.insert(0, projects.pop())
+        response = self.client.get(self.path)
+        self.check_valid_response(response, [project for project in projects])
+
+        # Make sure that it's at the front when on the second page as well
+        response = self.client.get(self.path + '?per_page=2')
+        self.check_valid_response(response, [project for project in projects[:2]])
+
+        # Make sure that other user's bookmarks don't interfere with this user
+        other_user = self.create_user()
+        self.create_project_bookmark(projects[1], user=other_user)
+        response = self.client.get(self.path)
+        self.check_valid_response(response, [project for project in projects])

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -115,6 +115,35 @@ class OffsetPaginatorTest(TestCase):
         assert not result5.next
         assert result5.prev
 
+    def test_order_by_multiple(self):
+        res1 = self.create_user('foo@example.com')
+        self.create_user('bar@example.com')
+        res3 = self.create_user('baz@example.com')
+
+        queryset = User.objects.all()
+
+        paginator = OffsetPaginator(queryset, 'id')
+        result = paginator.get_result(limit=1, cursor=None)
+        assert len(result) == 1, result
+        assert result[0] == res1
+        assert result.next
+        assert not result.prev
+
+        res3.update(is_active=False)
+
+        paginator = OffsetPaginator(queryset, ('is_active', 'id'))
+        result = paginator.get_result(limit=1, cursor=None)
+        assert len(result) == 1, result
+        assert result[0] == res3
+        assert result.next
+        assert not result.prev
+
+        result = paginator.get_result(limit=1, cursor=result.next)
+        assert len(result) == 1, (result, list(result))
+        assert result[0] == res1
+        assert result.next
+        assert result.prev
+
 
 class DateTimePaginatorTest(TestCase):
     def test_ascending(self):


### PR DESCRIPTION
Fixes an issue where favorites are missing from the first page of the Organization -> Projects
List. This occurs when there are many (> 100) projects, and the favourite is not on the first
page.

Also updated `OffsetPaginator` to accept multiple values for `order_by`. Stopped inheriting from
`BasePaginator` since it doesn't really use any of the functionality provided.

Fixes APP-218