### PR TITLE
fix(ui): Fix navigation crashes when URL has a "%"

### DIFF
--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
@@ -79,7 +79,9 @@ class EventOrGroupHeader extends React.Component {
         pathname: `/${orgId}/${projectId}/issues/${isEvent ? groupID : id}/${isEvent
           ? `events/${data.id}/`
           : ''}`,
-        search: `${this.props.query ? `?query=${this.props.query}` : ''}`,
+        search: `${this.props.query
+          ? `?query=${window.encodeURIComponent(this.props.query)}`
+          : ''}`,
       };
       Wrapper = ProjectLink;
     } else {


### PR DESCRIPTION
This fixes crashes in react-router when the URL contains an unencoded `%`. An example of this happening is when you search for a `%` in the stream, and the search results embed the query when you navigate to the Issue.

Fixes JAVASCRIPT-4JT