### PR TITLE
fix(api): Fix bug where releases with slashes in their name failed to load

### DIFF
--- a/src/sentry/api/endpoints/filechange.py
+++ b/src/sentry/api/endpoints/filechange.py
@@ -6,6 +6,7 @@ from sentry.api.base import DocSection
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
+from sentry.api.utils import get_release
 from sentry.models import CommitFileChange, Release, ReleaseCommit
 from rest_framework.response import Response
 
@@ -26,7 +27,7 @@ class CommitFileChangeEndpoint(OrganizationReleasesBaseEndpoint):
         :auth: required
         """
         try:
-            release = Release.objects.get(
+            release = get_release(
                 organization=organization,
                 version=version,
             )

--- a/src/sentry/api/endpoints/issues_resolved_in_release.py
+++ b/src/sentry/api/endpoints/issues_resolved_in_release.py
@@ -7,6 +7,7 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import GroupSerializer
+from sentry.api.utils import get_release
 from sentry.models import (
     Group,
     GroupLink,
@@ -34,7 +35,7 @@ class IssuesResolvedInReleaseEndpoint(ProjectEndpoint, EnvironmentMixin):
         :auth: required
         """
         try:
-            release = Release.objects.get(version=version, organization=project.organization)
+            release = get_release(version=version, organization=project.organization)
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
 

--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -14,6 +14,7 @@ from sentry.api.serializers.rest_framework import (
     ReleaseHeadCommitSerializerDeprecated,
     ReleaseHeadCommitSerializer,
 )
+from sentry.api.utils import get_release
 from sentry.models import Activity, Group, Release, ReleaseFile
 from sentry.utils.apidocs import scenario, attach_scenarios
 from sentry.constants import VERSION_LENGTH
@@ -74,8 +75,8 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         :auth: required
         """
         try:
-            release = Release.objects.get(
-                organization_id=organization.id,
+            release = get_release(
+                organization=organization,
                 version=version,
             )
         except Release.DoesNotExist:
@@ -120,10 +121,7 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         :auth: required
         """
         try:
-            release = Release.objects.get(
-                organization_id=organization,
-                version=version,
-            )
+            release = get_release(organization=organization, version=version)
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
 
@@ -202,10 +200,7 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         :auth: required
         """
         try:
-            release = Release.objects.get(
-                organization_id=organization.id,
-                version=version,
-            )
+            release = get_release(organization=organization, version=version)
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
 

--- a/src/sentry/api/endpoints/organization_release_file_details.py
+++ b/src/sentry/api/endpoints/organization_release_file_details.py
@@ -9,6 +9,7 @@ from sentry.api.base import DocSection
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
+from sentry.api.utils import get_release
 from sentry.models import Release, ReleaseFile
 try:
     from django.http import (CompatibleStreamingHttpResponse as StreamingHttpResponse)
@@ -52,10 +53,7 @@ class OrganizationReleaseFileDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         :auth: required
         """
         try:
-            release = Release.objects.get(
-                organization_id=organization.id,
-                version=version,
-            )
+            release = get_release(organization=organization, version=version)
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
 
@@ -94,10 +92,7 @@ class OrganizationReleaseFileDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         :auth: required
         """
         try:
-            release = Release.objects.get(
-                organization_id=organization.id,
-                version=version,
-            )
+            release = get_release(organization=organization, version=version)
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
 
@@ -141,10 +136,7 @@ class OrganizationReleaseFileDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         :auth: required
         """
         try:
-            release = Release.objects.get(
-                organization_id=organization.id,
-                version=version,
-            )
+            release = get_release(organization=organization, version=version)
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
 

--- a/src/sentry/api/endpoints/organization_release_files.py
+++ b/src/sentry/api/endpoints/organization_release_files.py
@@ -11,6 +11,7 @@ from sentry.api.content_negotiation import ConditionalContentNegotiation
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
+from sentry.api.utils import get_release
 from sentry.models import File, Release, ReleaseFile
 
 ERR_FILE_EXISTS = 'A file matching this name already exists for the given release'
@@ -34,10 +35,7 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint):
         :auth: required
         """
         try:
-            release = Release.objects.get(
-                organization_id=organization.id,
-                version=version,
-            )
+            release = get_release(organization=organization, version=version)
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
 
@@ -84,10 +82,7 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint):
         :auth: required
         """
         try:
-            release = Release.objects.get(
-                organization_id=organization.id,
-                version=version,
-            )
+            release = get_release(organization=organization, version=version)
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
 

--- a/src/sentry/api/endpoints/project_release_commits.py
+++ b/src/sentry/api/endpoints/project_release_commits.py
@@ -4,6 +4,7 @@ from sentry.api.base import DocSection
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
+from sentry.api.utils import get_release
 from sentry.models import Release, ReleaseCommit
 
 
@@ -26,8 +27,8 @@ class ProjectReleaseCommitsEndpoint(ProjectEndpoint):
         :auth: required
         """
         try:
-            release = Release.objects.get(
-                organization_id=project.organization_id,
+            release = get_release(
+                organization=project.organization,
                 projects=project,
                 version=version,
             )

--- a/src/sentry/api/endpoints/project_release_details.py
+++ b/src/sentry/api/endpoints/project_release_details.py
@@ -7,6 +7,7 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import CommitSerializer, ListField
+from sentry.api.utils import get_release
 from sentry.models import Activity, Group, Release, ReleaseFile
 from sentry.plugins.interfaces.releasehook import ReleaseHook
 from sentry.constants import VERSION_LENGTH
@@ -39,8 +40,8 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint):
         :auth: required
         """
         try:
-            release = Release.objects.get(
-                organization_id=project.organization_id,
+            release = get_release(
+                organization=project.organization,
                 projects=project,
                 version=version,
             )
@@ -73,8 +74,8 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint):
         :auth: required
         """
         try:
-            release = Release.objects.get(
-                organization_id=project.organization_id,
+            release = get_release(
+                organization=project.organization,
                 projects=project,
                 version=version,
             )
@@ -133,8 +134,8 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint):
         :auth: required
         """
         try:
-            release = Release.objects.get(
-                organization_id=project.organization_id,
+            release = get_release(
+                organization=project.organization,
                 projects=project,
                 version=version,
             )

--- a/src/sentry/api/endpoints/project_release_file_details.py
+++ b/src/sentry/api/endpoints/project_release_file_details.py
@@ -8,6 +8,7 @@ from sentry.api.base import DocSection
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
+from sentry.api.utils import get_release
 from sentry.models import Release, ReleaseFile
 from sentry.utils.apidocs import scenario, attach_scenarios
 try:
@@ -102,8 +103,8 @@ class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint):
         :auth: required
         """
         try:
-            release = Release.objects.get(
-                organization_id=project.organization_id,
+            release = get_release(
+                organization=project.organization,
                 projects=project,
                 version=version,
             )
@@ -144,8 +145,8 @@ class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint):
         :auth: required
         """
         try:
-            release = Release.objects.get(
-                organization_id=project.organization_id,
+            release = get_release(
+                organization=project.organization,
                 projects=project,
                 version=version,
             )
@@ -192,8 +193,8 @@ class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint):
         :auth: required
         """
         try:
-            release = Release.objects.get(
-                organization_id=project.organization_id,
+            release = get_release(
+                organization=project.organization,
                 projects=project,
                 version=version,
             )

--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -11,6 +11,7 @@ from sentry.api.content_negotiation import ConditionalContentNegotiation
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
+from sentry.api.utils import get_release
 from sentry.models import File, Release, ReleaseFile
 from sentry.utils.apidocs import scenario, attach_scenarios
 
@@ -69,8 +70,8 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint):
         :auth: required
         """
         try:
-            release = Release.objects.get(
-                organization_id=project.organization_id,
+            release = get_release(
+                organization=project.organization,
                 projects=project,
                 version=version,
             )
@@ -120,8 +121,8 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint):
         :auth: required
         """
         try:
-            release = Release.objects.get(
-                organization_id=project.organization_id,
+            release = get_release(
+                organization=project.organization,
                 projects=project,
                 version=version,
             )

--- a/src/sentry/api/endpoints/release_deploys.py
+++ b/src/sentry/api/endpoints/release_deploys.py
@@ -12,6 +12,7 @@ from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
+from sentry.api.utils import get_release
 from sentry.models import Deploy, Environment, Release, ReleaseProjectEnvironment
 from sentry.signals import deploy_created
 
@@ -44,7 +45,7 @@ class ReleaseDeploysEndpoint(OrganizationReleasesBaseEndpoint):
         :pparam string version: the version identifier of the release.
         """
         try:
-            release = Release.objects.get(
+            release = get_release(
                 version=version,
                 organization=organization,
             )
@@ -86,7 +87,7 @@ class ReleaseDeploysEndpoint(OrganizationReleasesBaseEndpoint):
                                       current time is used.
         """
         try:
-            release = Release.objects.get(
+            release = get_release(
                 version=version,
                 organization=organization,
             )

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -5,6 +5,7 @@ import six
 from collections import defaultdict
 from django.db.models import Sum
 from itertools import izip
+from six.moves.urllib.parse import quote
 
 from sentry import tagstore
 from sentry.api.serializers import Serializer, register, serialize
@@ -256,6 +257,7 @@ class ReleaseSerializer(Serializer):
         d = {
             'version': obj.version,
             'shortVersion': obj.short_version,
+            'safeVersion': quote(obj.version, safe=''),
             'ref': obj.ref,
             'url': obj.url,
             'dateReleased': obj.date_released,

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -257,7 +257,7 @@ class ReleaseSerializer(Serializer):
         d = {
             'version': obj.version,
             'shortVersion': obj.short_version,
-            'safeVersion': quote(obj.version, safe=''),
+            'slug': quote(obj.version, safe=''),
             'ref': obj.ref,
             'url': obj.url,
             'dateReleased': obj.date_released,

--- a/tests/sentry/api/endpoints/test_organization_release_commits.py
+++ b/tests/sentry/api/endpoints/test_organization_release_commits.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
+from six.moves.urllib.parse import quote
 
 from sentry.models import Commit, Release, ReleaseCommit, Repository
 from sentry.testutils import APITestCase
@@ -58,3 +59,43 @@ class ReleaseCommitsListTest(APITestCase):
         assert len(response.data) == 2
         assert response.data[0]['id'] == commit2.key
         assert response.data[1]['id'] == commit.key
+
+    def test_encoded_version(self):
+        project = self.create_project(
+            name='foo',
+        )
+        release = Release.objects.create(
+            organization_id=project.organization_id,
+            version='version/with/slashes',
+        )
+        release.add_project(project)
+        repo = Repository.objects.create(
+            organization_id=project.organization_id,
+            name=project.name,
+        )
+        commit = Commit.objects.create(
+            organization_id=project.organization_id,
+            repository_id=repo.id,
+            key='a' * 40,
+        )
+        ReleaseCommit.objects.create(
+            organization_id=project.organization_id,
+            release=release,
+            commit=commit,
+            order=1,
+        )
+        url = reverse(
+            'sentry-api-0-organization-release-commits',
+            kwargs={
+                'organization_slug': project.organization.slug,
+                'version': quote(release.version, safe=''),
+            }
+        )
+
+        self.login_as(user=self.user)
+
+        response = self.client.get(url)
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]['id'] == commit.key

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -108,7 +108,7 @@ class ReleaseSerializerTest(TestCase):
         result = serialize(release, user)
         assert result['version'] == release.version
         assert result['shortVersion'] == release.version
-        assert result['safeVersion'] == release.version
+        assert result['slug'] == release.version
         # should be sum of all projects
         assert result['newGroups'] == 2
         # should be tags from all projects
@@ -456,12 +456,6 @@ class ReleaseSerializerTest(TestCase):
         serialize(release)
 
     def test_encoded_version(self):
-        """
-        Testing when a repo gets deleted leaving dangling last commit id and author_ids
-        Made the decision that the Serializer must handle the data even in the case that the
-        commit_id or the author_ids point to records that do not exist.
-        """
-
         project = self.create_project()
         release = Release.objects.create(
             organization_id=project.organization_id,
@@ -469,7 +463,7 @@ class ReleaseSerializerTest(TestCase):
         )
         result = serialize(release)
         assert result['version'] == release.version
-        assert result['safeVersion'] == quote(release.version, safe='')
+        assert result['slug'] == quote(release.version, safe='')
 
 
 class ReleaseRefsSerializerTest(TestCase):


### PR DESCRIPTION
Not sure this is actually practical in production, because it relies on REQUEST_URI, which I'm not sure will always be available. Also unsure whether using it to overwrite PATH_INFO could have other negative effects.

Possibly a safer option option could be to include the encoded project version in `ReleaseSerializer` as  something like `safeVersion`. Then the FE could just include that as a parameter when making requests to the api, and it'd get double encoded when it encodes the url. Then we can just decode the version like in this diff and it'll work as expected.

Fixes #16012.