### PR TITLE
analytics(metrics): Do not record API paths

### DIFF
--- a/src/sentry/static/sentry/app/api.jsx
+++ b/src/sentry/static/sentry/app/api.jsx
@@ -191,7 +191,6 @@ export class Client {
             name: 'app.api.request-success',
             start: `api-request-start-${id}`,
             data: {
-              path,
               status: xhr && xhr.status,
             },
           });
@@ -205,7 +204,6 @@ export class Client {
             name: 'app.api.request-error',
             start: `api-request-start-${id}`,
             data: {
-              path,
               status: xhr && xhr.status,
             },
           });


### PR DESCRIPTION
These paths are non-normalized and causes issues with data bc of its high cardinality.