### PR TITLE
fix(ui) Fix broken multi-select widgets inside form containers

### DIFF
--- a/docs-ui/components/form.stories.js
+++ b/docs-ui/components/form.stories.js
@@ -17,6 +17,7 @@ import RangeSlider from 'app/views/settings/components/forms/controls/rangeSlide
 import Form from 'app/views/settings/components/forms/form';
 import FormField from 'app/views/settings/components/forms/formField';
 import TextField from 'app/views/settings/components/forms/textField';
+import SelectField from 'app/views/settings/components/forms/selectField';
 import Switch from 'app/components/switch';
 
 class UndoButton extends React.Component {
@@ -144,6 +145,45 @@ storiesOf('Forms|Fields', module)
         <RadioField
           name="radio"
           label="Radio Field"
+          choices={[
+            ['choice_one', 'Choice One'],
+            ['choice_two', 'Choice Two'],
+            ['choice_three', 'Choice Three'],
+          ]}
+        />
+      </Form>
+    ))
+  )
+  .add(
+    'SelectField',
+    withInfo({
+      text: 'Select Field',
+      propTablesExclude: [Form],
+    })(() => (
+      <Form>
+        <SelectField
+          name="select"
+          label="Select Field"
+          choices={[
+            ['choice_one', 'Choice One'],
+            ['choice_two', 'Choice Two'],
+            ['choice_three', 'Choice Three'],
+          ]}
+        />
+      </Form>
+    ))
+  )
+  .add(
+    'SelectField multiple',
+    withInfo({
+      text: 'Select Control w/ multiple',
+      propTablesExclude: [Form],
+    })(() => (
+      <Form>
+        <SelectField
+          name="select"
+          label="Multi Select"
+          multiple={true}
           choices={[
             ['choice_one', 'Choice One'],
             ['choice_two', 'Choice Two'],

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -367,7 +367,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                 {
                     'multiple': True,
                     'choices': self.make_choices(field_meta.get('allowedValues')),
-                    'default': []
+                    'default': ''
                 }
             )
 

--- a/src/sentry/static/sentry/app/views/settings/components/forms/selectField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/selectField.jsx
@@ -68,12 +68,13 @@ export default class SelectField extends React.Component {
           // Check if value quacks like mobx and get the raw array.
           // Inside Form containers `value` can be a mobx observable
           // which doesn't play nice with downstream code.
+          let val = props.value;
           if (
             multiple &&
-            Array.isArray(props.value) === false &&
-            typeof props.value.peek === 'function'
+            Array.isArray(val) === false &&
+            typeof val.peek === 'function'
           ) {
-            props.value = props.value.peek();
+            val = val.peek();
           }
           return (
             <SelectControl
@@ -82,7 +83,7 @@ export default class SelectField extends React.Component {
               multiple={multiple}
               disabled={disabled}
               onChange={this.handleChange.bind(this, onBlur, onChange)}
-              value={props.value}
+              value={val}
               options={choices.map(([value, label]) => ({
                 value,
                 label,

--- a/src/sentry/static/sentry/app/views/settings/components/forms/selectField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/selectField.jsx
@@ -61,11 +61,20 @@ export default class SelectField extends React.Component {
         {...otherProps}
         alignRight={this.props.small}
         field={({onChange, onBlur, disabled, required, ...props}) => {
+          // We remove the required property here since applying it to the
+          // DOM causes the native tooltip to render in strange places.
           let choices = getChoices(props);
 
-          // XXX: We remove the required property here since applying it to the
-          // DOM causes the native tooltip to render in strange places.
-
+          // Check if value quacks like mobx and get the raw array.
+          // Inside Form containers `value` can be a mobx observable
+          // which doesn't play nice with downstream code.
+          if (
+            multiple &&
+            Array.isArray(props.value) === false &&
+            typeof props.value.peek === 'function'
+          ) {
+            props.value = props.value.peek();
+          }
           return (
             <SelectControl
               {...props}


### PR DESCRIPTION
When inside a Form container array values are wrapped by mobx into observable arrays. The react-select component does not know how to handle this type and behaves poorly. By peeking at the observable value we can get the right behavior.

This fixes the broken version, component inputs on the jira integrations.

Fixes APP-856