### PR TITLE
fix(events-stream): Change Charts UI/UX

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/components/grid.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/grid.jsx
@@ -5,7 +5,7 @@
  */
 export default function Grid(props = {}) {
   return {
-    top: 40,
+    top: 20,
     bottom: 20,
     // This should allow for sufficient space for Y-axis labels
     left: '0%',

--- a/src/sentry/static/sentry/app/components/charts/components/toolBox.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/toolBox.jsx
@@ -23,7 +23,7 @@ export default function ToolBox(options, features = {}) {
   return {
     right: 0,
     top: 0,
-    itemSize: 20,
+    itemSize: 16,
 
     feature: getFeatures(features),
     ...options,

--- a/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
@@ -3,7 +3,7 @@ import 'echarts/lib/component/tooltip';
 import {getFormattedDate} from 'app/utils/dates';
 import {truncationFormatter} from '../utils';
 
-function formatAxisLabel(value, isTimestamp, utc) {
+function defaultFormatAxisLabel(value, isTimestamp, utc) {
   if (!isTimestamp) {
     return value;
   }
@@ -15,7 +15,7 @@ function valueFormatter(value) {
   return value.toLocaleString();
 }
 
-function getFormatter({filter, isGroupedByDate, truncate, utc}) {
+function getFormatter({filter, isGroupedByDate, truncate, formatAxisLabel, utc}) {
   const getFilter = seriesParam => {
     const value = seriesParam.data[1];
     if (typeof filter === 'function') {
@@ -28,7 +28,11 @@ function getFormatter({filter, isGroupedByDate, truncate, utc}) {
   return seriesParams => {
     const label =
       seriesParams.length &&
-      formatAxisLabel(seriesParams[0].axisValueLabel, isGroupedByDate, utc);
+      (formatAxisLabel || defaultFormatAxisLabel)(
+        seriesParams[0].axisValueLabel,
+        isGroupedByDate,
+        utc
+      );
     return [
       `<div>${truncationFormatter(label, truncate)}</div>`,
       seriesParams
@@ -46,9 +50,10 @@ function getFormatter({filter, isGroupedByDate, truncate, utc}) {
 }
 
 export default function Tooltip(
-  {filter, isGroupedByDate, formatter, truncate, utc, ...props} = {}
+  {filter, isGroupedByDate, formatter, truncate, utc, formatAxisLabel, ...props} = {}
 ) {
-  formatter = formatter || getFormatter({filter, isGroupedByDate, truncate, utc});
+  formatter =
+    formatter || getFormatter({filter, isGroupedByDate, truncate, utc, formatAxisLabel});
 
   return {
     show: true,

--- a/src/sentry/static/sentry/app/utils/theme.jsx
+++ b/src/sentry/static/sentry/app/utils/theme.jsx
@@ -234,7 +234,7 @@ theme.charts = {
     CHART_PALETTE[Math.min(CHART_PALETTE.length - 1, length + 1)],
 
   previousPeriod: theme.gray1,
-  symbolSize: 10,
+  symbolSize: 6,
 };
 
 theme.diff = {

--- a/tests/js/spec/views/organizationEvents/events.spec.jsx
+++ b/tests/js/spec/views/organizationEvents/events.spec.jsx
@@ -200,7 +200,7 @@ describe('OrganizationEventsErrors', function() {
       newParams = {
         zoom: '1',
         start: '2018-11-29T00:00:00',
-        end: '2018-12-02T23:59:59',
+        end: '2018-12-02T00:00:00',
       };
 
       expect(router.push).toHaveBeenLastCalledWith(
@@ -221,13 +221,13 @@ describe('OrganizationEventsErrors', function() {
 
       wrapper.update();
       expect(wrapper.state('start')).toEqual(getLocalDateObject('2018-11-29T00:00:00'));
-      expect(wrapper.state('end')).toEqual(getLocalDateObject('2018-12-02T23:59:59'));
+      expect(wrapper.state('end')).toEqual(getLocalDateObject('2018-12-02T00:00:00'));
 
       expect(wrapper.find('TimeRangeSelector').prop('start')).toEqual(
         getLocalDateObject('2018-11-29T00:00:00')
       );
       expect(wrapper.find('TimeRangeSelector').prop('end')).toEqual(
-        getLocalDateObject('2018-12-02T23:59:59')
+        getLocalDateObject('2018-12-02T00:00:00')
       );
     });
   });

--- a/tests/js/spec/views/organizationEvents/eventsChart.spec.jsx
+++ b/tests/js/spec/views/organizationEvents/eventsChart.spec.jsx
@@ -53,7 +53,7 @@ describe('EventsChart', function() {
     let newParams = {
       statsPeriod: null,
       start: '2018-11-29T00:00:00',
-      end: '2018-12-02T23:59:59',
+      end: '2018-12-02T00:00:00',
       zoom: '1',
     };
     expect(updateParams).toHaveBeenCalledWith(newParams);
@@ -81,14 +81,14 @@ describe('EventsChart', function() {
     ]);
     expect(wrapper.instance().currentPeriod.period).toEqual(null);
     expect(wrapper.instance().currentPeriod.start).toEqual('2018-11-29T00:00:00');
-    expect(wrapper.instance().currentPeriod.end).toEqual('2018-12-02T23:59:59');
+    expect(wrapper.instance().currentPeriod.end).toEqual('2018-12-02T00:00:00');
 
     // Zoom again
     mockZoomRange(3, 5);
     doZoom(wrapper, chart);
     expect(wrapper.instance().currentPeriod.period).toEqual(null);
     expect(wrapper.instance().currentPeriod.start).toEqual('2018-11-30T00:00:00');
-    expect(wrapper.instance().currentPeriod.end).toEqual('2018-12-02T23:59:59');
+    expect(wrapper.instance().currentPeriod.end).toEqual('2018-12-02T00:00:00');
 
     expect(wrapper.instance().history[0]).toEqual({
       period: '14d',
@@ -96,18 +96,18 @@ describe('EventsChart', function() {
       end: null,
     });
     expect(wrapper.instance().history[1].start).toEqual('2018-11-29T00:00:00');
-    expect(wrapper.instance().history[1].end).toEqual('2018-12-02T23:59:59');
+    expect(wrapper.instance().history[1].end).toEqual('2018-12-02T00:00:00');
 
     // go back in history
     mockZoomRange(null, null);
     doZoom(wrapper, chart);
     expect(wrapper.instance().currentPeriod.period).toEqual(null);
     expect(wrapper.instance().currentPeriod.start).toEqual('2018-11-29T00:00:00');
-    expect(wrapper.instance().currentPeriod.end).toEqual('2018-12-02T23:59:59');
+    expect(wrapper.instance().currentPeriod.end).toEqual('2018-12-02T00:00:00');
     newParams = {
       statsPeriod: null,
       start: '2018-11-29T00:00:00',
-      end: '2018-12-02T23:59:59',
+      end: '2018-12-02T00:00:00',
       zoom: '1',
     };
     expect(updateParams).toHaveBeenCalledWith(newParams);

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
@@ -527,7 +527,7 @@ exports[`Organization Developer Settings when Apps exist displays all Apps owned
                                                         ],
                                                         "getColorPalette": [Function],
                                                         "previousPeriod": "#BDB4C7",
-                                                        "symbolSize": 10,
+                                                        "symbolSize": 6,
                                                       },
                                                       "diff": Object {
                                                         "added": "#d8f0e4",
@@ -776,7 +776,7 @@ exports[`Organization Developer Settings when Apps exist displays all Apps owned
                                                                 ],
                                                                 "getColorPalette": [Function],
                                                                 "previousPeriod": "#BDB4C7",
-                                                                "symbolSize": 10,
+                                                                "symbolSize": 6,
                                                               },
                                                               "diff": Object {
                                                                 "added": "#d8f0e4",

--- a/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
@@ -650,7 +650,7 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                                   ],
                                                   "getColorPalette": [Function],
                                                   "previousPeriod": "#BDB4C7",
-                                                  "symbolSize": 10,
+                                                  "symbolSize": 6,
                                                 },
                                                 "diff": Object {
                                                   "added": "#d8f0e4",
@@ -916,7 +916,7 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                                           ],
                                                           "getColorPalette": [Function],
                                                           "previousPeriod": "#BDB4C7",
-                                                          "symbolSize": 10,
+                                                          "symbolSize": 6,
                                                         },
                                                         "diff": Object {
                                                           "added": "#d8f0e4",
@@ -2063,7 +2063,7 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                                   ],
                                                   "getColorPalette": [Function],
                                                   "previousPeriod": "#BDB4C7",
-                                                  "symbolSize": 10,
+                                                  "symbolSize": 6,
                                                 },
                                                 "diff": Object {
                                                   "added": "#d8f0e4",
@@ -2329,7 +2329,7 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                                           ],
                                                           "getColorPalette": [Function],
                                                           "previousPeriod": "#BDB4C7",
-                                                          "symbolSize": 10,
+                                                          "symbolSize": 6,
                                                         },
                                                         "diff": Object {
                                                           "added": "#d8f0e4",
@@ -3767,7 +3767,7 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                                   ],
                                                   "getColorPalette": [Function],
                                                   "previousPeriod": "#BDB4C7",
-                                                  "symbolSize": 10,
+                                                  "symbolSize": 6,
                                                 },
                                                 "diff": Object {
                                                   "added": "#d8f0e4",
@@ -4033,7 +4033,7 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                                           ],
                                                           "getColorPalette": [Function],
                                                           "previousPeriod": "#BDB4C7",
-                                                          "symbolSize": 10,
+                                                          "symbolSize": 6,
                                                         },
                                                         "diff": Object {
                                                           "added": "#d8f0e4",
@@ -4526,7 +4526,7 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                                   ],
                                                   "getColorPalette": [Function],
                                                   "previousPeriod": "#BDB4C7",
-                                                  "symbolSize": 10,
+                                                  "symbolSize": 6,
                                                 },
                                                 "diff": Object {
                                                   "added": "#d8f0e4",
@@ -4792,7 +4792,7 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                                           ],
                                                           "getColorPalette": [Function],
                                                           "previousPeriod": "#BDB4C7",
-                                                          "symbolSize": 10,
+                                                          "symbolSize": 6,
                                                         },
                                                         "diff": Object {
                                                           "added": "#d8f0e4",

--- a/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/sentryAppInstallations.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/sentryAppInstallations.spec.jsx.snap
@@ -320,7 +320,7 @@ exports[`Sentry App Installations when Apps exist displays all Apps owned by the
                                             ],
                                             "getColorPalette": [Function],
                                             "previousPeriod": "#BDB4C7",
-                                            "symbolSize": 10,
+                                            "symbolSize": 6,
                                           },
                                           "diff": Object {
                                             "added": "#d8f0e4",
@@ -586,7 +586,7 @@ exports[`Sentry App Installations when Apps exist displays all Apps owned by the
                                                     ],
                                                     "getColorPalette": [Function],
                                                     "previousPeriod": "#BDB4C7",
-                                                    "symbolSize": 10,
+                                                    "symbolSize": 6,
                                                   },
                                                   "diff": Object {
                                                     "added": "#d8f0e4",


### PR DESCRIPTION
Decreases time interval for chart to 30m + 5m (down from 1d/1h).
Less dots
Re-render chart when time interval changes (e.g. when changing from 7 days to 24 hrs)
Change axis/tooltip formatting
Removes zoom icons