### PR TITLE
fix(service-hooks): Handle race conditions

### DIFF
--- a/src/sentry/models/signals.py
+++ b/src/sentry/models/signals.py
@@ -8,5 +8,6 @@ from sentry.models import Group
 
 @receiver(post_save, sender=Group)
 def resource_changed(sender, instance, created, **kwargs):
-    from sentry.tasks.servicehooks import process_resource_change
-    process_resource_change.delay(sender, instance.id, created)
+    if created:
+        from sentry.tasks.servicehooks import process_resource_change
+        process_resource_change.delay(sender, instance.id)


### PR DESCRIPTION
I suspect the Issues we've seen pop up with this are due to a race condition where the task executes before the transaction to create the resource commits?

This change handles DoesNotExist errors explicitly without reporting to Sentry (until the max retries happen).

This also changes the `post_save` signal that enqueues a task when an Issue is saved, to only do so when it's a brand new Issue. Meaning updates to existing issues will not enqueue anything.