### PR TITLE
debug(ui): Debug firefox param parse errors

### DIFF
--- a/src/sentry/static/sentry/app/api.jsx
+++ b/src/sentry/static/sentry/app/api.jsx
@@ -9,6 +9,7 @@ import {
 } from 'app/constants/apiErrorCodes';
 import {openSudo, redirectToProject} from 'app/actionCreators/modal';
 import GroupActions from 'app/actions/groupActions';
+import sdk from 'app/utils/sdk';
 
 export class Request {
   constructor(xhr) {
@@ -142,7 +143,19 @@ export class Client {
   }
 
   request(path, options = {}) {
-    let query = $.param(options.query || '', true);
+    let query;
+    try {
+      query = $.param(options.query || '', true);
+    } catch (err) {
+      sdk.captureException(err, {
+        extra: {
+          path,
+          query: options.query,
+        },
+      });
+
+      throw err;
+    }
     let method = options.method || (options.data ? 'POST' : 'GET');
     let data = options.data;
     let id = this.uniqueId();


### PR DESCRIPTION
Not sure why this is failing (and seemingly only on firefox):
https://sentry.io/sentry/javascript/issues/770063543/\?query\=is%3Aunresolved%20split