### PR TITLE
feat: Publish (normalized) events in StoreView to Kafka

### DIFF
--- a/src/sentry/event_consumer.py
+++ b/src/sentry/event_consumer.py
@@ -10,7 +10,8 @@ def process_event_from_kafka(message):
 
     project = Project.objects.get_from_cache(pk=message['project_id'])
 
-    view = type_name_to_view[message['type']]
+    event_type = message['type']
+    view = type_name_to_view[event_type]
     helper_cls = view.helper_cls
     remote_addr = message['remote_addr']
     helper = helper_cls(
@@ -38,4 +39,5 @@ def process_event_from_kafka(message):
     event_manager._normalized = True
     del data
 
-    return process_event(event_manager, project, key, remote_addr, helper, attachments=None)
+    return process_event(event_type, event_manager, project, key,
+                         remote_addr, helper, attachments=None)

--- a/src/sentry/event_consumer.py
+++ b/src/sentry/event_consumer.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import, print_function
+
+from sentry.coreapi import Auth
+from sentry.event_manager import EventManager
+from sentry.web.api import process_event
+
+
+def process_event_from_kafka(message):
+    from sentry.models import Project
+    from sentry.utils.imports import import_string
+
+    project = Project.objects.get_from_cache(pk=message['project_id'])
+
+    helper_cls = import_string(message['helper_cls'])
+    remote_addr = message['remote_addr']
+    helper = helper_cls(
+        agent=message['agent'],
+        project_id=project.id,
+        ip_address=remote_addr,
+    )
+    auth = Auth(message['auth'], message['auth'].pop('is_public'))
+    key = helper.project_key_from_auth(auth)
+    data = message['data']
+    version = data['version']
+
+    event_manager = EventManager(
+        data,
+        project=project,
+        key=key,
+        auth=auth,
+        client_ip=remote_addr,
+        user_agent=helper.context.agent,
+        version=version,
+    )
+    event_manager._normalized = True
+    del data
+
+    return process_event(event_manager, project, key, remote_addr, helper, attachments=None)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -152,3 +152,7 @@ register('kafka-publisher.max-event-size', default=100000)
 
 # Event Stream
 register('eventstream.kafka.send-post_process-task', type=Bool, default=True)
+
+# Ingest refactor
+register('store.process-in-kafka', type=Bool, default=False)
+register('store.kafka-sample-rate', default=0.0)

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -91,6 +91,160 @@ def api(func):
     return wrapped
 
 
+def process_event(event_manager, project, key, remote_addr, helper, attachments):
+    event_received.send_robust(ip=remote_addr, project=project, sender=process_event)
+
+    start_time = time()
+    tsdb_start_time = to_datetime(start_time)
+    should_filter, filter_reason = event_manager.should_filter()
+    if should_filter:
+        increment_list = [
+            (tsdb.models.project_total_received, project.id),
+            (tsdb.models.project_total_blacklisted, project.id),
+            (tsdb.models.organization_total_received,
+                project.organization_id),
+            (tsdb.models.organization_total_blacklisted,
+                project.organization_id),
+            (tsdb.models.key_total_received, key.id),
+            (tsdb.models.key_total_blacklisted, key.id),
+        ]
+        try:
+            increment_list.append(
+                (FILTER_STAT_KEYS_TO_VALUES[filter_reason], project.id))
+        # should error when filter_reason does not match a key in FILTER_STAT_KEYS_TO_VALUES
+        except KeyError:
+            pass
+
+        tsdb.incr_multi(
+            increment_list,
+            timestamp=tsdb_start_time,
+        )
+
+        metrics.incr(
+            'events.blacklisted', tags={'reason': filter_reason}
+        )
+        event_filtered.send_robust(
+            ip=remote_addr,
+            project=project,
+            sender=process_event,
+        )
+        raise APIForbidden('Event dropped due to filter: %s' % (filter_reason,))
+
+    # TODO: improve this API (e.g. make RateLimit act on __ne__)
+    rate_limit = safe_execute(
+        quotas.is_rate_limited, project=project, key=key, _with_transaction=False
+    )
+    if isinstance(rate_limit, bool):
+        rate_limit = RateLimit(is_limited=rate_limit, retry_after=None)
+
+    # XXX(dcramer): when the rate limiter fails we drop events to ensure
+    # it cannot cascade
+    if rate_limit is None or rate_limit.is_limited:
+        if rate_limit is None:
+            api_logger.debug('Dropped event due to error with rate limiter')
+        tsdb.incr_multi(
+            [
+                (tsdb.models.project_total_received, project.id),
+                (tsdb.models.project_total_rejected, project.id),
+                (tsdb.models.organization_total_received,
+                    project.organization_id),
+                (tsdb.models.organization_total_rejected,
+                    project.organization_id),
+                (tsdb.models.key_total_received, key.id),
+                (tsdb.models.key_total_rejected, key.id),
+            ],
+            timestamp=tsdb_start_time,
+        )
+        metrics.incr(
+            'events.dropped',
+            tags={
+                'reason': rate_limit.reason_code if rate_limit else 'unknown',
+            }
+        )
+        event_dropped.send_robust(
+            ip=remote_addr,
+            project=project,
+            reason_code=rate_limit.reason_code if rate_limit else None,
+            sender=process_event,
+        )
+        if rate_limit is not None:
+            raise APIRateLimited(rate_limit.retry_after)
+    else:
+        tsdb.incr_multi(
+            [
+                (tsdb.models.project_total_received, project.id),
+                (tsdb.models.organization_total_received,
+                    project.organization_id),
+                (tsdb.models.key_total_received, key.id),
+            ],
+            timestamp=tsdb_start_time,
+        )
+
+    org_options = OrganizationOption.objects.get_all_values(
+        project.organization_id)
+
+    data = event_manager.get_data()
+    del event_manager
+
+    event_id = data['event_id']
+
+    # TODO(dcramer): ideally we'd only validate this if the event_id was
+    # supplied by the user
+    cache_key = 'ev:%s:%s' % (project.id, event_id, )
+
+    if cache.get(cache_key) is not None:
+        raise APIForbidden(
+            'An event with the same ID already exists (%s)' % (event_id, ))
+
+    scrub_ip_address = (org_options.get('sentry:require_scrub_ip_address', False) or
+                        project.get_option('sentry:scrub_ip_address', False))
+    scrub_data = (org_options.get('sentry:require_scrub_data', False) or
+                  project.get_option('sentry:scrub_data', True))
+
+    if scrub_data:
+        # We filter data immediately before it ever gets into the queue
+        sensitive_fields_key = 'sentry:sensitive_fields'
+        sensitive_fields = (
+            org_options.get(sensitive_fields_key, []) +
+            project.get_option(sensitive_fields_key, [])
+        )
+
+        exclude_fields_key = 'sentry:safe_fields'
+        exclude_fields = (
+            org_options.get(exclude_fields_key, []) +
+            project.get_option(exclude_fields_key, [])
+        )
+
+        scrub_defaults = (org_options.get('sentry:require_scrub_defaults', False) or
+                          project.get_option('sentry:scrub_defaults', True))
+
+        SensitiveDataFilter(
+            fields=sensitive_fields,
+            include_defaults=scrub_defaults,
+            exclude_fields=exclude_fields,
+        ).apply(data)
+
+    if scrub_ip_address:
+        # We filter data immediately before it ever gets into the queue
+        helper.ensure_does_not_have_ip(data)
+
+    # mutates data (strips a lot of context if not queued)
+    helper.insert_data_to_database(data, start_time=start_time, attachments=attachments)
+
+    cache.set(cache_key, '', 60 * 5)
+
+    api_logger.debug('New event received (%s)', event_id)
+
+    event_accepted.send_robust(
+        ip=remote_addr,
+        data=data,
+        project=project,
+        sender=process_event,
+    )
+
+    return event_id
+
+
 class APIView(BaseView):
     helper_cls = ClientApiHelper
 
@@ -378,7 +532,7 @@ class StoreView(APIView):
 
         remote_addr = request.META['REMOTE_ADDR']
 
-        event_mgr = EventManager(
+        event_manager = EventManager(
             data,
             project=project,
             key=key,
@@ -390,159 +544,53 @@ class StoreView(APIView):
         )
         del data
 
-        self.pre_normalize(event_mgr, helper)
-        event_mgr.normalize()
+        self.pre_normalize(event_manager, helper)
+        event_manager.normalize()
 
-        event_received.send_robust(ip=remote_addr, project=project, sender=type(self))
+        # TODO: Some form of coordination between the Kafka consumer
+        # and this method (the 'relay') to decide whether a 429 should
+        # be returned here.
 
-        start_time = time()
-        tsdb_start_time = to_datetime(start_time)
-        should_filter, filter_reason = event_mgr.should_filter()
-        if should_filter:
-            increment_list = [
-                (tsdb.models.project_total_received, project.id),
-                (tsdb.models.project_total_blacklisted, project.id),
-                (tsdb.models.organization_total_received,
-                 project.organization_id),
-                (tsdb.models.organization_total_blacklisted,
-                 project.organization_id),
-                (tsdb.models.key_total_received, key.id),
-                (tsdb.models.key_total_blacklisted, key.id),
-            ]
+        # Everything before this will eventually be done in the relay.
+        if (kafka_publisher is not None
+                and not attachments
+                and random.random() < options.get('store.kafka-sample-rate')):
+
+            process_in_kafka = options.get('store.process-in-kafka')
+
             try:
-                increment_list.append(
-                    (FILTER_STAT_KEYS_TO_VALUES[filter_reason], project.id))
-            # should error when filter_reason does not match a key in FILTER_STAT_KEYS_TO_VALUES
-            except KeyError:
-                pass
+                kafka_publisher.publish(
+                    channel=getattr(settings, 'KAFKA_EVENTS_PUBLISHER_TOPIC', 'store-events'),
+                    # Relay will (eventually) need to produce a Kafka message
+                    # with this JSON format.
+                    value=json.dumps({
+                        'data': event_manager.get_data(),
+                        'project_id': project.id,
+                        'auth': {
+                            'sentry_client': auth.client,
+                            'sentry_version': auth.version,
+                            'sentry_secret': auth.secret_key,
+                            'sentry_key': auth.public_key,
+                            'is_public': auth.is_public,
+                        },
+                        'remote_addr': remote_addr,
+                        'agent': request.META.get('HTTP_USER_AGENT'),
+                        'helper_cls': '.'.join((type(helper).__module__, type(helper).__name__)),
+                        # Whether or not the Kafka consumer is in charge
+                        # of actually processing this event.
+                        'should_process': process_in_kafka,
+                    })
+                )
+            except Exception as e:
+                logger.exception("Cannot publish event to Kafka: {}".format(e.message))
+            else:
+                if process_in_kafka:
+                    # This event will be processed by the Kafka consumer, so we
+                    # shouldn't double process it here.
+                    return event_manager.get_data()['event_id']
 
-            tsdb.incr_multi(
-                increment_list,
-                timestamp=tsdb_start_time,
-            )
-
-            metrics.incr('events.blacklisted', tags={
-                         'reason': filter_reason})
-            event_filtered.send_robust(
-                ip=remote_addr,
-                project=project,
-                sender=type(self),
-            )
-            raise APIForbidden('Event dropped due to filter: %s' % (filter_reason,))
-
-        # TODO: improve this API (e.g. make RateLimit act on __ne__)
-        rate_limit = safe_execute(
-            quotas.is_rate_limited, project=project, key=key, _with_transaction=False
-        )
-        if isinstance(rate_limit, bool):
-            rate_limit = RateLimit(is_limited=rate_limit, retry_after=None)
-
-        # XXX(dcramer): when the rate limiter fails we drop events to ensure
-        # it cannot cascade
-        if rate_limit is None or rate_limit.is_limited:
-            if rate_limit is None:
-                api_logger.debug('Dropped event due to error with rate limiter')
-            tsdb.incr_multi(
-                [
-                    (tsdb.models.project_total_received, project.id),
-                    (tsdb.models.project_total_rejected, project.id),
-                    (tsdb.models.organization_total_received,
-                     project.organization_id),
-                    (tsdb.models.organization_total_rejected,
-                     project.organization_id),
-                    (tsdb.models.key_total_received, key.id),
-                    (tsdb.models.key_total_rejected, key.id),
-                ],
-                timestamp=tsdb_start_time,
-            )
-            metrics.incr(
-                'events.dropped',
-                tags={
-                    'reason': rate_limit.reason_code if rate_limit else 'unknown',
-                }
-            )
-            event_dropped.send_robust(
-                ip=remote_addr,
-                project=project,
-                sender=type(self),
-                reason_code=rate_limit.reason_code if rate_limit else None,
-            )
-            if rate_limit is not None:
-                raise APIRateLimited(rate_limit.retry_after)
-        else:
-            tsdb.incr_multi(
-                [
-                    (tsdb.models.project_total_received, project.id),
-                    (tsdb.models.organization_total_received,
-                     project.organization_id),
-                    (tsdb.models.key_total_received, key.id),
-                ],
-                timestamp=tsdb_start_time,
-            )
-
-        org_options = OrganizationOption.objects.get_all_values(
-            project.organization_id)
-
-        data = event_mgr.get_data()
-        del event_mgr
-
-        event_id = data['event_id']
-
-        # TODO(dcramer): ideally we'd only validate this if the event_id was
-        # supplied by the user
-        cache_key = 'ev:%s:%s' % (project.id, event_id, )
-
-        if cache.get(cache_key) is not None:
-            raise APIForbidden(
-                'An event with the same ID already exists (%s)' % (event_id, ))
-
-        scrub_ip_address = (org_options.get('sentry:require_scrub_ip_address', False) or
-                            project.get_option('sentry:scrub_ip_address', False))
-        scrub_data = (org_options.get('sentry:require_scrub_data', False) or
-                      project.get_option('sentry:scrub_data', True))
-
-        if scrub_data:
-            # We filter data immediately before it ever gets into the queue
-            sensitive_fields_key = 'sentry:sensitive_fields'
-            sensitive_fields = (
-                org_options.get(sensitive_fields_key, []) +
-                project.get_option(sensitive_fields_key, [])
-            )
-
-            exclude_fields_key = 'sentry:safe_fields'
-            exclude_fields = (
-                org_options.get(exclude_fields_key, []) +
-                project.get_option(exclude_fields_key, [])
-            )
-
-            scrub_defaults = (org_options.get('sentry:require_scrub_defaults', False) or
-                              project.get_option('sentry:scrub_defaults', True))
-
-            SensitiveDataFilter(
-                fields=sensitive_fields,
-                include_defaults=scrub_defaults,
-                exclude_fields=exclude_fields,
-            ).apply(data)
-
-        if scrub_ip_address:
-            # We filter data immediately before it ever gets into the queue
-            helper.ensure_does_not_have_ip(data)
-
-        # mutates data (strips a lot of context if not queued)
-        helper.insert_data_to_database(data, start_time=start_time, attachments=attachments)
-
-        cache.set(cache_key, '', 60 * 5)
-
-        api_logger.debug('New event received (%s)', event_id)
-
-        event_accepted.send_robust(
-            ip=remote_addr,
-            data=data,
-            project=project,
-            sender=type(self),
-        )
-
-        return event_id
+        # Everything after this will eventually be done in a Kafka consumer.
+        return process_event(event_manager, project, key, remote_addr, helper, attachments)
 
 
 class MinidumpView(StoreView):

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -487,6 +487,7 @@ class StoreView(APIView):
        the user be authenticated, and a project_id be sent in the GET variables.
 
     """
+    type_name = 'store'
 
     def post(self, request, **kwargs):
         try:
@@ -575,7 +576,7 @@ class StoreView(APIView):
                         },
                         'remote_addr': remote_addr,
                         'agent': request.META.get('HTTP_USER_AGENT'),
-                        'helper_cls': '.'.join((type(helper).__module__, type(helper).__name__)),
+                        'type': type(self).type_name,
                         # Whether or not the Kafka consumer is in charge
                         # of actually processing this event.
                         'should_process': process_in_kafka,
@@ -594,6 +595,7 @@ class StoreView(APIView):
 
 
 class MinidumpView(StoreView):
+    type_name = 'minidump'
     helper_cls = MinidumpApiHelper
     content_types = ('multipart/form-data', )
 
@@ -761,6 +763,7 @@ class MinidumpView(StoreView):
 
 # Endpoint used by the Unreal Engine 4 (UE4) Crash Reporter.
 class UnrealView(StoreView):
+    type_name = 'unreal'
     content_types = ('application/octet-stream', )
 
     def _dispatch(self, request, helper, sentry_key, project_id=None, origin=None, *args, **kwargs):
@@ -851,6 +854,7 @@ class StoreSchemaView(BaseView):
 
 
 class SecurityReportView(StoreView):
+    type_name = 'security'
     helper_cls = SecurityApiHelper
     content_types = (
         'application/csp-report',
@@ -964,3 +968,10 @@ def crossdomain_xml(request, project_id):
     response['Content-Type'] = 'application/xml'
 
     return response
+
+
+type_name_to_view = {
+    v.type_name: v for v in [
+        StoreView, SecurityReportView, UnrealView, MinidumpView
+    ]
+}

--- a/tests/sentry/test_event_consumer.py
+++ b/tests/sentry/test_event_consumer.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import, print_function
+
+import mock
+
+from sentry.event_consumer import process_event_from_kafka
+from sentry.signals import event_accepted
+from sentry.testutils import (assert_mock_called_once_with_partial, TestCase)
+from sentry.utils import json
+
+
+class EventConsumerTest(TestCase):
+    @mock.patch('sentry.web.api.kafka_publisher')
+    def test_event_consumer(self, mock_kafka_publisher):
+        with self.options({
+            'store.kafka-sample-rate': 1.0,
+            'store.process-in-kafka': True,
+            'kafka-publisher.raw-event-sample-rate': 0.0,
+        }):
+            mock_event_accepted = mock.Mock()
+            event_accepted.connect(mock_event_accepted)
+
+            resp = self._postWithHeader({'logentry': {'message': u'hello'}})
+            assert resp.status_code == 200, resp.content
+
+            publish_args, publish_kwargs = list(mock_kafka_publisher.publish.call_args)
+            kafka_message_value = publish_kwargs['value']
+            process_event_from_kafka(json.loads(kafka_message_value))
+
+            assert_mock_called_once_with_partial(
+                mock_event_accepted,
+                ip='127.0.0.1',
+                project=self.project,
+                signal=event_accepted,
+            )


### PR DESCRIPTION
This begins the 'dividing' line in StoreView between what will
eventually be done in Relay (before Kafka publish) and what will
eventually be done in a Kafka consumer (after Kafka publish).

Post-Kafka logic is extracted to a `process_event` function so it can be
re-used in the Kafka consumer. The goal here is *not* to refactor our
entire event pipeline as part of this migration, so changes were kept to
a minimum.

The bare minimum state is published to Kafka that will allow the
consumer to continue on and re-use the existing StoreView processing
logic.

---

This should be considered a WIP in that it will certainly spark some discussion on what parts should be moved before or after the Kafka Publish. Note that we should be forward thinking and expect things to move in the future. For example: in the future Relay may handle all scrubbing, so we would (in the future) add a `scrubbed: True` key to the message and therefore skip the scrubbing logic in the Kafka consumer (but do the other work to finish processing the event).
