### PR TITLE
feat(api): Add OrganizationEventsMetaEndpoint to get total counts for event stream

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -86,12 +86,14 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
             return Response({'detail': exc.message}, status=400)
 
         data = raw_query(
-            selected_columns=['count'],
             aggregations=[['count()', '', 'count']],
             referrer='api.organization-event-meta',
+            turbo=True,
             **snuba_args
         )['data'][0]
 
         return Response({
-            'count': data['count']
+            # this needs to be multiplied to account for the `TURBO_SAMPLE_RATE`
+            # in snuba
+            'count': data['count'] * 10,
         })

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -75,3 +75,23 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
             ),
             status=200,
         )
+
+
+class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
+
+    def get(self, request, organization):
+        try:
+            snuba_args = self.get_snuba_query_args(request, organization)
+        except OrganizationEventsError as exc:
+            return Response({'detail': exc.message}, status=400)
+
+        data = raw_query(
+            selected_columns=['count'],
+            aggregations=[['count()', '', 'count']],
+            referrer='api.organization-event-meta',
+            **snuba_args
+        )['data'][0]
+
+        return Response({
+            'count': data['count']
+        })

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -61,7 +61,7 @@ from .endpoints.organization_details import OrganizationDetailsEndpoint
 from .endpoints.organization_discover_query import OrganizationDiscoverQueryEndpoint
 from .endpoints.organization_discover_saved_queries import OrganizationDiscoverSavedQueriesEndpoint
 from .endpoints.organization_discover_saved_query_detail import OrganizationDiscoverSavedQueryDetailEndpoint
-from .endpoints.organization_events import OrganizationEventsEndpoint, OrganizationEventsStatsEndpoint
+from .endpoints.organization_events import OrganizationEventsEndpoint, OrganizationEventsMetaEndpoint, OrganizationEventsStatsEndpoint
 from .endpoints.organization_health import OrganizationHealthTopEndpoint, OrganizationHealthGraphEndpoint
 from .endpoints.organization_shortid import ShortIdLookupEndpoint
 from .endpoints.organization_environments import OrganizationEnvironmentsEndpoint
@@ -500,6 +500,11 @@ urlpatterns = patterns(
         r'^organizations/(?P<organization_slug>[^\/]+)/events-stats/$',
         OrganizationEventsStatsEndpoint.as_view(),
         name='sentry-api-0-organization-events-stats'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/events-meta/$',
+        OrganizationEventsMetaEndpoint.as_view(),
+        name='sentry-api-0-organization-events-meta'
     ),
     url(
         r'^organizations/(?P<organization_slug>[^\/]+)/issues/new/$',

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -529,7 +529,7 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsTestBase):
         response = self.client.get(url, format='json')
 
         assert response.status_code == 200, response.content
-        assert response.data['count'] == 2
+        assert 'count' in response.data
 
     def test_search(self):
         self.login_as(user=self.user)
@@ -553,4 +553,4 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsTestBase):
         response = self.client.get(url, {'query': 'delet'}, format='json')
 
         assert response.status_code == 200, response.content
-        assert response.data['count'] == 1
+        assert 'count' in response.data

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -518,7 +518,7 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsTestBase):
         group = self.create_group(project=project)
         group2 = self.create_group(project=project2)
         self.create_event('a' * 32, group=group, datetime=self.min_ago)
-        self.create_event('b' * 32, group=group2, datetime=self.min_ago)
+        self.create_event('m' * 32, group=group2, datetime=self.min_ago)
 
         url = reverse(
             'sentry-api-0-organization-events-meta',
@@ -529,7 +529,8 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsTestBase):
         response = self.client.get(url, format='json')
 
         assert response.status_code == 200, response.content
-        assert 'count' in response.data
+        # this is not exact because of turbo=True
+        assert response.data['count'] == 10
 
     def test_search(self):
         self.login_as(user=self.user)
@@ -538,7 +539,7 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsTestBase):
         group = self.create_group(project=project)
         self.create_event('x' * 32, group=group, message="how to make fast", datetime=self.min_ago)
         self.create_event(
-            'y' * 32,
+            'm' * 32,
             group=group,
             message="Delet the Data",
             datetime=self.min_ago,
@@ -553,4 +554,5 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsTestBase):
         response = self.client.get(url, {'query': 'delet'}, format='json')
 
         assert response.status_code == 200, response.content
-        assert 'count' in response.data
+        # this is not exact because of turbo=True
+        assert response.data['count'] == 10


### PR DESCRIPTION
Talked about this with Alex briefly, but for context:
- we're trying to show number of results (or estimated number of results) on the event stream page
- i'm keeping it in a separate endpoint so that the additional (potentially slow) query doesn't slow down the actual results

Also, @alex-hofsteede i left `turbo=True` out because that was making my tests fail (it was showing 0 for something that had 1-2 results) -- i'm wondering if i should do something like only use turbo if there are more than 100 results? (like do an initial query without the count aggregation, with a limit and without turbo and return that if the count is lower than limit, otherwise run another query with turbo on?)