### PR TITLE
fix(service-hooks): Update resource change hook

### DIFF
--- a/src/sentry/models/signals.py
+++ b/src/sentry/models/signals.py
@@ -10,4 +10,8 @@ from sentry.models import Group
 def resource_changed(sender, instance, created, **kwargs):
     if created:
         from sentry.tasks.servicehooks import process_resource_change
-        process_resource_change.delay(sender, instance.id)
+
+        process_resource_change.delay(
+            sender=sender.__name__,
+            instance_id=instance.id,
+        )

--- a/src/sentry/tasks/servicehooks.py
+++ b/src/sentry/tasks/servicehooks.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function
 
 import six
+import inspect
 
 from time import time
 from celery.task import current
@@ -25,6 +26,10 @@ RESOURCE_RENAMES = {
     'Group': 'issue',
 }
 
+TYPES = {
+    'Group': Group,
+}
+
 
 @instrumented_task(
     'sentry.tasks.process_resource_change',
@@ -32,20 +37,28 @@ RESOURCE_RENAMES = {
     max_retries=5,
 )
 @retry()
-def process_resource_change(sender, instance_id):
-    model = sender.__name__
-    model = RESOURCE_RENAMES.get(model, model.lower())
+def process_resource_change(sender, instance_id, *args, **kwargs):
+    model = None
+    name = None
+
+    # Previous method signature.
+    if inspect.isclass(sender):
+        model = sender
+    else:
+        model = TYPES[sender]
+
+    name = RESOURCE_RENAMES.get(model.__name__, model.__name__.lower())
 
     # We may run into a race condition where this task executes before the
     # transaction that creates the Group has committed.
     try:
-        instance = sender.objects.get(id=instance_id)
-    except sender.DoesNotExist as e:
+        instance = model.objects.get(id=instance_id)
+    except model.DoesNotExist as e:
         # Explicitly requeue the task, so we don't report this to Sentry until
         # we hit the max number of retries.
         return current.retry(exc=e)
 
-    action = u'{}.created'.format(model)
+    action = u'{}.created'.format(name)
 
     if action not in ALLOWED_ACTIONS:
         return


### PR DESCRIPTION
- Adds `*args` and `**kwargs` to handle the signature change.
- Handles passing both a class object and class string (where the latter
will be how it works moving forward)