### PR TITLE
feat(integrations) Implement issue create for jira-server

### DIFF
--- a/src/sentry/integrations/jira/search.py
+++ b/src/sentry/integrations/jira/search.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from six.moves.urllib.parse import parse_qs, unquote_plus, urlencode, urlsplit, urlunsplit
-
 from rest_framework.response import Response
 
 from sentry.api.bases.integration import IntegrationEndpoint
@@ -44,7 +42,6 @@ class JiraSearchEndpoint(IntegrationEndpoint):
             return Response({'detail': 'query is a required parameter'}, status=400)
 
         installation = integration.get_installation(organization.id)
-
         if field == 'externalIssue':
             if not query:
                 return Response([])
@@ -57,84 +54,22 @@ class JiraSearchEndpoint(IntegrationEndpoint):
                 'value': i['key']
             } for i in resp.get('issues', [])])
 
+        # TODO: remove jira_url in follow up deploy.
         jira_url = request.GET.get('jira_url')
-        if jira_url:
-            jira_url = unquote_plus(jira_url)
-            parsed = list(urlsplit(jira_url))
-            jira_query = parse_qs(parsed[3])
-
+        if jira_url or field in ('assignee', 'reporter'):
             jira_client = installation.get_client()
-
-            is_user_api = '/rest/api/latest/user/' in jira_url
-
-            is_user_picker = '/rest/api/1.0/users/picker' in jira_url
-
-            if is_user_api:  # its the JSON version of the autocompleter
-                is_xml = False
-                jira_query['username'] = query.encode('utf8')
-                jira_query.pop(
-                    'issueKey', False
-                )  # some reason Jira complains if this key is in the URL.
-                jira_query['project'] = request.GET.get('project', '').encode('utf8')
-            elif is_user_picker:
-                is_xml = False
-                # for whatever reason, the create meta api returns an
-                # invalid path, so let's just use the correct, documented one here:
-                # https://docs.atlassian.com/jira/REST/cloud/#api/2/user
-                # also, only pass path so saved instance url will be used
-                parsed[0] = ''
-                parsed[1] = ''
-                parsed[2] = '/rest/api/2/user/picker'
-                jira_query['query'] = query.encode('utf8')
-            else:  # its the stupid XML version of the API.
-                is_xml = True
-                jira_query['query'] = query.encode('utf8')
-                if jira_query.get('fieldName'):
-                    # for some reason its a list.
-                    jira_query['fieldName'] = jira_query['fieldName'][0]
-
-            parsed[3] = urlencode(jira_query)
-            final_url = urlunsplit(parsed)
-
-            try:
-                autocomplete_response = jira_client.get_cached(final_url)
-            except (ApiUnauthorized, ApiError):
-                autocomplete_response = None
-
             users = []
+            try:
+                response = jira_client.search_users_for_project(
+                    request.GET.get('project', ''),
+                    query
+                )
+            except (ApiUnauthorized, ApiError):
+                return Response({'detail': 'Unable to fetch users from Jira'}, status=400)
 
-            if autocomplete_response is not None:
-                if is_user_picker:
-                    autocomplete_response = autocomplete_response['users']
-
-                if is_xml:
-                    for userxml in autocomplete_response.xml.findAll("users"):
-                        users.append(
-                            {
-                                'id': userxml.find('name').text,
-                                'text': userxml.find('html').text
-                            }
-                        )
-                else:
-                    for user in autocomplete_response:
-                        if user.get('name'):
-                            users.append(self._get_formatted_user(user))
-
-            # if Jira user doesn't have proper permission for user api,
-            # try the assignee api instead
-            if not users and is_user_api:
-                try:
-                    autocomplete_response = jira_client.search_users_for_project(
-                        request.GET.get('project', ''),
-                        jira_query.get('username'),
-                    )
-                except (ApiUnauthorized, ApiError):
-                    return Response({'detail': 'Unable to fetch users from Jira'}, status=400)
-
-                for user in autocomplete_response:
-                    if user.get('name'):
-                        users.append(self._get_formatted_user(user))
-
+            for user in response:
+                if user.get('name'):
+                    users.append(self._get_formatted_user(user))
             return Response(users)
 
         # TODO(jess): handle other autocomplete urls

--- a/src/sentry/integrations/jira/webhooks.py
+++ b/src/sentry/integrations/jira/webhooks.py
@@ -11,6 +11,70 @@ from sentry.models import sync_group_assignee_inbound
 logger = logging.getLogger('sentry.integrations.jira.webhooks')
 
 
+def handle_assignee_change(integration, data):
+    assignee_changed = any(
+        item for item in data['changelog']['items'] if item['field'] == 'assignee'
+    )
+    if not assignee_changed:
+        return
+
+    fields = data['issue']['fields']
+
+    # if no assignee, assume it was unassigned
+    assignee = fields.get('assignee')
+    issue_key = data['issue']['key']
+
+    if assignee is None:
+        sync_group_assignee_inbound(
+            integration, None, issue_key, assign=False,
+        )
+        return
+
+    if not assignee.get('emailAddress'):
+        logger.info(
+            'missing-assignee-email', extra={
+                'issue_key': issue_key,
+                'integration_id': integration.id,
+            }
+        )
+        return
+
+    sync_group_assignee_inbound(
+        integration, assignee['emailAddress'], issue_key, assign=True
+    )
+
+
+def handle_status_change(integration, data):
+    status_changed = any(
+        item for item in data['changelog']['items'] if item['field'] == 'status'
+    )
+    if not status_changed:
+        return
+
+    issue_key = data['issue']['key']
+
+    try:
+        changelog = next(
+            item for item in data['changelog']['items'] if item['field'] == 'status'
+        )
+    except StopIteration:
+        logger.info(
+            'missing-changelog-status', extra={
+                'issue_key': issue_key,
+                'integration_id': integration.id,
+            }
+        )
+        return
+
+    for org_id in integration.organizations.values_list('id', flat=True):
+        installation = integration.get_installation(org_id)
+
+        installation.sync_status_inbound(issue_key, {
+            'changelog': changelog,
+            'issue': data['issue'],
+        })
+
+
 class JiraIssueUpdatedWebhook(Endpoint):
     authentication_classes = ()
     permission_classes = ()
@@ -18,54 +82,6 @@ class JiraIssueUpdatedWebhook(Endpoint):
     @csrf_exempt
     def dispatch(self, request, *args, **kwargs):
         return super(JiraIssueUpdatedWebhook, self).dispatch(request, *args, **kwargs)
-
-    def handle_assignee_change(self, integration, data):
-        fields = data['issue']['fields']
-        # if no assignee, assume it was unassigned
-        assignee = fields.get('assignee')
-        issue_key = data['issue']['key']
-
-        if assignee is None:
-            sync_group_assignee_inbound(
-                integration, None, issue_key, assign=False,
-            )
-        else:
-            if not assignee.get('emailAddress'):
-                logger.info(
-                    'missing-assignee-email', extra={
-                        'issue_key': issue_key,
-                        'integration_id': integration.id,
-                    }
-                )
-                return
-
-            sync_group_assignee_inbound(
-                integration, assignee['emailAddress'], issue_key, assign=True,
-            )
-
-    def handle_status_change(self, integration, data):
-        issue_key = data['issue']['key']
-
-        try:
-            changelog = next(
-                item for item in data['changelog']['items'] if item['field'] == 'status'
-            )
-        except StopIteration:
-            logger.info(
-                'missing-changelog-status', extra={
-                    'issue_key': issue_key,
-                    'integration_id': integration.id,
-                }
-            )
-            return
-
-        for org_id in integration.organizations.values_list('id', flat=True):
-            installation = integration.get_installation(org_id)
-
-            installation.sync_status_inbound(issue_key, {
-                'changelog': changelog,
-                'issue': data['issue'],
-            })
 
     def post(self, request, *args, **kwargs):
         try:
@@ -91,19 +107,7 @@ class JiraIssueUpdatedWebhook(Endpoint):
             )
             return self.respond()
 
-        assignee_changed = any(
-            item for item in data['changelog']['items'] if item['field'] == 'assignee'
-        )
-
-        status_changed = any(
-            item for item in data['changelog']['items'] if item['field'] == 'status'
-        )
-
-        if assignee_changed or status_changed:
-            if assignee_changed:
-                self.handle_assignee_change(integration, data)
-
-            if status_changed:
-                self.handle_status_change(integration, data)
+        handle_assignee_change(integration, data)
+        handle_status_change(integration, data)
 
         return self.respond()

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -14,6 +14,8 @@ from sentry.utils.http import absolute_uri
 class JiraServerSetupClient(ApiClient):
     """
     Client for making requests to JiraServer to follow OAuth1 flow.
+
+    Jira OAuth1 docs: https://developer.atlassian.com/server/jira/platform/oauth/
     """
     request_token_url = u'{}/plugins/servlet/oauth/request-token'
     access_token_url = u'{}/plugins/servlet/oauth/access-token'
@@ -99,6 +101,10 @@ class JiraServer(object):
     """
     Contains the jira-server specifics that a JiraClient needs
     in order to communicate with jira
+
+    You can find JIRA REST API docs here:
+
+    https://developer.atlassian.com/server/jira/platform/rest-apis/
     """
 
     def __init__(self, credentials):

--- a/src/sentry/integrations/jira_server/webhooks.py
+++ b/src/sentry/integrations/jira_server/webhooks.py
@@ -1,8 +1,48 @@
 from __future__ import absolute_import
 
+import jwt
+import logging
+import six
 from django.views.decorators.csrf import csrf_exempt
 
 from sentry.api.base import Endpoint
+from sentry.integrations.jira.webhooks import (
+    handle_assignee_change,
+    handle_status_change
+)
+from sentry.models import Integration
+
+
+logger = logging.getLogger('sentry.integrations.jiraserver.webhooks')
+
+
+def get_integration_from_token(token):
+    """
+    When we create a jira server integration we create a webhook that contains
+    a JWT in the URL. We use that JWT to locate the matching sentry integration later
+    as Jira doesn't have any additional fields we can embed information in.
+    """
+    if not token:
+        raise ValueError('Token was empty')
+
+    try:
+        unvalidated = jwt.decode(token, verify=False)
+    except jwt.DecodeError:
+        raise ValueError('Could not decode JWT token')
+    if 'id' not in unvalidated:
+        raise ValueError('Token did not contain `id`')
+    try:
+        integration = Integration.objects.get(
+            provider='jira_server',
+            external_id=unvalidated['id'])
+    except Integration.DoesNotExist:
+        raise ValueError('Could not find integration for token')
+    try:
+        jwt.decode(token, integration.metadata['webhook_secret'])
+    except Exception as err:
+        raise ValueError('Could not validate JWT. Got %s' % err)
+
+    return integration
 
 
 class JiraIssueUpdatedWebhook(Endpoint):
@@ -13,6 +53,28 @@ class JiraIssueUpdatedWebhook(Endpoint):
     def dispatch(self, request, *args, **kwargs):
         return super(JiraIssueUpdatedWebhook, self).dispatch(request, *args, **kwargs)
 
-    def post(self, request, *args, **kwargs):
-        # TODO implement.
-        pass
+    def post(self, request, token, *args, **kwargs):
+        try:
+            integration = get_integration_from_token(token)
+        except ValueError as err:
+            logger.info('token-validation-error', extra={
+                'token': token,
+                'error': six.text_type(err)
+            })
+            return self.respond(status=400)
+
+        data = request.DATA
+
+        if not data.get('changelog'):
+            logger.info(
+                'missing-changelog', extra={
+                    'integration_id': integration.id,
+                    'data': data,
+                }
+            )
+            return self.respond()
+
+        handle_assignee_change(integration, data)
+        handle_status_change(integration, data)
+
+        return self.respond()

--- a/tests/sentry/integrations/jira/test_search_endpoint.py
+++ b/tests/sentry/integrations/jira/test_search_endpoint.py
@@ -1,13 +1,12 @@
 from __future__ import absolute_import
 
-import json
+import responses
 
-from mock import patch
+from exam import fixture
+from six.moves.urllib.parse import urlparse, parse_qs
 
 from django.core.urlresolvers import reverse
 
-from sentry.integrations.exceptions import IntegrationError
-from sentry.integrations.jira import JiraIntegration
 from sentry.models import Integration
 from sentry.testutils import APITestCase
 
@@ -35,44 +34,144 @@ SAMPLE_SEARCH_RESPONSE = """
 }
 """
 
+SAMPLE_USER_SEARCH_RESPONSE = """
+[
+    {"name": "bob", "displayName": "Bobby", "emailAddress": "bob@example.org"}
+]
+"""
+
 
 class JiraSearchEndpointTest(APITestCase):
-    @patch.object(JiraIntegration, 'search_issues',
-                  return_value=json.loads(SAMPLE_SEARCH_RESPONSE.strip()))
-    def test_simple(self, mock_search_issues):
+    @fixture
+    def integration(self):
+        integration = Integration.objects.create(
+            provider='jira',
+            name='Jira Cloud',
+            metadata={
+                'oauth_client_id': 'oauth-client-id',
+                'shared_secret': 'a-super-secret-key-from-atlassian',
+                'base_url': 'https://example.atlassian.net',
+                'domain_name': 'example.atlassian.net',
+            }
+        )
+        integration.add_organization(
+            self.organization,
+            self.user)
+        return integration
+
+    @responses.activate
+    def test_issue_search_text(self):
+        responses.add(
+            responses.GET,
+            'https://example.atlassian.net/rest/api/2/search/',
+            body=SAMPLE_SEARCH_RESPONSE,
+            content_type='json',
+            match_querystring=False
+        )
         org = self.organization
         self.login_as(self.user)
 
-        integration = Integration.objects.create(
-            provider='jira',
-            name='Example Jira',
-        )
-        integration.add_organization(org, self.user)
-
-        path = reverse('sentry-extensions-jira-search', args=[org.slug, integration.id])
+        path = reverse('sentry-extensions-jira-search', args=[org.slug, self.integration.id])
 
         resp = self.client.get('%s?field=externalIssue&query=test' % (path,))
         assert resp.status_code == 200
         assert resp.data == [
             {'label': '(HSP-1) this is a test issue summary', 'value': 'HSP-1'}
         ]
-        mock_search_issues.assert_called_with('test')
 
-    @patch.object(JiraIntegration, 'search_issues',
-                  side_effect=IntegrationError('Oh no, something went wrong'))
-    def test_error(self, mock_search_issues):
+    @responses.activate
+    def test_issue_search_id(self):
+        def responder(request):
+            query = parse_qs(urlparse(request.url).query)
+            assert 'id="HSP-1"' == query['jql'][0]
+            return (200, {}, SAMPLE_SEARCH_RESPONSE)
+
+        responses.add_callback(
+            responses.GET,
+            'https://example.atlassian.net/rest/api/2/search/',
+            callback=responder,
+            match_querystring=False
+        )
         org = self.organization
         self.login_as(self.user)
 
-        integration = Integration.objects.create(
-            provider='jira',
-            name='Example Jira',
-        )
-        integration.add_organization(org, self.user)
+        path = reverse('sentry-extensions-jira-search', args=[org.slug, self.integration.id])
 
-        path = reverse('sentry-extensions-jira-search', args=[org.slug, integration.id])
+        resp = self.client.get('%s?field=externalIssue&query=HSP-1' % (path,))
+        assert resp.status_code == 200
+        assert resp.data == [
+            {'label': '(HSP-1) this is a test issue summary', 'value': 'HSP-1'}
+        ]
+
+    @responses.activate
+    def test_issue_search_error(self):
+        responses.add(
+            responses.GET,
+            'https://example.atlassian.net/rest/api/2/search/',
+            status=500,
+            body='Totally broken',
+            match_querystring=False
+        )
+        org = self.organization
+        self.login_as(self.user)
+
+        path = reverse('sentry-extensions-jira-search', args=[org.slug, self.integration.id])
 
         resp = self.client.get('%s?field=externalIssue&query=test' % (path,))
         assert resp.status_code == 400
-        assert resp.data == {'detail': 'Oh no, something went wrong'}
-        mock_search_issues.assert_called_with('test')
+        assert resp.data == {'detail': 'Error Communicating with Jira (HTTP 500): unknown error'}
+
+    @responses.activate
+    def test_assignee_search(self):
+        responses.add(
+            responses.GET,
+            'https://example.atlassian.net/rest/api/2/project',
+            json=[{'key': 'HSP', 'id': '10000'}],
+            match_querystring=False
+        )
+
+        def responder(request):
+            query = parse_qs(urlparse(request.url).query)
+            assert 'HSP' == query['project'][0]
+            return (200, {}, SAMPLE_USER_SEARCH_RESPONSE)
+
+        responses.add_callback(
+            responses.GET,
+            'https://example.atlassian.net/rest/api/2/user/assignable/search',
+            callback=responder,
+            content_type='json',
+            match_querystring=False
+        )
+        org = self.organization
+        self.login_as(self.user)
+
+        path = reverse('sentry-extensions-jira-search', args=[org.slug, self.integration.id])
+
+        resp = self.client.get('%s?project=10000&field=assignee&query=bob' % (path,))
+        assert resp.status_code == 200
+        assert resp.data == [
+            {'value': 'bob', 'label': 'Bobby - bob@example.org (bob)'}
+        ]
+
+    @responses.activate
+    def test_assignee_search_error(self):
+        responses.add(
+            responses.GET,
+            'https://example.atlassian.net/rest/api/2/project',
+            json=[{'key': 'HSP', 'id': '10000'}],
+            match_querystring=False
+        )
+        responses.add(
+            responses.GET,
+            'https://example.atlassian.net/rest/api/2/user/assignable/search',
+            status=500,
+            body='Bad things',
+            match_querystring=False
+        )
+        org = self.organization
+        self.login_as(self.user)
+
+        path = reverse('sentry-extensions-jira-search', args=[org.slug, self.integration.id])
+
+        resp = self.client.get('%s?project=10000&field=assignee&query=bob' % (path,))
+        assert resp.status_code == 400

--- a/tests/sentry/integrations/jira_server/test_webhooks.py
+++ b/tests/sentry/integrations/jira_server/test_webhooks.py
@@ -1,0 +1,174 @@
+from __future__ import absolute_import
+
+import jwt
+
+from django.core.urlresolvers import reverse
+from exam import fixture
+from mock import patch
+
+from sentry.integrations.jira_server.integration import JiraServerIntegration
+from sentry.models import (
+    Integration,
+    IdentityProvider,
+    Identity,
+    IdentityStatus
+)
+from sentry.testutils import APITestCase
+from .testutils import EXAMPLE_PRIVATE_KEY
+
+
+class JiraWebhookEndpointTest(APITestCase):
+
+    @fixture
+    def integration(self):
+        integration = Integration.objects.create(
+            provider='jira_server',
+            name='Example Jira',
+            metadata={
+                'verify_ssl': False,
+                'webhook_secret': 'a long secret value',
+                'base_url': 'https://jira.example.org',
+            }
+        )
+        identity_provider = IdentityProvider.objects.create(
+            external_id='jira.example.org:sentry-test',
+            type='jira_server',
+        )
+        identity = Identity.objects.create(
+            idp=identity_provider,
+            user=self.user,
+            scopes=(),
+            status=IdentityStatus.VALID,
+            data={
+                'consumer_key': 'sentry-test',
+                'private_key': EXAMPLE_PRIVATE_KEY,
+                'access_token': 'access-token',
+                'access_token_secret': 'access-token-secret',
+            }
+        )
+        integration.add_organization(
+            self.organization,
+            self.user,
+            default_auth_id=identity.id)
+        return integration
+
+    @property
+    def jwt_token(self):
+        integration = self.integration
+        return jwt.encode(
+            {'id': integration.external_id},
+            integration.metadata['webhook_secret'])
+
+    def test_post_empty_token(self):
+        # Read the property to get side-effects in the database.
+        token = self.jwt_token
+        token = ' '
+        path = reverse('sentry-extensions-jiraserver-issue-updated', args=[token])
+        resp = self.client.post(path)
+
+        assert resp.status_code == 400
+
+    def test_post_token_missing_id(self):
+        integration = self.integration
+        # No id key in the token
+        token = jwt.encode(
+            {'no': integration.id},
+            integration.metadata['webhook_secret'])
+        path = reverse('sentry-extensions-jiraserver-issue-updated', args=[token])
+        resp = self.client.post(path)
+
+        assert resp.status_code == 400
+
+    def test_post_token_missing_integration(self):
+        integration = self.integration
+        # Use the wrong id in the token.
+        token = jwt.encode(
+            {'no': integration.id},
+            integration.metadata['webhook_secret'])
+        path = reverse('sentry-extensions-jiraserver-issue-updated', args=[token])
+        resp = self.client.post(path)
+
+        assert resp.status_code == 400
+
+    def test_post_token_invalid_signature(self):
+        integration = self.integration
+        # Use the wrong id in the token.
+        token = jwt.encode(
+            {'id': integration.external_id},
+            'bad-secret')
+        path = reverse('sentry-extensions-jiraserver-issue-updated', args=[token])
+        resp = self.client.post(path)
+
+        assert resp.status_code == 400
+
+    @patch('sentry.integrations.jira.webhooks.sync_group_assignee_inbound')
+    def test_post_update_assignee(self, mock_sync):
+        project = self.create_project()
+        self.create_group(project=project)
+
+        payload = {
+            'changelog': {
+                'items': [
+                    {'field': 'assignee'}
+                ],
+                'id': 12345
+            },
+            'issue': {
+                'fields': {
+                    'assignee': {'emailAddress': 'bob@example.org'}
+                },
+                'key': 'APP-1'
+            }
+        }
+        token = self.jwt_token
+        path = reverse('sentry-extensions-jiraserver-issue-updated', args=[token])
+        resp = self.client.post(path, data=payload)
+        assert resp.status_code == 200
+
+        mock_sync.assert_called_with(
+            self.integration,
+            'bob@example.org',
+            'APP-1',
+            assign=True
+        )
+
+    @patch.object(JiraServerIntegration, 'sync_status_inbound')
+    def test_post_update_status(self, mock_sync):
+        project = self.create_project()
+        self.create_group(project=project)
+
+        payload = {
+            'changelog': {
+                'items': [
+                    {
+                        'from': '10101',
+                        'field': 'status',
+                        'fromString': 'In Progress',
+                        'to': '10102',
+                        'toString': 'Done',
+                        'fieldtype': 'jira',
+                        'fieldId': 'status'
+                    }
+                ],
+                'id': 12345
+            },
+            'issue': {
+                'project': {
+                    'key': 'APP',
+                    'id': '10000',
+                },
+                'key': 'APP-1'
+            }
+        }
+        token = self.jwt_token
+        path = reverse('sentry-extensions-jiraserver-issue-updated', args=[token])
+        resp = self.client.post(path, data=payload)
+        assert resp.status_code == 200
+
+        mock_sync.assert_called_with(
+            'APP-1',
+            {
+                'changelog': payload['changelog']['items'][0],
+                'issue': payload['issue'],
+            }
+        )

--- a/tests/sentry/integrations/jira_server/testutils.py
+++ b/tests/sentry/integrations/jira_server/testutils.py
@@ -40,3 +40,9 @@ EXAMPLE_ISSUE_SEARCH = '''
   ]
 }
 '''
+
+EXAMPLE_USER_SEARCH_RESPONSE = """
+[
+    {"name": "bob", "displayName": "Bobby", "emailAddress": "bob@example.org"}
+]
+"""


### PR DESCRIPTION
The version of Jira server we're targeting >6.0 supports the same APIs as cloud does around issue creation. This means that we can re-use the same code. Because we're only supporting Jira versions that have JSON APIs I've remove all the XML API support and the older 'user picker' API which I cannot find documentation on.

Currently user search response caching is not functioning, but this was true before as well. Given that assignee/reporter map to typeahead search inputs in our UI I'm not sure caching is even worth the overhead.

Refs APP-574