### PR TITLE
feat(group): Send analytics for discard delete modal opening

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/actions.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 
+import {analytics} from 'app/utils/analytics';
 import {openModal} from 'app/actionCreators/modal';
 import {t} from 'app/locale';
 import ApiMixin from 'app/mixins/apiMixin';
@@ -72,7 +73,12 @@ class DeleteActions extends React.Component {
     </Feature>
   );
 
-  openDiscardModal = () => openModal(this.renderDiscardModal);
+  openDiscardModal = () => {
+    openModal(this.renderDiscardModal);
+    analytics('feature.discard_group.modal_opened', {
+      org_id: parseInt(this.props.organization.id, 10),
+    });
+  };
 
   render() {
     return (


### PR DESCRIPTION
Sends analytics when we a user opens the discard and delete modal

Refs: https://github.com/getsentry/reload/pull/75