### PR TITLE
feat(api): Support negative search in event stream

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -60,11 +60,11 @@ search_term     = space? (time_filter / has_filter / basic_filter) space?
 raw_search      = ~r".+$"
 
 # standard key:val filter
-basic_filter    = search_key sep search_value
+basic_filter    = negation? search_key sep search_value
 # filter specifically for the timestamp
 time_filter     = "timestamp" operator date_format
 # has filter for not null type checks
-has_filter      = "has" sep (search_key / search_value)
+has_filter      = negation? "has" sep (search_key / search_value)
 
 search_key      = key / quoted_key
 search_value    = quoted_value / value
@@ -82,6 +82,7 @@ date_format    = ~r"\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{1,6})?)?"
 operator        = ">=" / "<=" / ">" / "<" / "=" / "!="
 sep             = ":"
 space           = " "
+negation        = "!"
 """)
 
 
@@ -170,14 +171,23 @@ class SearchVisitor(NodeVisitor):
     def visit_date_format(self, node, children):
         return node.text
 
-    def visit_basic_filter(self, node, children):
-        search_key, _, search_value = children
+    def is_negated(self, node):
+        # Because negations are always optional, parsimonious returns a list of nodes
+        # containing one node when a negation exists, and a single node when it doesn't.
+        if isinstance(node, list):
+            node = node[0]
 
-        return SearchFilter(search_key, "=", search_value)
+        return node.text == '!'
+
+    def visit_basic_filter(self, node, children):
+        negation, search_key, _, search_value = children
+        operator = '!=' if self.is_negated(negation) else '='
+
+        return SearchFilter(search_key, operator, search_value)
 
     def visit_has_filter(self, node, children):
         # the key is has here, which we don't need
-        _, _, (search_key,) = children
+        negation, _, _, (search_key,) = children
 
         # if it matched search value instead, it's not a valid key
         if isinstance(search_key, SearchValue):
@@ -185,9 +195,11 @@ class SearchVisitor(NodeVisitor):
                 'Invalid format for "has" search: %s' %
                 (search_key.raw_value,))
 
+        operator = '=' if self.is_negated(negation) else '!='
+
         return SearchFilter(
             search_key,
-            '!=',
+            operator,
             SearchValue(''),
         )
 
@@ -229,7 +241,7 @@ def convert_endpoint_params(params):
 
 
 def get_snuba_query_args(query=None, params=None):
-    # NOTE: this function assumes project permisions check already happened
+    # NOTE: this function assumes project permissions check already happened
     parsed_filters = []
     if query is not None:
         try:
@@ -277,15 +289,20 @@ def get_snuba_query_args(query=None, params=None):
             )
 
         else:
+            if _filter.operator == '!=' or _filter.operator == '=' and _filter.value.value == '':
+                # Handle null columns on (in)equality comparisons. Any comparison between a value
+                # and a null will result to null. There are two cases we handle here:
+                # - A column doesn't equal a value. In this case, we need to convert the column to
+                # an empty string so that we don't exclude rows that have it set to null
+                # - Checking that a value isn't present. In some cases the column will be null,
+                # and in other cases an empty string. To generalize this we convert values in the
+                # column to an empty string and just check for that.
+                snuba_name = ['ifnull', [snuba_name, "''"]]
+
             if _filter.value.is_wildcard():
                 kwargs['conditions'].append(
-                    [['match', [snuba_name, "'%s'" % (value,)]], '=', 1]
+                    [['match', [snuba_name, "'%s'" % (value,)]], _filter.operator, 1]
                 )
             else:
-                kwargs['conditions'].append([
-                    snuba_name,
-                    _filter.operator,
-                    value,
-                ])
-
+                kwargs['conditions'].append([snuba_name, _filter.operator, value])
     return kwargs

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -104,12 +104,26 @@ class EventSearchTest(TestCase):
                 value=SearchValue(raw_value='a release'),
             ),
         ]
+        assert parse_search_query('!release:"a release"') == [
+            SearchFilter(
+                key=SearchKey(name='release'),
+                operator='!=',
+                value=SearchValue('a release'),
+            ),
+        ]
 
     def test_parse_search_query_quoted_key(self):
         assert parse_search_query('"hi:there":value') == [
             SearchFilter(
                 key=SearchKey(name='hi:there'),
                 operator='=',
+                value=SearchValue(raw_value='value'),
+            ),
+        ]
+        assert parse_search_query('!"hi:there":value') == [
+            SearchFilter(
+                key=SearchKey(name='hi:there'),
+                operator='!=',
                 value=SearchValue(raw_value='value'),
             ),
         ]
@@ -227,6 +241,25 @@ class EventSearchTest(TestCase):
         with self.assertRaises(InvalidSearchQuery):
             parse_search_query('has:"hi there"')
 
+    def test_parse_search_query_not_has_tag(self):
+        # unquoted key
+        assert parse_search_query('!has:release') == [
+            SearchFilter(
+                key=SearchKey(name='release'),
+                operator='=',
+                value=SearchValue(''),
+            ),
+        ]
+
+        # quoted key
+        assert parse_search_query('!has:"hi:there"') == [
+            SearchFilter(
+                key=SearchKey(name='hi:there'),
+                operator='=',
+                value=SearchValue(''),
+            ),
+        ]
+
     def test_get_snuba_query_args(self):
         assert get_snuba_query_args('user.email:foo@example.com release:1.2.1 fruit:apple hello', {
             'project_id': [1, 2, 3],
@@ -242,6 +275,14 @@ class EventSearchTest(TestCase):
             'filter_keys': {'project_id': [1, 2, 3]},
             'start': datetime.datetime(2015, 5, 18, 10, 15, 1, tzinfo=timezone.utc),
             'end': datetime.datetime(2015, 5, 19, 10, 15, 1, tzinfo=timezone.utc),
+        }
+
+    def test_negation_get_snuba_query_args(self):
+        assert get_snuba_query_args('!user.email:foo@example.com') == {
+            'conditions': [
+                [['ifnull', ['email', "''"]], '!=', 'foo@example.com'],
+            ],
+            'filter_keys': {},
         }
 
     def test_get_snuba_query_args_no_search(self):
@@ -265,10 +306,25 @@ class EventSearchTest(TestCase):
             'filter_keys': {},
         }
 
+    def test_get_snuba_query_args_negated_wildcard(self):
+        assert get_snuba_query_args('!release:3.1.* user.email:*@example.com') == {
+            'conditions': [
+                [['match', [['ifnull', ['tags[sentry:release]', "''"]], "'^3\\.1\\..*$'"]], '!=', 1],
+                [['match', ['email', "'^.*\\@example\\.com$'"]], '=', 1],
+            ],
+            'filter_keys': {},
+        }
+
     def test_get_snuba_query_args_has(self):
         assert get_snuba_query_args('has:release') == {
             'filter_keys': {},
-            'conditions': [['tags[sentry:release]', '!=', '']]
+            'conditions': [[['ifnull', ['tags[sentry:release]', "''"]], '!=', '']]
+        }
+
+    def test_get_snuba_query_args_not_has(self):
+        assert get_snuba_query_args('!has:release') == {
+            'filter_keys': {},
+            'conditions': [[['ifnull', ['tags[sentry:release]', "''"]], '=', '']]
         }
 
     def test_convert_endpoint_params(self):

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -96,7 +96,12 @@ class OrganizationEventsEndpointTest(OrganizationEventsTestBase):
 
         project = self.create_project()
         group = self.create_group(project=project)
-        self.create_event('x' * 32, group=group, message="how to make fast", datetime=self.min_ago)
+        event_1 = self.create_event(
+            'x' * 32,
+            group=group,
+            message="how to make fast",
+            datetime=self.min_ago,
+        )
         event_2 = self.create_event(
             'y' * 32,
             group=group,
@@ -117,6 +122,12 @@ class OrganizationEventsEndpointTest(OrganizationEventsTestBase):
         assert len(response.data) == 1
         assert response.data[0]['eventID'] == event_2.event_id
         assert response.data[0]['message'] == 'Delet the Data'
+
+        response = self.client.get(url, {'query': '!user.email:foo@example.com'}, format='json')
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]['eventID'] == event_1.event_id
+        assert response.data[0]['message'] == 'how to make fast'
 
     def test_invalid_search_terms(self):
         self.login_as(user=self.user)
@@ -349,7 +360,7 @@ class OrganizationEventsEndpointTest(OrganizationEventsTestBase):
         event_1 = self.create_event(
             'a' * 32, group=group, datetime=self.min_ago, tags={'fruit': 'apple'}
         )
-        self.create_event(
+        event_2 = self.create_event(
             'b' * 32, group=group, datetime=self.min_ago, tags={'fruit': 'orange'}
         )
 
@@ -364,6 +375,10 @@ class OrganizationEventsEndpointTest(OrganizationEventsTestBase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         self.assert_events_in_response(response, [event_1.event_id])
+        response = self.client.get('%s?query=!fruit:apple' % (base_url,), format='json')
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        self.assert_events_in_response(response, [event_2.event_id])
 
     def test_wildcard_search(self):
         user = self.create_user()
@@ -379,14 +394,14 @@ class OrganizationEventsEndpointTest(OrganizationEventsTestBase):
         event_1 = self.create_event(
             'a' * 32, group=group, datetime=self.min_ago, tags={'sentry:release': '3.1.2'}
         )
-        self.create_event(
+        event_2 = self.create_event(
             'b' * 32, group=group, datetime=self.min_ago, tags={'sentry:release': '4.1.2'}
         )
-        event_2 = self.create_event(
+        event_3 = self.create_event(
             'c' * 32, group=group, datetime=self.min_ago, user={'email': 'foo@example.com'}
         )
 
-        self.create_event(
+        event_4 = self.create_event(
             'd' * 32, group=group, datetime=self.min_ago, user={'email': 'foo@example.commmmmmmm'}
         )
 
@@ -402,10 +417,29 @@ class OrganizationEventsEndpointTest(OrganizationEventsTestBase):
         assert len(response.data) == 1
         self.assert_events_in_response(response, [event_1.event_id])
 
+        response = self.client.get('%s?query=!release:3.1.*' % (base_url,), format='json')
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 3
+        self.assert_events_in_response(
+            response,
+            [event_2.event_id, event_3.event_id, event_4.event_id],
+        )
+
         response = self.client.get('%s?query=user.email:*@example.com' % (base_url,), format='json')
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        self.assert_events_in_response(response, [event_2.event_id])
+        self.assert_events_in_response(response, [event_3.event_id])
+
+        response = self.client.get(
+            '%s?query=!user.email:*@example.com' % (base_url,),
+            format='json',
+        )
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 3
+        self.assert_events_in_response(
+            response,
+            [event_1.event_id, event_2.event_id, event_4.event_id],
+        )
 
     def test_has_tag(self):
         user = self.create_user()
@@ -445,6 +479,17 @@ class OrganizationEventsEndpointTest(OrganizationEventsTestBase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         self.assert_events_in_response(response, [event_2.event_id])
+
+        response = self.client.get('%s?query=!has:user.email' % (base_url,), format='json')
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        self.assert_events_in_response(response, [event_2.event_id])
+
+        # test custom tag
+        response = self.client.get('%s?query=!has:example_tag' % (base_url,), format='json')
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        self.assert_events_in_response(response, [event_1.event_id])
 
 
 class OrganizationEventsStatsEndpointTest(OrganizationEventsTestBase):


### PR DESCRIPTION
Support negative search in the event stream using `!` to invert the search. Can be used to exclude values for particular properties, and on `has` queries as well.

Examples:
!has:user.email - Returns all events without an email
!user.email:dfuller@sentry.io - Returns all events where the user has no email, or the email doesn't match dfuller@sentry.io

Fixes APP-857