### PR TITLE
fix(discover): By day query should order by time desc

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -220,7 +220,7 @@ export default function createQueryBuilder(initial = {}, organization) {
         ...originalQuery,
         groupby: ['time'],
         rollup: 60 * 60 * 24,
-        orderby: 'time',
+        orderby: '-time',
         limit: 1000,
       };
     }

--- a/tests/js/spec/views/organizationDiscover/discover.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/discover.spec.jsx
@@ -237,7 +237,7 @@ describe('Discover', function() {
         ...queryBuilder.getExternal(),
         groupby: ['time'],
         rollup: 60 * 60 * 24,
-        orderby: 'time',
+        orderby: '-time',
       });
     });
   });


### PR DESCRIPTION
We should make sure latest day data is accurate when results are
truncated by sorting by time desc. As a follow up we might want to
increase the limit as well if we're still getting a lot of weird
results.