### PR TITLE
fix(integrations) Remove jira_url as we don't use it.

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -3,8 +3,6 @@ from __future__ import absolute_import
 import logging
 import six
 
-from six.moves.urllib.parse import quote_plus
-
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 
@@ -350,10 +348,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         elif field_meta.get('autoCompleteUrl') and \
                 (schema.get('items') == 'user' or schema['type'] == 'user'):
             fieldtype = 'select'
-            sentry_url = self.search_url(group.organization.slug)
-            fkwargs['url'] = '%s?jira_url=%s' % (
-                sentry_url, quote_plus(field_meta['autoCompleteUrl']),
-            )
+            fkwargs['url'] = self.search_url(group.organization.slug)
             fkwargs['choices'] = []
         elif schema['type'] in ['timetracking']:
             # TODO: Implement timetracking (currently unsupported alltogether)

--- a/src/sentry/integrations/jira/search.py
+++ b/src/sentry/integrations/jira/search.py
@@ -54,9 +54,7 @@ class JiraSearchEndpoint(IntegrationEndpoint):
                 'value': i['key']
             } for i in resp.get('issues', [])])
 
-        # TODO: remove jira_url in follow up deploy.
-        jira_url = request.GET.get('jira_url')
-        if jira_url or field in ('assignee', 'reporter'):
+        if field in ('assignee', 'reporter'):
             jira_client = installation.get_client()
             users = []
             try:


### PR DESCRIPTION
There is no point in passing this big URL around if we don't use it.

Fixes APP-863