### PR TITLE
feat(sdk): Detect Rust panic entrypoints in stacktraces

### DIFF
--- a/src/sentry/utils/rust.py
+++ b/src/sentry/utils/rust.py
@@ -28,6 +28,7 @@ OUTER_BORDER_FRAMES = [
 
 INNER_BORDER_FRAMES = [
     "std::panicking::begin_panic",
+    "core::panicking::panic",
     "failure::error_message::err_msg",
     "failure::backtrace::Backtrace::new",
     "failure::backtrace::internal::InternalBacktrace::new",


### PR DESCRIPTION
This detects entrypoints for panics from [`core::panicking`](https://doc.rust-lang.org/1.30.0/src/core/panicking.rs.html) as border frames, used for instance in slice accesses.

Provides better stack traces for issues like [SENTRY-8HQ](https://sentry.io/sentry/sentry/issues/792133498/).