### PR TITLE
from six.moves import xrange for Python 3

### DIFF
--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -9,6 +9,8 @@ from contextlib import contextmanager
 
 import pytest
 
+from six.moves import xrange
+
 try:
     from confluent_kafka import Consumer, KafkaError, Producer, TopicPartition
     from sentry.eventstream.kafka.consumer import SynchronizedConsumer


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/getsentry/sentry on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./src/sentry/utils/strings.py:96:39: E999 SyntaxError: invalid syntax
    delimiters = re.compile(ur'([{}]+)'.format(''.join(map(re.escape, ',.$:/+@!?()<>[]{}'))))
                                      ^
./src/sentry/management/commands/backfill_eventstream.py:84:23: F821 undefined name 'raw_input'
            proceed = raw_input('Do you want to continue? [y/N] ')
                      ^
./tests/sentry/eventstream/kafka/test_consumer.py:93:18: F821 undefined name 'xrange'
        for i in xrange(10):  # this takes a while
                 ^
./tests/sentry/eventstream/kafka/test_consumer.py:124:18: F821 undefined name 'xrange'
        for i in xrange(5):
                 ^
./tests/sentry/eventstream/kafka/test_consumer.py:191:18: F821 undefined name 'xrange'
        for i in xrange(10):  # this takes a while
                 ^
./tests/sentry/eventstream/kafka/test_consumer.py:236:18: F821 undefined name 'xrange'
        for i in xrange(5):
                 ^
./tests/sentry/eventstream/kafka/test_consumer.py:293:18: F821 undefined name 'xrange'
        for i in xrange(10):  # this takes a while
                 ^
./tests/sentry/eventstream/kafka/test_consumer.py:319:22: F821 undefined name 'xrange'
            for i in xrange(10):  # this takes a while
                     ^
./tests/sentry/eventstream/kafka/test_consumer.py:357:22: F821 undefined name 'xrange'
            for i in xrange(5):
                     ^
./tests/sentry/eventstream/kafka/test_consumer.py:427:18: F821 undefined name 'xrange'
        for i in xrange(10):  # this takes a while
                 ^
./tests/sentry/eventstream/kafka/test_consumer.py:453:22: F821 undefined name 'xrange'
            for i in xrange(10):  # this takes a while
                     ^
./tests/sentry/eventstream/kafka/test_consumer.py:491:22: F821 undefined name 'xrange'
            for i in xrange(5):
                     ^
./tests/sentry/eventstream/kafka/test_consumer.py:510:14: F821 undefined name 'xrange'
    for i in xrange(iterations):
             ^
./tests/sentry/integrations/github/testutils.py:224:0: E999 SyntaxError: bytes can only contain ASCII literal characters.
}"""
^
./tests/sentry/integrations/github_enterprise/testutils.py:213:0: E999 SyntaxError: bytes can only contain ASCII literal characters.
}"""
^
3     E999 SyntaxError: invalid syntax
12    F821 undefined name 'raw_input'
15
```