### PR TITLE
api: Speed up releasefile endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_release_files.py
+++ b/src/sentry/api/endpoints/organization_release_files.py
@@ -46,7 +46,7 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint):
 
         file_list = ReleaseFile.objects.filter(
             release=release,
-        ).select_related('file').order_by('name')
+        ).select_related('file', 'dist').order_by('name')
 
         return self.paginate(
             request=request,

--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -79,7 +79,7 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint):
 
         file_list = ReleaseFile.objects.filter(
             release=release,
-        ).select_related('file').order_by('name')
+        ).select_related('file', 'dist').order_by('name')
 
         return self.paginate(
             request=request,

--- a/src/sentry/api/serializers/models/release_file.py
+++ b/src/sentry/api/serializers/models/release_file.py
@@ -12,7 +12,7 @@ class ReleaseFileSerializer(Serializer):
         return {
             'id': six.text_type(obj.id),
             'name': obj.name,
-            'dist': obj.dist and obj.dist.name or None,
+            'dist': obj.dist_id and obj.dist.name or None,
             'headers': obj.file.headers,
             'size': obj.file.size,
             'sha1': obj.file.checksum,

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -42,7 +42,7 @@ class ReleaseFile(Model):
 
     def save(self, *args, **kwargs):
         if not self.ident and self.name:
-            dist = self.dist and self.dist.name or None
+            dist = self.dist_id and self.dist.name or None
             self.ident = type(self).get_ident(self.name, dist)
         return super(ReleaseFile, self).save(*args, **kwargs)
 


### PR DESCRIPTION
The ReleaseFile serializer attempts to look at `self.dist` which causes
O(n) queries, so this changes the serializer to be lazy, as well as
adding a JOIN so it doesn't need to fetch it at all.