### PR TITLE
fix(discover): Do not fetch 'id' unnecessarily

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -225,13 +225,13 @@ export default function createQueryBuilder(initial = {}, organization) {
       };
     }
 
-    // If there are no aggregations, always ensure we fetch event ID and
-    // project ID so we can display the link to event
+    // If id or issue.id is present in query fields, always fetch the project.id
+    // so we can generate links
     if (type === 'baseQuery') {
       return originalQuery.fields.includes('id')
         ? {
             ...originalQuery,
-            fields: uniq([...originalQuery.fields, 'id', 'project.id']),
+            fields: uniq([...originalQuery.fields, 'project.id']),
           }
         : originalQuery;
     }


### PR DESCRIPTION
Since we're changing the way links are displayed we never need to fetch
'id' in cases where it's not already being requested.

This caused grouping on 'issue.id' to not work correctly.