### PR TITLE
Revert "fix(digests): Avoid creating unqualified queries on group deletion (#11023)"

### DIFF
--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -71,11 +71,11 @@ def fetch_state(project, records):
         Rule.objects.
         in_bulk(itertools.chain.from_iterable(record.value.rules for record in records)),
         'event_counts':
-        tsdb.get_sums(tsdb.models.group, groups.keys(), start, end) if groups else {},
+        tsdb.get_sums(tsdb.models.group, groups.keys(), start, end),
         'user_counts':
         tsdb.get_distinct_counts_totals(
             tsdb.models.users_affected_by_group, groups.keys(), start, end
-        ) if groups else {},
+        ),
     }
 
 


### PR DESCRIPTION
This reverts commit b111ce84ab23c9ab32edecb50996259a3ed0ebaf, which is unnecessary as of GH-11027 since this path will no longer error with an empty input.

padding the stats