### PR TITLE
fix(integrations) Give better error messages when creation fails

### DIFF
--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -310,4 +310,9 @@ class JiraServerIntegrationProvider(IntegrationProvider):
                 'error': six.text_type(err),
                 'external_id': external_id,
             })
-            raise IntegrationError('Could not create issue webhook in Jira')
+            try:
+                details = err.json['messages'][0].values().pop()
+            except Exception:
+                details = ''
+            message = u'Could not create issue webhook in Jira. {}'.format(details)
+            raise IntegrationError(message)


### PR DESCRIPTION
When an unprivileged user attempts to complete the integration setup, we can use the error message from Jira to give a better error message to the user.

Fixes APP-873