### PR TITLE
feat: Add StoreView Kafka event consumer

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,3 +1,4 @@
+batching-kafka-consumer==0.0.1
 BeautifulSoup>=3.2.1
 boto3>=1.4.1,<1.4.6
 botocore<1.5.71

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1450,3 +1450,8 @@ INVALID_EMAIL_ADDRESS_PATTERN = re.compile(r'\@qq\.com$', re.I)
 SENTRY_USER_PERMISSIONS = (
     'broadcasts.admin',
 )
+
+# Store Consumer configuration.
+CONSUMER_DEFAULT_BROKERS = ['localhost:9092']
+CONSUMER_DEFAULT_MAX_BATCH_SIZE = 1000
+CONSUMER_DEFAULT_MAX_BATCH_TIME_MS = 500

--- a/src/sentry/event_consumer.py
+++ b/src/sentry/event_consumer.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import, print_function
 
+import logging
+
+from batching_kafka_consumer import AbstractBatchWorker
 
 from batching_kafka_consumer import AbstractBatchWorker
 from sentry.coreapi import Auth, ClientApiHelper
@@ -7,6 +10,9 @@ from sentry.event_manager import EventManager
 from sentry.models import Project
 from sentry.utils import json
 from sentry.web.api import process_event
+
+
+logger = logging.getLogger('sentry.event_consumer')
 
 
 def process_event_from_kafka(message):
@@ -51,7 +57,10 @@ class EventConsumerWorker(AbstractBatchWorker):
 
     def flush_batch(self, batch):
         for event in batch:
-            process_event_from_kafka(event)
+            try:
+                process_event_from_kafka(event)
+            except Exception:
+                logger.exception('Error processing event.')
 
     def shutdown(self):
         pass

--- a/src/sentry/event_consumer.py
+++ b/src/sentry/event_consumer.py
@@ -4,7 +4,6 @@ import logging
 
 from batching_kafka_consumer import AbstractBatchWorker
 
-from batching_kafka_consumer import AbstractBatchWorker
 from sentry.coreapi import Auth, ClientApiHelper
 from sentry.event_manager import EventManager
 from sentry.models import Project

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -52,7 +52,7 @@ class Quota(Service):
     def __init__(self, **options):
         pass
 
-    def is_rate_limited(self, project, key=None):
+    def is_rate_limited(self, project, key=None, timestamp=None):
         return NotRateLimited()
 
     def refund(self, project, key=None, timestamp=None):

--- a/src/sentry/runner/commands/storeconsumer.py
+++ b/src/sentry/runner/commands/storeconsumer.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import, print_function
+
+import click
+import signal
+from django.conf import settings
+
+from sentry.runner.decorators import configuration
+
+
+@click.command()
+@click.option('--store-events-topic', default='store-events',
+              help='Topic to consume raw events from.')
+@click.option('--consumer-group', default='snuba-consumers',
+              help='Consumer group use for consuming the raw events topic.')
+@click.option('--bootstrap-server', default=settings.CONSUMER_DEFAULT_BROKERS, multiple=True,
+              help='Kafka bootstrap server to use.')
+@click.option('--max-batch-size', default=settings.CONSUMER_DEFAULT_MAX_BATCH_SIZE,
+              help='Max number of messages to batch in memory before writing to Kafka.')
+@click.option('--max-batch-time-ms', default=settings.CONSUMER_DEFAULT_MAX_BATCH_TIME_MS,
+              help='Max length of time to buffer messages in memory before writing to Kafka.')
+@click.option('--auto-offset-reset', default='error', type=click.Choice(['error', 'earliest', 'latest']),
+              help='Kafka consumer auto offset reset.')
+@click.option('--queued-max-messages-kbytes', default=50000, type=int,
+              help='Maximum number of kilobytes per topic+partition in the local consumer queue.')
+@click.option('--queued-min-messages', default=10000, type=int,
+              help='Minimum number of messages per topic+partition librdkafka tries to maintain in the local consumer queue.')
+@configuration
+def storeconsumer(store_events_topic, consumer_group, bootstrap_server, max_batch_size,
+                  max_batch_time_ms, auto_offset_reset, queued_max_messages_kbytes, queued_min_messages,
+                  log_level):
+
+    from batching_kafka_consumer import BatchingKafkaConsumer
+    from sentry.event_consumer import EventConsumerWorker
+
+    consumer = BatchingKafkaConsumer(
+        store_events_topic,
+        worker=EventConsumerWorker(),
+        max_batch_size=max_batch_size,
+        max_batch_time=max_batch_time_ms,
+        bootstrap_servers=bootstrap_server,
+        group_id=consumer_group,
+        auto_offset_reset=auto_offset_reset,
+    )
+
+    def handler(signum, frame):
+        consumer.signal_shutdown()
+
+    signal.signal(signal.SIGINT, handler)
+
+    consumer.run()


### PR DESCRIPTION
First pass at consumer that will process StoreView messages: https://github.com/getsentry/sentry/blob/3fbfd80baf5ed245ff9d03754bf12ffaf912bf1d/src/sentry/web/api.py#L566-L585

Note that this is still part of a larger refactor and testing. This will not be run against production data at this point in time -- or if we do it will only be projects/orgs we opt-in.