### PR TITLE
feat(api): Add new OrganizationUserReportsEndpoint to allow users to fetch user reports across an Organization

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -103,6 +103,12 @@ class OrganizationDiscoverSavedQueryPermission(OrganizationPermission):
     }
 
 
+class OrganizationUserReportsPermission(OrganizationPermission):
+    scope_map = {
+        'GET': ['project:read', 'project:write', 'project:admin'],
+    }
+
+
 class OrganizationEndpoint(Endpoint):
     permission_classes = (OrganizationPermission, )
 

--- a/src/sentry/api/endpoints/organization_user_reports.py
+++ b/src/sentry/api/endpoints/organization_user_reports.py
@@ -1,0 +1,74 @@
+from __future__ import absolute_import
+
+from sentry.api.bases.organization import (
+    OrganizationEndpoint,
+    OrganizationUserReportsPermission,
+)
+from sentry.api.paginator import DateTimePaginator
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models import UserReportWithGroupSerializer
+from sentry.models import (
+    GroupStatus,
+    UserReport,
+)
+from sentry.utils.apidocs import (
+    attach_scenarios,
+    scenario,
+)
+
+
+@scenario('ListOrganizationUserReports')
+def list_org_user_reports_scenario(runner):
+    runner.request(method='GET', path='/organizations/%s/user-feedback/' % (runner.org.slug, ))
+
+
+class OrganizationUserReportsEndpoint(OrganizationEndpoint):
+    permission_classes = (OrganizationUserReportsPermission, )
+
+    @attach_scenarios([list_org_user_reports_scenario])
+    def get(self, request, organization):
+        """
+        List an Organization's User Feedback
+        ``````````````````````````````
+
+        Return a list of user feedback items within this organization. Can be
+        filtered by projects/environments/creation date.
+
+        :pparam string organization_slug: the slug of the organization.
+        :pparam string project_slug: the slug of the project.
+        :auth: required
+        """
+        filter_params = self.get_filter_params(
+            request,
+            organization,
+            date_filter_optional=True,
+        )
+
+        queryset = UserReport.objects.filter(
+            project_id__in=filter_params['project_id'],
+            group__isnull=False,
+        ).select_related('group')
+        if 'environment' in filter_params:
+            queryset = queryset.filter(
+                environment__name__in=filter_params['environment'],
+            )
+        if filter_params['start'] and filter_params['end']:
+            queryset = queryset.filter(
+                date_added__range=(filter_params['start'], filter_params['end'])
+            )
+
+        status = request.GET.get('status', 'unresolved')
+        if status == 'unresolved':
+            queryset = queryset.filter(
+                group__status=GroupStatus.UNRESOLVED,
+            )
+        elif status:
+            return self.respond({'status': 'Invalid status choice'}, status=400)
+
+        return self.paginate(
+            request=request,
+            queryset=queryset,
+            order_by='-date_added',
+            on_results=lambda x: serialize(x, request.user, UserReportWithGroupSerializer()),
+            paginator_cls=DateTimePaginator,
+        )

--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -9,7 +9,10 @@ from uuid import uuid4
 from sentry.api.authentication import DSNAuthentication
 from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.api.serializers import serialize, ProjectUserReportSerializer
+from sentry.api.serializers import (
+    serialize,
+    UserReportWithGroupSerializer,
+)
 from sentry.api.paginator import DateTimePaginator
 from sentry.models import (
     Environment,
@@ -92,7 +95,7 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
             request=request,
             queryset=queryset,
             order_by='-date_added',
-            on_results=lambda x: serialize(x, request.user, ProjectUserReportSerializer(
+            on_results=lambda x: serialize(x, request.user, UserReportWithGroupSerializer(
                 environment_func=self._get_environment_func(
                     request, project.organization_id)
             )),
@@ -197,7 +200,7 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
 
         user_feedback_received.send(project=report.project, group=report.group, sender=self)
 
-        return self.respond(serialize(report, request.user, ProjectUserReportSerializer(
+        return self.respond(serialize(report, request.user, UserReportWithGroupSerializer(
             environment_func=self._get_environment_func(
                 request, project.organization_id)
         )))

--- a/src/sentry/api/serializers/models/userreport.py
+++ b/src/sentry/api/serializers/models/userreport.py
@@ -56,7 +56,7 @@ class UserReportSerializer(Serializer):
         }
 
 
-class ProjectUserReportSerializer(UserReportSerializer):
+class UserReportWithGroupSerializer(UserReportSerializer):
     def __init__(self, environment_func=None):
         self.environment_func = environment_func
 
@@ -71,7 +71,7 @@ class ProjectUserReportSerializer(UserReportSerializer):
                 GroupSerializer(environment_func=self.environment_func))
         }
 
-        attrs = super(ProjectUserReportSerializer, self).get_attrs(item_list, user)
+        attrs = super(UserReportWithGroupSerializer, self).get_attrs(item_list, user)
         for item in item_list:
             attrs[item].update(
                 {
@@ -81,7 +81,7 @@ class ProjectUserReportSerializer(UserReportSerializer):
         return attrs
 
     def serialize(self, obj, attrs, user):
-        context = super(ProjectUserReportSerializer, self).serialize(
+        context = super(UserReportWithGroupSerializer, self).serialize(
             obj,
             attrs,
             user,

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -95,6 +95,7 @@ from .endpoints.organization_repository_details import OrganizationRepositoryDet
 from .endpoints.organization_sentry_apps import OrganizationSentryAppsEndpoint
 from .endpoints.organization_tagkey_values import OrganizationTagKeyValuesEndpoint
 from .endpoints.organization_tags import OrganizationTagsEndpoint
+from .endpoints.organization_user_reports import OrganizationUserReportsEndpoint
 from .endpoints.sentry_app_installations import SentryAppInstallationsEndpoint
 from .endpoints.sentry_app_installation_details import SentryAppInstallationDetailsEndpoint
 from .endpoints.organization_stats import OrganizationStatsEndpoint
@@ -627,6 +628,11 @@ urlpatterns = patterns(
         r'^organizations/(?P<organization_slug>[^\/]+)/releases/(?P<version>[^/]+)/commits/$',
         OrganizationReleaseCommitsEndpoint.as_view(),
         name='sentry-api-0-organization-release-commits'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/user-feedback/$',
+        OrganizationUserReportsEndpoint.as_view(),
+        name='sentry-api-0-organization-user-feedback'
     ),
     url(
         r'^organizations/(?P<organization_slug>[^\/]+)/sentry-app-installations/$',

--- a/src/sentry/models/userreport.py
+++ b/src/sentry/models/userreport.py
@@ -37,7 +37,8 @@ class UserReport(Model):
     def notify(self):
         from django.contrib.auth.models import AnonymousUser
         from sentry.api.serializers import (
-            serialize, ProjectUserReportSerializer
+            serialize,
+            UserReportWithGroupSerializer,
         )
         from sentry.tasks.signals import signal
 
@@ -45,6 +46,6 @@ class UserReport(Model):
             name='user-reports.created',
             project_id=self.project_id,
             payload={
-                'report': serialize(self, AnonymousUser(), ProjectUserReportSerializer()),
+                'report': serialize(self, AnonymousUser(), UserReportWithGroupSerializer()),
             },
         )

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -429,7 +429,18 @@ class TransactionTestCase(BaseTestCase, TransactionTestCase):
 
 
 class APITestCase(BaseTestCase, BaseAPITestCase):
-    pass
+    endpoint = None
+    method = 'get'
+
+    def get_response(self, *args, **params):
+        if self.endpoint is None:
+            raise Exception('Implement self.endpoint to use this method.')
+        url = self.endpoint.format(*args)
+        return getattr(self.client, self.method)(
+            url,
+            format='json',
+            data=params,
+        )
 
 
 class TwoFactorAPITestCase(APITestCase):

--- a/tests/sentry/api/endpoints/test_organization_user_reports.py
+++ b/tests/sentry/api/endpoints/test_organization_user_reports.py
@@ -1,0 +1,112 @@
+from __future__ import absolute_import
+
+from datetime import (
+    datetime,
+    timedelta,
+)
+
+import six
+
+from sentry.models import (
+    GroupStatus,
+    UserReport,
+)
+from sentry.testutils import APITestCase
+
+
+class OrganizationUserReportListTest(APITestCase):
+    endpoint = u'/api/0/organizations/{}/user-feedback/'
+    method = 'get'
+
+    def setUp(self):
+        self.user = self.create_user('test@test.com')
+        self.login_as(user=self.user)
+        self.org = self.create_organization()
+        self.team = self.create_team(organization=self.org)
+        self.create_member(teams=[self.team], user=self.user, organization=self.org)
+
+        self.project_1 = self.create_project(organization=self.org, teams=[self.team], name='wat')
+        self.project_2 = self.create_project(organization=self.org, teams=[self.team], name='who')
+        self.group_1 = self.create_group(project=self.project_1)
+        self.group_2 = self.create_group(project=self.project_1, status=GroupStatus.RESOLVED)
+        self.env_1 = self.create_environment(name='prod', project=self.project_1)
+        self.env_2 = self.create_environment(name='dev', project=self.project_1)
+
+        self.report_1 = UserReport.objects.create(
+            project=self.project_1,
+            event_id='a' * 32,
+            name='Foo',
+            email='foo@example.com',
+            comments='Hello world',
+            group=self.group_1,
+            environment=self.env_1,
+        )
+
+        # should not be included due to missing link
+        UserReport.objects.create(
+            project=self.project_1,
+            event_id='b' * 32,
+            name='Bar',
+            email='bar@example.com',
+            comments='Hello world',
+        )
+
+        self.report_resolved_1 = UserReport.objects.create(
+            project=self.project_1,
+            event_id='c' * 32,
+            name='Baz',
+            email='baz@example.com',
+            comments='Hello world',
+            group=self.group_2,
+        )
+
+        self.report_2 = UserReport.objects.create(
+            project=self.project_2,
+            event_id='d' * 32,
+            name='Wat',
+            email='wat@example.com',
+            comments='Hello world',
+            group=self.group_1,
+            environment=self.env_2,
+            date_added=datetime.now() - timedelta(days=7)
+        )
+
+    def run_test(self, expected, **params):
+        response = self.get_response(
+            self.project_1.organization.slug,
+            **params
+        )
+
+        assert response.status_code == 200, response.content
+        result_ids = set(report['id'] for report in response.data)
+        assert result_ids == set(six.text_type(report.id) for report in expected)
+
+    def test_no_filters(self):
+        self.run_test([self.report_1, self.report_2])
+
+    def test_project_filter(self):
+        self.run_test([self.report_1], project=[self.project_1.id])
+        self.run_test([self.report_2], project=[self.project_2.id])
+
+    def test_environment_filter(self):
+        self.run_test([self.report_1], environment=[self.env_1.name])
+        self.run_test([self.report_2], environment=[self.env_2.name])
+
+    def test_date_filter(self):
+        self.run_test(
+            [self.report_1],
+            start=(datetime.now() - timedelta(days=1)).isoformat() + 'Z',
+            end=datetime.now().isoformat() + 'Z',
+        )
+        self.run_test(
+            [self.report_1, self.report_2],
+            start=(datetime.now() - timedelta(days=8)).isoformat() + 'Z',
+            end=datetime.now().isoformat() + 'Z',
+        )
+        self.run_test(
+            [self.report_1, self.report_2],
+            statsPeriod='14d',
+        )
+
+    def test_all_reports(self):
+        self.run_test([self.report_1, self.report_2, self.report_resolved_1], status='')

--- a/tests/sentry/plugins/mail/tests.py
+++ b/tests/sentry/plugins/mail/tests.py
@@ -14,7 +14,8 @@ from exam import fixture
 from mock import Mock
 
 from sentry.api.serializers import (
-    serialize, ProjectUserReportSerializer
+    serialize,
+    UserReportWithGroupSerializer,
 )
 from sentry.digests.notifications import build_digest, event_to_record
 from sentry.interfaces.stacktrace import Stacktrace
@@ -436,7 +437,7 @@ class MailPluginSignalsTest(TestCase):
                 name='user-reports.created',
                 project=self.project,
                 payload={
-                    'report': serialize(report, AnonymousUser(), ProjectUserReportSerializer()),
+                    'report': serialize(report, AnonymousUser(), UserReportWithGroupSerializer()),
                 },
             )
 


### PR DESCRIPTION
Adds an organization specific endpoint for retrieving UserReports. This supports our standard new methods of filtering by project/env/date.