### PR TITLE
fix(api): Fix bug in `OrganizationEndpoint.get_project_ids` when `request.user` is None

### DIFF
--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -204,6 +204,15 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
             project_ids=[self.project_1.id, self.project_2.id],
         )
 
+    def test_none_user(self):
+        request = RequestFactory().get('/')
+        result = self.endpoint.get_project_ids(request, self.org)
+        assert [] == result
+
+        request.user = None
+        result = self.endpoint.get_project_ids(request, self.org)
+        assert [] == result
+
 
 class GetEnvironmentsTest(BaseOrganizationEndpointTest):
     def setUp(self):


### PR DESCRIPTION
Turns out that user can be `None` due to the way our `ApiClient` works, so guard against that.

Fixes SENTRY-8QJ