### PR TITLE
feat(discover): Use group ID instead of short ID and link to group

### DIFF
--- a/src/sentry/api/endpoints/organization_discover_query.py
+++ b/src/sentry/api/endpoints/organization_discover_query.py
@@ -18,7 +18,7 @@ from sentry.api.serializers.rest_framework import ListField
 from sentry.api.bases.organization import OrganizationPermission
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.paginator import GenericOffsetPaginator
-from sentry.models import Project, Group, ProjectStatus, OrganizationMember, OrganizationMemberTeam
+from sentry.models import Project, ProjectStatus, OrganizationMember, OrganizationMemberTeam
 from sentry.utils import snuba
 from sentry import roles
 from sentry import features
@@ -244,20 +244,6 @@ class OrganizationDiscoverQueryEndpoint(OrganizationEndpoint):
                 result['project.name'] = projects[result['project.id']]
                 if 'project.id' not in requested_query['groupby']:
                     del result['project.id']
-
-        if 'issue.id' in (requested_query['selected_columns'] + requested_query['groupby']):
-            for col in snuba_results['meta']:
-                if col['name'] == 'issue.id':
-                    col['type'] = 'String'
-
-        for arr in [requested_query['selected_columns'], requested_query['groupby']]:
-            if 'issue.id' in arr:
-                groups = {k: v for k, v in Group.objects.filter(
-                    id__in=[row['issue.id'] for row in snuba_results['data']]
-                ).values_list('id', 'short_id')}
-
-                for result in snuba_results['data']:
-                    result['issue.id'] = six.text_type(groups.get(result['issue.id']))
 
         # Convert snuba types to json types
         for col in snuba_results['meta']:

--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -228,7 +228,7 @@ export default function createQueryBuilder(initial = {}, organization) {
     // If there are no aggregations, always ensure we fetch event ID and
     // project ID so we can display the link to event
     if (type === 'baseQuery') {
-      return originalQuery.fields.includes('id')
+      return originalQuery.fields.some(field => field === 'id' || field === 'issue.id')
         ? {
             ...originalQuery,
             fields: uniq([...originalQuery.fields, 'id', 'project.id']),

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/table.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/table.jsx
@@ -72,6 +72,11 @@ export default class ResultTable extends React.Component {
       value = this.getEventLink(data[rowIndex - 1]);
     }
 
+    // check for issue.id columm
+    if (columnIndex < cols.length && cols[columnIndex].name === 'issue.id') {
+      value = this.getIssueLink(data[rowIndex - 1]);
+    }
+
     return (
       <Cell key={key} style={style} isOddRow={rowIndex % 2 === 1} align={align}>
         {value}
@@ -88,6 +93,20 @@ export default class ResultTable extends React.Component {
       <Tooltip title={t('Open event')}>
         <Link href={`/${slug}/${projectSlug}/events/${event.id}/`} target="_blank">
           {event.id}
+        </Link>
+      </Tooltip>
+    );
+  };
+
+  getIssueLink = event => {
+    const {slug, projects} = this.context.organization;
+    const projectSlug = projects.find(project => project.id === `${event['project.id']}`)
+      .slug;
+
+    return (
+      <Tooltip title={t('Open issue')}>
+        <Link to={`/${slug}/${projectSlug}/issues/${event['issue.id']}`} target="_blank">
+          {event['issue.id']}
         </Link>
       </Tooltip>
     );

--- a/tests/snuba/test_organization_discover_query.py
+++ b/tests/snuba/test_organization_discover_query.py
@@ -228,47 +228,6 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
         assert len(response.data['data']) == 1
         assert(response.data['data'][0]['uniq_project_name']) == 1
 
-    def test_select_issue_id(self):
-        with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
-            response = self.client.post(url, {
-                'projects': [self.project.id],
-                'fields': ['issue.id'],
-                'range': '14d',
-                'orderby': '-timestamp',
-            })
-        assert response.status_code == 200, response.content
-        assert len(response.data['data']) == 1
-        assert(response.data['data'][0]['issue.id']) == '20'
-
-    def test_groupby_issue_id(self):
-        with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
-            response = self.client.post(url, {
-                'projects': [self.project.id],
-                'aggregations': [['count()', '', 'count']],
-                'fields': ['issue.id'],
-                'range': '14d',
-                'orderby': '-count',
-            })
-        assert response.status_code == 200, response.content
-        assert len(response.data['data']) == 1
-        assert(response.data['data'][0]['issue.id']) == '20'
-        assert(response.data['data'][0]['count']) == 1
-
-    def test_uniq_issue_id(self):
-        with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
-            response = self.client.post(url, {
-                'projects': [self.project.id],
-                'aggregations': [['uniq', 'issue.id', 'uniq_issue_id']],
-                'range': '14d',
-                'orderby': '-uniq_issue_id',
-            })
-        assert response.status_code == 200, response.content
-        assert len(response.data['data']) == 1
-        assert(response.data['data'][0]['uniq_issue_id']) == 1
-
     def test_meta_types(self):
         with self.feature('organizations:discover'):
             url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])


### PR DESCRIPTION
Group IDs open link to group, return the id instead of short ID to make
this possible