### PR TITLE
fix(integrations) Don't fail to handle stdlib errors

### DIFF
--- a/src/sentry/api/bases/integration.py
+++ b/src/sentry/api/bases/integration.py
@@ -14,7 +14,7 @@ class IntegrationEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationPermission, )
 
     def handle_exception(self, request, exc):
-        if exc.code == 503:
+        if hasattr(exc, 'code') and exc.code == 503:
             sys.stderr.write(traceback.format_exc())
             event_id = capture_exception()
             context = {

--- a/tests/sentry/api/bases/test_integration.py
+++ b/tests/sentry/api/bases/test_integration.py
@@ -25,3 +25,11 @@ class IntegrationEndpointTest(APITestCase):
         resp = IntegrationEndpoint().handle_exception(HttpRequest(), ApiError('This is an error', code=503))
         assert resp.status_code == 503
         assert resp.exception is True
+
+    def test_handle_exception_stdlib(self):
+        resp = IntegrationEndpoint().handle_exception(
+            HttpRequest(),
+            ValueError('This is an error')
+        )
+        assert resp.status_code == 500
+        assert resp.exception is True


### PR DESCRIPTION
Not all errors have `code` properties. We should check before we read arbitrary attributes.