### PR TITLE
fix(service-hooks): Disable SSL Verification

### DIFF
--- a/src/sentry/tasks/servicehooks.py
+++ b/src/sentry/tasks/servicehooks.py
@@ -67,10 +67,10 @@ def process_resource_change(sender, instance_id, created):
             serialize(instance),
         )
 
-        send_request(servicehook, payload)
+        send_request(servicehook, payload, verify_ssl=True)
 
 
-def send_request(servicehook, payload):
+def send_request(servicehook, payload, verify_ssl=None):
     from sentry import tsdb
     tsdb.incr(tsdb.models.servicehook_fired, servicehook.id)
 
@@ -86,7 +86,7 @@ def send_request(servicehook, payload):
         data=json.dumps(payload),
         headers=headers,
         timeout=5,
-        verify_ssl=True,
+        verify_ssl=(verify_ssl or False),
     )
 
 


### PR DESCRIPTION
I switched this to `True` in a recent commit, but I think there may be some Orgs depending on it being `False`.

Changing it to be conditional so we can enforce it for Platform Apps, but have it be the same it's always been for direct consumers.

Fixes SENTRY-8FW