### PR TITLE
fix(stream): Check firstEvent render *after* groupID length

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -710,10 +710,10 @@ const Stream = createReactClass({
       body = this.renderLoading();
     } else if (this.state.error) {
       body = <LoadingError message={this.state.error} onRetry={this.fetchData} />;
-    } else if (!project.firstEvent) {
-      body = this.renderAwaitingEvents();
     } else if (this.state.groupIds.length > 0) {
       body = this.renderGroupNodes(this.state.groupIds, this.state.statsPeriod);
+    } else if (!project.firstEvent) {
+      body = this.renderAwaitingEvents();
     } else {
       body = this.renderEmpty();
     }

--- a/tests/js/spec/views/stream/stream.spec.jsx
+++ b/tests/js/spec/views/stream/stream.spec.jsx
@@ -319,19 +319,30 @@ describe('Stream', function() {
       expect(wrapper.find('.empty-stream').length).toBeTruthy();
     });
 
-    it('shows "awaiting events" message when no events have been sent', function() {
-      context.project.firstEvent = false; // Set false for this test only
+    describe('no first event sent', function() {
+      it('shows "awaiting events" message when no events have been sent', function() {
+        context.project.firstEvent = false;
+        wrapper.setState({
+          error: false,
+          groupIds: [],
+          loading: false,
+          dataLoading: false,
+        });
 
-      wrapper.setState({
-        error: false,
-        groupIds: [],
-        loading: false,
-        dataLoading: false,
+        expect(wrapper.find(ErrorRobot)).toHaveLength(1);
       });
 
-      expect(wrapper.find(ErrorRobot)).toHaveLength(1);
+      it('does not show "awaiting events" when an event is recieved', function() {
+        context.project.firstEvent = false;
+        wrapper.setState({
+          error: false,
+          groupIds: ['1'],
+          loading: false,
+          dataLoading: false,
+        });
 
-      context.project.firstEvent = true; // Reset for other tests
+        expect(wrapper.find('.ref-group-list').length).toBeTruthy();
+      });
     });
 
     it('does not have real time event updates when events exist', function() {


### PR DESCRIPTION
When using real-time polling, the firstEvent on the `project` will not be updated until the project is updated on the frontend.

Refs #5920 