### PR TITLE
feat(ui): Support controlled query filter values in DropdownAutocompleteMenu

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -35,6 +35,17 @@ class DropdownAutoCompleteMenu extends React.Component {
       ),
     ]),
 
+    /**
+     * If this is undefined, autocomplete filter will use this value instead of the
+     * current value in the filter input element.
+     *
+     * This is useful if you need to strip characters out of the search
+     */
+    filterValue: PropTypes.string,
+
+    /**
+     * Used to control dropdown state (optional)
+     */
     isOpen: PropTypes.bool,
 
     /**
@@ -48,6 +59,9 @@ class DropdownAutoCompleteMenu extends React.Component {
      */
     emptyHidesInput: PropTypes.bool,
 
+    /**
+     * When an item is selected (via clicking dropdown, or keyboard navigation)
+     */
     onSelect: PropTypes.func,
     /**
      * When AutoComplete input changes
@@ -286,6 +300,7 @@ class DropdownAutoCompleteMenu extends React.Component {
       itemSize,
       busy,
       hideInput,
+      filterValue,
       emptyHidesInput,
       ...props
     } = this.props;
@@ -312,19 +327,26 @@ class DropdownAutoCompleteMenu extends React.Component {
           isOpen,
           actions,
         }) => {
+          // This is the value to use to filter (default to value in filter input)
+          let filterValueOrInput =
+            typeof filterValue !== 'undefined' ? filterValue : inputValue;
           // Only filter results if menu is open and there are items
           let autoCompleteResults =
-            (isOpen && items && this.autoCompleteFilter(items, inputValue)) || [];
+            (isOpen &&
+              items &&
+              this.autoCompleteFilter(items, filterValueOrInput || '')) ||
+            [];
 
           // Can't search if there are no items
           let hasItems = items && !!items.length;
-
           // Items are loading if null
           let itemsLoading = items === null;
+          // Has filtered results
           let hasResults = !!autoCompleteResults.length;
-          let showNoItems = !busy && !inputValue && !hasItems;
-          // Results mean there was a search (i.e. inputValue)
-          let showNoResultsMessage = !busy && inputValue && !hasResults;
+          // No items to display
+          let showNoItems = !busy && !filterValueOrInput && !hasItems;
+          // Results mean there was an attempt to search
+          let showNoResultsMessage = !busy && filterValueOrInput && !hasResults;
 
           // Hide the input when we have no items to filter, only if
           // emptyHidesInput is set to true.
@@ -336,6 +358,7 @@ class DropdownAutoCompleteMenu extends React.Component {
           return (
             <AutoCompleteRoot {...getRootProps()} className={rootClassName}>
               {children({
+                getInputProps,
                 getActorProps,
                 actions,
                 isOpen,

--- a/tests/js/spec/components/dropdownAutoCompleteMenu.spec.jsx
+++ b/tests/js/spec/components/dropdownAutoCompleteMenu.spec.jsx
@@ -149,6 +149,20 @@ describe('DropdownAutoCompleteMenu', function() {
       </DropdownAutoCompleteMenu>,
       routerContext
     );
+
     expect(wrapper.find('StyledInput')).toHaveLength(0);
+  });
+
+  it('filters using a value from prop instead of input', function() {
+    const wrapper = mount(
+      <DropdownAutoCompleteMenu isOpen={true} items={items} filterValue="Apple">
+        {() => 'Click Me!'}
+      </DropdownAutoCompleteMenu>,
+      routerContext
+    );
+    wrapper.find('StyledInput').simulate('change', {target: {value: 'U-S-A'}});
+    expect(wrapper.find('EmptyMessage')).toHaveLength(0);
+    expect(wrapper.find('AutoCompleteItem')).toHaveLength(1);
+    expect(wrapper.find('AutoCompleteItem').text()).toBe('Apple');
   });
 });


### PR DESCRIPTION
Adds a prop to `<DropdownAutoCompleteMenu>` to use to filter dropdown items (instead of value in input). This allows you to modify (e.g. strip special characters) before filtering.