### PR TITLE
fix(releases) Fix integrity errors in release creation

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -407,7 +407,6 @@ class Release(Model):
                         author, created = CommitAuthor.objects.create_or_update(
                             organization_id=self.organization_id,
                             email=author_email,
-                            defaults=author_data,
                             values=author_data)
                         if not created:
                             author = CommitAuthor.objects.get(
@@ -429,7 +428,6 @@ class Release(Model):
                         organization_id=self.organization_id,
                         repository_id=repo.id,
                         key=data['id'],
-                        defaults=commit_data,
                         values=commit_data)
                     if not created:
                         commit = Commit.objects.get(
@@ -444,16 +442,15 @@ class Release(Model):
 
                     patch_set = data.get('patch_set', [])
                     for patched_file in patch_set:
-                        commit_file_data = {
-                            'filename': patched_file['path'],
-                            'type': patched_file['type'],
-                        }
-                        CommitFileChange.objects.create_or_update(
-                            organization_id=self.organization.id,
-                            commit=commit,
-                            defaults=commit_file_data,
-                            values=commit_file_data
-                        )
+                        try:
+                            CommitFileChange.objects.create(
+                                organization_id=self.organization.id,
+                                commit=commit,
+                                filename=patched_file['path'],
+                                type=patched_file['type'],
+                            )
+                        except IntegrityError:
+                            pass
 
                     try:
                         ReleaseCommit.objects.create(

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -401,61 +401,70 @@ class Release(Model):
                     if not author_email:
                         author = None
                     elif author_email not in authors:
-                        authors[author_email] = author = CommitAuthor.objects.get_or_create(
+                        author_data = {
+                            'name': data.get('author_name')
+                        }
+                        author, created = CommitAuthor.objects.create_or_update(
                             organization_id=self.organization_id,
                             email=author_email,
-                            defaults={
-                                'name': data.get('author_name'),
-                            }
-                        )[0]
-                        if data.get('author_name') and author.name != data['author_name']:
-                            author.update(name=data['author_name'])
+                            defaults=author_data,
+                            values=author_data)
+                        if not created:
+                            author = CommitAuthor.objects.get(
+                                organization_id=self.organization_id,
+                                email=author_email)
+                        authors[author_email] = author
                     else:
                         author = authors[author_email]
 
-                    defaults = {
+                    commit_data = {
                         'message': data.get('message'),
-                        'author': author,
                         'date_added': data.get('timestamp') or timezone.now(),
                     }
-                    commit, created = Commit.objects.get_or_create(
+                    # If we didn't get an author don't overwrite an existing one.
+                    if author is not None:
+                        commit_data['author'] = author
+
+                    commit, created = Commit.objects.create_or_update(
                         organization_id=self.organization_id,
                         repository_id=repo.id,
                         key=data['id'],
-                        defaults=defaults,
-                    )
+                        defaults=commit_data,
+                        values=commit_data)
+                    if not created:
+                        commit = Commit.objects.get(
+                            organization_id=self.organization_id,
+                            repository_id=repo.id,
+                            key=data['id'])
+
                     if author is None:
                         author = commit.author
 
                     commit_author_by_commit[commit.id] = author
 
                     patch_set = data.get('patch_set', [])
-
                     for patched_file in patch_set:
-                        CommitFileChange.objects.get_or_create(
+                        commit_file_data = {
+                            'filename': patched_file['path'],
+                            'type': patched_file['type'],
+                        }
+                        CommitFileChange.objects.create_or_update(
                             organization_id=self.organization.id,
                             commit=commit,
-                            filename=patched_file['path'],
-                            type=patched_file['type'],
+                            defaults=commit_file_data,
+                            values=commit_file_data
                         )
 
-                    if not created:
-                        update_kwargs = {}
-                        if commit.message is None and defaults['message'] is not None:
-                            update_kwargs['message'] = defaults['message']
-                        if commit.author_id is None and defaults['author'] is not None:
-                            update_kwargs['author'] = defaults['author']
-                        if defaults.get('date_added') is not None:
-                            update_kwargs['date_added'] = defaults['date_added']
-                        if update_kwargs:
-                            commit.update(**update_kwargs)
+                    try:
+                        ReleaseCommit.objects.create(
+                            organization_id=self.organization_id,
+                            release=self,
+                            commit=commit,
+                            order=idx,
+                        )
+                    except IntegrityError:
+                        pass
 
-                    ReleaseCommit.objects.create(
-                        organization_id=self.organization_id,
-                        release=self,
-                        commit=commit,
-                        order=idx,
-                    )
                     if latest_commit is None:
                         latest_commit = commit
 


### PR DESCRIPTION
I've found a few integrity errors coming out of release commit creation steps. Using `create_or_update` should yield less error prone code as integrity errors are handled and converted into updates.

I've removed a bit of redundant update logic for commits. Only updating the commit message, author and date when the current values are none goes against expectations that PUT endpoints normally have.

Fixes SENTRY-8GT
Fixes SENTRY-8KJ