### PR TITLE
fix(plugins) Don't alert on plugin error.

### DIFF
--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -25,6 +25,7 @@ from sentry.digests.notifications import (
     event_to_record,
     unsplit_key,
 )
+from sentry.exceptions import PluginError
 from sentry.integrations.exceptions import ApiError
 from sentry.plugins import Notification, Plugin
 from sentry.plugins.base.configuration import react_plugin_config
@@ -72,7 +73,7 @@ class NotificationPlugin(Plugin):
         try:
             return self.notify_users(event.group, event, triggering_rules=[
                                      r.label for r in notification.rules])
-        except (SSLError, HTTPError, ApiError) as err:
+        except (SSLError, HTTPError, ApiError, PluginError) as err:
             self.logger.info('notification-plugin.notify-failed.', extra={
                 'error': six.text_type(err),
                 'plugin': self.slug

--- a/tests/sentry/plugins/bases/notify/tests.py
+++ b/tests/sentry/plugins/bases/notify/tests.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from sentry.exceptions import PluginError
 from sentry.integrations.exceptions import ApiError
 from sentry.plugins import NotificationPlugin
 from sentry.plugins.base.structs import Notification
@@ -31,6 +32,7 @@ class NotifyPlugin(TestCase):
             ApiError('The server is sad'),
             SSLError('[SSL: UNKNOWN_PROTOCOL] unknown protocol (_ssl.c:590)'),
             HTTPError('A bad response'),
+            PluginError('A plugin is sad'),
         )
         for err in errors:
             n = NotificationPlugin()


### PR DESCRIPTION
If a plugin fails to notify user's we don't need to be alerted. Logging will be enough.

I still need to fix the pagerduty plugin so that it emits a `PluginError`, but I'll do that before merging this.

Fixes SENTRY-89Z
Fixes SENTRY-8ER