### PR TITLE
ref(teams): Clarify messaging around admin user permissions

### DIFF
--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -259,6 +259,8 @@ def from_member(member, scopes=None):
 
     team_memberships = member.get_teams()
     if member.organization.flags.allow_joinleave:
+        # an org having open membership means anyone could in theory join any
+        # team, so for permission purposes, pretend they've joined them all
         team_access = list(member.organization.team_set.all())
     else:
         team_access = team_memberships

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1191,7 +1191,7 @@ SENTRY_ROLES = (
     }, {
         'id': 'admin',
         'name': 'Admin',
-        'desc': 'Admin privileges on any teams of which they\'re a member. They can create new teams and projects, as well as remove teams and projects which they already hold membership on.',
+        'desc': 'Admin privileges on any teams of which they\'re a member. They can create new teams and projects, as well as remove teams and projects which they already hold membership on (or all teams, if open membership is on).',
         'scopes': set(
             [
                 'event:read',

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/index.jsx
@@ -32,7 +32,7 @@ const STATIC_ROLE_LIST = [
     id: 'admin',
     name: 'Admin',
     desc:
-      "Admin privileges on any teams of which they're a member. They can create new teams and projects, as well as remove teams and projects which they already hold membership on.",
+      "Admin privileges on any teams of which they're a member. They can create new teams and projects, as well as remove teams and projects which they already hold membership on (or all teams, if open membership is on).",
   },
   {
     id: 'manager',

--- a/tests/js/fixtures/roleList.js
+++ b/tests/js/fixtures/roleList.js
@@ -39,7 +39,7 @@ export function RoleList(params = [], fullAccess = false) {
       allowed: fullAccess,
       id: 'admin',
       desc:
-        "Admin privileges on any teams of which they're a member. They can create new teams and projects, as well as remove teams and projects which they already hold membership on.",
+        "Admin privileges on any teams of which they're a member. They can create new teams and projects, as well as remove teams and projects which they already hold membership on (or all teams, if open membership is on).",
     },
     {
       scopes: [

--- a/tests/sentry/api/endpoints/test_team_details.py
+++ b/tests/sentry/api/endpoints/test_team_details.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import six
+
 from django.core.urlresolvers import reverse
 from mock import patch
 
@@ -7,43 +9,43 @@ from sentry.models import AuditLogEntry, AuditLogEntryEvent, Team, TeamStatus, D
 from sentry.testutils import APITestCase
 
 
-# class TeamDetailsTest(APITestCase):
-#     def test_simple(self):
-#         team = self.team  # force creation
-#         self.login_as(user=self.user)
-#         url = reverse(
-#             'sentry-api-0-team-details',
-#             kwargs={
-#                 'organization_slug': team.organization.slug,
-#                 'team_slug': team.slug,
-#             }
-#         )
-#         response = self.client.get(url)
-#         assert response.status_code == 200
-#         assert response.data['id'] == six.text_type(team.id)
+class TeamDetailsTest(APITestCase):
+    def test_simple(self):
+        team = self.team  # force creation
+        self.login_as(user=self.user)
+        url = reverse(
+            'sentry-api-0-team-details',
+            kwargs={
+                'organization_slug': team.organization.slug,
+                'team_slug': team.slug,
+            }
+        )
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert response.data['id'] == six.text_type(team.id)
 
 
-# class TeamUpdateTest(APITestCase):
-#     def test_simple(self):
-#         team = self.team  # force creation
-#         self.login_as(user=self.user)
-#         url = reverse(
-#             'sentry-api-0-team-details',
-#             kwargs={
-#                 'organization_slug': team.organization.slug,
-#                 'team_slug': team.slug,
-#             }
-#         )
-#         resp = self.client.put(
-#             url, data={
-#                 'name': 'hello world',
-#                 'slug': 'foobar',
-#             }
-#         )
-#         assert resp.status_code == 200, resp.content
-#         team = Team.objects.get(id=team.id)
-#         assert team.name == 'hello world'
-#         assert team.slug == 'foobar'
+class TeamUpdateTest(APITestCase):
+    def test_simple(self):
+        team = self.team  # force creation
+        self.login_as(user=self.user)
+        url = reverse(
+            'sentry-api-0-team-details',
+            kwargs={
+                'organization_slug': team.organization.slug,
+                'team_slug': team.slug,
+            }
+        )
+        resp = self.client.put(
+            url, data={
+                'name': 'hello world',
+                'slug': 'foobar',
+            }
+        )
+        assert resp.status_code == 200, resp.content
+        team = Team.objects.get(id=team.id)
+        assert team.name == 'hello world'
+        assert team.slug == 'foobar'
 
 
 class TeamDeleteTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_team_details.py
+++ b/tests/sentry/api/endpoints/test_team_details.py
@@ -1,76 +1,121 @@
 from __future__ import absolute_import
 
-import six
-
 from django.core.urlresolvers import reverse
 from mock import patch
 
-from sentry.models import Team, TeamStatus, DeletedTeam
+from sentry.models import AuditLogEntry, AuditLogEntryEvent, Team, TeamStatus, DeletedTeam
 from sentry.testutils import APITestCase
 
 
-class TeamDetailsTest(APITestCase):
-    def test_simple(self):
-        team = self.team  # force creation
-        self.login_as(user=self.user)
-        url = reverse(
-            'sentry-api-0-team-details',
-            kwargs={
-                'organization_slug': team.organization.slug,
-                'team_slug': team.slug,
-            }
-        )
-        response = self.client.get(url)
-        assert response.status_code == 200
-        assert response.data['id'] == six.text_type(team.id)
+# class TeamDetailsTest(APITestCase):
+#     def test_simple(self):
+#         team = self.team  # force creation
+#         self.login_as(user=self.user)
+#         url = reverse(
+#             'sentry-api-0-team-details',
+#             kwargs={
+#                 'organization_slug': team.organization.slug,
+#                 'team_slug': team.slug,
+#             }
+#         )
+#         response = self.client.get(url)
+#         assert response.status_code == 200
+#         assert response.data['id'] == six.text_type(team.id)
 
 
-class TeamUpdateTest(APITestCase):
-    def test_simple(self):
-        team = self.team  # force creation
-        self.login_as(user=self.user)
-        url = reverse(
-            'sentry-api-0-team-details',
-            kwargs={
-                'organization_slug': team.organization.slug,
-                'team_slug': team.slug,
-            }
-        )
-        resp = self.client.put(
-            url, data={
-                'name': 'hello world',
-                'slug': 'foobar',
-            }
-        )
-        assert resp.status_code == 200, resp.content
-        team = Team.objects.get(id=team.id)
-        assert team.name == 'hello world'
-        assert team.slug == 'foobar'
+# class TeamUpdateTest(APITestCase):
+#     def test_simple(self):
+#         team = self.team  # force creation
+#         self.login_as(user=self.user)
+#         url = reverse(
+#             'sentry-api-0-team-details',
+#             kwargs={
+#                 'organization_slug': team.organization.slug,
+#                 'team_slug': team.slug,
+#             }
+#         )
+#         resp = self.client.put(
+#             url, data={
+#                 'name': 'hello world',
+#                 'slug': 'foobar',
+#             }
+#         )
+#         assert resp.status_code == 200, resp.content
+#         team = Team.objects.get(id=team.id)
+#         assert team.name == 'hello world'
+#         assert team.slug == 'foobar'
 
 
 class TeamDeleteTest(APITestCase):
+
+    def assert_team_deleted(self, team_id, mock_delete_team, transaction_id):
+        """Checks team status, membership in DeletedTeams table, org
+           audit log, and to see that delete function has been called"""
+
+        team = Team.objects.get(id=team_id)
+
+        assert team.status == TeamStatus.PENDING_DELETION
+
+        deleted_team = DeletedTeam.objects.get(slug=team.slug)
+        # in spite of the name, this checks the DeletedTeam object, not the
+        # audit log
+        self.assert_valid_deleted_log(deleted_team, team)
+
+        # *this* actually checks the audit log
+        audit_log_entry = AuditLogEntry.objects.filter(
+            event=AuditLogEntryEvent.TEAM_REMOVE,
+            target_object=team.id
+        )
+        assert audit_log_entry
+
+        mock_delete_team.apply_async.assert_called_once_with(
+            kwargs={
+                'object_id': team.id,
+                'transaction_id': transaction_id,
+            },
+        )
+
+    def assert_team_not_deleted(self, team_id, mock_delete_team):
+        """Checks team status, membership in DeletedTeams table, org
+           audit log, and to see that delete function has been called"""
+
+        team = Team.objects.get(id=team_id)
+
+        assert team.status == TeamStatus.VISIBLE
+
+        deleted_team = DeletedTeam.objects.filter(slug=team.slug)
+        assert not deleted_team
+
+        audit_log_entry = AuditLogEntry.objects.filter(
+            event=AuditLogEntryEvent.TEAM_REMOVE,
+            target_object=team.id
+        )
+        assert not audit_log_entry
+
+        mock_delete_team.assert_not_called()  # NOQA
+
     @patch('sentry.api.endpoints.team_details.uuid4')
     @patch('sentry.api.endpoints.team_details.delete_team')
-    def test_can_remove_as_team_admin(self, delete_team, mock_uuid4):
+    def test_can_remove_as_admin_in_team(self, mock_delete_team, mock_uuid4):
+        """Admins can remove teams of which they're a part"""
+
+        # mock the transaction_id when mock_delete_team is called
         class uuid(object):
             hex = 'abc123'
-
         mock_uuid4.return_value = uuid
 
         org = self.create_organization()
         team = self.create_team(organization=org)
-        project = self.create_project(teams=[team])  # NOQA
-
-        user = self.create_user(email='foo@example.com', is_superuser=False)
+        admin_user = self.create_user(email='foo@example.com', is_superuser=False)
 
         self.create_member(
             organization=org,
-            user=user,
+            user=admin_user,
             role='admin',
             teams=[team],
         )
 
-        self.login_as(user)
+        self.login_as(admin_user)
 
         url = reverse(
             'sentry-api-0-team-details',
@@ -80,38 +125,37 @@ class TeamDeleteTest(APITestCase):
             }
         )
 
-        with self.settings(SENTRY_PROJECT=0):
-            response = self.client.delete(url)
+        response = self.client.delete(url)
 
         team = Team.objects.get(id=team.id)
 
         assert response.status_code == 204, response.data
+        self.assert_team_deleted(team.id, mock_delete_team, 'abc123')
 
-        assert team.status == TeamStatus.PENDING_DELETION
-        deleted_team = DeletedTeam.objects.get(slug=team.slug)
-        self.assert_valid_deleted_log(deleted_team, team)
+    @patch('sentry.api.endpoints.team_details.uuid4')
+    @patch('sentry.api.endpoints.team_details.delete_team')
+    def test_remove_as_admin_not_in_team(self, mock_delete_team, mock_uuid4):
+        """Admins can't remove teams of which they're not a part, unless
+           open membership is on."""
 
-        delete_team.apply_async.assert_called_once_with(
-            kwargs={
-                'object_id': team.id,
-                'transaction_id': 'abc123',
-            },
-        )
+        # mock the transaction_id when mock_delete_team is called
+        class uuid(object):
+            hex = 'abc123'
+        mock_uuid4.return_value = uuid
 
-    def test_cannot_remove_as_member(self):
-        org = self.create_organization(owner=self.user)
+        # an org with closed membership (byproduct of flags=0)
+        org = self.create_organization(owner=self.user, flags=0)
         team = self.create_team(organization=org)
-        project = self.create_project(teams=[team])  # NOQA
+        admin_user = self.create_user(email='foo@example.com', is_superuser=False)
 
-        user = self.create_user(email='foo@example.com', is_superuser=False)
-
-        team.organization.member_set.create_or_update(
-            organization=org, user=user, values={
-                'role': 'member',
-            }
+        self.create_member(
+            organization=org,
+            user=admin_user,
+            role='admin',
+            teams=[],  # note that admin_user isn't a member of `team`
         )
 
-        self.login_as(user=user)
+        self.login_as(admin_user)
 
         url = reverse(
             'sentry-api-0-team-details',
@@ -120,6 +164,47 @@ class TeamDeleteTest(APITestCase):
                 'team_slug': team.slug,
             }
         )
+
+        # first, try deleting the team with open membership off
         response = self.client.delete(url)
 
         assert response.status_code == 403
+        self.assert_team_not_deleted(team.id, mock_delete_team)
+
+        # now, with open membership on
+        org.flags.allow_joinleave = True
+        org.save()
+        response = self.client.delete(url)
+
+        assert response.status_code == 204
+        self.assert_team_deleted(team.id, mock_delete_team, 'abc123')
+
+    @patch('sentry.api.endpoints.team_details.delete_team')
+    def test_cannot_remove_as_member(self, mock_delete_team):
+        """Members can't remove teams, even if they belong to them"""
+
+        org = self.create_organization(owner=self.user)
+        team = self.create_team(organization=org)
+        member_user = self.create_user(email='foo@example.com', is_superuser=False)
+
+        self.create_member(
+            organization=org,
+            user=member_user,
+            role='member',
+            teams=[team],  # note that member_user is a member of `team`
+        )
+
+        self.login_as(member_user)
+
+        url = reverse(
+            'sentry-api-0-team-details',
+            kwargs={
+                'organization_slug': team.organization.slug,
+                'team_slug': team.slug,
+            }
+        )
+
+        response = self.client.delete(url)
+
+        assert response.status_code == 403
+        self.assert_team_not_deleted(team.id, mock_delete_team)

--- a/tests/sentry/api/endpoints/test_team_details.py
+++ b/tests/sentry/api/endpoints/test_team_details.py
@@ -77,7 +77,7 @@ class TeamDeleteTest(APITestCase):
 
     def assert_team_not_deleted(self, team_id, mock_delete_team):
         """Checks team status, membership in DeletedTeams table, org
-           audit log, and to see that delete function has been called"""
+           audit log, and to see that delete function has not been called"""
 
         team = Team.objects.get(id=team_id)
 


### PR DESCRIPTION
Admin users can delete all teams if membership is open, which has always been true (and makes sense - you can just join the team in order to delete it), but which wasn't clear to users before.

- Clarify messaging around this
- Add test for team deletion by admin members when membership is open
- Refactor team deletion tests to clean up duplicate code