### PR TITLE
feat(settings): Add project platform to settings (FEEDBACK-144)

### DIFF
--- a/src/sentry/static/sentry/app/components/avatar/projectAvatar.jsx
+++ b/src/sentry/static/sentry/app/components/avatar/projectAvatar.jsx
@@ -11,12 +11,6 @@ class ProjectAvatar extends React.Component {
   };
 
   getPlatforms = project => {
-    // `platforms` is a list of platforms that come from events received in the project (in a certain timeframe)
-    // i.e. if you haven't received recent events with a platform, it could be an empty array.
-    if (project && project.platforms && project.platforms.length > 0) {
-      return project.platforms;
-    }
-
     // `platform` is a user selectable option that is performed during the onboarding process. The reason why this
     // is not the default is because there currently is no way to update it. Fallback to this if project does not
     // have recent events with a platform.
@@ -30,7 +24,7 @@ class ProjectAvatar extends React.Component {
   render() {
     let {project, ...props} = this.props;
 
-    return <PlatformList platforms={this.getPlatforms(project)} {...props} />;
+    return <PlatformList platforms={this.getPlatforms(project)} {...props} max={1} />;
   }
 }
 export default ProjectAvatar;

--- a/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectHeader/projectSelector.jsx
@@ -52,12 +52,6 @@ const ProjectHeaderProjectSelector = withRouter(
     };
 
     render() {
-      let {organization: org} = this.props;
-
-      // TODO(billy): Only show platform icons for internal users
-      const internalOnly =
-        org && org.features && org.features.includes('internal-catchall');
-
       return (
         <ProjectSelector {...this.props} onSelect={this.handleSelect}>
           {({getActorProps, selectedItem, activeProject}) => (
@@ -65,8 +59,7 @@ const ProjectHeaderProjectSelector = withRouter(
               {activeProject ? (
                 <IdBadge
                   project={activeProject}
-                  avatarSize={16}
-                  hideAvatar={!internalOnly}
+                  avatarSize={20}
                   displayName={
                     <ProjectNameLink {...this.getProjectUrlProps(activeProject)}>
                       {this.getProjectLabel(activeProject)}
@@ -121,4 +114,5 @@ const ProjectNameLink = styled(Link)`
   font-size: 20px;
   line-height: 1.2;
   font-weight: 600;
+  margin-left: ${space(0.25)};
 `;

--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
@@ -84,7 +84,7 @@ export const fields = {
           {name}
         </PlatformWrapper>,
       ]),
-    help: t('The primary platform for this project'),
+    help: t('The primary platform for this project, used purely for aesthetics'),
   },
 
   subjectPrefix: {

--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
@@ -1,9 +1,14 @@
+import {Flex} from 'grid-emotion';
 import React from 'react';
+import styled from 'react-emotion';
 
 import {extractMultilineFields} from 'app/utils';
+import {flattenedPlatforms} from 'app/views/onboarding/utils';
 import {t, tct, tn} from 'app/locale';
+import Platformicon from 'app/components/platformicon';
 import getDynamicText from 'app/utils/getDynamicText';
 import slugify from 'app/utils/slugify';
+import space from 'app/styles/space';
 
 // Export route to make these forms searchable by label/help
 export const route = '/settings/:orgId/:projectId/';
@@ -65,6 +70,21 @@ export const fields = {
     saveOnBlur: false,
     saveMessageAlertType: 'info',
     saveMessage: t('You will be redirected to the new project slug after saving'),
+  },
+
+  platform: {
+    name: 'platform',
+    type: 'array',
+    label: t('Platform'),
+    choices: () =>
+      flattenedPlatforms.map(({id, name}) => [
+        id,
+        <PlatformWrapper key={id}>
+          <StyledPlatformicon platform={id} size="20" />
+          {name}
+        </PlatformWrapper>,
+      ]),
+    help: t('The primary platform for this project'),
   },
 
   subjectPrefix: {
@@ -261,3 +281,11 @@ export const fields = {
     help: t('Outbound requests will verify TLS (sometimes known as SSL) connections'),
   },
 };
+
+const PlatformWrapper = styled(Flex)`
+  align-items: center;
+`;
+const StyledPlatformicon = styled(Platformicon)`
+  border-radius: 3px;
+  margin-right: ${space(1)};
+`;

--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
@@ -84,7 +84,7 @@ export const fields = {
           {name}
         </PlatformWrapper>,
       ]),
-    help: t('The primary platform for this project, used purely for aesthetics'),
+    help: t('The primary platform for this project, used only for aesthetics'),
   },
 
   subjectPrefix: {

--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
@@ -20,6 +20,7 @@ import Field from 'app/views/settings/components/forms/field';
 import Form from 'app/views/settings/components/forms/form';
 import JsonForm from 'app/views/settings/components/forms/jsonForm';
 import PermissionAlert from 'app/views/settings/project/permissionAlert';
+import ProjectActions from 'app/actions/projectActions';
 import ProjectsStore from 'app/stores/projectsStore';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
@@ -250,12 +251,14 @@ class ProjectGeneralSettings extends AsyncView {
               // Container will redirect after stores get updated with new slug
               this.props.onChangeSlug(resp.slug);
             }
+            // This will update our project context
+            ProjectActions.updateSuccess(resp);
           }}
         >
           <JsonForm
             {...jsonFormProps}
             title={t('Project Details')}
-            fields={[fields.slug, fields.name]}
+            fields={[fields.slug, fields.name, fields.platform]}
           />
 
           <JsonForm

--- a/tests/js/spec/components/avatar.spec.jsx
+++ b/tests/js/spec/components/avatar.spec.jsx
@@ -143,10 +143,7 @@ describe('Avatar', function() {
         platform: 'java',
       });
       let avatar = mount(<Avatar project={project} />);
-      expect(avatar.find('PlatformList').prop('platforms')).toEqual([
-        'python',
-        'javascript',
-      ]);
+      expect(avatar.find('PlatformList').prop('platforms')).toEqual(['java']);
     });
 
     it('displays a fallback platform list for project Avatar using the `platform` specified during onboarding', function() {

--- a/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -14,9 +14,7 @@ exports[`ProjectCard renders 1`] = `
       "isBookmarked": false,
       "isMember": true,
       "name": "Project Name",
-      "platforms": Array [
-        "javascript",
-      ],
+      "platform": "javascript",
       "slug": "project-slug",
       "stats": Array [
         Array [
@@ -82,9 +80,7 @@ exports[`ProjectCard renders 1`] = `
                       "isBookmarked": false,
                       "isMember": true,
                       "name": "Project Name",
-                      "platforms": Array [
-                        "javascript",
-                      ],
+                      "platform": "javascript",
                       "slug": "project-slug",
                       "stats": Array [
                         Array [
@@ -115,9 +111,7 @@ exports[`ProjectCard renders 1`] = `
                         "isBookmarked": false,
                         "isMember": true,
                         "name": "Project Name",
-                        "platforms": Array [
-                          "javascript",
-                        ],
+                        "platform": "javascript",
                         "slug": "project-slug",
                         "stats": Array [
                           Array [
@@ -157,9 +151,7 @@ exports[`ProjectCard renders 1`] = `
                               "isBookmarked": false,
                               "isMember": true,
                               "name": "Project Name",
-                              "platforms": Array [
-                                "javascript",
-                              ],
+                              "platform": "javascript",
                               "slug": "project-slug",
                               "stats": Array [
                                 Array [
@@ -192,9 +184,7 @@ exports[`ProjectCard renders 1`] = `
                                 "isBookmarked": false,
                                 "isMember": true,
                                 "name": "Project Name",
-                                "platforms": Array [
-                                  "javascript",
-                                ],
+                                "platform": "javascript",
                                 "slug": "project-slug",
                                 "stats": Array [
                                   Array [
@@ -231,9 +221,7 @@ exports[`ProjectCard renders 1`] = `
                                         "isBookmarked": false,
                                         "isMember": true,
                                         "name": "Project Name",
-                                        "platforms": Array [
-                                          "javascript",
-                                        ],
+                                        "platform": "javascript",
                                         "slug": "project-slug",
                                         "stats": Array [
                                           Array [
@@ -260,9 +248,7 @@ exports[`ProjectCard renders 1`] = `
                                           "isBookmarked": false,
                                           "isMember": true,
                                           "name": "Project Name",
-                                          "platforms": Array [
-                                            "javascript",
-                                          ],
+                                          "platform": "javascript",
                                           "slug": "project-slug",
                                           "stats": Array [
                                             Array [
@@ -289,9 +275,7 @@ exports[`ProjectCard renders 1`] = `
                                             "isBookmarked": false,
                                             "isMember": true,
                                             "name": "Project Name",
-                                            "platforms": Array [
-                                              "javascript",
-                                            ],
+                                            "platform": "javascript",
                                             "slug": "project-slug",
                                             "stats": Array [
                                               Array [
@@ -313,7 +297,7 @@ exports[`ProjectCard renders 1`] = `
                                           consistentWidth={false}
                                           direction="right"
                                           hasTooltip={false}
-                                          max={3}
+                                          max={1}
                                           platforms={
                                             Array [
                                               "javascript",
@@ -324,13 +308,13 @@ exports[`ProjectCard renders 1`] = `
                                           <PlatformIcons
                                             consistentWidth={false}
                                             direction="right"
-                                            max={3}
+                                            max={1}
                                             size={24}
                                           >
                                             <div
                                               className="css-12u7e6y-PlatformIcons ezvce7z0"
                                               direction="right"
-                                              max={3}
+                                              max={1}
                                               size={24}
                                             >
                                               <StyledPlatformIcon
@@ -669,9 +653,7 @@ exports[`ProjectCard renders 1`] = `
                   "isBookmarked": false,
                   "isMember": true,
                   "name": "Project Name",
-                  "platforms": Array [
-                    "javascript",
-                  ],
+                  "platform": "javascript",
                   "slug": "project-slug",
                   "stats": Array [
                     Array [

--- a/tests/js/spec/views/organizationDashboard/projectCard.spec.jsx
+++ b/tests/js/spec/views/organizationDashboard/projectCard.spec.jsx
@@ -14,7 +14,7 @@ describe('ProjectCard', function() {
       <ProjectCard
         project={TestStubs.Project({
           stats: [[1525042800, 1], [1525046400, 2]],
-          platforms: ['javascript'],
+          platform: 'javascript',
         })}
         params={{orgId: 'org-slug'}}
       />,
@@ -24,7 +24,7 @@ describe('ProjectCard', function() {
     projectMock = MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/',
       method: 'PUT',
-      data: TestStubs.Project({isBookmarked: false, platforms: ['javascript']}),
+      data: TestStubs.Project({isBookmarked: false, platform: 'javascript'}),
     });
   });
 
@@ -74,7 +74,7 @@ describe('ProjectCard', function() {
       <ProjectCard
         project={TestStubs.Project({
           stats: [[1525042800, 1], [1525046400, 2]],
-          platforms: ['javascript'],
+          platform: 'javascript',
           latestDeploys,
         })}
         params={{orgId: 'org-slug'}}


### PR DESCRIPTION
This changes Project badges to use the `platform` from project data (instead of `platforms` AND `platform`). Adds a selector to project settings for `platform`. I think it's confusing that the Project badge uses the active platforms when the user has to go through the onboarding project selection (which saves to `platform`).

This also adds project icon to the main project selector (previously was internal only):
![image](https://user-images.githubusercontent.com/79684/49399693-d8885080-f6f6-11e8-8a79-3cb6c839c79a.png)


![image](https://user-images.githubusercontent.com/79684/49399670-c60e1700-f6f6-11e8-9752-f9c1c866103c.png)
