### PR TITLE
fix: Improve partition management in post-processing relay during rebalancing operations

### DIFF
--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -273,7 +273,7 @@ class KafkaEventStream(EventStream):
                 owned_partition_offsets[(topic, partition)] = offset
 
             # Handle revoked partitions by removing them from the owned
-            # partition offsets map, and commiting their offsets.
+            # partition offsets map, and committing  their offsets.
             offsets_to_commit = []
             for topic, partition in set(owned_partition_offsets) - updated_assignment:
                 offset = owned_partition_offsets.pop((topic, partition))
@@ -285,7 +285,7 @@ class KafkaEventStream(EventStream):
 
             if offsets_to_commit:
                 logger.debug(
-                    'Commiting offset(s) for %s revoked partition(s): %r',
+                    'Committing offset(s) for %s revoked partition(s): %r',
                     len(offsets_to_commit),
                     offsets_to_commit)
                 consumer.commit(offsets=offsets_to_commit, asynchronous=False)
@@ -306,7 +306,7 @@ class KafkaEventStream(EventStream):
 
             if offsets_to_commit:
                 logger.debug(
-                    'Commiting offset(s) for %s owned partition(s): %r',
+                    'Committing offset(s) for %s owned partition(s): %r',
                     len(offsets_to_commit),
                     offsets_to_commit)
                 consumer.commit(offsets=offsets_to_commit, asynchronous=False)

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -285,7 +285,7 @@ class KafkaEventStream(EventStream):
 
             if offsets_to_commit:
                 logger.debug(
-                    'Commiting offsets for %s revoked partitions: %r',
+                    'Commiting offset(s) for %s revoked partition(s): %r',
                     len(offsets_to_commit),
                     offsets_to_commit)
                 consumer.commit(offsets=offsets_to_commit, asynchronous=False)
@@ -306,7 +306,7 @@ class KafkaEventStream(EventStream):
 
             if offsets_to_commit:
                 logger.debug(
-                    'Commiting offset for %s owned partitions: %r',
+                    'Commiting offset(s) for %s owned partition(s): %r',
                     len(offsets_to_commit),
                     offsets_to_commit)
                 consumer.commit(offsets=offsets_to_commit, asynchronous=False)

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -244,7 +244,7 @@ class KafkaEventStream(EventStream):
 
     def relay(self, consumer_group, commit_log_topic,
               synchronize_commit_group, commit_batch_size=100, initial_offset_reset='latest'):
-        logger.info('Starting relay...')
+        logger.debug('Starting relay...')
 
         consumer = SynchronizedConsumer(
             bootstrap_servers=self.producer_configuration['bootstrap.servers'],
@@ -260,7 +260,7 @@ class KafkaEventStream(EventStream):
             for i in partitions:
                 key = (i.topic, i.partition)
                 if key not in owned_partition_offsets:
-                    logger.info('Received new partition assignment: %r', i)
+                    logger.debug('Received new partition assignment: %r', i)
                     if i.offset is OFFSET_INVALID:
                         offset = None
                     else:
@@ -273,7 +273,7 @@ class KafkaEventStream(EventStream):
 
                 owned_partition_offsets[key] = offset
 
-            logger.info(
+            logger.debug(
                 'Received assignment containing %s partitions: %r',
                 len(partitions),
                 partitions)
@@ -297,7 +297,7 @@ class KafkaEventStream(EventStream):
                 offsets_to_commit.append(TopicPartition(i.topic, i.partition, ))
 
             if offsets_to_commit:
-                logger.info(
+                logger.debug(
                     'Commiting offset for %s revoked partitions: %r',
                     len(offsets_to_commit),
                     offsets_to_commit)
@@ -319,7 +319,7 @@ class KafkaEventStream(EventStream):
                 offsets_to_commit.append(TopicPartition((topic, partition, offset)))
 
             if offsets_to_commit:
-                logger.info(
+                logger.debug(
                     'Commiting offset for %s owned partitions: %r',
                     len(offsets_to_commit),
                     offsets_to_commit)
@@ -353,7 +353,7 @@ class KafkaEventStream(EventStream):
         except KeyboardInterrupt:
             pass
 
-        logger.info('Committing offsets and closing consumer...')
+        logger.debug('Committing offsets and closing consumer...')
         commit_offsets()
 
         consumer.close()

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -260,7 +260,7 @@ class KafkaEventStream(EventStream):
             logger.debug('Received partition assignment: %r', partitions)
 
             for i in partitions:
-                if i.offset is OFFSET_INVALID:
+                if i.offset == OFFSET_INVALID:
                     updated_offset = None
                 elif i.offset < 0:
                     raise Exception(


### PR DESCRIPTION
This wasn't correctly handling revoked partitions before (or really handling them at all.) Now, when a consumer receives an assignment that does not include a partition that it believed that it owned, it will commit it's current offset for that partition (if it exists) and remove it from the set of partitions that it is responsible for.