### PR TITLE
feat(ui): Add `hideInput` to `DropdownAutoCompleteMenu`

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -89,6 +89,11 @@ class DropdownAutoCompleteMenu extends React.Component {
     blendCorner: PropTypes.bool,
 
     /**
+     * Hides the default filter input
+     */
+    hideInput: PropTypes.bool,
+
+    /**
      * Max height of dropdown menu. Units are assumed as `px` if number, otherwise will assume string has units
      */
     maxHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -280,6 +285,7 @@ class DropdownAutoCompleteMenu extends React.Component {
       searchPlaceholder,
       itemSize,
       busy,
+      hideInput,
       emptyHidesInput,
       ...props
     } = this.props;
@@ -322,7 +328,7 @@ class DropdownAutoCompleteMenu extends React.Component {
 
           // Hide the input when we have no items to filter, only if
           // emptyHidesInput is set to true.
-          let showInput = hasItems || !emptyHidesInput;
+          let showInput = !hideInput && (hasItems || !emptyHidesInput);
 
           let renderedFooter =
             typeof menuFooter === 'function' ? menuFooter({actions}) : menuFooter;

--- a/tests/js/spec/components/dropdownAutoCompleteMenu.spec.jsx
+++ b/tests/js/spec/components/dropdownAutoCompleteMenu.spec.jsx
@@ -141,4 +141,14 @@ describe('DropdownAutoCompleteMenu', function() {
     wrapper.find('StyledInput').simulate('change', {target: {value: 'U-S-A'}});
     expect(wrapper.find('EmptyMessage').text()).toBe('No search results');
   });
+
+  it('hides filter with `hideInput` prop', function() {
+    const wrapper = mount(
+      <DropdownAutoCompleteMenu isOpen={true} items={items} hideInput>
+        {() => 'Click Me!'}
+      </DropdownAutoCompleteMenu>,
+      routerContext
+    );
+    expect(wrapper.find('StyledInput')).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
This allows you to hide the filter input in `DropdownAutoCompleteMenu`