### PR TITLE
fix(app-platform): Use IDs not objects for create

### DIFF
--- a/src/sentry/mediators/sentry_app_installations/creator.py
+++ b/src/sentry/mediators/sentry_app_installations/creator.py
@@ -25,23 +25,23 @@ class Creator(Mediator):
 
     def _create_authorization(self):
         self.authorization = ApiAuthorization.objects.create(
-            application=self.api_application,
-            user=self.sentry_app.proxy_user,
+            application_id=self.api_application.id,
+            user_id=self.sentry_app.proxy_user.id,
             scope_list=self.sentry_app.scope_list,
         )
 
     def _create_install(self):
         self.install = SentryAppInstallation.objects.create(
-            organization=self.organization,
-            sentry_app=self.sentry_app,
-            authorization=self.authorization,
-            api_grant=self.api_grant,
+            organization_id=self.organization.id,
+            sentry_app_id=self.sentry_app.id,
+            authorization_id=self.authorization.id,
+            api_grant_id=self.api_grant.id,
         )
 
     def _create_api_grant(self):
         self.api_grant = ApiGrant.objects.create(
-            user=self.sentry_app.proxy_user,
-            application=self.api_application,
+            user_id=self.sentry_app.proxy_user.id,
+            application_id=self.api_application.id,
         )
 
     def _notify_service(self):

--- a/src/sentry/mediators/sentry_apps/creator.py
+++ b/src/sentry/mediators/sentry_apps/creator.py
@@ -31,15 +31,15 @@ class Creator(Mediator):
 
     def _create_api_application(self):
         return ApiApplication.objects.create(
-            owner=self.proxy,
+            owner_id=self.proxy.id,
         )
 
     def _create_sentry_app(self):
         return SentryApp.objects.create(
             name=self.name,
-            application=self.api_app,
-            owner=self.organization,
-            proxy_user=self.proxy,
+            application_id=self.api_app.id,
+            owner_id=self.organization.id,
+            proxy_user_id=self.proxy.id,
             scope_list=self.scopes,
             webhook_url=self.webhook_url,
             redirect_url=self.redirect_url,

--- a/src/sentry/mediators/service_hooks/creator.py
+++ b/src/sentry/mediators/service_hooks/creator.py
@@ -21,7 +21,7 @@ class Creator(Mediator):
 
     def _create_service_hook(self):
         return ServiceHook.objects.create(
-            application=self.application,
+            application_id=self.application.id,
             actor_id=self.actor.id,
             project_id=self.project.id,
             events=self.events,

--- a/tests/sentry/mediators/sentry_app_installations/test_creator.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_creator.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from mock import patch
 
 from sentry.mediators.sentry_app_installations import Creator
-from sentry.models import ApiAuthorization
+from sentry.models import ApiAuthorization, ApiGrant
 from sentry.testutils import TestCase
 
 
@@ -27,11 +27,11 @@ class TestCreator(TestCase):
     def test_creates_api_authorization(self):
         self.creator.call()
 
-        assert ApiAuthorization.objects.get(
+        assert ApiAuthorization.objects.filter(
             application=self.sentry_app.application,
             user=self.sentry_app.proxy_user,
             scopes=self.sentry_app.scopes,
-        )
+        ).exists()
 
     def test_creates_installation(self):
         install = self.creator.call()
@@ -39,7 +39,7 @@ class TestCreator(TestCase):
 
     def test_creates_api_grant(self):
         install = self.creator.call()
-        assert install.api_grant.pk
+        assert ApiGrant.objects.filter(id=install.api_grant_id).exists()
 
     @patch('sentry.tasks.app_platform.installation_webhook.delay')
     def test_notifies_service(self, installation_webhook):


### PR DESCRIPTION
Some of these fields are just integer columns, meaning Django doesn't know how to set the corresponding `*_id` field when passed an object, instead of an explicit id.

I'm honestly not sure how the tests passed before, as they were looking up objects from the DB explicitly. I'd expect them to fail since the foreign keys were not set, but :man_shrugging:

This change explicitly sets `*_id` columns instead of passing objects.