### PR TITLE
fix(metrics): Fix sentry for MS IE/Edge

### DIFF
--- a/src/sentry/static/sentry/app/utils/analytics.jsx
+++ b/src/sentry/static/sentry/app/utils/analytics.jsx
@@ -68,10 +68,17 @@ metric.measure = function metricMeasure({name, start, end, data, noCleanup} = {}
     throw new Error('Invalid arguments provided to `metric.measure`');
   }
 
+  let endMarkName = end;
+
   // Can't destructure from performance
   const {performance} = window;
 
-  performance.measure(name, start, end);
+  if (!end) {
+    endMarkName = `${start}-end`;
+    performance.mark(endMarkName);
+  }
+
+  performance.measure(name, start, endMarkName);
 
   // Retrieve measurement entries
   performance
@@ -82,5 +89,6 @@ metric.measure = function metricMeasure({name, start, end, data, noCleanup} = {}
   if (!noCleanup) {
     performance.clearMeasures(name);
     performance.clearMarks(start);
+    performance.clearMarks(endMarkName);
   }
 };

--- a/src/sentry/static/sentry/app/utils/analytics.jsx
+++ b/src/sentry/static/sentry/app/utils/analytics.jsx
@@ -73,6 +73,8 @@ metric.measure = function metricMeasure({name, start, end, data, noCleanup} = {}
   // Can't destructure from performance
   const {performance} = window;
 
+  // NOTE: Edge REQUIRES an end mark if it is given a start mark
+  // If we don't have an end mark, create one now.
   if (!end) {
     endMarkName = `${start}-end`;
     performance.mark(endMarkName);


### PR DESCRIPTION
Edge throws an exception when you provide `performance.measure` with a
start mark but NOT an end mark. If an end mark name is not given, generate
one in the `measure` function.

Fixes JAVASCRIPT-4R2