### PR TITLE
ref(tooltip): Attempt to make tooltips more better

### DIFF
--- a/src/sentry/static/sentry/app/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/tooltip.jsx
@@ -58,6 +58,8 @@ class Tooltip extends React.Component {
 
     this.$ref.tooltip({
       title,
+      delay: 100,
+      container: 'body',
       ...options,
     });
   };


### PR DESCRIPTION
* Adds a delay when showing the tooptip, this is similar to our popover, ensuring that tooltips don't just jankily show up.

 * Add the tooltip to the body instead of next to the element. This should hopefully improve positioning.