### PR TITLE
ref(tagstore): Refactor a couple of methods to support multi project/env

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -158,9 +158,9 @@ class GroupSerializer(Serializer):
             project_id = item_list[0].project_id
             item_ids = [g.id for g in item_list]
             user_counts = tagstore.get_groups_user_counts(
-                project_id,
+                [project_id],
                 item_ids,
-                environment_id=environment and environment.id,
+                environment_ids=environment and [environment.id],
             )
             first_seen = {}
             last_seen = {}

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -167,9 +167,9 @@ class GroupSerializer(Serializer):
             times_seen = {}
             if environment is not None:
                 environment_tagvalues = tagstore.get_group_list_tag_value(
-                    project_id,
+                    [project_id],
                     item_ids,
-                    environment.id,
+                    [environment.id],
                     'environment',
                     environment.name,
                 )

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -430,7 +430,7 @@ class Group(Model):
 
     def count_users_seen(self):
         return tagstore.get_groups_user_counts(
-            self.project_id, [self.id], environment_id=None)[self.id]
+            [self.project_id], [self.id], environment_ids=None)[self.id]
 
     @classmethod
     def calculate_score(cls, times_seen, last_seen):

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -351,9 +351,9 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def get_groups_user_counts(self, project_id, group_ids, environment_id):
+    def get_groups_user_counts(self, project_ids, group_ids, environment_ids):
         """
-        >>> get_groups_user_counts(1, [2, 3], 4)
+        >>> get_groups_user_counts([1, 2], [2, 3], [4, 5])
         """
         raise NotImplementedError
 

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -266,9 +266,9 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def get_group_list_tag_value(self, project_id, group_id_list, environment_id, key, value):
+    def get_group_list_tag_value(self, project_ids, group_id_list, environment_ids, key, value):
         """
-        >>> get_group_tag_value(1, [1, 2, 3, 4, 5], 3, "key1", "value1")
+        >>> get_group_tag_value([1, 2], [1, 2, 3, 4, 5], [3], "key1", "value1")
         """
         raise NotImplementedError
 

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -498,9 +498,13 @@ class LegacyTagStorage(TagStorage):
 
         return {'id__in': set(matches)}
 
-    def get_groups_user_counts(self, project_id, group_ids, environment_id):
+    def get_groups_user_counts(self, project_ids, group_ids, environment_ids):
+        # only the snuba backend supports multi project
+        if len(project_ids) > 1:
+            raise NotImplementedError
+
         qs = models.GroupTagKey.objects.filter(
-            project_id=project_id,
+            project_id=project_ids[0],
             group_id__in=group_ids,
             key='sentry:user'
         )
@@ -535,7 +539,8 @@ class LegacyTagStorage(TagStorage):
             last_seen__gte=cutoff,
         ).aggregate(t=Sum('times_seen'))['t']
 
-    def get_top_group_tag_values(self, project_id, group_id, environment_id, key, limit=TOP_VALUES_DEFAULT_LIMIT):
+    def get_top_group_tag_values(self, project_id, group_id,
+                                 environment_id, key, limit=TOP_VALUES_DEFAULT_LIMIT):
         if db.is_postgres():
             # This doesnt guarantee percentage is accurate, but it does ensure
             # that the query has a maximum cost
@@ -688,7 +693,7 @@ class LegacyTagStorage(TagStorage):
             )
 
     def get_tag_value_paginator(self, project_id, environment_id, key, query=None,
-            order_by='-last_seen'):
+                                order_by='-last_seen'):
         from sentry.api.paginator import DateTimePaginator
 
         queryset = models.TagValue.objects.filter(
@@ -715,7 +720,7 @@ class LegacyTagStorage(TagStorage):
         return RangeQuerySetWrapper(queryset=qs, callbacks=callbacks)
 
     def get_group_tag_value_paginator(self, project_id, group_id, environment_id, key,
-            order_by='-id'):
+                                      order_by='-id'):
         from sentry.api.paginator import DateTimePaginator, Paginator
 
         qs = self.get_group_tag_value_qs(project_id, group_id, environment_id, key)

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -356,9 +356,9 @@ class LegacyTagStorage(TagStorage):
         from sentry.tagstore.exceptions import GroupTagValueNotFound
 
         value = self.get_group_list_tag_value(
-            project_id,
+            [project_id],
             [group_id],
-            environment_id,
+            [environment_id] if environment_id is not None else environment_id,
             key,
             value,
         ).get(group_id)
@@ -376,7 +376,7 @@ class LegacyTagStorage(TagStorage):
 
         return set(map(transformers[models.GroupTagValue], qs))
 
-    def get_group_list_tag_value(self, project_id, group_id_list, environment_id, key, value):
+    def get_group_list_tag_value(self, project_ids, group_id_list, environment_ids, key, value):
         qs = models.GroupTagValue.objects.filter(
             group_id__in=group_id_list,
             key=key,

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -256,15 +256,15 @@ class SnubaTagStorage(TagStorage):
                                                 limit=None, raise_on_empty=False)
         return set(key.top_values)
 
-    def get_group_list_tag_value(self, project_id, group_id_list, environment_id, key, value):
+    def get_group_list_tag_value(self, project_ids, group_id_list, environment_ids, key, value):
         start, end = self.get_time_range()
         tag = u'tags[{}]'.format(key)
         filters = {
-            'project_id': [project_id],
+            'project_id': project_ids,
             'issue': group_id_list,
         }
-        if environment_id:
-            filters['environment'] = [environment_id]
+        if environment_ids:
+            filters['environment'] = environment_ids
         conditions = [
             [tag, '=', value]
         ]

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -468,14 +468,14 @@ class SnubaTagStorage(TagStorage):
                 )
         return values
 
-    def get_groups_user_counts(self, project_id, group_ids, environment_id):
+    def get_groups_user_counts(self, project_ids, group_ids, environment_ids):
         start, end = self.get_time_range()
         filters = {
-            'project_id': [project_id],
+            'project_id': project_ids,
             'issue': group_ids,
         }
-        if environment_id:
-            filters['environment'] = [environment_id]
+        if environment_ids:
+            filters['environment'] = environment_ids
         aggregations = [['uniq', 'tags[sentry:user]', 'count']]
 
         result = snuba.query(start, end, ['issue'], None, filters, aggregations,

--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -731,15 +731,19 @@ class V2TagStorage(TagStorage):
 
         return {'id__in': set(matches)}
 
-    def get_groups_user_counts(self, project_id, group_ids, environment_id):
+    def get_groups_user_counts(self, project_ids, group_ids, environment_ids):
+        # only the snuba backend supports multi project/env
+        if len(project_ids) > 1 or environment_ids and len(environment_ids) > 1:
+            raise NotImplementedError
+
         qs = models.GroupTagKey.objects.filter(
-            project_id=project_id,
+            project_id=project_ids[0],
             group_id__in=group_ids,
-            _key__project_id=project_id,
+            _key__project_id=project_ids[0],
             _key__key='sentry:user',
         )
 
-        qs = self._add_environment_filter(qs, environment_id)
+        qs = self._add_environment_filter(qs, environment_ids and environment_ids[0])
 
         return defaultdict(int, qs.values_list('group_id', 'values_seen'))
 
@@ -783,7 +787,8 @@ class V2TagStorage(TagStorage):
         qs = self._add_environment_filter(qs, environment_id)
         return qs.aggregate(t=Sum('times_seen'))['t']
 
-    def get_top_group_tag_values(self, project_id, group_id, environment_id, key, limit=TOP_VALUES_DEFAULT_LIMIT):
+    def get_top_group_tag_values(self, project_id, group_id,
+                                 environment_id, key, limit=TOP_VALUES_DEFAULT_LIMIT):
         if db.is_postgres():
             environment_id = AGGREGATE_ENVIRONMENT_ID if environment_id is None else environment_id
 

--- a/tests/sentry/tagstore/v2/test_backend.py
+++ b/tests/sentry/tagstore/v2/test_backend.py
@@ -484,9 +484,9 @@ class TagStorage(TestCase):
 
         assert dict(
             self.ts.get_groups_user_counts(
-                self.proj1.id,
+                [self.proj1.id],
                 [self.proj1group1.id, self.proj1group2.id],
-                self.proj1env1.id).items()) == {self.proj1group1.id: 7, self.proj1group2.id: 11}
+                [self.proj1env1.id]).items()) == {self.proj1group1.id: 7, self.proj1group2.id: 11}
 
     def test_get_group_tag_value_count(self):
         v1, _ = self.ts.get_or_create_group_tag_value(

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -230,9 +230,9 @@ class TagStorageTest(SnubaTestCase):
 
     def test_get_groups_user_counts(self):
         assert self.ts.get_groups_user_counts(
-            project_id=self.proj1.id,
+            project_ids=[self.proj1.id],
             group_ids=[self.proj1group1.id, self.proj1group2.id],
-            environment_id=self.proj1env1.id
+            environment_ids=[self.proj1env1.id]
         ) == {
             self.proj1group1.id: 2,
             self.proj1group2.id: 1,


### PR DESCRIPTION
Refactors `get_groups_user_counts` and `get_group_list_tag_value`, both of which are used in the GroupSerializer (which i'll be adapting to support multi project / env / flexible date ranges). This is so I can eventually add an org wide version of `ProjectGroupIndexEndpoint`
