### PR TITLE
feat(ui): Add total result count to event stream (internal only)

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
@@ -160,7 +160,9 @@ class OrganizationEvents extends AsyncView {
                   <TotalEventCount
                     organization={organization}
                     location={location}
-                    isAllResults={!parsedLinks.previous.results && !parsedLinks.next.results}
+                    isAllResults={
+                      !parsedLinks.previous.results && !parsedLinks.next.results
+                    }
                     numRows={events.length}
                   />
                 )}

--- a/tests/js/spec/views/organizationEvents/events.spec.jsx
+++ b/tests/js/spec/views/organizationEvents/events.spec.jsx
@@ -18,6 +18,7 @@ describe('OrganizationEventsErrors', function() {
   const org = TestStubs.Organization({projects: [project]});
   let eventsMock;
   let eventsStatsMock;
+  let eventsMetaMock;
 
   beforeEach(function() {
     // Search bar makes this request when mounted
@@ -35,6 +36,10 @@ describe('OrganizationEventsErrors', function() {
       body: (url, opts) => {
         return TestStubs.HealthGraph(opts.query);
       },
+    });
+    eventsMetaMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-meta/',
+      body: {count: 5},
     });
   });
 
@@ -69,6 +74,7 @@ describe('OrganizationEventsErrors', function() {
     await tick();
     wrapper.update();
     expect(eventsStatsMock).toHaveBeenCalled();
+    expect(eventsMetaMock).toHaveBeenCalled();
     expect(wrapper.find('LoadingIndicator')).toHaveLength(0);
     expect(wrapper.find('IdBadge')).toHaveLength(2);
   });


### PR DESCRIPTION
This is internal for now to make sure the api isn't too slow. Shows results + whether they are estimated or not:

![screenshot 2018-12-03 16 59 54](https://user-images.githubusercontent.com/5026776/49411234-fbc5f680-f71c-11e8-91b3-24402a1b8a6e.png)
![screenshot 2018-12-03 16 59 34](https://user-images.githubusercontent.com/5026776/49411235-fbc5f680-f71c-11e8-8e68-2ca2f8e4fbb8.png)
