### PR TITLE
feat(jiraserver) Remove guide step from jira server setup

### DIFF
--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -104,20 +104,6 @@ class InstallationForm(forms.Form):
         return self.cleaned_data['url'].rstrip('/')
 
 
-class InstallationGuideView(PipelineView):
-    """
-    Display a setup guide for creating an OAuth client in Jira
-    """
-
-    def dispatch(self, request, pipeline):
-        if 'completed_guide' in request.GET:
-            return pipeline.next_step()
-        return render_to_response(
-            template='sentry/integrations/jira-server-config.html',
-            request=request,
-        )
-
-
 class InstallationConfigView(PipelineView):
     """
     Collect the OAuth client credentials from the user.
@@ -254,7 +240,6 @@ class JiraServerIntegrationProvider(IntegrationProvider):
 
     def get_pipeline_views(self):
         return [
-            InstallationGuideView(),
             InstallationConfigView(),
             OAuthLoginView(),
             OAuthCallbackView(),
@@ -291,7 +276,7 @@ class JiraServerIntegrationProvider(IntegrationProvider):
             'user_identity': {
                 'type': 'jira_server',
                 'external_id': external_id,
-                'scopes': (),
+                'scopes': [],
                 'data': credentials
             }
         }

--- a/src/sentry/templates/sentry/integrations/jira-server-config.html
+++ b/src/sentry/templates/sentry/integrations/jira-server-config.html
@@ -27,9 +27,17 @@
 {% block title %} {% trans "Jira-Server Setup" %} | {{ block.super }} {% endblock %}
 
 {% block main %}
-{% if form %}
-<h3>{% trans "Step 2: Connect Sentry with your App" %}</h3>
+<h3>{% trans "Connect Sentry with your App" %}</h3>
   <p>{% trans "Add your Jira Server App credentials to Sentry." %}</p>
+  <p class="alert alert-block flex">
+    <i class="icon icon-exclamation"></i>
+    <span>
+        {% blocktrans %}
+        You must complete the <a href="https://docs.sentry.io/workflow/integrations/jira-server/">required steps</a>
+        in Jira Server before attempting to connect with Sentry.
+        {% endblocktrans %}
+    </span>
+  </p>
   <form action="" method="post" class="form-stacked">
     {% csrf_token %}
     <input type="hidden" name="provider" value="jira_server" />
@@ -42,25 +50,8 @@
 
     <fieldset class="form-actions clearfix">
       <div class="pull-right">
-        <a class="btn btn-default" href="{% url "sentry-extension-setup" "jira_server" %}">{% trans "Back to instructions" %}</a>
         <button type="submit" class="btn btn-primary" name="save_mappings" value="url">{% trans "Submit" %}</button>
       </div>
     </fieldset>
   </form>
-{% else %}
-<h3>{% trans "Step 1: Create a Sentry App in Jira Server" %}</h3>
-  <p>{% trans "To configure Jira Server with Sentry, you will need to create a Sentry app in your Jira Server instance." %}</p>
-  <ol>
-    <li>Coming Soon!</li>
-  </ol>
-  <p class="alert alert-block flex">
-    <i class="icon icon-exclamation"></i>
-    {% trans "You must complete the above steps in Jira Server to connect with Sentry." %}
-  </p>
-  <div class="form-actions clearfix">
-    <div class="pull-right">
-        <a class="btn btn-primary" href="{% url "sentry-extension-setup" "jira_server" %}?completed_guide">{% trans "Next" %}</a>
-    </div>
-  </div>
-  {% endif %}
 {% endblock %}

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -19,20 +19,13 @@ import responses
 class JiraServerIntegrationTest(IntegrationTestCase):
     provider = JiraServerIntegrationProvider
 
-    def test_setup_guide(self):
-        resp = self.client.get(self.init_path)
-        assert resp.status_code == 200
-        self.assertContains(resp, 'Step 1:')
-        self.assertContains(resp, 'Jira Server')
-        self.assertContains(resp, 'Next</a>')
-
     def test_config_view(self):
         resp = self.client.get(self.init_path)
         assert resp.status_code == 200
 
-        resp = self.client.get(self.setup_path + '?completed_guide')
+        resp = self.client.get(self.setup_path)
         assert resp.status_code == 200
-        self.assertContains(resp, 'Step 2:')
+        self.assertContains(resp, 'Connect Sentry')
         self.assertContains(resp, 'Submit</button>')
 
     @responses.activate
@@ -43,8 +36,7 @@ class JiraServerIntegrationTest(IntegrationTestCase):
             status=503)
 
         # Start pipeline and go to setup page.
-        self.client.get(self.init_path)
-        self.client.get(self.setup_path + '?completed_guide')
+        self.client.get(self.setup_path)
 
         # Submit credentials
         data = {
@@ -69,7 +61,6 @@ class JiraServerIntegrationTest(IntegrationTestCase):
 
         # Start pipeline
         self.client.get(self.init_path)
-        self.client.get(self.setup_path + '?completed_guide')
 
         # Submit credentials
         data = {
@@ -98,12 +89,8 @@ class JiraServerIntegrationTest(IntegrationTestCase):
             content_type='text/plain',
             body='<html>it broke</html>')
 
-        # Get guide page
-        resp = self.client.get(self.init_path)
-        assert resp.status_code == 200
-
         # Get config page
-        resp = self.client.get(self.setup_path + '?completed_guide')
+        resp = self.client.get(self.init_path)
         assert resp.status_code == 200
 
         # Submit credentials
@@ -123,12 +110,8 @@ class JiraServerIntegrationTest(IntegrationTestCase):
         self.assertContains(resp, 'access token from Jira')
 
     def install_integration(self):
-        # Get guide page
-        resp = self.client.get(self.init_path)
-        assert resp.status_code == 200
-
         # Get config page
-        resp = self.client.get(self.setup_path + '?completed_guide')
+        resp = self.client.get(self.setup_path)
         assert resp.status_code == 200
 
         # Submit credentials


### PR DESCRIPTION
We've decided to not have a 'guide' step for jira server as the setup steps for jira are long and complicated. Instead we'll be linking to the docs where we can include more information and screenshots on getting jira server setup.

Changing the empty tuple to the an empty list fixes a SQL syntax error when reconnecting jira-server to a previously used Oauth credential set.

<img width="726" alt="screen shot 2018-12-10 at 2 40 48 pm" src="https://user-images.githubusercontent.com/24086/49766284-ab551880-fc89-11e8-84c4-08a4dc481376.png">


Fixes APP-802