### PR TITLE
fix: Add links to docs and remove raven.config call for release config

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectReleaseTracking.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectReleaseTracking.jsx
@@ -84,19 +84,6 @@ class ProjectReleaseTracking extends AsyncView {
     );
   }
 
-  getReleaseClientConfigurationIntructions() {
-    return (
-      '// See SDK documentation for language specific usage.' +
-      '\n' +
-      "Raven.config('YOUR_DSN', {" +
-      '\n' +
-      '  ' +
-      "release: '0e4fdef81448dcfa0e16ecc4433ff3997aa53572'" +
-      '\n' +
-      '});'
-    );
-  }
-
   renderBody() {
     let {organization, project, plugins} = this.props;
     let hasWrite = organization.access.includes('project:write');
@@ -138,13 +125,18 @@ class ProjectReleaseTracking extends AsyncView {
           <PanelHeader>{t('Client Configuration')}</PanelHeader>
           <PanelBody disablePadding={false} flex>
             <p>
-              {tct('Start by binding the [release] attribute in your application', {
-                release: <code>release</code>,
-              })}
+              {tct(
+                'Start by binding the [release] attribute in your application, take a look at [link] to see how to configure this for the SDK you are using.',
+                {
+                  link: (
+                    <a href="https://docs.sentry.io/workflow/releases/?platform=javascript#tag-errors">
+                      our docs
+                    </a>
+                  ),
+                  release: <code>release</code>,
+                }
+              )}
             </p>
-            <AutoSelectText>
-              <pre>{this.getReleaseClientConfigurationIntructions()}</pre>
-            </AutoSelectText>
             <p>
               {t(
                 "This will annotate each event with the version of your application, as well as automatically create a release entity in the system the first time it's seen."


### PR DESCRIPTION
To only show the outdated example of `raven-js` is not much, I added a link instead.

Before: 
<img width="909" alt="screenshot 2018-12-10 13 44 41" src="https://user-images.githubusercontent.com/363802/49763936-e99b0980-fc82-11e8-8e91-ba2e7985ecd0.png">

After:
<img width="915" alt="screenshot 2018-12-10 13 44 30" src="https://user-images.githubusercontent.com/363802/49763949-f0298100-fc82-11e8-8846-3e3b01d4ef8e.png">

