### PR TITLE
fix: Support Windows UNC paths in debug images

### DIFF
--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 VERSION_RE = re.compile(r'(\d+\.\d+\.\d+)\s+(.*)')
 
 # Regular expression to guess whether we're dealing with Windows or Unix paths
-WINDOWS_PATH_RE = re.compile(r'^[a-z]:\\', re.IGNORECASE)
+WINDOWS_PATH_RE = re.compile(r'^([a-z]:\\|\\\\)', re.IGNORECASE)
 
 AppInfo = namedtuple('AppInfo', ['id', 'version', 'build', 'name'])
 

--- a/src/sentry/static/sentry/app/components/events/errorItem.jsx
+++ b/src/sentry/static/sentry/app/components/events/errorItem.jsx
@@ -45,7 +45,7 @@ class EventErrorItem extends React.Component {
 
     if (typeof data.image_path === 'string') {
       // Separate the image name for readability
-      let separator = /^[a-z]:\\/i.test(data.image_path) ? '\\' : '/';
+      let separator = /^([a-z]:\\|\\\\)/i.test(data.image_path) ? '\\' : '/';
       let path = data.image_path.split(separator);
       data.image_name = path.splice(-1, 1)[0];
       data.image_path = path.length ? path.join(separator) + separator : '';

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
@@ -19,7 +19,7 @@ class DebugMetaInterface extends React.Component {
       return null;
     }
 
-    let name = img.name.split(/^[a-z]:\\/i.test(img.name) ? '\\' : '/').pop();
+    let name = img.name.split(/^([a-z]:\\|\\\\)/i.test(img.name) ? '\\' : '/').pop();
     if (name == 'dyld_sim') return null; // this is only for simulator builds
 
     let version = null;

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -17,7 +17,7 @@ import Truncate from 'app/components/truncate';
 import space from 'app/styles/space';
 
 export function trimPackage(pkg) {
-  let pieces = pkg.split(/^[a-z]:\\/i.test(pkg) ? '\\' : '/');
+  let pieces = pkg.split(/^([a-z]:\\|\\\\)/i.test(pkg) ? '\\' : '/');
   let filename = pieces[pieces.length - 1] || pieces[pieces.length - 2] || pkg;
   return filename.replace(/\.(dylib|so|a|dll|exe)$/, '');
 }

--- a/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.jsx
@@ -230,7 +230,7 @@ const ProjectProcessingIssues = createReactClass({
   },
 
   getImageName(path) {
-    let pathSegments = path.split(/^[a-z]:\\/i.test(path) ? '\\' : '/');
+    let pathSegments = path.split(/^([a-z]:\\|\\\\)/i.test(path) ? '\\' : '/');
     return pathSegments[pathSegments.length - 1];
   },
 


### PR DESCRIPTION
Detects Windows UNC paths (`\\Some\Path`) and sets the correct splitting separator.