### PR TITLE
fix(ui): Show error msg when failed to create sample event

### DIFF
--- a/src/sentry/static/sentry/app/components/errorRobot.jsx
+++ b/src/sentry/static/sentry/app/components/errorRobot.jsx
@@ -1,13 +1,14 @@
-import React from 'react';
-import PropTypes from 'prop-types';
 import {Link, browserHistory} from 'react-router';
+import PropTypes from 'prop-types';
+import React from 'react';
 import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
 
+import {addErrorMessage} from 'app/actionCreators/indicator';
 import {analytics} from 'app/utils/analytics';
-import ApiMixin from 'app/mixins/apiMixin';
-import {t} from 'app/locale';
 import {sendSampleEvent} from 'app/actionCreators/projects';
+import {t} from 'app/locale';
+import ApiMixin from 'app/mixins/apiMixin';
 
 const ErrorRobot = createReactClass({
   displayName: 'ErrorRobot',
@@ -75,9 +76,11 @@ const ErrorRobot = createReactClass({
       source: 'robot',
     });
 
-    sendSampleEvent(this.api, org.slug, project.slug).then(data => {
-      browserHistory.push(`/${org.slug}/${project.slug}/issues/${data.groupID}/`);
-    });
+    sendSampleEvent(this.api, org.slug, project.slug)
+      .then(data => {
+        browserHistory.push(`/${org.slug}/${project.slug}/issues/${data.groupID}/`);
+      })
+      .catch(() => addErrorMessage(t('Unable to create sample event')));
   },
 
   render() {


### PR DESCRIPTION
Partially addresses https://sentry.io/sentry/javascript/issues/495069476/events/19386583d6b4433c9bc908e39277bc20/