### PR TITLE
feat(ui): Allow "Tab" key to select option in autocomplete menus

### DIFF
--- a/src/sentry/static/sentry/app/components/autoComplete.jsx
+++ b/src/sentry/static/sentry/app/components/autoComplete.jsx
@@ -39,6 +39,17 @@ class AutoComplete extends React.Component {
      * e.g. You have a button that opens this <AutoComplete> in a dropdown.
      */
     inputIsActor: PropTypes.bool,
+
+    /**
+     * Can select autocomplete item with "Enter" key
+     */
+    shouldSelectWithEnter: PropTypes.bool,
+
+    /**
+     * Can select autocomplete item with "Tab" key
+     */
+    shouldSelectWithTab: PropTypes.bool,
+
     onSelect: PropTypes.func,
     onOpen: PropTypes.func,
     onClose: PropTypes.func,
@@ -51,6 +62,8 @@ class AutoComplete extends React.Component {
     inputIsActor: true,
     disabled: false,
     closeOnSelect: true,
+    shouldSelectWithEnter: true,
+    shouldSelectWithTab: false,
   };
 
   constructor(props) {
@@ -148,10 +161,12 @@ class AutoComplete extends React.Component {
   };
 
   handleInputKeyDown = ({onKeyDown} = {}, e) => {
-    let shouldSelectWithEnter =
-      e.key === 'Enter' && this.items.size && this.items.has(this.state.highlightedIndex);
+    let hasHighlightedItem =
+      this.items.size && this.items.has(this.state.highlightedIndex);
+    let canSelectWithEnter = this.props.shouldSelectWithEnter && e.key === 'Enter';
+    let canSelectWithTab = this.props.shouldSelectWithTab && e.key === 'Tab';
 
-    if (shouldSelectWithEnter) {
+    if (hasHighlightedItem && (canSelectWithEnter || canSelectWithTab)) {
       this.handleSelect(this.items.get(this.state.highlightedIndex), e);
       e.preventDefault();
     }

--- a/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
@@ -39,6 +39,8 @@ exports[`DropdownAutoCompleteMenu renders with a group 1`] = `
     itemToString={[Function]}
     onSelect={[Function]}
     resetInputOnClose={true}
+    shouldSelectWithEnter={true}
+    shouldSelectWithTab={false}
   >
     <DropdownMenu
       closeOnEscape={true}
@@ -214,6 +216,8 @@ exports[`DropdownAutoCompleteMenu renders without a group 1`] = `
     itemToString={[Function]}
     onSelect={[Function]}
     resetInputOnClose={true}
+    shouldSelectWithEnter={true}
+    shouldSelectWithTab={false}
   >
     <DropdownMenu
       closeOnEscape={true}

--- a/tests/js/spec/components/autoComplete.spec.jsx
+++ b/tests/js/spec/components/autoComplete.spec.jsx
@@ -491,6 +491,42 @@ describe('AutoComplete', function() {
     });
   });
 
+  it('selects using enter key', function() {
+    wrapper = createWrapper({isOpen: true, shouldSelectWithEnter: false});
+    input.simulate('change', {target: {value: 'pine'}});
+    input.simulate('keyDown', {key: 'Enter'});
+    expect(mocks.onSelect).not.toHaveBeenCalled();
+
+    wrapper = createWrapper({isOpen: true, shouldSelectWithEnter: true});
+    input.simulate('change', {target: {value: 'pine'}});
+    input.simulate('keyDown', {key: 'Enter'});
+    expect(mocks.onSelect).toHaveBeenCalledWith(
+      items[1],
+      expect.objectContaining({inputValue: 'pine', highlightedIndex: 0}),
+      expect.anything()
+    );
+    expect(mocks.onClose).toHaveBeenCalledTimes(1);
+    expect(wrapper.state('inputValue')).toBe('Pineapple');
+  });
+
+  it('selects using tab key', function() {
+    wrapper = createWrapper({isOpen: true, shouldSelectWithTab: false});
+    input.simulate('change', {target: {value: 'pine'}});
+    input.simulate('keyDown', {key: 'Tab'});
+    expect(mocks.onSelect).not.toHaveBeenCalled();
+
+    wrapper = createWrapper({isOpen: true, shouldSelectWithTab: true});
+    input.simulate('change', {target: {value: 'pine'}});
+    input.simulate('keyDown', {key: 'Tab'});
+    expect(mocks.onSelect).toHaveBeenCalledWith(
+      items[1],
+      expect.objectContaining({inputValue: 'pine', highlightedIndex: 0}),
+      expect.anything()
+    );
+    expect(mocks.onClose).toHaveBeenCalledTimes(1);
+    expect(wrapper.state('inputValue')).toBe('Pineapple');
+  });
+
   it('does not reset highlight state if `closeOnSelect` is false and we select a new item', function() {
     wrapper = createWrapper({closeOnSelect: false});
     jest.useFakeTimers();

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -89,6 +89,8 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                           itemToString={[Function]}
                           onSelect={[Function]}
                           resetInputOnClose={true}
+                          shouldSelectWithEnter={true}
+                          shouldSelectWithTab={false}
                         >
                           <DropdownMenu
                             closeOnEscape={true}


### PR DESCRIPTION
This adds a prop (default false) to allow "tab" to select an option in autocomplete menus