### PR TITLE
feat: Treat issues "fixed in commit" as resolved

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -37,7 +37,7 @@ from sentry.interfaces.schemas import validate_and_default_interface
 from sentry.lang.native.utils import get_sdk_from_event
 from sentry.models import (
     Activity, Environment, Event, EventError, EventMapping, EventUser, Group,
-    GroupEnvironment, GroupHash, GroupRelease, GroupResolution, GroupStatus,
+    GroupEnvironment, GroupHash, GroupLink, GroupRelease, GroupResolution, GroupStatus,
     Project, Release, ReleaseEnvironment, ReleaseProject,
     ReleaseProjectEnvironment, UserReport
 )
@@ -213,6 +213,17 @@ def process_timestamp(value, current_datetime=None):
         raise InvalidTimestamp(EventError.PAST_TIMESTAMP)
 
     return float(value.strftime('%s'))
+
+
+def has_pending_commit_resolution(group):
+    return GroupLink.objects.filter(
+        group_id=group.id,
+        linked_type=GroupLink.LinkedType.commit,
+        relationship=GroupLink.Relationship.resolves,
+    ).extra(
+        where=[
+            "NOT EXISTS(SELECT 1 FROM sentry_releasecommit where commit_id = sentry_grouplink.linked_id)"]
+    ).exists()
 
 
 class HashDiscarded(Exception):
@@ -1319,6 +1330,9 @@ class EventManager(object):
         # we only mark it as a regression if the event's release is newer than
         # the release which we originally marked this as resolved
         elif GroupResolution.has_resolution(group, release):
+            return
+
+        elif has_pending_commit_resolution(group):
             return
 
         if not plugin_is_regression(group, event):

--- a/src/sentry/models/grouplink.py
+++ b/src/sentry/models/grouplink.py
@@ -54,4 +54,4 @@ class GroupLink(Model):
         db_table = 'sentry_grouplink'
         unique_together = (('group_id', 'linked_type', 'linked_id'), )
 
-    __repr__ = sane_repr('group_id', 'link', 'datetime')
+    __repr__ = sane_repr('group_id', 'linked_type', 'linked_id', 'relationship', 'datetime')

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -2,10 +2,11 @@ from __future__ import absolute_import, print_function
 
 from django.db import IntegrityError, transaction
 from django.db.models.signals import post_save
+from django.utils import timezone
 
 from sentry import analytics
 from sentry.models import (
-    Activity, Commit, GroupAssignee, GroupLink, Release, Repository, PullRequest
+    Activity, Commit, Group, GroupAssignee, GroupLink, GroupSubscription, GroupSubscriptionReason, GroupStatus, Release, Repository, PullRequest, UserOption
 )
 from sentry.signals import resolved_with_commit
 from sentry.tasks.clear_expired_resolutions import clear_expired_resolutions
@@ -18,7 +19,30 @@ def resolve_group_resolutions(instance, created, **kwargs):
     clear_expired_resolutions.delay(release_id=instance.id)
 
 
+def remove_resolved_link(link):
+    # TODO(dcramer): ideally this would simply "undo" the link change,
+    # but we don't know for a fact that the resolution was most recently from
+    # the GroupLink
+    with transaction.atomic():
+        link.delete()
+        affected = Group.objects.filter(
+            status=GroupStatus.RESOLVED,
+            id=link.group_id,
+        ).update(
+            status=GroupStatus.UNRESOLVED,
+        )
+        if affected:
+            Activity.objects.create(
+                project_id=link.project_id,
+                group_id=link.group_id,
+                type=Activity.SET_UNRESOLVED,
+                ident=link.group_id,
+            )
+
+
 def resolved_in_commit(instance, created, **kwargs):
+    current_datetime = timezone.now()
+
     groups = instance.find_referenced_groups()
 
     # Delete GroupLinks where message may have changed
@@ -30,7 +54,7 @@ def resolved_in_commit(instance, created, **kwargs):
     )
     for link in group_links:
         if link.group_id not in group_ids:
-            link.delete()
+            remove_resolved_link(link)
 
     try:
         repo = Repository.objects.get(id=instance.repository_id)
@@ -39,6 +63,8 @@ def resolved_in_commit(instance, created, **kwargs):
 
     for group in groups:
         try:
+            # XXX(dcramer): This code is somewhat duplicated from the
+            # project_group_index mutation api
             with transaction.atomic():
                 GroupLink.objects.create(
                     group_id=group.id,
@@ -52,19 +78,40 @@ def resolved_in_commit(instance, created, **kwargs):
                     user_list = list(instance.author.find_users())
                 else:
                     user_list = ()
+
                 if user_list:
+                    acting_user = user_list[0]
                     Activity.objects.create(
                         project_id=group.project_id,
                         group=group,
                         type=Activity.SET_RESOLVED_IN_COMMIT,
                         ident=instance.id,
-                        user=user_list[0],
+                        user=acting_user,
                         data={
                             'commit': instance.id,
                         }
                     )
-                    GroupAssignee.objects.assign(
-                        group=group, assigned_to=user_list[0], acting_user=user_list[0])
+                    self_assign_issue = UserOption.objects.get_value(
+                        user=acting_user,
+                        key='self_assign_issue',
+                        default='0'
+                    )
+                    if self_assign_issue == '1' and not group.assignee_set.exists():
+                        GroupAssignee.objects.assign(
+                            group=group,
+                            assigned_to=acting_user,
+                            acting_user=acting_user,
+                        )
+
+                    # while we only create activity and assignment for one user we want to
+                    # subscribe every user
+                    for user in user_list:
+                        GroupSubscription.objects.subscribe(
+                            user=user,
+                            group=group,
+                            reason=GroupSubscriptionReason.status_change,
+                        )
+
                 else:
                     Activity.objects.create(
                         project_id=group.project_id,
@@ -75,6 +122,12 @@ def resolved_in_commit(instance, created, **kwargs):
                             'commit': instance.id,
                         }
                     )
+                Group.objects.filter(
+                    id=group.id,
+                ).update(
+                    status=GroupStatus.RESOLVED,
+                    resolved_at=current_datetime,
+                )
         except IntegrityError:
             pass
         else:
@@ -103,7 +156,7 @@ def resolved_in_pull_request(instance, created, **kwargs):
     )
     for link in group_links:
         if link.group_id not in group_ids:
-            link.delete()
+            remove_resolved_link(link)
 
     try:
         repo = Repository.objects.get(id=instance.repository_id)

--- a/src/sentry/static/sentry/app/components/resolutionBox.jsx
+++ b/src/sentry/static/sentry/app/components/resolutionBox.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import Avatar from 'app/components/avatar';
+import CommitLink from 'app/components/commitLink';
 import Version from 'app/components/version';
 import {t, tct} from 'app/locale';
 
@@ -46,15 +47,29 @@ export default class ResolutionBox extends React.Component {
           />
         ),
       });
+    } else if (!!statusDetails.inCommit) {
+      return tct('This issue has been marked as resolved by [commit]', {
+        commit: (
+          <CommitLink
+            commitId={statusDetails.inCommit.id}
+            repository={statusDetails.inCommit.repository}
+          />
+        ),
+      });
     }
     return t('This issue has been marked as resolved.');
   };
 
   render = () => {
     return (
-      <div className="box">
-        <span className="icon icon-checkmark" />
-        <p className="truncate break-all">{this.renderReason()}</p>
+      <div
+        className="box"
+        style={{display: 'flex', alignItems: 'center', flex: 1, paddingBottom: 15}}
+      >
+        <span className="icon icon-checkmark" style={{position: 'static', top: 0}} />
+        <p className="truncate break-all" style={{paddingBottom: 0, paddingLeft: 16}}>
+          {this.renderReason()}
+        </p>
       </div>
     );
   };

--- a/tests/js/fixtures/commit.js
+++ b/tests/js/fixtures/commit.js
@@ -1,0 +1,14 @@
+import {CommitAuthor} from './commitAuthor';
+import {Repository} from './repository';
+
+export function Commit(params = {}) {
+  return {
+    dateCreated: '2018-11-30T18:46:31Z',
+    message:
+      '(improve) Add Links to Spike-Protection Email (#2408)\n\n* (improve) Add Links to Spike-Protection Email\r\n\r\nUsers now have access to useful links from the blogs and docs on Spike-protection.\r\n\r\n* fixed wording',
+    id: 'f7f395d14b2fe29a4e253bf1d3094d61e6ad4434',
+    author: CommitAuthor(),
+    repository: Repository(),
+    ...params,
+  };
+}

--- a/tests/js/fixtures/commitAuthor.js
+++ b/tests/js/fixtures/commitAuthor.js
@@ -1,0 +1,29 @@
+export function CommitAuthor(params = {}) {
+  return {
+    username: 'example@sentry.io',
+    lastLogin: '2018-11-30T21:18:09.812Z',
+    isSuperuser: true,
+    isManaged: false,
+    lastActive: '2018-11-30T21:25:15.222Z',
+    id: '224288',
+    isActive: true,
+    has2fa: false,
+    name: 'Foo Bar',
+    avatarUrl: 'https://example.com/avatar.png',
+    dateJoined: '2018-02-26T23:57:43.766Z',
+    emails: [
+      {
+        is_verified: true,
+        id: '231605',
+        email: 'example@sentry.io',
+      },
+    ],
+    avatar: {
+      avatarUuid: null,
+      avatarType: 'letter_avatar',
+    },
+    hasPasswordAuth: true,
+    email: 'example@sentry.io',
+    ...params,
+  };
+}

--- a/tests/js/spec/components/__snapshots__/resolutionBox.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/resolutionBox.spec.jsx.snap
@@ -3,14 +3,91 @@
 exports[`ResolutionBox render() handles default 1`] = `
 <div
   className="box"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flex": 1,
+      "paddingBottom": 15,
+    }
+  }
 >
   <span
     className="icon icon-checkmark"
+    style={
+      Object {
+        "position": "static",
+        "top": 0,
+      }
+    }
   />
   <p
     className="truncate break-all"
+    style={
+      Object {
+        "paddingBottom": 0,
+        "paddingLeft": 16,
+      }
+    }
   >
     This issue has been marked as resolved.
+  </p>
+</div>
+`;
+
+exports[`ResolutionBox render() handles inCommit 1`] = `
+<div
+  className="box"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flex": 1,
+      "paddingBottom": 15,
+    }
+  }
+>
+  <span
+    className="icon icon-checkmark"
+    style={
+      Object {
+        "position": "static",
+        "top": 0,
+      }
+    }
+  />
+  <p
+    className="truncate break-all"
+    style={
+      Object {
+        "paddingBottom": 0,
+        "paddingLeft": 16,
+      }
+    }
+  >
+    <span
+      key="3"
+    >
+      <span
+        key="0"
+      >
+        This issue has been marked as resolved by 
+      </span>
+      <CommitLink
+        commitId="f7f395d14b2fe29a4e253bf1d3094d61e6ad4434"
+        key="1"
+        repository={
+          Object {
+            "externalSlug": "example/repo-name",
+            "id": "4",
+            "name": "example/repo-name",
+            "provider": "github",
+            "status": "active",
+            "url": "https://github.com/example/repo-name",
+          }
+        }
+      />
+    </span>
   </p>
 </div>
 `;
@@ -18,12 +95,32 @@ exports[`ResolutionBox render() handles default 1`] = `
 exports[`ResolutionBox render() handles inNextRelease 1`] = `
 <div
   className="box"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flex": 1,
+      "paddingBottom": 15,
+    }
+  }
 >
   <span
     className="icon icon-checkmark"
+    style={
+      Object {
+        "position": "static",
+        "top": 0,
+      }
+    }
   />
   <p
     className="truncate break-all"
+    style={
+      Object {
+        "paddingBottom": 0,
+        "paddingLeft": 16,
+      }
+    }
   >
     This issue has been marked as resolved in the upcoming release.
   </p>
@@ -33,12 +130,32 @@ exports[`ResolutionBox render() handles inNextRelease 1`] = `
 exports[`ResolutionBox render() handles inNextRelease with actor 1`] = `
 <div
   className="box"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flex": 1,
+      "paddingBottom": 15,
+    }
+  }
 >
   <span
     className="icon icon-checkmark"
+    style={
+      Object {
+        "position": "static",
+        "top": 0,
+      }
+    }
   />
   <p
     className="truncate break-all"
+    style={
+      Object {
+        "paddingBottom": 0,
+        "paddingLeft": 16,
+      }
+    }
   >
     <span
       key="3"
@@ -81,12 +198,32 @@ exports[`ResolutionBox render() handles inNextRelease with actor 1`] = `
 exports[`ResolutionBox render() handles inRelease 1`] = `
 <div
   className="box"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flex": 1,
+      "paddingBottom": 15,
+    }
+  }
 >
   <span
     className="icon icon-checkmark"
+    style={
+      Object {
+        "position": "static",
+        "top": 0,
+      }
+    }
   />
   <p
     className="truncate break-all"
+    style={
+      Object {
+        "paddingBottom": 0,
+        "paddingLeft": 16,
+      }
+    }
   >
     <span
       key="4"
@@ -117,12 +254,32 @@ exports[`ResolutionBox render() handles inRelease 1`] = `
 exports[`ResolutionBox render() handles inRelease with actor 1`] = `
 <div
   className="box"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flex": 1,
+      "paddingBottom": 15,
+    }
+  }
 >
   <span
     className="icon icon-checkmark"
+    style={
+      Object {
+        "position": "static",
+        "top": 0,
+      }
+    }
   />
   <p
     className="truncate break-all"
+    style={
+      Object {
+        "paddingBottom": 0,
+        "paddingLeft": 16,
+      }
+    }
   >
     <span
       key="5"

--- a/tests/js/spec/components/resolutionBox.spec.jsx
+++ b/tests/js/spec/components/resolutionBox.spec.jsx
@@ -55,5 +55,16 @@ describe('ResolutionBox', function() {
       );
       expect(wrapper).toMatchSnapshot();
     });
+    it('handles inCommit', function() {
+      let wrapper = shallow(
+        <ResolutionBox
+          statusDetails={{
+            inCommit: TestStubs.Commit(),
+          }}
+          params={{orgId: 'org', projectId: 'project'}}
+        />
+      );
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 });

--- a/tests/sentry/api/endpoints/test_project_group_index.py
+++ b/tests/sentry/api/endpoints/test_project_group_index.py
@@ -993,16 +993,11 @@ class GroupUpdateTest(APITestCase):
         )
         assert response.status_code == 200
         assert response.data['status'] == 'resolved'
-        assert response.data['statusDetails']['inCommit'] == {
-            'commit': commit.key,
-            'repository': repo.name,
-        }
+        assert response.data['statusDetails']['inCommit']['id'] == commit.key
         assert response.data['statusDetails']['actor']['id'] == six.text_type(self.user.id)
 
         group = Group.objects.get(id=group.id)
-        # TODO(dcramer): we'd like this to mark things as resolved, but the current
-        # behavior does not yet do this due to some issues with 'resolved in commit'
-        assert group.status != GroupStatus.RESOLVED
+        assert group.status == GroupStatus.RESOLVED
 
         link = GroupLink.objects.get(group_id=group.id)
         assert link.linked_type == GroupLink.LinkedType.commit
@@ -1061,10 +1056,7 @@ class GroupUpdateTest(APITestCase):
         )
         assert response.status_code == 200
         assert response.data['status'] == 'resolved'
-        assert response.data['statusDetails']['inCommit'] == {
-            'commit': commit.key,
-            'repository': repo.name,
-        }
+        assert response.data['statusDetails']['inCommit']['id'] == commit.key
         assert response.data['statusDetails']['actor']['id'] == six.text_type(self.user.id)
 
         group = Group.objects.get(id=group.id)

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -6,8 +6,8 @@ from mock import patch
 from uuid import uuid4
 
 from sentry.models import (
-    Activity, Commit, CommitAuthor, GroupAssignee, GroupLink, OrganizationMember,
-    Release, Repository, UserEmail
+    Activity, Commit, CommitAuthor, Group, GroupAssignee, GroupLink, GroupStatus, GroupSubscription, OrganizationMember,
+    Release, Repository, UserEmail, UserOption
 )
 from sentry.testutils import TestCase
 
@@ -27,8 +27,31 @@ class ResolveGroupResolutionsTest(TestCase):
 
 
 class ResolvedInCommitTest(TestCase):
+    def assertResolvedFromCommit(self, group, commit):
+        assert GroupLink.objects.filter(
+            group_id=group.id,
+            linked_type=GroupLink.LinkedType.commit,
+            linked_id=commit.id,
+        ).exists()
+        assert Group.objects.filter(
+            id=group.id,
+            status=GroupStatus.RESOLVED,
+            resolved_at__isnull=False,
+        ).exists()
+
+    def assertNotResolvedFromCommit(self, group, commit):
+        assert not GroupLink.objects.filter(
+            group_id=group.id,
+            linked_type=GroupLink.LinkedType.commit,
+            linked_id=commit.id,
+        ).exists()
+        assert not Group.objects.filter(
+            id=group.id,
+            status=GroupStatus.RESOLVED,
+        ).exists()
+
     # TODO(dcramer): pull out short ID matching and expand regexp tests
-    def test_simple(self):
+    def test_simple_no_author(self):
         group = self.create_group()
 
         repo = Repository.objects.create(
@@ -43,10 +66,7 @@ class ResolvedInCommitTest(TestCase):
             message=u'Foo Biz\n\nFixes {}'.format(group.qualified_short_id),
         )
 
-        assert GroupLink.objects.filter(
-            group_id=group.id,
-            linked_type=GroupLink.LinkedType.commit,
-            linked_id=commit.id).exists()
+        self.assertResolvedFromCommit(group, commit)
 
     def test_updating_commit(self):
         group = self.create_group()
@@ -62,18 +82,12 @@ class ResolvedInCommitTest(TestCase):
             organization_id=group.organization.id,
         )
 
-        assert not GroupLink.objects.filter(
-            group_id=group.id,
-            linked_type=GroupLink.LinkedType.commit,
-            linked_id=commit.id).exists()
+        self.assertNotResolvedFromCommit(group, commit)
 
         commit.message = u'Foo Biz\n\nFixes {}'.format(group.qualified_short_id)
         commit.save()
 
-        assert GroupLink.objects.filter(
-            group_id=group.id,
-            linked_type=GroupLink.LinkedType.commit,
-            linked_id=commit.id).exists()
+        self.assertResolvedFromCommit(group, commit)
 
     def test_updating_commit_with_existing_grouplink(self):
         group = self.create_group()
@@ -90,18 +104,12 @@ class ResolvedInCommitTest(TestCase):
             message=u'Foo Biz\n\nFixes {}'.format(group.qualified_short_id),
         )
 
-        assert GroupLink.objects.filter(
-            group_id=group.id,
-            linked_type=GroupLink.LinkedType.commit,
-            linked_id=commit.id).exists()
+        self.assertResolvedFromCommit(group, commit)
 
         commit.message = u'Foo Bar Biz\n\nFixes {}'.format(group.qualified_short_id)
         commit.save()
 
-        assert GroupLink.objects.filter(
-            group_id=group.id,
-            linked_type=GroupLink.LinkedType.commit,
-            linked_id=commit.id).count() == 1
+        self.assertResolvedFromCommit(group, commit)
 
     def test_removes_group_link_when_message_changes(self):
         group = self.create_group()
@@ -118,18 +126,12 @@ class ResolvedInCommitTest(TestCase):
             message=u'Foo Biz\n\nFixes {}'.format(group.qualified_short_id),
         )
 
-        assert GroupLink.objects.filter(
-            group_id=group.id,
-            linked_type=GroupLink.LinkedType.commit,
-            linked_id=commit.id).exists()
+        self.assertResolvedFromCommit(group, commit)
 
         commit.message = 'no groups here'
         commit.save()
 
-        assert not GroupLink.objects.filter(
-            group_id=group.id,
-            linked_type=GroupLink.LinkedType.commit,
-            linked_id=commit.id).exists()
+        self.assertNotResolvedFromCommit(group, commit)
 
     def test_no_matching_group(self):
         repo = Repository.objects.create(
@@ -147,34 +149,10 @@ class ResolvedInCommitTest(TestCase):
 
         assert not GroupLink.objects.filter(
             linked_type=GroupLink.LinkedType.commit,
-            linked_id=commit.id).exists()
+            linked_id=commit.id,
+        ).exists()
 
-    def test_matching_author(self):
-        group = self.create_group()
-
-        repo = Repository.objects.create(
-            name='example',
-            organization_id=self.group.organization.id,
-        )
-
-        commit = Commit.objects.create(
-            key=sha1(uuid4().hex).hexdigest(),
-            organization_id=group.organization.id,
-            repository_id=repo.id,
-            message=u'Foo Biz\n\nFixes {}'.format(group.qualified_short_id),
-            author=CommitAuthor.objects.create(
-                organization_id=group.organization.id,
-                name=self.user.name,
-                email=self.user.email,
-            )
-        )
-
-        assert GroupLink.objects.filter(
-            group_id=group.id,
-            linked_type=GroupLink.LinkedType.commit,
-            linked_id=commit.id).exists()
-
-    def test_assigns_author(self):
+    def test_matching_author_with_assignment(self):
         group = self.create_group()
         user = self.create_user(
             name='Foo Bar', email='foo@example.com', is_active=True)
@@ -187,6 +165,12 @@ class ResolvedInCommitTest(TestCase):
         )
         OrganizationMember.objects.create(
             organization=group.project.organization, user=user)
+        UserOption.objects.set_value(
+            user=user,
+            key='self_assign_issue',
+            value='1'
+        )
+
         commit = Commit.objects.create(
             key=sha1(uuid4().hex).hexdigest(),
             organization_id=group.organization.id,
@@ -199,10 +183,7 @@ class ResolvedInCommitTest(TestCase):
             )
         )
 
-        assert GroupLink.objects.filter(
-            group_id=group.id,
-            linked_type=GroupLink.LinkedType.commit,
-            linked_id=commit.id).exists()
+        self.assertResolvedFromCommit(group, commit)
 
         assert GroupAssignee.objects.filter(group=group, user=user).exists()
 
@@ -216,3 +197,53 @@ class ResolvedInCommitTest(TestCase):
             'assigneeEmail': user.email,
             'assigneeType': 'user',
         }
+
+        assert GroupSubscription.objects.filter(
+            group=group,
+            user=user,
+        ).exists()
+
+    def test_matching_author_without_assignment(self):
+        group = self.create_group()
+        user = self.create_user(
+            name='Foo Bar', email='foo@example.com', is_active=True)
+        email = UserEmail.get_primary_email(user=user)
+        email.is_verified = True
+        email.save()
+        repo = Repository.objects.create(
+            name='example',
+            organization_id=self.group.organization.id,
+        )
+        OrganizationMember.objects.create(
+            organization=group.project.organization, user=user)
+        UserOption.objects.set_value(
+            user=user,
+            key='self_assign_issue',
+            value='0'
+        )
+
+        commit = Commit.objects.create(
+            key=sha1(uuid4().hex).hexdigest(),
+            organization_id=group.organization.id,
+            repository_id=repo.id,
+            message=u'Foo Biz\n\nFixes {}'.format(group.qualified_short_id),
+            author=CommitAuthor.objects.create(
+                organization_id=group.organization.id,
+                name=user.name,
+                email=user.email,
+            )
+        )
+
+        self.assertResolvedFromCommit(group, commit)
+
+        assert not Activity.objects.filter(
+            project=group.project,
+            group=group,
+            type=Activity.ASSIGNED,
+            user=user,
+        ).exists()
+
+        assert GroupSubscription.objects.filter(
+            group=group,
+            user=user,
+        ).exists()


### PR DESCRIPTION
Add a check for GroupLink on the regression path to determine if there is a suggested
pending fix which has yet to be released.

Additionally:

- Mark issues as resolved immediately when they're fixed in an upcoming commit
- Fix auto assignment and subscription in release webhooks
- Unresolve issues when GroupLink is removed (when appropriate)
- Adds a resolution reason in the UI when fixed via a commit

An identified and known issue with this is orphaned commits. That is, a commit that references an issue (as resolving it), and is never deployed as part of a release. This is a small number (< 5%), but it's something we should be aware of.

![screen shot 2018-11-28 at 2 25 04 pm](https://user-images.githubusercontent.com/23610/49186916-be2b2d00-f31a-11e8-8cac-c039c17b6002.png)
