### PR TITLE
fix(integrations) Allow multiple labels to be assigned in jira

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -29,7 +29,7 @@ FEATURE_DESCRIPTIONS = [
     FeatureDescription(
         """
         Create and link Sentry issue groups directly to a Jira ticket in any of your
-        projects, providing a quick way to jump from Sentry bug to tracked ticket!
+        projects, providing a quick way to jump from a Sentry bug to tracked ticket!
         """,
         IntegrationFeatures.ISSUE_BASIC,
     ),

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -475,6 +475,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
 
         dynamic_fields = issue_type_meta['fields'].keys()
         dynamic_fields.sort(key=lambda f: anti_gravity.get(f) or 0)
+
         # build up some dynamic fields based on required shit.
         for field in dynamic_fields:
             if field in standard_fields or field in [x.strip() for x in ignored_fields]:
@@ -523,6 +524,14 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                 continue
             elif field == 'summary':
                 cleaned_data['summary'] = data['title']
+                continue
+            elif field == 'labels' and 'labels' in data:
+                labels = [
+                    label.strip()
+                    for label in data['labels'].split(',')
+                    if label.strip()
+                ]
+                cleaned_data['labels'] = labels
                 continue
             if field in data.keys():
                 v = data.get(field)


### PR DESCRIPTION
Allow multiple labels to be applied to created issues via a comma separated string. I had originally thought of using a multi-select but the `creatable` mode doesn't work inside JsonConfig based forms.

Fixes APP-865