### PR TITLE
fix(url): Fix bad API redirect

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -347,7 +347,7 @@ urlpatterns += patterns(
     url(r'^api/new-token/$',
         RedirectView.as_view(pattern_name="sentry-api-new-auth-token", permanent=False)),
     url(r'^api/[^0]+/',
-        RedirectView.as_view(pattern_name="sentry-api-details", permanent=False),
+        RedirectView.as_view(pattern_name="sentry-api", permanent=False),
         ),
     url(r'^out/$', OutView.as_view()),
 
@@ -368,12 +368,11 @@ urlpatterns += patterns(
     url(r'^settings/account/notifications/', generic_react_page_view,
         name='sentry-account-settings-notifications'),
     url(r'^settings/account/emails/$', generic_react_page_view, name='sentry-account-settings-emails'),
-    url(r'^settings/account/api/$', generic_react_page_view, name='sentry-api'),
     url(r'^settings/account/api/applications/$',
         generic_react_page_view, name='sentry-api-applications'),
     url(r'^settings/account/api/auth-tokens/new-token/$',
         generic_react_page_view, name='sentry-api-new-auth-token'),
-    url(r'^settings/account/api/[^0]+/$', generic_react_page_view, name='sentry-api-details'),
+    url(r'^settings/account/api/', generic_react_page_view, name='sentry-api'),
     url(r'^settings/account/close-account/$', generic_react_page_view, name='sentry-remove-account'),
     url(r'^settings/account/', generic_react_page_view),
 


### PR DESCRIPTION
We want anything that does not start with `/api/0/` to redirect to `/settings/account/api/`

See: https://sentry.io/sentry/javascript/issues/496412334/events/?query=url%3A%22https%3A%2F%2Fsentry.io%2Fsettings%2Faccount%2Fapi%2F%255E%2F%22