### PR TITLE
feat: Allow specifying node_id

### DIFF
--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -8,10 +8,12 @@ sentry.db.models.fields.node
 
 from __future__ import absolute_import, print_function
 
+from base64 import b64encode
 import collections
 import logging
 import six
 import warnings
+from uuid import uuid4
 
 from django.conf import settings
 from django.db import models
@@ -39,8 +41,17 @@ class NodeIntegrityFailure(Exception):
 
 
 class NodeData(collections.MutableMapping):
+    """
+        A wrapper for nodestore data that fetches the underlying data
+        from nodestore.
+
+        Initializing with:
+        data=None means, this is a node that needs to be fetched from nodestore.
+        data={...} means, this is an object that should be saved to nodestore.
+    """
     def __init__(self, field, id, data=None):
         self.field = field
+        assert id is not None
         self.id = id
         self.ref = None
         # ref version is used to discredit a previous ref
@@ -100,6 +111,10 @@ class NodeData(collections.MutableMapping):
 
     @memoize
     def data(self):
+        """
+        Get the current data object, fetching from nodestore if necessary.
+        """
+
         if self._node_data is not None:
             return self._node_data
 
@@ -133,6 +148,24 @@ class NodeData(collections.MutableMapping):
             self.data['_ref'] = ref
             self.data['_ref_version'] = self.field.ref_version
 
+    def save(self):
+        """
+        Write current data back to nodestore.
+        """
+
+        # We never loaded any data for reading or writing, so there
+        # is nothing to save.
+        if self._node_data is None:
+            return
+
+        # We can't put our wrappers into the nodestore, so we need to
+        # ensure that the data is converted into a plain old dict
+        to_write = self._node_data
+        if isinstance(to_write, CANONICAL_TYPES):
+            to_write = dict(to_write.items())
+
+        nodestore.set(self.id, to_write)
+
 
 class NodeField(GzippedDictField):
     """
@@ -144,6 +177,7 @@ class NodeField(GzippedDictField):
         self.ref_func = kwargs.pop('ref_func', None)
         self.ref_version = kwargs.pop('ref_version', None)
         self.wrapper = kwargs.pop('wrapper', None)
+        self.id_func = kwargs.pop('id_func', lambda x: b64encode(uuid4().bytes))
         super(NodeField, self).__init__(*args, **kwargs)
 
     def contribute_to_class(self, cls, name):
@@ -158,45 +192,58 @@ class NodeField(GzippedDictField):
         nodestore.delete(value.id)
 
     def to_python(self, value):
-        if isinstance(value, six.string_types) and value:
+        # If value is a string, we assume this is a value we've loaded from the
+        # database, it should be decompressed/unpickled, and we should end up
+        # with a dict.
+        if value and isinstance(value, six.string_types):
             try:
                 value = pickle.loads(decompress(value))
             except Exception as e:
+                # TODO this is a bit dangerous as a failure to read/decode the
+                # node_id will end up with this record being replaced with an
+                # empty value under a new key, potentially orphaning an
+                # original value in nodestore. OTOH if we can't decode the info
+                # here, the node was already effectively orphaned.
                 logger.exception(e)
-                value = {}
-        elif not value:
-            value = {}
+                value = None
 
-        if 'node_id' in value:
-            node_id = value.pop('node_id')
-            data = None
+        if value:
+            if 'node_id' in value:
+                node_id = value.pop('node_id')
+                # If the value is now empty, that means that it only had the
+                # node_id in it, which means that we should be looking to *load*
+                # the event body from nodestore. If it does have other stuff in
+                # it, that means we got an event body with a precomputed id in
+                # it, and we want to *save* the rest of the body to nodestore.
+                if value == {}:
+                    value = None
+            else:
+                node_id = self.id_func(value)
         else:
-            node_id = None
-            data = value
+            # Either we were passed a null/empty value in the constructor, or
+            # we failed to decode the value from the database. In this case,
+            # generate an id, and set the data to an empty dict so that we don't
+            # try and load anything from nodestore.
+            value = {}
+            node_id = self.id_func(value)
 
-        if self.wrapper is not None and data is not None:
-            data = self.wrapper(data)
+        if value is not None and self.wrapper is not None:
+            value = self.wrapper(value)
 
-        return NodeData(self, node_id, data)
+        return NodeData(self, node_id, value)
 
     def get_prep_value(self, value):
+        """
+            Prepares the NodeData to be written in a Model.save() call.
+
+            Makes sure the event body is written to nodestore and
+            returns the node_id reference to be written to rowstore.
+        """
         if not value and self.null:
             # save ourselves some storage
             return None
 
-        # We can't put our wrappers into the nodestore, so we need to
-        # ensure that the data is converted into a plain old dict
-        data = value.data
-        if isinstance(data, CANONICAL_TYPES):
-            data = dict(data.items())
-
-        # TODO(dcramer): we should probably do this more intelligently
-        # and manually
-        if not value.id:
-            value.id = nodestore.create(data)
-        else:
-            nodestore.set(value.id, data)
-
+        value.save()
         return compress(pickle.dumps({'node_id': value.id}))
 
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -724,6 +724,8 @@ class EventManager(object):
         date = date.replace(tzinfo=timezone.utc)
         time_spent = data.get('time_spent')
 
+        data['node_id'] = Event.generate_node_id(project_id, event_id)
+
         return Event(
             project_id=project_id or self._project.id,
             event_id=event_id,

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -15,6 +15,7 @@ from collections import OrderedDict
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
+from hashlib import md5
 
 from sentry import eventtypes
 from sentry.db.models import (
@@ -57,6 +58,16 @@ class Event(Model):
         index_together = (('group_id', 'datetime'), )
 
     __repr__ = sane_repr('project_id', 'group_id')
+
+    @classmethod
+    def generate_node_id(cls, project_id, event_id):
+        """
+        Returns a deterministic node_id for this event based on the project_id
+        and event_id which together are globally unique. The event body should
+        be saved under this key in nodestore so it can be retrieved using the
+        same generated id when we only have project_id and event_id.
+        """
+        return md5('{}:{}'.format(project_id, event_id)).hexdigest()
 
     def __getstate__(self):
         state = Model.__getstate__(self)

--- a/src/sentry/utils/canonical.py
+++ b/src/sentry/utils/canonical.py
@@ -73,6 +73,9 @@ class CanonicalKeyView(collections.Mapping):
 
         raise KeyError(key)
 
+    def __repr__(self):
+        return self.data.__repr__()
+
 
 class CanonicalKeyDict(collections.MutableMapping):
     def __init__(self, data, legacy=None):
@@ -125,6 +128,9 @@ class CanonicalKeyDict(collections.MutableMapping):
 
     def __delitem__(self, key):
         del self.data[self._norm_func(key)]
+
+    def __repr__(self):
+        return self.data.__repr__()
 
 
 CANONICAL_TYPES = (CanonicalKeyDict, CanonicalKeyView)

--- a/tests/sentry/models/tests.py
+++ b/tests/sentry/models/tests.py
@@ -12,6 +12,7 @@ from django.http import HttpRequest
 from django.utils import timezone
 from exam import fixture
 
+from sentry import nodestore
 from sentry.db.models.fields.node import NodeData, NodeIntegrityFailure
 from sentry.models import ProjectKey, Event, LostPasswordHash
 from sentry.testutils import TestCase
@@ -119,7 +120,6 @@ class EventNodeStoreTest(TestCase):
         event = Event.objects.get(id=event_id)
         assert type(event.data) == NodeData
         assert event.data == data
-        assert event.data.id is None
 
         event.save()
 
@@ -133,6 +133,44 @@ class EventNodeStoreTest(TestCase):
 
         assert event.data == data
         assert event.data.id == node_id
+
+    def test_event_node_id(self):
+        # Create an event without specifying node_id. A node_id should be generated
+        e1 = Event(project_id=1, event_id='abc', data={'foo': 'bar'})
+        assert e1.data.id is not None, "We should have generated a node_id for this event"
+        e1_node_id = e1.data.id
+        e1.save()
+        e1_body = nodestore.get(e1_node_id)
+        assert e1_body == {'foo': 'bar'}, "The event body should be in nodestore"
+
+        e1 = Event.objects.get(project_id=1, event_id='abc')
+        assert e1.data.data == {'foo': 'bar'}, "The event body should be loaded from nodestore"
+        assert e1.data.id == e1_node_id, "The event's node_id should be the same after load"
+
+        # Create another event that references the same nodestore object as the first event.
+        e2 = Event(project_id=1, event_id='def', data={'node_id': e1_node_id})
+        assert e2.data.id == e1_node_id, "The event should use the provided node_id"
+        e2_body = nodestore.get(e1_node_id)
+        assert e2_body == {'foo': 'bar'}, "The event body should be in nodestore already"
+        e2.save()
+        e2_body = nodestore.get(e1_node_id)
+        assert e2_body == {'foo': 'bar'}, "The event body should not be overwritten by save"
+
+        e2 = Event.objects.get(project_id=1, event_id='def')
+        assert e2.data.data == {'foo': 'bar'}, "The event body should be loaded from nodestore"
+        assert e2.data.id == e1_node_id, "The event's node_id should be the same after load"
+
+        # Create an event with a new event body that specifies the node_id to use.
+        e3 = Event(project_id=1, event_id='ghi', data={'baz': 'quux', 'node_id': '1:ghi'})
+        assert e3.data.id == '1:ghi', "Event should have the specified node_id"
+        assert e3.data.data == {'baz': 'quux'}, "Event body should be the one provided (sans node_id)"
+        e3.save()
+        e3_body = nodestore.get('1:ghi')
+        assert e3_body == {'baz': 'quux'}, "Event body should be saved to nodestore"
+
+        e3 = Event.objects.get(project_id=1, event_id='ghi')
+        assert e3.data.data == {'baz': 'quux'}, "Event body should be loaded from nodestore"
+        assert e3.data.id == '1:ghi', "Loaded event should have the correct node_id"
 
     def test_screams_bloody_murder_when_ref_fails(self):
         project1 = self.create_project()


### PR DESCRIPTION
Same as https://github.com/getsentry/sentry/pull/10399 with an additional change to not generate an id automatically unless we actually have something to save to nodestore. This is so that `bind_nodes` doesn't get confused and try and load something at that id, which was the cause of our 404s in the last round.

I am still not 100% sure where Events with no data payload are being created and then `bind_nodes` called on them. This seems potentially like a logic error somewhere.