### PR TITLE
ref(meta): Allow data in meta errors

### DIFF
--- a/src/sentry/utils/meta.py
+++ b/src/sentry/utils/meta.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import collections
 import six
 
 
@@ -85,20 +86,52 @@ class Meta(object):
 
         return meta
 
-    def get_errors(self):
+    def iter_errors(self):
         """
-        Returns meta errors of the item at the current path.
+        Iterates over meta errors of the item at the current path, if any.
 
-        It is not safe to mutate the return value since it might be detached
-        from the actual meta tree.
+        Each error is a tuple ``(type, data)``, where:
+         - ``type`` is the error constant also used in EventError
+         - ``data`` a dictionary of additional error infos
         """
-        return self.get().get('err') or []
+        return (
+            ([err, {}] if isinstance(err, six.string_types) else err)
+            for err in self.get().get('err') or ()
+        )
 
-    def add_error(self, error, value=None):
+    def get_event_errors(self):
+        """
+        Returns all errors of the item at the current path in EventError schema,
+        which can directly be stored to an event's "errors" list.
+        """
+
+        errors = []
+        value = self.get().get('val')
+
+        for error, data in self.iter_errors():
+            eventerror = dict(data)
+            eventerror['type'] = error
+
+            if self._path:
+                eventerror['name'] = '.'.join(self._path)
+
+            if value is not None:
+                eventerror['value'] = value
+                value = None
+
+            errors.append(eventerror)
+
+        return errors
+
+    def add_error(self, error, value=None, data=None):
         """
         Adds an error to the meta data at the current path. The ``error``
-        argument is converted to string. If the optional ``value`` is given, it
-        is attached as original value into the meta data.
+        argument is converted to string. If optional ``data`` is specified, the
+        data hash is stored alongside the error.
+
+        If an optional ``value`` is specified, it is attached as original value
+        into the meta data. Note that there is only one original value, not one
+        per error.
 
         If no meta data entry exists for the current path, it is created, along
         with the entire parent tree.
@@ -106,7 +139,11 @@ class Meta(object):
         meta = self.create()
         if 'err' not in meta or meta['err'] is None:
             meta['err'] = []
-        meta['err'].append(six.text_type(error))
+
+        error = six.text_type(error)
+        if isinstance(data, collections.Mapping):
+            error = [error, dict(data)]
+        meta['err'].append(error)
 
         if value is not None:
             meta['val'] = value

--- a/tests/sentry/utils/test_meta.py
+++ b/tests/sentry/utils/test_meta.py
@@ -29,7 +29,8 @@ class MetaTests(TestCase):
     def test_get_new(self):
         assert Meta().raw() == {}
         assert Meta().get() == {}
-        assert Meta().get_errors() == []
+        assert list(Meta().iter_errors()) == []
+        assert Meta().get_event_errors() == []
 
     def test_create_new(self):
         meta = Meta()
@@ -52,7 +53,8 @@ class MetaTests(TestCase):
     def test_get_missing(self):
         assert Meta({}).raw() == {}
         assert Meta({}).get() == {}
-        assert Meta({}).get_errors() == []
+        assert list(Meta({}).iter_errors()) == []
+        assert Meta({}).get_event_errors() == []
 
     def test_create_missing(self):
         data = {}
@@ -78,7 +80,8 @@ class MetaTests(TestCase):
     def test_get_none(self):
         assert Meta({'': None}).raw() == {'': None}
         assert Meta({'': None}).get() == {}
-        assert Meta({'': None}).get_errors() == []
+        assert list(Meta({'': None}).iter_errors()) == []
+        assert Meta({'': None}).get_event_errors() == []
 
     def test_create_none(self):
         data = {'': None}
@@ -104,7 +107,8 @@ class MetaTests(TestCase):
     def test_get_empty(self):
         assert Meta({'': {}}).raw() == {'': {}}
         assert Meta({'': {}}).get() == {}
-        assert Meta({'': {}}).get_errors() == []
+        assert list(Meta({'': {}}).iter_errors()) == []
+        assert Meta({'': {}}).get_event_errors() == []
 
     def test_create_empty(self):
         data = {'': {}}
@@ -130,7 +134,10 @@ class MetaTests(TestCase):
     def test_get_root(self):
         assert Meta(input_meta).raw() == input_meta
         assert Meta(input_meta).get() == input_meta['']
-        assert Meta(input_meta).get_errors() == ['existing']
+        assert list(Meta(input_meta).iter_errors()) == [['existing', {}]]
+        assert Meta(input_meta).get_event_errors() == [
+            {'type': 'existing', 'value': 'original'},
+        ]
 
     def test_create_root(self):
         changed = deepcopy(input_meta)
@@ -159,7 +166,8 @@ class MetaTests(TestCase):
         data = {}
         assert Meta(data).enter('field').raw() == {}
         assert Meta(data).enter('field').get() == {}
-        assert Meta(data).enter('field').get_errors() == []
+        assert list(Meta(data).enter('field').iter_errors()) == []
+        assert Meta(data).enter('field').get_event_errors() == []
 
     def test_create_nested_missing(self):
         data = {}
@@ -186,7 +194,10 @@ class MetaTests(TestCase):
         data = {'field': input_meta}
         assert Meta(data).enter('field').raw() == input_meta
         assert Meta(data).enter('field').get() == input_meta['']
-        assert Meta(data).enter('field').get_errors() == ['existing']
+        assert list(Meta(data).enter('field').iter_errors()) == [['existing', {}]]
+        assert Meta(data).enter('field').get_event_errors() == [
+            {'type': 'existing', 'name': 'field', 'value': 'original'}
+        ]
 
     def test_create_nested_existing(self):
         data = {'field': input_meta}
@@ -217,7 +228,7 @@ class MetaTests(TestCase):
         data = {'0': input_meta}
         assert Meta(data).enter(0).raw() == input_meta
         assert Meta(data).enter(0).get() == input_meta['']
-        assert Meta(data).enter(0).get_errors() == ['existing']
+        assert list(Meta(data).enter(0).iter_errors()) == [['existing', {}]]
 
     def test_create_nested_index(self):
         data = {}
@@ -228,4 +239,17 @@ class MetaTests(TestCase):
     def test_stringify_error(self):
         meta = Meta()
         meta.add_error(ValueError('invalid stuff'), 'changed')
-        assert meta.get_errors() == ['invalid stuff']
+        assert list(meta.iter_errors()) == [['invalid stuff', {}]]
+
+    def test_error_with_data(self):
+        meta = Meta()
+        meta.add_error('invalid url', data={'url': 'invalid'})
+        assert list(meta.iter_errors()) == [['invalid url', {'url': 'invalid'}]]
+
+    def test_get_multiple_event_errors(self):
+        # XXX: Value is only added to the first error, which is usually the
+        # normalization error.
+        assert Meta(merged_meta).get_event_errors() == [
+            {'type': 'existing', 'value': 'changed'},
+            {'type': 'additional'}
+        ]


### PR DESCRIPTION
This changes meta errors to allow optional data:

```json
{
  "err": [
    "invalid_data",
    ["http_fetch_failed", {"url": "invalid"}],
  ],
  "val": "original value here"
}
```

The helper `get_event_errors()` then returns a list of errors that can be merged into the `errors` array in the event. Note that the **original value is only appended to the first error**:
```json
[
  {
    "type": "invalid_data",
    "value": "original value here",
    "name": "path.to.field"
  },
  {
    "type": "http_fetch_failed",
    "name": "path.to.field"
  }
]
```

`name` is omitted for errors directly on the event, e.g. those with an empty path.