### PR TITLE
feat: Add max request timeout for uwsgi

### DIFF
--- a/src/sentry/services/http.py
+++ b/src/sentry/services/http.py
@@ -59,6 +59,7 @@ class SentryHTTPServer(Service):
         options.setdefault('workers', 3)
         options.setdefault('threads', 4)
         options.setdefault('http-timeout', 30)
+        options.setdefault('harakiri', 120)
         options.setdefault('vacuum', True)
         options.setdefault('thunder-lock', True)
         options.setdefault('log-x-forwarded-for', False)


### PR DESCRIPTION
There's currently no limit on maximum request processing time.
`http-timeout` doesn't affect us because we 
Setting it to 120 seconds is a bit conservative, but can be later tweaked for production.