### PR TITLE
ref(api): Use tagstore for org tags endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -1,39 +1,27 @@
 from __future__ import absolute_import
 
-from functools32 import partial
-
 from rest_framework.response import Response
 
 from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError
-from sentry.api.paginator import GenericOffsetPaginator
-from sentry.utils.snuba import raw_query
+from sentry.api.serializers import serialize
+from sentry.tagstore.snuba.backend import SnubaTagStorage
 
 
 class OrganizationTagsEndpoint(OrganizationEventsEndpointBase):
 
     def get(self, request, organization):
         try:
-            snuba_args = self.get_snuba_query_args(request, organization)
+            filter_params = self.get_filter_params(request, organization)
         except OrganizationEventsError as exc:
             return Response({'detail': exc.message}, status=400)
 
-        data_fn = partial(
-            # extract 'data' from raw_query result
-            lambda *args, **kwargs: raw_query(*args, **kwargs)['data'],
-            aggregations=[
-                ('count()', '', 'count'),
-            ],
-            orderby='-count',
-            groupby=['tags_key'],
-            referrer='api.organization-tags',
-            **snuba_args
-        )
+        # TODO(jess): update this when snuba tagstore is the primary backend for us
+        tagstore = SnubaTagStorage()
 
-        return self.paginate(
-            request=request,
-            on_results=lambda results: [{
-                'tag': row['tags_key'],
-                'count': row['count'],
-            } for row in results],
-            paginator=GenericOffsetPaginator(data_fn=data_fn),
+        results = tagstore.get_tag_keys_for_projects(
+            filter_params['project_id'],
+            filter_params.get('environment'),
+            filter_params['start'],
+            filter_params['end'],
         )
+        return Response(serialize(results, request.user))

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -45,6 +45,7 @@ class TagStorage(Service):
         'get_group_tag_value',
         'get_group_tag_values',
         'get_group_list_tag_value',
+        'get_tag_keys_for_projects',
 
         'get_groups_user_counts',
         'get_group_event_filter',
@@ -216,6 +217,13 @@ class TagStorage(Service):
     def get_tag_keys(self, project_id, environment_id, status=TagKeyStatus.VISIBLE):
         """
         >>> get_tag_key(1, 2)
+        """
+        raise NotImplementedError
+
+    def get_tag_keys_for_projects(self, projects, environments, start,
+                                  end, status=TagKeyStatus.VISIBLE):
+        """
+        >>> get_tag_key([1], [2])
         """
         raise NotImplementedError
 

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -140,11 +140,23 @@ class SnubaTagStorage(TagStorage):
 
     def __get_tag_keys(self, project_id, group_id, environment_id, limit=1000, keys=None):
         start, end = self.get_time_range()
+        return self.__get_tag_keys_for_projects(
+            [project_id],
+            group_id,
+            [environment_id] if environment_id else None,
+            start,
+            end,
+            limit,
+            keys,
+        )
+
+    def __get_tag_keys_for_projects(self, projects, group_id,
+                                    environments, start, end, limit=1000, keys=None):
         filters = {
-            'project_id': [project_id],
+            'project_id': projects,
         }
-        if environment_id:
-            filters['environment'] = [environment_id]
+        if environments:
+            filters['environment'] = environments
         if group_id is not None:
             filters['issue'] = [group_id]
         if keys is not None:
@@ -211,6 +223,10 @@ class SnubaTagStorage(TagStorage):
     def get_tag_keys(self, project_id, environment_id, status=TagKeyStatus.VISIBLE):
         assert status is TagKeyStatus.VISIBLE
         return self.__get_tag_keys(project_id, None, environment_id)
+
+    def get_tag_keys_for_projects(self, projects, environments, start,
+                                  end, status=TagKeyStatus.VISIBLE):
+        return self.__get_tag_keys_for_projects(projects, None, environments, start, end)
 
     def get_tag_value(self, project_id, environment_id, key, value):
         return self.__get_tag_value(project_id, None, environment_id, key, value)

--- a/tests/snuba/api/endpoints/test_organization_tags.py
+++ b/tests/snuba/api/endpoints/test_organization_tags.py
@@ -45,4 +45,7 @@ class OrganizationTagsTest(APITestCase, SnubaTestCase):
 
         response = self.client.get(url, format='json')
         assert response.status_code == 200, response.content
-        assert response.data == [{'count': 3, 'tag': 'fruit'}, {'count': 1, 'tag': 'some_tag'}]
+        assert response.data == [
+            {'uniqueValues': 2, 'name': 'Fruit', 'key': 'fruit', 'totalValues': 3},
+            {'uniqueValues': 1, 'name': 'Some Tag', 'key': 'some_tag', 'totalValues': 1},
+        ]


### PR DESCRIPTION
The project tags endpoint doesn't have pagination, so I took it out here. Possible I should add it back though, lmk your thoughts.

cc @billyvg since the response is changing to this format: `{'uniqueValues': 2, 'name': 'Fruit', 'key': 'fruit', 'totalValues': 3}` -- we should coordinate for your autocomplete pr