### PR TITLE
fix(ui) Visually dim selectboxes when disabled

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/selectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.jsx
@@ -114,7 +114,7 @@ const StyledSelect = styled(React.forwardRef(forwardRef))`
   }
 
   &.Select--single.is-disabled .Select-control .Select-value .Select-value-label {
-    color: ${p => p.theme.gray1};
+    color: ${p => p.theme.disabled};
   }
 
   .Select-option.is-focused {

--- a/src/sentry/static/sentry/app/components/forms/selectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.jsx
@@ -113,6 +113,10 @@ const StyledSelect = styled(React.forwardRef(forwardRef))`
     }
   }
 
+  &.Select--single.is-disabled .Select-control .Select-value .Select-value-label {
+    color: ${p => p.theme.gray1};
+  }
+
   .Select-option.is-focused {
     color: white;
     background-color: ${p => p.theme.purple};

--- a/src/sentry/static/sentry/app/styles/input.jsx
+++ b/src/sentry/static/sentry/app/styles/input.jsx
@@ -9,7 +9,7 @@ const readOnlyStyle = props =>
 
 const inputStyles = props => {
   return css`
-    color: ${props.disabled ? props.theme.gray1 : props.theme.gray5};
+    color: ${props.disabled ? props.theme.disabled : props.theme.gray5};
     display: block;
     width: 100%;
     background: #fff;

--- a/src/sentry/static/sentry/app/views/organizationDashboard/projectNav.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/projectNav.jsx
@@ -131,7 +131,7 @@ const StyledDropdown = styled.div`
     background-color: ${p => p.theme.purpleDark};
   }
   li[disabled] {
-    color: ${p => p.theme.gray1};
+    color: ${p => p.theme.disabled};
     padding: 3px 10px;
   }
 `;

--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -581,7 +581,7 @@ const GraphToggle = styled.a`
   &:hover,
   &:focus,
   &:active {
-    color: ${p => (p.active ? p.theme.gray4 : p.theme.gray1)};
+    color: ${p => (p.active ? p.theme.gray4 : p.theme.disabled)};
   }
 `;
 

--- a/tests/js/spec/components/forms/__snapshots__/selectField.spec.jsx.snap
+++ b/tests/js/spec/components/forms/__snapshots__/selectField.spec.jsx.snap
@@ -169,7 +169,7 @@ exports[`SelectField renders without form context 1`] = `
             <ForwardRef(SelectPicker)
               arrowRenderer={[Function]}
               backspaceRemoves={true}
-              className="e1qrhqd00 css-7y4fj5-StyledSelect-StyledSelectControl eho28m20"
+              className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
               clearable={true}
               deleteRemoves={true}
               disabled={false}
@@ -196,7 +196,7 @@ exports[`SelectField renders without form context 1`] = `
               <SelectPicker
                 arrowRenderer={[Function]}
                 backspaceRemoves={true}
-                className="e1qrhqd00 css-7y4fj5-StyledSelect-StyledSelectControl eho28m20"
+                className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
                 clearable={true}
                 deleteRemoves={true}
                 disabled={false}
@@ -226,7 +226,7 @@ exports[`SelectField renders without form context 1`] = `
                   autosize={true}
                   backspaceRemoves={true}
                   backspaceToRemoveMessage="Press backspace to remove {label}"
-                  className="e1qrhqd00 css-7y4fj5-StyledSelect-StyledSelectControl eho28m20"
+                  className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
                   clearAllText="Clear all"
                   clearRenderer={[Function]}
                   clearValueText="Clear value"
@@ -286,7 +286,7 @@ exports[`SelectField renders without form context 1`] = `
                   valueKey="value"
                 >
                   <div
-                    className="Select e1qrhqd00 css-7y4fj5-StyledSelect-StyledSelectControl eho28m20 has-value is-clearable is-searchable Select--single"
+                    className="Select e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20 has-value is-clearable is-searchable Select--single"
                   >
                     <input
                       disabled={false}

--- a/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
@@ -233,7 +233,7 @@ exports[`Project Ownership Input renders 1`] = `
                       <ForwardRef(SelectPicker)
                         arrowRenderer={[Function]}
                         backspaceRemoves={false}
-                        className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                        className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                         clearable={false}
                         deleteRemoves={false}
                         disabled={false}
@@ -260,7 +260,7 @@ exports[`Project Ownership Input renders 1`] = `
                         <SelectPicker
                           arrowRenderer={[Function]}
                           backspaceRemoves={false}
-                          className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                          className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                           clearable={false}
                           deleteRemoves={false}
                           disabled={false}
@@ -290,7 +290,7 @@ exports[`Project Ownership Input renders 1`] = `
                             autosize={true}
                             backspaceRemoves={false}
                             backspaceToRemoveMessage="Press backspace to remove {label}"
-                            className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                            className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                             clearAllText="Clear all"
                             clearRenderer={[Function]}
                             clearValueText="Clear value"
@@ -350,7 +350,7 @@ exports[`Project Ownership Input renders 1`] = `
                             valueKey="value"
                           >
                             <div
-                              className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                              className="Select e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                             >
                               <input
                                 disabled={false}
@@ -628,7 +628,7 @@ exports[`Project Ownership Input renders 1`] = `
                         async={true}
                         backspaceRemoves={true}
                         cache={false}
-                        className="css-11afz1b-StyledSelect eho28m20"
+                        className="css-1j7mixw-StyledSelect eho28m20"
                         clearable={true}
                         defaultOptions={true}
                         deleteRemoves={true}
@@ -648,7 +648,7 @@ exports[`Project Ownership Input renders 1`] = `
                           async={true}
                           backspaceRemoves={true}
                           cache={false}
-                          className="css-11afz1b-StyledSelect eho28m20"
+                          className="css-1j7mixw-StyledSelect eho28m20"
                           clearable={true}
                           defaultOptions={true}
                           deleteRemoves={true}
@@ -669,7 +669,7 @@ exports[`Project Ownership Input renders 1`] = `
                             autoload={true}
                             backspaceRemoves={true}
                             cache={false}
-                            className="css-11afz1b-StyledSelect eho28m20"
+                            className="css-1j7mixw-StyledSelect eho28m20"
                             clearable={true}
                             defaultOptions={true}
                             deleteRemoves={true}
@@ -696,7 +696,7 @@ exports[`Project Ownership Input renders 1`] = `
                               backspaceRemoves={true}
                               backspaceToRemoveMessage="Press backspace to remove {label}"
                               cache={false}
-                              className="css-11afz1b-StyledSelect eho28m20"
+                              className="css-1j7mixw-StyledSelect eho28m20"
                               clearAllText="Clear all"
                               clearRenderer={[Function]}
                               clearValueText="Clear value"
@@ -748,7 +748,7 @@ exports[`Project Ownership Input renders 1`] = `
                               valueKey="value"
                             >
                               <div
-                                className="Select css-11afz1b-StyledSelect eho28m20 is-clearable is-loading is-searchable Select--multi"
+                                className="Select css-1j7mixw-StyledSelect eho28m20 is-clearable is-loading is-searchable Select--multi"
                               >
                                 <div
                                   className="Select-control"

--- a/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
@@ -233,7 +233,7 @@ exports[`Project Ownership Input renders 1`] = `
                       <ForwardRef(SelectPicker)
                         arrowRenderer={[Function]}
                         backspaceRemoves={false}
-                        className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                        className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                         clearable={false}
                         deleteRemoves={false}
                         disabled={false}
@@ -260,7 +260,7 @@ exports[`Project Ownership Input renders 1`] = `
                         <SelectPicker
                           arrowRenderer={[Function]}
                           backspaceRemoves={false}
-                          className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                          className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                           clearable={false}
                           deleteRemoves={false}
                           disabled={false}
@@ -290,7 +290,7 @@ exports[`Project Ownership Input renders 1`] = `
                             autosize={true}
                             backspaceRemoves={false}
                             backspaceToRemoveMessage="Press backspace to remove {label}"
-                            className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                            className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                             clearAllText="Clear all"
                             clearRenderer={[Function]}
                             clearValueText="Clear value"
@@ -350,7 +350,7 @@ exports[`Project Ownership Input renders 1`] = `
                             valueKey="value"
                           >
                             <div
-                              className="Select e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                              className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                             >
                               <input
                                 disabled={false}
@@ -628,7 +628,7 @@ exports[`Project Ownership Input renders 1`] = `
                         async={true}
                         backspaceRemoves={true}
                         cache={false}
-                        className="css-dovswj-StyledSelect eho28m20"
+                        className="css-11afz1b-StyledSelect eho28m20"
                         clearable={true}
                         defaultOptions={true}
                         deleteRemoves={true}
@@ -648,7 +648,7 @@ exports[`Project Ownership Input renders 1`] = `
                           async={true}
                           backspaceRemoves={true}
                           cache={false}
-                          className="css-dovswj-StyledSelect eho28m20"
+                          className="css-11afz1b-StyledSelect eho28m20"
                           clearable={true}
                           defaultOptions={true}
                           deleteRemoves={true}
@@ -669,7 +669,7 @@ exports[`Project Ownership Input renders 1`] = `
                             autoload={true}
                             backspaceRemoves={true}
                             cache={false}
-                            className="css-dovswj-StyledSelect eho28m20"
+                            className="css-11afz1b-StyledSelect eho28m20"
                             clearable={true}
                             defaultOptions={true}
                             deleteRemoves={true}
@@ -696,7 +696,7 @@ exports[`Project Ownership Input renders 1`] = `
                               backspaceRemoves={true}
                               backspaceToRemoveMessage="Press backspace to remove {label}"
                               cache={false}
-                              className="css-dovswj-StyledSelect eho28m20"
+                              className="css-11afz1b-StyledSelect eho28m20"
                               clearAllText="Clear all"
                               clearRenderer={[Function]}
                               clearValueText="Clear value"
@@ -748,7 +748,7 @@ exports[`Project Ownership Input renders 1`] = `
                               valueKey="value"
                             >
                               <div
-                                className="Select css-dovswj-StyledSelect eho28m20 is-clearable is-loading is-searchable Select--multi"
+                                className="Select css-11afz1b-StyledSelect eho28m20 is-clearable is-loading is-searchable Select--multi"
                               >
                                 <div
                                   className="Select-control"

--- a/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
@@ -403,7 +403,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                     <ForwardRef(SelectPicker)
                                       arrowRenderer={[Function]}
                                       backspaceRemoves={false}
-                                      className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                      className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                       clearable={false}
                                       deleteRemoves={false}
                                       disabled={false}
@@ -434,7 +434,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                       <SelectPicker
                                         arrowRenderer={[Function]}
                                         backspaceRemoves={false}
-                                        className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                        className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                         clearable={false}
                                         deleteRemoves={false}
                                         disabled={false}
@@ -468,7 +468,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                           autosize={true}
                                           backspaceRemoves={false}
                                           backspaceToRemoveMessage="Press backspace to remove {label}"
-                                          className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                          className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                           clearAllText="Clear all"
                                           clearRenderer={[Function]}
                                           clearValueText="Clear value"
@@ -532,7 +532,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                           valueKey="value"
                                         >
                                           <div
-                                            className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
+                                            className="Select e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
                                           >
                                             <div
                                               className="Select-control"
@@ -848,7 +848,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                               <ForwardRef(SelectPicker)
                                 arrowRenderer={[Function]}
                                 backspaceRemoves={false}
-                                className="css-6lbkok-StyledSelect eho28m20"
+                                className="css-1hiu7rq-StyledSelect eho28m20"
                                 clearable={false}
                                 deleteRemoves={false}
                                 height={36}
@@ -871,7 +871,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                 <SelectPicker
                                   arrowRenderer={[Function]}
                                   backspaceRemoves={false}
-                                  className="css-6lbkok-StyledSelect eho28m20"
+                                  className="css-1hiu7rq-StyledSelect eho28m20"
                                   clearable={false}
                                   deleteRemoves={false}
                                   forwardedRef={null}
@@ -897,7 +897,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                     autosize={true}
                                     backspaceRemoves={false}
                                     backspaceToRemoveMessage="Press backspace to remove {label}"
-                                    className="css-6lbkok-StyledSelect eho28m20"
+                                    className="css-1hiu7rq-StyledSelect eho28m20"
                                     clearAllText="Clear all"
                                     clearRenderer={[Function]}
                                     clearValueText="Clear value"
@@ -955,7 +955,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                     valueKey="value"
                                   >
                                     <div
-                                      className="Select css-6lbkok-StyledSelect eho28m20 is-searchable Select--single"
+                                      className="Select css-1hiu7rq-StyledSelect eho28m20 is-searchable Select--single"
                                     >
                                       <div
                                         className="Select-control"
@@ -1194,7 +1194,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                 <ForwardRef(SelectPicker)
                                   arrowRenderer={[Function]}
                                   backspaceRemoves={false}
-                                  className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                  className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                   clearable={false}
                                   deleteRemoves={false}
                                   disabled={false}
@@ -1225,7 +1225,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                   <SelectPicker
                                     arrowRenderer={[Function]}
                                     backspaceRemoves={false}
-                                    className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                    className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                     clearable={false}
                                     deleteRemoves={false}
                                     disabled={false}
@@ -1259,7 +1259,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                       autosize={true}
                                       backspaceRemoves={false}
                                       backspaceToRemoveMessage="Press backspace to remove {label}"
-                                      className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                      className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                       clearAllText="Clear all"
                                       clearRenderer={[Function]}
                                       clearValueText="Clear value"
@@ -1323,7 +1323,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                       valueKey="value"
                                     >
                                       <div
-                                        className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                                        className="Select e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                       >
                                         <input
                                           disabled={false}
@@ -1665,7 +1665,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                               <ForwardRef(SelectPicker)
                                 arrowRenderer={[Function]}
                                 backspaceRemoves={false}
-                                className="css-6lbkok-StyledSelect eho28m20"
+                                className="css-1hiu7rq-StyledSelect eho28m20"
                                 clearable={false}
                                 deleteRemoves={false}
                                 height={36}
@@ -1688,7 +1688,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                 <SelectPicker
                                   arrowRenderer={[Function]}
                                   backspaceRemoves={false}
-                                  className="css-6lbkok-StyledSelect eho28m20"
+                                  className="css-1hiu7rq-StyledSelect eho28m20"
                                   clearable={false}
                                   deleteRemoves={false}
                                   forwardedRef={null}
@@ -1714,7 +1714,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                     autosize={true}
                                     backspaceRemoves={false}
                                     backspaceToRemoveMessage="Press backspace to remove {label}"
-                                    className="css-6lbkok-StyledSelect eho28m20"
+                                    className="css-1hiu7rq-StyledSelect eho28m20"
                                     clearAllText="Clear all"
                                     clearRenderer={[Function]}
                                     clearValueText="Clear value"
@@ -1772,7 +1772,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                     valueKey="value"
                                   >
                                     <div
-                                      className="Select css-6lbkok-StyledSelect eho28m20 is-searchable Select--single"
+                                      className="Select css-1hiu7rq-StyledSelect eho28m20 is-searchable Select--single"
                                     >
                                       <div
                                         className="Select-control"
@@ -2110,7 +2110,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                     <ForwardRef(SelectPicker)
                                       arrowRenderer={[Function]}
                                       backspaceRemoves={false}
-                                      className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                      className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                       clearable={false}
                                       deleteRemoves={false}
                                       disabled={false}
@@ -2165,7 +2165,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                       <SelectPicker
                                         arrowRenderer={[Function]}
                                         backspaceRemoves={false}
-                                        className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                        className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                         clearable={false}
                                         deleteRemoves={false}
                                         disabled={false}
@@ -2223,7 +2223,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                           autosize={true}
                                           backspaceRemoves={false}
                                           backspaceToRemoveMessage="Press backspace to remove {label}"
-                                          className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                          className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                           clearAllText="Clear all"
                                           clearRenderer={[Function]}
                                           clearValueText="Clear value"
@@ -2311,7 +2311,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                           valueKey="value"
                                         >
                                           <div
-                                            className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
+                                            className="Select e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
                                           >
                                             <div
                                               className="Select-control"
@@ -2935,7 +2935,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                     <ForwardRef(SelectPicker)
                                       arrowRenderer={[Function]}
                                       backspaceRemoves={false}
-                                      className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                      className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                       clearable={false}
                                       deleteRemoves={false}
                                       disabled={false}
@@ -2966,7 +2966,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                       <SelectPicker
                                         arrowRenderer={[Function]}
                                         backspaceRemoves={false}
-                                        className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                        className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                         clearable={false}
                                         deleteRemoves={false}
                                         disabled={false}
@@ -3000,7 +3000,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                           autosize={true}
                                           backspaceRemoves={false}
                                           backspaceToRemoveMessage="Press backspace to remove {label}"
-                                          className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                          className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                           clearAllText="Clear all"
                                           clearRenderer={[Function]}
                                           clearValueText="Clear value"
@@ -3064,7 +3064,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                           valueKey="value"
                                         >
                                           <div
-                                            className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                                            className="Select e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                           >
                                             <input
                                               disabled={false}
@@ -3261,7 +3261,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                               <ForwardRef(SelectPicker)
                                 arrowRenderer={[Function]}
                                 backspaceRemoves={false}
-                                className="css-6lbkok-StyledSelect eho28m20"
+                                className="css-1hiu7rq-StyledSelect eho28m20"
                                 clearable={false}
                                 deleteRemoves={false}
                                 height={36}
@@ -3284,7 +3284,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                 <SelectPicker
                                   arrowRenderer={[Function]}
                                   backspaceRemoves={false}
-                                  className="css-6lbkok-StyledSelect eho28m20"
+                                  className="css-1hiu7rq-StyledSelect eho28m20"
                                   clearable={false}
                                   deleteRemoves={false}
                                   forwardedRef={null}
@@ -3310,7 +3310,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                     autosize={true}
                                     backspaceRemoves={false}
                                     backspaceToRemoveMessage="Press backspace to remove {label}"
-                                    className="css-6lbkok-StyledSelect eho28m20"
+                                    className="css-1hiu7rq-StyledSelect eho28m20"
                                     clearAllText="Clear all"
                                     clearRenderer={[Function]}
                                     clearValueText="Clear value"
@@ -3368,7 +3368,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                     valueKey="value"
                                   >
                                     <div
-                                      className="Select css-6lbkok-StyledSelect eho28m20 is-searchable Select--single"
+                                      className="Select css-1hiu7rq-StyledSelect eho28m20 is-searchable Select--single"
                                     >
                                       <div
                                         className="Select-control"
@@ -3607,7 +3607,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                 <ForwardRef(SelectPicker)
                                   arrowRenderer={[Function]}
                                   backspaceRemoves={false}
-                                  className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                  className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                   clearable={false}
                                   deleteRemoves={false}
                                   disabled={false}
@@ -3638,7 +3638,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                   <SelectPicker
                                     arrowRenderer={[Function]}
                                     backspaceRemoves={false}
-                                    className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                    className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                     clearable={false}
                                     deleteRemoves={false}
                                     disabled={false}
@@ -3672,7 +3672,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                       autosize={true}
                                       backspaceRemoves={false}
                                       backspaceToRemoveMessage="Press backspace to remove {label}"
-                                      className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                      className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                       clearAllText="Clear all"
                                       clearRenderer={[Function]}
                                       clearValueText="Clear value"
@@ -3736,7 +3736,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                       valueKey="value"
                                     >
                                       <div
-                                        className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                                        className="Select e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                       >
                                         <input
                                           disabled={false}
@@ -3931,7 +3931,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                               <ForwardRef(SelectPicker)
                                 arrowRenderer={[Function]}
                                 backspaceRemoves={false}
-                                className="css-6lbkok-StyledSelect eho28m20"
+                                className="css-1hiu7rq-StyledSelect eho28m20"
                                 clearable={false}
                                 deleteRemoves={false}
                                 height={36}
@@ -3954,7 +3954,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                 <SelectPicker
                                   arrowRenderer={[Function]}
                                   backspaceRemoves={false}
-                                  className="css-6lbkok-StyledSelect eho28m20"
+                                  className="css-1hiu7rq-StyledSelect eho28m20"
                                   clearable={false}
                                   deleteRemoves={false}
                                   forwardedRef={null}
@@ -3980,7 +3980,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                     autosize={true}
                                     backspaceRemoves={false}
                                     backspaceToRemoveMessage="Press backspace to remove {label}"
-                                    className="css-6lbkok-StyledSelect eho28m20"
+                                    className="css-1hiu7rq-StyledSelect eho28m20"
                                     clearAllText="Clear all"
                                     clearRenderer={[Function]}
                                     clearValueText="Clear value"
@@ -4038,7 +4038,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                     valueKey="value"
                                   >
                                     <div
-                                      className="Select css-6lbkok-StyledSelect eho28m20 is-searchable Select--single"
+                                      className="Select css-1hiu7rq-StyledSelect eho28m20 is-searchable Select--single"
                                     >
                                       <div
                                         className="Select-control"
@@ -4377,7 +4377,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                     <ForwardRef(SelectPicker)
                                       arrowRenderer={[Function]}
                                       backspaceRemoves={false}
-                                      className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                      className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                       clearable={false}
                                       deleteRemoves={false}
                                       disabled={false}
@@ -4432,7 +4432,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                       <SelectPicker
                                         arrowRenderer={[Function]}
                                         backspaceRemoves={false}
-                                        className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                        className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                         clearable={false}
                                         deleteRemoves={false}
                                         disabled={false}
@@ -4490,7 +4490,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                           autosize={true}
                                           backspaceRemoves={false}
                                           backspaceToRemoveMessage="Press backspace to remove {label}"
-                                          className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                          className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                           clearAllText="Clear all"
                                           clearRenderer={[Function]}
                                           clearValueText="Clear value"
@@ -4578,7 +4578,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                           valueKey="value"
                                         >
                                           <div
-                                            className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                                            className="Select e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                           >
                                             <input
                                               disabled={false}

--- a/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
@@ -403,7 +403,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                     <ForwardRef(SelectPicker)
                                       arrowRenderer={[Function]}
                                       backspaceRemoves={false}
-                                      className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                      className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                       clearable={false}
                                       deleteRemoves={false}
                                       disabled={false}
@@ -434,7 +434,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                       <SelectPicker
                                         arrowRenderer={[Function]}
                                         backspaceRemoves={false}
-                                        className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                        className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                         clearable={false}
                                         deleteRemoves={false}
                                         disabled={false}
@@ -468,7 +468,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                           autosize={true}
                                           backspaceRemoves={false}
                                           backspaceToRemoveMessage="Press backspace to remove {label}"
-                                          className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                          className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                           clearAllText="Clear all"
                                           clearRenderer={[Function]}
                                           clearValueText="Clear value"
@@ -532,7 +532,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                           valueKey="value"
                                         >
                                           <div
-                                            className="Select e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
+                                            className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
                                           >
                                             <div
                                               className="Select-control"
@@ -848,7 +848,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                               <ForwardRef(SelectPicker)
                                 arrowRenderer={[Function]}
                                 backspaceRemoves={false}
-                                className="css-7ogu3n-StyledSelect eho28m20"
+                                className="css-6lbkok-StyledSelect eho28m20"
                                 clearable={false}
                                 deleteRemoves={false}
                                 height={36}
@@ -871,7 +871,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                 <SelectPicker
                                   arrowRenderer={[Function]}
                                   backspaceRemoves={false}
-                                  className="css-7ogu3n-StyledSelect eho28m20"
+                                  className="css-6lbkok-StyledSelect eho28m20"
                                   clearable={false}
                                   deleteRemoves={false}
                                   forwardedRef={null}
@@ -897,7 +897,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                     autosize={true}
                                     backspaceRemoves={false}
                                     backspaceToRemoveMessage="Press backspace to remove {label}"
-                                    className="css-7ogu3n-StyledSelect eho28m20"
+                                    className="css-6lbkok-StyledSelect eho28m20"
                                     clearAllText="Clear all"
                                     clearRenderer={[Function]}
                                     clearValueText="Clear value"
@@ -955,7 +955,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                     valueKey="value"
                                   >
                                     <div
-                                      className="Select css-7ogu3n-StyledSelect eho28m20 is-searchable Select--single"
+                                      className="Select css-6lbkok-StyledSelect eho28m20 is-searchable Select--single"
                                     >
                                       <div
                                         className="Select-control"
@@ -1194,7 +1194,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                 <ForwardRef(SelectPicker)
                                   arrowRenderer={[Function]}
                                   backspaceRemoves={false}
-                                  className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                  className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                   clearable={false}
                                   deleteRemoves={false}
                                   disabled={false}
@@ -1225,7 +1225,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                   <SelectPicker
                                     arrowRenderer={[Function]}
                                     backspaceRemoves={false}
-                                    className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                    className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                     clearable={false}
                                     deleteRemoves={false}
                                     disabled={false}
@@ -1259,7 +1259,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                       autosize={true}
                                       backspaceRemoves={false}
                                       backspaceToRemoveMessage="Press backspace to remove {label}"
-                                      className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                      className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                       clearAllText="Clear all"
                                       clearRenderer={[Function]}
                                       clearValueText="Clear value"
@@ -1323,7 +1323,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                       valueKey="value"
                                     >
                                       <div
-                                        className="Select e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                                        className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                       >
                                         <input
                                           disabled={false}
@@ -1665,7 +1665,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                               <ForwardRef(SelectPicker)
                                 arrowRenderer={[Function]}
                                 backspaceRemoves={false}
-                                className="css-7ogu3n-StyledSelect eho28m20"
+                                className="css-6lbkok-StyledSelect eho28m20"
                                 clearable={false}
                                 deleteRemoves={false}
                                 height={36}
@@ -1688,7 +1688,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                 <SelectPicker
                                   arrowRenderer={[Function]}
                                   backspaceRemoves={false}
-                                  className="css-7ogu3n-StyledSelect eho28m20"
+                                  className="css-6lbkok-StyledSelect eho28m20"
                                   clearable={false}
                                   deleteRemoves={false}
                                   forwardedRef={null}
@@ -1714,7 +1714,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                     autosize={true}
                                     backspaceRemoves={false}
                                     backspaceToRemoveMessage="Press backspace to remove {label}"
-                                    className="css-7ogu3n-StyledSelect eho28m20"
+                                    className="css-6lbkok-StyledSelect eho28m20"
                                     clearAllText="Clear all"
                                     clearRenderer={[Function]}
                                     clearValueText="Clear value"
@@ -1772,7 +1772,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                     valueKey="value"
                                   >
                                     <div
-                                      className="Select css-7ogu3n-StyledSelect eho28m20 is-searchable Select--single"
+                                      className="Select css-6lbkok-StyledSelect eho28m20 is-searchable Select--single"
                                     >
                                       <div
                                         className="Select-control"
@@ -2110,7 +2110,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                     <ForwardRef(SelectPicker)
                                       arrowRenderer={[Function]}
                                       backspaceRemoves={false}
-                                      className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                      className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                       clearable={false}
                                       deleteRemoves={false}
                                       disabled={false}
@@ -2165,7 +2165,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                       <SelectPicker
                                         arrowRenderer={[Function]}
                                         backspaceRemoves={false}
-                                        className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                        className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                         clearable={false}
                                         deleteRemoves={false}
                                         disabled={false}
@@ -2223,7 +2223,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                           autosize={true}
                                           backspaceRemoves={false}
                                           backspaceToRemoveMessage="Press backspace to remove {label}"
-                                          className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                          className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                           clearAllText="Clear all"
                                           clearRenderer={[Function]}
                                           clearValueText="Clear value"
@@ -2311,7 +2311,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                           valueKey="value"
                                         >
                                           <div
-                                            className="Select e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
+                                            className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
                                           >
                                             <div
                                               className="Select-control"
@@ -2935,7 +2935,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                     <ForwardRef(SelectPicker)
                                       arrowRenderer={[Function]}
                                       backspaceRemoves={false}
-                                      className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                      className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                       clearable={false}
                                       deleteRemoves={false}
                                       disabled={false}
@@ -2966,7 +2966,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                       <SelectPicker
                                         arrowRenderer={[Function]}
                                         backspaceRemoves={false}
-                                        className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                        className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                         clearable={false}
                                         deleteRemoves={false}
                                         disabled={false}
@@ -3000,7 +3000,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                           autosize={true}
                                           backspaceRemoves={false}
                                           backspaceToRemoveMessage="Press backspace to remove {label}"
-                                          className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                          className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                           clearAllText="Clear all"
                                           clearRenderer={[Function]}
                                           clearValueText="Clear value"
@@ -3064,7 +3064,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                           valueKey="value"
                                         >
                                           <div
-                                            className="Select e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                                            className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                           >
                                             <input
                                               disabled={false}
@@ -3261,7 +3261,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                               <ForwardRef(SelectPicker)
                                 arrowRenderer={[Function]}
                                 backspaceRemoves={false}
-                                className="css-7ogu3n-StyledSelect eho28m20"
+                                className="css-6lbkok-StyledSelect eho28m20"
                                 clearable={false}
                                 deleteRemoves={false}
                                 height={36}
@@ -3284,7 +3284,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                 <SelectPicker
                                   arrowRenderer={[Function]}
                                   backspaceRemoves={false}
-                                  className="css-7ogu3n-StyledSelect eho28m20"
+                                  className="css-6lbkok-StyledSelect eho28m20"
                                   clearable={false}
                                   deleteRemoves={false}
                                   forwardedRef={null}
@@ -3310,7 +3310,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                     autosize={true}
                                     backspaceRemoves={false}
                                     backspaceToRemoveMessage="Press backspace to remove {label}"
-                                    className="css-7ogu3n-StyledSelect eho28m20"
+                                    className="css-6lbkok-StyledSelect eho28m20"
                                     clearAllText="Clear all"
                                     clearRenderer={[Function]}
                                     clearValueText="Clear value"
@@ -3368,7 +3368,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                     valueKey="value"
                                   >
                                     <div
-                                      className="Select css-7ogu3n-StyledSelect eho28m20 is-searchable Select--single"
+                                      className="Select css-6lbkok-StyledSelect eho28m20 is-searchable Select--single"
                                     >
                                       <div
                                         className="Select-control"
@@ -3607,7 +3607,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                 <ForwardRef(SelectPicker)
                                   arrowRenderer={[Function]}
                                   backspaceRemoves={false}
-                                  className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                  className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                   clearable={false}
                                   deleteRemoves={false}
                                   disabled={false}
@@ -3638,7 +3638,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                   <SelectPicker
                                     arrowRenderer={[Function]}
                                     backspaceRemoves={false}
-                                    className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                    className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                     clearable={false}
                                     deleteRemoves={false}
                                     disabled={false}
@@ -3672,7 +3672,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                       autosize={true}
                                       backspaceRemoves={false}
                                       backspaceToRemoveMessage="Press backspace to remove {label}"
-                                      className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                      className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                       clearAllText="Clear all"
                                       clearRenderer={[Function]}
                                       clearValueText="Clear value"
@@ -3736,7 +3736,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                       valueKey="value"
                                     >
                                       <div
-                                        className="Select e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                                        className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                       >
                                         <input
                                           disabled={false}
@@ -3931,7 +3931,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                               <ForwardRef(SelectPicker)
                                 arrowRenderer={[Function]}
                                 backspaceRemoves={false}
-                                className="css-7ogu3n-StyledSelect eho28m20"
+                                className="css-6lbkok-StyledSelect eho28m20"
                                 clearable={false}
                                 deleteRemoves={false}
                                 height={36}
@@ -3954,7 +3954,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                 <SelectPicker
                                   arrowRenderer={[Function]}
                                   backspaceRemoves={false}
-                                  className="css-7ogu3n-StyledSelect eho28m20"
+                                  className="css-6lbkok-StyledSelect eho28m20"
                                   clearable={false}
                                   deleteRemoves={false}
                                   forwardedRef={null}
@@ -3980,7 +3980,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                     autosize={true}
                                     backspaceRemoves={false}
                                     backspaceToRemoveMessage="Press backspace to remove {label}"
-                                    className="css-7ogu3n-StyledSelect eho28m20"
+                                    className="css-6lbkok-StyledSelect eho28m20"
                                     clearAllText="Clear all"
                                     clearRenderer={[Function]}
                                     clearValueText="Clear value"
@@ -4038,7 +4038,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                     valueKey="value"
                                   >
                                     <div
-                                      className="Select css-7ogu3n-StyledSelect eho28m20 is-searchable Select--single"
+                                      className="Select css-6lbkok-StyledSelect eho28m20 is-searchable Select--single"
                                     >
                                       <div
                                         className="Select-control"
@@ -4377,7 +4377,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                     <ForwardRef(SelectPicker)
                                       arrowRenderer={[Function]}
                                       backspaceRemoves={false}
-                                      className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                      className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                       clearable={false}
                                       deleteRemoves={false}
                                       disabled={false}
@@ -4432,7 +4432,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                       <SelectPicker
                                         arrowRenderer={[Function]}
                                         backspaceRemoves={false}
-                                        className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                        className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                         clearable={false}
                                         deleteRemoves={false}
                                         disabled={false}
@@ -4490,7 +4490,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                           autosize={true}
                                           backspaceRemoves={false}
                                           backspaceToRemoveMessage="Press backspace to remove {label}"
-                                          className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                          className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                           clearAllText="Clear all"
                                           clearRenderer={[Function]}
                                           clearValueText="Clear value"
@@ -4578,7 +4578,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                           valueKey="value"
                                         >
                                           <div
-                                            className="Select e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                                            className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                           >
                                             <input
                                               disabled={false}

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -208,7 +208,7 @@ exports[`RuleBuilder renders 1`] = `
                     <ForwardRef(SelectPicker)
                       arrowRenderer={[Function]}
                       backspaceRemoves={false}
-                      className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                      className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                       clearable={false}
                       deleteRemoves={false}
                       disabled={false}
@@ -235,7 +235,7 @@ exports[`RuleBuilder renders 1`] = `
                       <SelectPicker
                         arrowRenderer={[Function]}
                         backspaceRemoves={false}
-                        className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                        className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                         clearable={false}
                         deleteRemoves={false}
                         disabled={false}
@@ -265,7 +265,7 @@ exports[`RuleBuilder renders 1`] = `
                           autosize={true}
                           backspaceRemoves={false}
                           backspaceToRemoveMessage="Press backspace to remove {label}"
-                          className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                          className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                           clearAllText="Clear all"
                           clearRenderer={[Function]}
                           clearValueText="Clear value"
@@ -325,7 +325,7 @@ exports[`RuleBuilder renders 1`] = `
                           valueKey="value"
                         >
                           <div
-                            className="Select e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                            className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                           >
                             <input
                               disabled={false}
@@ -611,7 +611,7 @@ exports[`RuleBuilder renders 1`] = `
                       async={true}
                       backspaceRemoves={true}
                       cache={false}
-                      className="css-dovswj-StyledSelect eho28m20"
+                      className="css-11afz1b-StyledSelect eho28m20"
                       clearable={true}
                       defaultOptions={true}
                       deleteRemoves={true}
@@ -631,7 +631,7 @@ exports[`RuleBuilder renders 1`] = `
                         async={true}
                         backspaceRemoves={true}
                         cache={false}
-                        className="css-dovswj-StyledSelect eho28m20"
+                        className="css-11afz1b-StyledSelect eho28m20"
                         clearable={true}
                         defaultOptions={true}
                         deleteRemoves={true}
@@ -652,7 +652,7 @@ exports[`RuleBuilder renders 1`] = `
                           autoload={true}
                           backspaceRemoves={true}
                           cache={false}
-                          className="css-dovswj-StyledSelect eho28m20"
+                          className="css-11afz1b-StyledSelect eho28m20"
                           clearable={true}
                           defaultOptions={true}
                           deleteRemoves={true}
@@ -679,7 +679,7 @@ exports[`RuleBuilder renders 1`] = `
                             backspaceRemoves={true}
                             backspaceToRemoveMessage="Press backspace to remove {label}"
                             cache={false}
-                            className="css-dovswj-StyledSelect eho28m20"
+                            className="css-11afz1b-StyledSelect eho28m20"
                             clearAllText="Clear all"
                             clearRenderer={[Function]}
                             clearValueText="Clear value"
@@ -874,7 +874,7 @@ exports[`RuleBuilder renders 1`] = `
                             valueKey="value"
                           >
                             <div
-                              className="Select css-dovswj-StyledSelect eho28m20 is-clearable is-searchable Select--multi"
+                              className="Select css-11afz1b-StyledSelect eho28m20 is-clearable is-searchable Select--multi"
                             >
                               <div
                                 className="Select-control"
@@ -1502,7 +1502,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                     <ForwardRef(SelectPicker)
                       arrowRenderer={[Function]}
                       backspaceRemoves={false}
-                      className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                      className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                       clearable={false}
                       deleteRemoves={false}
                       disabled={false}
@@ -1529,7 +1529,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                       <SelectPicker
                         arrowRenderer={[Function]}
                         backspaceRemoves={false}
-                        className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                        className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                         clearable={false}
                         deleteRemoves={false}
                         disabled={false}
@@ -1559,7 +1559,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                           autosize={true}
                           backspaceRemoves={false}
                           backspaceToRemoveMessage="Press backspace to remove {label}"
-                          className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                          className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                           clearAllText="Clear all"
                           clearRenderer={[Function]}
                           clearValueText="Clear value"
@@ -1619,7 +1619,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                           valueKey="value"
                         >
                           <div
-                            className="Select e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                            className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                           >
                             <input
                               disabled={false}
@@ -2057,7 +2057,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                       async={true}
                       backspaceRemoves={true}
                       cache={false}
-                      className="css-dovswj-StyledSelect eho28m20"
+                      className="css-11afz1b-StyledSelect eho28m20"
                       clearable={true}
                       defaultOptions={true}
                       deleteRemoves={true}
@@ -2115,7 +2115,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                         async={true}
                         backspaceRemoves={true}
                         cache={false}
-                        className="css-dovswj-StyledSelect eho28m20"
+                        className="css-11afz1b-StyledSelect eho28m20"
                         clearable={true}
                         defaultOptions={true}
                         deleteRemoves={true}
@@ -2174,7 +2174,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                           autoload={true}
                           backspaceRemoves={true}
                           cache={false}
-                          className="css-dovswj-StyledSelect eho28m20"
+                          className="css-11afz1b-StyledSelect eho28m20"
                           clearable={true}
                           defaultOptions={true}
                           deleteRemoves={true}
@@ -2239,7 +2239,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                             backspaceRemoves={true}
                             backspaceToRemoveMessage="Press backspace to remove {label}"
                             cache={false}
-                            className="css-dovswj-StyledSelect eho28m20"
+                            className="css-11afz1b-StyledSelect eho28m20"
                             clearAllText="Clear all"
                             clearRenderer={[Function]}
                             clearValueText="Clear value"
@@ -2472,7 +2472,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                             valueKey="value"
                           >
                             <div
-                              className="Select css-dovswj-StyledSelect eho28m20 has-value is-clearable is-focused is-searchable Select--multi"
+                              className="Select css-11afz1b-StyledSelect eho28m20 has-value is-clearable is-focused is-searchable Select--multi"
                             >
                               <div
                                 className="Select-control"

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -208,7 +208,7 @@ exports[`RuleBuilder renders 1`] = `
                     <ForwardRef(SelectPicker)
                       arrowRenderer={[Function]}
                       backspaceRemoves={false}
-                      className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                      className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                       clearable={false}
                       deleteRemoves={false}
                       disabled={false}
@@ -235,7 +235,7 @@ exports[`RuleBuilder renders 1`] = `
                       <SelectPicker
                         arrowRenderer={[Function]}
                         backspaceRemoves={false}
-                        className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                        className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                         clearable={false}
                         deleteRemoves={false}
                         disabled={false}
@@ -265,7 +265,7 @@ exports[`RuleBuilder renders 1`] = `
                           autosize={true}
                           backspaceRemoves={false}
                           backspaceToRemoveMessage="Press backspace to remove {label}"
-                          className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                          className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                           clearAllText="Clear all"
                           clearRenderer={[Function]}
                           clearValueText="Clear value"
@@ -325,7 +325,7 @@ exports[`RuleBuilder renders 1`] = `
                           valueKey="value"
                         >
                           <div
-                            className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                            className="Select e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                           >
                             <input
                               disabled={false}
@@ -611,7 +611,7 @@ exports[`RuleBuilder renders 1`] = `
                       async={true}
                       backspaceRemoves={true}
                       cache={false}
-                      className="css-11afz1b-StyledSelect eho28m20"
+                      className="css-1j7mixw-StyledSelect eho28m20"
                       clearable={true}
                       defaultOptions={true}
                       deleteRemoves={true}
@@ -631,7 +631,7 @@ exports[`RuleBuilder renders 1`] = `
                         async={true}
                         backspaceRemoves={true}
                         cache={false}
-                        className="css-11afz1b-StyledSelect eho28m20"
+                        className="css-1j7mixw-StyledSelect eho28m20"
                         clearable={true}
                         defaultOptions={true}
                         deleteRemoves={true}
@@ -652,7 +652,7 @@ exports[`RuleBuilder renders 1`] = `
                           autoload={true}
                           backspaceRemoves={true}
                           cache={false}
-                          className="css-11afz1b-StyledSelect eho28m20"
+                          className="css-1j7mixw-StyledSelect eho28m20"
                           clearable={true}
                           defaultOptions={true}
                           deleteRemoves={true}
@@ -679,7 +679,7 @@ exports[`RuleBuilder renders 1`] = `
                             backspaceRemoves={true}
                             backspaceToRemoveMessage="Press backspace to remove {label}"
                             cache={false}
-                            className="css-11afz1b-StyledSelect eho28m20"
+                            className="css-1j7mixw-StyledSelect eho28m20"
                             clearAllText="Clear all"
                             clearRenderer={[Function]}
                             clearValueText="Clear value"
@@ -874,7 +874,7 @@ exports[`RuleBuilder renders 1`] = `
                             valueKey="value"
                           >
                             <div
-                              className="Select css-11afz1b-StyledSelect eho28m20 is-clearable is-searchable Select--multi"
+                              className="Select css-1j7mixw-StyledSelect eho28m20 is-clearable is-searchable Select--multi"
                             >
                               <div
                                 className="Select-control"
@@ -1502,7 +1502,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                     <ForwardRef(SelectPicker)
                       arrowRenderer={[Function]}
                       backspaceRemoves={false}
-                      className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                      className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                       clearable={false}
                       deleteRemoves={false}
                       disabled={false}
@@ -1529,7 +1529,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                       <SelectPicker
                         arrowRenderer={[Function]}
                         backspaceRemoves={false}
-                        className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                        className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                         clearable={false}
                         deleteRemoves={false}
                         disabled={false}
@@ -1559,7 +1559,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                           autosize={true}
                           backspaceRemoves={false}
                           backspaceToRemoveMessage="Press backspace to remove {label}"
-                          className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                          className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                           clearAllText="Clear all"
                           clearRenderer={[Function]}
                           clearValueText="Clear value"
@@ -1619,7 +1619,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                           valueKey="value"
                         >
                           <div
-                            className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                            className="Select e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                           >
                             <input
                               disabled={false}
@@ -2057,7 +2057,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                       async={true}
                       backspaceRemoves={true}
                       cache={false}
-                      className="css-11afz1b-StyledSelect eho28m20"
+                      className="css-1j7mixw-StyledSelect eho28m20"
                       clearable={true}
                       defaultOptions={true}
                       deleteRemoves={true}
@@ -2115,7 +2115,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                         async={true}
                         backspaceRemoves={true}
                         cache={false}
-                        className="css-11afz1b-StyledSelect eho28m20"
+                        className="css-1j7mixw-StyledSelect eho28m20"
                         clearable={true}
                         defaultOptions={true}
                         deleteRemoves={true}
@@ -2174,7 +2174,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                           autoload={true}
                           backspaceRemoves={true}
                           cache={false}
-                          className="css-11afz1b-StyledSelect eho28m20"
+                          className="css-1j7mixw-StyledSelect eho28m20"
                           clearable={true}
                           defaultOptions={true}
                           deleteRemoves={true}
@@ -2239,7 +2239,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                             backspaceRemoves={true}
                             backspaceToRemoveMessage="Press backspace to remove {label}"
                             cache={false}
-                            className="css-11afz1b-StyledSelect eho28m20"
+                            className="css-1j7mixw-StyledSelect eho28m20"
                             clearAllText="Clear all"
                             clearRenderer={[Function]}
                             clearValueText="Clear value"
@@ -2472,7 +2472,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                             valueKey="value"
                           >
                             <div
-                              className="Select css-11afz1b-StyledSelect eho28m20 has-value is-clearable is-focused is-searchable Select--multi"
+                              className="Select css-1j7mixw-StyledSelect eho28m20 has-value is-clearable is-focused is-searchable Select--multi"
                             >
                               <div
                                 className="Select-control"

--- a/tests/js/spec/views/onboarding/__snapshots__/createProject.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/__snapshots__/createProject.spec.jsx.snap
@@ -904,7 +904,7 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                           <ForwardRef(SelectPicker)
                             arrowRenderer={[Function]}
                             backspaceRemoves={false}
-                            className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                            className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                             clearable={false}
                             deleteRemoves={false}
                             disabled={false}
@@ -927,7 +927,7 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                             <SelectPicker
                               arrowRenderer={[Function]}
                               backspaceRemoves={false}
-                              className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                              className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                               clearable={false}
                               deleteRemoves={false}
                               disabled={false}
@@ -953,7 +953,7 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                                 autosize={true}
                                 backspaceRemoves={false}
                                 backspaceToRemoveMessage="Press backspace to remove {label}"
-                                className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                 clearAllText="Clear all"
                                 clearRenderer={[Function]}
                                 clearValueText="Clear value"
@@ -1009,7 +1009,7 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                                 valueKey="value"
                               >
                                 <div
-                                  className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                                  className="Select e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                 >
                                   <input
                                     disabled={false}
@@ -1641,7 +1641,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                           <ForwardRef(SelectPicker)
                             arrowRenderer={[Function]}
                             backspaceRemoves={false}
-                            className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                            className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                             clearable={false}
                             deleteRemoves={false}
                             disabled={false}
@@ -1664,7 +1664,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                             <SelectPicker
                               arrowRenderer={[Function]}
                               backspaceRemoves={false}
-                              className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                              className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                               clearable={false}
                               deleteRemoves={false}
                               disabled={false}
@@ -1690,7 +1690,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                                 autosize={true}
                                 backspaceRemoves={false}
                                 backspaceToRemoveMessage="Press backspace to remove {label}"
-                                className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                 clearAllText="Clear all"
                                 clearRenderer={[Function]}
                                 clearValueText="Clear value"
@@ -1746,7 +1746,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                                 valueKey="value"
                               >
                                 <div
-                                  className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                                  className="Select e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                 >
                                   <input
                                     disabled={false}
@@ -2768,7 +2768,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
                           <ForwardRef(SelectPicker)
                             arrowRenderer={[Function]}
                             backspaceRemoves={false}
-                            className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                            className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                             clearable={false}
                             deleteRemoves={false}
                             disabled={false}
@@ -2791,7 +2791,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
                             <SelectPicker
                               arrowRenderer={[Function]}
                               backspaceRemoves={false}
-                              className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                              className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                               clearable={false}
                               deleteRemoves={false}
                               disabled={false}
@@ -2817,7 +2817,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
                                 autosize={true}
                                 backspaceRemoves={false}
                                 backspaceToRemoveMessage="Press backspace to remove {label}"
-                                className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                className="e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20"
                                 clearAllText="Clear all"
                                 clearRenderer={[Function]}
                                 clearValueText="Clear value"
@@ -2873,7 +2873,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
                                 valueKey="value"
                               >
                                 <div
-                                  className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                                  className="Select e1qrhqd00 css-douamq-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                 >
                                   <input
                                     disabled={false}

--- a/tests/js/spec/views/onboarding/__snapshots__/createProject.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/__snapshots__/createProject.spec.jsx.snap
@@ -904,7 +904,7 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                           <ForwardRef(SelectPicker)
                             arrowRenderer={[Function]}
                             backspaceRemoves={false}
-                            className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                            className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                             clearable={false}
                             deleteRemoves={false}
                             disabled={false}
@@ -927,7 +927,7 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                             <SelectPicker
                               arrowRenderer={[Function]}
                               backspaceRemoves={false}
-                              className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                              className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                               clearable={false}
                               deleteRemoves={false}
                               disabled={false}
@@ -953,7 +953,7 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                                 autosize={true}
                                 backspaceRemoves={false}
                                 backspaceToRemoveMessage="Press backspace to remove {label}"
-                                className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                 clearAllText="Clear all"
                                 clearRenderer={[Function]}
                                 clearValueText="Clear value"
@@ -1009,7 +1009,7 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                                 valueKey="value"
                               >
                                 <div
-                                  className="Select e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                                  className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                 >
                                   <input
                                     disabled={false}
@@ -1641,7 +1641,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                           <ForwardRef(SelectPicker)
                             arrowRenderer={[Function]}
                             backspaceRemoves={false}
-                            className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                            className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                             clearable={false}
                             deleteRemoves={false}
                             disabled={false}
@@ -1664,7 +1664,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                             <SelectPicker
                               arrowRenderer={[Function]}
                               backspaceRemoves={false}
-                              className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                              className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                               clearable={false}
                               deleteRemoves={false}
                               disabled={false}
@@ -1690,7 +1690,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                                 autosize={true}
                                 backspaceRemoves={false}
                                 backspaceToRemoveMessage="Press backspace to remove {label}"
-                                className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                 clearAllText="Clear all"
                                 clearRenderer={[Function]}
                                 clearValueText="Clear value"
@@ -1746,7 +1746,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                                 valueKey="value"
                               >
                                 <div
-                                  className="Select e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                                  className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                 >
                                   <input
                                     disabled={false}
@@ -2768,7 +2768,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
                           <ForwardRef(SelectPicker)
                             arrowRenderer={[Function]}
                             backspaceRemoves={false}
-                            className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                            className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                             clearable={false}
                             deleteRemoves={false}
                             disabled={false}
@@ -2791,7 +2791,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
                             <SelectPicker
                               arrowRenderer={[Function]}
                               backspaceRemoves={false}
-                              className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                              className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                               clearable={false}
                               deleteRemoves={false}
                               disabled={false}
@@ -2817,7 +2817,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
                                 autosize={true}
                                 backspaceRemoves={false}
                                 backspaceToRemoveMessage="Press backspace to remove {label}"
-                                className="e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20"
+                                className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                                 clearAllText="Clear all"
                                 clearRenderer={[Function]}
                                 clearValueText="Clear value"
@@ -2873,7 +2873,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
                                 valueKey="value"
                               >
                                 <div
-                                  className="Select e1qrhqd00 css-17e2btp-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                                  className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                 >
                                   <input
                                     disabled={false}

--- a/tests/js/spec/views/onboarding/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/__snapshots__/index.spec.jsx.snap
@@ -931,7 +931,7 @@ exports[`OnboardingWizard render() should render and respond to click events 1`]
                               <ForwardRef(SelectPicker)
                                 arrowRenderer={[Function]}
                                 backspaceRemoves={false}
-                                className="e1qrhqd00 css-7y4fj5-StyledSelect-StyledSelectControl eho28m20"
+                                className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
                                 clearable={false}
                                 deleteRemoves={false}
                                 disabled={false}
@@ -947,7 +947,7 @@ exports[`OnboardingWizard render() should render and respond to click events 1`]
                                 <SelectPicker
                                   arrowRenderer={[Function]}
                                   backspaceRemoves={false}
-                                  className="e1qrhqd00 css-7y4fj5-StyledSelect-StyledSelectControl eho28m20"
+                                  className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
                                   clearable={false}
                                   deleteRemoves={false}
                                   disabled={false}
@@ -966,7 +966,7 @@ exports[`OnboardingWizard render() should render and respond to click events 1`]
                                     autosize={true}
                                     backspaceRemoves={false}
                                     backspaceToRemoveMessage="Press backspace to remove {label}"
-                                    className="e1qrhqd00 css-7y4fj5-StyledSelect-StyledSelectControl eho28m20"
+                                    className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
                                     clearAllText="Clear all"
                                     clearRenderer={[Function]}
                                     clearValueText="Clear value"
@@ -1015,7 +1015,7 @@ exports[`OnboardingWizard render() should render and respond to click events 1`]
                                     valueKey="value"
                                   >
                                     <div
-                                      className="Select e1qrhqd00 css-7y4fj5-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
+                                      className="Select e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
                                     >
                                       <div
                                         className="Select-control"
@@ -2071,7 +2071,7 @@ exports[`OnboardingWizard render() should render and respond to click events 2`]
                               <ForwardRef(SelectPicker)
                                 arrowRenderer={[Function]}
                                 backspaceRemoves={false}
-                                className="e1qrhqd00 css-7y4fj5-StyledSelect-StyledSelectControl eho28m20"
+                                className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
                                 clearable={false}
                                 deleteRemoves={false}
                                 disabled={false}
@@ -2087,7 +2087,7 @@ exports[`OnboardingWizard render() should render and respond to click events 2`]
                                 <SelectPicker
                                   arrowRenderer={[Function]}
                                   backspaceRemoves={false}
-                                  className="e1qrhqd00 css-7y4fj5-StyledSelect-StyledSelectControl eho28m20"
+                                  className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
                                   clearable={false}
                                   deleteRemoves={false}
                                   disabled={false}
@@ -2106,7 +2106,7 @@ exports[`OnboardingWizard render() should render and respond to click events 2`]
                                     autosize={true}
                                     backspaceRemoves={false}
                                     backspaceToRemoveMessage="Press backspace to remove {label}"
-                                    className="e1qrhqd00 css-7y4fj5-StyledSelect-StyledSelectControl eho28m20"
+                                    className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
                                     clearAllText="Clear all"
                                     clearRenderer={[Function]}
                                     clearValueText="Clear value"
@@ -2155,7 +2155,7 @@ exports[`OnboardingWizard render() should render and respond to click events 2`]
                                     valueKey="value"
                                   >
                                     <div
-                                      className="Select e1qrhqd00 css-7y4fj5-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
+                                      className="Select e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
                                     >
                                       <div
                                         className="Select-control"

--- a/tests/js/spec/views/onboarding/project/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/project/__snapshots__/index.spec.jsx.snap
@@ -957,7 +957,7 @@ exports[`Project render() should set required class on empty submit 1`] = `
                       <ForwardRef(SelectPicker)
                         arrowRenderer={[Function]}
                         backspaceRemoves={false}
-                        className="e1qrhqd00 css-7y4fj5-StyledSelect-StyledSelectControl eho28m20"
+                        className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
                         clearable={false}
                         deleteRemoves={false}
                         disabled={false}
@@ -973,7 +973,7 @@ exports[`Project render() should set required class on empty submit 1`] = `
                         <SelectPicker
                           arrowRenderer={[Function]}
                           backspaceRemoves={false}
-                          className="e1qrhqd00 css-7y4fj5-StyledSelect-StyledSelectControl eho28m20"
+                          className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
                           clearable={false}
                           deleteRemoves={false}
                           disabled={false}
@@ -992,7 +992,7 @@ exports[`Project render() should set required class on empty submit 1`] = `
                             autosize={true}
                             backspaceRemoves={false}
                             backspaceToRemoveMessage="Press backspace to remove {label}"
-                            className="e1qrhqd00 css-7y4fj5-StyledSelect-StyledSelectControl eho28m20"
+                            className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
                             clearAllText="Clear all"
                             clearRenderer={[Function]}
                             clearValueText="Clear value"
@@ -1041,7 +1041,7 @@ exports[`Project render() should set required class on empty submit 1`] = `
                             valueKey="value"
                           >
                             <div
-                              className="Select e1qrhqd00 css-7y4fj5-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
+                              className="Select e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
                             >
                               <div
                                 className="Select-control"


### PR DESCRIPTION
Make select boxes match their cousins when disabled.

![screen shot 2018-12-04 at 3 16 31 pm](https://user-images.githubusercontent.com/24086/49470697-c252c100-f7d8-11e8-99d1-e26a030011c7.png)
