### PR TITLE
feat: Allow id or event_id in project events endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -7,8 +7,9 @@ from rest_framework.response import Response
 from sentry.api.base import DocSection
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import Event
+from sentry.models import Event, Release, UserReport
 from sentry.utils.apidocs import scenario, attach_scenarios
+from sentry.utils.validators import is_event_id
 
 
 @scenario('RetrieveEventForProject')
@@ -23,6 +24,20 @@ def retrieve_event_for_project_scenario(runner):
 class ProjectEventDetailsEndpoint(ProjectEndpoint):
     doc_section = DocSection.EVENTS
 
+    def _get_release_info(self, request, event):
+        version = event.get_tag('sentry:release')
+        if not version:
+            return None
+        try:
+            release = Release.objects.get(
+                projects=event.project,
+                organization_id=event.project.organization_id,
+                version=version,
+            )
+        except Release.DoesNotExist:
+            return {'version': version}
+        return serialize(release, request.user)
+
     @attach_scenarios([retrieve_event_for_project_scenario])
     def get(self, request, project, event_id):
         """
@@ -35,16 +50,33 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
                                           event belongs to.
         :pparam string project_slug: the slug of the project the event
                                      belongs to.
-        :pparam string event_id: the hexadecimal ID of the event to
-                                 retrieve (as reported by the raven client).
+        :pparam string event_id: the id of the event to retrieve (either the
+                                 numeric primary-key or the hexadecimal id as
+                                 reported by the raven client)
         :auth: required
         """
-        try:
-            event = Event.objects.get(
-                event_id=event_id,
-                project_id=project.id,
-            )
-        except Event.DoesNotExist:
+
+        event = None
+        # If its a numeric string, check if it's an event Primary Key first
+        if event_id.isdigit():
+            try:
+                event = Event.objects.get(
+                    id=event_id,
+                    project_id=project.id,
+                )
+            except Event.DoesNotExist:
+                pass
+        # If it was not found as a PK, and its a possible event_id, search by that instead.
+        if event is None and is_event_id(event_id):
+            try:
+                event = Event.objects.get(
+                    event_id=event_id,
+                    project_id=project.id,
+                )
+            except Event.DoesNotExist:
+                pass
+
+        if event is None:
             return Response({'detail': 'Event not found'}, status=404)
 
         Event.objects.bind_nodes([event], 'data')
@@ -72,7 +104,17 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
         except IndexError:
             prev_event = None
 
+        try:
+            user_report = UserReport.objects.get(
+                event_id=event.event_id,
+                project=event.project,
+            )
+        except UserReport.DoesNotExist:
+            user_report = None
+
         data = serialize(event, request.user)
+        data['userReport'] = serialize(user_report, request.user)
+        data['release'] = self._get_release_info(request, event)
 
         if next_event:
             data['nextEventID'] = six.text_type(next_event.event_id)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -755,7 +755,7 @@ urlpatterns = patterns(
         name='sentry-api-0-project-events'
     ),
     url(
-        r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/events/(?P<event_id>[\w-]+)/$',
+        r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/events/(?P<event_id>(?:\d+|[A-Fa-f0-9]{32}))/$',
         ProjectEventDetailsEndpoint.as_view(),
         name='sentry-api-0-project-event-details'
     ),

--- a/src/sentry/static/sentry/app/views/groupEventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupEventDetails.jsx
@@ -38,12 +38,15 @@ const GroupEventDetails = createReactClass({
   },
 
   fetchData() {
-    let eventId = this.props.params.eventId || 'latest';
+    const eventId = this.props.params.eventId || 'latest';
+    const groupId = this.getGroup().id;
+    const orgSlug = this.getOrganization().slug;
+    const projSlug = this.getProject().slug;
 
     let url =
       eventId === 'latest' || eventId === 'oldest'
-        ? `/issues/${this.getGroup().id}/events/${eventId}/`
-        : `/projects/${this.getOrganization().slug}/${this.getProject().slug}/events/${eventId}/`;
+        ? `/issues/${groupId}/events/${eventId}/`
+        : `/projects/${orgSlug}/${projSlug}/events/${eventId}/`;
 
     this.setState({
       loading: true,
@@ -59,9 +62,9 @@ const GroupEventDetails = createReactClass({
         });
 
         this.api.bulkUpdate({
-          orgId: this.getOrganization().slug,
-          projectId: this.getProject().slug,
-          itemIds: [this.getGroup().id],
+          orgId: orgSlug,
+          projectId: projSlug,
+          itemIds: [groupId],
           failSilently: true,
           data: {hasSeen: true},
         });

--- a/src/sentry/static/sentry/app/views/groupEventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupEventDetails.jsx
@@ -42,8 +42,8 @@ const GroupEventDetails = createReactClass({
 
     let url =
       eventId === 'latest' || eventId === 'oldest'
-        ? '/issues/' + this.getGroup().id + '/events/' + eventId + '/'
-        : '/events/' + eventId + '/';
+        ? `/issues/${this.getGroup().id}/events/${eventId}/`
+        : `/projects/${this.getOrganization().slug}/${this.getProject().slug}/events/${eventId}/`;
 
     this.setState({
       loading: true,

--- a/tests/sentry/api/endpoints/test_project_event_details.py
+++ b/tests/sentry/api/endpoints/test_project_event_details.py
@@ -14,17 +14,17 @@ class ProjectEventDetailsTest(APITestCase):
 
         group = self.create_group()
         prev_event = self.create_event(
-            event_id='a',
+            event_id='a' * 32,
             group=group,
             datetime=datetime(2013, 8, 13, 3, 8, 24),
         )
         cur_event = self.create_event(
-            event_id='b',
+            event_id='b' * 32,
             group=group,
             datetime=datetime(2013, 8, 13, 3, 8, 25),
         )
         next_event = self.create_event(
-            event_id='c',
+            event_id='c' * 32,
             group=group,
             datetime=datetime(2013, 8, 13, 3, 8, 26),
         )
@@ -33,6 +33,23 @@ class ProjectEventDetailsTest(APITestCase):
             'sentry-api-0-project-event-details',
             kwargs={
                 'event_id': cur_event.event_id,
+                'project_slug': cur_event.project.slug,
+                'organization_slug': cur_event.project.organization.slug,
+            }
+        )
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert response.data['id'] == six.text_type(cur_event.id)
+        assert response.data['nextEventID'] == six.text_type(next_event.event_id)
+        assert response.data['previousEventID'] == six.text_type(prev_event.event_id)
+        assert response.data['groupID'] == six.text_type(group.id)
+
+        # Same event can be looked up by primary key
+        url = reverse(
+            'sentry-api-0-project-event-details',
+            kwargs={
+                'event_id': cur_event.id,
                 'project_slug': cur_event.project.slug,
                 'organization_slug': cur_event.project.organization.slug,
             }


### PR DESCRIPTION
Reprise of a previous PR that failed because there is no index
on `event_id` alone. Now I've added this functionality to the project
event details endpoint where we know we always have the project id
available, and I've made the fronted code use this endpoint instead
of the bare `/api/0/events/` endpoint.