### PR TITLE
fix(url): Fix old 2fa route to redirect

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -227,7 +227,7 @@ urlpatterns += patterns(
         RedirectView.as_view(pattern_name="sentry-account-settings", permanent=False),
         ),
     url(
-        r'^account/settings/2fa/$',
+        r'^account/settings/2fa/',
         RedirectView.as_view(pattern_name="sentry-account-settings-security", permanent=False),
     ),
     url(


### PR DESCRIPTION
Some users are hitting `https://sentry.io/account/settings/2fa/u2f/` --> redirect them to new account security section