### PR TITLE
ref: Provide a generic sentry.net.http:connection_from_url

### DIFF
--- a/src/sentry/net/http.py
+++ b/src/sentry/net/http.py
@@ -5,7 +5,7 @@ from socket import error as SocketError, timeout as SocketTimeout
 
 from requests import Session as _Session
 from requests.adapters import HTTPAdapter, DEFAULT_POOLBLOCK
-from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
+from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool, connection_from_url as _connection_from_url
 from urllib3.connection import HTTPConnection, HTTPSConnection
 from urllib3.exceptions import NewConnectionError, ConnectTimeoutError
 from urllib3.poolmanager import PoolManager
@@ -199,3 +199,9 @@ class UnixHTTPConnectionPool(HTTPConnectionPool):
     def __str__(self):
         return '%s(host=%r)' % (type(self).__name__,
                                 self.host)
+
+
+def connection_from_url(endpoint, **kw):
+    if endpoint[:1] == '/':
+        return UnixHTTPConnectionPool(endpoint, **kw)
+    return _connection_from_url(endpoint, **kw)

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -18,6 +18,7 @@ from sentry.models import (
     Environment, Group, GroupRelease,
     Organization, Project, Release, ReleaseProject
 )
+from sentry.net.http import connection_from_url
 from sentry.utils import metrics, json
 from sentry.utils.dates import to_timestamp
 
@@ -191,13 +192,6 @@ def options_override(overrides):
             OVERRIDE_OPTIONS[k] = v
         for k in delete:
             OVERRIDE_OPTIONS.pop(k)
-
-
-def connection_from_url(url, **kw):
-    if url[:1] == '/':
-        from sentry.net.http import UnixHTTPConnectionPool
-        return UnixHTTPConnectionPool(url, **kw)
-    return urllib3.connectionpool.connection_from_url(url, **kw)
 
 
 _snuba_pool = connection_from_url(


### PR DESCRIPTION
This removes it from being snuba specific into a utility that can be
reused.