### PR TITLE
fix(ui) Grey out disabled text inputs

### DIFF
--- a/src/sentry/static/sentry/app/styles/input.jsx
+++ b/src/sentry/static/sentry/app/styles/input.jsx
@@ -9,7 +9,7 @@ const readOnlyStyle = props =>
 
 const inputStyles = props => {
   return css`
-    color: ${props.theme.gray5};
+    color: ${props.disabled ? props.theme.gray1 : props.theme.gray5};
     display: block;
     width: 100%;
     background: #fff;


### PR DESCRIPTION
Make text inputs like other inputs and grey out their text so that the content doesn't look interactive.

![screen shot 2018-12-03 at 4 13 54 pm](https://user-images.githubusercontent.com/24086/49401932-7f301980-f716-11e8-9fa3-bcbaf4f6b858.png)
