### PR TITLE
fix(ui) Make links in alert boxes more consistent

### DIFF
--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1720,11 +1720,11 @@ header + .alert {
   }
 
   a {
-    font-weight: 600;
     color: inherit;
+    text-decoration: underline;
 
     &:hover {
-      color: inherit;
+      text-decoration: underline;
     }
   }
 


### PR DESCRIPTION
Make links in django alertboxes more visually consistent with the alert links in react. Previously links in alerts were indistinguishable from bold text.

<img width="581" alt="screen shot 2018-12-13 at 2 32 42 pm" src="https://user-images.githubusercontent.com/24086/49971733-4ea16a00-fee4-11e8-8962-509c63dd7bc6.png">
