### PR TITLE
fix(snuba): Never return hits from Snuba search

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -212,7 +212,7 @@ class SnubaSearchBackend(ds.DjangoSearchBackend):
                     ]):
                 group_queryset = group_queryset.order_by('-last_seen')
                 paginator = DateTimePaginator(group_queryset, '-last_seen', **paginator_options)
-                return paginator.get_result(limit, cursor, count_hits=count_hits)
+                return paginator.get_result(limit, cursor, count_hits=False)
 
         # TODO: Presumably we only want to search back to the project's max
         # retention date, which may be closer than 90 days in the past, but


### PR DESCRIPTION
We don't currently have a way to count hits for most Snuba searches.
This elimintes the counts from the only branch that supports them so we
at least have a consistent UI.

---

I don't know if this is a good idea or not, putting it up for discussion. Some searches currently return hits and others don't. In the short term it seemed like being consistent would reduce support requests/confusion. Not sure how to handle counts in the long term.