### PR TITLE
fix(discover): Fix ordering saved query list

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/savedQueryList.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/savedQueryList.jsx
@@ -41,8 +41,8 @@ export default class SavedQueries extends React.Component {
     // Update saved query if any name / details have been updated
     if (
       nextProps.savedQuery &&
-      this.state.topSavedQuery &&
-      nextProps.savedQuery.id === this.state.topSavedQuery.id
+      (!this.state.topSavedQuery ||
+        nextProps.savedQuery.id === this.state.topSavedQuery.id)
     ) {
       this.setState({
         topSavedQuery: nextProps.savedQuery,


### PR DESCRIPTION
Orders the active saved query at top of the saved query list if a saved
query is not already pinned to the top.