### PR TITLE
fix(event-search): Use ifNull instead of ifnull

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -297,7 +297,7 @@ def get_snuba_query_args(query=None, params=None):
                 # - Checking that a value isn't present. In some cases the column will be null,
                 # and in other cases an empty string. To generalize this we convert values in the
                 # column to an empty string and just check for that.
-                snuba_name = ['ifnull', [snuba_name, "''"]]
+                snuba_name = ['ifNull', [snuba_name, "''"]]
 
             if _filter.value.is_wildcard():
                 kwargs['conditions'].append(

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -280,7 +280,7 @@ class EventSearchTest(TestCase):
     def test_negation_get_snuba_query_args(self):
         assert get_snuba_query_args('!user.email:foo@example.com') == {
             'conditions': [
-                [['ifnull', ['email', "''"]], '!=', 'foo@example.com'],
+                [['ifNull', ['email', "''"]], '!=', 'foo@example.com'],
             ],
             'filter_keys': {},
         }
@@ -309,7 +309,7 @@ class EventSearchTest(TestCase):
     def test_get_snuba_query_args_negated_wildcard(self):
         assert get_snuba_query_args('!release:3.1.* user.email:*@example.com') == {
             'conditions': [
-                [['match', [['ifnull', ['tags[sentry:release]', "''"]], "'^3\\.1\\..*$'"]], '!=', 1],
+                [['match', [['ifNull', ['tags[sentry:release]', "''"]], "'^3\\.1\\..*$'"]], '!=', 1],
                 [['match', ['email', "'^.*\\@example\\.com$'"]], '=', 1],
             ],
             'filter_keys': {},
@@ -318,13 +318,13 @@ class EventSearchTest(TestCase):
     def test_get_snuba_query_args_has(self):
         assert get_snuba_query_args('has:release') == {
             'filter_keys': {},
-            'conditions': [[['ifnull', ['tags[sentry:release]', "''"]], '!=', '']]
+            'conditions': [[['ifNull', ['tags[sentry:release]', "''"]], '!=', '']]
         }
 
     def test_get_snuba_query_args_not_has(self):
         assert get_snuba_query_args('!has:release') == {
             'filter_keys': {},
-            'conditions': [[['ifnull', ['tags[sentry:release]', "''"]], '=', '']]
+            'conditions': [[['ifNull', ['tags[sentry:release]', "''"]], '=', '']]
         }
 
     def test_convert_endpoint_params(self):


### PR DESCRIPTION
Some org events tests were failing locally for me because of this. Not entirely sure why they weren't/aren't failing in travis...

https://clickhouse.yandex/docs/en/query_language/functions/functions_for_nulls/#ifnull