### PR TITLE
fix(snuba): Run post_process RuleProcessor code with Snuba's consiste…

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -24,6 +24,10 @@ from sentry.utils.dates import to_timestamp
 MAX_ISSUES = 500
 MAX_HASHES = 5000
 
+# Global Snuba request option override dictionary. Only intended
+# to be used with the `options_override` contextmanager below.
+OVERRIDE_OPTIONS = {}
+
 SENTRY_SNUBA_MAP = {
     # general
     'id': 'event_id',
@@ -155,6 +159,32 @@ def timer(name, prefix='snuba.client'):
         yield
     finally:
         metrics.timing(u'{}.{}'.format(prefix, name), time.time() - t)
+
+
+@contextmanager
+def options_override(overrides):
+    """\
+    Adds to OVERRIDE_OPTIONS, restoring previous values and removing
+    keys that didn't previously exist on exit, so that calls to this
+    can be nested.
+    """
+    previous = {}
+    delete = []
+
+    for k, v in overrides.items():
+        try:
+            previous[k] = OVERRIDE_OPTIONS[k]
+        except KeyError:
+            delete.append(k)
+        OVERRIDE_OPTIONS[k] = v
+
+    try:
+        yield
+    finally:
+        for k, v in previous.items():
+            OVERRIDE_OPTIONS[k] = v
+        for k in delete:
+            OVERRIDE_OPTIONS.pop(k)
 
 
 def connection_from_url(url, **kw):
@@ -362,6 +392,8 @@ def raw_query(start, end, groupby=None, conditions=None, filter_keys=None,
         'selected_columns': selected_columns,
         'turbo': turbo
     }) if v is not None}
+
+    request.update(OVERRIDE_OPTIONS)
 
     headers = {}
     if referrer:

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -26,6 +26,7 @@ MAX_HASHES = 5000
 
 # Global Snuba request option override dictionary. Only intended
 # to be used with the `options_override` contextmanager below.
+# NOT THREAD SAFE!
 OVERRIDE_OPTIONS = {}
 
 SENTRY_SNUBA_MAP = {
@@ -164,6 +165,8 @@ def timer(name, prefix='snuba.client'):
 @contextmanager
 def options_override(overrides):
     """\
+    NOT THREAD SAFE!
+
     Adds to OVERRIDE_OPTIONS, restoring previous values and removing
     keys that didn't previously exist on exit, so that calls to this
     can be nested.

--- a/tests/snuba/test_util.py
+++ b/tests/snuba/test_util.py
@@ -62,3 +62,12 @@ class SnubaUtilTest(TestCase):
                     ['count()', '', 'count'],
                 ],
             )
+
+    def test_override_options(self):
+        assert snuba.OVERRIDE_OPTIONS == {}
+        with snuba.options_override({'foo': 1}):
+            assert snuba.OVERRIDE_OPTIONS == {'foo': 1}
+            with snuba.options_override({'foo': 2}):
+                assert snuba.OVERRIDE_OPTIONS == {'foo': 2}
+            assert snuba.OVERRIDE_OPTIONS == {'foo': 1}
+        assert snuba.OVERRIDE_OPTIONS == {}


### PR DESCRIPTION
…nt=True

This will ensure that RuleProcessor code reads rows that were just
written by Snuba's ingest pipeline.

Depends on https://github.com/getsentry/snuba/pull/242