### PR TITLE
fix(api): Add pagination for channel.list in Slack integration

### DIFF
--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -191,13 +191,13 @@ class SlackNotifyServiceAction(EventAction):
                     'cursor': cursor
                 }))
             channels = channels.json()
-            if not resp.get('ok'):
-                self.logger.info('rule.slack.channel_list_failed', extra={'error': resp.get('error')})
+            if not channels.get('ok'):
+                self.logger.info('rule.slack.channel_list_failed', extra={'error': channels.get('error')})
                 return None
 
             cursor = channels.get('response_metadata', {}).get('next_cursor', None)
 
-            channel_id = {c['name']: c['id'] for c in resp['channels']}
+            channel_id = {c['name']: c['id'] for c in channels['channels']}
             if channel_id:
                 return (CHANNEL_PREFIX, channel_id)
 

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -183,13 +183,13 @@ class SlackNotifyServiceAction(EventAction):
         })
 
         # Slack limits the response of `channels.list` to 1000 channels, paginate if needed
-        channels = session.get('https://slack.com/api/channels.list', params=channels_payload)
         cursor = None
-        while cursor or len(channels) == 0:
-            if cursor:
-                channels = session.get('https://slack.com/api/channels.list', params=dict(channels_payload, **{
-                    'cursor': cursor
-                }))
+        channels_list_initial = True
+        while cursor or channels_list_initial:
+            channels_list_initial = False
+            channels = session.get('https://slack.com/api/channels.list', params=dict(channels_payload, **{
+                'cursor': cursor
+            }))
             channels = channels.json()
             if not channels.get('ok'):
                 self.logger.info('rule.slack.channel_list_failed', extra={'error': channels.get('error')})


### PR DESCRIPTION
In the global Slack integration, channel.list is used to grab the channel ID. However, in Slack instances with > 1000 channels, this is insufficient. This change will fire off subsequent requests if needed to fetch the entire list of channels.

Fixes GH-10056

This was recreated from https://github.com/getsentry/sentry/pull/10057 after a bad Git merge