### PR TITLE
fix(digests): Avoid creating unqualified queries on group deletion

### DIFF
--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -71,11 +71,11 @@ def fetch_state(project, records):
         Rule.objects.
         in_bulk(itertools.chain.from_iterable(record.value.rules for record in records)),
         'event_counts':
-        tsdb.get_sums(tsdb.models.group, groups.keys(), start, end),
+        tsdb.get_sums(tsdb.models.group, groups.keys(), start, end) if groups else {},
         'user_counts':
         tsdb.get_distinct_counts_totals(
             tsdb.models.users_affected_by_group, groups.keys(), start, end
-        ),
+        ) if groups else {},
     }
 
 


### PR DESCRIPTION
This happens when a group is merged or deleted between the time that a
record is added to a digest and the time the digest is built for
delivery.

There could be a reasonable argument made that this should resolve the
group redirects when building the digest, but this change at least
maintains the existing (pre-Snuba) behavior without throwing an
exception.

Fixes SENTRY-8M9