### PR TITLE
feat(events-stream): Change loading/error UI (APP-744)

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/events.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/events.jsx
@@ -104,7 +104,7 @@ export const doEventsRequest = (
 
   const absolutePeriods = getPeriod({start, end}, {shouldDoublePeriod});
 
-  const promise = Promise.all(
+  return Promise.all(
     absolutePeriods.filter(i => !!i).map(absolutePeriod =>
       api.requestPromise(`${BASE_URL(organization)}`, {
         query: {
@@ -113,12 +113,9 @@ export const doEventsRequest = (
         },
       })
     )
-  );
-  promise.then(results => ({
+  ).then(results => ({
     data: results.reduce((acc, {data}) => acc.concat(data), []),
   }));
-
-  return promise;
 };
 
 /**

--- a/src/sentry/static/sentry/app/actionCreators/events.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/events.jsx
@@ -104,7 +104,7 @@ export const doEventsRequest = (
 
   const absolutePeriods = getPeriod({start, end}, {shouldDoublePeriod});
 
-  return Promise.all(
+  const promise = Promise.all(
     absolutePeriods.filter(i => !!i).map(absolutePeriod =>
       api.requestPromise(`${BASE_URL(organization)}`, {
         query: {
@@ -113,9 +113,12 @@ export const doEventsRequest = (
         },
       })
     )
-  ).then(results => ({
+  );
+  promise.then(results => ({
     data: results.reduce((acc, {data}) => acc.concat(data), []),
   }));
+
+  return promise;
 };
 
 /**

--- a/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
@@ -93,11 +93,11 @@ class OrganizationEvents extends AsyncView {
 
   renderBody() {
     const {organization} = this.props;
-    const {loading, reloading, events, eventsPageLinks} = this.state;
+    const {error, loading, reloading, events, eventsPageLinks} = this.state;
 
     return (
       <React.Fragment>
-        {this.state.error && super.renderError()}
+        {error && super.renderError(new Error('Unable to load all required endpoints'))}
         <Panel>
           <EventsChart loading={loading || reloading} organization={organization} />
         </Panel>
@@ -109,12 +109,15 @@ class OrganizationEvents extends AsyncView {
           organization={organization}
         />
 
-        <Flex align="center" justify="space-between">
-          <RowDisplay>
-            {events.length ? t(`Results ${this.renderRowCounts()}`) : t('No Results')}
-          </RowDisplay>
-          <Pagination pageLinks={eventsPageLinks} className="" />
-        </Flex>
+        {!loading &&
+          !error && (
+            <Flex align="center" justify="space-between">
+              <RowDisplay>
+                {events.length ? t(`Results ${this.renderRowCounts()}`) : t('No Results')}
+              </RowDisplay>
+              <Pagination pageLinks={eventsPageLinks} className="" />
+            </Flex>
+          )}
       </React.Fragment>
     );
   }

--- a/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
@@ -3,19 +3,17 @@ import {isEqual} from 'lodash';
 import React from 'react';
 import styled from 'react-emotion';
 
-import utils from 'app/utils';
 import {Panel} from 'app/components/panels';
 import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
 import Pagination from 'app/components/pagination';
 import SentryTypes from 'app/sentryTypes';
+import utils from 'app/utils';
 import withOrganization from 'app/utils/withOrganization';
-import BetaTag from 'app/components/betaTag';
 
 import {getParams} from './utils/getParams';
 import EventsChart from './eventsChart';
 import EventsTable from './eventsTable';
-import SearchBar from './searchBar';
 
 const parseRowFromLinks = (links, numRows) => {
   links = utils.parseLinkHeader(links);
@@ -80,39 +78,17 @@ class OrganizationEvents extends AsyncView {
     return `Events - ${this.props.organization.slug}`;
   }
 
-  handleSearch = query => {
-    let {router, location} = this.props;
-    router.push({
-      pathname: location.pathname,
-      query: {
-        ...(location.query || {}),
-        query,
-      },
-    });
-  };
-
   renderRowCounts() {
     const {events, eventsPageLinks} = this.state;
     return parseRowFromLinks(eventsPageLinks, events.length);
   }
 
   renderBody() {
-    const {organization, location} = this.props;
+    const {organization} = this.props;
     const {reloading, events, eventsPageLinks} = this.state;
 
     return (
       <React.Fragment>
-        <Flex align="center" justify="space-between" mb={2}>
-          <HeaderTitle>
-            {t('Events')} <BetaTag />
-          </HeaderTitle>
-          <StyledSearchBar
-            query={(location.query && location.query.query) || ''}
-            onSearch={this.handleSearch}
-            organization={organization}
-          />
-        </Flex>
-
         <Panel>
           <EventsChart organization={organization} />
         </Panel>
@@ -129,19 +105,6 @@ class OrganizationEvents extends AsyncView {
     );
   }
 }
-
-const HeaderTitle = styled('h4')`
-  flex: 1;
-  font-size: ${p => p.theme.headerFontSize};
-  line-height: ${p => p.theme.headerFontSize};
-  font-weight: normal;
-  color: ${p => p.theme.gray4};
-  margin: 0;
-`;
-
-const StyledSearchBar = styled(SearchBar)`
-  flex: 1;
-`;
 
 const RowDisplay = styled('div')`
   color: ${p => p.theme.gray6};

--- a/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
@@ -83,17 +83,31 @@ class OrganizationEvents extends AsyncView {
     return parseRowFromLinks(eventsPageLinks, events.length);
   }
 
+  renderError() {
+    return this.renderBody();
+  }
+
+  renderLoading() {
+    return this.renderBody();
+  }
+
   renderBody() {
     const {organization} = this.props;
-    const {reloading, events, eventsPageLinks} = this.state;
+    const {loading, reloading, events, eventsPageLinks} = this.state;
 
     return (
       <React.Fragment>
+        {this.state.error && super.renderError()}
         <Panel>
-          <EventsChart organization={organization} />
+          <EventsChart loading={loading || reloading} organization={organization} />
         </Panel>
 
-        <EventsTable reloading={reloading} events={events} organization={organization} />
+        <EventsTable
+          loading={!reloading && loading}
+          reloading={reloading}
+          events={events}
+          organization={organization}
+        />
 
         <Flex align="center" justify="space-between">
           <RowDisplay>

--- a/src/sentry/static/sentry/app/views/organizationEvents/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/eventsChart.jsx
@@ -5,11 +5,12 @@ import moment from 'moment';
 
 import {t} from 'app/locale';
 import LineChart from 'app/components/charts/lineChart';
+import EventsContext from 'app/views/organizationEvents/utils/eventsContext';
+import EventsRequest from 'app/views/organizationEvents/utils/eventsRequest';
 import SentryTypes from 'app/sentryTypes';
 import withApi from 'app/utils/withApi';
 
-import {EventsRequestWithParams} from './utils/eventsRequest';
-import EventsContext from './utils/eventsContext';
+const DEFAULT_GET_CATEGORY = () => t('Events');
 
 class EventsChart extends React.PureComponent {
   static propTypes = {
@@ -18,10 +19,6 @@ class EventsChart extends React.PureComponent {
     period: PropTypes.string,
     utc: PropTypes.bool,
   };
-
-  constructor(props) {
-    super(props);
-  }
 
   handleDataZoom = (evt, chart) => {
     const model = chart.getModel();
@@ -89,12 +86,12 @@ class EventsChart extends React.PureComponent {
 
     return (
       <div>
-        <EventsRequestWithParams
+        <EventsRequest
           {...this.props}
           interval={interval}
           showLoading
           query={(location.query && location.query.query) || ''}
-          getCategory={() => t('Events')}
+          getCategory={DEFAULT_GET_CATEGORY}
           includePrevious={!!period}
         >
           {({timeseriesData, previousTimeseriesData}) => {
@@ -116,7 +113,7 @@ class EventsChart extends React.PureComponent {
               />
             );
           }}
-        </EventsRequestWithParams>
+        </EventsRequest>
       </div>
     );
   }
@@ -124,7 +121,7 @@ class EventsChart extends React.PureComponent {
 
 const EventsChartContainer = withRouter(
   withApi(
-    class EventsChartContainer extends React.Component {
+    class EventsChartWithParams extends React.Component {
       render() {
         return (
           <EventsContext.Consumer>

--- a/src/sentry/static/sentry/app/views/organizationEvents/eventsTable.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/eventsTable.jsx
@@ -18,6 +18,7 @@ import EventsContext from './utils/eventsContext';
 
 class EventsTable extends React.Component {
   static propTypes = {
+    loading: PropTypes.bool,
     reloading: PropTypes.bool,
     events: PropTypes.array,
     organization: SentryTypes.Organization,
@@ -32,7 +33,10 @@ class EventsTable extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    if (this.props.reloading !== nextProps.reloading) {
+    if (
+      this.props.reloading !== nextProps.reloading ||
+      this.props.loading !== nextProps.loading
+    ) {
       return true;
     }
 
@@ -63,7 +67,7 @@ class EventsTable extends React.Component {
   }
 
   render() {
-    const {events, organization, reloading, utc} = this.props;
+    const {events, organization, loading, reloading, utc} = this.props;
     const hasEvents = events && !!events.length;
 
     return (
@@ -76,7 +80,8 @@ class EventsTable extends React.Component {
             <div>{t('Time')}</div>
           </TableLayout>
         </PanelHeader>
-        {!hasEvents && <EmptyStateWarning>No events</EmptyStateWarning>}
+        {loading && <LoadingIndicator />}
+        {!loading && !hasEvents && <EmptyStateWarning>No events</EmptyStateWarning>}
         {hasEvents && (
           <StyledPanelBody>
             {reloading && <StyledLoadingIndicator overlay />}

--- a/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
@@ -8,12 +8,15 @@ import styled from 'react-emotion';
 import {DEFAULT_STATS_PERIOD, DEFAULT_USE_UTC} from 'app/constants';
 import {defined} from 'app/utils';
 import {getLocalDateObject, getUtcDateString} from 'app/utils/dates';
+import {t} from 'app/locale';
+import BetaTag from 'app/components/betaTag';
 import Feature from 'app/components/acl/feature';
 import Header from 'app/components/organizations/header';
 import HeaderSeparator from 'app/components/organizations/headerSeparator';
 import HeaderItemPosition from 'app/components/organizations/headerItemPosition';
 import MultipleEnvironmentSelector from 'app/components/organizations/multipleEnvironmentSelector';
 import MultipleProjectSelector from 'app/components/organizations/multipleProjectSelector';
+import SearchBar from 'app/components/searchBar';
 import SentryTypes from 'app/sentryTypes';
 import TimeRangeSelector from 'app/components/organizations/timeRangeSelector';
 import space from 'app/styles/space';
@@ -188,6 +191,17 @@ class OrganizationEventsContainer extends React.Component {
 
   handleUpdateProjects = () => this.handleUpdate('project');
 
+  handleSearch = query => {
+    let {router, location} = this.props;
+    router.push({
+      pathname: location.pathname,
+      query: {
+        ...(location.query || {}),
+        query,
+      },
+    });
+  };
+
   render() {
     const {organization, children} = this.props;
     const {period, start, end, utc} = this.state;
@@ -234,7 +248,20 @@ class OrganizationEventsContainer extends React.Component {
                 />
               </HeaderItemPosition>
             </Header>
-            <Body>{children}</Body>
+            <Body>
+              <Flex align="center" justify="space-between" mb={2}>
+                <HeaderTitle>
+                  {t('Events')} <BetaTag />
+                </HeaderTitle>
+                <StyledSearchBar
+                  query={(location.query && location.query.query) || ''}
+                  placeholder={t('Search for events, users, tags, and everything else.')}
+                  onSearch={this.handleSearch}
+                />
+              </Flex>
+
+              {children}
+            </Body>
           </OrganizationEventsContent>
         </EventsContext.Provider>
       </Feature>
@@ -258,4 +285,17 @@ const Body = styled('div')`
   flex-direction: column;
   flex: 1;
   padding: ${space(2)} ${space(4)} ${space(3)};
+`;
+
+const HeaderTitle = styled('h4')`
+  flex: 1;
+  font-size: ${p => p.theme.headerFontSize};
+  line-height: ${p => p.theme.headerFontSize};
+  font-weight: normal;
+  color: ${p => p.theme.gray4};
+  margin: 0;
+`;
+
+const StyledSearchBar = styled(SearchBar)`
+  flex: 1;
 `;

--- a/src/sentry/static/sentry/app/views/organizationEvents/utils/eventsRequest.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/utils/eventsRequest.jsx
@@ -2,7 +2,9 @@ import {isEqual, omitBy} from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import {addErrorMessage} from 'app/actionCreators/indicator';
 import {doEventsRequest} from 'app/actionCreators/events';
+import {t} from 'app/locale';
 import LoadingPanel from 'app/views/organizationHealth/loadingPanel';
 import SentryTypes from 'app/sentryTypes';
 
@@ -125,12 +127,18 @@ class EventsRequest extends React.Component {
 
   fetchData = async () => {
     const {api, ...props} = this.props;
+    let timeseriesData;
 
     this.setState(state => ({
       reloading: state.timeseriesData !== null,
     }));
 
-    const timeseriesData = await doEventsRequest(api, props);
+    try {
+      timeseriesData = await doEventsRequest(api, props);
+    } catch (err) {
+      addErrorMessage(t('Error loading chart data'));
+      timeseriesData = null;
+    }
 
     if (this.unmounting) return;
 

--- a/src/sentry/static/sentry/app/views/organizationEvents/utils/eventsRequest.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/utils/eventsRequest.jsx
@@ -5,12 +5,12 @@ import React from 'react';
 import {doEventsRequest} from 'app/actionCreators/events';
 import LoadingPanel from 'app/views/organizationHealth/loadingPanel';
 import SentryTypes from 'app/sentryTypes';
-import withApi from 'app/utils/withApi';
-import withLatestContext from 'app/utils/withLatestContext';
 
-import EventsContext from './eventsContext';
+const propNamesToIgnore = ['api', 'children', 'organizations', 'project', 'loading'];
+const omitIgnoredProps = props =>
+  omitBy(props, (value, key) => propNamesToIgnore.includes(key));
 
-class EventsRequestWithParams extends React.Component {
+class EventsRequest extends React.Component {
   static propTypes = {
     /**
      * API client instance
@@ -80,6 +80,9 @@ class EventsRequestWithParams extends React.Component {
      */
     timeAggregationSeriesName: PropTypes.string,
 
+    // Initial loading state
+    loading: PropTypes.bool,
+
     showLoading: PropTypes.bool,
   };
 
@@ -99,7 +102,7 @@ class EventsRequestWithParams extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      reloading: false,
+      reloading: false || props.loading,
       timeseriesData: null,
     };
   }
@@ -109,11 +112,6 @@ class EventsRequestWithParams extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const propNamesToIgnore = ['api', 'children', 'organizations', 'project'];
-
-    const omitIgnoredProps = props =>
-      omitBy(props, (value, key) => propNamesToIgnore.includes(key));
-
     if (isEqual(omitIgnoredProps(prevProps), omitIgnoredProps(this.props))) {
       return;
     }
@@ -260,7 +258,7 @@ class EventsRequestWithParams extends React.Component {
     const {timeseriesData, reloading} = this.state;
 
     // Is "loading" if data is null
-    const loading = reloading || timeseriesData === null;
+    const loading = this.props.loading || reloading || timeseriesData === null;
 
     if (showLoading && loading) {
       return <LoadingPanel />;
@@ -295,27 +293,4 @@ class EventsRequestWithParams extends React.Component {
   }
 }
 
-const EventsRequest = withLatestContext(
-  withApi(
-    class EventsRequest extends React.Component {
-      render() {
-        return (
-          <EventsContext.Consumer>
-            {({projects, environments, period, filters}) => (
-              <EventsRequestWithParams
-                projects={projects}
-                environments={environments}
-                period={period}
-                filters={filters}
-                {...this.props}
-              />
-            )}
-          </EventsContext.Consumer>
-        );
-      }
-    }
-  )
-);
-
 export default EventsRequest;
-export {EventsRequestWithParams};

--- a/tests/js/spec/views/organizationEvents/events.spec.jsx
+++ b/tests/js/spec/views/organizationEvents/events.spec.jsx
@@ -38,6 +38,29 @@ describe('OrganizationEventsErrors', function() {
     });
   });
 
+  it('renders with errors', async function() {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/events/`,
+      statusCode: 500,
+      body: {details: 'Error'},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/events-stats/`,
+      statusCode: 500,
+      body: {details: 'Error'},
+    });
+    let wrapper = mount(
+      <OrganizationEvents organization={org} location={{query: {}}} />,
+      TestStubs.routerContext()
+    );
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('EventsChart')).toHaveLength(1);
+    expect(wrapper.find('EventsTable')).toHaveLength(1);
+    expect(wrapper.find('RouteError')).toHaveLength(1);
+  });
+
   it('renders events table', async function() {
     let wrapper = mount(
       <OrganizationEvents organization={org} location={{query: {}}} />,

--- a/tests/js/spec/views/organizationEvents/utils/eventsRequest.spec.jsx
+++ b/tests/js/spec/views/organizationEvents/utils/eventsRequest.spec.jsx
@@ -2,7 +2,7 @@ import {mount} from 'enzyme';
 import React from 'react';
 
 import {doEventsRequest} from 'app/actionCreators/events';
-import {EventsRequestWithParams} from 'app/views/organizationEvents/utils/eventsRequest';
+import EventsRequest from 'app/views/organizationEvents/utils/eventsRequest';
 
 const COUNT_OBJ = {
   count: 123,
@@ -38,9 +38,7 @@ describe('EventsRequest', function() {
           data: [[new Date(), [COUNT_OBJ]]],
         })
       );
-      wrapper = mount(
-        <EventsRequestWithParams {...DEFAULTS}>{mock}</EventsRequestWithParams>
-      );
+      wrapper = mount(<EventsRequest {...DEFAULTS}>{mock}</EventsRequest>);
     });
 
     it('makes requests', async function() {
@@ -130,9 +128,9 @@ describe('EventsRequest', function() {
         })
       );
       wrapper = mount(
-        <EventsRequestWithParams {...DEFAULTS} includePrevious={true}>
+        <EventsRequest {...DEFAULTS} includePrevious={true}>
           {mock}
-        </EventsRequestWithParams>
+        </EventsRequest>
       );
 
       await tick();
@@ -205,9 +203,9 @@ describe('EventsRequest', function() {
       );
 
       wrapper = mount(
-        <EventsRequestWithParams {...DEFAULTS} includeTimeseries={true}>
+        <EventsRequest {...DEFAULTS} includeTimeseries={true}>
           {mock}
-        </EventsRequestWithParams>
+        </EventsRequest>
       );
 
       await tick();
@@ -244,13 +242,13 @@ describe('EventsRequest', function() {
       );
 
       wrapper = mount(
-        <EventsRequestWithParams
+        <EventsRequest
           {...DEFAULTS}
           includeTimeseries={true}
           getCategory={() => 'static-category'}
         >
           {mock}
-        </EventsRequestWithParams>
+        </EventsRequest>
       );
 
       await tick();


### PR DESCRIPTION
This changes the loading UI so that all UI components are always present.
Spinner is displayed inside of Table and the chart is just "grayed" out when loading.

When errors happen, show error message above content (and below header)

![image](https://user-images.githubusercontent.com/79684/49313985-dbd4cf80-f49d-11e8-8949-bee75275f1d9.png)

![loading](https://cl.ly/c62a96677483/download/Screen%20Recording%202018-11-30%20at%2012.47%20PM.gif)