### PR TITLE
fix(api): Fix bug in releases screen where releases don't show up when filtering by environments

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -110,7 +110,8 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, Environment
 
         if 'environment' in filter_params:
             queryset = queryset.filter(
-                releaseenvironment__environment__name__in=filter_params['environment'],
+                releaseprojectenvironment__environment__name__in=filter_params['environment'],
+                releaseprojectenvironment__project_id__in=filter_params['project_id'],
             )
 
         if query:

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -11,7 +11,12 @@ from sentry.api.paginator import OffsetPaginator
 from sentry.api.fields.user import UserField
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import CommitSerializer, ListField
-from sentry.models import Activity, CommitFileChange, Environment, Release, ReleaseEnvironment
+from sentry.models import (
+    Activity,
+    CommitFileChange,
+    Environment,
+    Release,
+)
 from sentry.plugins.interfaces.releasehook import ReleaseHook
 from sentry.constants import VERSION_LENGTH
 from sentry.signals import release_created
@@ -78,12 +83,10 @@ class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
                 projects=project, organization_id=project.organization_id
             ).select_related('owner')
             if environment is not None:
-                # TODO(LB): May want to change this to ReleaseProjectEnv don't see a
-                # reason to change now.
-                queryset = queryset.filter(id__in=ReleaseEnvironment.objects.filter(
-                    organization_id=project.organization_id,
-                    environment_id=environment.id,
-                ).values_list('release_id', flat=True))
+                queryset = queryset.filter(
+                    releaseprojectenvironment__project=project,
+                    releaseprojectenvironment__environment=environment,
+                )
 
         if query:
             queryset = queryset.filter(

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -11,7 +11,17 @@ from django.core.urlresolvers import reverse
 from exam import fixture
 
 from sentry.models import (
-    Activity, ApiKey, ApiToken, CommitAuthor, CommitFileChange, Environment, Release, ReleaseCommit, ReleaseEnvironment, ReleaseProject, Repository
+    Activity,
+    ApiKey,
+    ApiToken,
+    CommitAuthor,
+    CommitFileChange,
+    Environment,
+    Release,
+    ReleaseCommit,
+    ReleaseProjectEnvironment,
+    ReleaseProject,
+    Repository,
 )
 from sentry.plugins.providers.dummy.repository import DummyRepositoryProvider
 from sentry.testutils import APITestCase, ReleaseCommitPatchTest
@@ -918,8 +928,7 @@ class OrganizationReleaseListEnvironmentsTest(APITestCase):
             date_added=datetime(2013, 8, 13, 3, 8, 24, 880386),
         )
         release1.add_project(project1)
-        ReleaseEnvironment.objects.create(
-            organization_id=org.id,
+        ReleaseProjectEnvironment.objects.create(
             project_id=project1.id,
             release_id=release1.id,
             environment_id=env1.id,
@@ -931,8 +940,7 @@ class OrganizationReleaseListEnvironmentsTest(APITestCase):
             date_added=datetime(2013, 8, 14, 3, 8, 24, 880386),
         )
         release2.add_project(project2)
-        ReleaseEnvironment.objects.create(
-            organization_id=org.id,
+        ReleaseProjectEnvironment.objects.create(
             project_id=project2.id,
             release_id=release2.id,
             environment_id=env2.id,
@@ -945,8 +953,7 @@ class OrganizationReleaseListEnvironmentsTest(APITestCase):
             date_released=datetime(2013, 8, 15, 3, 8, 24, 880386),
         )
         release3.add_project(project1)
-        ReleaseEnvironment.objects.create(
-            organization_id=org.id,
+        ReleaseProjectEnvironment.objects.create(
             project_id=project1.id,
             release_id=release3.id,
             environment_id=env2.id,
@@ -964,13 +971,13 @@ class OrganizationReleaseListEnvironmentsTest(APITestCase):
         )
         release5.add_project(project1)
         release5.add_project(project2)
-        ReleaseEnvironment.objects.create(
-            organization_id=org.id,
+        ReleaseProjectEnvironment.objects.create(
+            project_id=project1.id,
             release_id=release5.id,
             environment_id=env1.id,
         )
-        ReleaseEnvironment.objects.create(
-            organization_id=org.id,
+        ReleaseProjectEnvironment.objects.create(
+            project_id=project2.id,
             release_id=release5.id,
             environment_id=env2.id,
         )
@@ -1026,8 +1033,7 @@ class OrganizationReleaseListEnvironmentsTest(APITestCase):
             }
         )
         env = self.make_environment('', self.project2)
-        ReleaseEnvironment.objects.create(
-            organization_id=self.org.id,
+        ReleaseProjectEnvironment.objects.create(
             project_id=self.project2.id,
             release_id=self.release4.id,
             environment_id=env.id,

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -5,7 +5,16 @@ from django.utils import timezone
 from django.core.urlresolvers import reverse
 from exam import fixture
 
-from sentry.models import CommitAuthor, CommitFileChange, Environment, Release, ReleaseCommit, ReleaseEnvironment, ReleaseProject, ReleaseProjectEnvironment, Repository
+from sentry.models import (
+    CommitAuthor,
+    CommitFileChange,
+    Environment,
+    Release,
+    ReleaseCommit,
+    ReleaseProject,
+    ReleaseProjectEnvironment,
+    Repository,
+)
 from sentry.testutils import APITestCase, ReleaseCommitPatchTest
 
 
@@ -126,12 +135,6 @@ class ProjectReleaseListEnvironmentsTest(APITestCase):
             date_added=self.datetime,
         )
         release1.add_project(project1)
-        ReleaseEnvironment.objects.create(
-            organization_id=project1.organization_id,
-            project_id=project1.id,
-            release_id=release1.id,
-            environment_id=env1.id,
-        )
         ReleaseProjectEnvironment.objects.create(
             release_id=release1.id,
             project_id=project1.id,
@@ -146,12 +149,6 @@ class ProjectReleaseListEnvironmentsTest(APITestCase):
             date_added=self.datetime,
         )
         release2.add_project(project2)
-        ReleaseEnvironment.objects.create(
-            organization_id=project2.organization_id,
-            project_id=project2.id,
-            release_id=release2.id,
-            environment_id=env2.id,
-        )
         ReleaseProjectEnvironment.objects.create(
             release_id=release2.id,
             project_id=project2.id,
@@ -167,12 +164,6 @@ class ProjectReleaseListEnvironmentsTest(APITestCase):
             date_released=self.datetime,
         )
         release3.add_project(project1)
-        ReleaseEnvironment.objects.create(
-            organization_id=project1.organization_id,
-            project_id=project1.id,
-            release_id=release3.id,
-            environment_id=env3.id,
-        )
         ReleaseProjectEnvironment.objects.create(
             release_id=release3.id,
             project_id=project1.id,
@@ -287,12 +278,6 @@ class ProjectReleaseListEnvironmentsTest(APITestCase):
             first_seen=self.datetime + timedelta(seconds=120),
             last_seen=self.datetime + timedelta(seconds=700),
             new_issues_count=7,
-        )
-        ReleaseEnvironment.objects.create(
-            organization_id=self.project1.organization_id,
-            project_id=self.project1.id,
-            release_id=self.release1.id,
-            environment_id=self.env3.id,
         )
 
         # TODO(LB): This is testing all environmetns but it will not work


### PR DESCRIPTION
This fixes an issue that occurs when a release is associated with an environment via a deploy, but there are no events associated with that release/env combination.

Fixes ISSUE-241