### PR TITLE
fix(cmd-pal): Trim whitespace from search queries

### DIFF
--- a/src/sentry/static/sentry/app/components/search/index.jsx
+++ b/src/sentry/static/sentry/app/components/search/index.jsx
@@ -161,7 +161,7 @@ class Search extends React.Component {
           highlightedIndex,
           onChange,
         }) => {
-          let searchQuery = inputValue.toLowerCase();
+          let searchQuery = inputValue.toLowerCase().trim();
           let isValidSearch = inputValue.length >= minSearch;
 
           this.saveQueryMetrics(searchQuery);


### PR DESCRIPTION
This fixes searches that have a trailing space, e.g. "DSN "