### PR TITLE
fix(settings): Hidden environments should nest properly

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -274,12 +274,10 @@ function routes() {
         name="Environments"
         path="environments/"
         component={errorHandler(ProjectEnvironments)}
-      />
-      <Route
-        name="Hidden Environments"
-        path="environments/hidden/"
-        component={errorHandler(ProjectEnvironments)}
-      />
+      >
+        <IndexRoute />
+        <Route path="hidden/" />
+      </Route>
       <Route name="Tags" path="tags/" component={errorHandler(ProjectTags)} />
       <Redirect from="issue-tracking/" to="/settings/:orgId/:projectId/plugins/" />
       <Route

--- a/src/sentry/static/sentry/app/views/projectEnvironments.jsx
+++ b/src/sentry/static/sentry/app/views/projectEnvironments.jsx
@@ -35,7 +35,6 @@ import space from 'app/styles/space';
 
 const ProjectEnvironments = createReactClass({
   propTypes: {
-    route: PropTypes.object,
     routes: PropTypes.array,
     params: PropTypes.object,
   },
@@ -43,7 +42,7 @@ const ProjectEnvironments = createReactClass({
   mixins: [ApiMixin, Reflux.listenTo(EnvironmentStore, 'onEnvironmentsChange')],
 
   getInitialState() {
-    const isHidden = this.props.route.path === 'environments/hidden/';
+    const isHidden = this.props.location.pathname.endsWith('hidden/');
     const environments = isHidden
       ? EnvironmentStore.getHidden()
       : EnvironmentStore.getActive();
@@ -65,7 +64,7 @@ const ProjectEnvironments = createReactClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    const isHidden = nextProps.route.path === 'environments/hidden/';
+    const isHidden = this.props.location.pathname.endsWith('hidden/');
     const environments = isHidden
       ? EnvironmentStore.getHidden()
       : EnvironmentStore.getActive();
@@ -325,15 +324,11 @@ const ProjectEnvironments = createReactClass({
           title={t('Manage Environments')}
           tabs={
             <NavTabs underlined={true}>
-              <ListLink
-                to={`${baseUrl}environments/`}
-                index={true}
-                isActive={() => !this.state.isHidden}
-              >
+              <ListLink to={baseUrl} index={true} isActive={() => !this.state.isHidden}>
                 {t('Environments')}
               </ListLink>
               <ListLink
-                to={`${baseUrl}environments/hidden/`}
+                to={`${baseUrl}hidden/`}
                 index={true}
                 isActive={() => this.state.isHidden}
               >

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -2,15 +2,15 @@
 
 exports[`ProjectEnvironments render active renders empty message 1`] = `
 <ProjectEnvironments
+  location={
+    Object {
+      "pathname": "environments/",
+    }
+  }
   params={
     Object {
       "orgId": "org-slug",
       "projectId": "project-slug",
-    }
-  }
-  route={
-    Object {
-      "path": "environments/",
     }
   }
   routes={Array []}
@@ -225,15 +225,15 @@ exports[`ProjectEnvironments render active renders empty message 1`] = `
 
 exports[`ProjectEnvironments render active renders environment list and sets staging as default env 1`] = `
 <ProjectEnvironments
+  location={
+    Object {
+      "pathname": "environments/",
+    }
+  }
   params={
     Object {
       "orgId": "org-slug",
       "projectId": "project-slug",
-    }
-  }
-  route={
-    Object {
-      "path": "environments/",
     }
   }
   routes={Array []}
@@ -830,15 +830,15 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
 
 exports[`ProjectEnvironments render hidden renders empty message 1`] = `
 <ProjectEnvironments
+  location={
+    Object {
+      "pathname": "environments/hidden/",
+    }
+  }
   params={
     Object {
       "orgId": "org-slug",
       "projectId": "project-slug",
-    }
-  }
-  route={
-    Object {
-      "path": "environments/hidden/",
     }
   }
   routes={Array []}
@@ -1053,15 +1053,15 @@ exports[`ProjectEnvironments render hidden renders empty message 1`] = `
 
 exports[`ProjectEnvironments render hidden renders environment list 1`] = `
 <ProjectEnvironments
+  location={
+    Object {
+      "pathname": "environments/hidden/",
+    }
+  }
   params={
     Object {
       "orgId": "org-slug",
       "projectId": "project-slug",
-    }
-  }
-  route={
-    Object {
-      "path": "environments/hidden/",
     }
   }
   routes={Array []}

--- a/tests/js/spec/views/projectEnvironments.spec.jsx
+++ b/tests/js/spec/views/projectEnvironments.spec.jsx
@@ -7,19 +7,19 @@ import recreateRoute from 'app/utils/recreateRoute';
 import {ALL_ENVIRONMENTS_KEY} from 'app/constants';
 
 jest.mock('app/utils/recreateRoute');
-recreateRoute.mockReturnValue('/org-slug/project-slug/settings/');
+recreateRoute.mockReturnValue('/org-slug/project-slug/settings/environments/');
 
 function mountComponent(isHidden) {
   const org = TestStubs.Organization();
   const project = TestStubs.Project();
-  let path = isHidden ? 'environments/hidden/' : 'environments/';
+  let pathname = isHidden ? 'environments/hidden/' : 'environments/';
   return mount(
     <ProjectEnvironments
       params={{
         orgId: org.slug,
         projectId: project.slug,
       }}
-      route={{path}}
+      location={{pathname}}
       routes={[]}
     />,
     TestStubs.routerContext()


### PR DESCRIPTION
This fixes the environments page so that the Hidden tab is still part of the Environments route (thus keeping the navigation item highlighted) and does not create a new entry in the breadcrumbs.