### PR TITLE
fix(ui): Fix API success callback

### DIFF
--- a/src/sentry/static/sentry/app/api.jsx
+++ b/src/sentry/static/sentry/app/api.jsx
@@ -200,7 +200,9 @@ export class Client {
               status: xhr && xhr.status,
             },
           });
-          this.wrapCallback(id, options.success)(...args);
+          if (!isUndefined(options.success)) {
+            this.wrapCallback(id, options.success)(...args);
+          }
         },
         error: (...args) => {
           let [, , xhr] = args || [];


### PR DESCRIPTION
When API requests with no success handler are called, would throw an error. This does not interrupt the API call but may leave undesired UI artifacts (e.g. toasts may not have disappeared after success).

Fixes JAVASCRIPT-4R1