### PR TITLE
fix(integrations) Only show repository delete buttons when they work

### DIFF
--- a/src/sentry/static/sentry/app/components/repositoryRow.jsx
+++ b/src/sentry/static/sentry/app/components/repositoryRow.jsx
@@ -10,6 +10,7 @@ import Access from 'app/components/acl/access';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
 import SpreadLayout from 'app/components/spreadLayout';
+import space from 'app/styles/space';
 
 class RepositoryRow extends React.Component {
   static propTypes = {
@@ -71,48 +72,40 @@ class RepositoryRow extends React.Component {
       <Access access={['org:admin']}>
         {({hasAccess}) => (
           <StyledRow status={repository.status}>
-            <Box p={2} flex="1">
-              <Flex direction="column">
-                <Box pb={1}>
-                  <strong>{repository.name}</strong>
-                  {!isActive && <small> — {this.getStatusLabel(repository)}</small>}
-                  {repository.status === 'pending_deletion' && (
-                    <Button
-                      size="xsmall"
-                      borderless
-                      icon="icon-circle-close"
-                      onClick={this.cancelDelete}
-                      disabled={!hasAccess}
-                      data-test-id="repo-cancel"
-                    >
-                      {t('Cancel')}
-                    </Button>
-                  )}
-                </Box>
-                <Box>
-                  {showProvider && (
-                    <small>{repository.provider.name}&nbsp;&mdash;&nbsp;</small>
-                  )}
-                  {repository.url && (
-                    <small>
-                      <a href={repository.url}>
-                        {repository.url.replace('https://', '')}
-                      </a>
-                    </small>
-                  )}
-                </Box>
-              </Flex>
-            </Box>
+            <Flex direction="column">
+              <RepositoryTitle>
+                <strong>{repository.name}</strong>
+                {!isActive && <small> &mdash; {this.getStatusLabel(repository)}</small>}
+                {repository.status === 'pending_deletion' && (
+                  <StyledButton
+                    size="xsmall"
+                    onClick={this.cancelDelete}
+                    disabled={!hasAccess}
+                    data-test-id="repo-cancel"
+                  >
+                    {t('Cancel')}
+                  </StyledButton>
+                )}
+              </RepositoryTitle>
+              <Box>
+                {showProvider && (
+                  <small>{repository.provider.name}&nbsp;&mdash;&nbsp;</small>
+                )}
+                {repository.url && (
+                  <small>
+                    <a href={repository.url}>{repository.url.replace('https://', '')}</a>
+                  </small>
+                )}
+              </Box>
+            </Flex>
 
-            <Box p={2}>
-              <Confirm
-                disabled={!hasAccess || (!isActive && repository.status !== 'disabled')}
-                onConfirm={this.deleteRepo}
-                message={t('Are you sure you want to remove this repository?')}
-              >
-                <Button size="xsmall" icon="icon-trash" disabled={!hasAccess} />
-              </Confirm>
-            </Box>
+            <Confirm
+              disabled={!hasAccess || (!isActive && repository.status !== 'disabled')}
+              onConfirm={this.deleteRepo}
+              message={t('Are you sure you want to remove this repository?')}
+            >
+              <Button size="xsmall" icon="icon-trash" disabled={!hasAccess} />
+            </Confirm>
           </StyledRow>
         )}
       </Access>
@@ -122,6 +115,10 @@ class RepositoryRow extends React.Component {
 
 const StyledRow = styled(SpreadLayout)`
   border-bottom: 1px solid ${p => p.theme.borderLight};
+  /* shorter top padding because of title lineheight */
+  padding: ${space(1)} ${space(2)} ${space(2)};
+  flex: 1;
+  align-items: space-between;
 
   ${p =>
     p.status === 'disabled' &&
@@ -133,6 +130,16 @@ const StyledRow = styled(SpreadLayout)`
   &:last-child {
     border-bottom: none;
   }
+`;
+
+const StyledButton = styled(Button)`
+  margin-left: ${space(1)};
+`;
+
+const RepositoryTitle = styled(Box)`
+  margin-bottom: ${space(1)};
+  /* accomodate cancel button height */
+  line-height: 26px;
 `;
 
 export default RepositoryRow;

--- a/src/sentry/static/sentry/app/components/repositoryRow.jsx
+++ b/src/sentry/static/sentry/app/components/repositoryRow.jsx
@@ -76,15 +76,18 @@ class RepositoryRow extends React.Component {
                 <Box pb={1}>
                   <strong>{repository.name}</strong>
                   {!isActive && <small> — {this.getStatusLabel(repository)}</small>}
-                  {hasAccess &&
-                    repository.status === 'pending_deletion' && (
-                      <small>
-                        {' '}
-                        (
-                        <a onClick={this.cancelDelete}>{t('Cancel')}</a>
-                        )
-                      </small>
-                    )}
+                  {repository.status === 'pending_deletion' && (
+                    <Button
+                      size="xsmall"
+                      borderless
+                      icon="icon-circle-close"
+                      onClick={this.cancelDelete}
+                      disabled={!hasAccess}
+                      data-test-id="repo-cancel"
+                    >
+                      {t('Cancel')}
+                    </Button>
+                  )}
                 </Box>
                 <Box>
                   {showProvider && (

--- a/src/sentry/static/sentry/app/components/repositoryRow.jsx
+++ b/src/sentry/static/sentry/app/components/repositoryRow.jsx
@@ -68,7 +68,7 @@ class RepositoryRow extends React.Component {
     let isActive = this.isActive;
 
     return (
-      <Access access={['org:write']}>
+      <Access access={['org:admin']}>
         {({hasAccess}) => (
           <StyledRow status={repository.status}>
             <Box p={2} flex="1">

--- a/tests/js/spec/components/repositoryRow.spec.jsx
+++ b/tests/js/spec/components/repositoryRow.spec.jsx
@@ -1,0 +1,140 @@
+/*global global*/
+import React from 'react';
+
+import {Client} from 'app/api';
+import {mount} from 'enzyme';
+import RepositoryRow from 'app/components/repositoryRow';
+
+describe('RepositoryRow', function() {
+  beforeEach(function() {
+    Client.clearMockResponses();
+  });
+
+  const repository = TestStubs.Repository();
+  const pendingRepo = TestStubs.Repository({
+    status: 'pending_deletion',
+  });
+  const api = new Client();
+
+  describe('rendering with access', function() {
+    const organization = TestStubs.Organization({
+      access: ['org:admin'],
+    });
+    const routerContext = TestStubs.routerContext([{organization}]);
+
+    it('displays provider information', function() {
+      const wrapper = mount(
+        <RepositoryRow repository={repository} api={api} orgId={organization.slug} />,
+        routerContext
+      );
+      expect(wrapper.find('strong').text()).toEqual(repository.name);
+      expect(wrapper.find('small a').text()).toEqual('github.com/example/repo-name');
+
+      // Trash button should display enabled
+      expect(wrapper.find('Confirm').props().disabled).toEqual(false);
+
+      // No cancel button
+      expect(wrapper.find('Button[icon="icon-circle-close"]')).toHaveLength(0);
+    });
+
+    it('displays cancel pending button', function() {
+      const wrapper = mount(
+        <RepositoryRow repository={pendingRepo} api={api} orgId={organization.slug} />,
+        routerContext
+      );
+
+      // Trash button should be disabled
+      expect(wrapper.find('Confirm').props().disabled).toEqual(true);
+      expect(wrapper.find('Button[icon="icon-trash"]').props().disabled).toEqual(true);
+
+      // Cancel button active
+      let cancel = wrapper.find('Button[icon="icon-circle-close"]');
+      expect(cancel).toHaveLength(1);
+      expect(cancel.props().disabled).toEqual(false);
+    });
+  });
+
+  describe('rendering without access', function() {
+    const organization = TestStubs.Organization({
+      access: ['org:write'],
+    });
+    const routerContext = TestStubs.routerContext([{organization}]);
+
+    it('displays disabled trash', function() {
+      const wrapper = mount(
+        <RepositoryRow repository={repository} api={api} orgId={organization.slug} />,
+        routerContext
+      );
+
+      // Trash button should be disabled
+      expect(wrapper.find('Confirm').props().disabled).toEqual(true);
+      expect(wrapper.find('Button[icon="icon-trash"]').props().disabled).toEqual(true);
+    });
+
+    it('displays disabled cancel', function() {
+      const wrapper = mount(
+        <RepositoryRow repository={pendingRepo} api={api} orgId={organization.slug} />,
+        routerContext
+      );
+
+      // Cancel should be disabled
+      expect(wrapper.find('Button[icon="icon-circle-close"]').props().disabled).toEqual(
+        true
+      );
+    });
+  });
+
+  describe('deletion', function() {
+    const organization = TestStubs.Organization({
+      access: ['org:admin'],
+    });
+    const routerContext = TestStubs.routerContext([{organization}]);
+
+    it('sends api request on delete', async function() {
+      let deleteRepo = Client.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/${repository.id}/`,
+        method: 'DELETE',
+        statusCode: 204,
+        body: {},
+      });
+
+      const wrapper = mount(
+        <RepositoryRow repository={repository} api={api} orgId={organization.slug} />,
+        routerContext
+      );
+      wrapper.find('Button[icon="icon-trash"]').simulate('click');
+      await tick();
+
+      // Confirm modal
+      wrapper.find('ModalDialog Button[priority="primary"]').simulate('click');
+      await wrapper.update();
+
+      expect(deleteRepo).toHaveBeenCalled();
+    });
+  });
+
+  describe('cancel deletion', function() {
+    const organization = TestStubs.Organization({
+      access: ['org:admin'],
+    });
+    const routerContext = TestStubs.routerContext([{organization}]);
+
+    it('sends api request to cancel', async function() {
+      let cancel = Client.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/${pendingRepo.id}/`,
+        method: 'PUT',
+        statusCode: 204,
+        body: {},
+      });
+
+      const wrapper = mount(
+        <RepositoryRow repository={pendingRepo} api={api} orgId={organization.slug} />,
+        routerContext
+      );
+      wrapper.find('Button[icon="icon-circle-close"]').simulate('click');
+      await wrapper.update();
+
+      expect(cancel).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/js/spec/components/repositoryRow.spec.jsx
+++ b/tests/js/spec/components/repositoryRow.spec.jsx
@@ -34,7 +34,7 @@ describe('RepositoryRow', function() {
       expect(wrapper.find('Confirm').props().disabled).toEqual(false);
 
       // No cancel button
-      expect(wrapper.find('Button[icon="icon-circle-close"]')).toHaveLength(0);
+      expect(wrapper.find('Button[data-test-id="repo-cancel"]')).toHaveLength(0);
     });
 
     it('displays cancel pending button', function() {
@@ -48,7 +48,7 @@ describe('RepositoryRow', function() {
       expect(wrapper.find('Button[icon="icon-trash"]').props().disabled).toEqual(true);
 
       // Cancel button active
-      let cancel = wrapper.find('Button[icon="icon-circle-close"]');
+      let cancel = wrapper.find('Button[data-test-id="repo-cancel"]');
       expect(cancel).toHaveLength(1);
       expect(cancel.props().disabled).toEqual(false);
     });
@@ -78,7 +78,7 @@ describe('RepositoryRow', function() {
       );
 
       // Cancel should be disabled
-      expect(wrapper.find('Button[icon="icon-circle-close"]').props().disabled).toEqual(
+      expect(wrapper.find('Button[data-test-id="repo-cancel"]').props().disabled).toEqual(
         true
       );
     });
@@ -131,7 +131,7 @@ describe('RepositoryRow', function() {
         <RepositoryRow repository={pendingRepo} api={api} orgId={organization.slug} />,
         routerContext
       );
-      wrapper.find('Button[icon="icon-circle-close"]').simulate('click');
+      wrapper.find('Button[data-test-id="repo-cancel"]').simulate('click');
       await wrapper.update();
 
       expect(cancel).toHaveBeenCalled();


### PR DESCRIPTION
Only users with org:admin can perform DELETE operations. Scope the repository delete buttons appropriately.