### PR TITLE
feat(app-platform): Event Subscription UI

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_details.py
+++ b/src/sentry/api/endpoints/sentry_app_details.py
@@ -38,6 +38,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
                 redirect_url=result.get('redirectUrl'),
                 is_alertable=result.get('isAlertable'),
                 scopes=result.get('scopes'),
+                events=result.get('events'),
                 overview=result.get('overview'),
             )
 

--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -7,10 +7,12 @@ from sentry.models import SentryApp
 @register(SentryApp)
 class SentryAppSerializer(Serializer):
     def serialize(self, obj, attrs, user):
+        from sentry.mediators.service_hooks.creator import consolidate_events
         return {
             'name': obj.name,
             'slug': obj.slug,
             'scopes': obj.get_scopes(),
+            'events': consolidate_events(obj.events),
             'status': obj.get_status_display(),
             'uuid': obj.uuid,
             'webhookUrl': obj.webhook_url,

--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 from rest_framework.serializers import Serializer, ValidationError
 
 from sentry.models import ApiScopes
+from sentry.models.sentryapp import VALID_EVENTS
 
 
 class ApiScopesField(serializers.WritableField):
@@ -17,9 +18,18 @@ class ApiScopesField(serializers.WritableField):
                 raise ValidationError(u'{} not a valid scope'.format(scope))
 
 
+class EventListField(serializers.WritableField):
+    def validate(self, data):
+        if not set(data).issubset(VALID_EVENTS):
+            raise ValidationError(u'Invalid event subscription: {}'.format(
+                ', '.join(set(data).difference(VALID_EVENTS))
+            ))
+
+
 class SentryAppSerializer(Serializer):
     name = serializers.CharField()
     scopes = ApiScopesField()
+    events = EventListField()
     webhookUrl = serializers.URLField()
     redirectUrl = serializers.URLField(required=False)
     isAlertable = serializers.BooleanField(required=False)

--- a/src/sentry/mediators/sentry_apps/creator.py
+++ b/src/sentry/mediators/sentry_apps/creator.py
@@ -12,6 +12,7 @@ class Creator(Mediator):
     name = Param(six.string_types)
     organization = Param('sentry.models.Organization')
     scopes = Param(Iterable)
+    events = Param(Iterable, default=lambda self: [])
     webhook_url = Param(six.string_types)
     redirect_url = Param(six.string_types, required=False)
     is_alertable = Param(bool, default=False)
@@ -35,12 +36,15 @@ class Creator(Mediator):
         )
 
     def _create_sentry_app(self):
+        from sentry.mediators.service_hooks.creator import expand_events
+
         return SentryApp.objects.create(
             name=self.name,
             application_id=self.api_app.id,
             owner_id=self.organization.id,
             proxy_user_id=self.proxy.id,
             scope_list=self.scopes,
+            events=expand_events(self.events),
             webhook_url=self.webhook_url,
             redirect_url=self.redirect_url,
             is_alertable=self.is_alertable,

--- a/src/sentry/mediators/sentry_apps/updater.py
+++ b/src/sentry/mediators/sentry_apps/updater.py
@@ -14,6 +14,7 @@ class Updater(Mediator):
     sentry_app = Param('sentry.models.SentryApp')
     name = Param(six.string_types, required=False)
     scopes = Param(Iterable, required=False)
+    events = Param(Iterable, required=False)
     webhook_url = Param(six.string_types, required=False)
     redirect_url = Param(six.string_types, required=False)
     is_alertable = Param(bool, required=False)
@@ -22,6 +23,7 @@ class Updater(Mediator):
     def call(self):
         self._update_name()
         self._update_scopes()
+        self._update_events()
         self._update_webhook_url()
         self._update_redirect_url()
         self._update_is_alertable()
@@ -38,6 +40,11 @@ class Updater(Mediator):
         if self.sentry_app.status == SentryAppStatus.PUBLISHED:
             raise APIError('Cannot update scopes on published App.')
         self.sentry_app.scope_list = self.scopes
+
+    @if_param('events')
+    def _update_events(self):
+        from sentry.mediators.service_hooks.creator import expand_events
+        self.sentry_app.events = expand_events(self.events)
 
     @if_param('webhook_url')
     def _update_webhook_url(self):

--- a/src/sentry/mediators/service_hooks/creator.py
+++ b/src/sentry/mediators/service_hooks/creator.py
@@ -3,9 +3,39 @@ from __future__ import absolute_import
 import six
 
 from collections import Iterable
+from itertools import chain
 
 from sentry.mediators import Mediator, Param
 from sentry.models import ServiceHook
+
+# Subscribing to these events via the UI is done in a resource-centric way.
+# This means you subscribe to "Issue" events. There are many types of Issue
+# events - this maps those resource-centric values to the actual events
+# emitted.
+EVENT_EXPANSION = {
+    'issue': ['issue.created'],
+}
+
+
+def expand_events(rolled_up_events):
+    """
+    Convert a list of rolled up events ('issue', etc) into a list of raw event
+    types ('issue.created', etc.)
+    """
+    return set(chain.from_iterable(
+        [EVENT_EXPANSION.get(event, [event]) for event in rolled_up_events]
+    ))
+
+
+def consolidate_events(raw_events):
+    """
+    Consolidate a list of raw event types ('issue.created', etc) into a list of
+    rolled up events ('issue', etc).
+    """
+    return set(
+        name for (name, rolled_up_events) in six.iteritems(EVENT_EXPANSION)
+        if any(set(raw_events) & set(rolled_up_events))
+    )
 
 
 class Creator(Mediator):
@@ -24,6 +54,6 @@ class Creator(Mediator):
             application_id=self.application.id,
             actor_id=self.actor.id,
             project_id=self.project.id,
-            events=self.events,
+            events=expand_events(self.events),
             url=self.url,
         )

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -9,9 +9,18 @@ from django.utils import timezone
 from django.template.defaultfilters import slugify
 
 from sentry.constants import SentryAppStatus, SENTRY_APP_SLUG_MAX_LENGTH
-from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, ParanoidModel
 from sentry.models import Organization
 from sentry.models.apiscopes import HasApiScopes
+from sentry.db.models import (
+    ArrayField,
+    BoundedPositiveIntegerField,
+    FlexibleForeignKey,
+    ParanoidModel,
+)
+
+VALID_EVENTS = (
+    'issue',
+)
 
 
 def default_uuid():
@@ -57,6 +66,8 @@ class SentryApp(ParanoidModel, HasApiScopes):
     # does the application subscribe to `event.alert`,
     # meaning can it be used in alert rules as a {service} ?
     is_alertable = models.BooleanField(default=False)
+
+    events = ArrayField(of=models.TextField, null=True)
 
     overview = models.TextField(null=True)
 

--- a/src/sentry/south_migrations/0452_auto__add_field_sentryapp_events.py
+++ b/src/sentry/south_migrations/0452_auto__add_field_sentryapp_events.py
@@ -1,0 +1,1245 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    # Flag to indicate if this migration is too risky
+    # to run online and needs to be coordinated for offline
+    is_dangerous = False
+
+    def forwards(self, orm):
+        # Adding field 'SentryApp.events'
+        db.add_column('sentry_sentryapp', 'events',
+                      self.gf('sentry.db.models.fields.array.ArrayField')(
+                          of=(u'django.db.models.fields.TextField', [], {})),
+                      keep_default=False)
+
+    def backwards(self, orm):
+        # Deleting field 'SentryApp.events'
+        db.delete_column('sentry_sentryapp', 'events')
+
+    models = {
+        'sentry.activity': {
+            'Meta': {'object_name': 'Activity'},
+            'data': ('sentry.db.models.fields.gzippeddict.GzippedDictField', [], {'null': 'True'}),
+            'datetime': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Group']", 'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'type': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']", 'null': 'True'})
+        },
+        'sentry.apiapplication': {
+            'Meta': {'object_name': 'ApiApplication'},
+            'allowed_origins': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'client_id': ('django.db.models.fields.CharField', [], {'default': "'e37e7e1807d84029bf7339b8a5971a938dbdc08da28a4e5f9475c446f2595a7f'", 'unique': 'True', 'max_length': '64'}),
+            'client_secret': ('sentry.db.models.fields.encrypted.EncryptedTextField', [], {'default': "'2842752ee75a48e78fb26862200e0c0d518a1c46d3d240f1890d22dd9227d355'"}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'homepage_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "'Learning Mullet'", 'max_length': '64', 'blank': 'True'}),
+            'owner': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"}),
+            'privacy_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True'}),
+            'redirect_uris': ('django.db.models.fields.TextField', [], {}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'terms_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True'})
+        },
+        'sentry.apiauthorization': {
+            'Meta': {'unique_together': "(('user', 'application'),)", 'object_name': 'ApiAuthorization'},
+            'application': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.ApiApplication']", 'null': 'True'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'scope_list': ('sentry.db.models.fields.array.ArrayField', [], {'of': (u'django.db.models.fields.TextField', [], {})}),
+            'scopes': ('django.db.models.fields.BigIntegerField', [], {'default': 'None'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"})
+        },
+        'sentry.apigrant': {
+            'Meta': {'object_name': 'ApiGrant'},
+            'application': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.ApiApplication']"}),
+            'code': ('django.db.models.fields.CharField', [], {'default': "'9c40f208f07b495780841b50cee45e3e'", 'max_length': '64', 'db_index': 'True'}),
+            'expires_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2018, 12, 11, 0, 0)', 'db_index': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'redirect_uri': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'scope_list': ('sentry.db.models.fields.array.ArrayField', [], {'of': (u'django.db.models.fields.TextField', [], {})}),
+            'scopes': ('django.db.models.fields.BigIntegerField', [], {'default': 'None'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"})
+        },
+        'sentry.apikey': {
+            'Meta': {'object_name': 'ApiKey'},
+            'allowed_origins': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '32'}),
+            'label': ('django.db.models.fields.CharField', [], {'default': "'Default'", 'max_length': '64', 'blank': 'True'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'key_set'", 'to': "orm['sentry.Organization']"}),
+            'scope_list': ('sentry.db.models.fields.array.ArrayField', [], {'of': (u'django.db.models.fields.TextField', [], {})}),
+            'scopes': ('django.db.models.fields.BigIntegerField', [], {'default': 'None'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'db_index': 'True'})
+        },
+        'sentry.apitoken': {
+            'Meta': {'object_name': 'ApiToken'},
+            'application': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.ApiApplication']", 'null': 'True'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'expires_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2019, 1, 10, 0, 0)', 'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'refresh_token': ('django.db.models.fields.CharField', [], {'default': "'5890b2c8f7084cefbea6e7d8c7fb6b0ca87d344c7f644856bc3d046005f838a7'", 'max_length': '64', 'unique': 'True', 'null': 'True'}),
+            'scope_list': ('sentry.db.models.fields.array.ArrayField', [], {'of': (u'django.db.models.fields.TextField', [], {})}),
+            'scopes': ('django.db.models.fields.BigIntegerField', [], {'default': 'None'}),
+            'token': ('django.db.models.fields.CharField', [], {'default': "'77fc24ba224e4f368c45d94b9e44a750293b4c1ac07d46bb96dcdb13947f07b1'", 'unique': 'True', 'max_length': '64'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"})
+        },
+        'sentry.assistantactivity': {
+            'Meta': {'unique_together': "(('user', 'guide_id'),)", 'object_name': 'AssistantActivity', 'db_table': "'sentry_assistant_activity'"},
+            'dismissed_ts': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'guide_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'useful': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"}),
+            'viewed_ts': ('django.db.models.fields.DateTimeField', [], {'null': 'True'})
+        },
+        'sentry.auditlogentry': {
+            'Meta': {'object_name': 'AuditLogEntry'},
+            'actor': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'blank': 'True', 'related_name': "'audit_actors'", 'null': 'True', 'to': "orm['sentry.User']"}),
+            'actor_key': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.ApiKey']", 'null': 'True', 'blank': 'True'}),
+            'actor_label': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'data': ('sentry.db.models.fields.gzippeddict.GzippedDictField', [], {}),
+            'datetime': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'event': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'ip_address': ('django.db.models.fields.GenericIPAddressField', [], {'max_length': '39', 'null': 'True'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']"}),
+            'target_object': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'target_user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'blank': 'True', 'related_name': "'audit_targets'", 'null': 'True', 'to': "orm['sentry.User']"})
+        },
+        'sentry.authenticator': {
+            'Meta': {'unique_together': "(('user', 'type'),)", 'object_name': 'Authenticator', 'db_table': "'auth_authenticator'"},
+            'config': ('sentry.db.models.fields.encrypted.EncryptedPickledObjectField', [], {}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedAutoField', [], {'primary_key': 'True'}),
+            'last_used_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'type': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"})
+        },
+        'sentry.authidentity': {
+            'Meta': {'unique_together': "(('auth_provider', 'ident'), ('auth_provider', 'user'))", 'object_name': 'AuthIdentity'},
+            'auth_provider': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.AuthProvider']"}),
+            'data': ('sentry.db.models.fields.encrypted.EncryptedJsonField', [], {'default': '{}'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'last_synced': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_verified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"})
+        },
+        'sentry.authprovider': {
+            'Meta': {'object_name': 'AuthProvider'},
+            'config': ('sentry.db.models.fields.encrypted.EncryptedJsonField', [], {'default': '{}'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'default_global_access': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'default_role': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '50'}),
+            'default_teams': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['sentry.Team']", 'symmetrical': 'False', 'blank': 'True'}),
+            'flags': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'last_sync': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']", 'unique': 'True'}),
+            'provider': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'sync_time': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'})
+        },
+        'sentry.broadcast': {
+            'Meta': {'object_name': 'Broadcast'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'date_expires': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2018, 12, 18, 0, 0)', 'null': 'True', 'blank': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'link': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'message': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'upstream_id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'})
+        },
+        'sentry.broadcastseen': {
+            'Meta': {'unique_together': "(('broadcast', 'user'),)", 'object_name': 'BroadcastSeen'},
+            'broadcast': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Broadcast']"}),
+            'date_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"})
+        },
+        'sentry.commit': {
+            'Meta': {'unique_together': "(('repository_id', 'key'),)", 'object_name': 'Commit', 'index_together': "(('repository_id', 'date_added'),)"},
+            'author': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.CommitAuthor']", 'null': 'True'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'message': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'repository_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {})
+        },
+        'sentry.commitauthor': {
+            'Meta': {'unique_together': "(('organization_id', 'email'), ('organization_id', 'external_id'))", 'object_name': 'CommitAuthor'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'external_id': ('django.db.models.fields.CharField', [], {'max_length': '164', 'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True'}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'})
+        },
+        'sentry.commitfilechange': {
+            'Meta': {'unique_together': "(('commit', 'filename'),)", 'object_name': 'CommitFileChange'},
+            'commit': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Commit']"}),
+            'filename': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '1'})
+        },
+        'sentry.counter': {
+            'Meta': {'object_name': 'Counter', 'db_table': "'sentry_projectcounter'"},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']", 'unique': 'True'}),
+            'value': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {})
+        },
+        'sentry.deletedorganization': {
+            'Meta': {'object_name': 'DeletedOrganization'},
+            'actor_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True'}),
+            'actor_key': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True'}),
+            'actor_label': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'date_deleted': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'ip_address': ('django.db.models.fields.GenericIPAddressField', [], {'max_length': '39', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'reason': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'})
+        },
+        'sentry.deletedproject': {
+            'Meta': {'object_name': 'DeletedProject'},
+            'actor_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True'}),
+            'actor_key': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True'}),
+            'actor_label': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'date_deleted': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'ip_address': ('django.db.models.fields.GenericIPAddressField', [], {'max_length': '39', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True'}),
+            'organization_name': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'organization_slug': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'}),
+            'platform': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'reason': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'})
+        },
+        'sentry.deletedteam': {
+            'Meta': {'object_name': 'DeletedTeam'},
+            'actor_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True'}),
+            'actor_key': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True'}),
+            'actor_label': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'date_deleted': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'ip_address': ('django.db.models.fields.GenericIPAddressField', [], {'max_length': '39', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True'}),
+            'organization_name': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'organization_slug': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'}),
+            'reason': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'})
+        },
+        'sentry.deploy': {
+            'Meta': {'object_name': 'Deploy'},
+            'date_finished': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'date_started': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'environment_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'notified': ('django.db.models.fields.NullBooleanField', [], {'default': 'False', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'release': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Release']"}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        'sentry.discoversavedquery': {
+            'Meta': {'object_name': 'DiscoverSavedQuery'},
+            'created_by': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'date_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']"}),
+            'projects': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['sentry.Project']", 'through': "orm['sentry.DiscoverSavedQueryProject']", 'symmetrical': 'False'}),
+            'query': ('jsonfield.fields.JSONField', [], {'default': '{}'})
+        },
+        'sentry.discoversavedqueryproject': {
+            'Meta': {'unique_together': "(('project', 'discover_saved_query'),)", 'object_name': 'DiscoverSavedQueryProject'},
+            'discover_saved_query': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.DiscoverSavedQuery']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"})
+        },
+        'sentry.distribution': {
+            'Meta': {'unique_together': "(('release', 'name'),)", 'object_name': 'Distribution'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'release': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Release']"})
+        },
+        'sentry.email': {
+            'Meta': {'object_name': 'Email'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('sentry.db.models.fields.citext.CIEmailField', [], {'unique': 'True', 'max_length': '75'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'})
+        },
+        'sentry.environment': {
+            'Meta': {'unique_together': "(('organization_id', 'name'),)", 'object_name': 'Environment'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'projects': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['sentry.Project']", 'through': "orm['sentry.EnvironmentProject']", 'symmetrical': 'False'})
+        },
+        'sentry.environmentproject': {
+            'Meta': {'unique_together': "(('project', 'environment'),)", 'object_name': 'EnvironmentProject'},
+            'environment': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Environment']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'is_hidden': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"})
+        },
+        'sentry.event': {
+            'Meta': {'unique_together': "(('project_id', 'event_id'),)", 'object_name': 'Event', 'db_table': "'sentry_message'", 'index_together': "(('group_id', 'datetime'),)"},
+            'data': ('sentry.db.models.fields.node.NodeField', [], {'null': 'True', 'blank': 'True'}),
+            'datetime': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'event_id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'db_column': "'message_id'"}),
+            'group_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {}),
+            'platform': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'time_spent': ('sentry.db.models.fields.bounded.BoundedIntegerField', [], {'null': 'True'})
+        },
+        'sentry.eventattachment': {
+            'Meta': {'unique_together': "(('project_id', 'event_id', 'file'),)", 'object_name': 'EventAttachment', 'index_together': "(('project_id', 'date_added'),)"},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'event_id': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'file': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.File']"}),
+            'group_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.TextField', [], {}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {})
+        },
+        'sentry.eventmapping': {
+            'Meta': {'unique_together': "(('project_id', 'event_id'),)", 'object_name': 'EventMapping'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'event_id': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'group_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {})
+        },
+        'sentry.eventprocessingissue': {
+            'Meta': {'unique_together': "(('raw_event', 'processing_issue'),)", 'object_name': 'EventProcessingIssue'},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'processing_issue': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.ProcessingIssue']"}),
+            'raw_event': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.RawEvent']"})
+        },
+        'sentry.eventtag': {
+            'Meta': {'unique_together': "(('event_id', 'key_id', 'value_id'),)", 'object_name': 'EventTag', 'index_together': "(('group_id', 'key_id', 'value_id'),)"},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'event_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {}),
+            'group_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {}),
+            'value_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {})
+        },
+        'sentry.eventuser': {
+            'Meta': {'unique_together': "(('project_id', 'ident'), ('project_id', 'hash'))", 'object_name': 'EventUser', 'index_together': "(('project_id', 'email'), ('project_id', 'username'), ('project_id', 'ip_address'))"},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True'}),
+            'hash': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True'}),
+            'ip_address': ('django.db.models.fields.GenericIPAddressField', [], {'max_length': '39', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True'})
+        },
+        'sentry.externalissue': {
+            'Meta': {'unique_together': "(('organization_id', 'integration_id', 'key'),)", 'object_name': 'ExternalIssue'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'integration_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'metadata': ('jsonfield.fields.JSONField', [], {'null': 'True'}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'title': ('django.db.models.fields.TextField', [], {'null': 'True'})
+        },
+        'sentry.featureadoption': {
+            'Meta': {'unique_together': "(('organization', 'feature_id'),)", 'object_name': 'FeatureAdoption'},
+            'applicable': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'complete': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'data': ('jsonfield.fields.JSONField', [], {'default': '{}'}),
+            'date_completed': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'feature_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']"})
+        },
+        'sentry.file': {
+            'Meta': {'object_name': 'File'},
+            'blob': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'legacy_blob'", 'null': 'True', 'to': "orm['sentry.FileBlob']"}),
+            'blobs': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['sentry.FileBlob']", 'through': "orm['sentry.FileBlobIndex']", 'symmetrical': 'False'}),
+            'checksum': ('django.db.models.fields.CharField', [], {'max_length': '40', 'null': 'True', 'db_index': 'True'}),
+            'headers': ('jsonfield.fields.JSONField', [], {'default': '{}'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.TextField', [], {}),
+            'path': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'size': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '64'})
+        },
+        'sentry.fileblob': {
+            'Meta': {'object_name': 'FileBlob'},
+            'checksum': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'path': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'size': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'})
+        },
+        'sentry.fileblobindex': {
+            'Meta': {'unique_together': "(('file', 'blob', 'offset'),)", 'object_name': 'FileBlobIndex'},
+            'blob': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.FileBlob']"}),
+            'file': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.File']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'offset': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {})
+        },
+        'sentry.fileblobowner': {
+            'Meta': {'unique_together': "(('blob', 'organization'),)", 'object_name': 'FileBlobOwner'},
+            'blob': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.FileBlob']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']"})
+        },
+        'sentry.group': {
+            'Meta': {'unique_together': "(('project', 'short_id'),)", 'object_name': 'Group', 'db_table': "'sentry_groupedmessage'", 'index_together': "(('project', 'first_release'),)"},
+            'active_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'culprit': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'db_column': "'view'", 'blank': 'True'}),
+            'data': ('sentry.db.models.fields.gzippeddict.GzippedDictField', [], {'null': 'True', 'blank': 'True'}),
+            'first_release': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Release']", 'null': 'True', 'on_delete': 'models.PROTECT'}),
+            'first_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.NullBooleanField', [], {'default': 'False', 'null': 'True', 'blank': 'True'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'level': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '40', 'db_index': 'True', 'blank': 'True'}),
+            'logger': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '64', 'db_index': 'True', 'blank': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {}),
+            'num_comments': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'null': 'True'}),
+            'platform': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True'}),
+            'resolved_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'score': ('sentry.db.models.fields.bounded.BoundedIntegerField', [], {'default': '0'}),
+            'short_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'time_spent_count': ('sentry.db.models.fields.bounded.BoundedIntegerField', [], {'default': '0'}),
+            'time_spent_total': ('sentry.db.models.fields.bounded.BoundedIntegerField', [], {'default': '0'}),
+            'times_seen': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '1', 'db_index': 'True'})
+        },
+        'sentry.groupassignee': {
+            'Meta': {'object_name': 'GroupAssignee', 'db_table': "'sentry_groupasignee'"},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'assignee_set'", 'unique': 'True', 'to': "orm['sentry.Group']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'assignee_set'", 'to': "orm['sentry.Project']"}),
+            'team': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'sentry_assignee_set'", 'null': 'True', 'to': "orm['sentry.Team']"}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'sentry_assignee_set'", 'null': 'True', 'to': "orm['sentry.User']"})
+        },
+        'sentry.groupbookmark': {
+            'Meta': {'unique_together': "(('project', 'user', 'group'),)", 'object_name': 'GroupBookmark'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True'}),
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'bookmark_set'", 'to': "orm['sentry.Group']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'bookmark_set'", 'to': "orm['sentry.Project']"}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'sentry_bookmark_set'", 'to': "orm['sentry.User']"})
+        },
+        'sentry.groupcommitresolution': {
+            'Meta': {'unique_together': "(('group_id', 'commit_id'),)", 'object_name': 'GroupCommitResolution'},
+            'commit_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'datetime': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'group_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'})
+        },
+        'sentry.groupemailthread': {
+            'Meta': {'unique_together': "(('email', 'group'), ('email', 'msgid'))", 'object_name': 'GroupEmailThread'},
+            'date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'groupemail_set'", 'to': "orm['sentry.Group']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'msgid': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'groupemail_set'", 'to': "orm['sentry.Project']"})
+        },
+        'sentry.groupenvironment': {
+            'Meta': {'unique_together': "[('group_id', 'environment_id')]", 'object_name': 'GroupEnvironment', 'index_together': "[('environment_id', 'first_release_id')]"},
+            'environment_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'first_release_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'group_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'})
+        },
+        'sentry.grouphash': {
+            'Meta': {'unique_together': "(('project', 'hash'),)", 'object_name': 'GroupHash'},
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Group']", 'null': 'True'}),
+            'group_tombstone_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'hash': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True'}),
+            'state': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'})
+        },
+        'sentry.grouplink': {
+            'Meta': {'unique_together': "(('group_id', 'linked_type', 'linked_id'),)", 'object_name': 'GroupLink'},
+            'data': ('jsonfield.fields.JSONField', [], {'default': '{}'}),
+            'datetime': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'group_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'linked_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {}),
+            'linked_type': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '1'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'db_index': 'True'}),
+            'relationship': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '2'})
+        },
+        'sentry.groupmeta': {
+            'Meta': {'unique_together': "(('group', 'key'),)", 'object_name': 'GroupMeta'},
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Group']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'value': ('django.db.models.fields.TextField', [], {})
+        },
+        'sentry.groupredirect': {
+            'Meta': {'object_name': 'GroupRedirect'},
+            'group_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'db_index': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'previous_group_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'unique': 'True'})
+        },
+        'sentry.grouprelease': {
+            'Meta': {'unique_together': "(('group_id', 'release_id', 'environment'),)", 'object_name': 'GroupRelease'},
+            'environment': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '64'}),
+            'first_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'group_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'release_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'})
+        },
+        'sentry.groupresolution': {
+            'Meta': {'object_name': 'GroupResolution'},
+            'actor_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'datetime': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Group']", 'unique': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'release': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Release']"}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'}),
+            'type': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'})
+        },
+        'sentry.grouprulestatus': {
+            'Meta': {'unique_together': "(('rule', 'group'),)", 'object_name': 'GroupRuleStatus'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Group']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'last_active': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'rule': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Rule']"}),
+            'status': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0'})
+        },
+        'sentry.groupseen': {
+            'Meta': {'unique_together': "(('user', 'group'),)", 'object_name': 'GroupSeen'},
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Group']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']", 'db_index': 'False'})
+        },
+        'sentry.groupshare': {
+            'Meta': {'object_name': 'GroupShare'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Group']", 'unique': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']", 'null': 'True'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'default': "'399187448b2e4728a4021e7138375d09'", 'unique': 'True', 'max_length': '32'})
+        },
+        'sentry.groupsnooze': {
+            'Meta': {'object_name': 'GroupSnooze'},
+            'actor_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'count': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Group']", 'unique': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'state': ('jsonfield.fields.JSONField', [], {'null': 'True'}),
+            'until': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'user_count': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'user_window': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'window': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'})
+        },
+        'sentry.groupsubscription': {
+            'Meta': {'unique_together': "(('group', 'user'),)", 'object_name': 'GroupSubscription'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True'}),
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'subscription_set'", 'to': "orm['sentry.Group']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'subscription_set'", 'to': "orm['sentry.Project']"}),
+            'reason': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"})
+        },
+        'sentry.grouptagkey': {
+            'Meta': {'unique_together': "(('project_id', 'group_id', 'key'),)", 'object_name': 'GroupTagKey'},
+            'group_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'values_seen': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'})
+        },
+        'sentry.grouptagvalue': {
+            'Meta': {'unique_together': "(('group_id', 'key', 'value'),)", 'object_name': 'GroupTagValue', 'db_table': "'sentry_messagefiltervalue'", 'index_together': "(('project_id', 'key', 'value', 'last_seen'),)"},
+            'first_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True', 'db_index': 'True'}),
+            'group_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True', 'db_index': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'times_seen': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        'sentry.grouptombstone': {
+            'Meta': {'object_name': 'GroupTombstone'},
+            'actor_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'culprit': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'data': ('sentry.db.models.fields.gzippeddict.GzippedDictField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'level': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '40', 'blank': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {}),
+            'previous_group_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'unique': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"})
+        },
+        'sentry.identity': {
+            'Meta': {'unique_together': "(('idp', 'external_id'), ('idp', 'user'))", 'object_name': 'Identity'},
+            'data': ('sentry.db.models.fields.encrypted.EncryptedJsonField', [], {'default': '{}'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'date_verified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'external_id': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'idp': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.IdentityProvider']"}),
+            'scopes': ('sentry.db.models.fields.array.ArrayField', [], {'of': (u'django.db.models.fields.TextField', [], {})}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"})
+        },
+        'sentry.identityprovider': {
+            'Meta': {'unique_together': "(('type', 'external_id'),)", 'object_name': 'IdentityProvider'},
+            'config': ('sentry.db.models.fields.encrypted.EncryptedJsonField', [], {'default': '{}'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True'}),
+            'external_id': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '64'})
+        },
+        'sentry.integration': {
+            'Meta': {'unique_together': "(('provider', 'external_id'),)", 'object_name': 'Integration'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True'}),
+            'external_id': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'metadata': ('sentry.db.models.fields.encrypted.EncryptedJsonField', [], {'default': '{}'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'organizations': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'integrations'", 'symmetrical': 'False', 'through': "orm['sentry.OrganizationIntegration']", 'to': "orm['sentry.Organization']"}),
+            'projects': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'integrations'", 'symmetrical': 'False', 'through': "orm['sentry.ProjectIntegration']", 'to': "orm['sentry.Project']"}),
+            'provider': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'null': 'True'})
+        },
+        'sentry.integrationexternalproject': {
+            'Meta': {'unique_together': "(('organization_integration_id', 'external_id'),)", 'object_name': 'IntegrationExternalProject'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'external_id': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'organization_integration_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'resolved_status': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'unresolved_status': ('django.db.models.fields.CharField', [], {'max_length': '64'})
+        },
+        'sentry.latestrelease': {
+            'Meta': {'unique_together': "(('repository_id', 'environment_id'),)", 'object_name': 'LatestRelease'},
+            'commit_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True'}),
+            'deploy_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True'}),
+            'environment_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'release_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {}),
+            'repository_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {})
+        },
+        'sentry.lostpasswordhash': {
+            'Meta': {'object_name': 'LostPasswordHash'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'hash': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']", 'unique': 'True'})
+        },
+        'sentry.option': {
+            'Meta': {'object_name': 'Option'},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'value': ('sentry.db.models.fields.encrypted.EncryptedPickledObjectField', [], {})
+        },
+        'sentry.organization': {
+            'Meta': {'object_name': 'Organization'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'default_role': ('django.db.models.fields.CharField', [], {'default': "'member'", 'max_length': '32'}),
+            'flags': ('django.db.models.fields.BigIntegerField', [], {'default': '1'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'members': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'org_memberships'", 'symmetrical': 'False', 'through': "orm['sentry.OrganizationMember']", 'to': "orm['sentry.User']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'})
+        },
+        'sentry.organizationaccessrequest': {
+            'Meta': {'unique_together': "(('team', 'member'),)", 'object_name': 'OrganizationAccessRequest'},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'member': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.OrganizationMember']"}),
+            'team': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Team']"})
+        },
+        'sentry.organizationavatar': {
+            'Meta': {'object_name': 'OrganizationAvatar'},
+            'avatar_type': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0'}),
+            'file': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.File']", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '32', 'db_index': 'True'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'avatar'", 'unique': 'True', 'to': "orm['sentry.Organization']"})
+        },
+        'sentry.organizationintegration': {
+            'Meta': {'unique_together': "(('organization', 'integration'),)", 'object_name': 'OrganizationIntegration'},
+            'config': ('sentry.db.models.fields.encrypted.EncryptedJsonField', [], {'default': '{}'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True'}),
+            'default_auth_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'integration': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Integration']"}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']"}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'})
+        },
+        'sentry.organizationmember': {
+            'Meta': {'unique_together': "(('organization', 'user'), ('organization', 'email'))", 'object_name': 'OrganizationMember'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'flags': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'has_global_access': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'member_set'", 'to': "orm['sentry.Organization']"}),
+            'role': ('django.db.models.fields.CharField', [], {'default': "'member'", 'max_length': '32'}),
+            'teams': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['sentry.Team']", 'symmetrical': 'False', 'through': "orm['sentry.OrganizationMemberTeam']", 'blank': 'True'}),
+            'token': ('django.db.models.fields.CharField', [], {'max_length': '64', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'token_expires_at': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True'}),
+            'type': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '50', 'blank': 'True'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'blank': 'True', 'related_name': "'sentry_orgmember_set'", 'null': 'True', 'to': "orm['sentry.User']"})
+        },
+        'sentry.organizationmemberteam': {
+            'Meta': {'unique_together': "(('team', 'organizationmember'),)", 'object_name': 'OrganizationMemberTeam', 'db_table': "'sentry_organizationmember_teams'"},
+            'id': ('sentry.db.models.fields.bounded.BoundedAutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'organizationmember': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.OrganizationMember']"}),
+            'team': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Team']"})
+        },
+        'sentry.organizationonboardingtask': {
+            'Meta': {'unique_together': "(('organization', 'task'),)", 'object_name': 'OrganizationOnboardingTask'},
+            'data': ('jsonfield.fields.JSONField', [], {'default': '{}'}),
+            'date_completed': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']"}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'task': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']", 'null': 'True'})
+        },
+        'sentry.organizationoption': {
+            'Meta': {'unique_together': "(('organization', 'key'),)", 'object_name': 'OrganizationOption', 'db_table': "'sentry_organizationoptions'"},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']"}),
+            'value': ('sentry.db.models.fields.encrypted.EncryptedPickledObjectField', [], {})
+        },
+        'sentry.processingissue': {
+            'Meta': {'unique_together': "(('project', 'checksum', 'type'),)", 'object_name': 'ProcessingIssue'},
+            'checksum': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'}),
+            'data': ('sentry.db.models.fields.gzippeddict.GzippedDictField', [], {}),
+            'datetime': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '30'})
+        },
+        'sentry.project': {
+            'Meta': {'unique_together': "(('organization', 'slug'),)", 'object_name': 'Project'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'first_event': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'flags': ('django.db.models.fields.BigIntegerField', [], {'default': '0', 'null': 'True'}),
+            'forced_color': ('django.db.models.fields.CharField', [], {'max_length': '6', 'null': 'True', 'blank': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']"}),
+            'platform': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50', 'null': 'True'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'teams': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'teams'", 'symmetrical': 'False', 'through': "orm['sentry.ProjectTeam']", 'to': "orm['sentry.Team']"})
+        },
+        'sentry.projectavatar': {
+            'Meta': {'object_name': 'ProjectAvatar'},
+            'avatar_type': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0'}),
+            'file': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.File']", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '32', 'db_index': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'avatar'", 'unique': 'True', 'to': "orm['sentry.Project']"})
+        },
+        'sentry.projectbookmark': {
+            'Meta': {'unique_together': "(('project', 'user'),)", 'object_name': 'ProjectBookmark'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True', 'blank': 'True'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"})
+        },
+        'sentry.projectcficachefile': {
+            'Meta': {'unique_together': "(('project', 'debug_file'),)", 'object_name': 'ProjectCfiCacheFile'},
+            'cache_file': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.File']"}),
+            'checksum': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'debug_file': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.ProjectDebugFile']", 'on_delete': 'models.DO_NOTHING', 'db_column': "'dsym_file_id'"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True'}),
+            'version': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {})
+        },
+        'sentry.projectdebugfile': {
+            'Meta': {'object_name': 'ProjectDebugFile', 'db_table': "'sentry_projectdsymfile'", 'index_together': "(('project', 'debug_id'),)"},
+            'cpu_name': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'data': ('jsonfield.fields.JSONField', [], {'null': 'True'}),
+            'debug_id': ('django.db.models.fields.CharField', [], {'max_length': '64', 'db_column': "'uuid'"}),
+            'file': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.File']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'object_name': ('django.db.models.fields.TextField', [], {}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True'})
+        },
+        'sentry.projectintegration': {
+            'Meta': {'unique_together': "(('project', 'integration'),)", 'object_name': 'ProjectIntegration'},
+            'config': ('sentry.db.models.fields.encrypted.EncryptedJsonField', [], {'default': '{}'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'integration': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Integration']"}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"})
+        },
+        'sentry.projectkey': {
+            'Meta': {'object_name': 'ProjectKey'},
+            'data': ('jsonfield.fields.JSONField', [], {'default': '{}'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'key_set'", 'to': "orm['sentry.Project']"}),
+            'public_key': ('django.db.models.fields.CharField', [], {'max_length': '32', 'unique': 'True', 'null': 'True'}),
+            'rate_limit_count': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'rate_limit_window': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'roles': ('django.db.models.fields.BigIntegerField', [], {'default': '1'}),
+            'secret_key': ('django.db.models.fields.CharField', [], {'max_length': '32', 'unique': 'True', 'null': 'True'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'db_index': 'True'})
+        },
+        'sentry.projectoption': {
+            'Meta': {'unique_together': "(('project', 'key'),)", 'object_name': 'ProjectOption', 'db_table': "'sentry_projectoptions'"},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'value': ('sentry.db.models.fields.encrypted.EncryptedPickledObjectField', [], {})
+        },
+        'sentry.projectownership': {
+            'Meta': {'object_name': 'ProjectOwnership'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'fallthrough': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']", 'unique': 'True'}),
+            'raw': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'schema': ('jsonfield.fields.JSONField', [], {'null': 'True'})
+        },
+        'sentry.projectplatform': {
+            'Meta': {'unique_together': "(('project_id', 'platform'),)", 'object_name': 'ProjectPlatform'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'platform': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {})
+        },
+        'sentry.projectredirect': {
+            'Meta': {'unique_together': "(('organization', 'redirect_slug'),)", 'object_name': 'ProjectRedirect'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']"}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'redirect_slug': ('django.db.models.fields.SlugField', [], {'max_length': '50'})
+        },
+        'sentry.projectsymcachefile': {
+            'Meta': {'unique_together': "(('project', 'debug_file'),)", 'object_name': 'ProjectSymCacheFile'},
+            'cache_file': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.File']"}),
+            'checksum': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'debug_file': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.ProjectDebugFile']", 'on_delete': 'models.DO_NOTHING', 'db_column': "'dsym_file_id'"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True'}),
+            'version': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {})
+        },
+        'sentry.projectteam': {
+            'Meta': {'unique_together': "(('project', 'team'),)", 'object_name': 'ProjectTeam'},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'team': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Team']"})
+        },
+        'sentry.promptsactivity': {
+            'Meta': {'unique_together': "(('user', 'feature', 'organization_id', 'project_id'),)", 'object_name': 'PromptsActivity'},
+            'data': ('jsonfield.fields.JSONField', [], {'default': '{}'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'feature': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"})
+        },
+        'sentry.pullrequest': {
+            'Meta': {'unique_together': "(('repository_id', 'key'),)", 'object_name': 'PullRequest', 'db_table': "'sentry_pull_request'", 'index_together': "(('repository_id', 'date_added'), ('organization_id', 'merge_commit_sha'))"},
+            'author': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.CommitAuthor']", 'null': 'True'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'merge_commit_sha': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'repository_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'title': ('django.db.models.fields.TextField', [], {'null': 'True'})
+        },
+        'sentry.pullrequestcommit': {
+            'Meta': {'unique_together': "(('pull_request', 'commit'),)", 'object_name': 'PullRequestCommit', 'db_table': "'sentry_pullrequest_commit'"},
+            'commit': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Commit']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'pull_request': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.PullRequest']"})
+        },
+        'sentry.rawevent': {
+            'Meta': {'unique_together': "(('project', 'event_id'),)", 'object_name': 'RawEvent'},
+            'data': ('sentry.db.models.fields.node.NodeField', [], {'null': 'True', 'blank': 'True'}),
+            'datetime': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'event_id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"})
+        },
+        'sentry.relay': {
+            'Meta': {'object_name': 'Relay'},
+            'first_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'is_internal': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'public_key': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'relay_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'})
+        },
+        'sentry.release': {
+            'Meta': {'unique_together': "(('organization', 'version'),)", 'object_name': 'Release'},
+            'authors': ('sentry.db.models.fields.array.ArrayField', [], {'of': (u'django.db.models.fields.TextField', [], {})}),
+            'commit_count': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'null': 'True'}),
+            'data': ('jsonfield.fields.JSONField', [], {'default': '{}'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'date_released': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'date_started': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'last_commit_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'last_deploy_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'new_groups': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']"}),
+            'owner': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'projects': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'releases'", 'symmetrical': 'False', 'through': "orm['sentry.ReleaseProject']", 'to': "orm['sentry.Project']"}),
+            'ref': ('django.db.models.fields.CharField', [], {'max_length': '250', 'null': 'True', 'blank': 'True'}),
+            'total_deploys': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'null': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '250'})
+        },
+        'sentry.releasecommit': {
+            'Meta': {'unique_together': "(('release', 'commit'), ('release', 'order'))", 'object_name': 'ReleaseCommit'},
+            'commit': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Commit']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'order': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'release': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Release']"})
+        },
+        'sentry.releaseenvironment': {
+            'Meta': {'unique_together': "(('organization_id', 'release_id', 'environment_id'),)", 'object_name': 'ReleaseEnvironment', 'db_table': "'sentry_environmentrelease'"},
+            'environment_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'first_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'release_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'})
+        },
+        'sentry.releasefile': {
+            'Meta': {'unique_together': "(('release', 'ident'),)", 'object_name': 'ReleaseFile'},
+            'dist': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Distribution']", 'null': 'True'}),
+            'file': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.File']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'name': ('django.db.models.fields.TextField', [], {}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']"}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'release': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Release']"})
+        },
+        'sentry.releaseheadcommit': {
+            'Meta': {'unique_together': "(('repository_id', 'release'),)", 'object_name': 'ReleaseHeadCommit'},
+            'commit': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Commit']"}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'release': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Release']"}),
+            'repository_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {})
+        },
+        'sentry.releaseproject': {
+            'Meta': {'unique_together': "(('project', 'release'),)", 'object_name': 'ReleaseProject', 'db_table': "'sentry_release_project'"},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'new_groups': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'null': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'release': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Release']"})
+        },
+        'sentry.releaseprojectenvironment': {
+            'Meta': {'unique_together': "(('project', 'release', 'environment'),)", 'object_name': 'ReleaseProjectEnvironment'},
+            'environment': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Environment']"}),
+            'first_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'last_deploy_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'new_issues_count': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'release': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Release']"})
+        },
+        'sentry.repository': {
+            'Meta': {'unique_together': "(('organization_id', 'name'), ('organization_id', 'provider', 'external_id'))", 'object_name': 'Repository'},
+            'config': ('jsonfield.fields.JSONField', [], {'default': '{}'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'external_id': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'integration_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'organization_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'provider': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True'})
+        },
+        'sentry.reprocessingreport': {
+            'Meta': {'unique_together': "(('project', 'event_id'),)", 'object_name': 'ReprocessingReport'},
+            'datetime': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'event_id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"})
+        },
+        'sentry.rule': {
+            'Meta': {'object_name': 'Rule'},
+            'data': ('sentry.db.models.fields.gzippeddict.GzippedDictField', [], {}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'environment_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'db_index': 'True'})
+        },
+        'sentry.savedsearch': {
+            'Meta': {'unique_together': "(('project', 'name'),)", 'object_name': 'SavedSearch'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'is_default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'owner': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']", 'null': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'query': ('django.db.models.fields.TextField', [], {})
+        },
+        'sentry.savedsearchuserdefault': {
+            'Meta': {'unique_together': "(('project', 'user'),)", 'object_name': 'SavedSearchUserDefault', 'db_table': "'sentry_savedsearch_userdefault'"},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"}),
+            'savedsearch': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.SavedSearch']"}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"})
+        },
+        'sentry.scheduleddeletion': {
+            'Meta': {'unique_together': "(('app_label', 'model_name', 'object_id'),)", 'object_name': 'ScheduledDeletion'},
+            'aborted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'actor_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True'}),
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'data': ('jsonfield.fields.JSONField', [], {'default': '{}'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'date_scheduled': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2019, 1, 10, 0, 0)'}),
+            'guid': ('django.db.models.fields.CharField', [], {'default': "'fa560023c9bb4281b3bd2d23e395c0f0'", 'unique': 'True', 'max_length': '32'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'in_progress': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'object_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {})
+        },
+        'sentry.scheduledjob': {
+            'Meta': {'object_name': 'ScheduledJob'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'date_scheduled': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'payload': ('jsonfield.fields.JSONField', [], {'default': '{}'})
+        },
+        'sentry.sentryapp': {
+            'Meta': {'object_name': 'SentryApp'},
+            'application': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'sentry_app'", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['sentry.ApiApplication']"}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'date_deleted': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'date_updated': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'events': ('sentry.db.models.fields.array.ArrayField', [], {'of': (u'django.db.models.fields.TextField', [], {})}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'is_alertable': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.TextField', [], {}),
+            'overview': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'owner': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'owned_sentry_apps'", 'to': "orm['sentry.Organization']"}),
+            'proxy_user': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'sentry_app'", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['sentry.User']"}),
+            'redirect_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True'}),
+            'scope_list': ('sentry.db.models.fields.array.ArrayField', [], {'of': (u'django.db.models.fields.TextField', [], {})}),
+            'scopes': ('django.db.models.fields.BigIntegerField', [], {'default': 'None'}),
+            'slug': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'default': "'89bfa32e-942e-4383-b481-03142af9f6a7'", 'max_length': '64'}),
+            'webhook_url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'sentry.sentryappavatar': {
+            'Meta': {'object_name': 'SentryAppAvatar'},
+            'avatar_type': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0'}),
+            'file': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.File']", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '32', 'db_index': 'True'}),
+            'sentry_app': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'avatar'", 'unique': 'True', 'to': "orm['sentry.SentryApp']"})
+        },
+        'sentry.sentryappinstallation': {
+            'Meta': {'object_name': 'SentryAppInstallation'},
+            'api_grant': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'sentry_app_installation'", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['sentry.ApiGrant']"}),
+            'authorization': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'sentry_app_installation'", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['sentry.ApiAuthorization']"}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'date_deleted': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'date_updated': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'sentry_app_installations'", 'to': "orm['sentry.Organization']"}),
+            'sentry_app': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'installations'", 'to': "orm['sentry.SentryApp']"}),
+            'uuid': ('django.db.models.fields.CharField', [], {'default': "'1f59102b-2ec3-4923-b9ee-c5d2e83003ce'", 'max_length': '64'})
+        },
+        'sentry.servicehook': {
+            'Meta': {'object_name': 'ServiceHook'},
+            'actor_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'application': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.ApiApplication']", 'null': 'True'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'events': ('sentry.db.models.fields.array.ArrayField', [], {'of': (u'django.db.models.fields.TextField', [], {})}),
+            'guid': ('django.db.models.fields.CharField', [], {'max_length': '32', 'unique': 'True', 'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'secret': ('sentry.db.models.fields.encrypted.EncryptedTextField', [], {'default': "'f9cf4692855941cbb3b30f6605b1ddb2746c59ef9b524c42a2a572ede90c672b'"}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '512'}),
+            'version': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'})
+        },
+        'sentry.tagkey': {
+            'Meta': {'unique_together': "(('project_id', 'key'),)", 'object_name': 'TagKey', 'db_table': "'sentry_filterkey'"},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'db_index': 'True'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'}),
+            'values_seen': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'})
+        },
+        'sentry.tagvalue': {
+            'Meta': {'unique_together': "(('project_id', 'key', 'value'),)", 'object_name': 'TagValue', 'db_table': "'sentry_filtervalue'", 'index_together': "(('project_id', 'key', 'last_seen'),)"},
+            'data': ('sentry.db.models.fields.gzippeddict.GzippedDictField', [], {'null': 'True', 'blank': 'True'}),
+            'first_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True', 'db_index': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True', 'db_index': 'True'}),
+            'project_id': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'times_seen': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        'sentry.team': {
+            'Meta': {'unique_together': "(('organization', 'slug'),)", 'object_name': 'Team'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']"}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50'}),
+            'status': ('sentry.db.models.fields.bounded.BoundedPositiveIntegerField', [], {'default': '0'})
+        },
+        'sentry.teamavatar': {
+            'Meta': {'object_name': 'TeamAvatar'},
+            'avatar_type': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0'}),
+            'file': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.File']", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '32', 'db_index': 'True'}),
+            'team': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'avatar'", 'unique': 'True', 'to': "orm['sentry.Team']"})
+        },
+        'sentry.user': {
+            'Meta': {'object_name': 'User', 'db_table': "'auth_user'"},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'flags': ('django.db.models.fields.BigIntegerField', [], {'default': '0', 'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedAutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_managed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_password_expired': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_sentry_app': ('django.db.models.fields.NullBooleanField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_active': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'null': 'True'}),
+            'last_password_change': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_column': "'first_name'", 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'session_nonce': ('django.db.models.fields.CharField', [], {'max_length': '12', 'null': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128'})
+        },
+        'sentry.useravatar': {
+            'Meta': {'object_name': 'UserAvatar'},
+            'avatar_type': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0'}),
+            'file': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.File']", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'ident': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '32', 'db_index': 'True'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'avatar'", 'unique': 'True', 'to': "orm['sentry.User']"})
+        },
+        'sentry.useremail': {
+            'Meta': {'unique_together': "(('user', 'email'),)", 'object_name': 'UserEmail'},
+            'date_hash_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'is_verified': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'related_name': "'emails'", 'to': "orm['sentry.User']"}),
+            'validation_hash': ('django.db.models.fields.CharField', [], {'default': "u'DcXJEI77xoMUdt0pYBbgmPcqKUxBxc9X'", 'max_length': '32'})
+        },
+        'sentry.userip': {
+            'Meta': {'unique_together': "(('user', 'ip_address'),)", 'object_name': 'UserIP'},
+            'country_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True'}),
+            'first_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'ip_address': ('django.db.models.fields.GenericIPAddressField', [], {'max_length': '39'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'region_code': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"})
+        },
+        'sentry.useroption': {
+            'Meta': {'unique_together': "(('user', 'project', 'key'), ('user', 'organization', 'key'))", 'object_name': 'UserOption'},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'organization': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Organization']", 'null': 'True'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']", 'null': 'True'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"}),
+            'value': ('sentry.db.models.fields.encrypted.EncryptedPickledObjectField', [], {})
+        },
+        'sentry.userpermission': {
+            'Meta': {'unique_together': "(('user', 'permission'),)", 'object_name': 'UserPermission'},
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'permission': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'user': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.User']"})
+        },
+        'sentry.userreport': {
+            'Meta': {'unique_together': "(('project', 'event_id'),)", 'object_name': 'UserReport', 'index_together': "(('project', 'event_id'), ('project', 'date_added'))"},
+            'comments': ('django.db.models.fields.TextField', [], {}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'environment': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Environment']", 'null': 'True'}),
+            'event_id': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'event_user_id': ('sentry.db.models.fields.bounded.BoundedBigIntegerField', [], {'null': 'True'}),
+            'group': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Group']", 'null': 'True'}),
+            'id': ('sentry.db.models.fields.bounded.BoundedBigAutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'project': ('sentry.db.models.fields.foreignkey.FlexibleForeignKey', [], {'to': "orm['sentry.Project']"})
+        }
+    }
+
+    complete_apps = ['sentry']

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
@@ -2,18 +2,22 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {browserHistory} from 'react-router';
 
+import {defined} from 'app/utils';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
 import Form from 'app/views/settings/components/forms/form';
 import FormField from 'app/views/settings/components/forms/formField';
+import MultipleCheckbox from 'app/views/settings/components/forms/controls/multipleCheckbox';
 import JsonForm from 'app/views/settings/components/forms/jsonForm';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextCopyInput from 'app/views/settings/components/forms/textCopyInput';
 import sentryApplicationForm from 'app/data/forms/sentryApplication';
 import getDynamicText from 'app/utils/getDynamicText';
 import ApplicationScopes from './applicationScopes';
+
+const EVENT_CHOICES = [['issue', 'Issue events']];
 
 class SentryApplicationDetails extends AsyncView {
   static contextTypes = {
@@ -29,14 +33,25 @@ class SentryApplicationDetails extends AsyncView {
 
   getEndpoints() {
     let {appSlug} = this.props.params;
+
     if (appSlug) {
       return [['app', `/sentry-apps/${appSlug}/`]];
     }
+
     return [];
   }
 
   getTitle() {
     return t('Sentry Application Details');
+  }
+
+  // Events may come from the API as "issue.created" when we just want "issue" here.
+  normalize(events) {
+    if (events.length == 0) {
+      return events;
+    }
+
+    return events.map(e => e.split('.').shift());
   }
 
   handleScopeChange = (onChange, onBlur, scope, scopes, e) => {
@@ -54,6 +69,7 @@ class SentryApplicationDetails extends AsyncView {
     const {app} = this.state;
     let method = app ? 'PUT' : 'POST';
     let endpoint = app ? `/sentry-apps/${app.slug}/` : '/sentry-apps/';
+
     return (
       <div>
         <SettingsPageHeader title={this.getTitle()} />
@@ -85,6 +101,28 @@ class SentryApplicationDetails extends AsyncView {
               </FormField>
             </PanelBody>
           </Panel>
+
+          <Panel>
+            <PanelHeader>{t('Event Subscriptions')}</PanelHeader>
+            <PanelBody>
+              <FormField
+                name="events"
+                inline={false}
+                flexibleControlStateSize={true}
+                choices={EVENT_CHOICES}
+                getData={data => ({events: data})}
+              >
+                {({onChange, value}) => (
+                  <MultipleCheckbox
+                    choices={EVENT_CHOICES}
+                    onChange={onChange}
+                    value={this.normalize((defined(value.peek) && value.peek()) || [])}
+                  />
+                )}
+              </FormField>
+            </PanelBody>
+          </Panel>
+
           {app && (
             <Panel>
               <PanelHeader>{t('Credentials')}</PanelHeader>

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -720,13 +720,18 @@ class Fixtures(object):
         if not webhook_url:
             webhook_url = 'https://example.com/webhook'
 
-        app = sentry_apps.Creator.run(
-            name=name,
-            organization=organization,
-            scopes=scopes,
-            webhook_url=webhook_url,
-            **kwargs
-        )
+        _kwargs = {
+            'name': name,
+            'organization': organization,
+            'scopes': scopes,
+            'webhook_url': webhook_url,
+            'events': [],
+        }
+
+        _kwargs.update(kwargs)
+
+        app = sentry_apps.Creator.run(**_kwargs)
+
         if published:
             app.update(status=SentryAppStatus.PUBLISHED)
 
@@ -750,10 +755,13 @@ class Fixtures(object):
         if not url:
             url = 'https://example/sentry/webhook'
 
-        return service_hooks.Creator.run(
-            actor=actor,
-            project=project,
-            events=events,
-            url=url,
-            **kwargs
-        )
+        _kwargs = {
+            'actor': actor,
+            'project': project,
+            'events': events,
+            'url': url,
+        }
+
+        _kwargs.update(kwargs)
+
+        return service_hooks.Creator.run(**_kwargs)

--- a/tests/js/fixtures/sentryApp.js
+++ b/tests/js/fixtures/sentryApp.js
@@ -3,6 +3,7 @@ export function SentryApp(params = {}) {
     name: 'Sample App',
     slug: 'sample-app',
     scopes: ['project:read'],
+    events: [],
     uuid: '123456123456123456123456',
     webhookUrl: 'https://example.com/webhook',
     redirectUrl: 'https://example/com/setup',

--- a/tests/js/spec/components/modals/__snapshots__/sentryAppPermissionsModal.spec.jsx.snap
+++ b/tests/js/spec/components/modals/__snapshots__/sentryAppPermissionsModal.spec.jsx.snap
@@ -8,6 +8,7 @@ exports[`SentryAppPermissionsModal installs the application 1`] = `
     Object {
       "clientId": "client-id",
       "clientSecret": "client-secret",
+      "events": Array [],
       "isAlertable": false,
       "name": "Sample App",
       "overview": "This is an app.",
@@ -228,6 +229,7 @@ exports[`SentryAppPermissionsModal renders permissions modal 1`] = `
     Object {
       "clientId": "client-id",
       "clientSecret": "client-secret",
+      "events": Array [],
       "isAlertable": false,
       "name": "Sample App",
       "overview": "This is an app.",

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
@@ -222,6 +222,7 @@ exports[`Organization Developer Settings when Apps exist displays all Apps owned
                       Object {
                         "clientId": "client-id",
                         "clientSecret": "client-secret",
+                        "events": Array [],
                         "isAlertable": false,
                         "name": "Sample App",
                         "overview": "This is an app.",
@@ -259,6 +260,7 @@ exports[`Organization Developer Settings when Apps exist displays all Apps owned
                                     Object {
                                       "clientId": "client-id",
                                       "clientSecret": "client-secret",
+                                      "events": Array [],
                                       "isAlertable": false,
                                       "name": "Sample App",
                                       "overview": "This is an app.",

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/sentryApplicationDetails.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/sentryApplicationDetails.spec.jsx.snap
@@ -62,6 +62,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
             Object {
               "clientId": "client-id",
               "clientSecret": "client-secret",
+              "events": Array [],
               "isAlertable": false,
               "name": "Sample App",
               "organization": "org-slug",
@@ -492,6 +493,20 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "name": "scopes",
                                                                     "required": true,
                                                                   },
+                                                                  "events" => Object {
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "issue",
+                                                                        "Issue events",
+                                                                      ],
+                                                                    ],
+                                                                    "flexibleControlStateSize": true,
+                                                                    "getData": [Function],
+                                                                    "hideErrorMessage": false,
+                                                                    "inline": false,
+                                                                    "name": "events",
+                                                                  },
                                                                   "clientId" => Object {
                                                                     "children": [Function],
                                                                     "flexibleControlStateSize": false,
@@ -513,6 +528,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                 "fields": Object {
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
+                                                                  "events": Array [],
                                                                   "isAlertable": false,
                                                                   "name": "Sample App",
                                                                   "organization": "org-slug",
@@ -529,6 +545,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                 "initialData": Object {
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
+                                                                  "events": Array [],
                                                                   "isAlertable": false,
                                                                   "name": "Sample App",
                                                                   "organization": "org-slug",
@@ -560,6 +577,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "scopes" => Array [
                                                                       "project:read",
                                                                     ],
+                                                                    "events" => Array [],
                                                                     "uuid" => "123456123456123456123456",
                                                                     "webhookUrl" => "https://example.com/webhook",
                                                                     "redirectUrl" => "https://example/com/setup",
@@ -642,6 +660,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             Object {
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
+                                                                                              "events": Array [],
                                                                                               "isAlertable": false,
                                                                                               "name": "Sample App",
                                                                                               "organization": "org-slug",
@@ -815,6 +834,20 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "name": "scopes",
                                                                                                 "required": true,
                                                                                               },
+                                                                                              "events" => Object {
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "issue",
+                                                                                                    "Issue events",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "flexibleControlStateSize": true,
+                                                                                                "getData": [Function],
+                                                                                                "hideErrorMessage": false,
+                                                                                                "inline": false,
+                                                                                                "name": "events",
+                                                                                              },
                                                                                               "clientId" => Object {
                                                                                                 "children": [Function],
                                                                                                 "flexibleControlStateSize": false,
@@ -836,6 +869,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "fields": Object {
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
+                                                                                              "events": Array [],
                                                                                               "isAlertable": false,
                                                                                               "name": "Sample App",
                                                                                               "organization": "org-slug",
@@ -852,6 +886,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "initialData": Object {
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
+                                                                                              "events": Array [],
                                                                                               "isAlertable": false,
                                                                                               "name": "Sample App",
                                                                                               "organization": "org-slug",
@@ -883,6 +918,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "scopes" => Array [
                                                                                                   "project:read",
                                                                                                 ],
+                                                                                                "events" => Array [],
                                                                                                 "uuid" => "123456123456123456123456",
                                                                                                 "webhookUrl" => "https://example.com/webhook",
                                                                                                 "redirectUrl" => "https://example/com/setup",
@@ -1156,6 +1192,20 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "name": "scopes",
                                                                     "required": true,
                                                                   },
+                                                                  "events" => Object {
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "issue",
+                                                                        "Issue events",
+                                                                      ],
+                                                                    ],
+                                                                    "flexibleControlStateSize": true,
+                                                                    "getData": [Function],
+                                                                    "hideErrorMessage": false,
+                                                                    "inline": false,
+                                                                    "name": "events",
+                                                                  },
                                                                   "clientId" => Object {
                                                                     "children": [Function],
                                                                     "flexibleControlStateSize": false,
@@ -1177,6 +1227,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                 "fields": Object {
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
+                                                                  "events": Array [],
                                                                   "isAlertable": false,
                                                                   "name": "Sample App",
                                                                   "organization": "org-slug",
@@ -1193,6 +1244,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                 "initialData": Object {
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
+                                                                  "events": Array [],
                                                                   "isAlertable": false,
                                                                   "name": "Sample App",
                                                                   "organization": "org-slug",
@@ -1224,6 +1276,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "scopes" => Array [
                                                                       "project:read",
                                                                     ],
+                                                                    "events" => Array [],
                                                                     "uuid" => "123456123456123456123456",
                                                                     "webhookUrl" => "https://example.com/webhook",
                                                                     "redirectUrl" => "https://example/com/setup",
@@ -1306,6 +1359,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             Object {
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
+                                                                                              "events": Array [],
                                                                                               "isAlertable": false,
                                                                                               "name": "Sample App",
                                                                                               "organization": "org-slug",
@@ -1479,6 +1533,20 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "name": "scopes",
                                                                                                 "required": true,
                                                                                               },
+                                                                                              "events" => Object {
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "issue",
+                                                                                                    "Issue events",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "flexibleControlStateSize": true,
+                                                                                                "getData": [Function],
+                                                                                                "hideErrorMessage": false,
+                                                                                                "inline": false,
+                                                                                                "name": "events",
+                                                                                              },
                                                                                               "clientId" => Object {
                                                                                                 "children": [Function],
                                                                                                 "flexibleControlStateSize": false,
@@ -1500,6 +1568,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "fields": Object {
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
+                                                                                              "events": Array [],
                                                                                               "isAlertable": false,
                                                                                               "name": "Sample App",
                                                                                               "organization": "org-slug",
@@ -1516,6 +1585,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "initialData": Object {
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
+                                                                                              "events": Array [],
                                                                                               "isAlertable": false,
                                                                                               "name": "Sample App",
                                                                                               "organization": "org-slug",
@@ -1547,6 +1617,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "scopes" => Array [
                                                                                                   "project:read",
                                                                                                 ],
+                                                                                                "events" => Array [],
                                                                                                 "uuid" => "123456123456123456123456",
                                                                                                 "webhookUrl" => "https://example.com/webhook",
                                                                                                 "redirectUrl" => "https://example/com/setup",
@@ -1811,6 +1882,20 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "name": "scopes",
                                                                     "required": true,
                                                                   },
+                                                                  "events" => Object {
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "issue",
+                                                                        "Issue events",
+                                                                      ],
+                                                                    ],
+                                                                    "flexibleControlStateSize": true,
+                                                                    "getData": [Function],
+                                                                    "hideErrorMessage": false,
+                                                                    "inline": false,
+                                                                    "name": "events",
+                                                                  },
                                                                   "clientId" => Object {
                                                                     "children": [Function],
                                                                     "flexibleControlStateSize": false,
@@ -1832,6 +1917,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                 "fields": Object {
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
+                                                                  "events": Array [],
                                                                   "isAlertable": false,
                                                                   "name": "Sample App",
                                                                   "organization": "org-slug",
@@ -1848,6 +1934,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                 "initialData": Object {
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
+                                                                  "events": Array [],
                                                                   "isAlertable": false,
                                                                   "name": "Sample App",
                                                                   "organization": "org-slug",
@@ -1879,6 +1966,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "scopes" => Array [
                                                                       "project:read",
                                                                     ],
+                                                                    "events" => Array [],
                                                                     "uuid" => "123456123456123456123456",
                                                                     "webhookUrl" => "https://example.com/webhook",
                                                                     "redirectUrl" => "https://example/com/setup",
@@ -1961,6 +2049,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             Object {
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
+                                                                                              "events": Array [],
                                                                                               "isAlertable": false,
                                                                                               "name": "Sample App",
                                                                                               "organization": "org-slug",
@@ -2132,6 +2221,20 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "name": "scopes",
                                                                                                 "required": true,
                                                                                               },
+                                                                                              "events" => Object {
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "issue",
+                                                                                                    "Issue events",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "flexibleControlStateSize": true,
+                                                                                                "getData": [Function],
+                                                                                                "hideErrorMessage": false,
+                                                                                                "inline": false,
+                                                                                                "name": "events",
+                                                                                              },
                                                                                               "clientId" => Object {
                                                                                                 "children": [Function],
                                                                                                 "flexibleControlStateSize": false,
@@ -2153,6 +2256,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "fields": Object {
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
+                                                                                              "events": Array [],
                                                                                               "isAlertable": false,
                                                                                               "name": "Sample App",
                                                                                               "organization": "org-slug",
@@ -2169,6 +2273,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "initialData": Object {
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
+                                                                                              "events": Array [],
                                                                                               "isAlertable": false,
                                                                                               "name": "Sample App",
                                                                                               "organization": "org-slug",
@@ -2200,6 +2305,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "scopes" => Array [
                                                                                                   "project:read",
                                                                                                 ],
+                                                                                                "events" => Array [],
                                                                                                 "uuid" => "123456123456123456123456",
                                                                                                 "webhookUrl" => "https://example.com/webhook",
                                                                                                 "redirectUrl" => "https://example/com/setup",
@@ -2564,6 +2670,20 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "name": "scopes",
                                                                     "required": true,
                                                                   },
+                                                                  "events" => Object {
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "issue",
+                                                                        "Issue events",
+                                                                      ],
+                                                                    ],
+                                                                    "flexibleControlStateSize": true,
+                                                                    "getData": [Function],
+                                                                    "hideErrorMessage": false,
+                                                                    "inline": false,
+                                                                    "name": "events",
+                                                                  },
                                                                   "clientId" => Object {
                                                                     "children": [Function],
                                                                     "flexibleControlStateSize": false,
@@ -2585,6 +2705,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                 "fields": Object {
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
+                                                                  "events": Array [],
                                                                   "isAlertable": false,
                                                                   "name": "Sample App",
                                                                   "organization": "org-slug",
@@ -2601,6 +2722,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                 "initialData": Object {
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
+                                                                  "events": Array [],
                                                                   "isAlertable": false,
                                                                   "name": "Sample App",
                                                                   "organization": "org-slug",
@@ -2632,6 +2754,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "scopes" => Array [
                                                                       "project:read",
                                                                     ],
+                                                                    "events" => Array [],
                                                                     "uuid" => "123456123456123456123456",
                                                                     "webhookUrl" => "https://example.com/webhook",
                                                                     "redirectUrl" => "https://example/com/setup",
@@ -2729,6 +2852,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             Object {
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
+                                                                                              "events": Array [],
                                                                                               "isAlertable": false,
                                                                                               "name": "Sample App",
                                                                                               "organization": "org-slug",
@@ -2919,6 +3043,20 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "name": "scopes",
                                                                                                 "required": true,
                                                                                               },
+                                                                                              "events" => Object {
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "issue",
+                                                                                                    "Issue events",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "flexibleControlStateSize": true,
+                                                                                                "getData": [Function],
+                                                                                                "hideErrorMessage": false,
+                                                                                                "inline": false,
+                                                                                                "name": "events",
+                                                                                              },
                                                                                               "clientId" => Object {
                                                                                                 "children": [Function],
                                                                                                 "flexibleControlStateSize": false,
@@ -2940,6 +3078,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "fields": Object {
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
+                                                                                              "events": Array [],
                                                                                               "isAlertable": false,
                                                                                               "name": "Sample App",
                                                                                               "organization": "org-slug",
@@ -2956,6 +3095,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "initialData": Object {
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
+                                                                                              "events": Array [],
                                                                                               "isAlertable": false,
                                                                                               "name": "Sample App",
                                                                                               "organization": "org-slug",
@@ -2987,6 +3127,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "scopes" => Array [
                                                                                                   "project:read",
                                                                                                 ],
+                                                                                                "events" => Array [],
                                                                                                 "uuid" => "123456123456123456123456",
                                                                                                 "webhookUrl" => "https://example.com/webhook",
                                                                                                 "redirectUrl" => "https://example/com/setup",
@@ -3251,6 +3392,20 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "name": "scopes",
                                                                     "required": true,
                                                                   },
+                                                                  "events" => Object {
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "issue",
+                                                                        "Issue events",
+                                                                      ],
+                                                                    ],
+                                                                    "flexibleControlStateSize": true,
+                                                                    "getData": [Function],
+                                                                    "hideErrorMessage": false,
+                                                                    "inline": false,
+                                                                    "name": "events",
+                                                                  },
                                                                   "clientId" => Object {
                                                                     "children": [Function],
                                                                     "flexibleControlStateSize": false,
@@ -3272,6 +3427,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                 "fields": Object {
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
+                                                                  "events": Array [],
                                                                   "isAlertable": false,
                                                                   "name": "Sample App",
                                                                   "organization": "org-slug",
@@ -3288,6 +3444,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                 "initialData": Object {
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
+                                                                  "events": Array [],
                                                                   "isAlertable": false,
                                                                   "name": "Sample App",
                                                                   "organization": "org-slug",
@@ -3319,6 +3476,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "scopes" => Array [
                                                                       "project:read",
                                                                     ],
+                                                                    "events" => Array [],
                                                                     "uuid" => "123456123456123456123456",
                                                                     "webhookUrl" => "https://example.com/webhook",
                                                                     "redirectUrl" => "https://example/com/setup",
@@ -3402,6 +3560,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             Object {
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
+                                                                                              "events": Array [],
                                                                                               "isAlertable": false,
                                                                                               "name": "Sample App",
                                                                                               "organization": "org-slug",
@@ -3599,6 +3758,20 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "name": "scopes",
                                                                                                 "required": true,
                                                                                               },
+                                                                                              "events" => Object {
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "issue",
+                                                                                                    "Issue events",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "flexibleControlStateSize": true,
+                                                                                                "getData": [Function],
+                                                                                                "hideErrorMessage": false,
+                                                                                                "inline": false,
+                                                                                                "name": "events",
+                                                                                              },
                                                                                               "clientId" => Object {
                                                                                                 "children": [Function],
                                                                                                 "flexibleControlStateSize": false,
@@ -3620,6 +3793,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "fields": Object {
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
+                                                                                              "events": Array [],
                                                                                               "isAlertable": false,
                                                                                               "name": "Sample App",
                                                                                               "organization": "org-slug",
@@ -3636,6 +3810,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "initialData": Object {
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
+                                                                                              "events": Array [],
                                                                                               "isAlertable": false,
                                                                                               "name": "Sample App",
                                                                                               "organization": "org-slug",
@@ -3667,6 +3842,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "scopes" => Array [
                                                                                                   "project:read",
                                                                                                 ],
+                                                                                                "events" => Array [],
                                                                                                 "uuid" => "123456123456123456123456",
                                                                                                 "webhookUrl" => "https://example.com/webhook",
                                                                                                 "redirectUrl" => "https://example/com/setup",
@@ -3908,6 +4084,20 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                     "name": "scopes",
                                                     "required": true,
                                                   },
+                                                  "events" => Object {
+                                                    "children": [Function],
+                                                    "choices": Array [
+                                                      Array [
+                                                        "issue",
+                                                        "Issue events",
+                                                      ],
+                                                    ],
+                                                    "flexibleControlStateSize": true,
+                                                    "getData": [Function],
+                                                    "hideErrorMessage": false,
+                                                    "inline": false,
+                                                    "name": "events",
+                                                  },
                                                   "clientId" => Object {
                                                     "children": [Function],
                                                     "flexibleControlStateSize": false,
@@ -3929,6 +4119,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                 "fields": Object {
                                                   "clientId": "client-id",
                                                   "clientSecret": "client-secret",
+                                                  "events": Array [],
                                                   "isAlertable": false,
                                                   "name": "Sample App",
                                                   "organization": "org-slug",
@@ -3945,6 +4136,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                 "initialData": Object {
                                                   "clientId": "client-id",
                                                   "clientSecret": "client-secret",
+                                                  "events": Array [],
                                                   "isAlertable": false,
                                                   "name": "Sample App",
                                                   "organization": "org-slug",
@@ -3976,6 +4168,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                     "scopes" => Array [
                                                       "project:read",
                                                     ],
+                                                    "events" => Array [],
                                                     "uuid" => "123456123456123456123456",
                                                     "webhookUrl" => "https://example.com/webhook",
                                                     "redirectUrl" => "https://example/com/setup",
@@ -5288,6 +5481,20 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                 "name": "scopes",
                                                                                 "required": true,
                                                                               },
+                                                                              "events" => Object {
+                                                                                "children": [Function],
+                                                                                "choices": Array [
+                                                                                  Array [
+                                                                                    "issue",
+                                                                                    "Issue events",
+                                                                                  ],
+                                                                                ],
+                                                                                "flexibleControlStateSize": true,
+                                                                                "getData": [Function],
+                                                                                "hideErrorMessage": false,
+                                                                                "inline": false,
+                                                                                "name": "events",
+                                                                              },
                                                                               "clientId" => Object {
                                                                                 "children": [Function],
                                                                                 "flexibleControlStateSize": false,
@@ -5309,6 +5516,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                             "fields": Object {
                                                                               "clientId": "client-id",
                                                                               "clientSecret": "client-secret",
+                                                                              "events": Array [],
                                                                               "isAlertable": false,
                                                                               "name": "Sample App",
                                                                               "organization": "org-slug",
@@ -5325,6 +5533,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                             "initialData": Object {
                                                                               "clientId": "client-id",
                                                                               "clientSecret": "client-secret",
+                                                                              "events": Array [],
                                                                               "isAlertable": false,
                                                                               "name": "Sample App",
                                                                               "organization": "org-slug",
@@ -5356,6 +5565,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                 "scopes" => Array [
                                                                                   "project:read",
                                                                                 ],
+                                                                                "events" => Array [],
                                                                                 "uuid" => "123456123456123456123456",
                                                                                 "webhookUrl" => "https://example.com/webhook",
                                                                                 "redirectUrl" => "https://example/com/setup",
@@ -5367,6 +5577,696 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                           }
                                                                         }
                                                                         name="scopes"
+                                                                      >
+                                                                        <Observer />
+                                                                        <Observer />
+                                                                      </ControlState>
+                                                                    </div>
+                                                                  </Base>
+                                                                </Flex>
+                                                              </Component>
+                                                            </FieldControlState>
+                                                          </div>
+                                                        </Base>
+                                                      </Flex>
+                                                    </Component>
+                                                  </FieldControlWrapper>
+                                                  <Observer />
+                                                </div>
+                                              </Base>
+                                            </Box>
+                                          </Component>
+                                        </FieldControlErrorWrapper>
+                                      </FieldControl>
+                                    </div>
+                                  </Base>
+                                </Flex>
+                              </Component>
+                            </FieldWrapper>
+                          </Field>
+                        </FormField>
+                      </div>
+                    </PanelBody>
+                  </div>
+                </Component>
+              </Panel>
+              <Panel>
+                <Component
+                  className="css-yahxlu-Panel e1laxa7d0"
+                >
+                  <div
+                    className="css-yahxlu-Panel e1laxa7d0"
+                  >
+                    <PanelHeader>
+                      <Component
+                        className="css-xhx6pj-PanelHeader-getPadding e1p8v8nv0"
+                      >
+                        <Flex
+                          align="center"
+                          className="css-xhx6pj-PanelHeader-getPadding e1p8v8nv0"
+                          justify="space-between"
+                        >
+                          <Base
+                            align="center"
+                            className="e1p8v8nv0 css-b7ices-PanelHeader-getPadding"
+                            justify="space-between"
+                          >
+                            <div
+                              className="e1p8v8nv0 css-b7ices-PanelHeader-getPadding"
+                              is={null}
+                            >
+                              Event Subscriptions
+                            </div>
+                          </Base>
+                        </Flex>
+                      </Component>
+                    </PanelHeader>
+                    <PanelBody
+                      direction="column"
+                      disablePadding={true}
+                      flex={false}
+                    >
+                      <div
+                        className="css-9vq8an-textStyles"
+                      >
+                        <FormField
+                          choices={
+                            Array [
+                              Array [
+                                "issue",
+                                "Issue events",
+                              ],
+                            ]
+                          }
+                          flexibleControlStateSize={true}
+                          getData={[Function]}
+                          hideErrorMessage={false}
+                          inline={false}
+                          name="events"
+                        >
+                          <Field
+                            alignRight={false}
+                            choices={
+                              Array [
+                                Array [
+                                  "issue",
+                                  "Issue events",
+                                ],
+                              ]
+                            }
+                            disabled={false}
+                            flexibleControlStateSize={true}
+                            getData={[Function]}
+                            id="events"
+                            inline={false}
+                            name="events"
+                            required={false}
+                            visible={true}
+                          >
+                            <FieldWrapper
+                              hasControlState={false}
+                              inline={false}
+                            >
+                              <Component
+                                className="css-11ihpht-FieldWrapper-getPadding-borderStyle-inlineStyle etqqcs20"
+                              >
+                                <Flex
+                                  className="css-11ihpht-FieldWrapper-getPadding-borderStyle-inlineStyle etqqcs20"
+                                >
+                                  <Base
+                                    className="etqqcs20 css-1uohzo7-FieldWrapper-getPadding-borderStyle-inlineStyle"
+                                  >
+                                    <div
+                                      className="etqqcs20 css-1uohzo7-FieldWrapper-getPadding-borderStyle-inlineStyle"
+                                      is={null}
+                                    >
+                                      <FieldControl
+                                        alignRight={false}
+                                        controlState={
+                                          <ControlState
+                                            model={
+                                              FormModel {
+                                                "api": Client {},
+                                                "errors": Object {},
+                                                "fieldDescriptor": Map {
+                                                  "name" => Object {
+                                                    "access": undefined,
+                                                    "children": [Function],
+                                                    "className": undefined,
+                                                    "disabled": undefined,
+                                                    "features": undefined,
+                                                    "field": [Function],
+                                                    "flexibleControlStateSize": false,
+                                                    "help": "Human readable name of your application.",
+                                                    "hideErrorMessage": false,
+                                                    "highlighted": false,
+                                                    "label": "Name",
+                                                    "name": "name",
+                                                    "placeholder": "e.g. My Application",
+                                                    "required": true,
+                                                    "type": "text",
+                                                  },
+                                                  "webhookUrl" => Object {
+                                                    "access": undefined,
+                                                    "children": [Function],
+                                                    "className": undefined,
+                                                    "disabled": undefined,
+                                                    "features": undefined,
+                                                    "field": [Function],
+                                                    "flexibleControlStateSize": false,
+                                                    "help": "The URL Sentry will send requests to on installation changes.",
+                                                    "hideErrorMessage": false,
+                                                    "highlighted": false,
+                                                    "label": "Webhook URL",
+                                                    "name": "webhookUrl",
+                                                    "placeholder": "e.g. https://example.com/sentry/webhook/",
+                                                    "required": true,
+                                                    "type": "text",
+                                                  },
+                                                  "redirectUrl" => Object {
+                                                    "access": undefined,
+                                                    "children": [Function],
+                                                    "className": undefined,
+                                                    "disabled": undefined,
+                                                    "features": undefined,
+                                                    "field": [Function],
+                                                    "flexibleControlStateSize": false,
+                                                    "help": "The URL Sentry will redirect users to after installation.",
+                                                    "hideErrorMessage": false,
+                                                    "highlighted": false,
+                                                    "label": "Redirect URL",
+                                                    "name": "redirectUrl",
+                                                    "placeholder": "e.g. https://example.com/sentry/setup/",
+                                                    "type": "text",
+                                                  },
+                                                  "isAlertable" => Object {
+                                                    "access": undefined,
+                                                    "children": [Function],
+                                                    "className": undefined,
+                                                    "disabled": undefined,
+                                                    "features": undefined,
+                                                    "field": [Function],
+                                                    "flexibleControlStateSize": false,
+                                                    "help": <span>
+                                                      <span>
+                                                        If enabled, this application will be an action under alert rules in Sentry. The notification destination is the Webhook URL specified above. More on actions 
+                                                      </span>
+                                                      <a
+                                                        href="https://docs.sentry.io/product/notifications/#actions"
+                                                      >
+                                                        <span>
+                                                          Here
+                                                        </span>
+                                                      </a>
+                                                      <span>
+                                                        .
+                                                      </span>
+                                                    </span>,
+                                                    "hideErrorMessage": false,
+                                                    "highlighted": false,
+                                                    "label": "Alert Rule Action",
+                                                    "name": "isAlertable",
+                                                    "resetOnError": true,
+                                                    "type": "boolean",
+                                                  },
+                                                  "overview" => Object {
+                                                    "access": undefined,
+                                                    "autosize": true,
+                                                    "children": [Function],
+                                                    "className": undefined,
+                                                    "disabled": undefined,
+                                                    "features": undefined,
+                                                    "field": [Function],
+                                                    "flexibleControlStateSize": false,
+                                                    "help": "Description of your application and its functionality.",
+                                                    "hideErrorMessage": false,
+                                                    "highlighted": false,
+                                                    "label": "Overview",
+                                                    "name": "overview",
+                                                    "type": "textarea",
+                                                  },
+                                                  "scopes" => Object {
+                                                    "children": [Function],
+                                                    "flexibleControlStateSize": true,
+                                                    "getData": [Function],
+                                                    "hideErrorMessage": false,
+                                                    "inline": false,
+                                                    "name": "scopes",
+                                                    "required": true,
+                                                  },
+                                                  "events" => Object {
+                                                    "children": [Function],
+                                                    "choices": Array [
+                                                      Array [
+                                                        "issue",
+                                                        "Issue events",
+                                                      ],
+                                                    ],
+                                                    "flexibleControlStateSize": true,
+                                                    "getData": [Function],
+                                                    "hideErrorMessage": false,
+                                                    "inline": false,
+                                                    "name": "events",
+                                                  },
+                                                  "clientId" => Object {
+                                                    "children": [Function],
+                                                    "flexibleControlStateSize": false,
+                                                    "hideErrorMessage": false,
+                                                    "label": "Client ID",
+                                                    "name": "clientId",
+                                                    "overflow": true,
+                                                  },
+                                                  "clientSecret" => Object {
+                                                    "children": [Function],
+                                                    "flexibleControlStateSize": false,
+                                                    "hideErrorMessage": false,
+                                                    "label": "Client Secret",
+                                                    "name": "clientSecret",
+                                                    "overflow": true,
+                                                  },
+                                                },
+                                                "fieldState": Object {},
+                                                "fields": Object {
+                                                  "clientId": "client-id",
+                                                  "clientSecret": "client-secret",
+                                                  "events": Array [],
+                                                  "isAlertable": false,
+                                                  "name": "Sample App",
+                                                  "organization": "org-slug",
+                                                  "overview": "This is an app.",
+                                                  "redirectUrl": "https://example/com/setup",
+                                                  "scopes": Array [
+                                                    "project:read",
+                                                  ],
+                                                  "slug": "sample-app",
+                                                  "uuid": "123456123456123456123456",
+                                                  "webhookUrl": "https://example.com/webhook",
+                                                },
+                                                "formState": undefined,
+                                                "initialData": Object {
+                                                  "clientId": "client-id",
+                                                  "clientSecret": "client-secret",
+                                                  "events": Array [],
+                                                  "isAlertable": false,
+                                                  "name": "Sample App",
+                                                  "organization": "org-slug",
+                                                  "overview": "This is an app.",
+                                                  "redirectUrl": "https://example/com/setup",
+                                                  "scopes": Array [
+                                                    "project:read",
+                                                  ],
+                                                  "slug": "sample-app",
+                                                  "uuid": "123456123456123456123456",
+                                                  "webhookUrl": "https://example.com/webhook",
+                                                },
+                                                "options": Object {
+                                                  "allowUndo": true,
+                                                  "apiEndpoint": "/sentry-apps/sample-app/",
+                                                  "apiMethod": "PUT",
+                                                  "onFieldChange": undefined,
+                                                  "onSubmitError": [Function],
+                                                  "onSubmitSuccess": [Function],
+                                                  "resetOnError": undefined,
+                                                  "saveOnBlur": false,
+                                                },
+                                                "snapshots": Array [
+                                                  Map {
+                                                    "organization" => "org-slug",
+                                                    "isAlertable" => false,
+                                                    "name" => "Sample App",
+                                                    "slug" => "sample-app",
+                                                    "scopes" => Array [
+                                                      "project:read",
+                                                    ],
+                                                    "events" => Array [],
+                                                    "uuid" => "123456123456123456123456",
+                                                    "webhookUrl" => "https://example.com/webhook",
+                                                    "redirectUrl" => "https://example/com/setup",
+                                                    "clientId" => "client-id",
+                                                    "clientSecret" => "client-secret",
+                                                    "overview" => "This is an app.",
+                                                  },
+                                                ],
+                                              }
+                                            }
+                                            name="events"
+                                          />
+                                        }
+                                        disabled={false}
+                                        errorState={
+                                          <Observer>
+                                            [Function]
+                                          </Observer>
+                                        }
+                                        flexibleControlStateSize={true}
+                                        inline={false}
+                                      >
+                                        <FieldControlErrorWrapper
+                                          inline={false}
+                                        >
+                                          <Component
+                                            className="css-1ge7tqf-FieldControlErrorWrapper e78b1iv0"
+                                            inline={false}
+                                          >
+                                            <Box
+                                              className="css-1ge7tqf-FieldControlErrorWrapper e78b1iv0"
+                                            >
+                                              <Base
+                                                className="e78b1iv0 css-nnn2ut-FieldControlErrorWrapper"
+                                              >
+                                                <div
+                                                  className="e78b1iv0 css-nnn2ut-FieldControlErrorWrapper"
+                                                  is={null}
+                                                >
+                                                  <FieldControlWrapper>
+                                                    <Component
+                                                      className="css-1ke1xob-FieldControlWrapper e78b1iv2"
+                                                    >
+                                                      <Flex
+                                                        className="css-1ke1xob-FieldControlWrapper e78b1iv2"
+                                                      >
+                                                        <Base
+                                                          className="e78b1iv2 css-w4o1g8-FieldControlWrapper"
+                                                        >
+                                                          <div
+                                                            className="e78b1iv2 css-w4o1g8-FieldControlWrapper"
+                                                            is={null}
+                                                          >
+                                                            <FieldControlStyled
+                                                              alignRight={false}
+                                                            >
+                                                              <Component
+                                                                alignRight={false}
+                                                                className="css-1pkvhmy-FieldControlStyled e78b1iv1"
+                                                              >
+                                                                <Box
+                                                                  className="css-1pkvhmy-FieldControlStyled e78b1iv1"
+                                                                >
+                                                                  <Base
+                                                                    className="e78b1iv1 css-wkkbba-FieldControlStyled"
+                                                                  >
+                                                                    <div
+                                                                      className="e78b1iv1 css-wkkbba-FieldControlStyled"
+                                                                      is={null}
+                                                                    >
+                                                                      <Observer>
+                                                                        <MultipleCheckbox
+                                                                          choices={
+                                                                            Array [
+                                                                              Array [
+                                                                                "issue",
+                                                                                "Issue events",
+                                                                              ],
+                                                                            ]
+                                                                          }
+                                                                          onChange={[Function]}
+                                                                          value={Array []}
+                                                                        >
+                                                                          <MultipleCheckboxWrapper>
+                                                                            <div
+                                                                              className="css-sjyy3m-MultipleCheckboxWrapper e18jwynw0"
+                                                                            >
+                                                                              <Box
+                                                                                key="issue"
+                                                                                w={
+                                                                                  Array [
+                                                                                    1,
+                                                                                    0.5,
+                                                                                    0.3333333333333333,
+                                                                                    0.25,
+                                                                                  ]
+                                                                                }
+                                                                              >
+                                                                                <Base
+                                                                                  className="css-1nqix7c"
+                                                                                  w={
+                                                                                    Array [
+                                                                                      1,
+                                                                                      0.5,
+                                                                                      0.3333333333333333,
+                                                                                      0.25,
+                                                                                    ]
+                                                                                  }
+                                                                                >
+                                                                                  <div
+                                                                                    className="css-1nqix7c"
+                                                                                    is={null}
+                                                                                  >
+                                                                                    <Label>
+                                                                                      <label
+                                                                                        className="css-ya7yx0-Label e18jwynw1"
+                                                                                      >
+                                                                                        <input
+                                                                                          checked={false}
+                                                                                          onChange={[Function]}
+                                                                                          type="checkbox"
+                                                                                          value="issue"
+                                                                                        />
+                                                                                        <CheckboxLabel>
+                                                                                          <span
+                                                                                            className="css-zrqf4y-CheckboxLabel e18jwynw2"
+                                                                                          >
+                                                                                            Issue events
+                                                                                          </span>
+                                                                                        </CheckboxLabel>
+                                                                                      </label>
+                                                                                    </Label>
+                                                                                  </div>
+                                                                                </Base>
+                                                                              </Box>
+                                                                            </div>
+                                                                          </MultipleCheckboxWrapper>
+                                                                        </MultipleCheckbox>
+                                                                      </Observer>
+                                                                    </div>
+                                                                  </Base>
+                                                                </Box>
+                                                              </Component>
+                                                            </FieldControlStyled>
+                                                            <FieldControlState
+                                                              flexibleControlStateSize={true}
+                                                            >
+                                                              <Component
+                                                                className="css-1x60lk6-FieldControlState e1rziqw00"
+                                                                flexibleControlStateSize={true}
+                                                              >
+                                                                <Flex
+                                                                  className="css-1x60lk6-FieldControlState e1rziqw00"
+                                                                >
+                                                                  <Base
+                                                                    className="e1rziqw00 css-dgyrfj-FieldControlState"
+                                                                  >
+                                                                    <div
+                                                                      className="e1rziqw00 css-dgyrfj-FieldControlState"
+                                                                      is={null}
+                                                                    >
+                                                                      <ControlState
+                                                                        model={
+                                                                          FormModel {
+                                                                            "api": Client {},
+                                                                            "errors": Object {},
+                                                                            "fieldDescriptor": Map {
+                                                                              "name" => Object {
+                                                                                "access": undefined,
+                                                                                "children": [Function],
+                                                                                "className": undefined,
+                                                                                "disabled": undefined,
+                                                                                "features": undefined,
+                                                                                "field": [Function],
+                                                                                "flexibleControlStateSize": false,
+                                                                                "help": "Human readable name of your application.",
+                                                                                "hideErrorMessage": false,
+                                                                                "highlighted": false,
+                                                                                "label": "Name",
+                                                                                "name": "name",
+                                                                                "placeholder": "e.g. My Application",
+                                                                                "required": true,
+                                                                                "type": "text",
+                                                                              },
+                                                                              "webhookUrl" => Object {
+                                                                                "access": undefined,
+                                                                                "children": [Function],
+                                                                                "className": undefined,
+                                                                                "disabled": undefined,
+                                                                                "features": undefined,
+                                                                                "field": [Function],
+                                                                                "flexibleControlStateSize": false,
+                                                                                "help": "The URL Sentry will send requests to on installation changes.",
+                                                                                "hideErrorMessage": false,
+                                                                                "highlighted": false,
+                                                                                "label": "Webhook URL",
+                                                                                "name": "webhookUrl",
+                                                                                "placeholder": "e.g. https://example.com/sentry/webhook/",
+                                                                                "required": true,
+                                                                                "type": "text",
+                                                                              },
+                                                                              "redirectUrl" => Object {
+                                                                                "access": undefined,
+                                                                                "children": [Function],
+                                                                                "className": undefined,
+                                                                                "disabled": undefined,
+                                                                                "features": undefined,
+                                                                                "field": [Function],
+                                                                                "flexibleControlStateSize": false,
+                                                                                "help": "The URL Sentry will redirect users to after installation.",
+                                                                                "hideErrorMessage": false,
+                                                                                "highlighted": false,
+                                                                                "label": "Redirect URL",
+                                                                                "name": "redirectUrl",
+                                                                                "placeholder": "e.g. https://example.com/sentry/setup/",
+                                                                                "type": "text",
+                                                                              },
+                                                                              "isAlertable" => Object {
+                                                                                "access": undefined,
+                                                                                "children": [Function],
+                                                                                "className": undefined,
+                                                                                "disabled": undefined,
+                                                                                "features": undefined,
+                                                                                "field": [Function],
+                                                                                "flexibleControlStateSize": false,
+                                                                                "help": <span>
+                                                                                  <span>
+                                                                                    If enabled, this application will be an action under alert rules in Sentry. The notification destination is the Webhook URL specified above. More on actions 
+                                                                                  </span>
+                                                                                  <a
+                                                                                    href="https://docs.sentry.io/product/notifications/#actions"
+                                                                                  >
+                                                                                    <span>
+                                                                                      Here
+                                                                                    </span>
+                                                                                  </a>
+                                                                                  <span>
+                                                                                    .
+                                                                                  </span>
+                                                                                </span>,
+                                                                                "hideErrorMessage": false,
+                                                                                "highlighted": false,
+                                                                                "label": "Alert Rule Action",
+                                                                                "name": "isAlertable",
+                                                                                "resetOnError": true,
+                                                                                "type": "boolean",
+                                                                              },
+                                                                              "overview" => Object {
+                                                                                "access": undefined,
+                                                                                "autosize": true,
+                                                                                "children": [Function],
+                                                                                "className": undefined,
+                                                                                "disabled": undefined,
+                                                                                "features": undefined,
+                                                                                "field": [Function],
+                                                                                "flexibleControlStateSize": false,
+                                                                                "help": "Description of your application and its functionality.",
+                                                                                "hideErrorMessage": false,
+                                                                                "highlighted": false,
+                                                                                "label": "Overview",
+                                                                                "name": "overview",
+                                                                                "type": "textarea",
+                                                                              },
+                                                                              "scopes" => Object {
+                                                                                "children": [Function],
+                                                                                "flexibleControlStateSize": true,
+                                                                                "getData": [Function],
+                                                                                "hideErrorMessage": false,
+                                                                                "inline": false,
+                                                                                "name": "scopes",
+                                                                                "required": true,
+                                                                              },
+                                                                              "events" => Object {
+                                                                                "children": [Function],
+                                                                                "choices": Array [
+                                                                                  Array [
+                                                                                    "issue",
+                                                                                    "Issue events",
+                                                                                  ],
+                                                                                ],
+                                                                                "flexibleControlStateSize": true,
+                                                                                "getData": [Function],
+                                                                                "hideErrorMessage": false,
+                                                                                "inline": false,
+                                                                                "name": "events",
+                                                                              },
+                                                                              "clientId" => Object {
+                                                                                "children": [Function],
+                                                                                "flexibleControlStateSize": false,
+                                                                                "hideErrorMessage": false,
+                                                                                "label": "Client ID",
+                                                                                "name": "clientId",
+                                                                                "overflow": true,
+                                                                              },
+                                                                              "clientSecret" => Object {
+                                                                                "children": [Function],
+                                                                                "flexibleControlStateSize": false,
+                                                                                "hideErrorMessage": false,
+                                                                                "label": "Client Secret",
+                                                                                "name": "clientSecret",
+                                                                                "overflow": true,
+                                                                              },
+                                                                            },
+                                                                            "fieldState": Object {},
+                                                                            "fields": Object {
+                                                                              "clientId": "client-id",
+                                                                              "clientSecret": "client-secret",
+                                                                              "events": Array [],
+                                                                              "isAlertable": false,
+                                                                              "name": "Sample App",
+                                                                              "organization": "org-slug",
+                                                                              "overview": "This is an app.",
+                                                                              "redirectUrl": "https://example/com/setup",
+                                                                              "scopes": Array [
+                                                                                "project:read",
+                                                                              ],
+                                                                              "slug": "sample-app",
+                                                                              "uuid": "123456123456123456123456",
+                                                                              "webhookUrl": "https://example.com/webhook",
+                                                                            },
+                                                                            "formState": undefined,
+                                                                            "initialData": Object {
+                                                                              "clientId": "client-id",
+                                                                              "clientSecret": "client-secret",
+                                                                              "events": Array [],
+                                                                              "isAlertable": false,
+                                                                              "name": "Sample App",
+                                                                              "organization": "org-slug",
+                                                                              "overview": "This is an app.",
+                                                                              "redirectUrl": "https://example/com/setup",
+                                                                              "scopes": Array [
+                                                                                "project:read",
+                                                                              ],
+                                                                              "slug": "sample-app",
+                                                                              "uuid": "123456123456123456123456",
+                                                                              "webhookUrl": "https://example.com/webhook",
+                                                                            },
+                                                                            "options": Object {
+                                                                              "allowUndo": true,
+                                                                              "apiEndpoint": "/sentry-apps/sample-app/",
+                                                                              "apiMethod": "PUT",
+                                                                              "onFieldChange": undefined,
+                                                                              "onSubmitError": [Function],
+                                                                              "onSubmitSuccess": [Function],
+                                                                              "resetOnError": undefined,
+                                                                              "saveOnBlur": false,
+                                                                            },
+                                                                            "snapshots": Array [
+                                                                              Map {
+                                                                                "organization" => "org-slug",
+                                                                                "isAlertable" => false,
+                                                                                "name" => "Sample App",
+                                                                                "slug" => "sample-app",
+                                                                                "scopes" => Array [
+                                                                                  "project:read",
+                                                                                ],
+                                                                                "events" => Array [],
+                                                                                "uuid" => "123456123456123456123456",
+                                                                                "webhookUrl" => "https://example.com/webhook",
+                                                                                "redirectUrl" => "https://example/com/setup",
+                                                                                "clientId" => "client-id",
+                                                                                "clientSecret" => "client-secret",
+                                                                                "overview" => "This is an app.",
+                                                                              },
+                                                                            ],
+                                                                          }
+                                                                        }
+                                                                        name="events"
                                                                       >
                                                                         <Observer />
                                                                         <Observer />
@@ -5615,6 +6515,20 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                     "name": "scopes",
                                                     "required": true,
                                                   },
+                                                  "events" => Object {
+                                                    "children": [Function],
+                                                    "choices": Array [
+                                                      Array [
+                                                        "issue",
+                                                        "Issue events",
+                                                      ],
+                                                    ],
+                                                    "flexibleControlStateSize": true,
+                                                    "getData": [Function],
+                                                    "hideErrorMessage": false,
+                                                    "inline": false,
+                                                    "name": "events",
+                                                  },
                                                   "clientId" => Object {
                                                     "children": [Function],
                                                     "flexibleControlStateSize": false,
@@ -5636,6 +6550,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                 "fields": Object {
                                                   "clientId": "client-id",
                                                   "clientSecret": "client-secret",
+                                                  "events": Array [],
                                                   "isAlertable": false,
                                                   "name": "Sample App",
                                                   "organization": "org-slug",
@@ -5652,6 +6567,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                 "initialData": Object {
                                                   "clientId": "client-id",
                                                   "clientSecret": "client-secret",
+                                                  "events": Array [],
                                                   "isAlertable": false,
                                                   "name": "Sample App",
                                                   "organization": "org-slug",
@@ -5683,6 +6599,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                     "scopes" => Array [
                                                       "project:read",
                                                     ],
+                                                    "events" => Array [],
                                                     "uuid" => "123456123456123456123456",
                                                     "webhookUrl" => "https://example.com/webhook",
                                                     "redirectUrl" => "https://example/com/setup",
@@ -5936,6 +6853,20 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                 "name": "scopes",
                                                                                 "required": true,
                                                                               },
+                                                                              "events" => Object {
+                                                                                "children": [Function],
+                                                                                "choices": Array [
+                                                                                  Array [
+                                                                                    "issue",
+                                                                                    "Issue events",
+                                                                                  ],
+                                                                                ],
+                                                                                "flexibleControlStateSize": true,
+                                                                                "getData": [Function],
+                                                                                "hideErrorMessage": false,
+                                                                                "inline": false,
+                                                                                "name": "events",
+                                                                              },
                                                                               "clientId" => Object {
                                                                                 "children": [Function],
                                                                                 "flexibleControlStateSize": false,
@@ -5957,6 +6888,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                             "fields": Object {
                                                                               "clientId": "client-id",
                                                                               "clientSecret": "client-secret",
+                                                                              "events": Array [],
                                                                               "isAlertable": false,
                                                                               "name": "Sample App",
                                                                               "organization": "org-slug",
@@ -5973,6 +6905,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                             "initialData": Object {
                                                                               "clientId": "client-id",
                                                                               "clientSecret": "client-secret",
+                                                                              "events": Array [],
                                                                               "isAlertable": false,
                                                                               "name": "Sample App",
                                                                               "organization": "org-slug",
@@ -6004,6 +6937,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                 "scopes" => Array [
                                                                                   "project:read",
                                                                                 ],
+                                                                                "events" => Array [],
                                                                                 "uuid" => "123456123456123456123456",
                                                                                 "webhookUrl" => "https://example.com/webhook",
                                                                                 "redirectUrl" => "https://example/com/setup",
@@ -6219,6 +7153,20 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                     "name": "scopes",
                                                     "required": true,
                                                   },
+                                                  "events" => Object {
+                                                    "children": [Function],
+                                                    "choices": Array [
+                                                      Array [
+                                                        "issue",
+                                                        "Issue events",
+                                                      ],
+                                                    ],
+                                                    "flexibleControlStateSize": true,
+                                                    "getData": [Function],
+                                                    "hideErrorMessage": false,
+                                                    "inline": false,
+                                                    "name": "events",
+                                                  },
                                                   "clientId" => Object {
                                                     "children": [Function],
                                                     "flexibleControlStateSize": false,
@@ -6240,6 +7188,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                 "fields": Object {
                                                   "clientId": "client-id",
                                                   "clientSecret": "client-secret",
+                                                  "events": Array [],
                                                   "isAlertable": false,
                                                   "name": "Sample App",
                                                   "organization": "org-slug",
@@ -6256,6 +7205,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                 "initialData": Object {
                                                   "clientId": "client-id",
                                                   "clientSecret": "client-secret",
+                                                  "events": Array [],
                                                   "isAlertable": false,
                                                   "name": "Sample App",
                                                   "organization": "org-slug",
@@ -6287,6 +7237,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                     "scopes" => Array [
                                                       "project:read",
                                                     ],
+                                                    "events" => Array [],
                                                     "uuid" => "123456123456123456123456",
                                                     "webhookUrl" => "https://example.com/webhook",
                                                     "redirectUrl" => "https://example/com/setup",
@@ -6540,6 +7491,20 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                 "name": "scopes",
                                                                                 "required": true,
                                                                               },
+                                                                              "events" => Object {
+                                                                                "children": [Function],
+                                                                                "choices": Array [
+                                                                                  Array [
+                                                                                    "issue",
+                                                                                    "Issue events",
+                                                                                  ],
+                                                                                ],
+                                                                                "flexibleControlStateSize": true,
+                                                                                "getData": [Function],
+                                                                                "hideErrorMessage": false,
+                                                                                "inline": false,
+                                                                                "name": "events",
+                                                                              },
                                                                               "clientId" => Object {
                                                                                 "children": [Function],
                                                                                 "flexibleControlStateSize": false,
@@ -6561,6 +7526,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                             "fields": Object {
                                                                               "clientId": "client-id",
                                                                               "clientSecret": "client-secret",
+                                                                              "events": Array [],
                                                                               "isAlertable": false,
                                                                               "name": "Sample App",
                                                                               "organization": "org-slug",
@@ -6577,6 +7543,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                             "initialData": Object {
                                                                               "clientId": "client-id",
                                                                               "clientSecret": "client-secret",
+                                                                              "events": Array [],
                                                                               "isAlertable": false,
                                                                               "name": "Sample App",
                                                                               "organization": "org-slug",
@@ -6608,6 +7575,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                 "scopes" => Array [
                                                                                   "project:read",
                                                                                 ],
+                                                                                "events" => Array [],
                                                                                 "uuid" => "123456123456123456123456",
                                                                                 "webhookUrl" => "https://example.com/webhook",
                                                                                 "redirectUrl" => "https://example/com/setup",
@@ -7202,6 +8170,20 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                     "name": "scopes",
                                                                     "required": true,
                                                                   },
+                                                                  "events" => Object {
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "issue",
+                                                                        "Issue events",
+                                                                      ],
+                                                                    ],
+                                                                    "flexibleControlStateSize": true,
+                                                                    "getData": [Function],
+                                                                    "hideErrorMessage": false,
+                                                                    "inline": false,
+                                                                    "name": "events",
+                                                                  },
                                                                 },
                                                                 "fieldState": Object {},
                                                                 "fields": Object {
@@ -7464,6 +8446,20 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                                 "inline": false,
                                                                                                 "name": "scopes",
                                                                                                 "required": true,
+                                                                                              },
+                                                                                              "events" => Object {
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "issue",
+                                                                                                    "Issue events",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "flexibleControlStateSize": true,
+                                                                                                "getData": [Function],
+                                                                                                "hideErrorMessage": false,
+                                                                                                "inline": false,
+                                                                                                "name": "events",
                                                                                               },
                                                                                             },
                                                                                             "fieldState": Object {},
@@ -7757,6 +8753,20 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                     "name": "scopes",
                                                                     "required": true,
                                                                   },
+                                                                  "events" => Object {
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "issue",
+                                                                        "Issue events",
+                                                                      ],
+                                                                    ],
+                                                                    "flexibleControlStateSize": true,
+                                                                    "getData": [Function],
+                                                                    "hideErrorMessage": false,
+                                                                    "inline": false,
+                                                                    "name": "events",
+                                                                  },
                                                                 },
                                                                 "fieldState": Object {},
                                                                 "fields": Object {
@@ -8019,6 +9029,20 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                                 "inline": false,
                                                                                                 "name": "scopes",
                                                                                                 "required": true,
+                                                                                              },
+                                                                                              "events" => Object {
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "issue",
+                                                                                                    "Issue events",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "flexibleControlStateSize": true,
+                                                                                                "getData": [Function],
+                                                                                                "hideErrorMessage": false,
+                                                                                                "inline": false,
+                                                                                                "name": "events",
                                                                                               },
                                                                                             },
                                                                                             "fieldState": Object {},
@@ -8303,6 +9327,20 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                     "name": "scopes",
                                                                     "required": true,
                                                                   },
+                                                                  "events" => Object {
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "issue",
+                                                                        "Issue events",
+                                                                      ],
+                                                                    ],
+                                                                    "flexibleControlStateSize": true,
+                                                                    "getData": [Function],
+                                                                    "hideErrorMessage": false,
+                                                                    "inline": false,
+                                                                    "name": "events",
+                                                                  },
                                                                 },
                                                                 "fieldState": Object {},
                                                                 "fields": Object {
@@ -8563,6 +9601,20 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                                 "inline": false,
                                                                                                 "name": "scopes",
                                                                                                 "required": true,
+                                                                                              },
+                                                                                              "events" => Object {
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "issue",
+                                                                                                    "Issue events",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "flexibleControlStateSize": true,
+                                                                                                "getData": [Function],
+                                                                                                "hideErrorMessage": false,
+                                                                                                "inline": false,
+                                                                                                "name": "events",
                                                                                               },
                                                                                             },
                                                                                             "fieldState": Object {},
@@ -8947,6 +9999,20 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                     "name": "scopes",
                                                                     "required": true,
                                                                   },
+                                                                  "events" => Object {
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "issue",
+                                                                        "Issue events",
+                                                                      ],
+                                                                    ],
+                                                                    "flexibleControlStateSize": true,
+                                                                    "getData": [Function],
+                                                                    "hideErrorMessage": false,
+                                                                    "inline": false,
+                                                                    "name": "events",
+                                                                  },
                                                                 },
                                                                 "fieldState": Object {},
                                                                 "fields": Object {
@@ -9242,6 +10308,20 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                                 "name": "scopes",
                                                                                                 "required": true,
                                                                                               },
+                                                                                              "events" => Object {
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "issue",
+                                                                                                    "Issue events",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "flexibleControlStateSize": true,
+                                                                                                "getData": [Function],
+                                                                                                "hideErrorMessage": false,
+                                                                                                "inline": false,
+                                                                                                "name": "events",
+                                                                                              },
                                                                                             },
                                                                                             "fieldState": Object {},
                                                                                             "fields": Object {
@@ -9524,6 +10604,20 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                     "inline": false,
                                                                     "name": "scopes",
                                                                     "required": true,
+                                                                  },
+                                                                  "events" => Object {
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "issue",
+                                                                        "Issue events",
+                                                                      ],
+                                                                    ],
+                                                                    "flexibleControlStateSize": true,
+                                                                    "getData": [Function],
+                                                                    "hideErrorMessage": false,
+                                                                    "inline": false,
+                                                                    "name": "events",
                                                                   },
                                                                 },
                                                                 "fieldState": Object {},
@@ -9813,6 +10907,20 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                                 "name": "scopes",
                                                                                                 "required": true,
                                                                                               },
+                                                                                              "events" => Object {
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "issue",
+                                                                                                    "Issue events",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "flexibleControlStateSize": true,
+                                                                                                "getData": [Function],
+                                                                                                "hideErrorMessage": false,
+                                                                                                "inline": false,
+                                                                                                "name": "events",
+                                                                                              },
                                                                                             },
                                                                                             "fieldState": Object {},
                                                                                             "fields": Object {
@@ -10072,6 +11180,20 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                     "inline": false,
                                                     "name": "scopes",
                                                     "required": true,
+                                                  },
+                                                  "events" => Object {
+                                                    "children": [Function],
+                                                    "choices": Array [
+                                                      Array [
+                                                        "issue",
+                                                        "Issue events",
+                                                      ],
+                                                    ],
+                                                    "flexibleControlStateSize": true,
+                                                    "getData": [Function],
+                                                    "hideErrorMessage": false,
+                                                    "inline": false,
+                                                    "name": "events",
                                                   },
                                                 },
                                                 "fieldState": Object {},
@@ -11400,6 +12522,20 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                 "name": "scopes",
                                                                                 "required": true,
                                                                               },
+                                                                              "events" => Object {
+                                                                                "children": [Function],
+                                                                                "choices": Array [
+                                                                                  Array [
+                                                                                    "issue",
+                                                                                    "Issue events",
+                                                                                  ],
+                                                                                ],
+                                                                                "flexibleControlStateSize": true,
+                                                                                "getData": [Function],
+                                                                                "hideErrorMessage": false,
+                                                                                "inline": false,
+                                                                                "name": "events",
+                                                                              },
                                                                             },
                                                                             "fieldState": Object {},
                                                                             "fields": Object {
@@ -11430,6 +12566,592 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                           }
                                                                         }
                                                                         name="scopes"
+                                                                      >
+                                                                        <Observer />
+                                                                        <Observer />
+                                                                      </ControlState>
+                                                                    </div>
+                                                                  </Base>
+                                                                </Flex>
+                                                              </Component>
+                                                            </FieldControlState>
+                                                          </div>
+                                                        </Base>
+                                                      </Flex>
+                                                    </Component>
+                                                  </FieldControlWrapper>
+                                                  <Observer />
+                                                </div>
+                                              </Base>
+                                            </Box>
+                                          </Component>
+                                        </FieldControlErrorWrapper>
+                                      </FieldControl>
+                                    </div>
+                                  </Base>
+                                </Flex>
+                              </Component>
+                            </FieldWrapper>
+                          </Field>
+                        </FormField>
+                      </div>
+                    </PanelBody>
+                  </div>
+                </Component>
+              </Panel>
+              <Panel>
+                <Component
+                  className="css-yahxlu-Panel e1laxa7d0"
+                >
+                  <div
+                    className="css-yahxlu-Panel e1laxa7d0"
+                  >
+                    <PanelHeader>
+                      <Component
+                        className="css-xhx6pj-PanelHeader-getPadding e1p8v8nv0"
+                      >
+                        <Flex
+                          align="center"
+                          className="css-xhx6pj-PanelHeader-getPadding e1p8v8nv0"
+                          justify="space-between"
+                        >
+                          <Base
+                            align="center"
+                            className="e1p8v8nv0 css-b7ices-PanelHeader-getPadding"
+                            justify="space-between"
+                          >
+                            <div
+                              className="e1p8v8nv0 css-b7ices-PanelHeader-getPadding"
+                              is={null}
+                            >
+                              Event Subscriptions
+                            </div>
+                          </Base>
+                        </Flex>
+                      </Component>
+                    </PanelHeader>
+                    <PanelBody
+                      direction="column"
+                      disablePadding={true}
+                      flex={false}
+                    >
+                      <div
+                        className="css-9vq8an-textStyles"
+                      >
+                        <FormField
+                          choices={
+                            Array [
+                              Array [
+                                "issue",
+                                "Issue events",
+                              ],
+                            ]
+                          }
+                          flexibleControlStateSize={true}
+                          getData={[Function]}
+                          hideErrorMessage={false}
+                          inline={false}
+                          name="events"
+                        >
+                          <Field
+                            alignRight={false}
+                            choices={
+                              Array [
+                                Array [
+                                  "issue",
+                                  "Issue events",
+                                ],
+                              ]
+                            }
+                            disabled={false}
+                            flexibleControlStateSize={true}
+                            getData={[Function]}
+                            id="events"
+                            inline={false}
+                            name="events"
+                            required={false}
+                            visible={true}
+                          >
+                            <FieldWrapper
+                              hasControlState={false}
+                              inline={false}
+                            >
+                              <Component
+                                className="css-11ihpht-FieldWrapper-getPadding-borderStyle-inlineStyle etqqcs20"
+                              >
+                                <Flex
+                                  className="css-11ihpht-FieldWrapper-getPadding-borderStyle-inlineStyle etqqcs20"
+                                >
+                                  <Base
+                                    className="etqqcs20 css-1uohzo7-FieldWrapper-getPadding-borderStyle-inlineStyle"
+                                  >
+                                    <div
+                                      className="etqqcs20 css-1uohzo7-FieldWrapper-getPadding-borderStyle-inlineStyle"
+                                      is={null}
+                                    >
+                                      <FieldControl
+                                        alignRight={false}
+                                        controlState={
+                                          <ControlState
+                                            model={
+                                              FormModel {
+                                                "api": Client {},
+                                                "errors": Object {},
+                                                "fieldDescriptor": Map {
+                                                  "name" => Object {
+                                                    "access": undefined,
+                                                    "children": [Function],
+                                                    "className": undefined,
+                                                    "disabled": undefined,
+                                                    "features": undefined,
+                                                    "field": [Function],
+                                                    "flexibleControlStateSize": false,
+                                                    "help": "Human readable name of your application.",
+                                                    "hideErrorMessage": false,
+                                                    "highlighted": false,
+                                                    "label": "Name",
+                                                    "name": "name",
+                                                    "placeholder": "e.g. My Application",
+                                                    "required": true,
+                                                    "type": "text",
+                                                  },
+                                                  "webhookUrl" => Object {
+                                                    "access": undefined,
+                                                    "children": [Function],
+                                                    "className": undefined,
+                                                    "disabled": undefined,
+                                                    "features": undefined,
+                                                    "field": [Function],
+                                                    "flexibleControlStateSize": false,
+                                                    "help": "The URL Sentry will send requests to on installation changes.",
+                                                    "hideErrorMessage": false,
+                                                    "highlighted": false,
+                                                    "label": "Webhook URL",
+                                                    "name": "webhookUrl",
+                                                    "placeholder": "e.g. https://example.com/sentry/webhook/",
+                                                    "required": true,
+                                                    "type": "text",
+                                                  },
+                                                  "redirectUrl" => Object {
+                                                    "access": undefined,
+                                                    "children": [Function],
+                                                    "className": undefined,
+                                                    "disabled": undefined,
+                                                    "features": undefined,
+                                                    "field": [Function],
+                                                    "flexibleControlStateSize": false,
+                                                    "help": "The URL Sentry will redirect users to after installation.",
+                                                    "hideErrorMessage": false,
+                                                    "highlighted": false,
+                                                    "label": "Redirect URL",
+                                                    "name": "redirectUrl",
+                                                    "placeholder": "e.g. https://example.com/sentry/setup/",
+                                                    "type": "text",
+                                                  },
+                                                  "isAlertable" => Object {
+                                                    "access": undefined,
+                                                    "children": [Function],
+                                                    "className": undefined,
+                                                    "disabled": undefined,
+                                                    "features": undefined,
+                                                    "field": [Function],
+                                                    "flexibleControlStateSize": false,
+                                                    "help": <span>
+                                                      <span>
+                                                        If enabled, this application will be an action under alert rules in Sentry. The notification destination is the Webhook URL specified above. More on actions 
+                                                      </span>
+                                                      <a
+                                                        href="https://docs.sentry.io/product/notifications/#actions"
+                                                      >
+                                                        <span>
+                                                          Here
+                                                        </span>
+                                                      </a>
+                                                      <span>
+                                                        .
+                                                      </span>
+                                                    </span>,
+                                                    "hideErrorMessage": false,
+                                                    "highlighted": false,
+                                                    "label": "Alert Rule Action",
+                                                    "name": "isAlertable",
+                                                    "resetOnError": true,
+                                                    "type": "boolean",
+                                                  },
+                                                  "overview" => Object {
+                                                    "access": undefined,
+                                                    "autosize": true,
+                                                    "children": [Function],
+                                                    "className": undefined,
+                                                    "disabled": undefined,
+                                                    "features": undefined,
+                                                    "field": [Function],
+                                                    "flexibleControlStateSize": false,
+                                                    "help": "Description of your application and its functionality.",
+                                                    "hideErrorMessage": false,
+                                                    "highlighted": false,
+                                                    "label": "Overview",
+                                                    "name": "overview",
+                                                    "type": "textarea",
+                                                  },
+                                                  "scopes" => Object {
+                                                    "children": [Function],
+                                                    "flexibleControlStateSize": true,
+                                                    "getData": [Function],
+                                                    "hideErrorMessage": false,
+                                                    "inline": false,
+                                                    "name": "scopes",
+                                                    "required": true,
+                                                  },
+                                                  "events" => Object {
+                                                    "children": [Function],
+                                                    "choices": Array [
+                                                      Array [
+                                                        "issue",
+                                                        "Issue events",
+                                                      ],
+                                                    ],
+                                                    "flexibleControlStateSize": true,
+                                                    "getData": [Function],
+                                                    "hideErrorMessage": false,
+                                                    "inline": false,
+                                                    "name": "events",
+                                                  },
+                                                },
+                                                "fieldState": Object {},
+                                                "fields": Object {
+                                                  "isAlertable": false,
+                                                  "organization": "org-slug",
+                                                },
+                                                "formState": undefined,
+                                                "initialData": Object {
+                                                  "isAlertable": false,
+                                                  "organization": "org-slug",
+                                                },
+                                                "options": Object {
+                                                  "allowUndo": true,
+                                                  "apiEndpoint": "/sentry-apps/",
+                                                  "apiMethod": "POST",
+                                                  "onFieldChange": undefined,
+                                                  "onSubmitError": [Function],
+                                                  "onSubmitSuccess": [Function],
+                                                  "resetOnError": undefined,
+                                                  "saveOnBlur": false,
+                                                },
+                                                "snapshots": Array [
+                                                  Map {
+                                                    "organization" => "org-slug",
+                                                    "isAlertable" => false,
+                                                  },
+                                                ],
+                                              }
+                                            }
+                                            name="events"
+                                          />
+                                        }
+                                        disabled={false}
+                                        errorState={
+                                          <Observer>
+                                            [Function]
+                                          </Observer>
+                                        }
+                                        flexibleControlStateSize={true}
+                                        inline={false}
+                                      >
+                                        <FieldControlErrorWrapper
+                                          inline={false}
+                                        >
+                                          <Component
+                                            className="css-1ge7tqf-FieldControlErrorWrapper e78b1iv0"
+                                            inline={false}
+                                          >
+                                            <Box
+                                              className="css-1ge7tqf-FieldControlErrorWrapper e78b1iv0"
+                                            >
+                                              <Base
+                                                className="e78b1iv0 css-nnn2ut-FieldControlErrorWrapper"
+                                              >
+                                                <div
+                                                  className="e78b1iv0 css-nnn2ut-FieldControlErrorWrapper"
+                                                  is={null}
+                                                >
+                                                  <FieldControlWrapper>
+                                                    <Component
+                                                      className="css-1ke1xob-FieldControlWrapper e78b1iv2"
+                                                    >
+                                                      <Flex
+                                                        className="css-1ke1xob-FieldControlWrapper e78b1iv2"
+                                                      >
+                                                        <Base
+                                                          className="e78b1iv2 css-w4o1g8-FieldControlWrapper"
+                                                        >
+                                                          <div
+                                                            className="e78b1iv2 css-w4o1g8-FieldControlWrapper"
+                                                            is={null}
+                                                          >
+                                                            <FieldControlStyled
+                                                              alignRight={false}
+                                                            >
+                                                              <Component
+                                                                alignRight={false}
+                                                                className="css-1pkvhmy-FieldControlStyled e78b1iv1"
+                                                              >
+                                                                <Box
+                                                                  className="css-1pkvhmy-FieldControlStyled e78b1iv1"
+                                                                >
+                                                                  <Base
+                                                                    className="e78b1iv1 css-wkkbba-FieldControlStyled"
+                                                                  >
+                                                                    <div
+                                                                      className="e78b1iv1 css-wkkbba-FieldControlStyled"
+                                                                      is={null}
+                                                                    >
+                                                                      <Observer>
+                                                                        <MultipleCheckbox
+                                                                          choices={
+                                                                            Array [
+                                                                              Array [
+                                                                                "issue",
+                                                                                "Issue events",
+                                                                              ],
+                                                                            ]
+                                                                          }
+                                                                          onChange={[Function]}
+                                                                          value={Array []}
+                                                                        >
+                                                                          <MultipleCheckboxWrapper>
+                                                                            <div
+                                                                              className="css-sjyy3m-MultipleCheckboxWrapper e18jwynw0"
+                                                                            >
+                                                                              <Box
+                                                                                key="issue"
+                                                                                w={
+                                                                                  Array [
+                                                                                    1,
+                                                                                    0.5,
+                                                                                    0.3333333333333333,
+                                                                                    0.25,
+                                                                                  ]
+                                                                                }
+                                                                              >
+                                                                                <Base
+                                                                                  className="css-1nqix7c"
+                                                                                  w={
+                                                                                    Array [
+                                                                                      1,
+                                                                                      0.5,
+                                                                                      0.3333333333333333,
+                                                                                      0.25,
+                                                                                    ]
+                                                                                  }
+                                                                                >
+                                                                                  <div
+                                                                                    className="css-1nqix7c"
+                                                                                    is={null}
+                                                                                  >
+                                                                                    <Label>
+                                                                                      <label
+                                                                                        className="css-ya7yx0-Label e18jwynw1"
+                                                                                      >
+                                                                                        <input
+                                                                                          checked={false}
+                                                                                          onChange={[Function]}
+                                                                                          type="checkbox"
+                                                                                          value="issue"
+                                                                                        />
+                                                                                        <CheckboxLabel>
+                                                                                          <span
+                                                                                            className="css-zrqf4y-CheckboxLabel e18jwynw2"
+                                                                                          >
+                                                                                            Issue events
+                                                                                          </span>
+                                                                                        </CheckboxLabel>
+                                                                                      </label>
+                                                                                    </Label>
+                                                                                  </div>
+                                                                                </Base>
+                                                                              </Box>
+                                                                            </div>
+                                                                          </MultipleCheckboxWrapper>
+                                                                        </MultipleCheckbox>
+                                                                      </Observer>
+                                                                    </div>
+                                                                  </Base>
+                                                                </Box>
+                                                              </Component>
+                                                            </FieldControlStyled>
+                                                            <FieldControlState
+                                                              flexibleControlStateSize={true}
+                                                            >
+                                                              <Component
+                                                                className="css-1x60lk6-FieldControlState e1rziqw00"
+                                                                flexibleControlStateSize={true}
+                                                              >
+                                                                <Flex
+                                                                  className="css-1x60lk6-FieldControlState e1rziqw00"
+                                                                >
+                                                                  <Base
+                                                                    className="e1rziqw00 css-dgyrfj-FieldControlState"
+                                                                  >
+                                                                    <div
+                                                                      className="e1rziqw00 css-dgyrfj-FieldControlState"
+                                                                      is={null}
+                                                                    >
+                                                                      <ControlState
+                                                                        model={
+                                                                          FormModel {
+                                                                            "api": Client {},
+                                                                            "errors": Object {},
+                                                                            "fieldDescriptor": Map {
+                                                                              "name" => Object {
+                                                                                "access": undefined,
+                                                                                "children": [Function],
+                                                                                "className": undefined,
+                                                                                "disabled": undefined,
+                                                                                "features": undefined,
+                                                                                "field": [Function],
+                                                                                "flexibleControlStateSize": false,
+                                                                                "help": "Human readable name of your application.",
+                                                                                "hideErrorMessage": false,
+                                                                                "highlighted": false,
+                                                                                "label": "Name",
+                                                                                "name": "name",
+                                                                                "placeholder": "e.g. My Application",
+                                                                                "required": true,
+                                                                                "type": "text",
+                                                                              },
+                                                                              "webhookUrl" => Object {
+                                                                                "access": undefined,
+                                                                                "children": [Function],
+                                                                                "className": undefined,
+                                                                                "disabled": undefined,
+                                                                                "features": undefined,
+                                                                                "field": [Function],
+                                                                                "flexibleControlStateSize": false,
+                                                                                "help": "The URL Sentry will send requests to on installation changes.",
+                                                                                "hideErrorMessage": false,
+                                                                                "highlighted": false,
+                                                                                "label": "Webhook URL",
+                                                                                "name": "webhookUrl",
+                                                                                "placeholder": "e.g. https://example.com/sentry/webhook/",
+                                                                                "required": true,
+                                                                                "type": "text",
+                                                                              },
+                                                                              "redirectUrl" => Object {
+                                                                                "access": undefined,
+                                                                                "children": [Function],
+                                                                                "className": undefined,
+                                                                                "disabled": undefined,
+                                                                                "features": undefined,
+                                                                                "field": [Function],
+                                                                                "flexibleControlStateSize": false,
+                                                                                "help": "The URL Sentry will redirect users to after installation.",
+                                                                                "hideErrorMessage": false,
+                                                                                "highlighted": false,
+                                                                                "label": "Redirect URL",
+                                                                                "name": "redirectUrl",
+                                                                                "placeholder": "e.g. https://example.com/sentry/setup/",
+                                                                                "type": "text",
+                                                                              },
+                                                                              "isAlertable" => Object {
+                                                                                "access": undefined,
+                                                                                "children": [Function],
+                                                                                "className": undefined,
+                                                                                "disabled": undefined,
+                                                                                "features": undefined,
+                                                                                "field": [Function],
+                                                                                "flexibleControlStateSize": false,
+                                                                                "help": <span>
+                                                                                  <span>
+                                                                                    If enabled, this application will be an action under alert rules in Sentry. The notification destination is the Webhook URL specified above. More on actions 
+                                                                                  </span>
+                                                                                  <a
+                                                                                    href="https://docs.sentry.io/product/notifications/#actions"
+                                                                                  >
+                                                                                    <span>
+                                                                                      Here
+                                                                                    </span>
+                                                                                  </a>
+                                                                                  <span>
+                                                                                    .
+                                                                                  </span>
+                                                                                </span>,
+                                                                                "hideErrorMessage": false,
+                                                                                "highlighted": false,
+                                                                                "label": "Alert Rule Action",
+                                                                                "name": "isAlertable",
+                                                                                "resetOnError": true,
+                                                                                "type": "boolean",
+                                                                              },
+                                                                              "overview" => Object {
+                                                                                "access": undefined,
+                                                                                "autosize": true,
+                                                                                "children": [Function],
+                                                                                "className": undefined,
+                                                                                "disabled": undefined,
+                                                                                "features": undefined,
+                                                                                "field": [Function],
+                                                                                "flexibleControlStateSize": false,
+                                                                                "help": "Description of your application and its functionality.",
+                                                                                "hideErrorMessage": false,
+                                                                                "highlighted": false,
+                                                                                "label": "Overview",
+                                                                                "name": "overview",
+                                                                                "type": "textarea",
+                                                                              },
+                                                                              "scopes" => Object {
+                                                                                "children": [Function],
+                                                                                "flexibleControlStateSize": true,
+                                                                                "getData": [Function],
+                                                                                "hideErrorMessage": false,
+                                                                                "inline": false,
+                                                                                "name": "scopes",
+                                                                                "required": true,
+                                                                              },
+                                                                              "events" => Object {
+                                                                                "children": [Function],
+                                                                                "choices": Array [
+                                                                                  Array [
+                                                                                    "issue",
+                                                                                    "Issue events",
+                                                                                  ],
+                                                                                ],
+                                                                                "flexibleControlStateSize": true,
+                                                                                "getData": [Function],
+                                                                                "hideErrorMessage": false,
+                                                                                "inline": false,
+                                                                                "name": "events",
+                                                                              },
+                                                                            },
+                                                                            "fieldState": Object {},
+                                                                            "fields": Object {
+                                                                              "isAlertable": false,
+                                                                              "organization": "org-slug",
+                                                                            },
+                                                                            "formState": undefined,
+                                                                            "initialData": Object {
+                                                                              "isAlertable": false,
+                                                                              "organization": "org-slug",
+                                                                            },
+                                                                            "options": Object {
+                                                                              "allowUndo": true,
+                                                                              "apiEndpoint": "/sentry-apps/",
+                                                                              "apiMethod": "POST",
+                                                                              "onFieldChange": undefined,
+                                                                              "onSubmitError": [Function],
+                                                                              "onSubmitSuccess": [Function],
+                                                                              "resetOnError": undefined,
+                                                                              "saveOnBlur": false,
+                                                                            },
+                                                                            "snapshots": Array [
+                                                                              Map {
+                                                                                "organization" => "org-slug",
+                                                                                "isAlertable" => false,
+                                                                              },
+                                                                            ],
+                                                                          }
+                                                                        }
+                                                                        name="events"
                                                                       >
                                                                         <Observer />
                                                                         <Observer />

--- a/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/sentryAppInstallations.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/sentryAppInstallations.spec.jsx.snap
@@ -8,6 +8,7 @@ exports[`Sentry App Installations when Apps exist displays all Apps owned by the
       Object {
         "clientId": "client-id",
         "clientSecret": "client-secret",
+        "events": Array [],
         "isAlertable": false,
         "name": "Sample App",
         "overview": "This is an app.",
@@ -29,6 +30,7 @@ exports[`Sentry App Installations when Apps exist displays all Apps owned by the
       Object {
         "clientId": "client-id",
         "clientSecret": "client-secret",
+        "events": Array [],
         "isAlertable": false,
         "name": "Sample App",
         "overview": "This is an app.",
@@ -68,6 +70,7 @@ exports[`Sentry App Installations when Apps exist displays all Apps owned by the
                     Object {
                       "clientId": "client-id",
                       "clientSecret": "client-secret",
+                      "events": Array [],
                       "isAlertable": false,
                       "name": "Sample App",
                       "overview": "This is an app.",

--- a/tests/sentry/api/endpoints/test_organization_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_apps.py
@@ -2,8 +2,16 @@ from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
 
+from sentry.utils import json
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import with_feature
+
+
+def assert_response_json(response, data):
+    """
+    Normalizes unicode strings by encoding/decoding expected output
+    """
+    assert json.loads(response.content) == json.loads(json.dumps(data))
 
 
 class OrganizationSentryAppsTest(APITestCase):
@@ -31,10 +39,12 @@ class GetOrganizationSentryAppsTest(OrganizationSentryAppsTest):
         response = self.client.get(self.url, format='json')
 
         assert response.status_code == 200
-        assert response.data == [{
+
+        assert_response_json(response, [{
             'name': self.unpublished_app.name,
             'slug': self.unpublished_app.slug,
             'scopes': [],
+            'events': [],
             'uuid': self.unpublished_app.uuid,
             'status': self.unpublished_app.get_status_display(),
             'webhookUrl': self.unpublished_app.webhook_url,
@@ -43,7 +53,7 @@ class GetOrganizationSentryAppsTest(OrganizationSentryAppsTest):
             'clientId': self.unpublished_app.application.client_id,
             'clientSecret': self.unpublished_app.application.client_secret,
             'overview': self.unpublished_app.overview,
-        }]
+        }])
 
     @with_feature('organizations:internal-catchall')
     def test_cannot_see_apps_in_other_orgs(self):

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 from django.core.urlresolvers import reverse
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import with_feature
+from sentry.utils import json
 
 
 class SentryAppDetailsTest(APITestCase):
@@ -108,10 +109,11 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             },
             format='json',
         )
-        assert response.data == {
+        assert json.loads(response.content) == {
             'name': 'NewName',
             'slug': self.published_app.slug,
             'scopes': [],
+            'events': [],
             'status': self.published_app.get_status_display(),
             'uuid': self.published_app.uuid,
             'webhookUrl': 'https://newurl.com',

--- a/tests/sentry/mediators/sentry_app_installations/test_creator.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_creator.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from mock import patch
 
 from sentry.mediators.sentry_app_installations import Creator
-from sentry.models import ApiAuthorization, ApiGrant
+from sentry.models import ApiAuthorization, ApiGrant, ServiceHook
 from sentry.testutils import TestCase
 
 
@@ -12,10 +12,14 @@ class TestCreator(TestCase):
         self.user = self.create_user()
         self.org = self.create_organization()
 
+        self.project1 = self.create_project(organization=self.org)
+        self.project2 = self.create_project(organization=self.org)
+
         self.sentry_app = self.create_sentry_app(
             name='nulldb',
             organization=self.org,
             scopes=('project:read',),
+            events=('issue.created', ),
         )
 
         self.creator = Creator(
@@ -40,6 +44,23 @@ class TestCreator(TestCase):
     def test_creates_api_grant(self):
         install = self.creator.call()
         assert ApiGrant.objects.filter(id=install.api_grant_id).exists()
+
+    def test_creates_service_hooks(self):
+        install = self.creator.call()
+
+        hook = ServiceHook.objects.get(project_id=self.project1.id)
+
+        assert hook.application_id == self.sentry_app.application.id
+        assert hook.actor_id == install.id
+        assert hook.project_id == self.project1.id
+        assert hook.events == self.sentry_app.events
+        assert hook.url == self.sentry_app.webhook_url
+
+    def test_creates_service_hooks_for_all_projects(self):
+        self.creator.call()
+
+        assert ServiceHook.objects.get(project_id=self.project1.id).events == self.sentry_app.events
+        assert ServiceHook.objects.get(project_id=self.project2.id).events == self.sentry_app.events
 
     @patch('sentry.tasks.app_platform.installation_webhook.delay')
     def test_notifies_service(self, installation_webhook):

--- a/tests/sentry/mediators/sentry_apps/test_creator.py
+++ b/tests/sentry/mediators/sentry_apps/test_creator.py
@@ -43,3 +43,11 @@ class TestCreator(TestCase):
 
         assert sentry_app
         assert sentry_app.scope_list == ['project:read']
+
+    def test_expands_rolled_up_events(self):
+        self.creator.events = ['issue']
+        app = self.creator.call()
+
+        sentry_app = SentryApp.objects.get(id=app.id)
+
+        assert 'issue.created' in sentry_app.events

--- a/tests/sentry/mediators/service_hooks/test_creator.py
+++ b/tests/sentry/mediators/service_hooks/test_creator.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from sentry.mediators.service_hooks import Creator
+from sentry.mediators.service_hooks.creator import expand_events, consolidate_events
 from sentry.models import ServiceHook
 from sentry.testutils import TestCase
 
@@ -29,3 +30,14 @@ class TestCreator(TestCase):
 
         assert service_hook
         assert service_hook.events == ['event.created']
+
+    def test_expands_resource_events_to_specific_events(self):
+        self.creator.events = ['issue']
+        service_hook = self.creator.call()
+        assert service_hook.events == ['issue.created']
+
+    def test_expand_events(self):
+        assert expand_events(['issue']) == set(['issue.created'])
+
+    def test_consolidate_events(self):
+        assert consolidate_events(['issue.created']) == set(['issue'])


### PR DESCRIPTION
Adds the UI and model logic to allow Sentry Apps to subscribe to certain types of events, via Service Hooks.

The actual Service Hooks get created when the app is installed to an Org, but they'll be created based on this data.

### Important Context

Event types are presented to users in a rolled up (to the resource) kind of way. Meaning, instead of offering a subscription choice for every single specific event type (`issue.created`, `issue.resolved`, etc.) we offer the ability to subscribe to "Issue events". You get all of them and it's up to you to actually consume the ones you care about. This is pretty standard for most platforms.

What this means, though, is that the UI presents the rolled up values, while the actual `ServiceHook` objects need to have a list of all the individual event types. Our API exposes the individual event types:

```json
{
  "events": ["issue.created", "issue.resolved"]
}
```

and the UI rolls that up to display "Issue":

![image](https://user-images.githubusercontent.com/36059/49169319-6080eb80-f2ee-11e8-9af0-8d351b7aaf88.png)

Similarly, when someone creates or updates a Sentry App, the backend is expanding the rolled up value to the individual ones. This only happens when someone creates or updates a Sentry App – which should be very infrequently.

### Service Hook Creation

When a user is creating/updating a Sentry App, we're just saving the list of events the app wishes to subscribe to. On _installation_ we actually create those `ServiceHook` records. Each Project within the Org gets it's own `ServiceHook`.

### Event Names

The new event type introduced in this PR is for Issues. Since they're actually called `Group` in the codebase, there's some logic to convert these names to the product/user names we use externally.

For example, when a `Group` is created, we'll emit an `issue.created` event. Just something to be aware of.
