### PR TITLE
fix(integrations): Fix Jira issue id search

### DIFF
--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -16,7 +16,7 @@ from sentry.utils.http import absolute_uri
 
 
 JIRA_KEY = '%s.jira' % (urlparse(absolute_uri()).hostname, )
-ISSUE_KEY_RE = re.compile(r'^[A-Z][A-Z0-9]*-\d+$')
+ISSUE_KEY_RE = re.compile(r'^[A-Za-z][A-Za-z0-9]*-\d+$')
 
 
 def md5(*bits):

--- a/tests/sentry/integrations/jira/test_search_endpoint.py
+++ b/tests/sentry/integrations/jira/test_search_endpoint.py
@@ -83,7 +83,7 @@ class JiraSearchEndpointTest(APITestCase):
     def test_issue_search_id(self):
         def responder(request):
             query = parse_qs(urlparse(request.url).query)
-            assert 'id="HSP-1"' == query['jql'][0]
+            assert 'id="hsp-1"' == query['jql'][0]
             return (200, {}, SAMPLE_SEARCH_RESPONSE)
 
         responses.add_callback(
@@ -97,7 +97,8 @@ class JiraSearchEndpointTest(APITestCase):
 
         path = reverse('sentry-extensions-jira-search', args=[org.slug, self.integration.id])
 
-        resp = self.client.get('%s?field=externalIssue&query=HSP-1' % (path,))
+        # queries come through from the front end lowercased, so HSP-1 -> hsp-1
+        resp = self.client.get('%s?field=externalIssue&query=hsp-1' % (path,))
         assert resp.status_code == 200
         assert resp.data == [
             {'label': '(HSP-1) this is a test issue summary', 'value': 'HSP-1'}


### PR DESCRIPTION
Our front end lowercases whatever you type into the search box (including an issue id like "APP-123"), but our search code was only treating the query as an id if it was all caps.

This fixes that, and the associated test (which was passing previously because it was assuming an uppercased query, even though in real life we never get one).

Tracked internally as [ISSUE-240](https://getsentry.atlassian.net/browse/ISSUE-240).