### PR TITLE
feat(search) Add search options for linked_ticket

### DIFF
--- a/src/sentry/models/grouplink.py
+++ b/src/sentry/models/grouplink.py
@@ -12,7 +12,12 @@ from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 from jsonfield import JSONField
 
-from sentry.db.models import Model, sane_repr, BoundedBigIntegerField, BoundedPositiveIntegerField
+from sentry.db.models import (
+    Model,
+    sane_repr,
+    BoundedBigIntegerField,
+    BoundedPositiveIntegerField
+)
 
 
 class GroupLink(Model):

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -410,6 +410,13 @@ def parse_query(project, query, user):
                 results.update(get_date_params(value, 'date_from', 'date_to'))
             elif key == 'timesSeen':
                 results.update(get_numeric_field_value('times_seen', value))
+            elif key == 'linked_ticket':
+                if value == 'true':
+                    results['linked_ticket'] = True
+                elif value == 'false':
+                    results['linked_ticket'] = False
+                else:
+                    raise InvalidQuery(u"'linked_ticket:' had unknown value '{}'.".format(value))
             else:
                 results['tags'][key] = value
 


### PR DESCRIPTION
Add linked_ticket as a search filter for both the django based search and as a pre-filter for snuba based search.

A request we've heard from customers is the need to find which issues in sentry have not been triaged into their external bug tracker. This new filter makes it possible to find groups that have or don't have integration based issues attached to them. Plugin based issue trackers are not covered by these changes as the `GroupMeta` data is stored in a way that makes searching it slow.

I wasn't able to run the snuba tests locally, so I'm going to rely on travis.

Refs APP-894