### PR TITLE
fix(search): Prevent SequencePaginator from throwing IndexError when used incorrectly

### DIFF
--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -262,7 +262,7 @@ def reverse_bisect_left(a, x, lo=0, hi=None):
     if lo < 0:
         raise ValueError('lo must be non-negative')
 
-    if hi is None:
+    if hi is None or hi > len(a):
         hi = len(a)
 
     while lo < hi:

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -345,6 +345,8 @@ def test_reverse_bisect_left():
     assert reverse_bisect_left([2, 2, 1], 1) == 2
     assert reverse_bisect_left([2, 2, 1], 2) == 0
 
+    assert reverse_bisect_left([3, 2, 1], 2, hi=10) == 1
+
 
 class SequencePaginatorTestCase(SimpleTestCase):
     def test_empty_results(self):


### PR DESCRIPTION
Fixes SENTRY-8KY