### PR TITLE
ref(integrations): Assure releases api accept patch set data.

### DIFF
--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -10,11 +10,26 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.fields.user import UserField
 from sentry.api.serializers import serialize
-from sentry.api.serializers.rest_framework import CommitSerializer, ListField
+from sentry.api.serializers.rest_framework import ListField
 from sentry.models import Activity, Environment, Release, ReleaseEnvironment
 from sentry.plugins.interfaces.releasehook import ReleaseHook
 from sentry.constants import VERSION_LENGTH
 from sentry.signals import release_created
+
+
+class CommitPatchSetSerializer(serializers.Serializer):
+    path = serializers.CharField(max_length=255)
+    type = serializers.CharField(max_length=1)
+
+
+class CommitSerializerWithPatchSet(serializers.Serializer):
+    id = serializers.CharField(max_length=64)
+    repository = serializers.CharField(max_length=64, required=False)
+    message = serializers.CharField(required=False)
+    author_name = serializers.CharField(max_length=128, required=False)
+    author_email = serializers.EmailField(max_length=75, required=False)
+    timestamp = serializers.DateTimeField(required=False)
+    patch_set = ListField(child=CommitPatchSetSerializer(), required=False, allow_null=False)
 
 
 class ReleaseSerializer(serializers.Serializer):
@@ -23,7 +38,7 @@ class ReleaseSerializer(serializers.Serializer):
     url = serializers.URLField(required=False)
     owner = UserField(required=False)
     dateReleased = serializers.DateTimeField(required=False)
-    commits = ListField(child=CommitSerializer(), required=False, allow_null=False)
+    commits = ListField(child=CommitSerializerWithPatchSet(), required=False, allow_null=False)
 
     def validate_version(self, attrs, source):
         value = attrs[source]

--- a/src/sentry/models/commitfilechange.py
+++ b/src/sentry/models/commitfilechange.py
@@ -4,6 +4,8 @@ from django.db import models
 
 from sentry.db.models import (BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr)
 
+COMMIT_FILE_CHANGE_TYPES = frozenset(('A', 'D', 'M'))
+
 
 class CommitFileChange(Model):
     __core__ = False
@@ -21,3 +23,7 @@ class CommitFileChange(Model):
         unique_together = (('commit', 'filename'), )
 
     __repr__ = sane_repr('commit_id', 'filename')
+
+    @staticmethod
+    def is_valid_type(value):
+        return value in COMMIT_FILE_CHANGE_TYPES

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 __all__ = (
     'TestCase', 'TransactionTestCase', 'APITestCase', 'TwoFactorAPITestCase', 'AuthProviderTestCase', 'RuleTestCase',
     'PermissionTestCase', 'PluginTestCase', 'CliTestCase', 'AcceptanceTestCase',
-    'IntegrationTestCase', 'UserReportEnvironmentTestCase', 'SnubaTestCase', 'IntegrationRepositoryTestCase',
+    'IntegrationTestCase', 'UserReportEnvironmentTestCase', 'SnubaTestCase', 'IntegrationRepositoryTestCase', 'ReleaseCommitPatchTest'
 )
 
 import base64
@@ -923,3 +923,32 @@ class IntegrationRepositoryTestCase(APITestCase):
     def assert_error_message(self, response, error_type, error_message):
         assert response.data['error_type'] == error_type
         assert error_message in response.data['errors']['__all__']
+
+
+class ReleaseCommitPatchTest(APITestCase):
+    def setUp(self):
+        user = self.create_user(is_staff=False, is_superuser=False)
+        self.org = self.create_organization()
+        self.org.save()
+
+        team = self.create_team(organization=self.org)
+        self.project = self.create_project(name='foo', organization=self.org, teams=[team])
+
+        self.create_member(teams=[team], user=user, organization=self.org)
+        self.login_as(user=user)
+
+    @fixture
+    def url(self):
+        raise NotImplementedError
+
+    def assert_commit(self, commit, repo_id, key, author_id, message):
+        assert commit.organization_id == self.org.id
+        assert commit.repository_id == repo_id
+        assert commit.key == key
+        assert commit.author_id == author_id
+        assert commit.message == message
+
+    def assert_file_change(self, file_change, type, filename, commit_id):
+        assert file_change.type == type
+        assert file_change.filename == filename
+        assert file_change.commit_id == commit_id

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -512,7 +512,7 @@ class OrganizationReleaseCreateTest(APITestCase):
                 "projects": [project.slug],
                 "commits": [
                     {
-                        "patch_set": [{"path": "hello.py", "type": "M"}],
+                        "patch_set": [{"path": "hello.py", "type": "M"}, {"path": "templates/hola.html", "type": "D"}],
                         "repository": "laurynsentry/helloworld",
                         "author_email": "lauryndbrown@gmail.com",
                         "timestamp": "2018-11-29T18:50:28+03:00",
@@ -520,7 +520,7 @@ class OrganizationReleaseCreateTest(APITestCase):
                         "message": "made changes to hello.",
                         "id": "2d1ab93fe4bb42db80890f01f8358fc9f8fbff3b"
                     }, {
-                        "patch_set": [{"path": "templates/hello.html", "type": "M"}],
+                        "patch_set": [{"path": "templates/hello.html", "type": "M"}, {"path": "templates/goodbye.html", "type": "A"}],
                         "repository": "laurynsentry/helloworld",
                         "author_email": "lauryndbrown@gmail.com",
                         "timestamp": "2018-11-30T22:51:14+03:00",
@@ -578,7 +578,7 @@ class OrganizationReleaseCreateTest(APITestCase):
 
         file_changes = CommitFileChange.objects.filter(
             organization_id=org.id
-        )
+        ).order_by('filename')
 
         file_change = file_changes[0]
         assert file_change.type == 'M'
@@ -586,9 +586,19 @@ class OrganizationReleaseCreateTest(APITestCase):
         assert file_change.commit_id == commits[0].id
 
         file_change = file_changes[1]
+        assert file_change.type == 'A'
+        assert file_change.filename == 'templates/goodbye.html'
+        assert file_change.commit_id == commits[1].id
+
+        file_change = file_changes[2]
         assert file_change.type == 'M'
         assert file_change.filename == 'templates/hello.html'
         assert file_change.commit_id == commits[1].id
+
+        file_change = file_changes[3]
+        assert file_change.type == 'D'
+        assert file_change.filename == 'templates/hola.html'
+        assert file_change.commit_id == commits[0].id
 
     @patch('sentry.tasks.commits.fetch_commits')
     def test_commits_from_provider(self, mock_fetch_commits):

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -5,12 +5,13 @@ from mock import patch
 from base64 import b64encode
 from datetime import datetime
 from django.core.urlresolvers import reverse
+from exam import fixture
 
 from sentry.models import (
     Activity, ApiKey, ApiToken, CommitAuthor, CommitFileChange, Environment, Release, ReleaseCommit, ReleaseEnvironment, ReleaseProject, Repository
 )
 from sentry.plugins.providers.dummy.repository import DummyRepositoryProvider
-from sentry.testutils import APITestCase
+from sentry.testutils import APITestCase, ReleaseCommitPatchTest
 
 
 class OrganizationReleaseListTest(APITestCase):
@@ -491,114 +492,6 @@ class OrganizationReleaseCreateTest(APITestCase):
         assert len(rc_list) == 2
         for rc in rc_list:
             assert rc.organization_id
-
-    def test_commits_with_patch_set(self):
-        user = self.create_user(is_staff=False, is_superuser=False)
-        org = self.create_organization()
-        org.flags.allow_joinleave = False
-        org.save()
-
-        team = self.create_team(organization=org)
-        project = self.create_project(name='foo', organization=org, teams=[team])
-
-        self.create_member(teams=[team], user=user, organization=org)
-        self.login_as(user=user)
-
-        url = reverse('sentry-api-0-organization-releases', kwargs={'organization_slug': org.slug})
-        response = self.client.post(
-            url,
-            data={
-                "version": "2d1ab93fe4bb42db80890f01f8358fc9f8fbff3b",
-                "projects": [project.slug],
-                "commits": [
-                    {
-                        "patch_set": [{"path": "hello.py", "type": "M"}, {"path": "templates/hola.html", "type": "D"}],
-                        "repository": "laurynsentry/helloworld",
-                        "author_email": "lauryndbrown@gmail.com",
-                        "timestamp": "2018-11-29T18:50:28+03:00",
-                        "author_name": "Lauryn Brown",
-                        "message": "made changes to hello.",
-                        "id": "2d1ab93fe4bb42db80890f01f8358fc9f8fbff3b"
-                    }, {
-                        "patch_set": [{"path": "templates/hello.html", "type": "M"}, {"path": "templates/goodbye.html", "type": "A"}],
-                        "repository": "laurynsentry/helloworld",
-                        "author_email": "lauryndbrown@gmail.com",
-                        "timestamp": "2018-11-30T22:51:14+03:00",
-                        "author_name": "Lauryn Brown",
-                        "message": "Changed release",
-                        "id": "be2fe070f6d1b8a572b67defc87af2582f9b0d78"
-                    }
-                ]
-            }
-        )
-
-        assert response.status_code == 201, (response.status_code, response.content)
-        assert response.data['version']
-
-        release = Release.objects.get(
-            organization_id=org.id,
-            version=response.data['version'],
-        )
-
-        repo = Repository.objects.get(
-            organization_id=org.id,
-            name='laurynsentry/helloworld',
-        )
-        assert repo.provider is None
-
-        rc_list = list(
-            ReleaseCommit.objects.filter(
-                release=release,
-            ).select_related('commit', 'commit__author').order_by('order')
-        )
-        assert len(rc_list) == 2
-        for rc in rc_list:
-            assert rc.organization_id
-
-        author = CommitAuthor.objects.get(
-            organization_id=org.id,
-            email='lauryndbrown@gmail.com'
-        )
-        assert author.name == 'Lauryn Brown'
-
-        commits = [rc.commit for rc in rc_list]
-        commits.sort(key=lambda c: c.date_added)
-
-        assert commits[0].organization_id == org.id
-        assert commits[0].repository_id == repo.id
-        assert commits[0].key == '2d1ab93fe4bb42db80890f01f8358fc9f8fbff3b'
-        assert commits[0].author_id == author.id
-        assert commits[0].message == 'made changes to hello.'
-
-        assert commits[1].organization_id == org.id
-        assert commits[1].repository_id == repo.id
-        assert commits[1].key == 'be2fe070f6d1b8a572b67defc87af2582f9b0d78'
-        assert commits[1].author_id == author.id
-        assert commits[1].message == 'Changed release'
-
-        file_changes = CommitFileChange.objects.filter(
-            organization_id=org.id
-        ).order_by('filename')
-
-        file_change = file_changes[0]
-        assert file_change.type == 'M'
-        assert file_change.filename == 'hello.py'
-        assert file_change.commit_id == commits[0].id
-
-        file_change = file_changes[1]
-        assert file_change.type == 'A'
-        assert file_change.filename == 'templates/goodbye.html'
-        assert file_change.commit_id == commits[1].id
-
-        file_change = file_changes[2]
-        assert file_change.type == 'M'
-        assert file_change.filename == 'templates/hello.html'
-        assert file_change.commit_id == commits[1].id
-
-        file_change = file_changes[3]
-        assert file_change.type == 'D'
-        assert file_change.filename == 'templates/hola.html'
-        assert file_change.commit_id == commits[0].id
 
     @patch('sentry.tasks.commits.fetch_commits')
     def test_commits_from_provider(self, mock_fetch_commits):
@@ -1140,3 +1033,97 @@ class OrganizationReleaseListEnvironmentsTest(APITestCase):
         )
         response = self.client.get(url + '?environment=' + 'invalid_environment', format='json')
         self.assert_releases(response, [])
+
+
+class OrganizationReleaseCreateCommitPatch(ReleaseCommitPatchTest):
+    @fixture
+    def url(self):
+        return reverse(
+            'sentry-api-0-organization-releases',
+            kwargs={'organization_slug': self.org.slug}
+        )
+
+    def test_commits_with_patch_set(self):
+        response = self.client.post(
+            self.url,
+            data={
+                "version": "2d1ab93fe4bb42db80890f01f8358fc9f8fbff3b",
+                "projects": [self.project.slug],
+                "commits": [
+                    {
+                        "patch_set": [{"path": "hello.py", "type": "M"}, {"path": "templates/hola.html", "type": "D"}],
+                        "repository": "laurynsentry/helloworld",
+                        "author_email": "lauryndbrown@gmail.com",
+                        "timestamp": "2018-11-29T18:50:28+03:00",
+                        "author_name": "Lauryn Brown",
+                        "message": "made changes to hello.",
+                        "id": "2d1ab93fe4bb42db80890f01f8358fc9f8fbff3b"
+                    }, {
+                        "patch_set": [{"path": "templates/hello.html", "type": "M"}, {"path": "templates/goodbye.html", "type": "A"}],
+                        "repository": "laurynsentry/helloworld",
+                        "author_email": "lauryndbrown@gmail.com",
+                        "timestamp": "2018-11-30T22:51:14+03:00",
+                        "author_name": "Lauryn Brown",
+                        "message": "Changed release",
+                        "id": "be2fe070f6d1b8a572b67defc87af2582f9b0d78"
+                    }
+                ]
+            }
+        )
+
+        assert response.status_code == 201, (response.status_code, response.content)
+        assert response.data['version']
+
+        release = Release.objects.get(
+            organization_id=self.org.id,
+            version=response.data['version'],
+        )
+
+        repo = Repository.objects.get(
+            organization_id=self.org.id,
+            name='laurynsentry/helloworld',
+        )
+        assert repo.provider is None
+
+        rc_list = list(
+            ReleaseCommit.objects.filter(
+                release=release,
+            ).select_related('commit', 'commit__author').order_by('order')
+        )
+        assert len(rc_list) == 2
+        for rc in rc_list:
+            assert rc.organization_id
+
+        author = CommitAuthor.objects.get(
+            organization_id=self.org.id,
+            email='lauryndbrown@gmail.com'
+        )
+        assert author.name == 'Lauryn Brown'
+
+        commits = [rc.commit for rc in rc_list]
+        commits.sort(key=lambda c: c.date_added)
+
+        self.assert_commit(
+            commit=commits[0],
+            repo_id=repo.id,
+            key='2d1ab93fe4bb42db80890f01f8358fc9f8fbff3b',
+            author_id=author.id,
+            message='made changes to hello.',
+        )
+
+        self.assert_commit(
+            commit=commits[1],
+            repo_id=repo.id,
+            key='be2fe070f6d1b8a572b67defc87af2582f9b0d78',
+            author_id=author.id,
+            message='Changed release',
+        )
+
+        file_changes = CommitFileChange.objects.filter(
+            organization_id=self.org.id
+        ).order_by('filename')
+
+        self.assert_file_change(file_changes[0], 'M', 'hello.py', commits[0].id)
+        self.assert_file_change(file_changes[1], 'A', 'templates/goodbye.html', commits[1].id)
+        self.assert_file_change(file_changes[2], 'M', 'templates/hello.html', commits[1].id)
+        self.assert_file_change(file_changes[3], 'D', 'templates/hola.html', commits[0].id)


### PR DESCRIPTION
This is a fix to the Releases endpoint's serializer to allow patch_set data to be submitted.