### PR TITLE
fix(plugins) Don't create issues when plugins/integrations are sad

### DIFF
--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -8,7 +8,6 @@ sentry.plugins.bases.notify
 from __future__ import absolute_import, print_function
 
 import logging
-import requests
 import six
 from six.moves.urllib.parse import (
     urlparse,
@@ -18,6 +17,7 @@ from six.moves.urllib.parse import (
 )
 
 from django import forms
+from requests.exceptions import SSLError, HTTPError
 
 from sentry import digests, ratelimits
 from sentry.digests import get_option_key as get_digest_option_key
@@ -71,7 +71,7 @@ class NotificationPlugin(Plugin):
         try:
             return self.notify_users(event.group, event, triggering_rules=[
                                      r.label for r in notification.rules])
-        except requests.HTTPError as err:
+        except (SSLError, HTTPError) as err:
             self.logger.info('notification-plugin.notify-failed.', extra={
                 'error': six.text_type(err),
                 'plugin': self.slug

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -25,6 +25,7 @@ from sentry.digests.notifications import (
     event_to_record,
     unsplit_key,
 )
+from sentry.integrations.exceptions import ApiError
 from sentry.plugins import Notification, Plugin
 from sentry.plugins.base.configuration import react_plugin_config
 from sentry.models import ProjectOption
@@ -71,7 +72,7 @@ class NotificationPlugin(Plugin):
         try:
             return self.notify_users(event.group, event, triggering_rules=[
                                      r.label for r in notification.rules])
-        except (SSLError, HTTPError) as err:
+        except (SSLError, HTTPError, ApiError) as err:
             self.logger.info('notification-plugin.notify-failed.', extra={
                 'error': six.text_type(err),
                 'plugin': self.slug

--- a/tests/sentry/plugins/bases/notify/tests.py
+++ b/tests/sentry/plugins/bases/notify/tests.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from sentry.plugins import NotificationPlugin
 from sentry.plugins.base.structs import Notification
 from sentry.testutils import TestCase
-from requests import HTTPError
+from requests.exceptions import HTTPError, SSLError
 
 
 class NotifyPlugin(TestCase):
@@ -26,13 +26,18 @@ class NotifyPlugin(TestCase):
         assert n.add_notification_referrer_param(url) == 'https://sentry.io/'
 
     def test_notify_failure(self):
-        n = NotificationPlugin()
-        n.slug = 'slack'
+        errors = (
+            SSLError('[SSL: UNKNOWN_PROTOCOL] unknown protocol (_ssl.c:590)'),
+            HTTPError('A bad response'),
+        )
+        for err in errors:
+            n = NotificationPlugin()
+            n.slug = 'slack'
 
-        def hook(*a, **kw):
-            raise HTTPError('401 Unauthorized')
-        event = self.create_event()
-        notification = Notification(event)
+            def hook(*a, **kw):
+                raise err
+            event = self.create_event()
+            notification = Notification(event)
 
-        n.notify_users = hook
-        assert n.notify(notification) is False
+            n.notify_users = hook
+            assert n.notify(notification) is False

--- a/tests/sentry/plugins/bases/notify/tests.py
+++ b/tests/sentry/plugins/bases/notify/tests.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from sentry.integrations.exceptions import ApiError
 from sentry.plugins import NotificationPlugin
 from sentry.plugins.base.structs import Notification
 from sentry.testutils import TestCase
@@ -27,6 +28,7 @@ class NotifyPlugin(TestCase):
 
     def test_notify_failure(self):
         errors = (
+            ApiError('The server is sad'),
             SSLError('[SSL: UNKNOWN_PROTOCOL] unknown protocol (_ssl.c:590)'),
             HTTPError('A bad response'),
         )


### PR DESCRIPTION
When an integration/plugin has a request fail we don't need to be alerted. Instead we can log to kibana and track routine network errors there.

Fixes SENTRY-8ER
Fixes SENTRY-306