### PR TITLE
feat(integration) Implement webhooks for jira-server

### DIFF
--- a/src/sentry/integrations/jira/webhooks.py
+++ b/src/sentry/integrations/jira/webhooks.py
@@ -11,6 +11,70 @@ from sentry.models import sync_group_assignee_inbound
 logger = logging.getLogger('sentry.integrations.jira.webhooks')
 
 
+def handle_assignee_change(integration, data):
+    assignee_changed = any(
+        item for item in data['changelog']['items'] if item['field'] == 'assignee'
+    )
+    if not assignee_changed:
+        return
+
+    fields = data['issue']['fields']
+
+    # if no assignee, assume it was unassigned
+    assignee = fields.get('assignee')
+    issue_key = data['issue']['key']
+
+    if assignee is None:
+        sync_group_assignee_inbound(
+            integration, None, issue_key, assign=False,
+        )
+        return
+
+    if not assignee.get('emailAddress'):
+        logger.info(
+            'missing-assignee-email', extra={
+                'issue_key': issue_key,
+                'integration_id': integration.id,
+            }
+        )
+        return
+
+    sync_group_assignee_inbound(
+        integration, assignee['emailAddress'], issue_key, assign=True
+    )
+
+
+def handle_status_change(integration, data):
+    status_changed = any(
+        item for item in data['changelog']['items'] if item['field'] == 'status'
+    )
+    if not status_changed:
+        return
+
+    issue_key = data['issue']['key']
+
+    try:
+        changelog = next(
+            item for item in data['changelog']['items'] if item['field'] == 'status'
+        )
+    except StopIteration:
+        logger.info(
+            'missing-changelog-status', extra={
+                'issue_key': issue_key,
+                'integration_id': integration.id,
+            }
+        )
+        return
+
+    for org_id in integration.organizations.values_list('id', flat=True):
+        installation = integration.get_installation(org_id)
+
+        installation.sync_status_inbound(issue_key, {
+            'changelog': changelog,
+            'issue': data['issue'],
+        })
+
+
 class JiraIssueUpdatedWebhook(Endpoint):
     authentication_classes = ()
     permission_classes = ()
@@ -18,54 +82,6 @@ class JiraIssueUpdatedWebhook(Endpoint):
     @csrf_exempt
     def dispatch(self, request, *args, **kwargs):
         return super(JiraIssueUpdatedWebhook, self).dispatch(request, *args, **kwargs)
-
-    def handle_assignee_change(self, integration, data):
-        fields = data['issue']['fields']
-        # if no assignee, assume it was unassigned
-        assignee = fields.get('assignee')
-        issue_key = data['issue']['key']
-
-        if assignee is None:
-            sync_group_assignee_inbound(
-                integration, None, issue_key, assign=False,
-            )
-        else:
-            if not assignee.get('emailAddress'):
-                logger.info(
-                    'missing-assignee-email', extra={
-                        'issue_key': issue_key,
-                        'integration_id': integration.id,
-                    }
-                )
-                return
-
-            sync_group_assignee_inbound(
-                integration, assignee['emailAddress'], issue_key, assign=True,
-            )
-
-    def handle_status_change(self, integration, data):
-        issue_key = data['issue']['key']
-
-        try:
-            changelog = next(
-                item for item in data['changelog']['items'] if item['field'] == 'status'
-            )
-        except StopIteration:
-            logger.info(
-                'missing-changelog-status', extra={
-                    'issue_key': issue_key,
-                    'integration_id': integration.id,
-                }
-            )
-            return
-
-        for org_id in integration.organizations.values_list('id', flat=True):
-            installation = integration.get_installation(org_id)
-
-            installation.sync_status_inbound(issue_key, {
-                'changelog': changelog,
-                'issue': data['issue'],
-            })
 
     def post(self, request, *args, **kwargs):
         try:
@@ -91,19 +107,7 @@ class JiraIssueUpdatedWebhook(Endpoint):
             )
             return self.respond()
 
-        assignee_changed = any(
-            item for item in data['changelog']['items'] if item['field'] == 'assignee'
-        )
-
-        status_changed = any(
-            item for item in data['changelog']['items'] if item['field'] == 'status'
-        )
-
-        if assignee_changed or status_changed:
-            if assignee_changed:
-                self.handle_assignee_change(integration, data)
-
-            if status_changed:
-                self.handle_status_change(integration, data)
+        handle_assignee_change(integration, data)
+        handle_status_change(integration, data)
 
         return self.respond()

--- a/src/sentry/integrations/jira_server/webhooks.py
+++ b/src/sentry/integrations/jira_server/webhooks.py
@@ -1,8 +1,48 @@
 from __future__ import absolute_import
 
+import jwt
+import logging
+import six
 from django.views.decorators.csrf import csrf_exempt
 
 from sentry.api.base import Endpoint
+from sentry.integrations.jira.webhooks import (
+    handle_assignee_change,
+    handle_status_change
+)
+from sentry.models import Integration
+
+
+logger = logging.getLogger('sentry.integrations.jiraserver.webhooks')
+
+
+def get_integration_from_token(token):
+    """
+    When we create a jira server integration we create a webhook that contains
+    a JWT in the URL. We use that JWT to locate the matching sentry integration later
+    as Jira doesn't have any additional fields we can embed information in.
+    """
+    if not token:
+        raise ValueError('Token was empty')
+
+    try:
+        unvalidated = jwt.decode(token, verify=False)
+    except jwt.DecodeError:
+        raise ValueError('Could not decode JWT token')
+    if 'id' not in unvalidated:
+        raise ValueError('Token did not contain `id`')
+    try:
+        integration = Integration.objects.get(
+            provider='jira_server',
+            external_id=unvalidated['id'])
+    except Integration.DoesNotExist:
+        raise ValueError('Could not find integration for token')
+    try:
+        jwt.decode(token, integration.metadata['webhook_secret'])
+    except Exception as err:
+        raise ValueError('Could not validate JWT. Got %s' % err)
+
+    return integration
 
 
 class JiraIssueUpdatedWebhook(Endpoint):
@@ -13,6 +53,28 @@ class JiraIssueUpdatedWebhook(Endpoint):
     def dispatch(self, request, *args, **kwargs):
         return super(JiraIssueUpdatedWebhook, self).dispatch(request, *args, **kwargs)
 
-    def post(self, request, *args, **kwargs):
-        # TODO implement.
-        pass
+    def post(self, request, token, *args, **kwargs):
+        try:
+            integration = get_integration_from_token(token)
+        except ValueError as err:
+            logger.info('token-validation-error', extra={
+                'token': token,
+                'error': six.text_type(err)
+            })
+            return self.respond(status=400)
+
+        data = request.DATA
+
+        if not data.get('changelog'):
+            logger.info(
+                'missing-changelog', extra={
+                    'integration_id': integration.id,
+                    'data': data,
+                }
+            )
+            return self.respond()
+
+        handle_assignee_change(integration, data)
+        handle_status_change(integration, data)
+
+        return self.respond()

--- a/tests/sentry/integrations/jira_server/test_webhooks.py
+++ b/tests/sentry/integrations/jira_server/test_webhooks.py
@@ -1,0 +1,174 @@
+from __future__ import absolute_import
+
+import jwt
+
+from django.core.urlresolvers import reverse
+from exam import fixture
+from mock import patch
+
+from sentry.integrations.jira_server.integration import JiraServerIntegration
+from sentry.models import (
+    Integration,
+    IdentityProvider,
+    Identity,
+    IdentityStatus
+)
+from sentry.testutils import APITestCase
+from .testutils import EXAMPLE_PRIVATE_KEY
+
+
+class JiraWebhookEndpointTest(APITestCase):
+
+    @fixture
+    def integration(self):
+        integration = Integration.objects.create(
+            provider='jira_server',
+            name='Example Jira',
+            metadata={
+                'verify_ssl': False,
+                'webhook_secret': 'a long secret value',
+                'base_url': 'https://jira.example.org',
+            }
+        )
+        identity_provider = IdentityProvider.objects.create(
+            external_id='jira.example.org:sentry-test',
+            type='jira_server',
+        )
+        identity = Identity.objects.create(
+            idp=identity_provider,
+            user=self.user,
+            scopes=(),
+            status=IdentityStatus.VALID,
+            data={
+                'consumer_key': 'sentry-test',
+                'private_key': EXAMPLE_PRIVATE_KEY,
+                'access_token': 'access-token',
+                'access_token_secret': 'access-token-secret',
+            }
+        )
+        integration.add_organization(
+            self.organization,
+            self.user,
+            default_auth_id=identity.id)
+        return integration
+
+    @property
+    def jwt_token(self):
+        integration = self.integration
+        return jwt.encode(
+            {'id': integration.external_id},
+            integration.metadata['webhook_secret'])
+
+    def test_post_empty_token(self):
+        # Read the property to get side-effects in the database.
+        token = self.jwt_token
+        token = ' '
+        path = reverse('sentry-extensions-jiraserver-issue-updated', args=[token])
+        resp = self.client.post(path)
+
+        assert resp.status_code == 400
+
+    def test_post_token_missing_id(self):
+        integration = self.integration
+        # No id key in the token
+        token = jwt.encode(
+            {'no': integration.id},
+            integration.metadata['webhook_secret'])
+        path = reverse('sentry-extensions-jiraserver-issue-updated', args=[token])
+        resp = self.client.post(path)
+
+        assert resp.status_code == 400
+
+    def test_post_token_missing_integration(self):
+        integration = self.integration
+        # Use the wrong id in the token.
+        token = jwt.encode(
+            {'no': integration.id},
+            integration.metadata['webhook_secret'])
+        path = reverse('sentry-extensions-jiraserver-issue-updated', args=[token])
+        resp = self.client.post(path)
+
+        assert resp.status_code == 400
+
+    def test_post_token_invalid_signature(self):
+        integration = self.integration
+        # Use the wrong id in the token.
+        token = jwt.encode(
+            {'id': integration.external_id},
+            'bad-secret')
+        path = reverse('sentry-extensions-jiraserver-issue-updated', args=[token])
+        resp = self.client.post(path)
+
+        assert resp.status_code == 400
+
+    @patch('sentry.integrations.jira.webhooks.sync_group_assignee_inbound')
+    def test_post_update_assignee(self, mock_sync):
+        project = self.create_project()
+        self.create_group(project=project)
+
+        payload = {
+            'changelog': {
+                'items': [
+                    {'field': 'assignee'}
+                ],
+                'id': 12345
+            },
+            'issue': {
+                'fields': {
+                    'assignee': {'emailAddress': 'bob@example.org'}
+                },
+                'key': 'APP-1'
+            }
+        }
+        token = self.jwt_token
+        path = reverse('sentry-extensions-jiraserver-issue-updated', args=[token])
+        resp = self.client.post(path, data=payload)
+        assert resp.status_code == 200
+
+        mock_sync.assert_called_with(
+            self.integration,
+            'bob@example.org',
+            'APP-1',
+            assign=True
+        )
+
+    @patch.object(JiraServerIntegration, 'sync_status_inbound')
+    def test_post_update_status(self, mock_sync):
+        project = self.create_project()
+        self.create_group(project=project)
+
+        payload = {
+            'changelog': {
+                'items': [
+                    {
+                        'from': '10101',
+                        'field': 'status',
+                        'fromString': 'In Progress',
+                        'to': '10102',
+                        'toString': 'Done',
+                        'fieldtype': 'jira',
+                        'fieldId': 'status'
+                    }
+                ],
+                'id': 12345
+            },
+            'issue': {
+                'project': {
+                    'key': 'APP',
+                    'id': '10000',
+                },
+                'key': 'APP-1'
+            }
+        }
+        token = self.jwt_token
+        path = reverse('sentry-extensions-jiraserver-issue-updated', args=[token])
+        resp = self.client.post(path, data=payload)
+        assert resp.status_code == 200
+
+        mock_sync.assert_called_with(
+            'APP-1',
+            {
+                'changelog': payload['changelog']['items'][0],
+                'issue': payload['issue'],
+            }
+        )


### PR DESCRIPTION
Implement the webhooks required to do inbound sync with Jira-Server issues. I've refactored how hook handling works for jira-cloud so that I could re-use the existing code without resorting to inheritance.

Refs APP-576