### PR TITLE
fix(integrations) Fix jira form being unsubmittable

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
@@ -166,6 +166,7 @@ class MockModel {
   }
   setValue() {}
   setFieldDescriptor() {}
+  removeField() {}
   handleBlurField() {}
   getValue() {
     return this.props.value;
@@ -242,6 +243,10 @@ class FormField extends React.Component {
   componentDidMount() {
     // Tell model about this field's props
     this.getModel().setFieldDescriptor(this.props.name, this.props);
+  }
+
+  componentWillUnmount() {
+    this.getModel().removeField(this.props.name);
   }
 
   getError(props, context) {

--- a/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
@@ -148,6 +148,14 @@ class FormModel {
   }
 
   /**
+   * Remove a field from the descriptor map and errors.
+   */
+  removeField(id) {
+    this.fieldDescriptor.delete(id);
+    this.errors.delete(id);
+  }
+
+  /**
    * Creates a cloned Map of `this.fields` and returns a closure that when called
    * will save Map to `snapshots
    */

--- a/tests/js/spec/components/forms/formField.spec.jsx
+++ b/tests/js/spec/components/forms/formField.spec.jsx
@@ -70,4 +70,28 @@ describe('FormField + model', function() {
     expect(model.initialData.fieldName).toBe('foofoo');
     expect(model.fields.get('fieldName')).toBe('foofoo');
   });
+
+  it('sets field descriptor in model', function() {
+    wrapper = mount(
+      <Form model={model} initialData={{fieldName: 'test'}}>
+        <TextField name="fieldName" required />
+      </Form>,
+      routerContext
+    );
+
+    expect(model.getDescriptor('fieldName', 'required')).toBe(true);
+  });
+
+  it('removes field descriptor in model on unmount', function() {
+    wrapper = mount(
+      <Form model={model} initialData={{fieldName: 'test'}}>
+        <TextField name="fieldName" required />
+      </Form>,
+      routerContext
+    );
+    expect(model.fieldDescriptor.has('fieldName')).toBe(true);
+
+    wrapper.unmount();
+    expect(model.fieldDescriptor.has('fieldName')).toBe(false);
+  });
 });


### PR DESCRIPTION
A few customers have run into issues where their jira integration cannot
create new issues. This happens when:

* The customer has multiple projects.
* Some of the projects have required fields that are not present on all  projects.
* The customer selects a project with a required custom field and then  selects a project *without* the required custom field.

When this happens the form cannot be submitted as the old required fields are still in the FormModel and contain validation errors. Those validation errors can never be cleared as the field has no input
attached.

By removing fields from the form model as the inputs are unmounted we can keep the form model more in-sync with the visible fields and prevent phantom validation errors.

Fixes ISSUE-235