### PR TITLE
ref(app-platform): Simplify Installation mediator

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_installations.py
+++ b/src/sentry/api/endpoints/sentry_app_installations.py
@@ -52,7 +52,7 @@ class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
-        install, grant = Creator.run(
+        install = Creator.run(
             organization=organization,
             slug=serializer.object.get('slug'),
             user=request.user,

--- a/src/sentry/mediators/sentry_app_installations/creator.py
+++ b/src/sentry/mediators/sentry_app_installations/creator.py
@@ -21,7 +21,7 @@ class Creator(Mediator):
         self._create_install()
         self._notify_service()
         self.install.is_new = True
-        return (self.install, self.api_grant)
+        return self.install
 
     def _create_authorization(self):
         self.authorization = ApiAuthorization.objects.create(

--- a/tests/sentry/api/bases/test_sentryapps.py
+++ b/tests/sentry/api/bases/test_sentryapps.py
@@ -71,7 +71,7 @@ class SentryAppInstallationPermissionTest(TestCase):
             organization=self.org,
         )
 
-        self.installation, _ = SentryAppInstallationCreator.run(
+        self.installation = SentryAppInstallationCreator.run(
             slug=self.sentry_app.slug,
             organization=self.org,
             user=self.user,
@@ -120,7 +120,7 @@ class SentryAppInstallationBaseEndpointTest(TestCase):
             organization=self.org,
         )
 
-        self.installation, _ = SentryAppInstallationCreator.run(
+        self.installation = SentryAppInstallationCreator.run(
             slug=self.sentry_app.slug,
             organization=self.org,
             user=self.user,

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -20,7 +20,7 @@ class SentryAppInstallationDetailsTest(APITestCase):
             published=True,
         )
 
-        self.installation, _ = Creator.run(
+        self.installation = Creator.run(
             slug=self.published_app.slug,
             organization=self.super_org,
             user=self.superuser,
@@ -31,7 +31,7 @@ class SentryAppInstallationDetailsTest(APITestCase):
             organization=self.org,
         )
 
-        self.installation2, _ = Creator.run(
+        self.installation2 = Creator.run(
             slug=self.unpublished_app.slug,
             organization=self.org,
             user=self.user,

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -26,13 +26,13 @@ class SentryAppInstallationsTest(APITestCase):
             organization=self.org,
         )
 
-        self.installation, _ = Creator.run(
+        self.installation = Creator.run(
             slug=self.published_app.slug,
             organization=self.super_org,
             user=self.superuser,
         )
 
-        self.installation2, _ = Creator.run(
+        self.installation2 = Creator.run(
             slug=self.unpublished_app.slug,
             organization=self.org,
             user=self.user,

--- a/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
@@ -32,7 +32,7 @@ class TestSentryAppAuthorizations(APITestCase):
             webhook_url='http://example.com',
         )
 
-        self.install, self.grant = SentryAppInstallationCreator.run(
+        self.install = SentryAppInstallationCreator.run(
             organization=self.org,
             slug='nulldb',
             user=self.user,
@@ -48,7 +48,7 @@ class TestSentryAppAuthorizations(APITestCase):
             'client_id': self.sentry_app.application.client_id,
             'client_secret': self.sentry_app.application.client_secret,
             'grant_type': 'authorization_code',
-            'code': self.grant.code,
+            'code': self.install.api_grant.code,
         }
         data.update(**kwargs)
         return self.client.post(self.url, data, headers={
@@ -84,7 +84,7 @@ class TestSentryAppAuthorizations(APITestCase):
         assert response.status_code == 403
 
     def test_invalid_installation(self):
-        self.install, _ = SentryAppInstallationCreator.run(
+        self.install = SentryAppInstallationCreator.run(
             organization=self.org,
             slug='slowdb',
             user=self.user,
@@ -114,7 +114,7 @@ class TestSentryAppAuthorizations(APITestCase):
         assert response.status_code == 403
 
     def test_expired_grant(self):
-        self.grant.update(expires_at=timezone.now() - timedelta(minutes=2))
+        self.install.api_grant.update(expires_at=timezone.now() - timedelta(minutes=2))
         response = self._run_request()
         assert response.status_code == 403
 

--- a/tests/sentry/mediators/sentry_app_installations/test_authorizer.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_authorizer.py
@@ -17,7 +17,7 @@ class TestAuthorizer(TestCase):
             organization=self.org,
         )
 
-        self.install, self.grant = Creator.run(
+        self.install = Creator.run(
             organization=self.org,
             slug='nulldb',
             user=self.user,
@@ -26,7 +26,7 @@ class TestAuthorizer(TestCase):
         self.authorizer = Authorizer(
             install=self.install,
             grant_type='authorization_code',
-            code=self.grant.code,
+            code=self.install.api_grant.code,
             client_id=self.sentry_app.application.client_id,
             user=self.sentry_app.proxy_user,
         )

--- a/tests/sentry/mediators/sentry_app_installations/test_creator.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_creator.py
@@ -25,7 +25,7 @@ class TestCreator(TestCase):
         )
 
     def test_creates_api_authorization(self):
-        install, grant = self.creator.call()
+        self.creator.call()
 
         assert ApiAuthorization.objects.get(
             application=self.sentry_app.application,
@@ -34,20 +34,20 @@ class TestCreator(TestCase):
         )
 
     def test_creates_installation(self):
-        install, grant = self.creator.call()
+        install = self.creator.call()
         assert install.pk
 
     def test_creates_api_grant(self):
-        install, grant = self.creator.call()
-        assert grant.pk
+        install = self.creator.call()
+        assert install.api_grant.pk
 
     @patch('sentry.tasks.app_platform.installation_webhook.delay')
     def test_notifies_service(self, installation_webhook):
-        install, _ = self.creator.call()
+        install = self.creator.call()
         installation_webhook.assert_called_once_with(install.id, self.user.id)
 
     def test_associations(self):
-        install, grant = self.creator.call()
+        install = self.creator.call()
 
-        assert install.api_grant == grant
+        assert install.api_grant is not None
         assert install.authorization is not None

--- a/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
@@ -18,7 +18,7 @@ class TestDestroyer(TestCase):
             scopes=('project:read',),
         )
 
-        self.install, self.grant = Creator.run(
+        self.install = Creator.run(
             organization=self.org,
             slug='nulldb',
             user=self.user,

--- a/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
@@ -21,7 +21,7 @@ class TestInstallationNotifier(TestCase):
             scopes=(),
         )
 
-        self.install, _ = Creator.run(
+        self.install = Creator.run(
             slug='foo',
             organization=self.org,
             user=self.user,

--- a/tests/sentry/tasks/test_app_platform.py
+++ b/tests/sentry/tasks/test_app_platform.py
@@ -19,7 +19,7 @@ class TestAppPlatformTasks(TestCase):
             scopes=(),
         )
 
-        self.install, _ = sentry_app_installations.Creator.run(
+        self.install = sentry_app_installations.Creator.run(
             slug='foo',
             organization=self.org,
             user=self.user,

--- a/tests/sentry/tasks/test_servicehooks.py
+++ b/tests/sentry/tasks/test_servicehooks.py
@@ -31,7 +31,7 @@ class TestServiceHooks(TestCase):
     def setUp(self):
         self.project = self.create_project()
 
-        self.install, _ = self.create_sentry_app_installation(
+        self.install = self.create_sentry_app_installation(
             organization=self.project.organization
         )
 


### PR DESCRIPTION
It was previous necessary to return the API Grant along with the Installation, since they were not related.

We've since associated the two objects explicitly so it's no longer necessary.

This change alters `sentry_app_installations.Creator` to just return the installation object alone. This is more in line with all other Mediators.