### PR TITLE
feat(UX): design header and background consistency audit

### DIFF
--- a/docs-ui/components/pageHeader.stories.js
+++ b/docs-ui/components/pageHeader.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {withInfo} from '@storybook/addon-info';
+
+import PageHeader from 'app/components/pageHeader';
+
+storiesOf('UI|PageHeader', module).add(
+  'default',
+  withInfo(
+    'Every page should have a header, and the header should be made with this.'
+  )(() => <PageHeader>Page Header</PageHeader>)
+);

--- a/docs-ui/components/pageHeading.stories.js
+++ b/docs-ui/components/pageHeading.stories.js
@@ -2,11 +2,11 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import PageHeader from 'app/components/pageHeader';
+import PageHeading from 'app/components/pageHeading';
 
-storiesOf('UI|PageHeader', module).add(
+storiesOf('UI|PageHeading', module).add(
   'default',
   withInfo(
     'Every page should have a header, and the header should be made with this.'
-  )(() => <PageHeader>Page Header</PageHeader>)
+  )(() => <PageHeading>Page Header</PageHeading>)
 );

--- a/docs-ui/components/pageHeading.stories.js
+++ b/docs-ui/components/pageHeading.stories.js
@@ -8,5 +8,5 @@ storiesOf('UI|PageHeading', module).add(
   'default',
   withInfo(
     'Every page should have a header, and the header should be made with this.'
-  )(() => <PageHeading>Page Header</PageHeading>)
+  )(() => <PageHeading withMargins>Page Header</PageHeading>)
 );

--- a/src/sentry/static/sentry/app/components/organizationIssueList.jsx
+++ b/src/sentry/static/sentry/app/components/organizationIssueList.jsx
@@ -1,9 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
+import styled from 'react-emotion';
 
 import GroupStore from 'app/stores/groupStore';
 import IssueList from 'app/components/issueList';
+import PageHeader from 'app/components/pageHeader';
+import space from 'app/styles/space';
 import OrganizationHomeContainer from 'app/components/organizations/homeContainer';
 import {t} from 'app/locale';
 
@@ -61,7 +64,7 @@ class OrganizationIssueList extends React.Component {
             </Link>
           </div>
         </div>
-        <h4>{this.props.title}</h4>
+        <StyledPageHeader withPadding>{this.props.title}</StyledPageHeader>
         <IssueList
           endpoint={this.props.endpoint}
           emptyText={this.props.emptyText}
@@ -77,5 +80,10 @@ class OrganizationIssueList extends React.Component {
     );
   }
 }
+
+const StyledPageHeader = styled(PageHeader)`
+  margin-bottom: ${space(3)};
+  margin-top: ${space(0.5)};
+`;
 
 export default OrganizationIssueList;

--- a/src/sentry/static/sentry/app/components/organizationIssueList.jsx
+++ b/src/sentry/static/sentry/app/components/organizationIssueList.jsx
@@ -1,12 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
-import styled from 'react-emotion';
 
 import GroupStore from 'app/stores/groupStore';
 import IssueList from 'app/components/issueList';
 import PageHeading from 'app/components/pageHeading';
-import space from 'app/styles/space';
 import OrganizationHomeContainer from 'app/components/organizations/homeContainer';
 import {t} from 'app/locale';
 
@@ -64,7 +62,7 @@ class OrganizationIssueList extends React.Component {
             </Link>
           </div>
         </div>
-        <StyledPageHeading withMargins>{this.props.title}</StyledPageHeading>
+        <PageHeading withMargins>{this.props.title}</PageHeading>
         <IssueList
           endpoint={this.props.endpoint}
           emptyText={this.props.emptyText}
@@ -80,9 +78,5 @@ class OrganizationIssueList extends React.Component {
     );
   }
 }
-
-const StyledPageHeading = styled(PageHeading)`
-  margin-top: ${space(0.5)};
-`;
 
 export default OrganizationIssueList;

--- a/src/sentry/static/sentry/app/components/organizationIssueList.jsx
+++ b/src/sentry/static/sentry/app/components/organizationIssueList.jsx
@@ -5,7 +5,7 @@ import styled from 'react-emotion';
 
 import GroupStore from 'app/stores/groupStore';
 import IssueList from 'app/components/issueList';
-import PageHeader from 'app/components/pageHeader';
+import PageHeading from 'app/components/pageHeading';
 import space from 'app/styles/space';
 import OrganizationHomeContainer from 'app/components/organizations/homeContainer';
 import {t} from 'app/locale';
@@ -64,7 +64,7 @@ class OrganizationIssueList extends React.Component {
             </Link>
           </div>
         </div>
-        <StyledPageHeader withPadding>{this.props.title}</StyledPageHeader>
+        <StyledPageHeading withPadding>{this.props.title}</StyledPageHeading>
         <IssueList
           endpoint={this.props.endpoint}
           emptyText={this.props.emptyText}
@@ -81,7 +81,7 @@ class OrganizationIssueList extends React.Component {
   }
 }
 
-const StyledPageHeader = styled(PageHeader)`
+const StyledPageHeading = styled(PageHeading)`
   margin-bottom: ${space(3)};
   margin-top: ${space(0.5)};
 `;

--- a/src/sentry/static/sentry/app/components/organizationIssueList.jsx
+++ b/src/sentry/static/sentry/app/components/organizationIssueList.jsx
@@ -64,7 +64,7 @@ class OrganizationIssueList extends React.Component {
             </Link>
           </div>
         </div>
-        <StyledPageHeading withPadding>{this.props.title}</StyledPageHeading>
+        <StyledPageHeading withMargins>{this.props.title}</StyledPageHeading>
         <IssueList
           endpoint={this.props.endpoint}
           emptyText={this.props.emptyText}
@@ -82,7 +82,6 @@ class OrganizationIssueList extends React.Component {
 }
 
 const StyledPageHeading = styled(PageHeading)`
-  margin-bottom: ${space(3)};
   margin-top: ${space(0.5)};
 `;
 

--- a/src/sentry/static/sentry/app/components/organizations/homeContainer.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/homeContainer.jsx
@@ -3,7 +3,7 @@ import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
 
 import OrganizationState from 'app/mixins/organizationState';
-import ProjectNav from 'app/views/organizationDashboard/projectNav';
+import ProjectNav from 'app/views/organizationProjectsDashboard/projectNav';
 import space from 'app/styles/space';
 
 const HomeContainer = createReactClass({

--- a/src/sentry/static/sentry/app/components/organizations/homeContainer.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/homeContainer.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
+import styled from 'react-emotion';
 
 import OrganizationState from 'app/mixins/organizationState';
-import ProjectNav from 'app/views/organizationProjectsDashboard/projectNav';
+import ProjectNav from 'app/views/organizationDashboard/projectNav';
+import space from 'app/styles/space';
 
 const HomeContainer = createReactClass({
   displayName: 'HomeContainer',
@@ -13,10 +15,16 @@ const HomeContainer = createReactClass({
     return (
       <div className={`${this.props.className || ''} organization-home`}>
         <ProjectNav />
-        <div className="container">{this.props.children}</div>
+        <div className="container">
+          <Content>{this.props.children}</Content>
+        </div>
       </div>
     );
   },
 });
+
+const Content = styled('div')`
+  padding-top: ${space(3)};
+`;
 
 export default HomeContainer;

--- a/src/sentry/static/sentry/app/components/pageHeader.jsx
+++ b/src/sentry/static/sentry/app/components/pageHeader.jsx
@@ -1,0 +1,11 @@
+import styled from 'react-emotion';
+
+const PageHeader = styled('h1')`
+  font-size: ${p => p.theme.headerFontSize};
+  line-height: ${p => p.theme.headerFontSize};
+  font-weight: normal;
+  color: ${p => p.theme.gray4};
+  margin: 0;
+`;
+
+export default PageHeader;

--- a/src/sentry/static/sentry/app/components/pageHeader.jsx
+++ b/src/sentry/static/sentry/app/components/pageHeader.jsx
@@ -1,6 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'react-emotion';
 
-const PageHeader = styled('h1')`
+class PageHeader extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+    className: PropTypes.string,
+  };
+
+  render() {
+    const {children, className} = this.props;
+    return <Wrapper className={className}>{children}</Wrapper>;
+  }
+}
+
+const Wrapper = styled('h1')`
   font-size: ${p => p.theme.headerFontSize};
   line-height: ${p => p.theme.headerFontSize};
   font-weight: normal;

--- a/src/sentry/static/sentry/app/components/pageHeading.jsx
+++ b/src/sentry/static/sentry/app/components/pageHeading.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'react-emotion';
 
-class PageHeader extends React.Component {
+class PageHeading extends React.Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -22,4 +22,4 @@ const Wrapper = styled('h1')`
   margin: 0;
 `;
 
-export default PageHeader;
+export default PageHeading;

--- a/src/sentry/static/sentry/app/components/pageHeading.jsx
+++ b/src/sentry/static/sentry/app/components/pageHeading.jsx
@@ -2,15 +2,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'react-emotion';
 
+import space from 'app/styles/space';
+
 class PageHeading extends React.Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
+    withMargins: PropTypes.bool,
   };
 
   render() {
-    const {children, className} = this.props;
-    return <Wrapper className={className}>{children}</Wrapper>;
+    const {children, className, withMargins} = this.props;
+    return (
+      <Wrapper className={className} withMargins={withMargins}>
+        {children}
+      </Wrapper>
+    );
   }
 }
 
@@ -20,6 +27,8 @@ const Wrapper = styled('h1')`
   font-weight: normal;
   color: ${p => p.theme.gray4};
   margin: 0;
+  margin-bottom: ${p => p.withMargins && space(3)};
+  margin-top: ${p => p.withMargins && space(1)};
 `;
 
 export default PageHeading;

--- a/src/sentry/static/sentry/app/views/onboarding/project/index.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/project/index.jsx
@@ -6,6 +6,7 @@ import {analytics} from 'app/utils/analytics';
 import PlatformPicker from 'app/views/onboarding/project/platformpicker';
 import PlatformiconTile from 'app/views/onboarding/project/platformiconTile';
 import SelectField from 'app/components/forms/selectField';
+import PageHeading from 'app/components/pageHeading';
 import {t} from 'app/locale';
 
 class OnboardingProject extends React.Component {
@@ -51,7 +52,7 @@ class OnboardingProject extends React.Component {
     let {team, teams, setTeam} = this.props;
     return (
       <div className="new-project-team">
-        <h4>{t('Team') + ':'}</h4>
+        <PageHeading withMargins>{t('Team') + ':'}</PageHeading>
         <div>
           <SelectField
             name="select-team"
@@ -72,11 +73,11 @@ class OnboardingProject extends React.Component {
   render() {
     return (
       <div className="onboarding-info">
-        <h4>{t('Choose a language or framework') + ':'}</h4>
+        <PageHeading withMargins>{t('Choose a language or framework') + ':'}</PageHeading>
         <PlatformPicker {...this.props} showOther={true} />
         <div className="create-project-form">
           <div className="new-project-name client-platform">
-            <h4>{t('Give your project a name') + ':'}</h4>
+            <PageHeading withMargins>{t('Give your project a name') + ':'}</PageHeading>
             <div
               className={classnames('project-name-wrapper', {
                 required: this.state.projectRequired,

--- a/src/sentry/static/sentry/app/views/onboarding/project/index.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/project/index.jsx
@@ -6,10 +6,7 @@ import {analytics} from 'app/utils/analytics';
 import PlatformPicker from 'app/views/onboarding/project/platformpicker';
 import PlatformiconTile from 'app/views/onboarding/project/platformiconTile';
 import SelectField from 'app/components/forms/selectField';
-import PageHeading from 'app/components/pageHeading';
 import {t} from 'app/locale';
-import styled from 'react-emotion';
-import space from 'app/styles/space';
 
 class OnboardingProject extends React.Component {
   static propTypes = {
@@ -54,7 +51,7 @@ class OnboardingProject extends React.Component {
     let {team, teams, setTeam} = this.props;
     return (
       <div className="new-project-team">
-        <PageHeading withMargins>{t('Team') + ':'}</PageHeading>
+        <h4>{t('Team') + ':'}</h4>
         <div>
           <SelectField
             name="select-team"
@@ -74,12 +71,12 @@ class OnboardingProject extends React.Component {
 
   render() {
     return (
-      <Wrapper>
-        <PageHeading withMargins>{t('Choose a language or framework') + ':'}</PageHeading>
+      <div className="onboarding-info">
+        <h4>{t('Choose a language or framework') + ':'}</h4>
         <PlatformPicker {...this.props} showOther={true} />
         <div className="create-project-form">
           <div className="new-project-name client-platform">
-            <PageHeading withMargins>{t('Give your project a name') + ':'}</PageHeading>
+            <h4>{t('Give your project a name') + ':'}</h4>
             <div
               className={classnames('project-name-wrapper', {
                 required: this.state.projectRequired,
@@ -109,13 +106,9 @@ class OnboardingProject extends React.Component {
             )}
           </p>
         </div>
-      </Wrapper>
+      </div>
     );
   }
 }
-
-const Wrapper = styled('div')`
-  margin-top: ${space(3)};
-`;
 
 export default OnboardingProject;

--- a/src/sentry/static/sentry/app/views/onboarding/project/index.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/project/index.jsx
@@ -6,7 +6,10 @@ import {analytics} from 'app/utils/analytics';
 import PlatformPicker from 'app/views/onboarding/project/platformpicker';
 import PlatformiconTile from 'app/views/onboarding/project/platformiconTile';
 import SelectField from 'app/components/forms/selectField';
+import PageHeading from 'app/components/pageHeading';
 import {t} from 'app/locale';
+import styled from 'react-emotion';
+import space from 'app/styles/space';
 
 class OnboardingProject extends React.Component {
   static propTypes = {
@@ -51,7 +54,7 @@ class OnboardingProject extends React.Component {
     let {team, teams, setTeam} = this.props;
     return (
       <div className="new-project-team">
-        <h4>{t('Team') + ':'}</h4>
+        <PageHeading withMargins>{t('Team') + ':'}</PageHeading>
         <div>
           <SelectField
             name="select-team"
@@ -71,12 +74,12 @@ class OnboardingProject extends React.Component {
 
   render() {
     return (
-      <div className="onboarding-info">
-        <h4>{t('Choose a language or framework') + ':'}</h4>
+      <Wrapper>
+        <PageHeading withMargins>{t('Choose a language or framework') + ':'}</PageHeading>
         <PlatformPicker {...this.props} showOther={true} />
         <div className="create-project-form">
           <div className="new-project-name client-platform">
-            <h4>{t('Give your project a name') + ':'}</h4>
+            <PageHeading withMargins>{t('Give your project a name') + ':'}</PageHeading>
             <div
               className={classnames('project-name-wrapper', {
                 required: this.state.projectRequired,
@@ -106,9 +109,13 @@ class OnboardingProject extends React.Component {
             )}
           </p>
         </div>
-      </div>
+      </Wrapper>
     );
   }
 }
+
+const Wrapper = styled('div')`
+  margin-top: ${space(3)};
+`;
 
 export default OnboardingProject;

--- a/src/sentry/static/sentry/app/views/organizationActivity.jsx
+++ b/src/sentry/static/sentry/app/views/organizationActivity.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
+import styled from 'react-emotion';
 
 import AsyncView from 'app/views/asyncView';
 import ActivityFeed from 'app/components/activity/feed';
 import OrganizationHomeContainer from 'app/components/organizations/homeContainer';
+import PageHeader from 'app/components/pageHeader';
+import space from 'app/styles/space';
 
 import {t} from 'app/locale';
 
@@ -18,7 +21,7 @@ export default class OrganizationActivity extends AsyncView {
   render() {
     return (
       <OrganizationHomeContainer>
-        <h4>{t('Activity')}</h4>
+        <StyledPageHeader>{t('Activity')}</StyledPageHeader>
         <ActivityFeed
           endpoint={this.getEndpoint()}
           query={{
@@ -31,3 +34,8 @@ export default class OrganizationActivity extends AsyncView {
     );
   }
 }
+
+const StyledPageHeader = styled(PageHeader)`
+  margin-bottom: ${space(3)};
+  margin-top: ${space(0.5)};
+`;

--- a/src/sentry/static/sentry/app/views/organizationActivity.jsx
+++ b/src/sentry/static/sentry/app/views/organizationActivity.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import styled from 'react-emotion';
 
 import AsyncView from 'app/views/asyncView';
 import ActivityFeed from 'app/components/activity/feed';
 import OrganizationHomeContainer from 'app/components/organizations/homeContainer';
 import PageHeading from 'app/components/pageHeading';
-import space from 'app/styles/space';
 
 import {t} from 'app/locale';
 
@@ -21,7 +19,7 @@ export default class OrganizationActivity extends AsyncView {
   render() {
     return (
       <OrganizationHomeContainer>
-        <StyledPageHeading withMargins>{t('Activity')}</StyledPageHeading>
+        <PageHeading withMargins>{t('Activity')}</PageHeading>
         <ActivityFeed
           endpoint={this.getEndpoint()}
           query={{
@@ -34,7 +32,3 @@ export default class OrganizationActivity extends AsyncView {
     );
   }
 }
-
-const StyledPageHeading = styled(PageHeading)`
-  margin-top: ${space(0.5)};
-`;

--- a/src/sentry/static/sentry/app/views/organizationActivity.jsx
+++ b/src/sentry/static/sentry/app/views/organizationActivity.jsx
@@ -21,7 +21,7 @@ export default class OrganizationActivity extends AsyncView {
   render() {
     return (
       <OrganizationHomeContainer>
-        <StyledPageHeading>{t('Activity')}</StyledPageHeading>
+        <StyledPageHeading withMargins>{t('Activity')}</StyledPageHeading>
         <ActivityFeed
           endpoint={this.getEndpoint()}
           query={{
@@ -36,6 +36,5 @@ export default class OrganizationActivity extends AsyncView {
 }
 
 const StyledPageHeading = styled(PageHeading)`
-  margin-bottom: ${space(3)};
   margin-top: ${space(0.5)};
 `;

--- a/src/sentry/static/sentry/app/views/organizationActivity.jsx
+++ b/src/sentry/static/sentry/app/views/organizationActivity.jsx
@@ -4,7 +4,7 @@ import styled from 'react-emotion';
 import AsyncView from 'app/views/asyncView';
 import ActivityFeed from 'app/components/activity/feed';
 import OrganizationHomeContainer from 'app/components/organizations/homeContainer';
-import PageHeader from 'app/components/pageHeader';
+import PageHeading from 'app/components/pageHeading';
 import space from 'app/styles/space';
 
 import {t} from 'app/locale';
@@ -21,7 +21,7 @@ export default class OrganizationActivity extends AsyncView {
   render() {
     return (
       <OrganizationHomeContainer>
-        <StyledPageHeader>{t('Activity')}</StyledPageHeader>
+        <StyledPageHeading>{t('Activity')}</StyledPageHeading>
         <ActivityFeed
           endpoint={this.getEndpoint()}
           query={{
@@ -35,7 +35,7 @@ export default class OrganizationActivity extends AsyncView {
   }
 }
 
-const StyledPageHeader = styled(PageHeader)`
+const StyledPageHeading = styled(PageHeading)`
   margin-bottom: ${space(3)};
   margin-top: ${space(0.5)};
 `;

--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -9,6 +9,7 @@ import {t, tct} from 'app/locale';
 import {updateProjects, updateDateTime} from 'app/actionCreators/globalSelection';
 import BetaTag from 'app/components/betaTag';
 import SentryTypes from 'app/sentryTypes';
+import PageHeader from 'app/components/pageHeader';
 
 import {
   DiscoverContainer,
@@ -16,7 +17,6 @@ import {
   Body,
   BodyContent,
   HeadingContainer,
-  Heading,
   Sidebar,
   SidebarTabs,
   SavedQueryWrapper,
@@ -418,9 +418,9 @@ export default class OrganizationDiscover extends React.Component {
               <React.Fragment>
                 <div>
                   <HeadingContainer>
-                    <Heading>
+                    <PageHeader>
                       {t('Discover')} <BetaTag />
-                    </Heading>
+                    </PageHeader>
                   </HeadingContainer>
                 </div>
                 <Intro updateQuery={this.updateAndRunQuery} />

--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -9,7 +9,7 @@ import {t, tct} from 'app/locale';
 import {updateProjects, updateDateTime} from 'app/actionCreators/globalSelection';
 import BetaTag from 'app/components/betaTag';
 import SentryTypes from 'app/sentryTypes';
-import PageHeader from 'app/components/pageHeader';
+import PageHeading from 'app/components/pageHeading';
 
 import {
   DiscoverContainer,
@@ -418,9 +418,9 @@ export default class OrganizationDiscover extends React.Component {
               <React.Fragment>
                 <div>
                   <HeadingContainer>
-                    <PageHeader>
+                    <PageHeading>
                       {t('Discover')} <BetaTag />
-                    </PageHeader>
+                    </PageHeading>
                   </HeadingContainer>
                 </div>
                 <Intro updateQuery={this.updateAndRunQuery} />

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
@@ -8,6 +8,7 @@ import getDynamicText from 'app/utils/getDynamicText';
 import BarChart from 'app/components/charts/barChart';
 import LineChart from 'app/components/charts/lineChart';
 import InlineSvg from 'app/components/inlineSvg';
+import PageHeader from 'app/components/pageHeader';
 
 import {getChartData, getChartDataByDay, getRowsPageRange, downloadAsCsv} from './utils';
 import Table from './table';
@@ -15,7 +16,6 @@ import Pagination from './pagination';
 import VisualizationsToggle from './visualizationsToggle';
 import {
   HeadingContainer,
-  Heading,
   ResultSummary,
   ResultContainer,
   ResultInnerContainer,
@@ -152,9 +152,9 @@ export default class Result extends React.Component {
   renderSavedQueryHeader() {
     return (
       <React.Fragment>
-        <Heading>
+        <PageHeader>
           {getDynamicText({value: this.props.savedQuery.name, fixed: 'saved query'})}
-        </Heading>
+        </PageHeader>
         <SavedQueryAction onClick={this.props.onToggleEdit}>
           <InlineSvg src="icon-edit" />
         </SavedQueryAction>
@@ -163,7 +163,7 @@ export default class Result extends React.Component {
   }
 
   renderQueryResultHeader() {
-    return <Heading>{t('Result')}</Heading>;
+    return <PageHeader>{t('Result')}</PageHeader>;
   }
 
   render() {

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
@@ -8,7 +8,7 @@ import getDynamicText from 'app/utils/getDynamicText';
 import BarChart from 'app/components/charts/barChart';
 import LineChart from 'app/components/charts/lineChart';
 import InlineSvg from 'app/components/inlineSvg';
-import PageHeader from 'app/components/pageHeader';
+import PageHeading from 'app/components/pageHeading';
 
 import {getChartData, getChartDataByDay, getRowsPageRange, downloadAsCsv} from './utils';
 import Table from './table';
@@ -152,9 +152,9 @@ export default class Result extends React.Component {
   renderSavedQueryHeader() {
     return (
       <React.Fragment>
-        <PageHeader>
+        <PageHeading>
           {getDynamicText({value: this.props.savedQuery.name, fixed: 'saved query'})}
-        </PageHeader>
+        </PageHeading>
         <SavedQueryAction onClick={this.props.onToggleEdit}>
           <InlineSvg src="icon-edit" />
         </SavedQueryAction>
@@ -163,7 +163,7 @@ export default class Result extends React.Component {
   }
 
   renderQueryResultHeader() {
-    return <PageHeader>{t('Result')}</PageHeader>;
+    return <PageHeading>{t('Result')}</PageHeading>;
   }
 
   render() {

--- a/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/queryPanel.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/queryPanel.jsx
@@ -2,13 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import InlineSvg from 'app/components/inlineSvg';
+import PageHeader from 'app/components/pageHeader';
 
-import {
-  QueryPanelContainer,
-  QueryPanelTitle,
-  QueryPanelCloseLink,
-  Heading,
-} from '../styles';
+import {QueryPanelContainer, QueryPanelTitle, QueryPanelCloseLink} from '../styles';
 
 export default class QueryPanel extends React.Component {
   static propTypes = {
@@ -20,7 +16,7 @@ export default class QueryPanel extends React.Component {
     return (
       <QueryPanelContainer>
         <QueryPanelTitle>
-          <Heading>{title}</Heading>
+          <PageHeader>{title}</PageHeader>
 
           <QueryPanelCloseLink onClick={onClose}>
             <InlineSvg src="icon-close" height="38px" />

--- a/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/queryPanel.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/queryPanel.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import InlineSvg from 'app/components/inlineSvg';
-import PageHeader from 'app/components/pageHeader';
+import PageHeading from 'app/components/pageHeading';
 
 import {QueryPanelContainer, QueryPanelTitle, QueryPanelCloseLink} from '../styles';
 
@@ -16,7 +16,7 @@ export default class QueryPanel extends React.Component {
     return (
       <QueryPanelContainer>
         <QueryPanelTitle>
-          <PageHeader>{title}</PageHeader>
+          <PageHeading>{title}</PageHeading>
 
           <QueryPanelCloseLink onClick={onClose}>
             <InlineSvg src="icon-close" height="38px" />

--- a/src/sentry/static/sentry/app/views/organizationDiscover/styles.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/styles.jsx
@@ -172,14 +172,6 @@ export const HeadingContainer = styled(Flex)`
   align-items: center;
 `;
 
-export const Heading = styled.h2`
-  font-size: ${p => p.theme.headerFontSize};
-  line-height: ${p => p.theme.headerFontSize};
-  font-weight: normal;
-  color: ${p => p.theme.gray4};
-  margin: 0;
-`;
-
 export const Fieldset = styled.fieldset`
   margin: ${space(3)} ${space(3)} 0;
 `;

--- a/src/sentry/static/sentry/app/views/organizationDiscover/styles.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/styles.jsx
@@ -88,6 +88,7 @@ export const Sidebar = styled(props => (
   <Flex {...props} direction="column" w={[300, 300, 300, 360]} />
 ))`
   border-right: 1px solid ${p => p.theme.borderDark};
+  background: #fff;
   min-width: 320px;
   position: relative;
   padding-top: ${HEADER_HEIGHT}px;

--- a/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
@@ -9,6 +9,11 @@ import BetaTag from 'app/components/betaTag';
 import Feature from 'app/components/acl/feature';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import SentryTypes from 'app/sentryTypes';
+<<<<<<< HEAD
+=======
+import PageHeader from 'app/components/pageHeader';
+import space from 'app/styles/space';
+>>>>>>> move Header component out of discover/styles.jsx for usage sitewide
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 import {PageContent, PageHeader, HeaderTitle} from 'app/styles/organization';
@@ -89,6 +94,11 @@ const Body = styled('div')`
   flex-direction: column;
   flex: 1;
   overflow: hidden;
+  padding: ${space(3)} ${space(4)};
+`;
+
+const HeaderTitle = styled(PageHeader)`
+  flex: 1;
 `;
 
 const StyledSearchBar = styled(SearchBar)`

--- a/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
@@ -85,9 +85,10 @@ export default withRouter(
 export {OrganizationEventsContainer};
 
 const Body = styled('div')`
-  display: flex;
+  background-color: ${p => p.theme.whiteDark};
   flex-direction: column;
   flex: 1;
+  overflow: hidden;
 `;
 
 const StyledSearchBar = styled(SearchBar)`

--- a/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
@@ -10,7 +10,6 @@ import Feature from 'app/components/acl/feature';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import SentryTypes from 'app/sentryTypes';
 import PageHeading from 'app/components/pageHeading';
-import space from 'app/styles/space';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 import {PageContent, PageHeader} from 'app/styles/organization';
@@ -90,8 +89,6 @@ const Body = styled('div')`
   background-color: ${p => p.theme.whiteDark};
   flex-direction: column;
   flex: 1;
-  overflow: hidden;
-  padding: ${space(3)} ${space(4)};
 `;
 
 const HeaderTitle = styled(PageHeading)`

--- a/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
@@ -9,11 +9,8 @@ import BetaTag from 'app/components/betaTag';
 import Feature from 'app/components/acl/feature';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import SentryTypes from 'app/sentryTypes';
-<<<<<<< HEAD
-=======
 import PageHeader from 'app/components/pageHeader';
 import space from 'app/styles/space';
->>>>>>> move Header component out of discover/styles.jsx for usage sitewide
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 import {PageContent, PageHeader, HeaderTitle} from 'app/styles/organization';

--- a/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
@@ -9,7 +9,7 @@ import BetaTag from 'app/components/betaTag';
 import Feature from 'app/components/acl/feature';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import SentryTypes from 'app/sentryTypes';
-import PageHeader from 'app/components/pageHeader';
+import PageHeading from 'app/components/pageHeading';
 import space from 'app/styles/space';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
@@ -94,7 +94,7 @@ const Body = styled('div')`
   padding: ${space(3)} ${space(4)};
 `;
 
-const HeaderTitle = styled(PageHeader)`
+const HeaderTitle = styled(PageHeading)`
   flex: 1;
 `;
 

--- a/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
@@ -13,7 +13,7 @@ import PageHeading from 'app/components/pageHeading';
 import space from 'app/styles/space';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
-import {PageContent, PageHeader, HeaderTitle} from 'app/styles/organization';
+import {PageContent, PageHeader} from 'app/styles/organization';
 
 import EventsContext from './utils/eventsContext';
 import SearchBar from './searchBar';

--- a/src/sentry/static/sentry/app/views/organizationProjectsDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationProjectsDashboard/index.jsx
@@ -1,8 +1,10 @@
+import {Link} from 'react-router';
 import LazyLoad from 'react-lazyload';
 import React from 'react';
 import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import {Flex} from 'grid-emotion';
+import styled from 'react-emotion';
 
 import SentryTypes from 'app/sentryTypes';
 import IdBadge from 'app/components/idBadge';
@@ -43,6 +45,8 @@ class Dashboard extends React.Component {
     const access = new Set(organization.access);
     const teamsMap = new Map(teams.map(teamObj => [teamObj.slug, teamObj]));
 
+    const hasTeamAdminAccess = access.has('team:admin');
+
     if (projects.length === 1 && !projects[0].firstEvent) {
       return <Resources org={organization} project={projects[0]} />;
     }
@@ -70,7 +74,15 @@ class Dashboard extends React.Component {
                 orgId={params.orgId}
                 team={team}
                 showBorder={showBorder}
-                title={<IdBadge team={team} />}
+                title={
+                  hasTeamAdminAccess ? (
+                    <TeamLink to={`/settings/${organization.slug}/teams/${team.slug}/`}>
+                      <IdBadge team={team} />
+                    </TeamLink>
+                  ) : (
+                    <IdBadge team={team} />
+                  )
+                }
                 projects={projectsByTeam[slug]}
                 access={access}
               />
@@ -99,6 +111,11 @@ const OrganizationDashboard = createReactClass({
     );
   },
 });
+
+const TeamLink = styled(Link)`
+  display: flex;
+  align-items: center;
+`;
 
 export {Dashboard};
 export default withTeams(withProjects(OrganizationDashboard));

--- a/src/sentry/static/sentry/app/views/organizationProjectsDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationProjectsDashboard/index.jsx
@@ -1,10 +1,8 @@
-import {Link} from 'react-router';
 import LazyLoad from 'react-lazyload';
 import React from 'react';
 import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import {Flex} from 'grid-emotion';
-import styled from 'react-emotion';
 
 import SentryTypes from 'app/sentryTypes';
 import IdBadge from 'app/components/idBadge';
@@ -45,8 +43,6 @@ class Dashboard extends React.Component {
     const access = new Set(organization.access);
     const teamsMap = new Map(teams.map(teamObj => [teamObj.slug, teamObj]));
 
-    const hasTeamAdminAccess = access.has('team:admin');
-
     if (projects.length === 1 && !projects[0].firstEvent) {
       return <Resources org={organization} project={projects[0]} />;
     }
@@ -74,15 +70,7 @@ class Dashboard extends React.Component {
                 orgId={params.orgId}
                 team={team}
                 showBorder={showBorder}
-                title={
-                  hasTeamAdminAccess ? (
-                    <TeamLink to={`/settings/${organization.slug}/teams/${team.slug}/`}>
-                      <IdBadge team={team} />
-                    </TeamLink>
-                  ) : (
-                    <IdBadge team={team} />
-                  )
-                }
+                title={<IdBadge team={team} />}
                 projects={projectsByTeam[slug]}
                 access={access}
               />
@@ -111,11 +99,6 @@ const OrganizationDashboard = createReactClass({
     );
   },
 });
-
-const TeamLink = styled(Link)`
-  display: flex;
-  align-items: center;
-`;
 
 export {Dashboard};
 export default withTeams(withProjects(OrganizationDashboard));

--- a/src/sentry/static/sentry/app/views/organizationProjectsDashboard/teamSection.jsx
+++ b/src/sentry/static/sentry/app/views/organizationProjectsDashboard/teamSection.jsx
@@ -5,6 +5,7 @@ import styled from 'react-emotion';
 
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
+import PageHeader from 'app/components/pageHeader';
 
 import TeamMembers from './teamMembers';
 import ProjectCard from './projectCard';
@@ -67,9 +68,8 @@ const TeamTitleBar = styled(Flex)`
   padding: ${space(3)} ${space(4)} 10px;
 `;
 
-const TeamName = styled.h4`
-  margin: 0;
-  font-size: 20px;
+const TeamName = styled(PageHeader)`
+  margin: 4px;
   line-height: 24px; /* We need this so that header doesn't flicker when lazy loading because avatarList height > this */
 `;
 

--- a/src/sentry/static/sentry/app/views/organizationProjectsDashboard/teamSection.jsx
+++ b/src/sentry/static/sentry/app/views/organizationProjectsDashboard/teamSection.jsx
@@ -5,7 +5,7 @@ import styled from 'react-emotion';
 
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
-import PageHeader from 'app/components/pageHeader';
+import PageHeading from 'app/components/pageHeading';
 
 import TeamMembers from './teamMembers';
 import ProjectCard from './projectCard';
@@ -68,7 +68,7 @@ const TeamTitleBar = styled(Flex)`
   padding: ${space(3)} ${space(4)} 10px;
 `;
 
-const TeamName = styled(PageHeader)`
+const TeamName = styled(PageHeading)`
   margin: 4px;
   line-height: 24px; /* We need this so that header doesn't flicker when lazy loading because avatarList height > this */
 `;

--- a/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'react-emotion';
 
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {intcomma} from 'app/utils';
@@ -10,6 +11,8 @@ import Pagination from 'app/components/pagination';
 import ProjectTable from 'app/views/organizationStats/projectTable';
 import StackedBarChart from 'app/components/stackedBarChart';
 import TextBlock from 'app/views/settings/components/text/textBlock';
+import PageHeader from 'app/components/pageHeader';
+import space from 'app/styles/space';
 import {
   ProjectTableLayout,
   ProjectTableDataElement,
@@ -65,7 +68,7 @@ class OrganizationStats extends React.Component {
 
     return (
       <div>
-        <h4>{t('Organization Stats')}</h4>
+        <StyledPageHeader>{t('Organization Stats')}</StyledPageHeader>
         <div className="row">
           <div className="col-md-9">
             <TextBlock>
@@ -137,5 +140,10 @@ class OrganizationStats extends React.Component {
     );
   }
 }
+
+const StyledPageHeader = styled(PageHeader)`
+  margin-bottom: ${space(3)};
+  margin-top: ${space(0.5)};
+`;
 
 export default OrganizationStats;

--- a/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import styled from 'react-emotion';
 
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {intcomma} from 'app/utils';
@@ -12,7 +11,6 @@ import ProjectTable from 'app/views/organizationStats/projectTable';
 import StackedBarChart from 'app/components/stackedBarChart';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import PageHeading from 'app/components/pageHeading';
-import space from 'app/styles/space';
 import {
   ProjectTableLayout,
   ProjectTableDataElement,
@@ -68,7 +66,7 @@ class OrganizationStats extends React.Component {
 
     return (
       <div>
-        <StyledPageHeading withMargins>{t('Organization Stats')}</StyledPageHeading>
+        <PageHeading withMargins>{t('Organization Stats')}</PageHeading>
         <div className="row">
           <div className="col-md-9">
             <TextBlock>
@@ -140,9 +138,5 @@ class OrganizationStats extends React.Component {
     );
   }
 }
-
-const StyledPageHeading = styled(PageHeading)`
-  margin-top: ${space(0.5)};
-`;
 
 export default OrganizationStats;

--- a/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
@@ -11,7 +11,7 @@ import Pagination from 'app/components/pagination';
 import ProjectTable from 'app/views/organizationStats/projectTable';
 import StackedBarChart from 'app/components/stackedBarChart';
 import TextBlock from 'app/views/settings/components/text/textBlock';
-import PageHeader from 'app/components/pageHeader';
+import PageHeading from 'app/components/pageHeading';
 import space from 'app/styles/space';
 import {
   ProjectTableLayout,
@@ -68,7 +68,7 @@ class OrganizationStats extends React.Component {
 
     return (
       <div>
-        <StyledPageHeader>{t('Organization Stats')}</StyledPageHeader>
+        <StyledPageHeading>{t('Organization Stats')}</StyledPageHeading>
         <div className="row">
           <div className="col-md-9">
             <TextBlock>
@@ -141,7 +141,7 @@ class OrganizationStats extends React.Component {
   }
 }
 
-const StyledPageHeader = styled(PageHeader)`
+const StyledPageHeading = styled(PageHeading)`
   margin-bottom: ${space(3)};
   margin-top: ${space(0.5)};
 `;

--- a/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
@@ -68,7 +68,7 @@ class OrganizationStats extends React.Component {
 
     return (
       <div>
-        <StyledPageHeading>{t('Organization Stats')}</StyledPageHeading>
+        <StyledPageHeading withMargins>{t('Organization Stats')}</StyledPageHeading>
         <div className="row">
           <div className="col-md-9">
             <TextBlock>
@@ -142,7 +142,6 @@ class OrganizationStats extends React.Component {
 }
 
 const StyledPageHeading = styled(PageHeading)`
-  margin-bottom: ${space(3)};
   margin-top: ${space(0.5)};
 `;
 

--- a/src/sentry/static/sentry/app/views/projectDashboard/chart.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/chart.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'react-emotion';
 import createReactClass from 'create-react-class';
 import moment from 'moment';
 import SentryTypes from 'app/sentryTypes';
@@ -123,7 +124,7 @@ const ProjectChart = createReactClass({
 
     return (
       <div className="chart-wrapper">
-        <BarChart
+        <StyledBarChart
           points={points}
           markers={markers}
           label="events"
@@ -151,5 +152,9 @@ const ProjectChart = createReactClass({
     );
   },
 });
+
+const StyledBarChart = styled(BarChart)`
+  background: #fff;
+`;
 
 export default ProjectChart;

--- a/src/sentry/static/sentry/app/views/projectDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/index.jsx
@@ -2,12 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import {Link} from 'react-router';
-import styled from 'react-emotion';
 
 import SentryTypes from 'app/sentryTypes';
 import ProjectState from 'app/mixins/projectState';
 import PageHeading from 'app/components/pageHeading';
-import space from 'app/styles/space';
 import {t} from 'app/locale';
 import withEnvironmentInQueryString from 'app/utils/withEnvironmentInQueryString';
 
@@ -102,7 +100,7 @@ const ProjectDashboard = createReactClass({
       <div>
         <div className="row">
           <div className="col-sm-9">
-            <StyledPageHeading>{t('Overview')}</StyledPageHeading>
+            <PageHeading withMargins>{t('Overview')}</PageHeading>
           </div>
           <div className="col-sm-3" style={{textAlign: 'right'}}>
             <div className="btn-group">
@@ -171,10 +169,5 @@ const ProjectDashboard = createReactClass({
     );
   },
 });
-
-const StyledPageHeading = styled(PageHeading)`
-  margin-bottom: ${space(3)};
-  margin-top: ${space(1)};
-`;
 
 export default withEnvironmentInQueryString(ProjectDashboard);

--- a/src/sentry/static/sentry/app/views/projectDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/index.jsx
@@ -6,7 +6,7 @@ import styled from 'react-emotion';
 
 import SentryTypes from 'app/sentryTypes';
 import ProjectState from 'app/mixins/projectState';
-import PageHeader from 'app/components/pageHeader';
+import PageHeading from 'app/components/pageHeading';
 import space from 'app/styles/space';
 import {t} from 'app/locale';
 import withEnvironmentInQueryString from 'app/utils/withEnvironmentInQueryString';
@@ -102,7 +102,7 @@ const ProjectDashboard = createReactClass({
       <div>
         <div className="row">
           <div className="col-sm-9">
-            <StyledPageHeader>{t('Overview')}</StyledPageHeader>
+            <StyledPageHeading>{t('Overview')}</StyledPageHeading>
           </div>
           <div className="col-sm-3" style={{textAlign: 'right'}}>
             <div className="btn-group">
@@ -172,7 +172,7 @@ const ProjectDashboard = createReactClass({
   },
 });
 
-const StyledPageHeader = styled(PageHeader)`
+const StyledPageHeading = styled(PageHeading)`
   margin-bottom: ${space(3)};
   margin-top: ${space(1)};
 `;

--- a/src/sentry/static/sentry/app/views/projectDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/index.jsx
@@ -2,9 +2,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import {Link} from 'react-router';
+import styled from 'react-emotion';
 
 import SentryTypes from 'app/sentryTypes';
 import ProjectState from 'app/mixins/projectState';
+import PageHeader from 'app/components/pageHeader';
+import space from 'app/styles/space';
 import {t} from 'app/locale';
 import withEnvironmentInQueryString from 'app/utils/withEnvironmentInQueryString';
 
@@ -97,8 +100,11 @@ const ProjectDashboard = createReactClass({
 
     return (
       <div>
-        <div>
-          <div className="pull-right">
+        <div className="row">
+          <div className="col-sm-9">
+            <StyledPageHeader>{t('Overview')}</StyledPageHeader>
+          </div>
+          <div className="col-sm-3" style={{textAlign: 'right'}}>
             <div className="btn-group">
               <Link
                 to={{
@@ -137,7 +143,6 @@ const ProjectDashboard = createReactClass({
               </Link>
             </div>
           </div>
-          <h3>{t('Overview')}</h3>
         </div>
         <ProjectChart
           dateSince={dateSince}
@@ -166,5 +171,10 @@ const ProjectDashboard = createReactClass({
     );
   },
 });
+
+const StyledPageHeader = styled(PageHeader)`
+  margin-bottom: ${space(3)};
+  margin-top: ${space(1)};
+`;
 
 export default withEnvironmentInQueryString(ProjectDashboard);

--- a/src/sentry/static/sentry/app/views/projectDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/index.jsx
@@ -98,11 +98,11 @@ const ProjectDashboard = createReactClass({
 
     return (
       <div>
-        <div className="row">
+        <div className="row" style={{marginBottom: '5px'}}>
           <div className="col-sm-9">
             <PageHeading withMargins>{t('Overview')}</PageHeading>
           </div>
-          <div className="col-sm-3" style={{textAlign: 'right'}}>
+          <div className="col-sm-3" style={{textAlign: 'right', marginTop: '4px'}}>
             <div className="btn-group">
               <Link
                 to={{

--- a/src/sentry/static/sentry/app/views/projectDetailsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/projectDetailsLayout.jsx
@@ -59,7 +59,7 @@ const ProjectDetailsLayout = createReactClass({
           activeEnvironment={this.props.environment}
         />
         <div className="container">
-          <div className="content">
+          <div className="content content-with-margin">
             {React.cloneElement(this.props.children, {
               setProjectNavSection: this.setProjectNavSection,
               memberList: this.state.memberList,

--- a/src/sentry/static/sentry/app/views/projectInstall/gettingStarted.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/gettingStarted.jsx
@@ -1,10 +1,11 @@
-import {Box} from 'grid-emotion';
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'react-emotion';
 
 import ProjectContext from 'app/views/projects/projectContext';
 import ProjectDocsContext from 'app/views/projectInstall/docsContext';
 import ProjectSelector from 'app/components/projectHeader/projectSelector';
+import space from 'app/styles/space';
 
 class GettingStartedBody extends React.Component {
   static contextTypes = {
@@ -15,7 +16,7 @@ class GettingStartedBody extends React.Component {
   render() {
     let {project, organization} = this.context;
     return (
-      <Box flex={1}>
+      <Container>
         <div className="sub-header flex flex-container flex-vertically-centered">
           <div className="p-t-1 p-b-1">
             <ProjectSelector organization={organization} projectId={project.slug} />
@@ -31,7 +32,7 @@ class GettingStartedBody extends React.Component {
             </ProjectDocsContext>
           </div>
         </div>
-      </Box>
+      </Container>
     );
   }
 }
@@ -46,5 +47,11 @@ class GettingStarted extends React.Component {
     );
   }
 }
+
+const Container = styled('div')`
+  flex: 1;
+  background: #fff;
+  margin-bottom: -${space(3)};
+`;
 
 export default GettingStarted;

--- a/src/sentry/static/sentry/app/views/projectInstall/gettingStarted.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/gettingStarted.jsx
@@ -23,14 +23,12 @@ class GettingStartedBody extends React.Component {
           </div>
         </div>
         <div className="container">
-          <div className="content">
-            <ProjectDocsContext>
-              {React.cloneElement(this.props.children, {
-                linkPath: (orgId, projectId, platform) =>
-                  `/${orgId}/${projectId}/getting-started/${platform}/`,
-              })}
-            </ProjectDocsContext>
-          </div>
+          <ProjectDocsContext>
+            {React.cloneElement(this.props.children, {
+              linkPath: (orgId, projectId, platform) =>
+                `/${orgId}/${projectId}/getting-started/${platform}/`,
+            })}
+          </ProjectDocsContext>
         </div>
       </Container>
     );

--- a/src/sentry/static/sentry/app/views/projectInstall/gettingStarted.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/gettingStarted.jsx
@@ -23,12 +23,14 @@ class GettingStartedBody extends React.Component {
           </div>
         </div>
         <div className="container">
-          <ProjectDocsContext>
-            {React.cloneElement(this.props.children, {
-              linkPath: (orgId, projectId, platform) =>
-                `/${orgId}/${projectId}/getting-started/${platform}/`,
-            })}
-          </ProjectDocsContext>
+          <Content>
+            <ProjectDocsContext>
+              {React.cloneElement(this.props.children, {
+                linkPath: (orgId, projectId, platform) =>
+                  `/${orgId}/${projectId}/getting-started/${platform}/`,
+              })}
+            </ProjectDocsContext>
+          </Content>
         </div>
       </Container>
     );
@@ -49,7 +51,11 @@ class GettingStarted extends React.Component {
 const Container = styled('div')`
   flex: 1;
   background: #fff;
-  margin-bottom: -${space(3)};
+  margin-bottom: -${space(3)}; /* cleans up a bg gap at bottom */
+`;
+
+const Content = styled('div')`
+  margin-top: ${space(3)};
 `;
 
 export default GettingStarted;

--- a/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
@@ -1,7 +1,8 @@
-import {Box} from 'grid-emotion';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import DocumentTitle from 'react-document-title';
+import styled from 'react-emotion';
+import space from 'app/styles/space';
 
 import OrganizationState from 'app/mixins/organizationState';
 
@@ -14,7 +15,7 @@ const NewProject = createReactClass({
 
   render() {
     return (
-      <Box flex={1}>
+      <Container>
         <div className="sub-header flex flex-container flex-vertically-centered">
           <div className="p-t-1 p-b-1">
             <ProjectSelector organization={this.getOrganization()} />
@@ -31,9 +32,15 @@ const NewProject = createReactClass({
             />
           </div>
         </div>
-      </Box>
+      </Container>
     );
   },
 });
+
+const Container = styled('div')`
+  flex: 1;
+  background: #fff;
+  margin-bottom: -${space(3)}; /* cleans up a bg gap at bottom */
+`;
 
 export default NewProject;

--- a/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
@@ -22,13 +22,15 @@ const NewProject = createReactClass({
           </div>
         </div>
         <div className="container">
-          <DocumentTitle title={'Sentry'} />
-          <CreateProject
-            getDocsUrl={({slug, projectSlug, platform}) => {
-              if (platform === 'other') platform = '';
-              return `/${slug}/${projectSlug}/getting-started/${platform}`;
-            }}
-          />
+          <Content>
+            <DocumentTitle title={'Sentry'} />
+            <CreateProject
+              getDocsUrl={({slug, projectSlug, platform}) => {
+                if (platform === 'other') platform = '';
+                return `/${slug}/${projectSlug}/getting-started/${platform}`;
+              }}
+            />
+          </Content>
         </div>
       </Container>
     );
@@ -39,6 +41,10 @@ const Container = styled('div')`
   flex: 1;
   background: #fff;
   margin-bottom: -${space(3)}; /* cleans up a bg gap at bottom */
+`;
+
+const Content = styled('div')`
+  margin-top: ${space(3)};
 `;
 
 export default NewProject;

--- a/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
@@ -22,15 +22,13 @@ const NewProject = createReactClass({
           </div>
         </div>
         <div className="container">
-          <div className="content">
-            <DocumentTitle title={'Sentry'} />
-            <CreateProject
-              getDocsUrl={({slug, projectSlug, platform}) => {
-                if (platform === 'other') platform = '';
-                return `/${slug}/${projectSlug}/getting-started/${platform}`;
-              }}
-            />
-          </div>
+          <DocumentTitle title={'Sentry'} />
+          <CreateProject
+            getDocsUrl={({slug, projectSlug, platform}) => {
+              if (platform === 'other') platform = '';
+              return `/${slug}/${projectSlug}/getting-started/${platform}`;
+            }}
+          />
         </div>
       </Container>
     );

--- a/src/sentry/static/sentry/app/views/releases/list/organizationReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/organizationReleases/index.jsx
@@ -16,7 +16,8 @@ import AsyncView from 'app/views/asyncView';
 
 import withOrganization from 'app/utils/withOrganization';
 
-import {PageContent, PageHeader, HeaderTitle} from 'app/styles/organization';
+import {PageContent, PageHeader} from 'app/styles/organization';
+import PageHeading from 'app/components/pageHeading';
 
 import ReleaseList from '../shared/releaseList';
 import ReleaseListHeader from '../shared/releaseListHeader';
@@ -102,7 +103,7 @@ class OrganizationReleases extends AsyncView {
         <GlobalSelectionHeader organization={organization} />
         <PageContent>
           <PageHeader>
-            <HeaderTitle>{t('Releases')}</HeaderTitle>
+            <PageHeading>{t('Releases')}</PageHeading>
             <div>
               <SearchBar
                 defaultQuery=""

--- a/src/sentry/static/sentry/app/views/releases/list/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/projectReleases/index.jsx
@@ -204,11 +204,11 @@ const ProjectReleases = createReactClass({
     return (
       <div className="ref-project-releases">
         <GuideAnchor target="releases" type="invisible" />
-        <div className="row">
+        <div className="row" style={{marginBottom: '5px'}}>
           <div className="col-sm-7">
             <PageHeading withMargins>{t('Releases')}</PageHeading>
           </div>
-          <div className="col-sm-5 release-search">
+          <div className="col-sm-5 release-search" style={{marginTop: '5px'}}>
             <SearchBar
               defaultQuery=""
               placeholder={t('Search for a release')}

--- a/src/sentry/static/sentry/app/views/releases/list/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/projectReleases/index.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import styled from 'react-emotion';
 import createReactClass from 'create-react-class';
 import {browserHistory} from 'react-router';
 import {omit, isEqual} from 'lodash';
@@ -25,7 +24,6 @@ import ReleaseProgress from 'app/views/releases/list/projectReleases/releaseProg
 import ReleaseEmptyState from './releaseEmptyState';
 import ReleaseList from '../shared/releaseList';
 import PageHeading from 'app/components/pageHeading';
-import space from 'app/styles/space';
 import withEnvironmentInQueryString from 'app/utils/withEnvironmentInQueryString';
 
 import ReleaseEmptyState from './releaseEmptyState';
@@ -212,7 +210,7 @@ const ProjectReleases = createReactClass({
         <GuideAnchor target="releases" type="invisible" />
         <div className="row">
           <div className="col-sm-7">
-            <StyledPageHeading>{t('Releases')}</StyledPageHeading>
+            <PageHeading withMargins>{t('Releases')}</PageHeading>
           </div>
           <div className="col-sm-5 release-search">
             <SearchBar
@@ -235,8 +233,3 @@ const ProjectReleases = createReactClass({
 
 export {ProjectReleases}; // For tests
 export default withEnvironmentInQueryString(ProjectReleases);
-
-const StyledPageHeading = styled(PageHeading)`
-  margin-top: ${space(1)};
-  margin-bottom: ${space(3)};
-`;

--- a/src/sentry/static/sentry/app/views/releases/list/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/projectReleases/index.jsx
@@ -24,7 +24,7 @@ import ReleaseLanding from 'app/views/releases/list/projectReleases/releaseLandi
 import ReleaseProgress from 'app/views/releases/list/projectReleases/releaseProgress';
 import ReleaseEmptyState from './releaseEmptyState';
 import ReleaseList from '../shared/releaseList';
-import PageHeader from 'app/components/pageHeader';
+import PageHeading from 'app/components/pageHeading';
 import space from 'app/styles/space';
 import withEnvironmentInQueryString from 'app/utils/withEnvironmentInQueryString';
 
@@ -212,7 +212,7 @@ const ProjectReleases = createReactClass({
         <GuideAnchor target="releases" type="invisible" />
         <div className="row">
           <div className="col-sm-7">
-            <StyledPageHeader>{t('Releases')}</StyledPageHeader>
+            <StyledPageHeading>{t('Releases')}</StyledPageHeading>
           </div>
           <div className="col-sm-5 release-search">
             <SearchBar
@@ -236,7 +236,7 @@ const ProjectReleases = createReactClass({
 export {ProjectReleases}; // For tests
 export default withEnvironmentInQueryString(ProjectReleases);
 
-const StyledPageHeader = styled(PageHeader)`
+const StyledPageHeading = styled(PageHeading)`
   margin-top: ${space(1)};
   margin-bottom: ${space(3)};
 `;

--- a/src/sentry/static/sentry/app/views/releases/list/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/projectReleases/index.jsx
@@ -4,6 +4,7 @@ import createReactClass from 'create-react-class';
 import {browserHistory} from 'react-router';
 import {omit, isEqual} from 'lodash';
 import qs from 'query-string';
+import styled from 'react-emotion';
 
 import {analytics} from 'app/utils/analytics';
 import SentryTypes from 'app/sentryTypes';
@@ -16,12 +17,15 @@ import SearchBar from 'app/components/searchBar';
 import {t, tct} from 'app/locale';
 import {Panel, PanelBody} from 'app/components/panels';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
+import ReleaseEmptyState from 'app/views/projectReleases/releaseEmptyState';
+import ReleaseList from 'app/views/projectReleases/releaseList';
 import withEnvironmentInQueryString from 'app/utils/withEnvironmentInQueryString';
-
 import ReleaseLanding from 'app/views/releases/list/projectReleases/releaseLanding';
 import ReleaseProgress from 'app/views/releases/list/projectReleases/releaseProgress';
 import ReleaseEmptyState from './releaseEmptyState';
 import ReleaseList from '../shared/releaseList';
+import PageHeader from 'app/components/pageHeader';
+import space from 'app/styles/space';
 import ReleaseListHeader from '../shared/releaseListHeader';
 
 const DEFAULT_QUERY = '';
@@ -202,9 +206,9 @@ const ProjectReleases = createReactClass({
     return (
       <div className="ref-project-releases">
         <GuideAnchor target="releases" type="invisible" />
-        <div className="row release-list-header">
+        <div className="row">
           <div className="col-sm-7">
-            <h3>{t('Releases')}</h3>
+            <StyledPageHeader>{t('Releases')}</StyledPageHeader>
           </div>
           <div className="col-sm-5 release-search">
             <SearchBar
@@ -227,3 +231,8 @@ const ProjectReleases = createReactClass({
 
 export {ProjectReleases}; // For tests
 export default withEnvironmentInQueryString(ProjectReleases);
+
+const StyledPageHeader = styled(PageHeader)`
+  margin-top: ${space(1)};
+  margin-bottom: ${space(3)};
+`;

--- a/src/sentry/static/sentry/app/views/releases/list/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/projectReleases/index.jsx
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'react-emotion';
 import createReactClass from 'create-react-class';
 import {browserHistory} from 'react-router';
 import {omit, isEqual} from 'lodash';
 import qs from 'query-string';
-import styled from 'react-emotion';
 
 import {analytics} from 'app/utils/analytics';
 import SentryTypes from 'app/sentryTypes';
@@ -26,6 +26,10 @@ import ReleaseEmptyState from './releaseEmptyState';
 import ReleaseList from '../shared/releaseList';
 import PageHeader from 'app/components/pageHeader';
 import space from 'app/styles/space';
+import withEnvironmentInQueryString from 'app/utils/withEnvironmentInQueryString';
+
+import ReleaseEmptyState from './releaseEmptyState';
+import ReleaseList from '../shared/releaseList';
 import ReleaseListHeader from '../shared/releaseListHeader';
 
 const DEFAULT_QUERY = '';

--- a/src/sentry/static/sentry/app/views/releases/list/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/projectReleases/index.jsx
@@ -16,15 +16,11 @@ import SearchBar from 'app/components/searchBar';
 import {t, tct} from 'app/locale';
 import {Panel, PanelBody} from 'app/components/panels';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
-import ReleaseEmptyState from 'app/views/projectReleases/releaseEmptyState';
-import ReleaseList from 'app/views/projectReleases/releaseList';
 import withEnvironmentInQueryString from 'app/utils/withEnvironmentInQueryString';
+
 import ReleaseLanding from 'app/views/releases/list/projectReleases/releaseLanding';
 import ReleaseProgress from 'app/views/releases/list/projectReleases/releaseProgress';
-import ReleaseEmptyState from './releaseEmptyState';
-import ReleaseList from '../shared/releaseList';
 import PageHeading from 'app/components/pageHeading';
-import withEnvironmentInQueryString from 'app/utils/withEnvironmentInQueryString';
 
 import ReleaseEmptyState from './releaseEmptyState';
 import ReleaseList from '../shared/releaseList';

--- a/src/sentry/static/sentry/app/views/userFeedback/container.jsx
+++ b/src/sentry/static/sentry/app/views/userFeedback/container.jsx
@@ -3,8 +3,6 @@ import {Link} from 'react-router';
 import styled from 'react-emotion';
 import PropTypes from 'prop-types';
 import {omit} from 'lodash';
-import styled from 'react-emotion';
-import space from 'app/styles/space';
 import {t} from 'app/locale';
 import Pagination from 'app/components/pagination';
 import {Panel, PanelBody} from 'app/components/panels';
@@ -29,9 +27,9 @@ export default class UserFeedbackContainer extends React.Component {
         <div className="row">
           <div className="col-sm-9">
             {params.projectId ? (
-              <StyledPageHeading>{t('User Feedback')}</StyledPageHeader>
+              <PageHeading withMargins>{t('User Feedback')}</PageHeading>
             ) : (
-              <StyledPageHeading>{t('User Feedback')}</StyledPageHeader>
+              <PageHeading withMargins>{t('User Feedback')}</PageHeading>
             )}
           </div>
           <div className="col-sm-3" style={{textAlign: 'right'}}>
@@ -61,8 +59,3 @@ export default class UserFeedbackContainer extends React.Component {
     );
   }
 }
-
-const StyledPageHeading = styled(PageHeading)`
-  margin-top: ${space(1)};
-  margin-bottom: ${space(3)};
-`;

--- a/src/sentry/static/sentry/app/views/userFeedback/container.jsx
+++ b/src/sentry/static/sentry/app/views/userFeedback/container.jsx
@@ -3,9 +3,12 @@ import {Link} from 'react-router';
 import styled from 'react-emotion';
 import PropTypes from 'prop-types';
 import {omit} from 'lodash';
+import styled from 'react-emotion';
+import space from 'app/styles/space';
 import {t} from 'app/locale';
 import Pagination from 'app/components/pagination';
 import {Panel, PanelBody} from 'app/components/panels';
+import PageHeader from 'app/components/pageHeader';
 
 export default class UserFeedbackContainer extends React.Component {
   static propTypes = {
@@ -23,13 +26,17 @@ export default class UserFeedbackContainer extends React.Component {
 
     return (
       <div>
-        <div className="row release-list-header">
+        <div className="row">
           <div className="col-sm-9">
+<<<<<<< HEAD
             {params.projectId ? (
-              <h3>{t('User Feedback')}</h3>
+              <StyledPageHeader>{t('User Feedback')}</StyledPageHeader>
             ) : (
-              <Header>{t('User Feedback')}</Header>
+              <StyledPageHeader>{t('User Feedback')}</StyledPageHeader>
             )}
+=======
+
+>>>>>>> consistency between issue views
           </div>
           <div className="col-sm-3" style={{textAlign: 'right'}}>
             <div className="btn-group">
@@ -59,6 +66,7 @@ export default class UserFeedbackContainer extends React.Component {
   }
 }
 
-const Header = styled('h4')`
-  font-weight: normal;
+const StyledPageHeader = styled(PageHeader)`
+  margin-top: ${space(1)};
+  margin-bottom: ${space(3)};
 `;

--- a/src/sentry/static/sentry/app/views/userFeedback/container.jsx
+++ b/src/sentry/static/sentry/app/views/userFeedback/container.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {Link} from 'react-router';
-import styled from 'react-emotion';
 import PropTypes from 'prop-types';
 import {omit} from 'lodash';
 import {t} from 'app/locale';

--- a/src/sentry/static/sentry/app/views/userFeedback/container.jsx
+++ b/src/sentry/static/sentry/app/views/userFeedback/container.jsx
@@ -8,7 +8,7 @@ import space from 'app/styles/space';
 import {t} from 'app/locale';
 import Pagination from 'app/components/pagination';
 import {Panel, PanelBody} from 'app/components/panels';
-import PageHeader from 'app/components/pageHeader';
+import PageHeading from 'app/components/pageHeading';
 
 export default class UserFeedbackContainer extends React.Component {
   static propTypes = {
@@ -28,15 +28,11 @@ export default class UserFeedbackContainer extends React.Component {
       <div>
         <div className="row">
           <div className="col-sm-9">
-<<<<<<< HEAD
             {params.projectId ? (
-              <StyledPageHeader>{t('User Feedback')}</StyledPageHeader>
+              <StyledPageHeading>{t('User Feedback')}</StyledPageHeader>
             ) : (
-              <StyledPageHeader>{t('User Feedback')}</StyledPageHeader>
+              <StyledPageHeading>{t('User Feedback')}</StyledPageHeader>
             )}
-=======
-
->>>>>>> consistency between issue views
           </div>
           <div className="col-sm-3" style={{textAlign: 'right'}}>
             <div className="btn-group">
@@ -66,7 +62,7 @@ export default class UserFeedbackContainer extends React.Component {
   }
 }
 
-const StyledPageHeader = styled(PageHeader)`
+const StyledPageHeading = styled(PageHeading)`
   margin-top: ${space(1)};
   margin-bottom: ${space(3)};
 `;

--- a/src/sentry/static/sentry/app/views/userFeedback/container.jsx
+++ b/src/sentry/static/sentry/app/views/userFeedback/container.jsx
@@ -24,14 +24,14 @@ export default class UserFeedbackContainer extends React.Component {
     return (
       <div>
         <div className="row">
-          <div className="col-sm-9">
+          <div className="col-sm-9" style={{marginBottom: '5px'}}>
             {params.projectId ? (
               <PageHeading withMargins>{t('User Feedback')}</PageHeading>
             ) : (
               <PageHeading withMargins>{t('User Feedback')}</PageHeading>
             )}
           </div>
-          <div className="col-sm-3" style={{textAlign: 'right'}}>
+          <div className="col-sm-3" style={{textAlign: 'right', marginTop: '4px'}}>
             <div className="btn-group">
               <Link
                 to={{pathname, query: unresolvedQuery}}

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -766,6 +766,7 @@
 .event-details-container {
   display: flex;
   margin: -20px -40px;
+  background: #fff;
 
   .primary {
     flex: 1;

--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -8,6 +8,7 @@ body {
   font-size: 16px;
   line-height: 24px;
   color: @gray-darker;
+  background: @white-dark;
   -webkit-font-smoothing: antialiased;
   overflow-x: hidden;
   min-height: 100vh;
@@ -36,13 +37,6 @@ body {
 
     &.collapsed {
       padding-left: @sidebar-collapsed-width;
-    }
-
-    /* This is for organization level views e.g. "Assigned to me" */
-    .organization-home {
-      .container {
-        margin-top: 24px;
-      }
     }
   }
 
@@ -280,6 +274,7 @@ body.auth {
   position: relative;
   padding-left: 30px;
   padding-right: 30px;
+  padding-top: 20px;
   width: 100% !important;
   flex: 1;
 }
@@ -304,9 +299,10 @@ body.auth {
 
 .sub-header {
   color: @gray-dark;
+  background: #fff;
   border-bottom: 1px solid darken(@trim, 5);
   position: relative;
-  margin: 0 0 20px;
+  margin: 0;
   line-height: 1;
   font-size: 16px;
   min-height: 62px;
@@ -451,8 +447,8 @@ footer {
   text-align: center;
   color: @gray;
   border-top: 1px solid @trim;
-  margin-top: 20px;
   padding: 28px 0;
+  margin-top: 20px;
 
   .container {
     // Ensure dropdowns inside application views
@@ -592,7 +588,7 @@ footer {
   }
 
   .container {
-    padding: 0 14px;
+    padding: 20px 14px 0 14px;
   }
 
   .sub-header .align-right {

--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -274,9 +274,12 @@ body.auth {
   position: relative;
   padding-left: 30px;
   padding-right: 30px;
-  padding-top: 20px;
   width: 100% !important;
   flex: 1;
+}
+
+.content {
+  margin-top: 20px;
 }
 
 // Container around content in app.jsx
@@ -588,7 +591,7 @@ footer {
   }
 
   .container {
-    padding: 20px 14px 0 14px;
+    padding: 0 14px;
   }
 
   .sub-header .align-right {

--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -278,7 +278,7 @@ body.auth {
   flex: 1;
 }
 
-.content {
+.content-with-margin {
   margin-top: 20px;
 }
 

--- a/src/sentry/static/sentry/less/onboarding.less
+++ b/src/sentry/static/sentry/less/onboarding.less
@@ -173,6 +173,10 @@
     margin-top: 20px;
     color: @50;
   }
+
+  @media (max-width: @screen-sm-max) {
+    margin-top: 20px;
+  }
 }
 
 .new-project-name {

--- a/src/sentry/static/sentry/less/releases.less
+++ b/src/sentry/static/sentry/less/releases.less
@@ -3,10 +3,6 @@
 * ============================================================================
 */
 
-.release-list-header {
-  margin: 4px -15px 4px;
-}
-
 .release-search {
   .search-input {
     margin-top: -6px;

--- a/src/sentry/static/sentry/less/stream.less
+++ b/src/sentry/static/sentry/less/stream.less
@@ -865,7 +865,7 @@
 .saved-search-selector {
   .dropdown-toggle {
     display: inline-block;
-    font-size: 24px;
+    font-size: 22px;
     line-height: 36px;
     margin-right: 10px;
     color: @gray-darker;

--- a/tests/js/spec/components/__snapshots__/pageHeader.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/pageHeader.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PageHeader renders 1`] = `
+exports[`PageHeading renders 1`] = `
 <Wrapper>
   New Header
 </Wrapper>

--- a/tests/js/spec/components/__snapshots__/pageHeader.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/pageHeader.spec.jsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PageHeader renders 1`] = `
+<Wrapper>
+  New Header
+</Wrapper>
+`;

--- a/tests/js/spec/components/pageHeader.spec.jsx
+++ b/tests/js/spec/components/pageHeader.spec.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import PageHeader from 'app/components/pageHeader';
+import PageHeading from 'app/components/pageHeading';
 
-describe('PageHeader', function() {
+describe('PageHeading', function() {
   it('renders', function() {
-    let wrapper = shallow(<PageHeader>New Header</PageHeader>);
+    let wrapper = shallow(<PageHeading>New Header</PageHeading>);
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/tests/js/spec/components/pageHeader.spec.jsx
+++ b/tests/js/spec/components/pageHeader.spec.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import PageHeader from 'app/components/pageHeader';
+
+describe('PageHeader', function() {
+  it('renders', function() {
+    let wrapper = shallow(<PageHeader>New Header</PageHeader>);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/tests/js/spec/views/onboarding/__snapshots__/createProject.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/__snapshots__/createProject.spec.jsx.snap
@@ -65,9 +65,19 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
       <div
         className="onboarding-info"
       >
-        <h4>
-          Choose a language or framework:
-        </h4>
+        <PageHeading
+          withMargins={true}
+        >
+          <Wrapper
+            withMargins={true}
+          >
+            <h1
+              className="css-13ev48w-Wrapper e1f8hk460"
+            >
+              Choose a language or framework:
+            </h1>
+          </Wrapper>
+        </PageHeading>
         <PlatformPicker
           name=""
           next={[Function]}
@@ -769,9 +779,19 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
           <div
             className="new-project-name client-platform"
           >
-            <h4>
-              Give your project a name:
-            </h4>
+            <PageHeading
+              withMargins={true}
+            >
+              <Wrapper
+                withMargins={true}
+              >
+                <h1
+                  className="css-13ev48w-Wrapper e1f8hk460"
+                >
+                  Give your project a name:
+                </h1>
+              </Wrapper>
+            </PageHeading>
             <div
               className="project-name-wrapper"
             >
@@ -800,9 +820,19 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
           <div
             className="new-project-team"
           >
-            <h4>
-              Team:
-            </h4>
+            <PageHeading
+              withMargins={true}
+            >
+              <Wrapper
+                withMargins={true}
+              >
+                <h1
+                  className="css-13ev48w-Wrapper e1f8hk460"
+                >
+                  Team:
+                </h1>
+              </Wrapper>
+            </PageHeading>
             <div>
               <SelectField
                 clearable={false}
@@ -1192,9 +1222,19 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
       <div
         className="onboarding-info"
       >
-        <h4>
-          Choose a language or framework:
-        </h4>
+        <PageHeading
+          withMargins={true}
+        >
+          <Wrapper
+            withMargins={true}
+          >
+            <h1
+              className="css-13ev48w-Wrapper e1f8hk460"
+            >
+              Choose a language or framework:
+            </h1>
+          </Wrapper>
+        </PageHeading>
         <PlatformPicker
           name="Ruby"
           next={[Function]}
@@ -1506,9 +1546,19 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
           <div
             className="new-project-name client-platform"
           >
-            <h4>
-              Give your project a name:
-            </h4>
+            <PageHeading
+              withMargins={true}
+            >
+              <Wrapper
+                withMargins={true}
+              >
+                <h1
+                  className="css-13ev48w-Wrapper e1f8hk460"
+                >
+                  Give your project a name:
+                </h1>
+              </Wrapper>
+            </PageHeading>
             <div
               className="project-name-wrapper"
             >
@@ -1537,9 +1587,19 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
           <div
             className="new-project-team"
           >
-            <h4>
-              Team:
-            </h4>
+            <PageHeading
+              withMargins={true}
+            >
+              <Wrapper
+                withMargins={true}
+              >
+                <h1
+                  className="css-13ev48w-Wrapper e1f8hk460"
+                >
+                  Team:
+                </h1>
+              </Wrapper>
+            </PageHeading>
             <div>
               <SelectField
                 clearable={false}
@@ -1929,9 +1989,19 @@ exports[`CreateProject should fill in project name if its empty when platform is
       <div
         className="onboarding-info"
       >
-        <h4>
-          Choose a language or framework:
-        </h4>
+        <PageHeading
+          withMargins={true}
+        >
+          <Wrapper
+            withMargins={true}
+          >
+            <h1
+              className="css-13ev48w-Wrapper e1f8hk460"
+            >
+              Choose a language or framework:
+            </h1>
+          </Wrapper>
+        </PageHeading>
         <PlatformPicker
           name="another"
           next={[Function]}
@@ -2633,9 +2703,19 @@ exports[`CreateProject should fill in project name if its empty when platform is
           <div
             className="new-project-name client-platform"
           >
-            <h4>
-              Give your project a name:
-            </h4>
+            <PageHeading
+              withMargins={true}
+            >
+              <Wrapper
+                withMargins={true}
+              >
+                <h1
+                  className="css-13ev48w-Wrapper e1f8hk460"
+                >
+                  Give your project a name:
+                </h1>
+              </Wrapper>
+            </PageHeading>
             <div
               className="project-name-wrapper"
             >
@@ -2664,9 +2744,19 @@ exports[`CreateProject should fill in project name if its empty when platform is
           <div
             className="new-project-team"
           >
-            <h4>
-              Team:
-            </h4>
+            <PageHeading
+              withMargins={true}
+            >
+              <Wrapper
+                withMargins={true}
+              >
+                <h1
+                  className="css-13ev48w-Wrapper e1f8hk460"
+                >
+                  Team:
+                </h1>
+              </Wrapper>
+            </PageHeading>
             <div>
               <SelectField
                 clearable={false}

--- a/tests/js/spec/views/onboarding/__snapshots__/createProject.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/__snapshots__/createProject.spec.jsx.snap
@@ -62,807 +62,818 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
         ]
       }
     >
-      <div
-        className="onboarding-info"
-      >
-        <h4>
-          Choose a language or framework:
-        </h4>
-        <PlatformPicker
-          name=""
-          next={[Function]}
-          platform=""
-          setName={[Function]}
-          setPlatform={[Function]}
-          setTeam={[Function]}
-          showOther={true}
-          team="test"
-          teams={
-            Array [
-              Object {
-                "hasAccess": true,
-                "id": "1",
-                "name": "test",
-                "slug": "test",
-              },
-            ]
-          }
-        >
-          <div
-            className="platform-picker"
-          >
-            <NavTabs>
-              <ul
-                className="nav nav-tabs"
-              >
-                <li
-                  style={
-                    Object {
-                      "float": "right",
-                      "marginRight": 0,
-                    }
-                  }
-                >
-                  <div
-                    className="platform-filter-container"
-                  >
-                    <span
-                      className="icon icon-search"
-                    />
-                    <input
-                      className="platform-filter"
-                      label="Filter"
-                      onChange={[Function]}
-                      placeholder="Filter"
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </li>
-                <ListLink
-                  activeClassName="active"
-                  index={false}
-                  isActive={[Function]}
-                  key="popular"
-                  onClick={[Function]}
-                  to=""
-                >
-                  <li
-                    className="active"
-                  >
-                    <Link
-                      onClick={[Function]}
-                      onlyActiveOnIndex={false}
-                      style={Object {}}
-                      to=""
-                    >
-                      <a
-                        onClick={[Function]}
-                        style={Object {}}
-                      >
-                        Popular
-                      </a>
-                    </Link>
-                  </li>
-                </ListLink>
-                <ListLink
-                  activeClassName="active"
-                  index={false}
-                  isActive={[Function]}
-                  key="browser"
-                  onClick={[Function]}
-                  to=""
-                >
-                  <li
-                    className=""
-                  >
-                    <Link
-                      onClick={[Function]}
-                      onlyActiveOnIndex={false}
-                      style={Object {}}
-                      to=""
-                    >
-                      <a
-                        onClick={[Function]}
-                        style={Object {}}
-                      >
-                        Browser
-                      </a>
-                    </Link>
-                  </li>
-                </ListLink>
-                <ListLink
-                  activeClassName="active"
-                  index={false}
-                  isActive={[Function]}
-                  key="server"
-                  onClick={[Function]}
-                  to=""
-                >
-                  <li
-                    className=""
-                  >
-                    <Link
-                      onClick={[Function]}
-                      onlyActiveOnIndex={false}
-                      style={Object {}}
-                      to=""
-                    >
-                      <a
-                        onClick={[Function]}
-                        style={Object {}}
-                      >
-                        Server
-                      </a>
-                    </Link>
-                  </li>
-                </ListLink>
-                <ListLink
-                  activeClassName="active"
-                  index={false}
-                  isActive={[Function]}
-                  key="mobile"
-                  onClick={[Function]}
-                  to=""
-                >
-                  <li
-                    className=""
-                  >
-                    <Link
-                      onClick={[Function]}
-                      onlyActiveOnIndex={false}
-                      style={Object {}}
-                      to=""
-                    >
-                      <a
-                        onClick={[Function]}
-                        style={Object {}}
-                      >
-                        Mobile
-                      </a>
-                    </Link>
-                  </li>
-                </ListLink>
-                <ListLink
-                  activeClassName="active"
-                  index={false}
-                  isActive={[Function]}
-                  key="desktop"
-                  onClick={[Function]}
-                  to=""
-                >
-                  <li
-                    className=""
-                  >
-                    <Link
-                      onClick={[Function]}
-                      onlyActiveOnIndex={false}
-                      style={Object {}}
-                      to=""
-                    >
-                      <a
-                        onClick={[Function]}
-                        style={Object {}}
-                      >
-                        Desktop
-                      </a>
-                    </Link>
-                  </li>
-                </ListLink>
-                <ListLink
-                  activeClassName="active"
-                  index={false}
-                  isActive={[Function]}
-                  key="all"
-                  onClick={[Function]}
-                  to=""
-                >
-                  <li
-                    className=""
-                  >
-                    <Link
-                      onClick={[Function]}
-                      onlyActiveOnIndex={false}
-                      style={Object {}}
-                      to=""
-                    >
-                      <a
-                        onClick={[Function]}
-                        style={Object {}}
-                      >
-                        All
-                      </a>
-                    </Link>
-                  </li>
-                </ListLink>
-              </ul>
-            </NavTabs>
-            <ul
-              className="client-platform-list platform-tiles"
-            >
-              <PlatformCard
-                className=""
-                key="csharp"
-                onClick={[Function]}
-                platform="csharp"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="csharp"
-                  >
-                    <li
-                      className="platform-tile list-unstyled csharp csharp "
-                    >
-                      <span
-                        className="platformicon platformicon-csharp"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    C#
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="java"
-                onClick={[Function]}
-                platform="java"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="java"
-                  >
-                    <li
-                      className="platform-tile list-unstyled java java "
-                    >
-                      <span
-                        className="platformicon platformicon-java"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Java
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="javascript-angular"
-                onClick={[Function]}
-                platform="javascript-angular"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="javascript-angular"
-                  >
-                    <li
-                      className="platform-tile list-unstyled javascript-angular javascript "
-                    >
-                      <span
-                        className="platformicon platformicon-javascript-angular"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Angular
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="javascript"
-                onClick={[Function]}
-                platform="javascript"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="javascript"
-                  >
-                    <li
-                      className="platform-tile list-unstyled javascript javascript "
-                    >
-                      <span
-                        className="platformicon platformicon-javascript"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    JavaScript
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="javascript-react"
-                onClick={[Function]}
-                platform="javascript-react"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="javascript-react"
-                  >
-                    <li
-                      className="platform-tile list-unstyled javascript-react javascript "
-                    >
-                      <span
-                        className="platformicon platformicon-javascript-react"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    React
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="node-express"
-                onClick={[Function]}
-                platform="node-express"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="node-express"
-                  >
-                    <li
-                      className="platform-tile list-unstyled node-express node "
-                    >
-                      <span
-                        className="platformicon platformicon-node-express"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Express
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="node"
-                onClick={[Function]}
-                platform="node"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="node"
-                  >
-                    <li
-                      className="platform-tile list-unstyled node node "
-                    >
-                      <span
-                        className="platformicon platformicon-node"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Node.js
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="php-laravel"
-                onClick={[Function]}
-                platform="php-laravel"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="php-laravel"
-                  >
-                    <li
-                      className="platform-tile list-unstyled php-laravel php "
-                    >
-                      <span
-                        className="platformicon platformicon-php-laravel"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Laravel
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="php"
-                onClick={[Function]}
-                platform="php"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="php"
-                  >
-                    <li
-                      className="platform-tile list-unstyled php php "
-                    >
-                      <span
-                        className="platformicon platformicon-php"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    PHP
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="php-symfony2"
-                onClick={[Function]}
-                platform="php-symfony2"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="php-symfony2"
-                  >
-                    <li
-                      className="platform-tile list-unstyled php-symfony2 php "
-                    >
-                      <span
-                        className="platformicon platformicon-php-symfony2"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Symfony2
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="python-django"
-                onClick={[Function]}
-                platform="python-django"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="python-django"
-                  >
-                    <li
-                      className="platform-tile list-unstyled python-django python "
-                    >
-                      <span
-                        className="platformicon platformicon-python-django"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Django
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="python-flask"
-                onClick={[Function]}
-                platform="python-flask"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="python-flask"
-                  >
-                    <li
-                      className="platform-tile list-unstyled python-flask python "
-                    >
-                      <span
-                        className="platformicon platformicon-python-flask"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Flask
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="python"
-                onClick={[Function]}
-                platform="python"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="python"
-                  >
-                    <li
-                      className="platform-tile list-unstyled python python "
-                    >
-                      <span
-                        className="platformicon platformicon-python"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Python
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="cocoa"
-                onClick={[Function]}
-                platform="cocoa"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="cocoa"
-                  >
-                    <li
-                      className="platform-tile list-unstyled cocoa cocoa "
-                    >
-                      <span
-                        className="platformicon platformicon-cocoa"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    React-Native
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="ruby-rails"
-                onClick={[Function]}
-                platform="ruby-rails"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="ruby-rails"
-                  >
-                    <li
-                      className="platform-tile list-unstyled ruby-rails ruby "
-                    >
-                      <span
-                        className="platformicon platformicon-ruby-rails"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Rails
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="ruby"
-                onClick={[Function]}
-                platform="ruby"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="ruby"
-                  >
-                    <li
-                      className="platform-tile list-unstyled ruby ruby "
-                    >
-                      <span
-                        className="platformicon platformicon-ruby"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Ruby
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-            </ul>
-          </div>
-        </PlatformPicker>
+      <Wrapper>
         <div
-          className="create-project-form"
+          className="css-a5urgt-Wrapper e1bu5aqa0"
         >
-          <div
-            className="new-project-name client-platform"
+          <PageHeading
+            withMargins={true}
           >
-            <h4>
-              Give your project a name:
-            </h4>
-            <div
-              className="project-name-wrapper"
+            <Wrapper
+              withMargins={true}
             >
-              <PlatformiconTile
-                platform=""
+              <h1
+                className="css-13ev48w-Wrapper e1f8hk460"
               >
-                <li
-                  className="platform-tile list-unstyled   undefined"
+                Choose a language or framework:
+              </h1>
+            </Wrapper>
+          </PageHeading>
+          <PlatformPicker
+            name=""
+            next={[Function]}
+            platform=""
+            setName={[Function]}
+            setPlatform={[Function]}
+            setTeam={[Function]}
+            showOther={true}
+            team="test"
+            teams={
+              Array [
+                Object {
+                  "hasAccess": true,
+                  "id": "1",
+                  "name": "test",
+                  "slug": "test",
+                },
+              ]
+            }
+          >
+            <div
+              className="platform-picker"
+            >
+              <NavTabs>
+                <ul
+                  className="nav nav-tabs"
+                >
+                  <li
+                    style={
+                      Object {
+                        "float": "right",
+                        "marginRight": 0,
+                      }
+                    }
+                  >
+                    <div
+                      className="platform-filter-container"
+                    >
+                      <span
+                        className="icon icon-search"
+                      />
+                      <input
+                        className="platform-filter"
+                        label="Filter"
+                        onChange={[Function]}
+                        placeholder="Filter"
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </li>
+                  <ListLink
+                    activeClassName="active"
+                    index={false}
+                    isActive={[Function]}
+                    key="popular"
+                    onClick={[Function]}
+                    to=""
+                  >
+                    <li
+                      className="active"
+                    >
+                      <Link
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        style={Object {}}
+                        to=""
+                      >
+                        <a
+                          onClick={[Function]}
+                          style={Object {}}
+                        >
+                          Popular
+                        </a>
+                      </Link>
+                    </li>
+                  </ListLink>
+                  <ListLink
+                    activeClassName="active"
+                    index={false}
+                    isActive={[Function]}
+                    key="browser"
+                    onClick={[Function]}
+                    to=""
+                  >
+                    <li
+                      className=""
+                    >
+                      <Link
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        style={Object {}}
+                        to=""
+                      >
+                        <a
+                          onClick={[Function]}
+                          style={Object {}}
+                        >
+                          Browser
+                        </a>
+                      </Link>
+                    </li>
+                  </ListLink>
+                  <ListLink
+                    activeClassName="active"
+                    index={false}
+                    isActive={[Function]}
+                    key="server"
+                    onClick={[Function]}
+                    to=""
+                  >
+                    <li
+                      className=""
+                    >
+                      <Link
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        style={Object {}}
+                        to=""
+                      >
+                        <a
+                          onClick={[Function]}
+                          style={Object {}}
+                        >
+                          Server
+                        </a>
+                      </Link>
+                    </li>
+                  </ListLink>
+                  <ListLink
+                    activeClassName="active"
+                    index={false}
+                    isActive={[Function]}
+                    key="mobile"
+                    onClick={[Function]}
+                    to=""
+                  >
+                    <li
+                      className=""
+                    >
+                      <Link
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        style={Object {}}
+                        to=""
+                      >
+                        <a
+                          onClick={[Function]}
+                          style={Object {}}
+                        >
+                          Mobile
+                        </a>
+                      </Link>
+                    </li>
+                  </ListLink>
+                  <ListLink
+                    activeClassName="active"
+                    index={false}
+                    isActive={[Function]}
+                    key="desktop"
+                    onClick={[Function]}
+                    to=""
+                  >
+                    <li
+                      className=""
+                    >
+                      <Link
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        style={Object {}}
+                        to=""
+                      >
+                        <a
+                          onClick={[Function]}
+                          style={Object {}}
+                        >
+                          Desktop
+                        </a>
+                      </Link>
+                    </li>
+                  </ListLink>
+                  <ListLink
+                    activeClassName="active"
+                    index={false}
+                    isActive={[Function]}
+                    key="all"
+                    onClick={[Function]}
+                    to=""
+                  >
+                    <li
+                      className=""
+                    >
+                      <Link
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        style={Object {}}
+                        to=""
+                      >
+                        <a
+                          onClick={[Function]}
+                          style={Object {}}
+                        >
+                          All
+                        </a>
+                      </Link>
+                    </li>
+                  </ListLink>
+                </ul>
+              </NavTabs>
+              <ul
+                className="client-platform-list platform-tiles"
+              >
+                <PlatformCard
+                  className=""
+                  key="csharp"
+                  onClick={[Function]}
+                  platform="csharp"
                 >
                   <span
-                    className="platformicon platformicon-"
-                  />
-                </li>
-              </PlatformiconTile>
-              <input
-                autoComplete="off"
-                label="Project Name"
-                name="name"
-                onChange={[Function]}
-                placeholder="Project name"
-                type="text"
-                value=""
-              />
-            </div>
-          </div>
-          <div
-            className="new-project-team"
-          >
-            <h4>
-              Team:
-            </h4>
-            <div>
-              <SelectField
-                clearable={false}
-                disabled={false}
-                hideErrorMessage={false}
-                multiple={false}
-                name="select-team"
-                onChange={[Function]}
-                options={
-                  Array [
-                    Object {
-                      "label": "#test",
-                      "value": "test",
-                    },
-                  ]
-                }
-                required={false}
-                style={
-                  Object {
-                    "marginBottom": 0,
-                    "width": 180,
-                  }
-                }
-                value="test"
-              >
-                <div
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="csharp"
+                    >
+                      <li
+                        className="platform-tile list-unstyled csharp csharp "
+                      >
+                        <span
+                          className="platformicon platformicon-csharp"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      C#
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
                   className=""
+                  key="java"
+                  onClick={[Function]}
+                  platform="java"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="java"
+                    >
+                      <li
+                        className="platform-tile list-unstyled java java "
+                      >
+                        <span
+                          className="platformicon platformicon-java"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Java
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="javascript-angular"
+                  onClick={[Function]}
+                  platform="javascript-angular"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="javascript-angular"
+                    >
+                      <li
+                        className="platform-tile list-unstyled javascript-angular javascript "
+                      >
+                        <span
+                          className="platformicon platformicon-javascript-angular"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Angular
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="javascript"
+                  onClick={[Function]}
+                  platform="javascript"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="javascript"
+                    >
+                      <li
+                        className="platform-tile list-unstyled javascript javascript "
+                      >
+                        <span
+                          className="platformicon platformicon-javascript"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      JavaScript
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="javascript-react"
+                  onClick={[Function]}
+                  platform="javascript-react"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="javascript-react"
+                    >
+                      <li
+                        className="platform-tile list-unstyled javascript-react javascript "
+                      >
+                        <span
+                          className="platformicon platformicon-javascript-react"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      React
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="node-express"
+                  onClick={[Function]}
+                  platform="node-express"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="node-express"
+                    >
+                      <li
+                        className="platform-tile list-unstyled node-express node "
+                      >
+                        <span
+                          className="platformicon platformicon-node-express"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Express
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="node"
+                  onClick={[Function]}
+                  platform="node"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="node"
+                    >
+                      <li
+                        className="platform-tile list-unstyled node node "
+                      >
+                        <span
+                          className="platformicon platformicon-node"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Node.js
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="php-laravel"
+                  onClick={[Function]}
+                  platform="php-laravel"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="php-laravel"
+                    >
+                      <li
+                        className="platform-tile list-unstyled php-laravel php "
+                      >
+                        <span
+                          className="platformicon platformicon-php-laravel"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Laravel
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="php"
+                  onClick={[Function]}
+                  platform="php"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="php"
+                    >
+                      <li
+                        className="platform-tile list-unstyled php php "
+                      >
+                        <span
+                          className="platformicon platformicon-php"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      PHP
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="php-symfony2"
+                  onClick={[Function]}
+                  platform="php-symfony2"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="php-symfony2"
+                    >
+                      <li
+                        className="platform-tile list-unstyled php-symfony2 php "
+                      >
+                        <span
+                          className="platformicon platformicon-php-symfony2"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Symfony2
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="python-django"
+                  onClick={[Function]}
+                  platform="python-django"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="python-django"
+                    >
+                      <li
+                        className="platform-tile list-unstyled python-django python "
+                      >
+                        <span
+                          className="platformicon platformicon-python-django"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Django
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="python-flask"
+                  onClick={[Function]}
+                  platform="python-flask"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="python-flask"
+                    >
+                      <li
+                        className="platform-tile list-unstyled python-flask python "
+                      >
+                        <span
+                          className="platformicon platformicon-python-flask"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Flask
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="python"
+                  onClick={[Function]}
+                  platform="python"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="python"
+                    >
+                      <li
+                        className="platform-tile list-unstyled python python "
+                      >
+                        <span
+                          className="platformicon platformicon-python"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Python
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="cocoa"
+                  onClick={[Function]}
+                  platform="cocoa"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="cocoa"
+                    >
+                      <li
+                        className="platform-tile list-unstyled cocoa cocoa "
+                      >
+                        <span
+                          className="platformicon platformicon-cocoa"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      React-Native
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="ruby-rails"
+                  onClick={[Function]}
+                  platform="ruby-rails"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="ruby-rails"
+                    >
+                      <li
+                        className="platform-tile list-unstyled ruby-rails ruby "
+                      >
+                        <span
+                          className="platformicon platformicon-ruby-rails"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Rails
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="ruby"
+                  onClick={[Function]}
+                  platform="ruby"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="ruby"
+                    >
+                      <li
+                        className="platform-tile list-unstyled ruby ruby "
+                      >
+                        <span
+                          className="platformicon platformicon-ruby"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Ruby
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+              </ul>
+            </div>
+          </PlatformPicker>
+          <div
+            className="create-project-form"
+          >
+            <div
+              className="new-project-name client-platform"
+            >
+              <PageHeading
+                withMargins={true}
+              >
+                <Wrapper
+                  withMargins={true}
+                >
+                  <h1
+                    className="css-13ev48w-Wrapper e1f8hk460"
+                  >
+                    Give your project a name:
+                  </h1>
+                </Wrapper>
+              </PageHeading>
+              <div
+                className="project-name-wrapper"
+              >
+                <PlatformiconTile
+                  platform=""
+                >
+                  <li
+                    className="platform-tile list-unstyled   undefined"
+                  >
+                    <span
+                      className="platformicon platformicon-"
+                    />
+                  </li>
+                </PlatformiconTile>
+                <input
+                  autoComplete="off"
+                  label="Project Name"
+                  name="name"
+                  onChange={[Function]}
+                  placeholder="Project name"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              className="new-project-team"
+            >
+              <PageHeading
+                withMargins={true}
+              >
+                <Wrapper
+                  withMargins={true}
+                >
+                  <h1
+                    className="css-13ev48w-Wrapper e1f8hk460"
+                  >
+                    Team:
+                  </h1>
+                </Wrapper>
+              </PageHeading>
+              <div>
+                <SelectField
+                  clearable={false}
+                  disabled={false}
+                  hideErrorMessage={false}
+                  multiple={false}
+                  name="select-team"
+                  onChange={[Function]}
+                  options={
+                    Array [
+                      Object {
+                        "label": "#test",
+                        "value": "test",
+                      },
+                    ]
+                  }
+                  required={false}
                   style={
                     Object {
                       "marginBottom": 0,
                       "width": 180,
                     }
                   }
+                  value="test"
                 >
                   <div
-                    className="controls"
-                  >
-                    <StyledSelectControl
-                      clearable={false}
-                      disabled={false}
-                      id="id-select-team"
-                      multiple={false}
-                      name="select-team"
-                      onChange={[Function]}
-                      options={
-                        Array [
-                          Object {
-                            "label": "#test",
-                            "value": "test",
-                          },
-                        ]
+                    className=""
+                    style={
+                      Object {
+                        "marginBottom": 0,
+                        "width": 180,
                       }
-                      required={false}
-                      value="test"
+                    }
+                  >
+                    <div
+                      className="controls"
                     >
-                      <SelectControl
-                        className="css-j6zs66-StyledSelectControl e1qrhqd00"
+                      <StyledSelectControl
                         clearable={false}
                         disabled={false}
-                        height={36}
                         id="id-select-team"
                         multiple={false}
                         name="select-team"
@@ -878,12 +889,9 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                         required={false}
                         value="test"
                       >
-                        <StyledSelect
-                          arrowRenderer={[Function]}
-                          backspaceRemoves={false}
+                        <SelectControl
                           className="css-j6zs66-StyledSelectControl e1qrhqd00"
                           clearable={false}
-                          deleteRemoves={false}
                           disabled={false}
                           height={36}
                           id="id-select-team"
@@ -901,10 +909,10 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                           required={false}
                           value="test"
                         >
-                          <ForwardRef(SelectPicker)
+                          <StyledSelect
                             arrowRenderer={[Function]}
                             backspaceRemoves={false}
-                            className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                            className="css-j6zs66-StyledSelectControl e1qrhqd00"
                             clearable={false}
                             deleteRemoves={false}
                             disabled={false}
@@ -924,14 +932,13 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                             required={false}
                             value="test"
                           >
-                            <SelectPicker
+                            <ForwardRef(SelectPicker)
                               arrowRenderer={[Function]}
                               backspaceRemoves={false}
                               className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                               clearable={false}
                               deleteRemoves={false}
                               disabled={false}
-                              forwardedRef={null}
                               height={36}
                               id="id-select-team"
                               multiple={false}
@@ -948,44 +955,19 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                               required={false}
                               value="test"
                             >
-                              <Select
+                              <SelectPicker
                                 arrowRenderer={[Function]}
-                                autosize={true}
                                 backspaceRemoves={false}
-                                backspaceToRemoveMessage="Press backspace to remove {label}"
                                 className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
-                                clearAllText="Clear all"
-                                clearRenderer={[Function]}
-                                clearValueText="Clear value"
                                 clearable={false}
-                                closeOnSelect={true}
                                 deleteRemoves={false}
-                                delimiter=","
                                 disabled={false}
-                                escapeClearsValue={true}
-                                filterOptions={[Function]}
+                                forwardedRef={null}
                                 height={36}
                                 id="id-select-team"
-                                ignoreAccents={true}
-                                ignoreCase={true}
-                                inputProps={Object {}}
-                                isLoading={false}
-                                joinValues={false}
-                                labelKey="label"
-                                matchPos="any"
-                                matchProp="any"
-                                menuBuffer={0}
-                                menuRenderer={[Function]}
-                                multi={false}
                                 multiple={false}
                                 name="select-team"
-                                noResultsText="No results found"
-                                onBlurResetsInput={true}
                                 onChange={[Function]}
-                                onCloseResetsInput={true}
-                                onSelectResetsInput={true}
-                                openOnClick={true}
-                                optionComponent={[Function]}
                                 options={
                                   Array [
                                     Object {
@@ -994,161 +976,211 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                                     },
                                   ]
                                 }
-                                pageSize={5}
-                                placeholder="Select..."
-                                removeSelected={true}
                                 required={false}
-                                rtl={false}
-                                scrollMenuIntoView={true}
-                                searchable={true}
-                                simpleValue={false}
-                                tabSelectsValue={true}
-                                trimFilter={true}
                                 value="test"
-                                valueComponent={[Function]}
-                                valueKey="value"
                               >
-                                <div
-                                  className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                                <Select
+                                  arrowRenderer={[Function]}
+                                  autosize={true}
+                                  backspaceRemoves={false}
+                                  backspaceToRemoveMessage="Press backspace to remove {label}"
+                                  className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                  clearAllText="Clear all"
+                                  clearRenderer={[Function]}
+                                  clearValueText="Clear value"
+                                  clearable={false}
+                                  closeOnSelect={true}
+                                  deleteRemoves={false}
+                                  delimiter=","
+                                  disabled={false}
+                                  escapeClearsValue={true}
+                                  filterOptions={[Function]}
+                                  height={36}
+                                  id="id-select-team"
+                                  ignoreAccents={true}
+                                  ignoreCase={true}
+                                  inputProps={Object {}}
+                                  isLoading={false}
+                                  joinValues={false}
+                                  labelKey="label"
+                                  matchPos="any"
+                                  matchProp="any"
+                                  menuBuffer={0}
+                                  menuRenderer={[Function]}
+                                  multi={false}
+                                  multiple={false}
+                                  name="select-team"
+                                  noResultsText="No results found"
+                                  onBlurResetsInput={true}
+                                  onChange={[Function]}
+                                  onCloseResetsInput={true}
+                                  onSelectResetsInput={true}
+                                  openOnClick={true}
+                                  optionComponent={[Function]}
+                                  options={
+                                    Array [
+                                      Object {
+                                        "label": "#test",
+                                        "value": "test",
+                                      },
+                                    ]
+                                  }
+                                  pageSize={5}
+                                  placeholder="Select..."
+                                  removeSelected={true}
+                                  required={false}
+                                  rtl={false}
+                                  scrollMenuIntoView={true}
+                                  searchable={true}
+                                  simpleValue={false}
+                                  tabSelectsValue={true}
+                                  trimFilter={true}
+                                  value="test"
+                                  valueComponent={[Function]}
+                                  valueKey="value"
                                 >
-                                  <input
-                                    disabled={false}
-                                    key="hidden.0"
-                                    name="select-team"
-                                    type="hidden"
-                                    value="test"
-                                  />
                                   <div
-                                    className="Select-control"
-                                    onKeyDown={[Function]}
-                                    onMouseDown={[Function]}
-                                    onTouchEnd={[Function]}
-                                    onTouchMove={[Function]}
-                                    onTouchStart={[Function]}
+                                    className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                   >
-                                    <span
-                                      className="Select-multi-value-wrapper"
-                                      id="react-select-4--value"
-                                    >
-                                      <Value
-                                        disabled={false}
-                                        id="react-select-4--value-item"
-                                        instancePrefix="react-select-4-"
-                                        onClick={null}
-                                        placeholder="Select..."
-                                        value={
-                                          Object {
-                                            "label": "#test",
-                                            "value": "test",
-                                          }
-                                        }
-                                      >
-                                        <div
-                                          className="Select-value"
-                                        >
-                                          <span
-                                            aria-selected="true"
-                                            className="Select-value-label"
-                                            id="react-select-4--value-item"
-                                            role="option"
-                                          >
-                                            #test
-                                          </span>
-                                        </div>
-                                      </Value>
-                                      <AutosizeInput
-                                        aria-activedescendant="react-select-4--value"
-                                        aria-expanded="false"
-                                        aria-haspopup="false"
-                                        aria-owns=""
-                                        className="Select-input"
-                                        id="id-select-team"
-                                        injectStyles={true}
-                                        minWidth="5"
-                                        onBlur={[Function]}
-                                        onChange={[Function]}
-                                        onFocus={[Function]}
-                                        required={false}
-                                        role="combobox"
-                                        value=""
-                                      >
-                                        <div
-                                          className="Select-input"
-                                          style={
-                                            Object {
-                                              "display": "inline-block",
-                                            }
-                                          }
-                                        >
-                                          <input
-                                            aria-activedescendant="react-select-4--value"
-                                            aria-expanded="false"
-                                            aria-haspopup="false"
-                                            aria-owns=""
-                                            id="id-select-team"
-                                            onBlur={[Function]}
-                                            onChange={[Function]}
-                                            onFocus={[Function]}
-                                            required={false}
-                                            role="combobox"
-                                            style={
-                                              Object {
-                                                "boxSizing": "content-box",
-                                                "width": "5px",
-                                              }
-                                            }
-                                            value=""
-                                          />
-                                          <div
-                                            style={
-                                              Object {
-                                                "height": 0,
-                                                "left": 0,
-                                                "overflow": "scroll",
-                                                "position": "absolute",
-                                                "top": 0,
-                                                "visibility": "hidden",
-                                                "whiteSpace": "pre",
-                                              }
-                                            }
-                                          />
-                                        </div>
-                                      </AutosizeInput>
-                                    </span>
-                                    <span
-                                      className="Select-arrow-zone"
+                                    <input
+                                      disabled={false}
+                                      key="hidden.0"
+                                      name="select-team"
+                                      type="hidden"
+                                      value="test"
+                                    />
+                                    <div
+                                      className="Select-control"
+                                      onKeyDown={[Function]}
                                       onMouseDown={[Function]}
+                                      onTouchEnd={[Function]}
+                                      onTouchMove={[Function]}
+                                      onTouchStart={[Function]}
                                     >
                                       <span
-                                        className="icon-arrow-down"
-                                      />
-                                    </span>
+                                        className="Select-multi-value-wrapper"
+                                        id="react-select-4--value"
+                                      >
+                                        <Value
+                                          disabled={false}
+                                          id="react-select-4--value-item"
+                                          instancePrefix="react-select-4-"
+                                          onClick={null}
+                                          placeholder="Select..."
+                                          value={
+                                            Object {
+                                              "label": "#test",
+                                              "value": "test",
+                                            }
+                                          }
+                                        >
+                                          <div
+                                            className="Select-value"
+                                          >
+                                            <span
+                                              aria-selected="true"
+                                              className="Select-value-label"
+                                              id="react-select-4--value-item"
+                                              role="option"
+                                            >
+                                              #test
+                                            </span>
+                                          </div>
+                                        </Value>
+                                        <AutosizeInput
+                                          aria-activedescendant="react-select-4--value"
+                                          aria-expanded="false"
+                                          aria-haspopup="false"
+                                          aria-owns=""
+                                          className="Select-input"
+                                          id="id-select-team"
+                                          injectStyles={true}
+                                          minWidth="5"
+                                          onBlur={[Function]}
+                                          onChange={[Function]}
+                                          onFocus={[Function]}
+                                          required={false}
+                                          role="combobox"
+                                          value=""
+                                        >
+                                          <div
+                                            className="Select-input"
+                                            style={
+                                              Object {
+                                                "display": "inline-block",
+                                              }
+                                            }
+                                          >
+                                            <input
+                                              aria-activedescendant="react-select-4--value"
+                                              aria-expanded="false"
+                                              aria-haspopup="false"
+                                              aria-owns=""
+                                              id="id-select-team"
+                                              onBlur={[Function]}
+                                              onChange={[Function]}
+                                              onFocus={[Function]}
+                                              required={false}
+                                              role="combobox"
+                                              style={
+                                                Object {
+                                                  "boxSizing": "content-box",
+                                                  "width": "5px",
+                                                }
+                                              }
+                                              value=""
+                                            />
+                                            <div
+                                              style={
+                                                Object {
+                                                  "height": 0,
+                                                  "left": 0,
+                                                  "overflow": "scroll",
+                                                  "position": "absolute",
+                                                  "top": 0,
+                                                  "visibility": "hidden",
+                                                  "whiteSpace": "pre",
+                                                }
+                                              }
+                                            />
+                                          </div>
+                                        </AutosizeInput>
+                                      </span>
+                                      <span
+                                        className="Select-arrow-zone"
+                                        onMouseDown={[Function]}
+                                      >
+                                        <span
+                                          className="icon-arrow-down"
+                                        />
+                                      </span>
+                                    </div>
                                   </div>
-                                </div>
-                              </Select>
-                            </SelectPicker>
-                          </ForwardRef(SelectPicker)>
-                        </StyledSelect>
-                      </SelectControl>
-                    </StyledSelectControl>
+                                </Select>
+                              </SelectPicker>
+                            </ForwardRef(SelectPicker)>
+                          </StyledSelect>
+                        </SelectControl>
+                      </StyledSelectControl>
+                    </div>
                   </div>
-                </div>
-              </SelectField>
+                </SelectField>
+              </div>
             </div>
+            <div>
+              <button
+                className="btn btn-primary new-project-submit"
+                onClick={[Function]}
+              >
+                Create Project
+              </button>
+            </div>
+            <p>
+              Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
+            </p>
           </div>
-          <div>
-            <button
-              className="btn btn-primary new-project-submit"
-              onClick={[Function]}
-            >
-              Create Project
-            </button>
-          </div>
-          <p>
-            Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
-          </p>
         </div>
-      </div>
+      </Wrapper>
     </OnboardingProject>
   </div>
 </CreateProject>
@@ -1189,417 +1221,428 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
         ]
       }
     >
-      <div
-        className="onboarding-info"
-      >
-        <h4>
-          Choose a language or framework:
-        </h4>
-        <PlatformPicker
-          name="Ruby"
-          next={[Function]}
-          platform="ruby"
-          setName={[Function]}
-          setPlatform={[Function]}
-          setTeam={[Function]}
-          showOther={true}
-          team="test"
-          teams={
-            Array [
-              Object {
-                "hasAccess": true,
-                "id": "1",
-                "name": "test",
-                "slug": "test",
-              },
-            ]
-          }
-        >
-          <div
-            className="platform-picker"
-          >
-            <NavTabs>
-              <ul
-                className="nav nav-tabs"
-              >
-                <li
-                  style={
-                    Object {
-                      "float": "right",
-                      "marginRight": 0,
-                    }
-                  }
-                >
-                  <div
-                    className="platform-filter-container"
-                  >
-                    <span
-                      className="icon icon-search"
-                    />
-                    <input
-                      className="platform-filter"
-                      label="Filter"
-                      onChange={[Function]}
-                      placeholder="Filter"
-                      type="text"
-                      value="ruby"
-                    />
-                  </div>
-                </li>
-                <ListLink
-                  activeClassName="active"
-                  index={false}
-                  isActive={[Function]}
-                  key="popular"
-                  onClick={[Function]}
-                  to=""
-                >
-                  <li
-                    className=""
-                  >
-                    <Link
-                      onClick={[Function]}
-                      onlyActiveOnIndex={false}
-                      style={Object {}}
-                      to=""
-                    >
-                      <a
-                        onClick={[Function]}
-                        style={Object {}}
-                      >
-                        Popular
-                      </a>
-                    </Link>
-                  </li>
-                </ListLink>
-                <ListLink
-                  activeClassName="active"
-                  index={false}
-                  isActive={[Function]}
-                  key="browser"
-                  onClick={[Function]}
-                  to=""
-                >
-                  <li
-                    className=""
-                  >
-                    <Link
-                      onClick={[Function]}
-                      onlyActiveOnIndex={false}
-                      style={Object {}}
-                      to=""
-                    >
-                      <a
-                        onClick={[Function]}
-                        style={Object {}}
-                      >
-                        Browser
-                      </a>
-                    </Link>
-                  </li>
-                </ListLink>
-                <ListLink
-                  activeClassName="active"
-                  index={false}
-                  isActive={[Function]}
-                  key="server"
-                  onClick={[Function]}
-                  to=""
-                >
-                  <li
-                    className=""
-                  >
-                    <Link
-                      onClick={[Function]}
-                      onlyActiveOnIndex={false}
-                      style={Object {}}
-                      to=""
-                    >
-                      <a
-                        onClick={[Function]}
-                        style={Object {}}
-                      >
-                        Server
-                      </a>
-                    </Link>
-                  </li>
-                </ListLink>
-                <ListLink
-                  activeClassName="active"
-                  index={false}
-                  isActive={[Function]}
-                  key="mobile"
-                  onClick={[Function]}
-                  to=""
-                >
-                  <li
-                    className=""
-                  >
-                    <Link
-                      onClick={[Function]}
-                      onlyActiveOnIndex={false}
-                      style={Object {}}
-                      to=""
-                    >
-                      <a
-                        onClick={[Function]}
-                        style={Object {}}
-                      >
-                        Mobile
-                      </a>
-                    </Link>
-                  </li>
-                </ListLink>
-                <ListLink
-                  activeClassName="active"
-                  index={false}
-                  isActive={[Function]}
-                  key="desktop"
-                  onClick={[Function]}
-                  to=""
-                >
-                  <li
-                    className=""
-                  >
-                    <Link
-                      onClick={[Function]}
-                      onlyActiveOnIndex={false}
-                      style={Object {}}
-                      to=""
-                    >
-                      <a
-                        onClick={[Function]}
-                        style={Object {}}
-                      >
-                        Desktop
-                      </a>
-                    </Link>
-                  </li>
-                </ListLink>
-                <ListLink
-                  activeClassName="active"
-                  index={false}
-                  isActive={[Function]}
-                  key="all"
-                  onClick={[Function]}
-                  to=""
-                >
-                  <li
-                    className="active"
-                  >
-                    <Link
-                      onClick={[Function]}
-                      onlyActiveOnIndex={false}
-                      style={Object {}}
-                      to=""
-                    >
-                      <a
-                        onClick={[Function]}
-                        style={Object {}}
-                      >
-                        All
-                      </a>
-                    </Link>
-                  </li>
-                </ListLink>
-              </ul>
-            </NavTabs>
-            <ul
-              className="client-platform-list platform-tiles"
-            >
-              <PlatformCard
-                className=""
-                key="ruby-rack"
-                onClick={[Function]}
-                platform="ruby-rack"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="ruby-rack"
-                  >
-                    <li
-                      className="platform-tile list-unstyled ruby-rack ruby "
-                    >
-                      <span
-                        className="platformicon platformicon-ruby-rack"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Rack
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="ruby-rails"
-                onClick={[Function]}
-                platform="ruby-rails"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="ruby-rails"
-                  >
-                    <li
-                      className="platform-tile list-unstyled ruby-rails ruby "
-                    >
-                      <span
-                        className="platformicon platformicon-ruby-rails"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Rails
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className="selected"
-                key="ruby"
-                onClick={[Function]}
-                platform="ruby"
-              >
-                <span
-                  className="platform-card selected"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className="selected"
-                    onClick={[Function]}
-                    platform="ruby"
-                  >
-                    <li
-                      className="platform-tile list-unstyled ruby ruby selected"
-                    >
-                      <span
-                        className="platformicon platformicon-ruby"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Ruby
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-            </ul>
-          </div>
-        </PlatformPicker>
+      <Wrapper>
         <div
-          className="create-project-form"
+          className="css-a5urgt-Wrapper e1bu5aqa0"
         >
-          <div
-            className="new-project-name client-platform"
+          <PageHeading
+            withMargins={true}
           >
-            <h4>
-              Give your project a name:
-            </h4>
-            <div
-              className="project-name-wrapper"
+            <Wrapper
+              withMargins={true}
             >
-              <PlatformiconTile
-                platform="ruby"
+              <h1
+                className="css-13ev48w-Wrapper e1f8hk460"
               >
-                <li
-                  className="platform-tile list-unstyled ruby ruby undefined"
+                Choose a language or framework:
+              </h1>
+            </Wrapper>
+          </PageHeading>
+          <PlatformPicker
+            name="Ruby"
+            next={[Function]}
+            platform="ruby"
+            setName={[Function]}
+            setPlatform={[Function]}
+            setTeam={[Function]}
+            showOther={true}
+            team="test"
+            teams={
+              Array [
+                Object {
+                  "hasAccess": true,
+                  "id": "1",
+                  "name": "test",
+                  "slug": "test",
+                },
+              ]
+            }
+          >
+            <div
+              className="platform-picker"
+            >
+              <NavTabs>
+                <ul
+                  className="nav nav-tabs"
+                >
+                  <li
+                    style={
+                      Object {
+                        "float": "right",
+                        "marginRight": 0,
+                      }
+                    }
+                  >
+                    <div
+                      className="platform-filter-container"
+                    >
+                      <span
+                        className="icon icon-search"
+                      />
+                      <input
+                        className="platform-filter"
+                        label="Filter"
+                        onChange={[Function]}
+                        placeholder="Filter"
+                        type="text"
+                        value="ruby"
+                      />
+                    </div>
+                  </li>
+                  <ListLink
+                    activeClassName="active"
+                    index={false}
+                    isActive={[Function]}
+                    key="popular"
+                    onClick={[Function]}
+                    to=""
+                  >
+                    <li
+                      className=""
+                    >
+                      <Link
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        style={Object {}}
+                        to=""
+                      >
+                        <a
+                          onClick={[Function]}
+                          style={Object {}}
+                        >
+                          Popular
+                        </a>
+                      </Link>
+                    </li>
+                  </ListLink>
+                  <ListLink
+                    activeClassName="active"
+                    index={false}
+                    isActive={[Function]}
+                    key="browser"
+                    onClick={[Function]}
+                    to=""
+                  >
+                    <li
+                      className=""
+                    >
+                      <Link
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        style={Object {}}
+                        to=""
+                      >
+                        <a
+                          onClick={[Function]}
+                          style={Object {}}
+                        >
+                          Browser
+                        </a>
+                      </Link>
+                    </li>
+                  </ListLink>
+                  <ListLink
+                    activeClassName="active"
+                    index={false}
+                    isActive={[Function]}
+                    key="server"
+                    onClick={[Function]}
+                    to=""
+                  >
+                    <li
+                      className=""
+                    >
+                      <Link
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        style={Object {}}
+                        to=""
+                      >
+                        <a
+                          onClick={[Function]}
+                          style={Object {}}
+                        >
+                          Server
+                        </a>
+                      </Link>
+                    </li>
+                  </ListLink>
+                  <ListLink
+                    activeClassName="active"
+                    index={false}
+                    isActive={[Function]}
+                    key="mobile"
+                    onClick={[Function]}
+                    to=""
+                  >
+                    <li
+                      className=""
+                    >
+                      <Link
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        style={Object {}}
+                        to=""
+                      >
+                        <a
+                          onClick={[Function]}
+                          style={Object {}}
+                        >
+                          Mobile
+                        </a>
+                      </Link>
+                    </li>
+                  </ListLink>
+                  <ListLink
+                    activeClassName="active"
+                    index={false}
+                    isActive={[Function]}
+                    key="desktop"
+                    onClick={[Function]}
+                    to=""
+                  >
+                    <li
+                      className=""
+                    >
+                      <Link
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        style={Object {}}
+                        to=""
+                      >
+                        <a
+                          onClick={[Function]}
+                          style={Object {}}
+                        >
+                          Desktop
+                        </a>
+                      </Link>
+                    </li>
+                  </ListLink>
+                  <ListLink
+                    activeClassName="active"
+                    index={false}
+                    isActive={[Function]}
+                    key="all"
+                    onClick={[Function]}
+                    to=""
+                  >
+                    <li
+                      className="active"
+                    >
+                      <Link
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        style={Object {}}
+                        to=""
+                      >
+                        <a
+                          onClick={[Function]}
+                          style={Object {}}
+                        >
+                          All
+                        </a>
+                      </Link>
+                    </li>
+                  </ListLink>
+                </ul>
+              </NavTabs>
+              <ul
+                className="client-platform-list platform-tiles"
+              >
+                <PlatformCard
+                  className=""
+                  key="ruby-rack"
+                  onClick={[Function]}
+                  platform="ruby-rack"
                 >
                   <span
-                    className="platformicon platformicon-ruby"
-                  />
-                </li>
-              </PlatformiconTile>
-              <input
-                autoComplete="off"
-                label="Project Name"
-                name="name"
-                onChange={[Function]}
-                placeholder="Project name"
-                type="text"
-                value="Ruby"
-              />
-            </div>
-          </div>
-          <div
-            className="new-project-team"
-          >
-            <h4>
-              Team:
-            </h4>
-            <div>
-              <SelectField
-                clearable={false}
-                disabled={false}
-                hideErrorMessage={false}
-                multiple={false}
-                name="select-team"
-                onChange={[Function]}
-                options={
-                  Array [
-                    Object {
-                      "label": "#test",
-                      "value": "test",
-                    },
-                  ]
-                }
-                required={false}
-                style={
-                  Object {
-                    "marginBottom": 0,
-                    "width": 180,
-                  }
-                }
-                value="test"
-              >
-                <div
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="ruby-rack"
+                    >
+                      <li
+                        className="platform-tile list-unstyled ruby-rack ruby "
+                      >
+                        <span
+                          className="platformicon platformicon-ruby-rack"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Rack
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
                   className=""
+                  key="ruby-rails"
+                  onClick={[Function]}
+                  platform="ruby-rails"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="ruby-rails"
+                    >
+                      <li
+                        className="platform-tile list-unstyled ruby-rails ruby "
+                      >
+                        <span
+                          className="platformicon platformicon-ruby-rails"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Rails
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className="selected"
+                  key="ruby"
+                  onClick={[Function]}
+                  platform="ruby"
+                >
+                  <span
+                    className="platform-card selected"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className="selected"
+                      onClick={[Function]}
+                      platform="ruby"
+                    >
+                      <li
+                        className="platform-tile list-unstyled ruby ruby selected"
+                      >
+                        <span
+                          className="platformicon platformicon-ruby"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Ruby
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+              </ul>
+            </div>
+          </PlatformPicker>
+          <div
+            className="create-project-form"
+          >
+            <div
+              className="new-project-name client-platform"
+            >
+              <PageHeading
+                withMargins={true}
+              >
+                <Wrapper
+                  withMargins={true}
+                >
+                  <h1
+                    className="css-13ev48w-Wrapper e1f8hk460"
+                  >
+                    Give your project a name:
+                  </h1>
+                </Wrapper>
+              </PageHeading>
+              <div
+                className="project-name-wrapper"
+              >
+                <PlatformiconTile
+                  platform="ruby"
+                >
+                  <li
+                    className="platform-tile list-unstyled ruby ruby undefined"
+                  >
+                    <span
+                      className="platformicon platformicon-ruby"
+                    />
+                  </li>
+                </PlatformiconTile>
+                <input
+                  autoComplete="off"
+                  label="Project Name"
+                  name="name"
+                  onChange={[Function]}
+                  placeholder="Project name"
+                  type="text"
+                  value="Ruby"
+                />
+              </div>
+            </div>
+            <div
+              className="new-project-team"
+            >
+              <PageHeading
+                withMargins={true}
+              >
+                <Wrapper
+                  withMargins={true}
+                >
+                  <h1
+                    className="css-13ev48w-Wrapper e1f8hk460"
+                  >
+                    Team:
+                  </h1>
+                </Wrapper>
+              </PageHeading>
+              <div>
+                <SelectField
+                  clearable={false}
+                  disabled={false}
+                  hideErrorMessage={false}
+                  multiple={false}
+                  name="select-team"
+                  onChange={[Function]}
+                  options={
+                    Array [
+                      Object {
+                        "label": "#test",
+                        "value": "test",
+                      },
+                    ]
+                  }
+                  required={false}
                   style={
                     Object {
                       "marginBottom": 0,
                       "width": 180,
                     }
                   }
+                  value="test"
                 >
                   <div
-                    className="controls"
-                  >
-                    <StyledSelectControl
-                      clearable={false}
-                      disabled={false}
-                      id="id-select-team"
-                      multiple={false}
-                      name="select-team"
-                      onChange={[Function]}
-                      options={
-                        Array [
-                          Object {
-                            "label": "#test",
-                            "value": "test",
-                          },
-                        ]
+                    className=""
+                    style={
+                      Object {
+                        "marginBottom": 0,
+                        "width": 180,
                       }
-                      required={false}
-                      value="test"
+                    }
+                  >
+                    <div
+                      className="controls"
                     >
-                      <SelectControl
-                        className="css-j6zs66-StyledSelectControl e1qrhqd00"
+                      <StyledSelectControl
                         clearable={false}
                         disabled={false}
-                        height={36}
                         id="id-select-team"
                         multiple={false}
                         name="select-team"
@@ -1615,12 +1658,9 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                         required={false}
                         value="test"
                       >
-                        <StyledSelect
-                          arrowRenderer={[Function]}
-                          backspaceRemoves={false}
+                        <SelectControl
                           className="css-j6zs66-StyledSelectControl e1qrhqd00"
                           clearable={false}
-                          deleteRemoves={false}
                           disabled={false}
                           height={36}
                           id="id-select-team"
@@ -1638,10 +1678,10 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                           required={false}
                           value="test"
                         >
-                          <ForwardRef(SelectPicker)
+                          <StyledSelect
                             arrowRenderer={[Function]}
                             backspaceRemoves={false}
-                            className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                            className="css-j6zs66-StyledSelectControl e1qrhqd00"
                             clearable={false}
                             deleteRemoves={false}
                             disabled={false}
@@ -1661,14 +1701,13 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                             required={false}
                             value="test"
                           >
-                            <SelectPicker
+                            <ForwardRef(SelectPicker)
                               arrowRenderer={[Function]}
                               backspaceRemoves={false}
                               className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                               clearable={false}
                               deleteRemoves={false}
                               disabled={false}
-                              forwardedRef={null}
                               height={36}
                               id="id-select-team"
                               multiple={false}
@@ -1685,44 +1724,19 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                               required={false}
                               value="test"
                             >
-                              <Select
+                              <SelectPicker
                                 arrowRenderer={[Function]}
-                                autosize={true}
                                 backspaceRemoves={false}
-                                backspaceToRemoveMessage="Press backspace to remove {label}"
                                 className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
-                                clearAllText="Clear all"
-                                clearRenderer={[Function]}
-                                clearValueText="Clear value"
                                 clearable={false}
-                                closeOnSelect={true}
                                 deleteRemoves={false}
-                                delimiter=","
                                 disabled={false}
-                                escapeClearsValue={true}
-                                filterOptions={[Function]}
+                                forwardedRef={null}
                                 height={36}
                                 id="id-select-team"
-                                ignoreAccents={true}
-                                ignoreCase={true}
-                                inputProps={Object {}}
-                                isLoading={false}
-                                joinValues={false}
-                                labelKey="label"
-                                matchPos="any"
-                                matchProp="any"
-                                menuBuffer={0}
-                                menuRenderer={[Function]}
-                                multi={false}
                                 multiple={false}
                                 name="select-team"
-                                noResultsText="No results found"
-                                onBlurResetsInput={true}
                                 onChange={[Function]}
-                                onCloseResetsInput={true}
-                                onSelectResetsInput={true}
-                                openOnClick={true}
-                                optionComponent={[Function]}
                                 options={
                                   Array [
                                     Object {
@@ -1731,161 +1745,211 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                                     },
                                   ]
                                 }
-                                pageSize={5}
-                                placeholder="Select..."
-                                removeSelected={true}
                                 required={false}
-                                rtl={false}
-                                scrollMenuIntoView={true}
-                                searchable={true}
-                                simpleValue={false}
-                                tabSelectsValue={true}
-                                trimFilter={true}
                                 value="test"
-                                valueComponent={[Function]}
-                                valueKey="value"
                               >
-                                <div
-                                  className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                                <Select
+                                  arrowRenderer={[Function]}
+                                  autosize={true}
+                                  backspaceRemoves={false}
+                                  backspaceToRemoveMessage="Press backspace to remove {label}"
+                                  className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                  clearAllText="Clear all"
+                                  clearRenderer={[Function]}
+                                  clearValueText="Clear value"
+                                  clearable={false}
+                                  closeOnSelect={true}
+                                  deleteRemoves={false}
+                                  delimiter=","
+                                  disabled={false}
+                                  escapeClearsValue={true}
+                                  filterOptions={[Function]}
+                                  height={36}
+                                  id="id-select-team"
+                                  ignoreAccents={true}
+                                  ignoreCase={true}
+                                  inputProps={Object {}}
+                                  isLoading={false}
+                                  joinValues={false}
+                                  labelKey="label"
+                                  matchPos="any"
+                                  matchProp="any"
+                                  menuBuffer={0}
+                                  menuRenderer={[Function]}
+                                  multi={false}
+                                  multiple={false}
+                                  name="select-team"
+                                  noResultsText="No results found"
+                                  onBlurResetsInput={true}
+                                  onChange={[Function]}
+                                  onCloseResetsInput={true}
+                                  onSelectResetsInput={true}
+                                  openOnClick={true}
+                                  optionComponent={[Function]}
+                                  options={
+                                    Array [
+                                      Object {
+                                        "label": "#test",
+                                        "value": "test",
+                                      },
+                                    ]
+                                  }
+                                  pageSize={5}
+                                  placeholder="Select..."
+                                  removeSelected={true}
+                                  required={false}
+                                  rtl={false}
+                                  scrollMenuIntoView={true}
+                                  searchable={true}
+                                  simpleValue={false}
+                                  tabSelectsValue={true}
+                                  trimFilter={true}
+                                  value="test"
+                                  valueComponent={[Function]}
+                                  valueKey="value"
                                 >
-                                  <input
-                                    disabled={false}
-                                    key="hidden.0"
-                                    name="select-team"
-                                    type="hidden"
-                                    value="test"
-                                  />
                                   <div
-                                    className="Select-control"
-                                    onKeyDown={[Function]}
-                                    onMouseDown={[Function]}
-                                    onTouchEnd={[Function]}
-                                    onTouchMove={[Function]}
-                                    onTouchStart={[Function]}
+                                    className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                   >
-                                    <span
-                                      className="Select-multi-value-wrapper"
-                                      id="react-select-3--value"
-                                    >
-                                      <Value
-                                        disabled={false}
-                                        id="react-select-3--value-item"
-                                        instancePrefix="react-select-3-"
-                                        onClick={null}
-                                        placeholder="Select..."
-                                        value={
-                                          Object {
-                                            "label": "#test",
-                                            "value": "test",
-                                          }
-                                        }
-                                      >
-                                        <div
-                                          className="Select-value"
-                                        >
-                                          <span
-                                            aria-selected="true"
-                                            className="Select-value-label"
-                                            id="react-select-3--value-item"
-                                            role="option"
-                                          >
-                                            #test
-                                          </span>
-                                        </div>
-                                      </Value>
-                                      <AutosizeInput
-                                        aria-activedescendant="react-select-3--value"
-                                        aria-expanded="false"
-                                        aria-haspopup="false"
-                                        aria-owns=""
-                                        className="Select-input"
-                                        id="id-select-team"
-                                        injectStyles={true}
-                                        minWidth="5"
-                                        onBlur={[Function]}
-                                        onChange={[Function]}
-                                        onFocus={[Function]}
-                                        required={false}
-                                        role="combobox"
-                                        value=""
-                                      >
-                                        <div
-                                          className="Select-input"
-                                          style={
-                                            Object {
-                                              "display": "inline-block",
-                                            }
-                                          }
-                                        >
-                                          <input
-                                            aria-activedescendant="react-select-3--value"
-                                            aria-expanded="false"
-                                            aria-haspopup="false"
-                                            aria-owns=""
-                                            id="id-select-team"
-                                            onBlur={[Function]}
-                                            onChange={[Function]}
-                                            onFocus={[Function]}
-                                            required={false}
-                                            role="combobox"
-                                            style={
-                                              Object {
-                                                "boxSizing": "content-box",
-                                                "width": "5px",
-                                              }
-                                            }
-                                            value=""
-                                          />
-                                          <div
-                                            style={
-                                              Object {
-                                                "height": 0,
-                                                "left": 0,
-                                                "overflow": "scroll",
-                                                "position": "absolute",
-                                                "top": 0,
-                                                "visibility": "hidden",
-                                                "whiteSpace": "pre",
-                                              }
-                                            }
-                                          />
-                                        </div>
-                                      </AutosizeInput>
-                                    </span>
-                                    <span
-                                      className="Select-arrow-zone"
+                                    <input
+                                      disabled={false}
+                                      key="hidden.0"
+                                      name="select-team"
+                                      type="hidden"
+                                      value="test"
+                                    />
+                                    <div
+                                      className="Select-control"
+                                      onKeyDown={[Function]}
                                       onMouseDown={[Function]}
+                                      onTouchEnd={[Function]}
+                                      onTouchMove={[Function]}
+                                      onTouchStart={[Function]}
                                     >
                                       <span
-                                        className="icon-arrow-down"
-                                      />
-                                    </span>
+                                        className="Select-multi-value-wrapper"
+                                        id="react-select-3--value"
+                                      >
+                                        <Value
+                                          disabled={false}
+                                          id="react-select-3--value-item"
+                                          instancePrefix="react-select-3-"
+                                          onClick={null}
+                                          placeholder="Select..."
+                                          value={
+                                            Object {
+                                              "label": "#test",
+                                              "value": "test",
+                                            }
+                                          }
+                                        >
+                                          <div
+                                            className="Select-value"
+                                          >
+                                            <span
+                                              aria-selected="true"
+                                              className="Select-value-label"
+                                              id="react-select-3--value-item"
+                                              role="option"
+                                            >
+                                              #test
+                                            </span>
+                                          </div>
+                                        </Value>
+                                        <AutosizeInput
+                                          aria-activedescendant="react-select-3--value"
+                                          aria-expanded="false"
+                                          aria-haspopup="false"
+                                          aria-owns=""
+                                          className="Select-input"
+                                          id="id-select-team"
+                                          injectStyles={true}
+                                          minWidth="5"
+                                          onBlur={[Function]}
+                                          onChange={[Function]}
+                                          onFocus={[Function]}
+                                          required={false}
+                                          role="combobox"
+                                          value=""
+                                        >
+                                          <div
+                                            className="Select-input"
+                                            style={
+                                              Object {
+                                                "display": "inline-block",
+                                              }
+                                            }
+                                          >
+                                            <input
+                                              aria-activedescendant="react-select-3--value"
+                                              aria-expanded="false"
+                                              aria-haspopup="false"
+                                              aria-owns=""
+                                              id="id-select-team"
+                                              onBlur={[Function]}
+                                              onChange={[Function]}
+                                              onFocus={[Function]}
+                                              required={false}
+                                              role="combobox"
+                                              style={
+                                                Object {
+                                                  "boxSizing": "content-box",
+                                                  "width": "5px",
+                                                }
+                                              }
+                                              value=""
+                                            />
+                                            <div
+                                              style={
+                                                Object {
+                                                  "height": 0,
+                                                  "left": 0,
+                                                  "overflow": "scroll",
+                                                  "position": "absolute",
+                                                  "top": 0,
+                                                  "visibility": "hidden",
+                                                  "whiteSpace": "pre",
+                                                }
+                                              }
+                                            />
+                                          </div>
+                                        </AutosizeInput>
+                                      </span>
+                                      <span
+                                        className="Select-arrow-zone"
+                                        onMouseDown={[Function]}
+                                      >
+                                        <span
+                                          className="icon-arrow-down"
+                                        />
+                                      </span>
+                                    </div>
                                   </div>
-                                </div>
-                              </Select>
-                            </SelectPicker>
-                          </ForwardRef(SelectPicker)>
-                        </StyledSelect>
-                      </SelectControl>
-                    </StyledSelectControl>
+                                </Select>
+                              </SelectPicker>
+                            </ForwardRef(SelectPicker)>
+                          </StyledSelect>
+                        </SelectControl>
+                      </StyledSelectControl>
+                    </div>
                   </div>
-                </div>
-              </SelectField>
+                </SelectField>
+              </div>
             </div>
+            <div>
+              <button
+                className="btn btn-primary new-project-submit"
+                onClick={[Function]}
+              >
+                Create Project
+              </button>
+            </div>
+            <p>
+              Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
+            </p>
           </div>
-          <div>
-            <button
-              className="btn btn-primary new-project-submit"
-              onClick={[Function]}
-            >
-              Create Project
-            </button>
-          </div>
-          <p>
-            Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
-          </p>
         </div>
-      </div>
+      </Wrapper>
     </OnboardingProject>
   </div>
 </CreateProject>
@@ -1926,807 +1990,818 @@ exports[`CreateProject should fill in project name if its empty when platform is
         ]
       }
     >
-      <div
-        className="onboarding-info"
-      >
-        <h4>
-          Choose a language or framework:
-        </h4>
-        <PlatformPicker
-          name="another"
-          next={[Function]}
-          platform="csharp"
-          setName={[Function]}
-          setPlatform={[Function]}
-          setTeam={[Function]}
-          showOther={true}
-          team="test"
-          teams={
-            Array [
-              Object {
-                "hasAccess": true,
-                "id": "1",
-                "name": "test",
-                "slug": "test",
-              },
-            ]
-          }
-        >
-          <div
-            className="platform-picker"
-          >
-            <NavTabs>
-              <ul
-                className="nav nav-tabs"
-              >
-                <li
-                  style={
-                    Object {
-                      "float": "right",
-                      "marginRight": 0,
-                    }
-                  }
-                >
-                  <div
-                    className="platform-filter-container"
-                  >
-                    <span
-                      className="icon icon-search"
-                    />
-                    <input
-                      className="platform-filter"
-                      label="Filter"
-                      onChange={[Function]}
-                      placeholder="Filter"
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </li>
-                <ListLink
-                  activeClassName="active"
-                  index={false}
-                  isActive={[Function]}
-                  key="popular"
-                  onClick={[Function]}
-                  to=""
-                >
-                  <li
-                    className="active"
-                  >
-                    <Link
-                      onClick={[Function]}
-                      onlyActiveOnIndex={false}
-                      style={Object {}}
-                      to=""
-                    >
-                      <a
-                        onClick={[Function]}
-                        style={Object {}}
-                      >
-                        Popular
-                      </a>
-                    </Link>
-                  </li>
-                </ListLink>
-                <ListLink
-                  activeClassName="active"
-                  index={false}
-                  isActive={[Function]}
-                  key="browser"
-                  onClick={[Function]}
-                  to=""
-                >
-                  <li
-                    className=""
-                  >
-                    <Link
-                      onClick={[Function]}
-                      onlyActiveOnIndex={false}
-                      style={Object {}}
-                      to=""
-                    >
-                      <a
-                        onClick={[Function]}
-                        style={Object {}}
-                      >
-                        Browser
-                      </a>
-                    </Link>
-                  </li>
-                </ListLink>
-                <ListLink
-                  activeClassName="active"
-                  index={false}
-                  isActive={[Function]}
-                  key="server"
-                  onClick={[Function]}
-                  to=""
-                >
-                  <li
-                    className=""
-                  >
-                    <Link
-                      onClick={[Function]}
-                      onlyActiveOnIndex={false}
-                      style={Object {}}
-                      to=""
-                    >
-                      <a
-                        onClick={[Function]}
-                        style={Object {}}
-                      >
-                        Server
-                      </a>
-                    </Link>
-                  </li>
-                </ListLink>
-                <ListLink
-                  activeClassName="active"
-                  index={false}
-                  isActive={[Function]}
-                  key="mobile"
-                  onClick={[Function]}
-                  to=""
-                >
-                  <li
-                    className=""
-                  >
-                    <Link
-                      onClick={[Function]}
-                      onlyActiveOnIndex={false}
-                      style={Object {}}
-                      to=""
-                    >
-                      <a
-                        onClick={[Function]}
-                        style={Object {}}
-                      >
-                        Mobile
-                      </a>
-                    </Link>
-                  </li>
-                </ListLink>
-                <ListLink
-                  activeClassName="active"
-                  index={false}
-                  isActive={[Function]}
-                  key="desktop"
-                  onClick={[Function]}
-                  to=""
-                >
-                  <li
-                    className=""
-                  >
-                    <Link
-                      onClick={[Function]}
-                      onlyActiveOnIndex={false}
-                      style={Object {}}
-                      to=""
-                    >
-                      <a
-                        onClick={[Function]}
-                        style={Object {}}
-                      >
-                        Desktop
-                      </a>
-                    </Link>
-                  </li>
-                </ListLink>
-                <ListLink
-                  activeClassName="active"
-                  index={false}
-                  isActive={[Function]}
-                  key="all"
-                  onClick={[Function]}
-                  to=""
-                >
-                  <li
-                    className=""
-                  >
-                    <Link
-                      onClick={[Function]}
-                      onlyActiveOnIndex={false}
-                      style={Object {}}
-                      to=""
-                    >
-                      <a
-                        onClick={[Function]}
-                        style={Object {}}
-                      >
-                        All
-                      </a>
-                    </Link>
-                  </li>
-                </ListLink>
-              </ul>
-            </NavTabs>
-            <ul
-              className="client-platform-list platform-tiles"
-            >
-              <PlatformCard
-                className="selected"
-                key="csharp"
-                onClick={[Function]}
-                platform="csharp"
-              >
-                <span
-                  className="platform-card selected"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className="selected"
-                    onClick={[Function]}
-                    platform="csharp"
-                  >
-                    <li
-                      className="platform-tile list-unstyled csharp csharp selected"
-                    >
-                      <span
-                        className="platformicon platformicon-csharp"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    C#
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="java"
-                onClick={[Function]}
-                platform="java"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="java"
-                  >
-                    <li
-                      className="platform-tile list-unstyled java java "
-                    >
-                      <span
-                        className="platformicon platformicon-java"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Java
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="javascript-angular"
-                onClick={[Function]}
-                platform="javascript-angular"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="javascript-angular"
-                  >
-                    <li
-                      className="platform-tile list-unstyled javascript-angular javascript "
-                    >
-                      <span
-                        className="platformicon platformicon-javascript-angular"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Angular
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="javascript"
-                onClick={[Function]}
-                platform="javascript"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="javascript"
-                  >
-                    <li
-                      className="platform-tile list-unstyled javascript javascript "
-                    >
-                      <span
-                        className="platformicon platformicon-javascript"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    JavaScript
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="javascript-react"
-                onClick={[Function]}
-                platform="javascript-react"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="javascript-react"
-                  >
-                    <li
-                      className="platform-tile list-unstyled javascript-react javascript "
-                    >
-                      <span
-                        className="platformicon platformicon-javascript-react"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    React
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="node-express"
-                onClick={[Function]}
-                platform="node-express"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="node-express"
-                  >
-                    <li
-                      className="platform-tile list-unstyled node-express node "
-                    >
-                      <span
-                        className="platformicon platformicon-node-express"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Express
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="node"
-                onClick={[Function]}
-                platform="node"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="node"
-                  >
-                    <li
-                      className="platform-tile list-unstyled node node "
-                    >
-                      <span
-                        className="platformicon platformicon-node"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Node.js
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="php-laravel"
-                onClick={[Function]}
-                platform="php-laravel"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="php-laravel"
-                  >
-                    <li
-                      className="platform-tile list-unstyled php-laravel php "
-                    >
-                      <span
-                        className="platformicon platformicon-php-laravel"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Laravel
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="php"
-                onClick={[Function]}
-                platform="php"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="php"
-                  >
-                    <li
-                      className="platform-tile list-unstyled php php "
-                    >
-                      <span
-                        className="platformicon platformicon-php"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    PHP
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="php-symfony2"
-                onClick={[Function]}
-                platform="php-symfony2"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="php-symfony2"
-                  >
-                    <li
-                      className="platform-tile list-unstyled php-symfony2 php "
-                    >
-                      <span
-                        className="platformicon platformicon-php-symfony2"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Symfony2
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="python-django"
-                onClick={[Function]}
-                platform="python-django"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="python-django"
-                  >
-                    <li
-                      className="platform-tile list-unstyled python-django python "
-                    >
-                      <span
-                        className="platformicon platformicon-python-django"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Django
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="python-flask"
-                onClick={[Function]}
-                platform="python-flask"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="python-flask"
-                  >
-                    <li
-                      className="platform-tile list-unstyled python-flask python "
-                    >
-                      <span
-                        className="platformicon platformicon-python-flask"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Flask
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="python"
-                onClick={[Function]}
-                platform="python"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="python"
-                  >
-                    <li
-                      className="platform-tile list-unstyled python python "
-                    >
-                      <span
-                        className="platformicon platformicon-python"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Python
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="cocoa"
-                onClick={[Function]}
-                platform="cocoa"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="cocoa"
-                  >
-                    <li
-                      className="platform-tile list-unstyled cocoa cocoa "
-                    >
-                      <span
-                        className="platformicon platformicon-cocoa"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    React-Native
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="ruby-rails"
-                onClick={[Function]}
-                platform="ruby-rails"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="ruby-rails"
-                  >
-                    <li
-                      className="platform-tile list-unstyled ruby-rails ruby "
-                    >
-                      <span
-                        className="platformicon platformicon-ruby-rails"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Rails
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-              <PlatformCard
-                className=""
-                key="ruby"
-                onClick={[Function]}
-                platform="ruby"
-              >
-                <span
-                  className="platform-card"
-                  onClick={[Function]}
-                >
-                  <PlatformiconTile
-                    className=""
-                    onClick={[Function]}
-                    platform="ruby"
-                  >
-                    <li
-                      className="platform-tile list-unstyled ruby ruby "
-                    >
-                      <span
-                        className="platformicon platformicon-ruby"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <h5>
-                     
-                    Ruby
-                     
-                  </h5>
-                </span>
-              </PlatformCard>
-            </ul>
-          </div>
-        </PlatformPicker>
+      <Wrapper>
         <div
-          className="create-project-form"
+          className="css-a5urgt-Wrapper e1bu5aqa0"
         >
-          <div
-            className="new-project-name client-platform"
+          <PageHeading
+            withMargins={true}
           >
-            <h4>
-              Give your project a name:
-            </h4>
-            <div
-              className="project-name-wrapper"
+            <Wrapper
+              withMargins={true}
             >
-              <PlatformiconTile
-                platform="csharp"
+              <h1
+                className="css-13ev48w-Wrapper e1f8hk460"
               >
-                <li
-                  className="platform-tile list-unstyled csharp csharp undefined"
+                Choose a language or framework:
+              </h1>
+            </Wrapper>
+          </PageHeading>
+          <PlatformPicker
+            name="another"
+            next={[Function]}
+            platform="csharp"
+            setName={[Function]}
+            setPlatform={[Function]}
+            setTeam={[Function]}
+            showOther={true}
+            team="test"
+            teams={
+              Array [
+                Object {
+                  "hasAccess": true,
+                  "id": "1",
+                  "name": "test",
+                  "slug": "test",
+                },
+              ]
+            }
+          >
+            <div
+              className="platform-picker"
+            >
+              <NavTabs>
+                <ul
+                  className="nav nav-tabs"
+                >
+                  <li
+                    style={
+                      Object {
+                        "float": "right",
+                        "marginRight": 0,
+                      }
+                    }
+                  >
+                    <div
+                      className="platform-filter-container"
+                    >
+                      <span
+                        className="icon icon-search"
+                      />
+                      <input
+                        className="platform-filter"
+                        label="Filter"
+                        onChange={[Function]}
+                        placeholder="Filter"
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </li>
+                  <ListLink
+                    activeClassName="active"
+                    index={false}
+                    isActive={[Function]}
+                    key="popular"
+                    onClick={[Function]}
+                    to=""
+                  >
+                    <li
+                      className="active"
+                    >
+                      <Link
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        style={Object {}}
+                        to=""
+                      >
+                        <a
+                          onClick={[Function]}
+                          style={Object {}}
+                        >
+                          Popular
+                        </a>
+                      </Link>
+                    </li>
+                  </ListLink>
+                  <ListLink
+                    activeClassName="active"
+                    index={false}
+                    isActive={[Function]}
+                    key="browser"
+                    onClick={[Function]}
+                    to=""
+                  >
+                    <li
+                      className=""
+                    >
+                      <Link
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        style={Object {}}
+                        to=""
+                      >
+                        <a
+                          onClick={[Function]}
+                          style={Object {}}
+                        >
+                          Browser
+                        </a>
+                      </Link>
+                    </li>
+                  </ListLink>
+                  <ListLink
+                    activeClassName="active"
+                    index={false}
+                    isActive={[Function]}
+                    key="server"
+                    onClick={[Function]}
+                    to=""
+                  >
+                    <li
+                      className=""
+                    >
+                      <Link
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        style={Object {}}
+                        to=""
+                      >
+                        <a
+                          onClick={[Function]}
+                          style={Object {}}
+                        >
+                          Server
+                        </a>
+                      </Link>
+                    </li>
+                  </ListLink>
+                  <ListLink
+                    activeClassName="active"
+                    index={false}
+                    isActive={[Function]}
+                    key="mobile"
+                    onClick={[Function]}
+                    to=""
+                  >
+                    <li
+                      className=""
+                    >
+                      <Link
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        style={Object {}}
+                        to=""
+                      >
+                        <a
+                          onClick={[Function]}
+                          style={Object {}}
+                        >
+                          Mobile
+                        </a>
+                      </Link>
+                    </li>
+                  </ListLink>
+                  <ListLink
+                    activeClassName="active"
+                    index={false}
+                    isActive={[Function]}
+                    key="desktop"
+                    onClick={[Function]}
+                    to=""
+                  >
+                    <li
+                      className=""
+                    >
+                      <Link
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        style={Object {}}
+                        to=""
+                      >
+                        <a
+                          onClick={[Function]}
+                          style={Object {}}
+                        >
+                          Desktop
+                        </a>
+                      </Link>
+                    </li>
+                  </ListLink>
+                  <ListLink
+                    activeClassName="active"
+                    index={false}
+                    isActive={[Function]}
+                    key="all"
+                    onClick={[Function]}
+                    to=""
+                  >
+                    <li
+                      className=""
+                    >
+                      <Link
+                        onClick={[Function]}
+                        onlyActiveOnIndex={false}
+                        style={Object {}}
+                        to=""
+                      >
+                        <a
+                          onClick={[Function]}
+                          style={Object {}}
+                        >
+                          All
+                        </a>
+                      </Link>
+                    </li>
+                  </ListLink>
+                </ul>
+              </NavTabs>
+              <ul
+                className="client-platform-list platform-tiles"
+              >
+                <PlatformCard
+                  className="selected"
+                  key="csharp"
+                  onClick={[Function]}
+                  platform="csharp"
                 >
                   <span
-                    className="platformicon platformicon-csharp"
-                  />
-                </li>
-              </PlatformiconTile>
-              <input
-                autoComplete="off"
-                label="Project Name"
-                name="name"
-                onChange={[Function]}
-                placeholder="Project name"
-                type="text"
-                value="another"
-              />
-            </div>
-          </div>
-          <div
-            className="new-project-team"
-          >
-            <h4>
-              Team:
-            </h4>
-            <div>
-              <SelectField
-                clearable={false}
-                disabled={false}
-                hideErrorMessage={false}
-                multiple={false}
-                name="select-team"
-                onChange={[Function]}
-                options={
-                  Array [
-                    Object {
-                      "label": "#test",
-                      "value": "test",
-                    },
-                  ]
-                }
-                required={false}
-                style={
-                  Object {
-                    "marginBottom": 0,
-                    "width": 180,
-                  }
-                }
-                value="test"
-              >
-                <div
+                    className="platform-card selected"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className="selected"
+                      onClick={[Function]}
+                      platform="csharp"
+                    >
+                      <li
+                        className="platform-tile list-unstyled csharp csharp selected"
+                      >
+                        <span
+                          className="platformicon platformicon-csharp"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      C#
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
                   className=""
+                  key="java"
+                  onClick={[Function]}
+                  platform="java"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="java"
+                    >
+                      <li
+                        className="platform-tile list-unstyled java java "
+                      >
+                        <span
+                          className="platformicon platformicon-java"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Java
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="javascript-angular"
+                  onClick={[Function]}
+                  platform="javascript-angular"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="javascript-angular"
+                    >
+                      <li
+                        className="platform-tile list-unstyled javascript-angular javascript "
+                      >
+                        <span
+                          className="platformicon platformicon-javascript-angular"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Angular
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="javascript"
+                  onClick={[Function]}
+                  platform="javascript"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="javascript"
+                    >
+                      <li
+                        className="platform-tile list-unstyled javascript javascript "
+                      >
+                        <span
+                          className="platformicon platformicon-javascript"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      JavaScript
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="javascript-react"
+                  onClick={[Function]}
+                  platform="javascript-react"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="javascript-react"
+                    >
+                      <li
+                        className="platform-tile list-unstyled javascript-react javascript "
+                      >
+                        <span
+                          className="platformicon platformicon-javascript-react"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      React
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="node-express"
+                  onClick={[Function]}
+                  platform="node-express"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="node-express"
+                    >
+                      <li
+                        className="platform-tile list-unstyled node-express node "
+                      >
+                        <span
+                          className="platformicon platformicon-node-express"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Express
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="node"
+                  onClick={[Function]}
+                  platform="node"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="node"
+                    >
+                      <li
+                        className="platform-tile list-unstyled node node "
+                      >
+                        <span
+                          className="platformicon platformicon-node"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Node.js
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="php-laravel"
+                  onClick={[Function]}
+                  platform="php-laravel"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="php-laravel"
+                    >
+                      <li
+                        className="platform-tile list-unstyled php-laravel php "
+                      >
+                        <span
+                          className="platformicon platformicon-php-laravel"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Laravel
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="php"
+                  onClick={[Function]}
+                  platform="php"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="php"
+                    >
+                      <li
+                        className="platform-tile list-unstyled php php "
+                      >
+                        <span
+                          className="platformicon platformicon-php"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      PHP
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="php-symfony2"
+                  onClick={[Function]}
+                  platform="php-symfony2"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="php-symfony2"
+                    >
+                      <li
+                        className="platform-tile list-unstyled php-symfony2 php "
+                      >
+                        <span
+                          className="platformicon platformicon-php-symfony2"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Symfony2
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="python-django"
+                  onClick={[Function]}
+                  platform="python-django"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="python-django"
+                    >
+                      <li
+                        className="platform-tile list-unstyled python-django python "
+                      >
+                        <span
+                          className="platformicon platformicon-python-django"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Django
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="python-flask"
+                  onClick={[Function]}
+                  platform="python-flask"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="python-flask"
+                    >
+                      <li
+                        className="platform-tile list-unstyled python-flask python "
+                      >
+                        <span
+                          className="platformicon platformicon-python-flask"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Flask
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="python"
+                  onClick={[Function]}
+                  platform="python"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="python"
+                    >
+                      <li
+                        className="platform-tile list-unstyled python python "
+                      >
+                        <span
+                          className="platformicon platformicon-python"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Python
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="cocoa"
+                  onClick={[Function]}
+                  platform="cocoa"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="cocoa"
+                    >
+                      <li
+                        className="platform-tile list-unstyled cocoa cocoa "
+                      >
+                        <span
+                          className="platformicon platformicon-cocoa"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      React-Native
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="ruby-rails"
+                  onClick={[Function]}
+                  platform="ruby-rails"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="ruby-rails"
+                    >
+                      <li
+                        className="platform-tile list-unstyled ruby-rails ruby "
+                      >
+                        <span
+                          className="platformicon platformicon-ruby-rails"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Rails
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+                <PlatformCard
+                  className=""
+                  key="ruby"
+                  onClick={[Function]}
+                  platform="ruby"
+                >
+                  <span
+                    className="platform-card"
+                    onClick={[Function]}
+                  >
+                    <PlatformiconTile
+                      className=""
+                      onClick={[Function]}
+                      platform="ruby"
+                    >
+                      <li
+                        className="platform-tile list-unstyled ruby ruby "
+                      >
+                        <span
+                          className="platformicon platformicon-ruby"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <h5>
+                       
+                      Ruby
+                       
+                    </h5>
+                  </span>
+                </PlatformCard>
+              </ul>
+            </div>
+          </PlatformPicker>
+          <div
+            className="create-project-form"
+          >
+            <div
+              className="new-project-name client-platform"
+            >
+              <PageHeading
+                withMargins={true}
+              >
+                <Wrapper
+                  withMargins={true}
+                >
+                  <h1
+                    className="css-13ev48w-Wrapper e1f8hk460"
+                  >
+                    Give your project a name:
+                  </h1>
+                </Wrapper>
+              </PageHeading>
+              <div
+                className="project-name-wrapper"
+              >
+                <PlatformiconTile
+                  platform="csharp"
+                >
+                  <li
+                    className="platform-tile list-unstyled csharp csharp undefined"
+                  >
+                    <span
+                      className="platformicon platformicon-csharp"
+                    />
+                  </li>
+                </PlatformiconTile>
+                <input
+                  autoComplete="off"
+                  label="Project Name"
+                  name="name"
+                  onChange={[Function]}
+                  placeholder="Project name"
+                  type="text"
+                  value="another"
+                />
+              </div>
+            </div>
+            <div
+              className="new-project-team"
+            >
+              <PageHeading
+                withMargins={true}
+              >
+                <Wrapper
+                  withMargins={true}
+                >
+                  <h1
+                    className="css-13ev48w-Wrapper e1f8hk460"
+                  >
+                    Team:
+                  </h1>
+                </Wrapper>
+              </PageHeading>
+              <div>
+                <SelectField
+                  clearable={false}
+                  disabled={false}
+                  hideErrorMessage={false}
+                  multiple={false}
+                  name="select-team"
+                  onChange={[Function]}
+                  options={
+                    Array [
+                      Object {
+                        "label": "#test",
+                        "value": "test",
+                      },
+                    ]
+                  }
+                  required={false}
                   style={
                     Object {
                       "marginBottom": 0,
                       "width": 180,
                     }
                   }
+                  value="test"
                 >
                   <div
-                    className="controls"
-                  >
-                    <StyledSelectControl
-                      clearable={false}
-                      disabled={false}
-                      id="id-select-team"
-                      multiple={false}
-                      name="select-team"
-                      onChange={[Function]}
-                      options={
-                        Array [
-                          Object {
-                            "label": "#test",
-                            "value": "test",
-                          },
-                        ]
+                    className=""
+                    style={
+                      Object {
+                        "marginBottom": 0,
+                        "width": 180,
                       }
-                      required={false}
-                      value="test"
+                    }
+                  >
+                    <div
+                      className="controls"
                     >
-                      <SelectControl
-                        className="css-j6zs66-StyledSelectControl e1qrhqd00"
+                      <StyledSelectControl
                         clearable={false}
                         disabled={false}
-                        height={36}
                         id="id-select-team"
                         multiple={false}
                         name="select-team"
@@ -2742,12 +2817,9 @@ exports[`CreateProject should fill in project name if its empty when platform is
                         required={false}
                         value="test"
                       >
-                        <StyledSelect
-                          arrowRenderer={[Function]}
-                          backspaceRemoves={false}
+                        <SelectControl
                           className="css-j6zs66-StyledSelectControl e1qrhqd00"
                           clearable={false}
-                          deleteRemoves={false}
                           disabled={false}
                           height={36}
                           id="id-select-team"
@@ -2765,10 +2837,10 @@ exports[`CreateProject should fill in project name if its empty when platform is
                           required={false}
                           value="test"
                         >
-                          <ForwardRef(SelectPicker)
+                          <StyledSelect
                             arrowRenderer={[Function]}
                             backspaceRemoves={false}
-                            className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                            className="css-j6zs66-StyledSelectControl e1qrhqd00"
                             clearable={false}
                             deleteRemoves={false}
                             disabled={false}
@@ -2788,14 +2860,13 @@ exports[`CreateProject should fill in project name if its empty when platform is
                             required={false}
                             value="test"
                           >
-                            <SelectPicker
+                            <ForwardRef(SelectPicker)
                               arrowRenderer={[Function]}
                               backspaceRemoves={false}
                               className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                               clearable={false}
                               deleteRemoves={false}
                               disabled={false}
-                              forwardedRef={null}
                               height={36}
                               id="id-select-team"
                               multiple={false}
@@ -2812,44 +2883,19 @@ exports[`CreateProject should fill in project name if its empty when platform is
                               required={false}
                               value="test"
                             >
-                              <Select
+                              <SelectPicker
                                 arrowRenderer={[Function]}
-                                autosize={true}
                                 backspaceRemoves={false}
-                                backspaceToRemoveMessage="Press backspace to remove {label}"
                                 className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
-                                clearAllText="Clear all"
-                                clearRenderer={[Function]}
-                                clearValueText="Clear value"
                                 clearable={false}
-                                closeOnSelect={true}
                                 deleteRemoves={false}
-                                delimiter=","
                                 disabled={false}
-                                escapeClearsValue={true}
-                                filterOptions={[Function]}
+                                forwardedRef={null}
                                 height={36}
                                 id="id-select-team"
-                                ignoreAccents={true}
-                                ignoreCase={true}
-                                inputProps={Object {}}
-                                isLoading={false}
-                                joinValues={false}
-                                labelKey="label"
-                                matchPos="any"
-                                matchProp="any"
-                                menuBuffer={0}
-                                menuRenderer={[Function]}
-                                multi={false}
                                 multiple={false}
                                 name="select-team"
-                                noResultsText="No results found"
-                                onBlurResetsInput={true}
                                 onChange={[Function]}
-                                onCloseResetsInput={true}
-                                onSelectResetsInput={true}
-                                openOnClick={true}
-                                optionComponent={[Function]}
                                 options={
                                   Array [
                                     Object {
@@ -2858,161 +2904,211 @@ exports[`CreateProject should fill in project name if its empty when platform is
                                     },
                                   ]
                                 }
-                                pageSize={5}
-                                placeholder="Select..."
-                                removeSelected={true}
                                 required={false}
-                                rtl={false}
-                                scrollMenuIntoView={true}
-                                searchable={true}
-                                simpleValue={false}
-                                tabSelectsValue={true}
-                                trimFilter={true}
                                 value="test"
-                                valueComponent={[Function]}
-                                valueKey="value"
                               >
-                                <div
-                                  className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                                <Select
+                                  arrowRenderer={[Function]}
+                                  autosize={true}
+                                  backspaceRemoves={false}
+                                  backspaceToRemoveMessage="Press backspace to remove {label}"
+                                  className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                  clearAllText="Clear all"
+                                  clearRenderer={[Function]}
+                                  clearValueText="Clear value"
+                                  clearable={false}
+                                  closeOnSelect={true}
+                                  deleteRemoves={false}
+                                  delimiter=","
+                                  disabled={false}
+                                  escapeClearsValue={true}
+                                  filterOptions={[Function]}
+                                  height={36}
+                                  id="id-select-team"
+                                  ignoreAccents={true}
+                                  ignoreCase={true}
+                                  inputProps={Object {}}
+                                  isLoading={false}
+                                  joinValues={false}
+                                  labelKey="label"
+                                  matchPos="any"
+                                  matchProp="any"
+                                  menuBuffer={0}
+                                  menuRenderer={[Function]}
+                                  multi={false}
+                                  multiple={false}
+                                  name="select-team"
+                                  noResultsText="No results found"
+                                  onBlurResetsInput={true}
+                                  onChange={[Function]}
+                                  onCloseResetsInput={true}
+                                  onSelectResetsInput={true}
+                                  openOnClick={true}
+                                  optionComponent={[Function]}
+                                  options={
+                                    Array [
+                                      Object {
+                                        "label": "#test",
+                                        "value": "test",
+                                      },
+                                    ]
+                                  }
+                                  pageSize={5}
+                                  placeholder="Select..."
+                                  removeSelected={true}
+                                  required={false}
+                                  rtl={false}
+                                  scrollMenuIntoView={true}
+                                  searchable={true}
+                                  simpleValue={false}
+                                  tabSelectsValue={true}
+                                  trimFilter={true}
+                                  value="test"
+                                  valueComponent={[Function]}
+                                  valueKey="value"
                                 >
-                                  <input
-                                    disabled={false}
-                                    key="hidden.0"
-                                    name="select-team"
-                                    type="hidden"
-                                    value="test"
-                                  />
                                   <div
-                                    className="Select-control"
-                                    onKeyDown={[Function]}
-                                    onMouseDown={[Function]}
-                                    onTouchEnd={[Function]}
-                                    onTouchMove={[Function]}
-                                    onTouchStart={[Function]}
+                                    className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                   >
-                                    <span
-                                      className="Select-multi-value-wrapper"
-                                      id="react-select-2--value"
-                                    >
-                                      <Value
-                                        disabled={false}
-                                        id="react-select-2--value-item"
-                                        instancePrefix="react-select-2-"
-                                        onClick={null}
-                                        placeholder="Select..."
-                                        value={
-                                          Object {
-                                            "label": "#test",
-                                            "value": "test",
-                                          }
-                                        }
-                                      >
-                                        <div
-                                          className="Select-value"
-                                        >
-                                          <span
-                                            aria-selected="true"
-                                            className="Select-value-label"
-                                            id="react-select-2--value-item"
-                                            role="option"
-                                          >
-                                            #test
-                                          </span>
-                                        </div>
-                                      </Value>
-                                      <AutosizeInput
-                                        aria-activedescendant="react-select-2--value"
-                                        aria-expanded="false"
-                                        aria-haspopup="false"
-                                        aria-owns=""
-                                        className="Select-input"
-                                        id="id-select-team"
-                                        injectStyles={true}
-                                        minWidth="5"
-                                        onBlur={[Function]}
-                                        onChange={[Function]}
-                                        onFocus={[Function]}
-                                        required={false}
-                                        role="combobox"
-                                        value=""
-                                      >
-                                        <div
-                                          className="Select-input"
-                                          style={
-                                            Object {
-                                              "display": "inline-block",
-                                            }
-                                          }
-                                        >
-                                          <input
-                                            aria-activedescendant="react-select-2--value"
-                                            aria-expanded="false"
-                                            aria-haspopup="false"
-                                            aria-owns=""
-                                            id="id-select-team"
-                                            onBlur={[Function]}
-                                            onChange={[Function]}
-                                            onFocus={[Function]}
-                                            required={false}
-                                            role="combobox"
-                                            style={
-                                              Object {
-                                                "boxSizing": "content-box",
-                                                "width": "5px",
-                                              }
-                                            }
-                                            value=""
-                                          />
-                                          <div
-                                            style={
-                                              Object {
-                                                "height": 0,
-                                                "left": 0,
-                                                "overflow": "scroll",
-                                                "position": "absolute",
-                                                "top": 0,
-                                                "visibility": "hidden",
-                                                "whiteSpace": "pre",
-                                              }
-                                            }
-                                          />
-                                        </div>
-                                      </AutosizeInput>
-                                    </span>
-                                    <span
-                                      className="Select-arrow-zone"
+                                    <input
+                                      disabled={false}
+                                      key="hidden.0"
+                                      name="select-team"
+                                      type="hidden"
+                                      value="test"
+                                    />
+                                    <div
+                                      className="Select-control"
+                                      onKeyDown={[Function]}
                                       onMouseDown={[Function]}
+                                      onTouchEnd={[Function]}
+                                      onTouchMove={[Function]}
+                                      onTouchStart={[Function]}
                                     >
                                       <span
-                                        className="icon-arrow-down"
-                                      />
-                                    </span>
+                                        className="Select-multi-value-wrapper"
+                                        id="react-select-2--value"
+                                      >
+                                        <Value
+                                          disabled={false}
+                                          id="react-select-2--value-item"
+                                          instancePrefix="react-select-2-"
+                                          onClick={null}
+                                          placeholder="Select..."
+                                          value={
+                                            Object {
+                                              "label": "#test",
+                                              "value": "test",
+                                            }
+                                          }
+                                        >
+                                          <div
+                                            className="Select-value"
+                                          >
+                                            <span
+                                              aria-selected="true"
+                                              className="Select-value-label"
+                                              id="react-select-2--value-item"
+                                              role="option"
+                                            >
+                                              #test
+                                            </span>
+                                          </div>
+                                        </Value>
+                                        <AutosizeInput
+                                          aria-activedescendant="react-select-2--value"
+                                          aria-expanded="false"
+                                          aria-haspopup="false"
+                                          aria-owns=""
+                                          className="Select-input"
+                                          id="id-select-team"
+                                          injectStyles={true}
+                                          minWidth="5"
+                                          onBlur={[Function]}
+                                          onChange={[Function]}
+                                          onFocus={[Function]}
+                                          required={false}
+                                          role="combobox"
+                                          value=""
+                                        >
+                                          <div
+                                            className="Select-input"
+                                            style={
+                                              Object {
+                                                "display": "inline-block",
+                                              }
+                                            }
+                                          >
+                                            <input
+                                              aria-activedescendant="react-select-2--value"
+                                              aria-expanded="false"
+                                              aria-haspopup="false"
+                                              aria-owns=""
+                                              id="id-select-team"
+                                              onBlur={[Function]}
+                                              onChange={[Function]}
+                                              onFocus={[Function]}
+                                              required={false}
+                                              role="combobox"
+                                              style={
+                                                Object {
+                                                  "boxSizing": "content-box",
+                                                  "width": "5px",
+                                                }
+                                              }
+                                              value=""
+                                            />
+                                            <div
+                                              style={
+                                                Object {
+                                                  "height": 0,
+                                                  "left": 0,
+                                                  "overflow": "scroll",
+                                                  "position": "absolute",
+                                                  "top": 0,
+                                                  "visibility": "hidden",
+                                                  "whiteSpace": "pre",
+                                                }
+                                              }
+                                            />
+                                          </div>
+                                        </AutosizeInput>
+                                      </span>
+                                      <span
+                                        className="Select-arrow-zone"
+                                        onMouseDown={[Function]}
+                                      >
+                                        <span
+                                          className="icon-arrow-down"
+                                        />
+                                      </span>
+                                    </div>
                                   </div>
-                                </div>
-                              </Select>
-                            </SelectPicker>
-                          </ForwardRef(SelectPicker)>
-                        </StyledSelect>
-                      </SelectControl>
-                    </StyledSelectControl>
+                                </Select>
+                              </SelectPicker>
+                            </ForwardRef(SelectPicker)>
+                          </StyledSelect>
+                        </SelectControl>
+                      </StyledSelectControl>
+                    </div>
                   </div>
-                </div>
-              </SelectField>
+                </SelectField>
+              </div>
             </div>
+            <div>
+              <button
+                className="btn btn-primary new-project-submit"
+                onClick={[Function]}
+              >
+                Create Project
+              </button>
+            </div>
+            <p>
+              Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
+            </p>
           </div>
-          <div>
-            <button
-              className="btn btn-primary new-project-submit"
-              onClick={[Function]}
-            >
-              Create Project
-            </button>
-          </div>
-          <p>
-            Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
-          </p>
         </div>
-      </div>
+      </Wrapper>
     </OnboardingProject>
   </div>
 </CreateProject>

--- a/tests/js/spec/views/onboarding/__snapshots__/createProject.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/__snapshots__/createProject.spec.jsx.snap
@@ -62,818 +62,807 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
         ]
       }
     >
-      <Wrapper>
-        <div
-          className="css-a5urgt-Wrapper e1bu5aqa0"
+      <div
+        className="onboarding-info"
+      >
+        <h4>
+          Choose a language or framework:
+        </h4>
+        <PlatformPicker
+          name=""
+          next={[Function]}
+          platform=""
+          setName={[Function]}
+          setPlatform={[Function]}
+          setTeam={[Function]}
+          showOther={true}
+          team="test"
+          teams={
+            Array [
+              Object {
+                "hasAccess": true,
+                "id": "1",
+                "name": "test",
+                "slug": "test",
+              },
+            ]
+          }
         >
-          <PageHeading
-            withMargins={true}
-          >
-            <Wrapper
-              withMargins={true}
-            >
-              <h1
-                className="css-13ev48w-Wrapper e1f8hk460"
-              >
-                Choose a language or framework:
-              </h1>
-            </Wrapper>
-          </PageHeading>
-          <PlatformPicker
-            name=""
-            next={[Function]}
-            platform=""
-            setName={[Function]}
-            setPlatform={[Function]}
-            setTeam={[Function]}
-            showOther={true}
-            team="test"
-            teams={
-              Array [
-                Object {
-                  "hasAccess": true,
-                  "id": "1",
-                  "name": "test",
-                  "slug": "test",
-                },
-              ]
-            }
-          >
-            <div
-              className="platform-picker"
-            >
-              <NavTabs>
-                <ul
-                  className="nav nav-tabs"
-                >
-                  <li
-                    style={
-                      Object {
-                        "float": "right",
-                        "marginRight": 0,
-                      }
-                    }
-                  >
-                    <div
-                      className="platform-filter-container"
-                    >
-                      <span
-                        className="icon icon-search"
-                      />
-                      <input
-                        className="platform-filter"
-                        label="Filter"
-                        onChange={[Function]}
-                        placeholder="Filter"
-                        type="text"
-                        value=""
-                      />
-                    </div>
-                  </li>
-                  <ListLink
-                    activeClassName="active"
-                    index={false}
-                    isActive={[Function]}
-                    key="popular"
-                    onClick={[Function]}
-                    to=""
-                  >
-                    <li
-                      className="active"
-                    >
-                      <Link
-                        onClick={[Function]}
-                        onlyActiveOnIndex={false}
-                        style={Object {}}
-                        to=""
-                      >
-                        <a
-                          onClick={[Function]}
-                          style={Object {}}
-                        >
-                          Popular
-                        </a>
-                      </Link>
-                    </li>
-                  </ListLink>
-                  <ListLink
-                    activeClassName="active"
-                    index={false}
-                    isActive={[Function]}
-                    key="browser"
-                    onClick={[Function]}
-                    to=""
-                  >
-                    <li
-                      className=""
-                    >
-                      <Link
-                        onClick={[Function]}
-                        onlyActiveOnIndex={false}
-                        style={Object {}}
-                        to=""
-                      >
-                        <a
-                          onClick={[Function]}
-                          style={Object {}}
-                        >
-                          Browser
-                        </a>
-                      </Link>
-                    </li>
-                  </ListLink>
-                  <ListLink
-                    activeClassName="active"
-                    index={false}
-                    isActive={[Function]}
-                    key="server"
-                    onClick={[Function]}
-                    to=""
-                  >
-                    <li
-                      className=""
-                    >
-                      <Link
-                        onClick={[Function]}
-                        onlyActiveOnIndex={false}
-                        style={Object {}}
-                        to=""
-                      >
-                        <a
-                          onClick={[Function]}
-                          style={Object {}}
-                        >
-                          Server
-                        </a>
-                      </Link>
-                    </li>
-                  </ListLink>
-                  <ListLink
-                    activeClassName="active"
-                    index={false}
-                    isActive={[Function]}
-                    key="mobile"
-                    onClick={[Function]}
-                    to=""
-                  >
-                    <li
-                      className=""
-                    >
-                      <Link
-                        onClick={[Function]}
-                        onlyActiveOnIndex={false}
-                        style={Object {}}
-                        to=""
-                      >
-                        <a
-                          onClick={[Function]}
-                          style={Object {}}
-                        >
-                          Mobile
-                        </a>
-                      </Link>
-                    </li>
-                  </ListLink>
-                  <ListLink
-                    activeClassName="active"
-                    index={false}
-                    isActive={[Function]}
-                    key="desktop"
-                    onClick={[Function]}
-                    to=""
-                  >
-                    <li
-                      className=""
-                    >
-                      <Link
-                        onClick={[Function]}
-                        onlyActiveOnIndex={false}
-                        style={Object {}}
-                        to=""
-                      >
-                        <a
-                          onClick={[Function]}
-                          style={Object {}}
-                        >
-                          Desktop
-                        </a>
-                      </Link>
-                    </li>
-                  </ListLink>
-                  <ListLink
-                    activeClassName="active"
-                    index={false}
-                    isActive={[Function]}
-                    key="all"
-                    onClick={[Function]}
-                    to=""
-                  >
-                    <li
-                      className=""
-                    >
-                      <Link
-                        onClick={[Function]}
-                        onlyActiveOnIndex={false}
-                        style={Object {}}
-                        to=""
-                      >
-                        <a
-                          onClick={[Function]}
-                          style={Object {}}
-                        >
-                          All
-                        </a>
-                      </Link>
-                    </li>
-                  </ListLink>
-                </ul>
-              </NavTabs>
-              <ul
-                className="client-platform-list platform-tiles"
-              >
-                <PlatformCard
-                  className=""
-                  key="csharp"
-                  onClick={[Function]}
-                  platform="csharp"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="csharp"
-                    >
-                      <li
-                        className="platform-tile list-unstyled csharp csharp "
-                      >
-                        <span
-                          className="platformicon platformicon-csharp"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      C#
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="java"
-                  onClick={[Function]}
-                  platform="java"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="java"
-                    >
-                      <li
-                        className="platform-tile list-unstyled java java "
-                      >
-                        <span
-                          className="platformicon platformicon-java"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Java
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="javascript-angular"
-                  onClick={[Function]}
-                  platform="javascript-angular"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="javascript-angular"
-                    >
-                      <li
-                        className="platform-tile list-unstyled javascript-angular javascript "
-                      >
-                        <span
-                          className="platformicon platformicon-javascript-angular"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Angular
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="javascript"
-                  onClick={[Function]}
-                  platform="javascript"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="javascript"
-                    >
-                      <li
-                        className="platform-tile list-unstyled javascript javascript "
-                      >
-                        <span
-                          className="platformicon platformicon-javascript"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      JavaScript
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="javascript-react"
-                  onClick={[Function]}
-                  platform="javascript-react"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="javascript-react"
-                    >
-                      <li
-                        className="platform-tile list-unstyled javascript-react javascript "
-                      >
-                        <span
-                          className="platformicon platformicon-javascript-react"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      React
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="node-express"
-                  onClick={[Function]}
-                  platform="node-express"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="node-express"
-                    >
-                      <li
-                        className="platform-tile list-unstyled node-express node "
-                      >
-                        <span
-                          className="platformicon platformicon-node-express"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Express
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="node"
-                  onClick={[Function]}
-                  platform="node"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="node"
-                    >
-                      <li
-                        className="platform-tile list-unstyled node node "
-                      >
-                        <span
-                          className="platformicon platformicon-node"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Node.js
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="php-laravel"
-                  onClick={[Function]}
-                  platform="php-laravel"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="php-laravel"
-                    >
-                      <li
-                        className="platform-tile list-unstyled php-laravel php "
-                      >
-                        <span
-                          className="platformicon platformicon-php-laravel"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Laravel
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="php"
-                  onClick={[Function]}
-                  platform="php"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="php"
-                    >
-                      <li
-                        className="platform-tile list-unstyled php php "
-                      >
-                        <span
-                          className="platformicon platformicon-php"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      PHP
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="php-symfony2"
-                  onClick={[Function]}
-                  platform="php-symfony2"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="php-symfony2"
-                    >
-                      <li
-                        className="platform-tile list-unstyled php-symfony2 php "
-                      >
-                        <span
-                          className="platformicon platformicon-php-symfony2"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Symfony2
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="python-django"
-                  onClick={[Function]}
-                  platform="python-django"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="python-django"
-                    >
-                      <li
-                        className="platform-tile list-unstyled python-django python "
-                      >
-                        <span
-                          className="platformicon platformicon-python-django"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Django
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="python-flask"
-                  onClick={[Function]}
-                  platform="python-flask"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="python-flask"
-                    >
-                      <li
-                        className="platform-tile list-unstyled python-flask python "
-                      >
-                        <span
-                          className="platformicon platformicon-python-flask"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Flask
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="python"
-                  onClick={[Function]}
-                  platform="python"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="python"
-                    >
-                      <li
-                        className="platform-tile list-unstyled python python "
-                      >
-                        <span
-                          className="platformicon platformicon-python"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Python
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="cocoa"
-                  onClick={[Function]}
-                  platform="cocoa"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="cocoa"
-                    >
-                      <li
-                        className="platform-tile list-unstyled cocoa cocoa "
-                      >
-                        <span
-                          className="platformicon platformicon-cocoa"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      React-Native
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="ruby-rails"
-                  onClick={[Function]}
-                  platform="ruby-rails"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="ruby-rails"
-                    >
-                      <li
-                        className="platform-tile list-unstyled ruby-rails ruby "
-                      >
-                        <span
-                          className="platformicon platformicon-ruby-rails"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Rails
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="ruby"
-                  onClick={[Function]}
-                  platform="ruby"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="ruby"
-                    >
-                      <li
-                        className="platform-tile list-unstyled ruby ruby "
-                      >
-                        <span
-                          className="platformicon platformicon-ruby"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Ruby
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-              </ul>
-            </div>
-          </PlatformPicker>
           <div
-            className="create-project-form"
+            className="platform-picker"
           >
-            <div
-              className="new-project-name client-platform"
-            >
-              <PageHeading
-                withMargins={true}
+            <NavTabs>
+              <ul
+                className="nav nav-tabs"
               >
-                <Wrapper
-                  withMargins={true}
+                <li
+                  style={
+                    Object {
+                      "float": "right",
+                      "marginRight": 0,
+                    }
+                  }
                 >
-                  <h1
-                    className="css-13ev48w-Wrapper e1f8hk460"
-                  >
-                    Give your project a name:
-                  </h1>
-                </Wrapper>
-              </PageHeading>
-              <div
-                className="project-name-wrapper"
-              >
-                <PlatformiconTile
-                  platform=""
-                >
-                  <li
-                    className="platform-tile list-unstyled   undefined"
+                  <div
+                    className="platform-filter-container"
                   >
                     <span
-                      className="platformicon platformicon-"
+                      className="icon icon-search"
                     />
-                  </li>
-                </PlatformiconTile>
-                <input
-                  autoComplete="off"
-                  label="Project Name"
-                  name="name"
-                  onChange={[Function]}
-                  placeholder="Project name"
-                  type="text"
-                  value=""
-                />
-              </div>
-            </div>
-            <div
-              className="new-project-team"
-            >
-              <PageHeading
-                withMargins={true}
-              >
-                <Wrapper
-                  withMargins={true}
+                    <input
+                      className="platform-filter"
+                      label="Filter"
+                      onChange={[Function]}
+                      placeholder="Filter"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </li>
+                <ListLink
+                  activeClassName="active"
+                  index={false}
+                  isActive={[Function]}
+                  key="popular"
+                  onClick={[Function]}
+                  to=""
                 >
-                  <h1
-                    className="css-13ev48w-Wrapper e1f8hk460"
+                  <li
+                    className="active"
                   >
-                    Team:
-                  </h1>
-                </Wrapper>
-              </PageHeading>
-              <div>
-                <SelectField
-                  clearable={false}
-                  disabled={false}
-                  hideErrorMessage={false}
-                  multiple={false}
-                  name="select-team"
-                  onChange={[Function]}
-                  options={
-                    Array [
-                      Object {
-                        "label": "#test",
-                        "value": "test",
-                      },
-                    ]
+                    <Link
+                      onClick={[Function]}
+                      onlyActiveOnIndex={false}
+                      style={Object {}}
+                      to=""
+                    >
+                      <a
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        Popular
+                      </a>
+                    </Link>
+                  </li>
+                </ListLink>
+                <ListLink
+                  activeClassName="active"
+                  index={false}
+                  isActive={[Function]}
+                  key="browser"
+                  onClick={[Function]}
+                  to=""
+                >
+                  <li
+                    className=""
+                  >
+                    <Link
+                      onClick={[Function]}
+                      onlyActiveOnIndex={false}
+                      style={Object {}}
+                      to=""
+                    >
+                      <a
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        Browser
+                      </a>
+                    </Link>
+                  </li>
+                </ListLink>
+                <ListLink
+                  activeClassName="active"
+                  index={false}
+                  isActive={[Function]}
+                  key="server"
+                  onClick={[Function]}
+                  to=""
+                >
+                  <li
+                    className=""
+                  >
+                    <Link
+                      onClick={[Function]}
+                      onlyActiveOnIndex={false}
+                      style={Object {}}
+                      to=""
+                    >
+                      <a
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        Server
+                      </a>
+                    </Link>
+                  </li>
+                </ListLink>
+                <ListLink
+                  activeClassName="active"
+                  index={false}
+                  isActive={[Function]}
+                  key="mobile"
+                  onClick={[Function]}
+                  to=""
+                >
+                  <li
+                    className=""
+                  >
+                    <Link
+                      onClick={[Function]}
+                      onlyActiveOnIndex={false}
+                      style={Object {}}
+                      to=""
+                    >
+                      <a
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        Mobile
+                      </a>
+                    </Link>
+                  </li>
+                </ListLink>
+                <ListLink
+                  activeClassName="active"
+                  index={false}
+                  isActive={[Function]}
+                  key="desktop"
+                  onClick={[Function]}
+                  to=""
+                >
+                  <li
+                    className=""
+                  >
+                    <Link
+                      onClick={[Function]}
+                      onlyActiveOnIndex={false}
+                      style={Object {}}
+                      to=""
+                    >
+                      <a
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        Desktop
+                      </a>
+                    </Link>
+                  </li>
+                </ListLink>
+                <ListLink
+                  activeClassName="active"
+                  index={false}
+                  isActive={[Function]}
+                  key="all"
+                  onClick={[Function]}
+                  to=""
+                >
+                  <li
+                    className=""
+                  >
+                    <Link
+                      onClick={[Function]}
+                      onlyActiveOnIndex={false}
+                      style={Object {}}
+                      to=""
+                    >
+                      <a
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        All
+                      </a>
+                    </Link>
+                  </li>
+                </ListLink>
+              </ul>
+            </NavTabs>
+            <ul
+              className="client-platform-list platform-tiles"
+            >
+              <PlatformCard
+                className=""
+                key="csharp"
+                onClick={[Function]}
+                platform="csharp"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="csharp"
+                  >
+                    <li
+                      className="platform-tile list-unstyled csharp csharp "
+                    >
+                      <span
+                        className="platformicon platformicon-csharp"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    C#
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="java"
+                onClick={[Function]}
+                platform="java"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="java"
+                  >
+                    <li
+                      className="platform-tile list-unstyled java java "
+                    >
+                      <span
+                        className="platformicon platformicon-java"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Java
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="javascript-angular"
+                onClick={[Function]}
+                platform="javascript-angular"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="javascript-angular"
+                  >
+                    <li
+                      className="platform-tile list-unstyled javascript-angular javascript "
+                    >
+                      <span
+                        className="platformicon platformicon-javascript-angular"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Angular
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="javascript"
+                onClick={[Function]}
+                platform="javascript"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="javascript"
+                  >
+                    <li
+                      className="platform-tile list-unstyled javascript javascript "
+                    >
+                      <span
+                        className="platformicon platformicon-javascript"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    JavaScript
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="javascript-react"
+                onClick={[Function]}
+                platform="javascript-react"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="javascript-react"
+                  >
+                    <li
+                      className="platform-tile list-unstyled javascript-react javascript "
+                    >
+                      <span
+                        className="platformicon platformicon-javascript-react"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    React
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="node-express"
+                onClick={[Function]}
+                platform="node-express"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="node-express"
+                  >
+                    <li
+                      className="platform-tile list-unstyled node-express node "
+                    >
+                      <span
+                        className="platformicon platformicon-node-express"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Express
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="node"
+                onClick={[Function]}
+                platform="node"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="node"
+                  >
+                    <li
+                      className="platform-tile list-unstyled node node "
+                    >
+                      <span
+                        className="platformicon platformicon-node"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Node.js
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="php-laravel"
+                onClick={[Function]}
+                platform="php-laravel"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="php-laravel"
+                  >
+                    <li
+                      className="platform-tile list-unstyled php-laravel php "
+                    >
+                      <span
+                        className="platformicon platformicon-php-laravel"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Laravel
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="php"
+                onClick={[Function]}
+                platform="php"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="php"
+                  >
+                    <li
+                      className="platform-tile list-unstyled php php "
+                    >
+                      <span
+                        className="platformicon platformicon-php"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    PHP
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="php-symfony2"
+                onClick={[Function]}
+                platform="php-symfony2"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="php-symfony2"
+                  >
+                    <li
+                      className="platform-tile list-unstyled php-symfony2 php "
+                    >
+                      <span
+                        className="platformicon platformicon-php-symfony2"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Symfony2
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="python-django"
+                onClick={[Function]}
+                platform="python-django"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="python-django"
+                  >
+                    <li
+                      className="platform-tile list-unstyled python-django python "
+                    >
+                      <span
+                        className="platformicon platformicon-python-django"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Django
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="python-flask"
+                onClick={[Function]}
+                platform="python-flask"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="python-flask"
+                  >
+                    <li
+                      className="platform-tile list-unstyled python-flask python "
+                    >
+                      <span
+                        className="platformicon platformicon-python-flask"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Flask
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="python"
+                onClick={[Function]}
+                platform="python"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="python"
+                  >
+                    <li
+                      className="platform-tile list-unstyled python python "
+                    >
+                      <span
+                        className="platformicon platformicon-python"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Python
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="cocoa"
+                onClick={[Function]}
+                platform="cocoa"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="cocoa"
+                  >
+                    <li
+                      className="platform-tile list-unstyled cocoa cocoa "
+                    >
+                      <span
+                        className="platformicon platformicon-cocoa"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    React-Native
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="ruby-rails"
+                onClick={[Function]}
+                platform="ruby-rails"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="ruby-rails"
+                  >
+                    <li
+                      className="platform-tile list-unstyled ruby-rails ruby "
+                    >
+                      <span
+                        className="platformicon platformicon-ruby-rails"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Rails
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="ruby"
+                onClick={[Function]}
+                platform="ruby"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="ruby"
+                  >
+                    <li
+                      className="platform-tile list-unstyled ruby ruby "
+                    >
+                      <span
+                        className="platformicon platformicon-ruby"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Ruby
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+            </ul>
+          </div>
+        </PlatformPicker>
+        <div
+          className="create-project-form"
+        >
+          <div
+            className="new-project-name client-platform"
+          >
+            <h4>
+              Give your project a name:
+            </h4>
+            <div
+              className="project-name-wrapper"
+            >
+              <PlatformiconTile
+                platform=""
+              >
+                <li
+                  className="platform-tile list-unstyled   undefined"
+                >
+                  <span
+                    className="platformicon platformicon-"
+                  />
+                </li>
+              </PlatformiconTile>
+              <input
+                autoComplete="off"
+                label="Project Name"
+                name="name"
+                onChange={[Function]}
+                placeholder="Project name"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            className="new-project-team"
+          >
+            <h4>
+              Team:
+            </h4>
+            <div>
+              <SelectField
+                clearable={false}
+                disabled={false}
+                hideErrorMessage={false}
+                multiple={false}
+                name="select-team"
+                onChange={[Function]}
+                options={
+                  Array [
+                    Object {
+                      "label": "#test",
+                      "value": "test",
+                    },
+                  ]
+                }
+                required={false}
+                style={
+                  Object {
+                    "marginBottom": 0,
+                    "width": 180,
                   }
-                  required={false}
+                }
+                value="test"
+              >
+                <div
+                  className=""
                   style={
                     Object {
                       "marginBottom": 0,
                       "width": 180,
                     }
                   }
-                  value="test"
                 >
                   <div
-                    className=""
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "width": 180,
-                      }
-                    }
+                    className="controls"
                   >
-                    <div
-                      className="controls"
+                    <StyledSelectControl
+                      clearable={false}
+                      disabled={false}
+                      id="id-select-team"
+                      multiple={false}
+                      name="select-team"
+                      onChange={[Function]}
+                      options={
+                        Array [
+                          Object {
+                            "label": "#test",
+                            "value": "test",
+                          },
+                        ]
+                      }
+                      required={false}
+                      value="test"
                     >
-                      <StyledSelectControl
+                      <SelectControl
+                        className="css-j6zs66-StyledSelectControl e1qrhqd00"
                         clearable={false}
                         disabled={false}
+                        height={36}
                         id="id-select-team"
                         multiple={false}
                         name="select-team"
@@ -889,9 +878,12 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                         required={false}
                         value="test"
                       >
-                        <SelectControl
+                        <StyledSelect
+                          arrowRenderer={[Function]}
+                          backspaceRemoves={false}
                           className="css-j6zs66-StyledSelectControl e1qrhqd00"
                           clearable={false}
+                          deleteRemoves={false}
                           disabled={false}
                           height={36}
                           id="id-select-team"
@@ -909,10 +901,10 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                           required={false}
                           value="test"
                         >
-                          <StyledSelect
+                          <ForwardRef(SelectPicker)
                             arrowRenderer={[Function]}
                             backspaceRemoves={false}
-                            className="css-j6zs66-StyledSelectControl e1qrhqd00"
+                            className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                             clearable={false}
                             deleteRemoves={false}
                             disabled={false}
@@ -932,13 +924,14 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                             required={false}
                             value="test"
                           >
-                            <ForwardRef(SelectPicker)
+                            <SelectPicker
                               arrowRenderer={[Function]}
                               backspaceRemoves={false}
                               className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                               clearable={false}
                               deleteRemoves={false}
                               disabled={false}
+                              forwardedRef={null}
                               height={36}
                               id="id-select-team"
                               multiple={false}
@@ -955,19 +948,44 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                               required={false}
                               value="test"
                             >
-                              <SelectPicker
+                              <Select
                                 arrowRenderer={[Function]}
+                                autosize={true}
                                 backspaceRemoves={false}
+                                backspaceToRemoveMessage="Press backspace to remove {label}"
                                 className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                clearAllText="Clear all"
+                                clearRenderer={[Function]}
+                                clearValueText="Clear value"
                                 clearable={false}
+                                closeOnSelect={true}
                                 deleteRemoves={false}
+                                delimiter=","
                                 disabled={false}
-                                forwardedRef={null}
+                                escapeClearsValue={true}
+                                filterOptions={[Function]}
                                 height={36}
                                 id="id-select-team"
+                                ignoreAccents={true}
+                                ignoreCase={true}
+                                inputProps={Object {}}
+                                isLoading={false}
+                                joinValues={false}
+                                labelKey="label"
+                                matchPos="any"
+                                matchProp="any"
+                                menuBuffer={0}
+                                menuRenderer={[Function]}
+                                multi={false}
                                 multiple={false}
                                 name="select-team"
+                                noResultsText="No results found"
+                                onBlurResetsInput={true}
                                 onChange={[Function]}
+                                onCloseResetsInput={true}
+                                onSelectResetsInput={true}
+                                openOnClick={true}
+                                optionComponent={[Function]}
                                 options={
                                   Array [
                                     Object {
@@ -976,211 +994,161 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                                     },
                                   ]
                                 }
+                                pageSize={5}
+                                placeholder="Select..."
+                                removeSelected={true}
                                 required={false}
+                                rtl={false}
+                                scrollMenuIntoView={true}
+                                searchable={true}
+                                simpleValue={false}
+                                tabSelectsValue={true}
+                                trimFilter={true}
                                 value="test"
+                                valueComponent={[Function]}
+                                valueKey="value"
                               >
-                                <Select
-                                  arrowRenderer={[Function]}
-                                  autosize={true}
-                                  backspaceRemoves={false}
-                                  backspaceToRemoveMessage="Press backspace to remove {label}"
-                                  className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
-                                  clearAllText="Clear all"
-                                  clearRenderer={[Function]}
-                                  clearValueText="Clear value"
-                                  clearable={false}
-                                  closeOnSelect={true}
-                                  deleteRemoves={false}
-                                  delimiter=","
-                                  disabled={false}
-                                  escapeClearsValue={true}
-                                  filterOptions={[Function]}
-                                  height={36}
-                                  id="id-select-team"
-                                  ignoreAccents={true}
-                                  ignoreCase={true}
-                                  inputProps={Object {}}
-                                  isLoading={false}
-                                  joinValues={false}
-                                  labelKey="label"
-                                  matchPos="any"
-                                  matchProp="any"
-                                  menuBuffer={0}
-                                  menuRenderer={[Function]}
-                                  multi={false}
-                                  multiple={false}
-                                  name="select-team"
-                                  noResultsText="No results found"
-                                  onBlurResetsInput={true}
-                                  onChange={[Function]}
-                                  onCloseResetsInput={true}
-                                  onSelectResetsInput={true}
-                                  openOnClick={true}
-                                  optionComponent={[Function]}
-                                  options={
-                                    Array [
-                                      Object {
-                                        "label": "#test",
-                                        "value": "test",
-                                      },
-                                    ]
-                                  }
-                                  pageSize={5}
-                                  placeholder="Select..."
-                                  removeSelected={true}
-                                  required={false}
-                                  rtl={false}
-                                  scrollMenuIntoView={true}
-                                  searchable={true}
-                                  simpleValue={false}
-                                  tabSelectsValue={true}
-                                  trimFilter={true}
-                                  value="test"
-                                  valueComponent={[Function]}
-                                  valueKey="value"
+                                <div
+                                  className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                 >
+                                  <input
+                                    disabled={false}
+                                    key="hidden.0"
+                                    name="select-team"
+                                    type="hidden"
+                                    value="test"
+                                  />
                                   <div
-                                    className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                                    className="Select-control"
+                                    onKeyDown={[Function]}
+                                    onMouseDown={[Function]}
+                                    onTouchEnd={[Function]}
+                                    onTouchMove={[Function]}
+                                    onTouchStart={[Function]}
                                   >
-                                    <input
-                                      disabled={false}
-                                      key="hidden.0"
-                                      name="select-team"
-                                      type="hidden"
-                                      value="test"
-                                    />
-                                    <div
-                                      className="Select-control"
-                                      onKeyDown={[Function]}
-                                      onMouseDown={[Function]}
-                                      onTouchEnd={[Function]}
-                                      onTouchMove={[Function]}
-                                      onTouchStart={[Function]}
+                                    <span
+                                      className="Select-multi-value-wrapper"
+                                      id="react-select-4--value"
                                     >
-                                      <span
-                                        className="Select-multi-value-wrapper"
-                                        id="react-select-4--value"
+                                      <Value
+                                        disabled={false}
+                                        id="react-select-4--value-item"
+                                        instancePrefix="react-select-4-"
+                                        onClick={null}
+                                        placeholder="Select..."
+                                        value={
+                                          Object {
+                                            "label": "#test",
+                                            "value": "test",
+                                          }
+                                        }
                                       >
-                                        <Value
-                                          disabled={false}
-                                          id="react-select-4--value-item"
-                                          instancePrefix="react-select-4-"
-                                          onClick={null}
-                                          placeholder="Select..."
-                                          value={
+                                        <div
+                                          className="Select-value"
+                                        >
+                                          <span
+                                            aria-selected="true"
+                                            className="Select-value-label"
+                                            id="react-select-4--value-item"
+                                            role="option"
+                                          >
+                                            #test
+                                          </span>
+                                        </div>
+                                      </Value>
+                                      <AutosizeInput
+                                        aria-activedescendant="react-select-4--value"
+                                        aria-expanded="false"
+                                        aria-haspopup="false"
+                                        aria-owns=""
+                                        className="Select-input"
+                                        id="id-select-team"
+                                        injectStyles={true}
+                                        minWidth="5"
+                                        onBlur={[Function]}
+                                        onChange={[Function]}
+                                        onFocus={[Function]}
+                                        required={false}
+                                        role="combobox"
+                                        value=""
+                                      >
+                                        <div
+                                          className="Select-input"
+                                          style={
                                             Object {
-                                              "label": "#test",
-                                              "value": "test",
+                                              "display": "inline-block",
                                             }
                                           }
                                         >
-                                          <div
-                                            className="Select-value"
-                                          >
-                                            <span
-                                              aria-selected="true"
-                                              className="Select-value-label"
-                                              id="react-select-4--value-item"
-                                              role="option"
-                                            >
-                                              #test
-                                            </span>
-                                          </div>
-                                        </Value>
-                                        <AutosizeInput
-                                          aria-activedescendant="react-select-4--value"
-                                          aria-expanded="false"
-                                          aria-haspopup="false"
-                                          aria-owns=""
-                                          className="Select-input"
-                                          id="id-select-team"
-                                          injectStyles={true}
-                                          minWidth="5"
-                                          onBlur={[Function]}
-                                          onChange={[Function]}
-                                          onFocus={[Function]}
-                                          required={false}
-                                          role="combobox"
-                                          value=""
-                                        >
-                                          <div
-                                            className="Select-input"
+                                          <input
+                                            aria-activedescendant="react-select-4--value"
+                                            aria-expanded="false"
+                                            aria-haspopup="false"
+                                            aria-owns=""
+                                            id="id-select-team"
+                                            onBlur={[Function]}
+                                            onChange={[Function]}
+                                            onFocus={[Function]}
+                                            required={false}
+                                            role="combobox"
                                             style={
                                               Object {
-                                                "display": "inline-block",
+                                                "boxSizing": "content-box",
+                                                "width": "5px",
                                               }
                                             }
-                                          >
-                                            <input
-                                              aria-activedescendant="react-select-4--value"
-                                              aria-expanded="false"
-                                              aria-haspopup="false"
-                                              aria-owns=""
-                                              id="id-select-team"
-                                              onBlur={[Function]}
-                                              onChange={[Function]}
-                                              onFocus={[Function]}
-                                              required={false}
-                                              role="combobox"
-                                              style={
-                                                Object {
-                                                  "boxSizing": "content-box",
-                                                  "width": "5px",
-                                                }
+                                            value=""
+                                          />
+                                          <div
+                                            style={
+                                              Object {
+                                                "height": 0,
+                                                "left": 0,
+                                                "overflow": "scroll",
+                                                "position": "absolute",
+                                                "top": 0,
+                                                "visibility": "hidden",
+                                                "whiteSpace": "pre",
                                               }
-                                              value=""
-                                            />
-                                            <div
-                                              style={
-                                                Object {
-                                                  "height": 0,
-                                                  "left": 0,
-                                                  "overflow": "scroll",
-                                                  "position": "absolute",
-                                                  "top": 0,
-                                                  "visibility": "hidden",
-                                                  "whiteSpace": "pre",
-                                                }
-                                              }
-                                            />
-                                          </div>
-                                        </AutosizeInput>
-                                      </span>
+                                            }
+                                          />
+                                        </div>
+                                      </AutosizeInput>
+                                    </span>
+                                    <span
+                                      className="Select-arrow-zone"
+                                      onMouseDown={[Function]}
+                                    >
                                       <span
-                                        className="Select-arrow-zone"
-                                        onMouseDown={[Function]}
-                                      >
-                                        <span
-                                          className="icon-arrow-down"
-                                        />
-                                      </span>
-                                    </div>
+                                        className="icon-arrow-down"
+                                      />
+                                    </span>
                                   </div>
-                                </Select>
-                              </SelectPicker>
-                            </ForwardRef(SelectPicker)>
-                          </StyledSelect>
-                        </SelectControl>
-                      </StyledSelectControl>
-                    </div>
+                                </div>
+                              </Select>
+                            </SelectPicker>
+                          </ForwardRef(SelectPicker)>
+                        </StyledSelect>
+                      </SelectControl>
+                    </StyledSelectControl>
                   </div>
-                </SelectField>
-              </div>
+                </div>
+              </SelectField>
             </div>
-            <div>
-              <button
-                className="btn btn-primary new-project-submit"
-                onClick={[Function]}
-              >
-                Create Project
-              </button>
-            </div>
-            <p>
-              Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
-            </p>
           </div>
+          <div>
+            <button
+              className="btn btn-primary new-project-submit"
+              onClick={[Function]}
+            >
+              Create Project
+            </button>
+          </div>
+          <p>
+            Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
+          </p>
         </div>
-      </Wrapper>
+      </div>
     </OnboardingProject>
   </div>
 </CreateProject>
@@ -1221,428 +1189,417 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
         ]
       }
     >
-      <Wrapper>
-        <div
-          className="css-a5urgt-Wrapper e1bu5aqa0"
+      <div
+        className="onboarding-info"
+      >
+        <h4>
+          Choose a language or framework:
+        </h4>
+        <PlatformPicker
+          name="Ruby"
+          next={[Function]}
+          platform="ruby"
+          setName={[Function]}
+          setPlatform={[Function]}
+          setTeam={[Function]}
+          showOther={true}
+          team="test"
+          teams={
+            Array [
+              Object {
+                "hasAccess": true,
+                "id": "1",
+                "name": "test",
+                "slug": "test",
+              },
+            ]
+          }
         >
-          <PageHeading
-            withMargins={true}
-          >
-            <Wrapper
-              withMargins={true}
-            >
-              <h1
-                className="css-13ev48w-Wrapper e1f8hk460"
-              >
-                Choose a language or framework:
-              </h1>
-            </Wrapper>
-          </PageHeading>
-          <PlatformPicker
-            name="Ruby"
-            next={[Function]}
-            platform="ruby"
-            setName={[Function]}
-            setPlatform={[Function]}
-            setTeam={[Function]}
-            showOther={true}
-            team="test"
-            teams={
-              Array [
-                Object {
-                  "hasAccess": true,
-                  "id": "1",
-                  "name": "test",
-                  "slug": "test",
-                },
-              ]
-            }
-          >
-            <div
-              className="platform-picker"
-            >
-              <NavTabs>
-                <ul
-                  className="nav nav-tabs"
-                >
-                  <li
-                    style={
-                      Object {
-                        "float": "right",
-                        "marginRight": 0,
-                      }
-                    }
-                  >
-                    <div
-                      className="platform-filter-container"
-                    >
-                      <span
-                        className="icon icon-search"
-                      />
-                      <input
-                        className="platform-filter"
-                        label="Filter"
-                        onChange={[Function]}
-                        placeholder="Filter"
-                        type="text"
-                        value="ruby"
-                      />
-                    </div>
-                  </li>
-                  <ListLink
-                    activeClassName="active"
-                    index={false}
-                    isActive={[Function]}
-                    key="popular"
-                    onClick={[Function]}
-                    to=""
-                  >
-                    <li
-                      className=""
-                    >
-                      <Link
-                        onClick={[Function]}
-                        onlyActiveOnIndex={false}
-                        style={Object {}}
-                        to=""
-                      >
-                        <a
-                          onClick={[Function]}
-                          style={Object {}}
-                        >
-                          Popular
-                        </a>
-                      </Link>
-                    </li>
-                  </ListLink>
-                  <ListLink
-                    activeClassName="active"
-                    index={false}
-                    isActive={[Function]}
-                    key="browser"
-                    onClick={[Function]}
-                    to=""
-                  >
-                    <li
-                      className=""
-                    >
-                      <Link
-                        onClick={[Function]}
-                        onlyActiveOnIndex={false}
-                        style={Object {}}
-                        to=""
-                      >
-                        <a
-                          onClick={[Function]}
-                          style={Object {}}
-                        >
-                          Browser
-                        </a>
-                      </Link>
-                    </li>
-                  </ListLink>
-                  <ListLink
-                    activeClassName="active"
-                    index={false}
-                    isActive={[Function]}
-                    key="server"
-                    onClick={[Function]}
-                    to=""
-                  >
-                    <li
-                      className=""
-                    >
-                      <Link
-                        onClick={[Function]}
-                        onlyActiveOnIndex={false}
-                        style={Object {}}
-                        to=""
-                      >
-                        <a
-                          onClick={[Function]}
-                          style={Object {}}
-                        >
-                          Server
-                        </a>
-                      </Link>
-                    </li>
-                  </ListLink>
-                  <ListLink
-                    activeClassName="active"
-                    index={false}
-                    isActive={[Function]}
-                    key="mobile"
-                    onClick={[Function]}
-                    to=""
-                  >
-                    <li
-                      className=""
-                    >
-                      <Link
-                        onClick={[Function]}
-                        onlyActiveOnIndex={false}
-                        style={Object {}}
-                        to=""
-                      >
-                        <a
-                          onClick={[Function]}
-                          style={Object {}}
-                        >
-                          Mobile
-                        </a>
-                      </Link>
-                    </li>
-                  </ListLink>
-                  <ListLink
-                    activeClassName="active"
-                    index={false}
-                    isActive={[Function]}
-                    key="desktop"
-                    onClick={[Function]}
-                    to=""
-                  >
-                    <li
-                      className=""
-                    >
-                      <Link
-                        onClick={[Function]}
-                        onlyActiveOnIndex={false}
-                        style={Object {}}
-                        to=""
-                      >
-                        <a
-                          onClick={[Function]}
-                          style={Object {}}
-                        >
-                          Desktop
-                        </a>
-                      </Link>
-                    </li>
-                  </ListLink>
-                  <ListLink
-                    activeClassName="active"
-                    index={false}
-                    isActive={[Function]}
-                    key="all"
-                    onClick={[Function]}
-                    to=""
-                  >
-                    <li
-                      className="active"
-                    >
-                      <Link
-                        onClick={[Function]}
-                        onlyActiveOnIndex={false}
-                        style={Object {}}
-                        to=""
-                      >
-                        <a
-                          onClick={[Function]}
-                          style={Object {}}
-                        >
-                          All
-                        </a>
-                      </Link>
-                    </li>
-                  </ListLink>
-                </ul>
-              </NavTabs>
-              <ul
-                className="client-platform-list platform-tiles"
-              >
-                <PlatformCard
-                  className=""
-                  key="ruby-rack"
-                  onClick={[Function]}
-                  platform="ruby-rack"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="ruby-rack"
-                    >
-                      <li
-                        className="platform-tile list-unstyled ruby-rack ruby "
-                      >
-                        <span
-                          className="platformicon platformicon-ruby-rack"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Rack
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="ruby-rails"
-                  onClick={[Function]}
-                  platform="ruby-rails"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="ruby-rails"
-                    >
-                      <li
-                        className="platform-tile list-unstyled ruby-rails ruby "
-                      >
-                        <span
-                          className="platformicon platformicon-ruby-rails"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Rails
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className="selected"
-                  key="ruby"
-                  onClick={[Function]}
-                  platform="ruby"
-                >
-                  <span
-                    className="platform-card selected"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className="selected"
-                      onClick={[Function]}
-                      platform="ruby"
-                    >
-                      <li
-                        className="platform-tile list-unstyled ruby ruby selected"
-                      >
-                        <span
-                          className="platformicon platformicon-ruby"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Ruby
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-              </ul>
-            </div>
-          </PlatformPicker>
           <div
-            className="create-project-form"
+            className="platform-picker"
           >
-            <div
-              className="new-project-name client-platform"
-            >
-              <PageHeading
-                withMargins={true}
+            <NavTabs>
+              <ul
+                className="nav nav-tabs"
               >
-                <Wrapper
-                  withMargins={true}
+                <li
+                  style={
+                    Object {
+                      "float": "right",
+                      "marginRight": 0,
+                    }
+                  }
                 >
-                  <h1
-                    className="css-13ev48w-Wrapper e1f8hk460"
-                  >
-                    Give your project a name:
-                  </h1>
-                </Wrapper>
-              </PageHeading>
-              <div
-                className="project-name-wrapper"
-              >
-                <PlatformiconTile
-                  platform="ruby"
-                >
-                  <li
-                    className="platform-tile list-unstyled ruby ruby undefined"
+                  <div
+                    className="platform-filter-container"
                   >
                     <span
-                      className="platformicon platformicon-ruby"
+                      className="icon icon-search"
                     />
-                  </li>
-                </PlatformiconTile>
-                <input
-                  autoComplete="off"
-                  label="Project Name"
-                  name="name"
-                  onChange={[Function]}
-                  placeholder="Project name"
-                  type="text"
-                  value="Ruby"
-                />
-              </div>
-            </div>
-            <div
-              className="new-project-team"
-            >
-              <PageHeading
-                withMargins={true}
-              >
-                <Wrapper
-                  withMargins={true}
+                    <input
+                      className="platform-filter"
+                      label="Filter"
+                      onChange={[Function]}
+                      placeholder="Filter"
+                      type="text"
+                      value="ruby"
+                    />
+                  </div>
+                </li>
+                <ListLink
+                  activeClassName="active"
+                  index={false}
+                  isActive={[Function]}
+                  key="popular"
+                  onClick={[Function]}
+                  to=""
                 >
-                  <h1
-                    className="css-13ev48w-Wrapper e1f8hk460"
+                  <li
+                    className=""
                   >
-                    Team:
-                  </h1>
-                </Wrapper>
-              </PageHeading>
-              <div>
-                <SelectField
-                  clearable={false}
-                  disabled={false}
-                  hideErrorMessage={false}
-                  multiple={false}
-                  name="select-team"
-                  onChange={[Function]}
-                  options={
-                    Array [
-                      Object {
-                        "label": "#test",
-                        "value": "test",
-                      },
-                    ]
+                    <Link
+                      onClick={[Function]}
+                      onlyActiveOnIndex={false}
+                      style={Object {}}
+                      to=""
+                    >
+                      <a
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        Popular
+                      </a>
+                    </Link>
+                  </li>
+                </ListLink>
+                <ListLink
+                  activeClassName="active"
+                  index={false}
+                  isActive={[Function]}
+                  key="browser"
+                  onClick={[Function]}
+                  to=""
+                >
+                  <li
+                    className=""
+                  >
+                    <Link
+                      onClick={[Function]}
+                      onlyActiveOnIndex={false}
+                      style={Object {}}
+                      to=""
+                    >
+                      <a
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        Browser
+                      </a>
+                    </Link>
+                  </li>
+                </ListLink>
+                <ListLink
+                  activeClassName="active"
+                  index={false}
+                  isActive={[Function]}
+                  key="server"
+                  onClick={[Function]}
+                  to=""
+                >
+                  <li
+                    className=""
+                  >
+                    <Link
+                      onClick={[Function]}
+                      onlyActiveOnIndex={false}
+                      style={Object {}}
+                      to=""
+                    >
+                      <a
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        Server
+                      </a>
+                    </Link>
+                  </li>
+                </ListLink>
+                <ListLink
+                  activeClassName="active"
+                  index={false}
+                  isActive={[Function]}
+                  key="mobile"
+                  onClick={[Function]}
+                  to=""
+                >
+                  <li
+                    className=""
+                  >
+                    <Link
+                      onClick={[Function]}
+                      onlyActiveOnIndex={false}
+                      style={Object {}}
+                      to=""
+                    >
+                      <a
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        Mobile
+                      </a>
+                    </Link>
+                  </li>
+                </ListLink>
+                <ListLink
+                  activeClassName="active"
+                  index={false}
+                  isActive={[Function]}
+                  key="desktop"
+                  onClick={[Function]}
+                  to=""
+                >
+                  <li
+                    className=""
+                  >
+                    <Link
+                      onClick={[Function]}
+                      onlyActiveOnIndex={false}
+                      style={Object {}}
+                      to=""
+                    >
+                      <a
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        Desktop
+                      </a>
+                    </Link>
+                  </li>
+                </ListLink>
+                <ListLink
+                  activeClassName="active"
+                  index={false}
+                  isActive={[Function]}
+                  key="all"
+                  onClick={[Function]}
+                  to=""
+                >
+                  <li
+                    className="active"
+                  >
+                    <Link
+                      onClick={[Function]}
+                      onlyActiveOnIndex={false}
+                      style={Object {}}
+                      to=""
+                    >
+                      <a
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        All
+                      </a>
+                    </Link>
+                  </li>
+                </ListLink>
+              </ul>
+            </NavTabs>
+            <ul
+              className="client-platform-list platform-tiles"
+            >
+              <PlatformCard
+                className=""
+                key="ruby-rack"
+                onClick={[Function]}
+                platform="ruby-rack"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="ruby-rack"
+                  >
+                    <li
+                      className="platform-tile list-unstyled ruby-rack ruby "
+                    >
+                      <span
+                        className="platformicon platformicon-ruby-rack"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Rack
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="ruby-rails"
+                onClick={[Function]}
+                platform="ruby-rails"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="ruby-rails"
+                  >
+                    <li
+                      className="platform-tile list-unstyled ruby-rails ruby "
+                    >
+                      <span
+                        className="platformicon platformicon-ruby-rails"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Rails
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className="selected"
+                key="ruby"
+                onClick={[Function]}
+                platform="ruby"
+              >
+                <span
+                  className="platform-card selected"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className="selected"
+                    onClick={[Function]}
+                    platform="ruby"
+                  >
+                    <li
+                      className="platform-tile list-unstyled ruby ruby selected"
+                    >
+                      <span
+                        className="platformicon platformicon-ruby"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Ruby
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+            </ul>
+          </div>
+        </PlatformPicker>
+        <div
+          className="create-project-form"
+        >
+          <div
+            className="new-project-name client-platform"
+          >
+            <h4>
+              Give your project a name:
+            </h4>
+            <div
+              className="project-name-wrapper"
+            >
+              <PlatformiconTile
+                platform="ruby"
+              >
+                <li
+                  className="platform-tile list-unstyled ruby ruby undefined"
+                >
+                  <span
+                    className="platformicon platformicon-ruby"
+                  />
+                </li>
+              </PlatformiconTile>
+              <input
+                autoComplete="off"
+                label="Project Name"
+                name="name"
+                onChange={[Function]}
+                placeholder="Project name"
+                type="text"
+                value="Ruby"
+              />
+            </div>
+          </div>
+          <div
+            className="new-project-team"
+          >
+            <h4>
+              Team:
+            </h4>
+            <div>
+              <SelectField
+                clearable={false}
+                disabled={false}
+                hideErrorMessage={false}
+                multiple={false}
+                name="select-team"
+                onChange={[Function]}
+                options={
+                  Array [
+                    Object {
+                      "label": "#test",
+                      "value": "test",
+                    },
+                  ]
+                }
+                required={false}
+                style={
+                  Object {
+                    "marginBottom": 0,
+                    "width": 180,
                   }
-                  required={false}
+                }
+                value="test"
+              >
+                <div
+                  className=""
                   style={
                     Object {
                       "marginBottom": 0,
                       "width": 180,
                     }
                   }
-                  value="test"
                 >
                   <div
-                    className=""
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "width": 180,
-                      }
-                    }
+                    className="controls"
                   >
-                    <div
-                      className="controls"
+                    <StyledSelectControl
+                      clearable={false}
+                      disabled={false}
+                      id="id-select-team"
+                      multiple={false}
+                      name="select-team"
+                      onChange={[Function]}
+                      options={
+                        Array [
+                          Object {
+                            "label": "#test",
+                            "value": "test",
+                          },
+                        ]
+                      }
+                      required={false}
+                      value="test"
                     >
-                      <StyledSelectControl
+                      <SelectControl
+                        className="css-j6zs66-StyledSelectControl e1qrhqd00"
                         clearable={false}
                         disabled={false}
+                        height={36}
                         id="id-select-team"
                         multiple={false}
                         name="select-team"
@@ -1658,9 +1615,12 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                         required={false}
                         value="test"
                       >
-                        <SelectControl
+                        <StyledSelect
+                          arrowRenderer={[Function]}
+                          backspaceRemoves={false}
                           className="css-j6zs66-StyledSelectControl e1qrhqd00"
                           clearable={false}
+                          deleteRemoves={false}
                           disabled={false}
                           height={36}
                           id="id-select-team"
@@ -1678,10 +1638,10 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                           required={false}
                           value="test"
                         >
-                          <StyledSelect
+                          <ForwardRef(SelectPicker)
                             arrowRenderer={[Function]}
                             backspaceRemoves={false}
-                            className="css-j6zs66-StyledSelectControl e1qrhqd00"
+                            className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                             clearable={false}
                             deleteRemoves={false}
                             disabled={false}
@@ -1701,13 +1661,14 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                             required={false}
                             value="test"
                           >
-                            <ForwardRef(SelectPicker)
+                            <SelectPicker
                               arrowRenderer={[Function]}
                               backspaceRemoves={false}
                               className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                               clearable={false}
                               deleteRemoves={false}
                               disabled={false}
+                              forwardedRef={null}
                               height={36}
                               id="id-select-team"
                               multiple={false}
@@ -1724,19 +1685,44 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                               required={false}
                               value="test"
                             >
-                              <SelectPicker
+                              <Select
                                 arrowRenderer={[Function]}
+                                autosize={true}
                                 backspaceRemoves={false}
+                                backspaceToRemoveMessage="Press backspace to remove {label}"
                                 className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                clearAllText="Clear all"
+                                clearRenderer={[Function]}
+                                clearValueText="Clear value"
                                 clearable={false}
+                                closeOnSelect={true}
                                 deleteRemoves={false}
+                                delimiter=","
                                 disabled={false}
-                                forwardedRef={null}
+                                escapeClearsValue={true}
+                                filterOptions={[Function]}
                                 height={36}
                                 id="id-select-team"
+                                ignoreAccents={true}
+                                ignoreCase={true}
+                                inputProps={Object {}}
+                                isLoading={false}
+                                joinValues={false}
+                                labelKey="label"
+                                matchPos="any"
+                                matchProp="any"
+                                menuBuffer={0}
+                                menuRenderer={[Function]}
+                                multi={false}
                                 multiple={false}
                                 name="select-team"
+                                noResultsText="No results found"
+                                onBlurResetsInput={true}
                                 onChange={[Function]}
+                                onCloseResetsInput={true}
+                                onSelectResetsInput={true}
+                                openOnClick={true}
+                                optionComponent={[Function]}
                                 options={
                                   Array [
                                     Object {
@@ -1745,211 +1731,161 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                                     },
                                   ]
                                 }
+                                pageSize={5}
+                                placeholder="Select..."
+                                removeSelected={true}
                                 required={false}
+                                rtl={false}
+                                scrollMenuIntoView={true}
+                                searchable={true}
+                                simpleValue={false}
+                                tabSelectsValue={true}
+                                trimFilter={true}
                                 value="test"
+                                valueComponent={[Function]}
+                                valueKey="value"
                               >
-                                <Select
-                                  arrowRenderer={[Function]}
-                                  autosize={true}
-                                  backspaceRemoves={false}
-                                  backspaceToRemoveMessage="Press backspace to remove {label}"
-                                  className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
-                                  clearAllText="Clear all"
-                                  clearRenderer={[Function]}
-                                  clearValueText="Clear value"
-                                  clearable={false}
-                                  closeOnSelect={true}
-                                  deleteRemoves={false}
-                                  delimiter=","
-                                  disabled={false}
-                                  escapeClearsValue={true}
-                                  filterOptions={[Function]}
-                                  height={36}
-                                  id="id-select-team"
-                                  ignoreAccents={true}
-                                  ignoreCase={true}
-                                  inputProps={Object {}}
-                                  isLoading={false}
-                                  joinValues={false}
-                                  labelKey="label"
-                                  matchPos="any"
-                                  matchProp="any"
-                                  menuBuffer={0}
-                                  menuRenderer={[Function]}
-                                  multi={false}
-                                  multiple={false}
-                                  name="select-team"
-                                  noResultsText="No results found"
-                                  onBlurResetsInput={true}
-                                  onChange={[Function]}
-                                  onCloseResetsInput={true}
-                                  onSelectResetsInput={true}
-                                  openOnClick={true}
-                                  optionComponent={[Function]}
-                                  options={
-                                    Array [
-                                      Object {
-                                        "label": "#test",
-                                        "value": "test",
-                                      },
-                                    ]
-                                  }
-                                  pageSize={5}
-                                  placeholder="Select..."
-                                  removeSelected={true}
-                                  required={false}
-                                  rtl={false}
-                                  scrollMenuIntoView={true}
-                                  searchable={true}
-                                  simpleValue={false}
-                                  tabSelectsValue={true}
-                                  trimFilter={true}
-                                  value="test"
-                                  valueComponent={[Function]}
-                                  valueKey="value"
+                                <div
+                                  className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                 >
+                                  <input
+                                    disabled={false}
+                                    key="hidden.0"
+                                    name="select-team"
+                                    type="hidden"
+                                    value="test"
+                                  />
                                   <div
-                                    className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                                    className="Select-control"
+                                    onKeyDown={[Function]}
+                                    onMouseDown={[Function]}
+                                    onTouchEnd={[Function]}
+                                    onTouchMove={[Function]}
+                                    onTouchStart={[Function]}
                                   >
-                                    <input
-                                      disabled={false}
-                                      key="hidden.0"
-                                      name="select-team"
-                                      type="hidden"
-                                      value="test"
-                                    />
-                                    <div
-                                      className="Select-control"
-                                      onKeyDown={[Function]}
-                                      onMouseDown={[Function]}
-                                      onTouchEnd={[Function]}
-                                      onTouchMove={[Function]}
-                                      onTouchStart={[Function]}
+                                    <span
+                                      className="Select-multi-value-wrapper"
+                                      id="react-select-3--value"
                                     >
-                                      <span
-                                        className="Select-multi-value-wrapper"
-                                        id="react-select-3--value"
+                                      <Value
+                                        disabled={false}
+                                        id="react-select-3--value-item"
+                                        instancePrefix="react-select-3-"
+                                        onClick={null}
+                                        placeholder="Select..."
+                                        value={
+                                          Object {
+                                            "label": "#test",
+                                            "value": "test",
+                                          }
+                                        }
                                       >
-                                        <Value
-                                          disabled={false}
-                                          id="react-select-3--value-item"
-                                          instancePrefix="react-select-3-"
-                                          onClick={null}
-                                          placeholder="Select..."
-                                          value={
+                                        <div
+                                          className="Select-value"
+                                        >
+                                          <span
+                                            aria-selected="true"
+                                            className="Select-value-label"
+                                            id="react-select-3--value-item"
+                                            role="option"
+                                          >
+                                            #test
+                                          </span>
+                                        </div>
+                                      </Value>
+                                      <AutosizeInput
+                                        aria-activedescendant="react-select-3--value"
+                                        aria-expanded="false"
+                                        aria-haspopup="false"
+                                        aria-owns=""
+                                        className="Select-input"
+                                        id="id-select-team"
+                                        injectStyles={true}
+                                        minWidth="5"
+                                        onBlur={[Function]}
+                                        onChange={[Function]}
+                                        onFocus={[Function]}
+                                        required={false}
+                                        role="combobox"
+                                        value=""
+                                      >
+                                        <div
+                                          className="Select-input"
+                                          style={
                                             Object {
-                                              "label": "#test",
-                                              "value": "test",
+                                              "display": "inline-block",
                                             }
                                           }
                                         >
-                                          <div
-                                            className="Select-value"
-                                          >
-                                            <span
-                                              aria-selected="true"
-                                              className="Select-value-label"
-                                              id="react-select-3--value-item"
-                                              role="option"
-                                            >
-                                              #test
-                                            </span>
-                                          </div>
-                                        </Value>
-                                        <AutosizeInput
-                                          aria-activedescendant="react-select-3--value"
-                                          aria-expanded="false"
-                                          aria-haspopup="false"
-                                          aria-owns=""
-                                          className="Select-input"
-                                          id="id-select-team"
-                                          injectStyles={true}
-                                          minWidth="5"
-                                          onBlur={[Function]}
-                                          onChange={[Function]}
-                                          onFocus={[Function]}
-                                          required={false}
-                                          role="combobox"
-                                          value=""
-                                        >
-                                          <div
-                                            className="Select-input"
+                                          <input
+                                            aria-activedescendant="react-select-3--value"
+                                            aria-expanded="false"
+                                            aria-haspopup="false"
+                                            aria-owns=""
+                                            id="id-select-team"
+                                            onBlur={[Function]}
+                                            onChange={[Function]}
+                                            onFocus={[Function]}
+                                            required={false}
+                                            role="combobox"
                                             style={
                                               Object {
-                                                "display": "inline-block",
+                                                "boxSizing": "content-box",
+                                                "width": "5px",
                                               }
                                             }
-                                          >
-                                            <input
-                                              aria-activedescendant="react-select-3--value"
-                                              aria-expanded="false"
-                                              aria-haspopup="false"
-                                              aria-owns=""
-                                              id="id-select-team"
-                                              onBlur={[Function]}
-                                              onChange={[Function]}
-                                              onFocus={[Function]}
-                                              required={false}
-                                              role="combobox"
-                                              style={
-                                                Object {
-                                                  "boxSizing": "content-box",
-                                                  "width": "5px",
-                                                }
+                                            value=""
+                                          />
+                                          <div
+                                            style={
+                                              Object {
+                                                "height": 0,
+                                                "left": 0,
+                                                "overflow": "scroll",
+                                                "position": "absolute",
+                                                "top": 0,
+                                                "visibility": "hidden",
+                                                "whiteSpace": "pre",
                                               }
-                                              value=""
-                                            />
-                                            <div
-                                              style={
-                                                Object {
-                                                  "height": 0,
-                                                  "left": 0,
-                                                  "overflow": "scroll",
-                                                  "position": "absolute",
-                                                  "top": 0,
-                                                  "visibility": "hidden",
-                                                  "whiteSpace": "pre",
-                                                }
-                                              }
-                                            />
-                                          </div>
-                                        </AutosizeInput>
-                                      </span>
+                                            }
+                                          />
+                                        </div>
+                                      </AutosizeInput>
+                                    </span>
+                                    <span
+                                      className="Select-arrow-zone"
+                                      onMouseDown={[Function]}
+                                    >
                                       <span
-                                        className="Select-arrow-zone"
-                                        onMouseDown={[Function]}
-                                      >
-                                        <span
-                                          className="icon-arrow-down"
-                                        />
-                                      </span>
-                                    </div>
+                                        className="icon-arrow-down"
+                                      />
+                                    </span>
                                   </div>
-                                </Select>
-                              </SelectPicker>
-                            </ForwardRef(SelectPicker)>
-                          </StyledSelect>
-                        </SelectControl>
-                      </StyledSelectControl>
-                    </div>
+                                </div>
+                              </Select>
+                            </SelectPicker>
+                          </ForwardRef(SelectPicker)>
+                        </StyledSelect>
+                      </SelectControl>
+                    </StyledSelectControl>
                   </div>
-                </SelectField>
-              </div>
+                </div>
+              </SelectField>
             </div>
-            <div>
-              <button
-                className="btn btn-primary new-project-submit"
-                onClick={[Function]}
-              >
-                Create Project
-              </button>
-            </div>
-            <p>
-              Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
-            </p>
           </div>
+          <div>
+            <button
+              className="btn btn-primary new-project-submit"
+              onClick={[Function]}
+            >
+              Create Project
+            </button>
+          </div>
+          <p>
+            Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
+          </p>
         </div>
-      </Wrapper>
+      </div>
     </OnboardingProject>
   </div>
 </CreateProject>
@@ -1990,818 +1926,807 @@ exports[`CreateProject should fill in project name if its empty when platform is
         ]
       }
     >
-      <Wrapper>
-        <div
-          className="css-a5urgt-Wrapper e1bu5aqa0"
+      <div
+        className="onboarding-info"
+      >
+        <h4>
+          Choose a language or framework:
+        </h4>
+        <PlatformPicker
+          name="another"
+          next={[Function]}
+          platform="csharp"
+          setName={[Function]}
+          setPlatform={[Function]}
+          setTeam={[Function]}
+          showOther={true}
+          team="test"
+          teams={
+            Array [
+              Object {
+                "hasAccess": true,
+                "id": "1",
+                "name": "test",
+                "slug": "test",
+              },
+            ]
+          }
         >
-          <PageHeading
-            withMargins={true}
-          >
-            <Wrapper
-              withMargins={true}
-            >
-              <h1
-                className="css-13ev48w-Wrapper e1f8hk460"
-              >
-                Choose a language or framework:
-              </h1>
-            </Wrapper>
-          </PageHeading>
-          <PlatformPicker
-            name="another"
-            next={[Function]}
-            platform="csharp"
-            setName={[Function]}
-            setPlatform={[Function]}
-            setTeam={[Function]}
-            showOther={true}
-            team="test"
-            teams={
-              Array [
-                Object {
-                  "hasAccess": true,
-                  "id": "1",
-                  "name": "test",
-                  "slug": "test",
-                },
-              ]
-            }
-          >
-            <div
-              className="platform-picker"
-            >
-              <NavTabs>
-                <ul
-                  className="nav nav-tabs"
-                >
-                  <li
-                    style={
-                      Object {
-                        "float": "right",
-                        "marginRight": 0,
-                      }
-                    }
-                  >
-                    <div
-                      className="platform-filter-container"
-                    >
-                      <span
-                        className="icon icon-search"
-                      />
-                      <input
-                        className="platform-filter"
-                        label="Filter"
-                        onChange={[Function]}
-                        placeholder="Filter"
-                        type="text"
-                        value=""
-                      />
-                    </div>
-                  </li>
-                  <ListLink
-                    activeClassName="active"
-                    index={false}
-                    isActive={[Function]}
-                    key="popular"
-                    onClick={[Function]}
-                    to=""
-                  >
-                    <li
-                      className="active"
-                    >
-                      <Link
-                        onClick={[Function]}
-                        onlyActiveOnIndex={false}
-                        style={Object {}}
-                        to=""
-                      >
-                        <a
-                          onClick={[Function]}
-                          style={Object {}}
-                        >
-                          Popular
-                        </a>
-                      </Link>
-                    </li>
-                  </ListLink>
-                  <ListLink
-                    activeClassName="active"
-                    index={false}
-                    isActive={[Function]}
-                    key="browser"
-                    onClick={[Function]}
-                    to=""
-                  >
-                    <li
-                      className=""
-                    >
-                      <Link
-                        onClick={[Function]}
-                        onlyActiveOnIndex={false}
-                        style={Object {}}
-                        to=""
-                      >
-                        <a
-                          onClick={[Function]}
-                          style={Object {}}
-                        >
-                          Browser
-                        </a>
-                      </Link>
-                    </li>
-                  </ListLink>
-                  <ListLink
-                    activeClassName="active"
-                    index={false}
-                    isActive={[Function]}
-                    key="server"
-                    onClick={[Function]}
-                    to=""
-                  >
-                    <li
-                      className=""
-                    >
-                      <Link
-                        onClick={[Function]}
-                        onlyActiveOnIndex={false}
-                        style={Object {}}
-                        to=""
-                      >
-                        <a
-                          onClick={[Function]}
-                          style={Object {}}
-                        >
-                          Server
-                        </a>
-                      </Link>
-                    </li>
-                  </ListLink>
-                  <ListLink
-                    activeClassName="active"
-                    index={false}
-                    isActive={[Function]}
-                    key="mobile"
-                    onClick={[Function]}
-                    to=""
-                  >
-                    <li
-                      className=""
-                    >
-                      <Link
-                        onClick={[Function]}
-                        onlyActiveOnIndex={false}
-                        style={Object {}}
-                        to=""
-                      >
-                        <a
-                          onClick={[Function]}
-                          style={Object {}}
-                        >
-                          Mobile
-                        </a>
-                      </Link>
-                    </li>
-                  </ListLink>
-                  <ListLink
-                    activeClassName="active"
-                    index={false}
-                    isActive={[Function]}
-                    key="desktop"
-                    onClick={[Function]}
-                    to=""
-                  >
-                    <li
-                      className=""
-                    >
-                      <Link
-                        onClick={[Function]}
-                        onlyActiveOnIndex={false}
-                        style={Object {}}
-                        to=""
-                      >
-                        <a
-                          onClick={[Function]}
-                          style={Object {}}
-                        >
-                          Desktop
-                        </a>
-                      </Link>
-                    </li>
-                  </ListLink>
-                  <ListLink
-                    activeClassName="active"
-                    index={false}
-                    isActive={[Function]}
-                    key="all"
-                    onClick={[Function]}
-                    to=""
-                  >
-                    <li
-                      className=""
-                    >
-                      <Link
-                        onClick={[Function]}
-                        onlyActiveOnIndex={false}
-                        style={Object {}}
-                        to=""
-                      >
-                        <a
-                          onClick={[Function]}
-                          style={Object {}}
-                        >
-                          All
-                        </a>
-                      </Link>
-                    </li>
-                  </ListLink>
-                </ul>
-              </NavTabs>
-              <ul
-                className="client-platform-list platform-tiles"
-              >
-                <PlatformCard
-                  className="selected"
-                  key="csharp"
-                  onClick={[Function]}
-                  platform="csharp"
-                >
-                  <span
-                    className="platform-card selected"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className="selected"
-                      onClick={[Function]}
-                      platform="csharp"
-                    >
-                      <li
-                        className="platform-tile list-unstyled csharp csharp selected"
-                      >
-                        <span
-                          className="platformicon platformicon-csharp"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      C#
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="java"
-                  onClick={[Function]}
-                  platform="java"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="java"
-                    >
-                      <li
-                        className="platform-tile list-unstyled java java "
-                      >
-                        <span
-                          className="platformicon platformicon-java"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Java
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="javascript-angular"
-                  onClick={[Function]}
-                  platform="javascript-angular"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="javascript-angular"
-                    >
-                      <li
-                        className="platform-tile list-unstyled javascript-angular javascript "
-                      >
-                        <span
-                          className="platformicon platformicon-javascript-angular"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Angular
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="javascript"
-                  onClick={[Function]}
-                  platform="javascript"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="javascript"
-                    >
-                      <li
-                        className="platform-tile list-unstyled javascript javascript "
-                      >
-                        <span
-                          className="platformicon platformicon-javascript"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      JavaScript
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="javascript-react"
-                  onClick={[Function]}
-                  platform="javascript-react"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="javascript-react"
-                    >
-                      <li
-                        className="platform-tile list-unstyled javascript-react javascript "
-                      >
-                        <span
-                          className="platformicon platformicon-javascript-react"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      React
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="node-express"
-                  onClick={[Function]}
-                  platform="node-express"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="node-express"
-                    >
-                      <li
-                        className="platform-tile list-unstyled node-express node "
-                      >
-                        <span
-                          className="platformicon platformicon-node-express"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Express
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="node"
-                  onClick={[Function]}
-                  platform="node"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="node"
-                    >
-                      <li
-                        className="platform-tile list-unstyled node node "
-                      >
-                        <span
-                          className="platformicon platformicon-node"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Node.js
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="php-laravel"
-                  onClick={[Function]}
-                  platform="php-laravel"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="php-laravel"
-                    >
-                      <li
-                        className="platform-tile list-unstyled php-laravel php "
-                      >
-                        <span
-                          className="platformicon platformicon-php-laravel"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Laravel
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="php"
-                  onClick={[Function]}
-                  platform="php"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="php"
-                    >
-                      <li
-                        className="platform-tile list-unstyled php php "
-                      >
-                        <span
-                          className="platformicon platformicon-php"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      PHP
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="php-symfony2"
-                  onClick={[Function]}
-                  platform="php-symfony2"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="php-symfony2"
-                    >
-                      <li
-                        className="platform-tile list-unstyled php-symfony2 php "
-                      >
-                        <span
-                          className="platformicon platformicon-php-symfony2"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Symfony2
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="python-django"
-                  onClick={[Function]}
-                  platform="python-django"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="python-django"
-                    >
-                      <li
-                        className="platform-tile list-unstyled python-django python "
-                      >
-                        <span
-                          className="platformicon platformicon-python-django"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Django
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="python-flask"
-                  onClick={[Function]}
-                  platform="python-flask"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="python-flask"
-                    >
-                      <li
-                        className="platform-tile list-unstyled python-flask python "
-                      >
-                        <span
-                          className="platformicon platformicon-python-flask"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Flask
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="python"
-                  onClick={[Function]}
-                  platform="python"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="python"
-                    >
-                      <li
-                        className="platform-tile list-unstyled python python "
-                      >
-                        <span
-                          className="platformicon platformicon-python"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Python
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="cocoa"
-                  onClick={[Function]}
-                  platform="cocoa"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="cocoa"
-                    >
-                      <li
-                        className="platform-tile list-unstyled cocoa cocoa "
-                      >
-                        <span
-                          className="platformicon platformicon-cocoa"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      React-Native
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="ruby-rails"
-                  onClick={[Function]}
-                  platform="ruby-rails"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="ruby-rails"
-                    >
-                      <li
-                        className="platform-tile list-unstyled ruby-rails ruby "
-                      >
-                        <span
-                          className="platformicon platformicon-ruby-rails"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Rails
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-                <PlatformCard
-                  className=""
-                  key="ruby"
-                  onClick={[Function]}
-                  platform="ruby"
-                >
-                  <span
-                    className="platform-card"
-                    onClick={[Function]}
-                  >
-                    <PlatformiconTile
-                      className=""
-                      onClick={[Function]}
-                      platform="ruby"
-                    >
-                      <li
-                        className="platform-tile list-unstyled ruby ruby "
-                      >
-                        <span
-                          className="platformicon platformicon-ruby"
-                        />
-                      </li>
-                    </PlatformiconTile>
-                    <h5>
-                       
-                      Ruby
-                       
-                    </h5>
-                  </span>
-                </PlatformCard>
-              </ul>
-            </div>
-          </PlatformPicker>
           <div
-            className="create-project-form"
+            className="platform-picker"
           >
-            <div
-              className="new-project-name client-platform"
-            >
-              <PageHeading
-                withMargins={true}
+            <NavTabs>
+              <ul
+                className="nav nav-tabs"
               >
-                <Wrapper
-                  withMargins={true}
+                <li
+                  style={
+                    Object {
+                      "float": "right",
+                      "marginRight": 0,
+                    }
+                  }
                 >
-                  <h1
-                    className="css-13ev48w-Wrapper e1f8hk460"
-                  >
-                    Give your project a name:
-                  </h1>
-                </Wrapper>
-              </PageHeading>
-              <div
-                className="project-name-wrapper"
-              >
-                <PlatformiconTile
-                  platform="csharp"
-                >
-                  <li
-                    className="platform-tile list-unstyled csharp csharp undefined"
+                  <div
+                    className="platform-filter-container"
                   >
                     <span
-                      className="platformicon platformicon-csharp"
+                      className="icon icon-search"
                     />
-                  </li>
-                </PlatformiconTile>
-                <input
-                  autoComplete="off"
-                  label="Project Name"
-                  name="name"
-                  onChange={[Function]}
-                  placeholder="Project name"
-                  type="text"
-                  value="another"
-                />
-              </div>
-            </div>
-            <div
-              className="new-project-team"
-            >
-              <PageHeading
-                withMargins={true}
-              >
-                <Wrapper
-                  withMargins={true}
+                    <input
+                      className="platform-filter"
+                      label="Filter"
+                      onChange={[Function]}
+                      placeholder="Filter"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </li>
+                <ListLink
+                  activeClassName="active"
+                  index={false}
+                  isActive={[Function]}
+                  key="popular"
+                  onClick={[Function]}
+                  to=""
                 >
-                  <h1
-                    className="css-13ev48w-Wrapper e1f8hk460"
+                  <li
+                    className="active"
                   >
-                    Team:
-                  </h1>
-                </Wrapper>
-              </PageHeading>
-              <div>
-                <SelectField
-                  clearable={false}
-                  disabled={false}
-                  hideErrorMessage={false}
-                  multiple={false}
-                  name="select-team"
-                  onChange={[Function]}
-                  options={
-                    Array [
-                      Object {
-                        "label": "#test",
-                        "value": "test",
-                      },
-                    ]
+                    <Link
+                      onClick={[Function]}
+                      onlyActiveOnIndex={false}
+                      style={Object {}}
+                      to=""
+                    >
+                      <a
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        Popular
+                      </a>
+                    </Link>
+                  </li>
+                </ListLink>
+                <ListLink
+                  activeClassName="active"
+                  index={false}
+                  isActive={[Function]}
+                  key="browser"
+                  onClick={[Function]}
+                  to=""
+                >
+                  <li
+                    className=""
+                  >
+                    <Link
+                      onClick={[Function]}
+                      onlyActiveOnIndex={false}
+                      style={Object {}}
+                      to=""
+                    >
+                      <a
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        Browser
+                      </a>
+                    </Link>
+                  </li>
+                </ListLink>
+                <ListLink
+                  activeClassName="active"
+                  index={false}
+                  isActive={[Function]}
+                  key="server"
+                  onClick={[Function]}
+                  to=""
+                >
+                  <li
+                    className=""
+                  >
+                    <Link
+                      onClick={[Function]}
+                      onlyActiveOnIndex={false}
+                      style={Object {}}
+                      to=""
+                    >
+                      <a
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        Server
+                      </a>
+                    </Link>
+                  </li>
+                </ListLink>
+                <ListLink
+                  activeClassName="active"
+                  index={false}
+                  isActive={[Function]}
+                  key="mobile"
+                  onClick={[Function]}
+                  to=""
+                >
+                  <li
+                    className=""
+                  >
+                    <Link
+                      onClick={[Function]}
+                      onlyActiveOnIndex={false}
+                      style={Object {}}
+                      to=""
+                    >
+                      <a
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        Mobile
+                      </a>
+                    </Link>
+                  </li>
+                </ListLink>
+                <ListLink
+                  activeClassName="active"
+                  index={false}
+                  isActive={[Function]}
+                  key="desktop"
+                  onClick={[Function]}
+                  to=""
+                >
+                  <li
+                    className=""
+                  >
+                    <Link
+                      onClick={[Function]}
+                      onlyActiveOnIndex={false}
+                      style={Object {}}
+                      to=""
+                    >
+                      <a
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        Desktop
+                      </a>
+                    </Link>
+                  </li>
+                </ListLink>
+                <ListLink
+                  activeClassName="active"
+                  index={false}
+                  isActive={[Function]}
+                  key="all"
+                  onClick={[Function]}
+                  to=""
+                >
+                  <li
+                    className=""
+                  >
+                    <Link
+                      onClick={[Function]}
+                      onlyActiveOnIndex={false}
+                      style={Object {}}
+                      to=""
+                    >
+                      <a
+                        onClick={[Function]}
+                        style={Object {}}
+                      >
+                        All
+                      </a>
+                    </Link>
+                  </li>
+                </ListLink>
+              </ul>
+            </NavTabs>
+            <ul
+              className="client-platform-list platform-tiles"
+            >
+              <PlatformCard
+                className="selected"
+                key="csharp"
+                onClick={[Function]}
+                platform="csharp"
+              >
+                <span
+                  className="platform-card selected"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className="selected"
+                    onClick={[Function]}
+                    platform="csharp"
+                  >
+                    <li
+                      className="platform-tile list-unstyled csharp csharp selected"
+                    >
+                      <span
+                        className="platformicon platformicon-csharp"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    C#
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="java"
+                onClick={[Function]}
+                platform="java"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="java"
+                  >
+                    <li
+                      className="platform-tile list-unstyled java java "
+                    >
+                      <span
+                        className="platformicon platformicon-java"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Java
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="javascript-angular"
+                onClick={[Function]}
+                platform="javascript-angular"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="javascript-angular"
+                  >
+                    <li
+                      className="platform-tile list-unstyled javascript-angular javascript "
+                    >
+                      <span
+                        className="platformicon platformicon-javascript-angular"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Angular
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="javascript"
+                onClick={[Function]}
+                platform="javascript"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="javascript"
+                  >
+                    <li
+                      className="platform-tile list-unstyled javascript javascript "
+                    >
+                      <span
+                        className="platformicon platformicon-javascript"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    JavaScript
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="javascript-react"
+                onClick={[Function]}
+                platform="javascript-react"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="javascript-react"
+                  >
+                    <li
+                      className="platform-tile list-unstyled javascript-react javascript "
+                    >
+                      <span
+                        className="platformicon platformicon-javascript-react"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    React
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="node-express"
+                onClick={[Function]}
+                platform="node-express"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="node-express"
+                  >
+                    <li
+                      className="platform-tile list-unstyled node-express node "
+                    >
+                      <span
+                        className="platformicon platformicon-node-express"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Express
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="node"
+                onClick={[Function]}
+                platform="node"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="node"
+                  >
+                    <li
+                      className="platform-tile list-unstyled node node "
+                    >
+                      <span
+                        className="platformicon platformicon-node"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Node.js
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="php-laravel"
+                onClick={[Function]}
+                platform="php-laravel"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="php-laravel"
+                  >
+                    <li
+                      className="platform-tile list-unstyled php-laravel php "
+                    >
+                      <span
+                        className="platformicon platformicon-php-laravel"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Laravel
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="php"
+                onClick={[Function]}
+                platform="php"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="php"
+                  >
+                    <li
+                      className="platform-tile list-unstyled php php "
+                    >
+                      <span
+                        className="platformicon platformicon-php"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    PHP
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="php-symfony2"
+                onClick={[Function]}
+                platform="php-symfony2"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="php-symfony2"
+                  >
+                    <li
+                      className="platform-tile list-unstyled php-symfony2 php "
+                    >
+                      <span
+                        className="platformicon platformicon-php-symfony2"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Symfony2
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="python-django"
+                onClick={[Function]}
+                platform="python-django"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="python-django"
+                  >
+                    <li
+                      className="platform-tile list-unstyled python-django python "
+                    >
+                      <span
+                        className="platformicon platformicon-python-django"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Django
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="python-flask"
+                onClick={[Function]}
+                platform="python-flask"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="python-flask"
+                  >
+                    <li
+                      className="platform-tile list-unstyled python-flask python "
+                    >
+                      <span
+                        className="platformicon platformicon-python-flask"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Flask
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="python"
+                onClick={[Function]}
+                platform="python"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="python"
+                  >
+                    <li
+                      className="platform-tile list-unstyled python python "
+                    >
+                      <span
+                        className="platformicon platformicon-python"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Python
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="cocoa"
+                onClick={[Function]}
+                platform="cocoa"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="cocoa"
+                  >
+                    <li
+                      className="platform-tile list-unstyled cocoa cocoa "
+                    >
+                      <span
+                        className="platformicon platformicon-cocoa"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    React-Native
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="ruby-rails"
+                onClick={[Function]}
+                platform="ruby-rails"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="ruby-rails"
+                  >
+                    <li
+                      className="platform-tile list-unstyled ruby-rails ruby "
+                    >
+                      <span
+                        className="platformicon platformicon-ruby-rails"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Rails
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+              <PlatformCard
+                className=""
+                key="ruby"
+                onClick={[Function]}
+                platform="ruby"
+              >
+                <span
+                  className="platform-card"
+                  onClick={[Function]}
+                >
+                  <PlatformiconTile
+                    className=""
+                    onClick={[Function]}
+                    platform="ruby"
+                  >
+                    <li
+                      className="platform-tile list-unstyled ruby ruby "
+                    >
+                      <span
+                        className="platformicon platformicon-ruby"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <h5>
+                     
+                    Ruby
+                     
+                  </h5>
+                </span>
+              </PlatformCard>
+            </ul>
+          </div>
+        </PlatformPicker>
+        <div
+          className="create-project-form"
+        >
+          <div
+            className="new-project-name client-platform"
+          >
+            <h4>
+              Give your project a name:
+            </h4>
+            <div
+              className="project-name-wrapper"
+            >
+              <PlatformiconTile
+                platform="csharp"
+              >
+                <li
+                  className="platform-tile list-unstyled csharp csharp undefined"
+                >
+                  <span
+                    className="platformicon platformicon-csharp"
+                  />
+                </li>
+              </PlatformiconTile>
+              <input
+                autoComplete="off"
+                label="Project Name"
+                name="name"
+                onChange={[Function]}
+                placeholder="Project name"
+                type="text"
+                value="another"
+              />
+            </div>
+          </div>
+          <div
+            className="new-project-team"
+          >
+            <h4>
+              Team:
+            </h4>
+            <div>
+              <SelectField
+                clearable={false}
+                disabled={false}
+                hideErrorMessage={false}
+                multiple={false}
+                name="select-team"
+                onChange={[Function]}
+                options={
+                  Array [
+                    Object {
+                      "label": "#test",
+                      "value": "test",
+                    },
+                  ]
+                }
+                required={false}
+                style={
+                  Object {
+                    "marginBottom": 0,
+                    "width": 180,
                   }
-                  required={false}
+                }
+                value="test"
+              >
+                <div
+                  className=""
                   style={
                     Object {
                       "marginBottom": 0,
                       "width": 180,
                     }
                   }
-                  value="test"
                 >
                   <div
-                    className=""
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "width": 180,
-                      }
-                    }
+                    className="controls"
                   >
-                    <div
-                      className="controls"
+                    <StyledSelectControl
+                      clearable={false}
+                      disabled={false}
+                      id="id-select-team"
+                      multiple={false}
+                      name="select-team"
+                      onChange={[Function]}
+                      options={
+                        Array [
+                          Object {
+                            "label": "#test",
+                            "value": "test",
+                          },
+                        ]
+                      }
+                      required={false}
+                      value="test"
                     >
-                      <StyledSelectControl
+                      <SelectControl
+                        className="css-j6zs66-StyledSelectControl e1qrhqd00"
                         clearable={false}
                         disabled={false}
+                        height={36}
                         id="id-select-team"
                         multiple={false}
                         name="select-team"
@@ -2817,9 +2742,12 @@ exports[`CreateProject should fill in project name if its empty when platform is
                         required={false}
                         value="test"
                       >
-                        <SelectControl
+                        <StyledSelect
+                          arrowRenderer={[Function]}
+                          backspaceRemoves={false}
                           className="css-j6zs66-StyledSelectControl e1qrhqd00"
                           clearable={false}
+                          deleteRemoves={false}
                           disabled={false}
                           height={36}
                           id="id-select-team"
@@ -2837,10 +2765,10 @@ exports[`CreateProject should fill in project name if its empty when platform is
                           required={false}
                           value="test"
                         >
-                          <StyledSelect
+                          <ForwardRef(SelectPicker)
                             arrowRenderer={[Function]}
                             backspaceRemoves={false}
-                            className="css-j6zs66-StyledSelectControl e1qrhqd00"
+                            className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                             clearable={false}
                             deleteRemoves={false}
                             disabled={false}
@@ -2860,13 +2788,14 @@ exports[`CreateProject should fill in project name if its empty when platform is
                             required={false}
                             value="test"
                           >
-                            <ForwardRef(SelectPicker)
+                            <SelectPicker
                               arrowRenderer={[Function]}
                               backspaceRemoves={false}
                               className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
                               clearable={false}
                               deleteRemoves={false}
                               disabled={false}
+                              forwardedRef={null}
                               height={36}
                               id="id-select-team"
                               multiple={false}
@@ -2883,19 +2812,44 @@ exports[`CreateProject should fill in project name if its empty when platform is
                               required={false}
                               value="test"
                             >
-                              <SelectPicker
+                              <Select
                                 arrowRenderer={[Function]}
+                                autosize={true}
                                 backspaceRemoves={false}
+                                backspaceToRemoveMessage="Press backspace to remove {label}"
                                 className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
+                                clearAllText="Clear all"
+                                clearRenderer={[Function]}
+                                clearValueText="Clear value"
                                 clearable={false}
+                                closeOnSelect={true}
                                 deleteRemoves={false}
+                                delimiter=","
                                 disabled={false}
-                                forwardedRef={null}
+                                escapeClearsValue={true}
+                                filterOptions={[Function]}
                                 height={36}
                                 id="id-select-team"
+                                ignoreAccents={true}
+                                ignoreCase={true}
+                                inputProps={Object {}}
+                                isLoading={false}
+                                joinValues={false}
+                                labelKey="label"
+                                matchPos="any"
+                                matchProp="any"
+                                menuBuffer={0}
+                                menuRenderer={[Function]}
+                                multi={false}
                                 multiple={false}
                                 name="select-team"
+                                noResultsText="No results found"
+                                onBlurResetsInput={true}
                                 onChange={[Function]}
+                                onCloseResetsInput={true}
+                                onSelectResetsInput={true}
+                                openOnClick={true}
+                                optionComponent={[Function]}
                                 options={
                                   Array [
                                     Object {
@@ -2904,211 +2858,161 @@ exports[`CreateProject should fill in project name if its empty when platform is
                                     },
                                   ]
                                 }
+                                pageSize={5}
+                                placeholder="Select..."
+                                removeSelected={true}
                                 required={false}
+                                rtl={false}
+                                scrollMenuIntoView={true}
+                                searchable={true}
+                                simpleValue={false}
+                                tabSelectsValue={true}
+                                trimFilter={true}
                                 value="test"
+                                valueComponent={[Function]}
+                                valueKey="value"
                               >
-                                <Select
-                                  arrowRenderer={[Function]}
-                                  autosize={true}
-                                  backspaceRemoves={false}
-                                  backspaceToRemoveMessage="Press backspace to remove {label}"
-                                  className="e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20"
-                                  clearAllText="Clear all"
-                                  clearRenderer={[Function]}
-                                  clearValueText="Clear value"
-                                  clearable={false}
-                                  closeOnSelect={true}
-                                  deleteRemoves={false}
-                                  delimiter=","
-                                  disabled={false}
-                                  escapeClearsValue={true}
-                                  filterOptions={[Function]}
-                                  height={36}
-                                  id="id-select-team"
-                                  ignoreAccents={true}
-                                  ignoreCase={true}
-                                  inputProps={Object {}}
-                                  isLoading={false}
-                                  joinValues={false}
-                                  labelKey="label"
-                                  matchPos="any"
-                                  matchProp="any"
-                                  menuBuffer={0}
-                                  menuRenderer={[Function]}
-                                  multi={false}
-                                  multiple={false}
-                                  name="select-team"
-                                  noResultsText="No results found"
-                                  onBlurResetsInput={true}
-                                  onChange={[Function]}
-                                  onCloseResetsInput={true}
-                                  onSelectResetsInput={true}
-                                  openOnClick={true}
-                                  optionComponent={[Function]}
-                                  options={
-                                    Array [
-                                      Object {
-                                        "label": "#test",
-                                        "value": "test",
-                                      },
-                                    ]
-                                  }
-                                  pageSize={5}
-                                  placeholder="Select..."
-                                  removeSelected={true}
-                                  required={false}
-                                  rtl={false}
-                                  scrollMenuIntoView={true}
-                                  searchable={true}
-                                  simpleValue={false}
-                                  tabSelectsValue={true}
-                                  trimFilter={true}
-                                  value="test"
-                                  valueComponent={[Function]}
-                                  valueKey="value"
+                                <div
+                                  className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
                                 >
+                                  <input
+                                    disabled={false}
+                                    key="hidden.0"
+                                    name="select-team"
+                                    type="hidden"
+                                    value="test"
+                                  />
                                   <div
-                                    className="Select e1qrhqd00 css-pr263a-StyledSelect-StyledSelectControl eho28m20 has-value is-searchable Select--single"
+                                    className="Select-control"
+                                    onKeyDown={[Function]}
+                                    onMouseDown={[Function]}
+                                    onTouchEnd={[Function]}
+                                    onTouchMove={[Function]}
+                                    onTouchStart={[Function]}
                                   >
-                                    <input
-                                      disabled={false}
-                                      key="hidden.0"
-                                      name="select-team"
-                                      type="hidden"
-                                      value="test"
-                                    />
-                                    <div
-                                      className="Select-control"
-                                      onKeyDown={[Function]}
-                                      onMouseDown={[Function]}
-                                      onTouchEnd={[Function]}
-                                      onTouchMove={[Function]}
-                                      onTouchStart={[Function]}
+                                    <span
+                                      className="Select-multi-value-wrapper"
+                                      id="react-select-2--value"
                                     >
-                                      <span
-                                        className="Select-multi-value-wrapper"
-                                        id="react-select-2--value"
+                                      <Value
+                                        disabled={false}
+                                        id="react-select-2--value-item"
+                                        instancePrefix="react-select-2-"
+                                        onClick={null}
+                                        placeholder="Select..."
+                                        value={
+                                          Object {
+                                            "label": "#test",
+                                            "value": "test",
+                                          }
+                                        }
                                       >
-                                        <Value
-                                          disabled={false}
-                                          id="react-select-2--value-item"
-                                          instancePrefix="react-select-2-"
-                                          onClick={null}
-                                          placeholder="Select..."
-                                          value={
+                                        <div
+                                          className="Select-value"
+                                        >
+                                          <span
+                                            aria-selected="true"
+                                            className="Select-value-label"
+                                            id="react-select-2--value-item"
+                                            role="option"
+                                          >
+                                            #test
+                                          </span>
+                                        </div>
+                                      </Value>
+                                      <AutosizeInput
+                                        aria-activedescendant="react-select-2--value"
+                                        aria-expanded="false"
+                                        aria-haspopup="false"
+                                        aria-owns=""
+                                        className="Select-input"
+                                        id="id-select-team"
+                                        injectStyles={true}
+                                        minWidth="5"
+                                        onBlur={[Function]}
+                                        onChange={[Function]}
+                                        onFocus={[Function]}
+                                        required={false}
+                                        role="combobox"
+                                        value=""
+                                      >
+                                        <div
+                                          className="Select-input"
+                                          style={
                                             Object {
-                                              "label": "#test",
-                                              "value": "test",
+                                              "display": "inline-block",
                                             }
                                           }
                                         >
-                                          <div
-                                            className="Select-value"
-                                          >
-                                            <span
-                                              aria-selected="true"
-                                              className="Select-value-label"
-                                              id="react-select-2--value-item"
-                                              role="option"
-                                            >
-                                              #test
-                                            </span>
-                                          </div>
-                                        </Value>
-                                        <AutosizeInput
-                                          aria-activedescendant="react-select-2--value"
-                                          aria-expanded="false"
-                                          aria-haspopup="false"
-                                          aria-owns=""
-                                          className="Select-input"
-                                          id="id-select-team"
-                                          injectStyles={true}
-                                          minWidth="5"
-                                          onBlur={[Function]}
-                                          onChange={[Function]}
-                                          onFocus={[Function]}
-                                          required={false}
-                                          role="combobox"
-                                          value=""
-                                        >
-                                          <div
-                                            className="Select-input"
+                                          <input
+                                            aria-activedescendant="react-select-2--value"
+                                            aria-expanded="false"
+                                            aria-haspopup="false"
+                                            aria-owns=""
+                                            id="id-select-team"
+                                            onBlur={[Function]}
+                                            onChange={[Function]}
+                                            onFocus={[Function]}
+                                            required={false}
+                                            role="combobox"
                                             style={
                                               Object {
-                                                "display": "inline-block",
+                                                "boxSizing": "content-box",
+                                                "width": "5px",
                                               }
                                             }
-                                          >
-                                            <input
-                                              aria-activedescendant="react-select-2--value"
-                                              aria-expanded="false"
-                                              aria-haspopup="false"
-                                              aria-owns=""
-                                              id="id-select-team"
-                                              onBlur={[Function]}
-                                              onChange={[Function]}
-                                              onFocus={[Function]}
-                                              required={false}
-                                              role="combobox"
-                                              style={
-                                                Object {
-                                                  "boxSizing": "content-box",
-                                                  "width": "5px",
-                                                }
+                                            value=""
+                                          />
+                                          <div
+                                            style={
+                                              Object {
+                                                "height": 0,
+                                                "left": 0,
+                                                "overflow": "scroll",
+                                                "position": "absolute",
+                                                "top": 0,
+                                                "visibility": "hidden",
+                                                "whiteSpace": "pre",
                                               }
-                                              value=""
-                                            />
-                                            <div
-                                              style={
-                                                Object {
-                                                  "height": 0,
-                                                  "left": 0,
-                                                  "overflow": "scroll",
-                                                  "position": "absolute",
-                                                  "top": 0,
-                                                  "visibility": "hidden",
-                                                  "whiteSpace": "pre",
-                                                }
-                                              }
-                                            />
-                                          </div>
-                                        </AutosizeInput>
-                                      </span>
+                                            }
+                                          />
+                                        </div>
+                                      </AutosizeInput>
+                                    </span>
+                                    <span
+                                      className="Select-arrow-zone"
+                                      onMouseDown={[Function]}
+                                    >
                                       <span
-                                        className="Select-arrow-zone"
-                                        onMouseDown={[Function]}
-                                      >
-                                        <span
-                                          className="icon-arrow-down"
-                                        />
-                                      </span>
-                                    </div>
+                                        className="icon-arrow-down"
+                                      />
+                                    </span>
                                   </div>
-                                </Select>
-                              </SelectPicker>
-                            </ForwardRef(SelectPicker)>
-                          </StyledSelect>
-                        </SelectControl>
-                      </StyledSelectControl>
-                    </div>
+                                </div>
+                              </Select>
+                            </SelectPicker>
+                          </ForwardRef(SelectPicker)>
+                        </StyledSelect>
+                      </SelectControl>
+                    </StyledSelectControl>
                   </div>
-                </SelectField>
-              </div>
+                </div>
+              </SelectField>
             </div>
-            <div>
-              <button
-                className="btn btn-primary new-project-submit"
-                onClick={[Function]}
-              >
-                Create Project
-              </button>
-            </div>
-            <p>
-              Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
-            </p>
           </div>
+          <div>
+            <button
+              className="btn btn-primary new-project-submit"
+              onClick={[Function]}
+            >
+              Create Project
+            </button>
+          </div>
+          <p>
+            Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
+          </p>
         </div>
-      </Wrapper>
+      </div>
     </OnboardingProject>
   </div>
 </CreateProject>

--- a/tests/js/spec/views/onboarding/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/__snapshots__/index.spec.jsx.snap
@@ -129,9 +129,19 @@ exports[`OnboardingWizard render() should render and respond to click events 1`]
           <div
             className="onboarding-info"
           >
-            <h4>
-              Choose a language or framework:
-            </h4>
+            <PageHeading
+              withMargins={true}
+            >
+              <Wrapper
+                withMargins={true}
+              >
+                <h1
+                  className="css-wxef79-Wrapper e1f8hk460"
+                >
+                  Choose a language or framework:
+                </h1>
+              </Wrapper>
+            </PageHeading>
             <PlatformPicker
               name=""
               next={[MockFunction]}
@@ -824,9 +834,19 @@ exports[`OnboardingWizard render() should render and respond to click events 1`]
               <div
                 className="new-project-name client-platform"
               >
-                <h4>
-                  Give your project a name:
-                </h4>
+                <PageHeading
+                  withMargins={true}
+                >
+                  <Wrapper
+                    withMargins={true}
+                  >
+                    <h1
+                      className="css-wxef79-Wrapper e1f8hk460"
+                    >
+                      Give your project a name:
+                    </h1>
+                  </Wrapper>
+                </PageHeading>
                 <div
                   className="project-name-wrapper"
                 >
@@ -855,9 +875,19 @@ exports[`OnboardingWizard render() should render and respond to click events 1`]
               <div
                 className="new-project-team"
               >
-                <h4>
-                  Team:
-                </h4>
+                <PageHeading
+                  withMargins={true}
+                >
+                  <Wrapper
+                    withMargins={true}
+                  >
+                    <h1
+                      className="css-wxef79-Wrapper e1f8hk460"
+                    >
+                      Team:
+                    </h1>
+                  </Wrapper>
+                </PageHeading>
                 <div>
                   <SelectField
                     clearable={false}
@@ -1255,9 +1285,19 @@ exports[`OnboardingWizard render() should render and respond to click events 2`]
           <div
             className="onboarding-info"
           >
-            <h4>
-              Choose a language or framework:
-            </h4>
+            <PageHeading
+              withMargins={true}
+            >
+              <Wrapper
+                withMargins={true}
+              >
+                <h1
+                  className="css-wxef79-Wrapper e1f8hk460"
+                >
+                  Choose a language or framework:
+                </h1>
+              </Wrapper>
+            </PageHeading>
             <PlatformPicker
               name=""
               next={[MockFunction]}
@@ -1964,9 +2004,19 @@ exports[`OnboardingWizard render() should render and respond to click events 2`]
               <div
                 className="new-project-name client-platform"
               >
-                <h4>
-                  Give your project a name:
-                </h4>
+                <PageHeading
+                  withMargins={true}
+                >
+                  <Wrapper
+                    withMargins={true}
+                  >
+                    <h1
+                      className="css-wxef79-Wrapper e1f8hk460"
+                    >
+                      Give your project a name:
+                    </h1>
+                  </Wrapper>
+                </PageHeading>
                 <div
                   className="project-name-wrapper"
                 >
@@ -1995,9 +2045,19 @@ exports[`OnboardingWizard render() should render and respond to click events 2`]
               <div
                 className="new-project-team"
               >
-                <h4>
-                  Team:
-                </h4>
+                <PageHeading
+                  withMargins={true}
+                >
+                  <Wrapper
+                    withMargins={true}
+                  >
+                    <h1
+                      className="css-wxef79-Wrapper e1f8hk460"
+                    >
+                      Team:
+                    </h1>
+                  </Wrapper>
+                </PageHeading>
                 <div>
                   <SelectField
                     clearable={false}

--- a/tests/js/spec/views/onboarding/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/__snapshots__/index.spec.jsx.snap
@@ -126,784 +126,802 @@ exports[`OnboardingWizard render() should render and respond to click events 1`]
           team=""
           teams={Array []}
         >
-          <div
-            className="onboarding-info"
-          >
-            <h4>
-              Choose a language or framework:
-            </h4>
-            <PlatformPicker
-              name=""
-              next={[MockFunction]}
-              platform=""
-              setName={[MockFunction]}
-              setPlatform={[MockFunction]}
-              setTeam={[Function]}
-              showOther={true}
-              team=""
-              teams={Array []}
-            >
-              <div
-                className="platform-picker"
-              >
-                <NavTabs>
-                  <ul
-                    className="nav nav-tabs"
-                  >
-                    <li
-                      style={
-                        Object {
-                          "float": "right",
-                          "marginRight": 0,
-                        }
-                      }
-                    >
-                      <div
-                        className="platform-filter-container"
-                      >
-                        <span
-                          className="icon icon-search"
-                        />
-                        <input
-                          className="platform-filter"
-                          label="Filter"
-                          onChange={[Function]}
-                          placeholder="Filter"
-                          type="text"
-                          value=""
-                        />
-                      </div>
-                    </li>
-                    <ListLink
-                      activeClassName="active"
-                      index={false}
-                      isActive={[Function]}
-                      key="popular"
-                      onClick={[Function]}
-                      to=""
-                    >
-                      <li
-                        className="active"
-                      >
-                        <Link
-                          onClick={[Function]}
-                          onlyActiveOnIndex={false}
-                          style={Object {}}
-                          to=""
-                        >
-                          <a
-                            onClick={[Function]}
-                            style={Object {}}
-                          >
-                            Popular
-                          </a>
-                        </Link>
-                      </li>
-                    </ListLink>
-                    <ListLink
-                      activeClassName="active"
-                      index={false}
-                      isActive={[Function]}
-                      key="browser"
-                      onClick={[Function]}
-                      to=""
-                    >
-                      <li
-                        className=""
-                      >
-                        <Link
-                          onClick={[Function]}
-                          onlyActiveOnIndex={false}
-                          style={Object {}}
-                          to=""
-                        >
-                          <a
-                            onClick={[Function]}
-                            style={Object {}}
-                          >
-                            Browser
-                          </a>
-                        </Link>
-                      </li>
-                    </ListLink>
-                    <ListLink
-                      activeClassName="active"
-                      index={false}
-                      isActive={[Function]}
-                      key="server"
-                      onClick={[Function]}
-                      to=""
-                    >
-                      <li
-                        className=""
-                      >
-                        <Link
-                          onClick={[Function]}
-                          onlyActiveOnIndex={false}
-                          style={Object {}}
-                          to=""
-                        >
-                          <a
-                            onClick={[Function]}
-                            style={Object {}}
-                          >
-                            Server
-                          </a>
-                        </Link>
-                      </li>
-                    </ListLink>
-                    <ListLink
-                      activeClassName="active"
-                      index={false}
-                      isActive={[Function]}
-                      key="mobile"
-                      onClick={[Function]}
-                      to=""
-                    >
-                      <li
-                        className=""
-                      >
-                        <Link
-                          onClick={[Function]}
-                          onlyActiveOnIndex={false}
-                          style={Object {}}
-                          to=""
-                        >
-                          <a
-                            onClick={[Function]}
-                            style={Object {}}
-                          >
-                            Mobile
-                          </a>
-                        </Link>
-                      </li>
-                    </ListLink>
-                    <ListLink
-                      activeClassName="active"
-                      index={false}
-                      isActive={[Function]}
-                      key="desktop"
-                      onClick={[Function]}
-                      to=""
-                    >
-                      <li
-                        className=""
-                      >
-                        <Link
-                          onClick={[Function]}
-                          onlyActiveOnIndex={false}
-                          style={Object {}}
-                          to=""
-                        >
-                          <a
-                            onClick={[Function]}
-                            style={Object {}}
-                          >
-                            Desktop
-                          </a>
-                        </Link>
-                      </li>
-                    </ListLink>
-                    <ListLink
-                      activeClassName="active"
-                      index={false}
-                      isActive={[Function]}
-                      key="all"
-                      onClick={[Function]}
-                      to=""
-                    >
-                      <li
-                        className=""
-                      >
-                        <Link
-                          onClick={[Function]}
-                          onlyActiveOnIndex={false}
-                          style={Object {}}
-                          to=""
-                        >
-                          <a
-                            onClick={[Function]}
-                            style={Object {}}
-                          >
-                            All
-                          </a>
-                        </Link>
-                      </li>
-                    </ListLink>
-                  </ul>
-                </NavTabs>
-                <ul
-                  className="client-platform-list platform-tiles"
-                >
-                  <PlatformCard
-                    className=""
-                    key="csharp"
-                    onClick={[Function]}
-                    platform="csharp"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="csharp"
-                      >
-                        <li
-                          className="platform-tile list-unstyled csharp csharp "
-                        >
-                          <span
-                            className="platformicon platformicon-csharp"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        C#
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="java"
-                    onClick={[Function]}
-                    platform="java"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="java"
-                      >
-                        <li
-                          className="platform-tile list-unstyled java java "
-                        >
-                          <span
-                            className="platformicon platformicon-java"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Java
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="javascript-angular"
-                    onClick={[Function]}
-                    platform="javascript-angular"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="javascript-angular"
-                      >
-                        <li
-                          className="platform-tile list-unstyled javascript-angular javascript "
-                        >
-                          <span
-                            className="platformicon platformicon-javascript-angular"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Angular
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="javascript"
-                    onClick={[Function]}
-                    platform="javascript"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="javascript"
-                      >
-                        <li
-                          className="platform-tile list-unstyled javascript javascript "
-                        >
-                          <span
-                            className="platformicon platformicon-javascript"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        JavaScript
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="javascript-react"
-                    onClick={[Function]}
-                    platform="javascript-react"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="javascript-react"
-                      >
-                        <li
-                          className="platform-tile list-unstyled javascript-react javascript "
-                        >
-                          <span
-                            className="platformicon platformicon-javascript-react"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        React
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="node-express"
-                    onClick={[Function]}
-                    platform="node-express"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="node-express"
-                      >
-                        <li
-                          className="platform-tile list-unstyled node-express node "
-                        >
-                          <span
-                            className="platformicon platformicon-node-express"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Express
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="node"
-                    onClick={[Function]}
-                    platform="node"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="node"
-                      >
-                        <li
-                          className="platform-tile list-unstyled node node "
-                        >
-                          <span
-                            className="platformicon platformicon-node"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Node.js
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="php-laravel"
-                    onClick={[Function]}
-                    platform="php-laravel"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="php-laravel"
-                      >
-                        <li
-                          className="platform-tile list-unstyled php-laravel php "
-                        >
-                          <span
-                            className="platformicon platformicon-php-laravel"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Laravel
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="php"
-                    onClick={[Function]}
-                    platform="php"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="php"
-                      >
-                        <li
-                          className="platform-tile list-unstyled php php "
-                        >
-                          <span
-                            className="platformicon platformicon-php"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        PHP
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="php-symfony2"
-                    onClick={[Function]}
-                    platform="php-symfony2"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="php-symfony2"
-                      >
-                        <li
-                          className="platform-tile list-unstyled php-symfony2 php "
-                        >
-                          <span
-                            className="platformicon platformicon-php-symfony2"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Symfony2
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="python-django"
-                    onClick={[Function]}
-                    platform="python-django"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="python-django"
-                      >
-                        <li
-                          className="platform-tile list-unstyled python-django python "
-                        >
-                          <span
-                            className="platformicon platformicon-python-django"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Django
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="python-flask"
-                    onClick={[Function]}
-                    platform="python-flask"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="python-flask"
-                      >
-                        <li
-                          className="platform-tile list-unstyled python-flask python "
-                        >
-                          <span
-                            className="platformicon platformicon-python-flask"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Flask
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="python"
-                    onClick={[Function]}
-                    platform="python"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="python"
-                      >
-                        <li
-                          className="platform-tile list-unstyled python python "
-                        >
-                          <span
-                            className="platformicon platformicon-python"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Python
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="cocoa"
-                    onClick={[Function]}
-                    platform="cocoa"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="cocoa"
-                      >
-                        <li
-                          className="platform-tile list-unstyled cocoa cocoa "
-                        >
-                          <span
-                            className="platformicon platformicon-cocoa"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        React-Native
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="ruby-rails"
-                    onClick={[Function]}
-                    platform="ruby-rails"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="ruby-rails"
-                      >
-                        <li
-                          className="platform-tile list-unstyled ruby-rails ruby "
-                        >
-                          <span
-                            className="platformicon platformicon-ruby-rails"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Rails
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="ruby"
-                    onClick={[Function]}
-                    platform="ruby"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="ruby"
-                      >
-                        <li
-                          className="platform-tile list-unstyled ruby ruby "
-                        >
-                          <span
-                            className="platformicon platformicon-ruby"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Ruby
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                </ul>
-              </div>
-            </PlatformPicker>
+          <Wrapper>
             <div
-              className="create-project-form"
+              className="css-a5urgt-Wrapper e1bu5aqa0"
             >
-              <div
-                className="new-project-name client-platform"
+              <PageHeading
+                withMargins={true}
               >
-                <h4>
-                  Give your project a name:
-                </h4>
-                <div
-                  className="project-name-wrapper"
+                <Wrapper
+                  withMargins={true}
                 >
-                  <PlatformiconTile
-                    platform=""
+                  <h1
+                    className="css-wxef79-Wrapper e1f8hk460"
                   >
-                    <li
-                      className="platform-tile list-unstyled   undefined"
+                    Choose a language or framework:
+                  </h1>
+                </Wrapper>
+              </PageHeading>
+              <PlatformPicker
+                name=""
+                next={[MockFunction]}
+                platform=""
+                setName={[MockFunction]}
+                setPlatform={[MockFunction]}
+                setTeam={[Function]}
+                showOther={true}
+                team=""
+                teams={Array []}
+              >
+                <div
+                  className="platform-picker"
+                >
+                  <NavTabs>
+                    <ul
+                      className="nav nav-tabs"
+                    >
+                      <li
+                        style={
+                          Object {
+                            "float": "right",
+                            "marginRight": 0,
+                          }
+                        }
+                      >
+                        <div
+                          className="platform-filter-container"
+                        >
+                          <span
+                            className="icon icon-search"
+                          />
+                          <input
+                            className="platform-filter"
+                            label="Filter"
+                            onChange={[Function]}
+                            placeholder="Filter"
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </li>
+                      <ListLink
+                        activeClassName="active"
+                        index={false}
+                        isActive={[Function]}
+                        key="popular"
+                        onClick={[Function]}
+                        to=""
+                      >
+                        <li
+                          className="active"
+                        >
+                          <Link
+                            onClick={[Function]}
+                            onlyActiveOnIndex={false}
+                            style={Object {}}
+                            to=""
+                          >
+                            <a
+                              onClick={[Function]}
+                              style={Object {}}
+                            >
+                              Popular
+                            </a>
+                          </Link>
+                        </li>
+                      </ListLink>
+                      <ListLink
+                        activeClassName="active"
+                        index={false}
+                        isActive={[Function]}
+                        key="browser"
+                        onClick={[Function]}
+                        to=""
+                      >
+                        <li
+                          className=""
+                        >
+                          <Link
+                            onClick={[Function]}
+                            onlyActiveOnIndex={false}
+                            style={Object {}}
+                            to=""
+                          >
+                            <a
+                              onClick={[Function]}
+                              style={Object {}}
+                            >
+                              Browser
+                            </a>
+                          </Link>
+                        </li>
+                      </ListLink>
+                      <ListLink
+                        activeClassName="active"
+                        index={false}
+                        isActive={[Function]}
+                        key="server"
+                        onClick={[Function]}
+                        to=""
+                      >
+                        <li
+                          className=""
+                        >
+                          <Link
+                            onClick={[Function]}
+                            onlyActiveOnIndex={false}
+                            style={Object {}}
+                            to=""
+                          >
+                            <a
+                              onClick={[Function]}
+                              style={Object {}}
+                            >
+                              Server
+                            </a>
+                          </Link>
+                        </li>
+                      </ListLink>
+                      <ListLink
+                        activeClassName="active"
+                        index={false}
+                        isActive={[Function]}
+                        key="mobile"
+                        onClick={[Function]}
+                        to=""
+                      >
+                        <li
+                          className=""
+                        >
+                          <Link
+                            onClick={[Function]}
+                            onlyActiveOnIndex={false}
+                            style={Object {}}
+                            to=""
+                          >
+                            <a
+                              onClick={[Function]}
+                              style={Object {}}
+                            >
+                              Mobile
+                            </a>
+                          </Link>
+                        </li>
+                      </ListLink>
+                      <ListLink
+                        activeClassName="active"
+                        index={false}
+                        isActive={[Function]}
+                        key="desktop"
+                        onClick={[Function]}
+                        to=""
+                      >
+                        <li
+                          className=""
+                        >
+                          <Link
+                            onClick={[Function]}
+                            onlyActiveOnIndex={false}
+                            style={Object {}}
+                            to=""
+                          >
+                            <a
+                              onClick={[Function]}
+                              style={Object {}}
+                            >
+                              Desktop
+                            </a>
+                          </Link>
+                        </li>
+                      </ListLink>
+                      <ListLink
+                        activeClassName="active"
+                        index={false}
+                        isActive={[Function]}
+                        key="all"
+                        onClick={[Function]}
+                        to=""
+                      >
+                        <li
+                          className=""
+                        >
+                          <Link
+                            onClick={[Function]}
+                            onlyActiveOnIndex={false}
+                            style={Object {}}
+                            to=""
+                          >
+                            <a
+                              onClick={[Function]}
+                              style={Object {}}
+                            >
+                              All
+                            </a>
+                          </Link>
+                        </li>
+                      </ListLink>
+                    </ul>
+                  </NavTabs>
+                  <ul
+                    className="client-platform-list platform-tiles"
+                  >
+                    <PlatformCard
+                      className=""
+                      key="csharp"
+                      onClick={[Function]}
+                      platform="csharp"
                     >
                       <span
-                        className="platformicon platformicon-"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <input
-                    autoComplete="off"
-                    label="Project Name"
-                    name="name"
-                    onChange={[Function]}
-                    placeholder="Project name"
-                    type="text"
-                    value=""
-                  />
-                </div>
-              </div>
-              <div
-                className="new-project-team"
-              >
-                <h4>
-                  Team:
-                </h4>
-                <div>
-                  <SelectField
-                    clearable={false}
-                    disabled={false}
-                    hideErrorMessage={false}
-                    multiple={false}
-                    name="select-team"
-                    onChange={[Function]}
-                    options={Array []}
-                    required={false}
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "width": 180,
-                      }
-                    }
-                    value=""
-                  >
-                    <div
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="csharp"
+                        >
+                          <li
+                            className="platform-tile list-unstyled csharp csharp "
+                          >
+                            <span
+                              className="platformicon platformicon-csharp"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          C#
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
                       className=""
+                      key="java"
+                      onClick={[Function]}
+                      platform="java"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="java"
+                        >
+                          <li
+                            className="platform-tile list-unstyled java java "
+                          >
+                            <span
+                              className="platformicon platformicon-java"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Java
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="javascript-angular"
+                      onClick={[Function]}
+                      platform="javascript-angular"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="javascript-angular"
+                        >
+                          <li
+                            className="platform-tile list-unstyled javascript-angular javascript "
+                          >
+                            <span
+                              className="platformicon platformicon-javascript-angular"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Angular
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="javascript"
+                      onClick={[Function]}
+                      platform="javascript"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="javascript"
+                        >
+                          <li
+                            className="platform-tile list-unstyled javascript javascript "
+                          >
+                            <span
+                              className="platformicon platformicon-javascript"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          JavaScript
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="javascript-react"
+                      onClick={[Function]}
+                      platform="javascript-react"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="javascript-react"
+                        >
+                          <li
+                            className="platform-tile list-unstyled javascript-react javascript "
+                          >
+                            <span
+                              className="platformicon platformicon-javascript-react"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          React
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="node-express"
+                      onClick={[Function]}
+                      platform="node-express"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="node-express"
+                        >
+                          <li
+                            className="platform-tile list-unstyled node-express node "
+                          >
+                            <span
+                              className="platformicon platformicon-node-express"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Express
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="node"
+                      onClick={[Function]}
+                      platform="node"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="node"
+                        >
+                          <li
+                            className="platform-tile list-unstyled node node "
+                          >
+                            <span
+                              className="platformicon platformicon-node"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Node.js
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="php-laravel"
+                      onClick={[Function]}
+                      platform="php-laravel"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="php-laravel"
+                        >
+                          <li
+                            className="platform-tile list-unstyled php-laravel php "
+                          >
+                            <span
+                              className="platformicon platformicon-php-laravel"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Laravel
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="php"
+                      onClick={[Function]}
+                      platform="php"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="php"
+                        >
+                          <li
+                            className="platform-tile list-unstyled php php "
+                          >
+                            <span
+                              className="platformicon platformicon-php"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          PHP
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="php-symfony2"
+                      onClick={[Function]}
+                      platform="php-symfony2"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="php-symfony2"
+                        >
+                          <li
+                            className="platform-tile list-unstyled php-symfony2 php "
+                          >
+                            <span
+                              className="platformicon platformicon-php-symfony2"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Symfony2
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="python-django"
+                      onClick={[Function]}
+                      platform="python-django"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="python-django"
+                        >
+                          <li
+                            className="platform-tile list-unstyled python-django python "
+                          >
+                            <span
+                              className="platformicon platformicon-python-django"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Django
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="python-flask"
+                      onClick={[Function]}
+                      platform="python-flask"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="python-flask"
+                        >
+                          <li
+                            className="platform-tile list-unstyled python-flask python "
+                          >
+                            <span
+                              className="platformicon platformicon-python-flask"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Flask
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="python"
+                      onClick={[Function]}
+                      platform="python"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="python"
+                        >
+                          <li
+                            className="platform-tile list-unstyled python python "
+                          >
+                            <span
+                              className="platformicon platformicon-python"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Python
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="cocoa"
+                      onClick={[Function]}
+                      platform="cocoa"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="cocoa"
+                        >
+                          <li
+                            className="platform-tile list-unstyled cocoa cocoa "
+                          >
+                            <span
+                              className="platformicon platformicon-cocoa"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          React-Native
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="ruby-rails"
+                      onClick={[Function]}
+                      platform="ruby-rails"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="ruby-rails"
+                        >
+                          <li
+                            className="platform-tile list-unstyled ruby-rails ruby "
+                          >
+                            <span
+                              className="platformicon platformicon-ruby-rails"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Rails
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="ruby"
+                      onClick={[Function]}
+                      platform="ruby"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="ruby"
+                        >
+                          <li
+                            className="platform-tile list-unstyled ruby ruby "
+                          >
+                            <span
+                              className="platformicon platformicon-ruby"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Ruby
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                  </ul>
+                </div>
+              </PlatformPicker>
+              <div
+                className="create-project-form"
+              >
+                <div
+                  className="new-project-name client-platform"
+                >
+                  <PageHeading
+                    withMargins={true}
+                  >
+                    <Wrapper
+                      withMargins={true}
+                    >
+                      <h1
+                        className="css-wxef79-Wrapper e1f8hk460"
+                      >
+                        Give your project a name:
+                      </h1>
+                    </Wrapper>
+                  </PageHeading>
+                  <div
+                    className="project-name-wrapper"
+                  >
+                    <PlatformiconTile
+                      platform=""
+                    >
+                      <li
+                        className="platform-tile list-unstyled   undefined"
+                      >
+                        <span
+                          className="platformicon platformicon-"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <input
+                      autoComplete="off"
+                      label="Project Name"
+                      name="name"
+                      onChange={[Function]}
+                      placeholder="Project name"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+                <div
+                  className="new-project-team"
+                >
+                  <PageHeading
+                    withMargins={true}
+                  >
+                    <Wrapper
+                      withMargins={true}
+                    >
+                      <h1
+                        className="css-wxef79-Wrapper e1f8hk460"
+                      >
+                        Team:
+                      </h1>
+                    </Wrapper>
+                  </PageHeading>
+                  <div>
+                    <SelectField
+                      clearable={false}
+                      disabled={false}
+                      hideErrorMessage={false}
+                      multiple={false}
+                      name="select-team"
+                      onChange={[Function]}
+                      options={Array []}
+                      required={false}
                       style={
                         Object {
                           "marginBottom": 0,
                           "width": 180,
                         }
                       }
+                      value=""
                     >
                       <div
-                        className="controls"
+                        className=""
+                        style={
+                          Object {
+                            "marginBottom": 0,
+                            "width": 180,
+                          }
+                        }
                       >
-                        <StyledSelectControl
-                          clearable={false}
-                          disabled={false}
-                          id="id-select-team"
-                          multiple={false}
-                          name="select-team"
-                          onChange={[Function]}
-                          options={Array []}
-                          required={false}
-                          value=""
+                        <div
+                          className="controls"
                         >
-                          <SelectControl
-                            className="css-j6zs66-StyledSelectControl e1qrhqd00"
+                          <StyledSelectControl
                             clearable={false}
                             disabled={false}
-                            height={36}
                             id="id-select-team"
                             multiple={false}
                             name="select-team"
@@ -912,12 +930,9 @@ exports[`OnboardingWizard render() should render and respond to click events 1`]
                             required={false}
                             value=""
                           >
-                            <StyledSelect
-                              arrowRenderer={[Function]}
-                              backspaceRemoves={false}
+                            <SelectControl
                               className="css-j6zs66-StyledSelectControl e1qrhqd00"
                               clearable={false}
-                              deleteRemoves={false}
                               disabled={false}
                               height={36}
                               id="id-select-team"
@@ -928,10 +943,10 @@ exports[`OnboardingWizard render() should render and respond to click events 1`]
                               required={false}
                               value=""
                             >
-                              <ForwardRef(SelectPicker)
+                              <StyledSelect
                                 arrowRenderer={[Function]}
                                 backspaceRemoves={false}
-                                className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
+                                className="css-j6zs66-StyledSelectControl e1qrhqd00"
                                 clearable={false}
                                 deleteRemoves={false}
                                 disabled={false}
@@ -944,14 +959,13 @@ exports[`OnboardingWizard render() should render and respond to click events 1`]
                                 required={false}
                                 value=""
                               >
-                                <SelectPicker
+                                <ForwardRef(SelectPicker)
                                   arrowRenderer={[Function]}
                                   backspaceRemoves={false}
                                   className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
                                   clearable={false}
                                   deleteRemoves={false}
                                   disabled={false}
-                                  forwardedRef={null}
                                   height={36}
                                   id="id-select-team"
                                   multiple={false}
@@ -961,172 +975,190 @@ exports[`OnboardingWizard render() should render and respond to click events 1`]
                                   required={false}
                                   value=""
                                 >
-                                  <Select
+                                  <SelectPicker
                                     arrowRenderer={[Function]}
-                                    autosize={true}
                                     backspaceRemoves={false}
-                                    backspaceToRemoveMessage="Press backspace to remove {label}"
                                     className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
-                                    clearAllText="Clear all"
-                                    clearRenderer={[Function]}
-                                    clearValueText="Clear value"
                                     clearable={false}
-                                    closeOnSelect={true}
                                     deleteRemoves={false}
-                                    delimiter=","
                                     disabled={false}
-                                    escapeClearsValue={true}
-                                    filterOptions={[Function]}
+                                    forwardedRef={null}
                                     height={36}
                                     id="id-select-team"
-                                    ignoreAccents={true}
-                                    ignoreCase={true}
-                                    inputProps={Object {}}
-                                    isLoading={false}
-                                    joinValues={false}
-                                    labelKey="label"
-                                    matchPos="any"
-                                    matchProp="any"
-                                    menuBuffer={0}
-                                    menuRenderer={[Function]}
-                                    multi={false}
                                     multiple={false}
                                     name="select-team"
-                                    noResultsText="No results found"
-                                    onBlurResetsInput={true}
                                     onChange={[Function]}
-                                    onCloseResetsInput={true}
-                                    onSelectResetsInput={true}
-                                    openOnClick={true}
-                                    optionComponent={[Function]}
                                     options={Array []}
-                                    pageSize={5}
-                                    placeholder="Select..."
-                                    removeSelected={true}
                                     required={false}
-                                    rtl={false}
-                                    scrollMenuIntoView={true}
-                                    searchable={true}
-                                    simpleValue={false}
-                                    tabSelectsValue={true}
-                                    trimFilter={true}
                                     value=""
-                                    valueComponent={[Function]}
-                                    valueKey="value"
                                   >
-                                    <div
-                                      className="Select e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
+                                    <Select
+                                      arrowRenderer={[Function]}
+                                      autosize={true}
+                                      backspaceRemoves={false}
+                                      backspaceToRemoveMessage="Press backspace to remove {label}"
+                                      className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
+                                      clearAllText="Clear all"
+                                      clearRenderer={[Function]}
+                                      clearValueText="Clear value"
+                                      clearable={false}
+                                      closeOnSelect={true}
+                                      deleteRemoves={false}
+                                      delimiter=","
+                                      disabled={false}
+                                      escapeClearsValue={true}
+                                      filterOptions={[Function]}
+                                      height={36}
+                                      id="id-select-team"
+                                      ignoreAccents={true}
+                                      ignoreCase={true}
+                                      inputProps={Object {}}
+                                      isLoading={false}
+                                      joinValues={false}
+                                      labelKey="label"
+                                      matchPos="any"
+                                      matchProp="any"
+                                      menuBuffer={0}
+                                      menuRenderer={[Function]}
+                                      multi={false}
+                                      multiple={false}
+                                      name="select-team"
+                                      noResultsText="No results found"
+                                      onBlurResetsInput={true}
+                                      onChange={[Function]}
+                                      onCloseResetsInput={true}
+                                      onSelectResetsInput={true}
+                                      openOnClick={true}
+                                      optionComponent={[Function]}
+                                      options={Array []}
+                                      pageSize={5}
+                                      placeholder="Select..."
+                                      removeSelected={true}
+                                      required={false}
+                                      rtl={false}
+                                      scrollMenuIntoView={true}
+                                      searchable={true}
+                                      simpleValue={false}
+                                      tabSelectsValue={true}
+                                      trimFilter={true}
+                                      value=""
+                                      valueComponent={[Function]}
+                                      valueKey="value"
                                     >
                                       <div
-                                        className="Select-control"
-                                        onKeyDown={[Function]}
-                                        onMouseDown={[Function]}
-                                        onTouchEnd={[Function]}
-                                        onTouchMove={[Function]}
-                                        onTouchStart={[Function]}
+                                        className="Select e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
                                       >
-                                        <span
-                                          className="Select-multi-value-wrapper"
-                                          id="react-select-2--value"
-                                        >
-                                          <div
-                                            className="Select-placeholder"
-                                          >
-                                            Select...
-                                          </div>
-                                          <AutosizeInput
-                                            aria-activedescendant="react-select-2--value"
-                                            aria-expanded="false"
-                                            aria-haspopup="false"
-                                            aria-owns=""
-                                            className="Select-input"
-                                            id="id-select-team"
-                                            injectStyles={true}
-                                            minWidth="5"
-                                            onBlur={[Function]}
-                                            onChange={[Function]}
-                                            onFocus={[Function]}
-                                            required={false}
-                                            role="combobox"
-                                            value=""
-                                          >
-                                            <div
-                                              className="Select-input"
-                                              style={
-                                                Object {
-                                                  "display": "inline-block",
-                                                }
-                                              }
-                                            >
-                                              <input
-                                                aria-activedescendant="react-select-2--value"
-                                                aria-expanded="false"
-                                                aria-haspopup="false"
-                                                aria-owns=""
-                                                id="id-select-team"
-                                                onBlur={[Function]}
-                                                onChange={[Function]}
-                                                onFocus={[Function]}
-                                                required={false}
-                                                role="combobox"
-                                                style={
-                                                  Object {
-                                                    "boxSizing": "content-box",
-                                                    "width": "5px",
-                                                  }
-                                                }
-                                                value=""
-                                              />
-                                              <div
-                                                style={
-                                                  Object {
-                                                    "height": 0,
-                                                    "left": 0,
-                                                    "overflow": "scroll",
-                                                    "position": "absolute",
-                                                    "top": 0,
-                                                    "visibility": "hidden",
-                                                    "whiteSpace": "pre",
-                                                  }
-                                                }
-                                              />
-                                            </div>
-                                          </AutosizeInput>
-                                        </span>
-                                        <span
-                                          className="Select-arrow-zone"
+                                        <div
+                                          className="Select-control"
+                                          onKeyDown={[Function]}
                                           onMouseDown={[Function]}
+                                          onTouchEnd={[Function]}
+                                          onTouchMove={[Function]}
+                                          onTouchStart={[Function]}
                                         >
                                           <span
-                                            className="icon-arrow-down"
-                                          />
-                                        </span>
+                                            className="Select-multi-value-wrapper"
+                                            id="react-select-2--value"
+                                          >
+                                            <div
+                                              className="Select-placeholder"
+                                            >
+                                              Select...
+                                            </div>
+                                            <AutosizeInput
+                                              aria-activedescendant="react-select-2--value"
+                                              aria-expanded="false"
+                                              aria-haspopup="false"
+                                              aria-owns=""
+                                              className="Select-input"
+                                              id="id-select-team"
+                                              injectStyles={true}
+                                              minWidth="5"
+                                              onBlur={[Function]}
+                                              onChange={[Function]}
+                                              onFocus={[Function]}
+                                              required={false}
+                                              role="combobox"
+                                              value=""
+                                            >
+                                              <div
+                                                className="Select-input"
+                                                style={
+                                                  Object {
+                                                    "display": "inline-block",
+                                                  }
+                                                }
+                                              >
+                                                <input
+                                                  aria-activedescendant="react-select-2--value"
+                                                  aria-expanded="false"
+                                                  aria-haspopup="false"
+                                                  aria-owns=""
+                                                  id="id-select-team"
+                                                  onBlur={[Function]}
+                                                  onChange={[Function]}
+                                                  onFocus={[Function]}
+                                                  required={false}
+                                                  role="combobox"
+                                                  style={
+                                                    Object {
+                                                      "boxSizing": "content-box",
+                                                      "width": "5px",
+                                                    }
+                                                  }
+                                                  value=""
+                                                />
+                                                <div
+                                                  style={
+                                                    Object {
+                                                      "height": 0,
+                                                      "left": 0,
+                                                      "overflow": "scroll",
+                                                      "position": "absolute",
+                                                      "top": 0,
+                                                      "visibility": "hidden",
+                                                      "whiteSpace": "pre",
+                                                    }
+                                                  }
+                                                />
+                                              </div>
+                                            </AutosizeInput>
+                                          </span>
+                                          <span
+                                            className="Select-arrow-zone"
+                                            onMouseDown={[Function]}
+                                          >
+                                            <span
+                                              className="icon-arrow-down"
+                                            />
+                                          </span>
+                                        </div>
                                       </div>
-                                    </div>
-                                  </Select>
-                                </SelectPicker>
-                              </ForwardRef(SelectPicker)>
-                            </StyledSelect>
-                          </SelectControl>
-                        </StyledSelectControl>
+                                    </Select>
+                                  </SelectPicker>
+                                </ForwardRef(SelectPicker)>
+                              </StyledSelect>
+                            </SelectControl>
+                          </StyledSelectControl>
+                        </div>
                       </div>
-                    </div>
-                  </SelectField>
+                    </SelectField>
+                  </div>
                 </div>
+                <div>
+                  <button
+                    className="btn btn-primary new-project-submit"
+                    onClick={[Function]}
+                  >
+                    Create Project
+                  </button>
+                </div>
+                <p>
+                  Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
+                </p>
               </div>
-              <div>
-                <button
-                  className="btn btn-primary new-project-submit"
-                  onClick={[Function]}
-                >
-                  Create Project
-                </button>
-              </div>
-              <p>
-                Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
-              </p>
             </div>
-          </div>
+          </Wrapper>
         </OnboardingProject>
       </div>
     </div>
@@ -1252,798 +1284,816 @@ exports[`OnboardingWizard render() should render and respond to click events 2`]
           team=""
           teams={Array []}
         >
-          <div
-            className="onboarding-info"
-          >
-            <h4>
-              Choose a language or framework:
-            </h4>
-            <PlatformPicker
-              name=""
-              next={[MockFunction]}
-              platform=""
-              setName={[MockFunction]}
-              setPlatform={
-                [MockFunction] {
-                  "calls": Array [
-                    Array [
-                      "csharp",
-                    ],
-                  ],
-                  "results": Array [
-                    Object {
-                      "isThrow": false,
-                      "value": undefined,
-                    },
-                  ],
-                }
-              }
-              setTeam={[Function]}
-              showOther={true}
-              team=""
-              teams={Array []}
-            >
-              <div
-                className="platform-picker"
-              >
-                <NavTabs>
-                  <ul
-                    className="nav nav-tabs"
-                  >
-                    <li
-                      style={
-                        Object {
-                          "float": "right",
-                          "marginRight": 0,
-                        }
-                      }
-                    >
-                      <div
-                        className="platform-filter-container"
-                      >
-                        <span
-                          className="icon icon-search"
-                        />
-                        <input
-                          className="platform-filter"
-                          label="Filter"
-                          onChange={[Function]}
-                          placeholder="Filter"
-                          type="text"
-                          value=""
-                        />
-                      </div>
-                    </li>
-                    <ListLink
-                      activeClassName="active"
-                      index={false}
-                      isActive={[Function]}
-                      key="popular"
-                      onClick={[Function]}
-                      to=""
-                    >
-                      <li
-                        className="active"
-                      >
-                        <Link
-                          onClick={[Function]}
-                          onlyActiveOnIndex={false}
-                          style={Object {}}
-                          to=""
-                        >
-                          <a
-                            onClick={[Function]}
-                            style={Object {}}
-                          >
-                            Popular
-                          </a>
-                        </Link>
-                      </li>
-                    </ListLink>
-                    <ListLink
-                      activeClassName="active"
-                      index={false}
-                      isActive={[Function]}
-                      key="browser"
-                      onClick={[Function]}
-                      to=""
-                    >
-                      <li
-                        className=""
-                      >
-                        <Link
-                          onClick={[Function]}
-                          onlyActiveOnIndex={false}
-                          style={Object {}}
-                          to=""
-                        >
-                          <a
-                            onClick={[Function]}
-                            style={Object {}}
-                          >
-                            Browser
-                          </a>
-                        </Link>
-                      </li>
-                    </ListLink>
-                    <ListLink
-                      activeClassName="active"
-                      index={false}
-                      isActive={[Function]}
-                      key="server"
-                      onClick={[Function]}
-                      to=""
-                    >
-                      <li
-                        className=""
-                      >
-                        <Link
-                          onClick={[Function]}
-                          onlyActiveOnIndex={false}
-                          style={Object {}}
-                          to=""
-                        >
-                          <a
-                            onClick={[Function]}
-                            style={Object {}}
-                          >
-                            Server
-                          </a>
-                        </Link>
-                      </li>
-                    </ListLink>
-                    <ListLink
-                      activeClassName="active"
-                      index={false}
-                      isActive={[Function]}
-                      key="mobile"
-                      onClick={[Function]}
-                      to=""
-                    >
-                      <li
-                        className=""
-                      >
-                        <Link
-                          onClick={[Function]}
-                          onlyActiveOnIndex={false}
-                          style={Object {}}
-                          to=""
-                        >
-                          <a
-                            onClick={[Function]}
-                            style={Object {}}
-                          >
-                            Mobile
-                          </a>
-                        </Link>
-                      </li>
-                    </ListLink>
-                    <ListLink
-                      activeClassName="active"
-                      index={false}
-                      isActive={[Function]}
-                      key="desktop"
-                      onClick={[Function]}
-                      to=""
-                    >
-                      <li
-                        className=""
-                      >
-                        <Link
-                          onClick={[Function]}
-                          onlyActiveOnIndex={false}
-                          style={Object {}}
-                          to=""
-                        >
-                          <a
-                            onClick={[Function]}
-                            style={Object {}}
-                          >
-                            Desktop
-                          </a>
-                        </Link>
-                      </li>
-                    </ListLink>
-                    <ListLink
-                      activeClassName="active"
-                      index={false}
-                      isActive={[Function]}
-                      key="all"
-                      onClick={[Function]}
-                      to=""
-                    >
-                      <li
-                        className=""
-                      >
-                        <Link
-                          onClick={[Function]}
-                          onlyActiveOnIndex={false}
-                          style={Object {}}
-                          to=""
-                        >
-                          <a
-                            onClick={[Function]}
-                            style={Object {}}
-                          >
-                            All
-                          </a>
-                        </Link>
-                      </li>
-                    </ListLink>
-                  </ul>
-                </NavTabs>
-                <ul
-                  className="client-platform-list platform-tiles"
-                >
-                  <PlatformCard
-                    className=""
-                    key="csharp"
-                    onClick={[Function]}
-                    platform="csharp"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="csharp"
-                      >
-                        <li
-                          className="platform-tile list-unstyled csharp csharp "
-                        >
-                          <span
-                            className="platformicon platformicon-csharp"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        C#
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="java"
-                    onClick={[Function]}
-                    platform="java"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="java"
-                      >
-                        <li
-                          className="platform-tile list-unstyled java java "
-                        >
-                          <span
-                            className="platformicon platformicon-java"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Java
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="javascript-angular"
-                    onClick={[Function]}
-                    platform="javascript-angular"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="javascript-angular"
-                      >
-                        <li
-                          className="platform-tile list-unstyled javascript-angular javascript "
-                        >
-                          <span
-                            className="platformicon platformicon-javascript-angular"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Angular
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="javascript"
-                    onClick={[Function]}
-                    platform="javascript"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="javascript"
-                      >
-                        <li
-                          className="platform-tile list-unstyled javascript javascript "
-                        >
-                          <span
-                            className="platformicon platformicon-javascript"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        JavaScript
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="javascript-react"
-                    onClick={[Function]}
-                    platform="javascript-react"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="javascript-react"
-                      >
-                        <li
-                          className="platform-tile list-unstyled javascript-react javascript "
-                        >
-                          <span
-                            className="platformicon platformicon-javascript-react"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        React
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="node-express"
-                    onClick={[Function]}
-                    platform="node-express"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="node-express"
-                      >
-                        <li
-                          className="platform-tile list-unstyled node-express node "
-                        >
-                          <span
-                            className="platformicon platformicon-node-express"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Express
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="node"
-                    onClick={[Function]}
-                    platform="node"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="node"
-                      >
-                        <li
-                          className="platform-tile list-unstyled node node "
-                        >
-                          <span
-                            className="platformicon platformicon-node"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Node.js
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="php-laravel"
-                    onClick={[Function]}
-                    platform="php-laravel"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="php-laravel"
-                      >
-                        <li
-                          className="platform-tile list-unstyled php-laravel php "
-                        >
-                          <span
-                            className="platformicon platformicon-php-laravel"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Laravel
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="php"
-                    onClick={[Function]}
-                    platform="php"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="php"
-                      >
-                        <li
-                          className="platform-tile list-unstyled php php "
-                        >
-                          <span
-                            className="platformicon platformicon-php"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        PHP
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="php-symfony2"
-                    onClick={[Function]}
-                    platform="php-symfony2"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="php-symfony2"
-                      >
-                        <li
-                          className="platform-tile list-unstyled php-symfony2 php "
-                        >
-                          <span
-                            className="platformicon platformicon-php-symfony2"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Symfony2
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="python-django"
-                    onClick={[Function]}
-                    platform="python-django"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="python-django"
-                      >
-                        <li
-                          className="platform-tile list-unstyled python-django python "
-                        >
-                          <span
-                            className="platformicon platformicon-python-django"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Django
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="python-flask"
-                    onClick={[Function]}
-                    platform="python-flask"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="python-flask"
-                      >
-                        <li
-                          className="platform-tile list-unstyled python-flask python "
-                        >
-                          <span
-                            className="platformicon platformicon-python-flask"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Flask
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="python"
-                    onClick={[Function]}
-                    platform="python"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="python"
-                      >
-                        <li
-                          className="platform-tile list-unstyled python python "
-                        >
-                          <span
-                            className="platformicon platformicon-python"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Python
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="cocoa"
-                    onClick={[Function]}
-                    platform="cocoa"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="cocoa"
-                      >
-                        <li
-                          className="platform-tile list-unstyled cocoa cocoa "
-                        >
-                          <span
-                            className="platformicon platformicon-cocoa"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        React-Native
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="ruby-rails"
-                    onClick={[Function]}
-                    platform="ruby-rails"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="ruby-rails"
-                      >
-                        <li
-                          className="platform-tile list-unstyled ruby-rails ruby "
-                        >
-                          <span
-                            className="platformicon platformicon-ruby-rails"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Rails
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                  <PlatformCard
-                    className=""
-                    key="ruby"
-                    onClick={[Function]}
-                    platform="ruby"
-                  >
-                    <span
-                      className="platform-card"
-                      onClick={[Function]}
-                    >
-                      <PlatformiconTile
-                        className=""
-                        onClick={[Function]}
-                        platform="ruby"
-                      >
-                        <li
-                          className="platform-tile list-unstyled ruby ruby "
-                        >
-                          <span
-                            className="platformicon platformicon-ruby"
-                          />
-                        </li>
-                      </PlatformiconTile>
-                      <h5>
-                         
-                        Ruby
-                         
-                      </h5>
-                    </span>
-                  </PlatformCard>
-                </ul>
-              </div>
-            </PlatformPicker>
+          <Wrapper>
             <div
-              className="create-project-form"
+              className="css-a5urgt-Wrapper e1bu5aqa0"
             >
-              <div
-                className="new-project-name client-platform"
+              <PageHeading
+                withMargins={true}
               >
-                <h4>
-                  Give your project a name:
-                </h4>
-                <div
-                  className="project-name-wrapper"
+                <Wrapper
+                  withMargins={true}
                 >
-                  <PlatformiconTile
-                    platform=""
+                  <h1
+                    className="css-wxef79-Wrapper e1f8hk460"
                   >
-                    <li
-                      className="platform-tile list-unstyled   undefined"
+                    Choose a language or framework:
+                  </h1>
+                </Wrapper>
+              </PageHeading>
+              <PlatformPicker
+                name=""
+                next={[MockFunction]}
+                platform=""
+                setName={[MockFunction]}
+                setPlatform={
+                  [MockFunction] {
+                    "calls": Array [
+                      Array [
+                        "csharp",
+                      ],
+                    ],
+                    "results": Array [
+                      Object {
+                        "isThrow": false,
+                        "value": undefined,
+                      },
+                    ],
+                  }
+                }
+                setTeam={[Function]}
+                showOther={true}
+                team=""
+                teams={Array []}
+              >
+                <div
+                  className="platform-picker"
+                >
+                  <NavTabs>
+                    <ul
+                      className="nav nav-tabs"
+                    >
+                      <li
+                        style={
+                          Object {
+                            "float": "right",
+                            "marginRight": 0,
+                          }
+                        }
+                      >
+                        <div
+                          className="platform-filter-container"
+                        >
+                          <span
+                            className="icon icon-search"
+                          />
+                          <input
+                            className="platform-filter"
+                            label="Filter"
+                            onChange={[Function]}
+                            placeholder="Filter"
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </li>
+                      <ListLink
+                        activeClassName="active"
+                        index={false}
+                        isActive={[Function]}
+                        key="popular"
+                        onClick={[Function]}
+                        to=""
+                      >
+                        <li
+                          className="active"
+                        >
+                          <Link
+                            onClick={[Function]}
+                            onlyActiveOnIndex={false}
+                            style={Object {}}
+                            to=""
+                          >
+                            <a
+                              onClick={[Function]}
+                              style={Object {}}
+                            >
+                              Popular
+                            </a>
+                          </Link>
+                        </li>
+                      </ListLink>
+                      <ListLink
+                        activeClassName="active"
+                        index={false}
+                        isActive={[Function]}
+                        key="browser"
+                        onClick={[Function]}
+                        to=""
+                      >
+                        <li
+                          className=""
+                        >
+                          <Link
+                            onClick={[Function]}
+                            onlyActiveOnIndex={false}
+                            style={Object {}}
+                            to=""
+                          >
+                            <a
+                              onClick={[Function]}
+                              style={Object {}}
+                            >
+                              Browser
+                            </a>
+                          </Link>
+                        </li>
+                      </ListLink>
+                      <ListLink
+                        activeClassName="active"
+                        index={false}
+                        isActive={[Function]}
+                        key="server"
+                        onClick={[Function]}
+                        to=""
+                      >
+                        <li
+                          className=""
+                        >
+                          <Link
+                            onClick={[Function]}
+                            onlyActiveOnIndex={false}
+                            style={Object {}}
+                            to=""
+                          >
+                            <a
+                              onClick={[Function]}
+                              style={Object {}}
+                            >
+                              Server
+                            </a>
+                          </Link>
+                        </li>
+                      </ListLink>
+                      <ListLink
+                        activeClassName="active"
+                        index={false}
+                        isActive={[Function]}
+                        key="mobile"
+                        onClick={[Function]}
+                        to=""
+                      >
+                        <li
+                          className=""
+                        >
+                          <Link
+                            onClick={[Function]}
+                            onlyActiveOnIndex={false}
+                            style={Object {}}
+                            to=""
+                          >
+                            <a
+                              onClick={[Function]}
+                              style={Object {}}
+                            >
+                              Mobile
+                            </a>
+                          </Link>
+                        </li>
+                      </ListLink>
+                      <ListLink
+                        activeClassName="active"
+                        index={false}
+                        isActive={[Function]}
+                        key="desktop"
+                        onClick={[Function]}
+                        to=""
+                      >
+                        <li
+                          className=""
+                        >
+                          <Link
+                            onClick={[Function]}
+                            onlyActiveOnIndex={false}
+                            style={Object {}}
+                            to=""
+                          >
+                            <a
+                              onClick={[Function]}
+                              style={Object {}}
+                            >
+                              Desktop
+                            </a>
+                          </Link>
+                        </li>
+                      </ListLink>
+                      <ListLink
+                        activeClassName="active"
+                        index={false}
+                        isActive={[Function]}
+                        key="all"
+                        onClick={[Function]}
+                        to=""
+                      >
+                        <li
+                          className=""
+                        >
+                          <Link
+                            onClick={[Function]}
+                            onlyActiveOnIndex={false}
+                            style={Object {}}
+                            to=""
+                          >
+                            <a
+                              onClick={[Function]}
+                              style={Object {}}
+                            >
+                              All
+                            </a>
+                          </Link>
+                        </li>
+                      </ListLink>
+                    </ul>
+                  </NavTabs>
+                  <ul
+                    className="client-platform-list platform-tiles"
+                  >
+                    <PlatformCard
+                      className=""
+                      key="csharp"
+                      onClick={[Function]}
+                      platform="csharp"
                     >
                       <span
-                        className="platformicon platformicon-"
-                      />
-                    </li>
-                  </PlatformiconTile>
-                  <input
-                    autoComplete="off"
-                    label="Project Name"
-                    name="name"
-                    onChange={[Function]}
-                    placeholder="Project name"
-                    type="text"
-                    value=""
-                  />
-                </div>
-              </div>
-              <div
-                className="new-project-team"
-              >
-                <h4>
-                  Team:
-                </h4>
-                <div>
-                  <SelectField
-                    clearable={false}
-                    disabled={false}
-                    hideErrorMessage={false}
-                    multiple={false}
-                    name="select-team"
-                    onChange={[Function]}
-                    options={Array []}
-                    required={false}
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "width": 180,
-                      }
-                    }
-                    value=""
-                  >
-                    <div
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="csharp"
+                        >
+                          <li
+                            className="platform-tile list-unstyled csharp csharp "
+                          >
+                            <span
+                              className="platformicon platformicon-csharp"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          C#
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
                       className=""
+                      key="java"
+                      onClick={[Function]}
+                      platform="java"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="java"
+                        >
+                          <li
+                            className="platform-tile list-unstyled java java "
+                          >
+                            <span
+                              className="platformicon platformicon-java"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Java
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="javascript-angular"
+                      onClick={[Function]}
+                      platform="javascript-angular"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="javascript-angular"
+                        >
+                          <li
+                            className="platform-tile list-unstyled javascript-angular javascript "
+                          >
+                            <span
+                              className="platformicon platformicon-javascript-angular"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Angular
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="javascript"
+                      onClick={[Function]}
+                      platform="javascript"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="javascript"
+                        >
+                          <li
+                            className="platform-tile list-unstyled javascript javascript "
+                          >
+                            <span
+                              className="platformicon platformicon-javascript"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          JavaScript
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="javascript-react"
+                      onClick={[Function]}
+                      platform="javascript-react"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="javascript-react"
+                        >
+                          <li
+                            className="platform-tile list-unstyled javascript-react javascript "
+                          >
+                            <span
+                              className="platformicon platformicon-javascript-react"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          React
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="node-express"
+                      onClick={[Function]}
+                      platform="node-express"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="node-express"
+                        >
+                          <li
+                            className="platform-tile list-unstyled node-express node "
+                          >
+                            <span
+                              className="platformicon platformicon-node-express"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Express
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="node"
+                      onClick={[Function]}
+                      platform="node"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="node"
+                        >
+                          <li
+                            className="platform-tile list-unstyled node node "
+                          >
+                            <span
+                              className="platformicon platformicon-node"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Node.js
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="php-laravel"
+                      onClick={[Function]}
+                      platform="php-laravel"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="php-laravel"
+                        >
+                          <li
+                            className="platform-tile list-unstyled php-laravel php "
+                          >
+                            <span
+                              className="platformicon platformicon-php-laravel"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Laravel
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="php"
+                      onClick={[Function]}
+                      platform="php"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="php"
+                        >
+                          <li
+                            className="platform-tile list-unstyled php php "
+                          >
+                            <span
+                              className="platformicon platformicon-php"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          PHP
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="php-symfony2"
+                      onClick={[Function]}
+                      platform="php-symfony2"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="php-symfony2"
+                        >
+                          <li
+                            className="platform-tile list-unstyled php-symfony2 php "
+                          >
+                            <span
+                              className="platformicon platformicon-php-symfony2"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Symfony2
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="python-django"
+                      onClick={[Function]}
+                      platform="python-django"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="python-django"
+                        >
+                          <li
+                            className="platform-tile list-unstyled python-django python "
+                          >
+                            <span
+                              className="platformicon platformicon-python-django"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Django
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="python-flask"
+                      onClick={[Function]}
+                      platform="python-flask"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="python-flask"
+                        >
+                          <li
+                            className="platform-tile list-unstyled python-flask python "
+                          >
+                            <span
+                              className="platformicon platformicon-python-flask"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Flask
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="python"
+                      onClick={[Function]}
+                      platform="python"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="python"
+                        >
+                          <li
+                            className="platform-tile list-unstyled python python "
+                          >
+                            <span
+                              className="platformicon platformicon-python"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Python
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="cocoa"
+                      onClick={[Function]}
+                      platform="cocoa"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="cocoa"
+                        >
+                          <li
+                            className="platform-tile list-unstyled cocoa cocoa "
+                          >
+                            <span
+                              className="platformicon platformicon-cocoa"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          React-Native
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="ruby-rails"
+                      onClick={[Function]}
+                      platform="ruby-rails"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="ruby-rails"
+                        >
+                          <li
+                            className="platform-tile list-unstyled ruby-rails ruby "
+                          >
+                            <span
+                              className="platformicon platformicon-ruby-rails"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Rails
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                    <PlatformCard
+                      className=""
+                      key="ruby"
+                      onClick={[Function]}
+                      platform="ruby"
+                    >
+                      <span
+                        className="platform-card"
+                        onClick={[Function]}
+                      >
+                        <PlatformiconTile
+                          className=""
+                          onClick={[Function]}
+                          platform="ruby"
+                        >
+                          <li
+                            className="platform-tile list-unstyled ruby ruby "
+                          >
+                            <span
+                              className="platformicon platformicon-ruby"
+                            />
+                          </li>
+                        </PlatformiconTile>
+                        <h5>
+                           
+                          Ruby
+                           
+                        </h5>
+                      </span>
+                    </PlatformCard>
+                  </ul>
+                </div>
+              </PlatformPicker>
+              <div
+                className="create-project-form"
+              >
+                <div
+                  className="new-project-name client-platform"
+                >
+                  <PageHeading
+                    withMargins={true}
+                  >
+                    <Wrapper
+                      withMargins={true}
+                    >
+                      <h1
+                        className="css-wxef79-Wrapper e1f8hk460"
+                      >
+                        Give your project a name:
+                      </h1>
+                    </Wrapper>
+                  </PageHeading>
+                  <div
+                    className="project-name-wrapper"
+                  >
+                    <PlatformiconTile
+                      platform=""
+                    >
+                      <li
+                        className="platform-tile list-unstyled   undefined"
+                      >
+                        <span
+                          className="platformicon platformicon-"
+                        />
+                      </li>
+                    </PlatformiconTile>
+                    <input
+                      autoComplete="off"
+                      label="Project Name"
+                      name="name"
+                      onChange={[Function]}
+                      placeholder="Project name"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+                <div
+                  className="new-project-team"
+                >
+                  <PageHeading
+                    withMargins={true}
+                  >
+                    <Wrapper
+                      withMargins={true}
+                    >
+                      <h1
+                        className="css-wxef79-Wrapper e1f8hk460"
+                      >
+                        Team:
+                      </h1>
+                    </Wrapper>
+                  </PageHeading>
+                  <div>
+                    <SelectField
+                      clearable={false}
+                      disabled={false}
+                      hideErrorMessage={false}
+                      multiple={false}
+                      name="select-team"
+                      onChange={[Function]}
+                      options={Array []}
+                      required={false}
                       style={
                         Object {
                           "marginBottom": 0,
                           "width": 180,
                         }
                       }
+                      value=""
                     >
                       <div
-                        className="controls"
+                        className=""
+                        style={
+                          Object {
+                            "marginBottom": 0,
+                            "width": 180,
+                          }
+                        }
                       >
-                        <StyledSelectControl
-                          clearable={false}
-                          disabled={false}
-                          id="id-select-team"
-                          multiple={false}
-                          name="select-team"
-                          onChange={[Function]}
-                          options={Array []}
-                          required={false}
-                          value=""
+                        <div
+                          className="controls"
                         >
-                          <SelectControl
-                            className="css-j6zs66-StyledSelectControl e1qrhqd00"
+                          <StyledSelectControl
                             clearable={false}
                             disabled={false}
-                            height={36}
                             id="id-select-team"
                             multiple={false}
                             name="select-team"
@@ -2052,12 +2102,9 @@ exports[`OnboardingWizard render() should render and respond to click events 2`]
                             required={false}
                             value=""
                           >
-                            <StyledSelect
-                              arrowRenderer={[Function]}
-                              backspaceRemoves={false}
+                            <SelectControl
                               className="css-j6zs66-StyledSelectControl e1qrhqd00"
                               clearable={false}
-                              deleteRemoves={false}
                               disabled={false}
                               height={36}
                               id="id-select-team"
@@ -2068,10 +2115,10 @@ exports[`OnboardingWizard render() should render and respond to click events 2`]
                               required={false}
                               value=""
                             >
-                              <ForwardRef(SelectPicker)
+                              <StyledSelect
                                 arrowRenderer={[Function]}
                                 backspaceRemoves={false}
-                                className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
+                                className="css-j6zs66-StyledSelectControl e1qrhqd00"
                                 clearable={false}
                                 deleteRemoves={false}
                                 disabled={false}
@@ -2084,14 +2131,13 @@ exports[`OnboardingWizard render() should render and respond to click events 2`]
                                 required={false}
                                 value=""
                               >
-                                <SelectPicker
+                                <ForwardRef(SelectPicker)
                                   arrowRenderer={[Function]}
                                   backspaceRemoves={false}
                                   className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
                                   clearable={false}
                                   deleteRemoves={false}
                                   disabled={false}
-                                  forwardedRef={null}
                                   height={36}
                                   id="id-select-team"
                                   multiple={false}
@@ -2101,172 +2147,190 @@ exports[`OnboardingWizard render() should render and respond to click events 2`]
                                   required={false}
                                   value=""
                                 >
-                                  <Select
+                                  <SelectPicker
                                     arrowRenderer={[Function]}
-                                    autosize={true}
                                     backspaceRemoves={false}
-                                    backspaceToRemoveMessage="Press backspace to remove {label}"
                                     className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
-                                    clearAllText="Clear all"
-                                    clearRenderer={[Function]}
-                                    clearValueText="Clear value"
                                     clearable={false}
-                                    closeOnSelect={true}
                                     deleteRemoves={false}
-                                    delimiter=","
                                     disabled={false}
-                                    escapeClearsValue={true}
-                                    filterOptions={[Function]}
+                                    forwardedRef={null}
                                     height={36}
                                     id="id-select-team"
-                                    ignoreAccents={true}
-                                    ignoreCase={true}
-                                    inputProps={Object {}}
-                                    isLoading={false}
-                                    joinValues={false}
-                                    labelKey="label"
-                                    matchPos="any"
-                                    matchProp="any"
-                                    menuBuffer={0}
-                                    menuRenderer={[Function]}
-                                    multi={false}
                                     multiple={false}
                                     name="select-team"
-                                    noResultsText="No results found"
-                                    onBlurResetsInput={true}
                                     onChange={[Function]}
-                                    onCloseResetsInput={true}
-                                    onSelectResetsInput={true}
-                                    openOnClick={true}
-                                    optionComponent={[Function]}
                                     options={Array []}
-                                    pageSize={5}
-                                    placeholder="Select..."
-                                    removeSelected={true}
                                     required={false}
-                                    rtl={false}
-                                    scrollMenuIntoView={true}
-                                    searchable={true}
-                                    simpleValue={false}
-                                    tabSelectsValue={true}
-                                    trimFilter={true}
                                     value=""
-                                    valueComponent={[Function]}
-                                    valueKey="value"
                                   >
-                                    <div
-                                      className="Select e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
+                                    <Select
+                                      arrowRenderer={[Function]}
+                                      autosize={true}
+                                      backspaceRemoves={false}
+                                      backspaceToRemoveMessage="Press backspace to remove {label}"
+                                      className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
+                                      clearAllText="Clear all"
+                                      clearRenderer={[Function]}
+                                      clearValueText="Clear value"
+                                      clearable={false}
+                                      closeOnSelect={true}
+                                      deleteRemoves={false}
+                                      delimiter=","
+                                      disabled={false}
+                                      escapeClearsValue={true}
+                                      filterOptions={[Function]}
+                                      height={36}
+                                      id="id-select-team"
+                                      ignoreAccents={true}
+                                      ignoreCase={true}
+                                      inputProps={Object {}}
+                                      isLoading={false}
+                                      joinValues={false}
+                                      labelKey="label"
+                                      matchPos="any"
+                                      matchProp="any"
+                                      menuBuffer={0}
+                                      menuRenderer={[Function]}
+                                      multi={false}
+                                      multiple={false}
+                                      name="select-team"
+                                      noResultsText="No results found"
+                                      onBlurResetsInput={true}
+                                      onChange={[Function]}
+                                      onCloseResetsInput={true}
+                                      onSelectResetsInput={true}
+                                      openOnClick={true}
+                                      optionComponent={[Function]}
+                                      options={Array []}
+                                      pageSize={5}
+                                      placeholder="Select..."
+                                      removeSelected={true}
+                                      required={false}
+                                      rtl={false}
+                                      scrollMenuIntoView={true}
+                                      searchable={true}
+                                      simpleValue={false}
+                                      tabSelectsValue={true}
+                                      trimFilter={true}
+                                      value=""
+                                      valueComponent={[Function]}
+                                      valueKey="value"
                                     >
                                       <div
-                                        className="Select-control"
-                                        onKeyDown={[Function]}
-                                        onMouseDown={[Function]}
-                                        onTouchEnd={[Function]}
-                                        onTouchMove={[Function]}
-                                        onTouchStart={[Function]}
+                                        className="Select e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
                                       >
-                                        <span
-                                          className="Select-multi-value-wrapper"
-                                          id="react-select-2--value"
-                                        >
-                                          <div
-                                            className="Select-placeholder"
-                                          >
-                                            Select...
-                                          </div>
-                                          <AutosizeInput
-                                            aria-activedescendant="react-select-2--value"
-                                            aria-expanded="false"
-                                            aria-haspopup="false"
-                                            aria-owns=""
-                                            className="Select-input"
-                                            id="id-select-team"
-                                            injectStyles={true}
-                                            minWidth="5"
-                                            onBlur={[Function]}
-                                            onChange={[Function]}
-                                            onFocus={[Function]}
-                                            required={false}
-                                            role="combobox"
-                                            value=""
-                                          >
-                                            <div
-                                              className="Select-input"
-                                              style={
-                                                Object {
-                                                  "display": "inline-block",
-                                                }
-                                              }
-                                            >
-                                              <input
-                                                aria-activedescendant="react-select-2--value"
-                                                aria-expanded="false"
-                                                aria-haspopup="false"
-                                                aria-owns=""
-                                                id="id-select-team"
-                                                onBlur={[Function]}
-                                                onChange={[Function]}
-                                                onFocus={[Function]}
-                                                required={false}
-                                                role="combobox"
-                                                style={
-                                                  Object {
-                                                    "boxSizing": "content-box",
-                                                    "width": "5px",
-                                                  }
-                                                }
-                                                value=""
-                                              />
-                                              <div
-                                                style={
-                                                  Object {
-                                                    "height": 0,
-                                                    "left": 0,
-                                                    "overflow": "scroll",
-                                                    "position": "absolute",
-                                                    "top": 0,
-                                                    "visibility": "hidden",
-                                                    "whiteSpace": "pre",
-                                                  }
-                                                }
-                                              />
-                                            </div>
-                                          </AutosizeInput>
-                                        </span>
-                                        <span
-                                          className="Select-arrow-zone"
+                                        <div
+                                          className="Select-control"
+                                          onKeyDown={[Function]}
                                           onMouseDown={[Function]}
+                                          onTouchEnd={[Function]}
+                                          onTouchMove={[Function]}
+                                          onTouchStart={[Function]}
                                         >
                                           <span
-                                            className="icon-arrow-down"
-                                          />
-                                        </span>
+                                            className="Select-multi-value-wrapper"
+                                            id="react-select-2--value"
+                                          >
+                                            <div
+                                              className="Select-placeholder"
+                                            >
+                                              Select...
+                                            </div>
+                                            <AutosizeInput
+                                              aria-activedescendant="react-select-2--value"
+                                              aria-expanded="false"
+                                              aria-haspopup="false"
+                                              aria-owns=""
+                                              className="Select-input"
+                                              id="id-select-team"
+                                              injectStyles={true}
+                                              minWidth="5"
+                                              onBlur={[Function]}
+                                              onChange={[Function]}
+                                              onFocus={[Function]}
+                                              required={false}
+                                              role="combobox"
+                                              value=""
+                                            >
+                                              <div
+                                                className="Select-input"
+                                                style={
+                                                  Object {
+                                                    "display": "inline-block",
+                                                  }
+                                                }
+                                              >
+                                                <input
+                                                  aria-activedescendant="react-select-2--value"
+                                                  aria-expanded="false"
+                                                  aria-haspopup="false"
+                                                  aria-owns=""
+                                                  id="id-select-team"
+                                                  onBlur={[Function]}
+                                                  onChange={[Function]}
+                                                  onFocus={[Function]}
+                                                  required={false}
+                                                  role="combobox"
+                                                  style={
+                                                    Object {
+                                                      "boxSizing": "content-box",
+                                                      "width": "5px",
+                                                    }
+                                                  }
+                                                  value=""
+                                                />
+                                                <div
+                                                  style={
+                                                    Object {
+                                                      "height": 0,
+                                                      "left": 0,
+                                                      "overflow": "scroll",
+                                                      "position": "absolute",
+                                                      "top": 0,
+                                                      "visibility": "hidden",
+                                                      "whiteSpace": "pre",
+                                                    }
+                                                  }
+                                                />
+                                              </div>
+                                            </AutosizeInput>
+                                          </span>
+                                          <span
+                                            className="Select-arrow-zone"
+                                            onMouseDown={[Function]}
+                                          >
+                                            <span
+                                              className="icon-arrow-down"
+                                            />
+                                          </span>
+                                        </div>
                                       </div>
-                                    </div>
-                                  </Select>
-                                </SelectPicker>
-                              </ForwardRef(SelectPicker)>
-                            </StyledSelect>
-                          </SelectControl>
-                        </StyledSelectControl>
+                                    </Select>
+                                  </SelectPicker>
+                                </ForwardRef(SelectPicker)>
+                              </StyledSelect>
+                            </SelectControl>
+                          </StyledSelectControl>
+                        </div>
                       </div>
-                    </div>
-                  </SelectField>
+                    </SelectField>
+                  </div>
                 </div>
+                <div>
+                  <button
+                    className="btn btn-primary new-project-submit"
+                    onClick={[Function]}
+                  >
+                    Create Project
+                  </button>
+                </div>
+                <p>
+                  Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
+                </p>
               </div>
-              <div>
-                <button
-                  className="btn btn-primary new-project-submit"
-                  onClick={[Function]}
-                >
-                  Create Project
-                </button>
-              </div>
-              <p>
-                Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
-              </p>
             </div>
-          </div>
+          </Wrapper>
         </OnboardingProject>
       </div>
     </div>

--- a/tests/js/spec/views/onboarding/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/__snapshots__/index.spec.jsx.snap
@@ -126,802 +126,784 @@ exports[`OnboardingWizard render() should render and respond to click events 1`]
           team=""
           teams={Array []}
         >
-          <Wrapper>
-            <div
-              className="css-a5urgt-Wrapper e1bu5aqa0"
+          <div
+            className="onboarding-info"
+          >
+            <h4>
+              Choose a language or framework:
+            </h4>
+            <PlatformPicker
+              name=""
+              next={[MockFunction]}
+              platform=""
+              setName={[MockFunction]}
+              setPlatform={[MockFunction]}
+              setTeam={[Function]}
+              showOther={true}
+              team=""
+              teams={Array []}
             >
-              <PageHeading
-                withMargins={true}
-              >
-                <Wrapper
-                  withMargins={true}
-                >
-                  <h1
-                    className="css-wxef79-Wrapper e1f8hk460"
-                  >
-                    Choose a language or framework:
-                  </h1>
-                </Wrapper>
-              </PageHeading>
-              <PlatformPicker
-                name=""
-                next={[MockFunction]}
-                platform=""
-                setName={[MockFunction]}
-                setPlatform={[MockFunction]}
-                setTeam={[Function]}
-                showOther={true}
-                team=""
-                teams={Array []}
-              >
-                <div
-                  className="platform-picker"
-                >
-                  <NavTabs>
-                    <ul
-                      className="nav nav-tabs"
-                    >
-                      <li
-                        style={
-                          Object {
-                            "float": "right",
-                            "marginRight": 0,
-                          }
-                        }
-                      >
-                        <div
-                          className="platform-filter-container"
-                        >
-                          <span
-                            className="icon icon-search"
-                          />
-                          <input
-                            className="platform-filter"
-                            label="Filter"
-                            onChange={[Function]}
-                            placeholder="Filter"
-                            type="text"
-                            value=""
-                          />
-                        </div>
-                      </li>
-                      <ListLink
-                        activeClassName="active"
-                        index={false}
-                        isActive={[Function]}
-                        key="popular"
-                        onClick={[Function]}
-                        to=""
-                      >
-                        <li
-                          className="active"
-                        >
-                          <Link
-                            onClick={[Function]}
-                            onlyActiveOnIndex={false}
-                            style={Object {}}
-                            to=""
-                          >
-                            <a
-                              onClick={[Function]}
-                              style={Object {}}
-                            >
-                              Popular
-                            </a>
-                          </Link>
-                        </li>
-                      </ListLink>
-                      <ListLink
-                        activeClassName="active"
-                        index={false}
-                        isActive={[Function]}
-                        key="browser"
-                        onClick={[Function]}
-                        to=""
-                      >
-                        <li
-                          className=""
-                        >
-                          <Link
-                            onClick={[Function]}
-                            onlyActiveOnIndex={false}
-                            style={Object {}}
-                            to=""
-                          >
-                            <a
-                              onClick={[Function]}
-                              style={Object {}}
-                            >
-                              Browser
-                            </a>
-                          </Link>
-                        </li>
-                      </ListLink>
-                      <ListLink
-                        activeClassName="active"
-                        index={false}
-                        isActive={[Function]}
-                        key="server"
-                        onClick={[Function]}
-                        to=""
-                      >
-                        <li
-                          className=""
-                        >
-                          <Link
-                            onClick={[Function]}
-                            onlyActiveOnIndex={false}
-                            style={Object {}}
-                            to=""
-                          >
-                            <a
-                              onClick={[Function]}
-                              style={Object {}}
-                            >
-                              Server
-                            </a>
-                          </Link>
-                        </li>
-                      </ListLink>
-                      <ListLink
-                        activeClassName="active"
-                        index={false}
-                        isActive={[Function]}
-                        key="mobile"
-                        onClick={[Function]}
-                        to=""
-                      >
-                        <li
-                          className=""
-                        >
-                          <Link
-                            onClick={[Function]}
-                            onlyActiveOnIndex={false}
-                            style={Object {}}
-                            to=""
-                          >
-                            <a
-                              onClick={[Function]}
-                              style={Object {}}
-                            >
-                              Mobile
-                            </a>
-                          </Link>
-                        </li>
-                      </ListLink>
-                      <ListLink
-                        activeClassName="active"
-                        index={false}
-                        isActive={[Function]}
-                        key="desktop"
-                        onClick={[Function]}
-                        to=""
-                      >
-                        <li
-                          className=""
-                        >
-                          <Link
-                            onClick={[Function]}
-                            onlyActiveOnIndex={false}
-                            style={Object {}}
-                            to=""
-                          >
-                            <a
-                              onClick={[Function]}
-                              style={Object {}}
-                            >
-                              Desktop
-                            </a>
-                          </Link>
-                        </li>
-                      </ListLink>
-                      <ListLink
-                        activeClassName="active"
-                        index={false}
-                        isActive={[Function]}
-                        key="all"
-                        onClick={[Function]}
-                        to=""
-                      >
-                        <li
-                          className=""
-                        >
-                          <Link
-                            onClick={[Function]}
-                            onlyActiveOnIndex={false}
-                            style={Object {}}
-                            to=""
-                          >
-                            <a
-                              onClick={[Function]}
-                              style={Object {}}
-                            >
-                              All
-                            </a>
-                          </Link>
-                        </li>
-                      </ListLink>
-                    </ul>
-                  </NavTabs>
-                  <ul
-                    className="client-platform-list platform-tiles"
-                  >
-                    <PlatformCard
-                      className=""
-                      key="csharp"
-                      onClick={[Function]}
-                      platform="csharp"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="csharp"
-                        >
-                          <li
-                            className="platform-tile list-unstyled csharp csharp "
-                          >
-                            <span
-                              className="platformicon platformicon-csharp"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          C#
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="java"
-                      onClick={[Function]}
-                      platform="java"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="java"
-                        >
-                          <li
-                            className="platform-tile list-unstyled java java "
-                          >
-                            <span
-                              className="platformicon platformicon-java"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Java
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="javascript-angular"
-                      onClick={[Function]}
-                      platform="javascript-angular"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="javascript-angular"
-                        >
-                          <li
-                            className="platform-tile list-unstyled javascript-angular javascript "
-                          >
-                            <span
-                              className="platformicon platformicon-javascript-angular"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Angular
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="javascript"
-                      onClick={[Function]}
-                      platform="javascript"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="javascript"
-                        >
-                          <li
-                            className="platform-tile list-unstyled javascript javascript "
-                          >
-                            <span
-                              className="platformicon platformicon-javascript"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          JavaScript
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="javascript-react"
-                      onClick={[Function]}
-                      platform="javascript-react"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="javascript-react"
-                        >
-                          <li
-                            className="platform-tile list-unstyled javascript-react javascript "
-                          >
-                            <span
-                              className="platformicon platformicon-javascript-react"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          React
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="node-express"
-                      onClick={[Function]}
-                      platform="node-express"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="node-express"
-                        >
-                          <li
-                            className="platform-tile list-unstyled node-express node "
-                          >
-                            <span
-                              className="platformicon platformicon-node-express"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Express
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="node"
-                      onClick={[Function]}
-                      platform="node"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="node"
-                        >
-                          <li
-                            className="platform-tile list-unstyled node node "
-                          >
-                            <span
-                              className="platformicon platformicon-node"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Node.js
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="php-laravel"
-                      onClick={[Function]}
-                      platform="php-laravel"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="php-laravel"
-                        >
-                          <li
-                            className="platform-tile list-unstyled php-laravel php "
-                          >
-                            <span
-                              className="platformicon platformicon-php-laravel"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Laravel
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="php"
-                      onClick={[Function]}
-                      platform="php"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="php"
-                        >
-                          <li
-                            className="platform-tile list-unstyled php php "
-                          >
-                            <span
-                              className="platformicon platformicon-php"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          PHP
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="php-symfony2"
-                      onClick={[Function]}
-                      platform="php-symfony2"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="php-symfony2"
-                        >
-                          <li
-                            className="platform-tile list-unstyled php-symfony2 php "
-                          >
-                            <span
-                              className="platformicon platformicon-php-symfony2"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Symfony2
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="python-django"
-                      onClick={[Function]}
-                      platform="python-django"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="python-django"
-                        >
-                          <li
-                            className="platform-tile list-unstyled python-django python "
-                          >
-                            <span
-                              className="platformicon platformicon-python-django"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Django
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="python-flask"
-                      onClick={[Function]}
-                      platform="python-flask"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="python-flask"
-                        >
-                          <li
-                            className="platform-tile list-unstyled python-flask python "
-                          >
-                            <span
-                              className="platformicon platformicon-python-flask"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Flask
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="python"
-                      onClick={[Function]}
-                      platform="python"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="python"
-                        >
-                          <li
-                            className="platform-tile list-unstyled python python "
-                          >
-                            <span
-                              className="platformicon platformicon-python"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Python
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="cocoa"
-                      onClick={[Function]}
-                      platform="cocoa"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="cocoa"
-                        >
-                          <li
-                            className="platform-tile list-unstyled cocoa cocoa "
-                          >
-                            <span
-                              className="platformicon platformicon-cocoa"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          React-Native
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="ruby-rails"
-                      onClick={[Function]}
-                      platform="ruby-rails"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="ruby-rails"
-                        >
-                          <li
-                            className="platform-tile list-unstyled ruby-rails ruby "
-                          >
-                            <span
-                              className="platformicon platformicon-ruby-rails"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Rails
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="ruby"
-                      onClick={[Function]}
-                      platform="ruby"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="ruby"
-                        >
-                          <li
-                            className="platform-tile list-unstyled ruby ruby "
-                          >
-                            <span
-                              className="platformicon platformicon-ruby"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Ruby
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                  </ul>
-                </div>
-              </PlatformPicker>
               <div
-                className="create-project-form"
+                className="platform-picker"
               >
-                <div
-                  className="new-project-name client-platform"
-                >
-                  <PageHeading
-                    withMargins={true}
+                <NavTabs>
+                  <ul
+                    className="nav nav-tabs"
                   >
-                    <Wrapper
-                      withMargins={true}
+                    <li
+                      style={
+                        Object {
+                          "float": "right",
+                          "marginRight": 0,
+                        }
+                      }
                     >
-                      <h1
-                        className="css-wxef79-Wrapper e1f8hk460"
-                      >
-                        Give your project a name:
-                      </h1>
-                    </Wrapper>
-                  </PageHeading>
-                  <div
-                    className="project-name-wrapper"
-                  >
-                    <PlatformiconTile
-                      platform=""
-                    >
-                      <li
-                        className="platform-tile list-unstyled   undefined"
+                      <div
+                        className="platform-filter-container"
                       >
                         <span
-                          className="platformicon platformicon-"
+                          className="icon icon-search"
                         />
-                      </li>
-                    </PlatformiconTile>
-                    <input
-                      autoComplete="off"
-                      label="Project Name"
-                      name="name"
-                      onChange={[Function]}
-                      placeholder="Project name"
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </div>
-                <div
-                  className="new-project-team"
-                >
-                  <PageHeading
-                    withMargins={true}
-                  >
-                    <Wrapper
-                      withMargins={true}
+                        <input
+                          className="platform-filter"
+                          label="Filter"
+                          onChange={[Function]}
+                          placeholder="Filter"
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </li>
+                    <ListLink
+                      activeClassName="active"
+                      index={false}
+                      isActive={[Function]}
+                      key="popular"
+                      onClick={[Function]}
+                      to=""
                     >
-                      <h1
-                        className="css-wxef79-Wrapper e1f8hk460"
+                      <li
+                        className="active"
                       >
-                        Team:
-                      </h1>
-                    </Wrapper>
-                  </PageHeading>
-                  <div>
-                    <SelectField
-                      clearable={false}
-                      disabled={false}
-                      hideErrorMessage={false}
-                      multiple={false}
-                      name="select-team"
-                      onChange={[Function]}
-                      options={Array []}
-                      required={false}
+                        <Link
+                          onClick={[Function]}
+                          onlyActiveOnIndex={false}
+                          style={Object {}}
+                          to=""
+                        >
+                          <a
+                            onClick={[Function]}
+                            style={Object {}}
+                          >
+                            Popular
+                          </a>
+                        </Link>
+                      </li>
+                    </ListLink>
+                    <ListLink
+                      activeClassName="active"
+                      index={false}
+                      isActive={[Function]}
+                      key="browser"
+                      onClick={[Function]}
+                      to=""
+                    >
+                      <li
+                        className=""
+                      >
+                        <Link
+                          onClick={[Function]}
+                          onlyActiveOnIndex={false}
+                          style={Object {}}
+                          to=""
+                        >
+                          <a
+                            onClick={[Function]}
+                            style={Object {}}
+                          >
+                            Browser
+                          </a>
+                        </Link>
+                      </li>
+                    </ListLink>
+                    <ListLink
+                      activeClassName="active"
+                      index={false}
+                      isActive={[Function]}
+                      key="server"
+                      onClick={[Function]}
+                      to=""
+                    >
+                      <li
+                        className=""
+                      >
+                        <Link
+                          onClick={[Function]}
+                          onlyActiveOnIndex={false}
+                          style={Object {}}
+                          to=""
+                        >
+                          <a
+                            onClick={[Function]}
+                            style={Object {}}
+                          >
+                            Server
+                          </a>
+                        </Link>
+                      </li>
+                    </ListLink>
+                    <ListLink
+                      activeClassName="active"
+                      index={false}
+                      isActive={[Function]}
+                      key="mobile"
+                      onClick={[Function]}
+                      to=""
+                    >
+                      <li
+                        className=""
+                      >
+                        <Link
+                          onClick={[Function]}
+                          onlyActiveOnIndex={false}
+                          style={Object {}}
+                          to=""
+                        >
+                          <a
+                            onClick={[Function]}
+                            style={Object {}}
+                          >
+                            Mobile
+                          </a>
+                        </Link>
+                      </li>
+                    </ListLink>
+                    <ListLink
+                      activeClassName="active"
+                      index={false}
+                      isActive={[Function]}
+                      key="desktop"
+                      onClick={[Function]}
+                      to=""
+                    >
+                      <li
+                        className=""
+                      >
+                        <Link
+                          onClick={[Function]}
+                          onlyActiveOnIndex={false}
+                          style={Object {}}
+                          to=""
+                        >
+                          <a
+                            onClick={[Function]}
+                            style={Object {}}
+                          >
+                            Desktop
+                          </a>
+                        </Link>
+                      </li>
+                    </ListLink>
+                    <ListLink
+                      activeClassName="active"
+                      index={false}
+                      isActive={[Function]}
+                      key="all"
+                      onClick={[Function]}
+                      to=""
+                    >
+                      <li
+                        className=""
+                      >
+                        <Link
+                          onClick={[Function]}
+                          onlyActiveOnIndex={false}
+                          style={Object {}}
+                          to=""
+                        >
+                          <a
+                            onClick={[Function]}
+                            style={Object {}}
+                          >
+                            All
+                          </a>
+                        </Link>
+                      </li>
+                    </ListLink>
+                  </ul>
+                </NavTabs>
+                <ul
+                  className="client-platform-list platform-tiles"
+                >
+                  <PlatformCard
+                    className=""
+                    key="csharp"
+                    onClick={[Function]}
+                    platform="csharp"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="csharp"
+                      >
+                        <li
+                          className="platform-tile list-unstyled csharp csharp "
+                        >
+                          <span
+                            className="platformicon platformicon-csharp"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        C#
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="java"
+                    onClick={[Function]}
+                    platform="java"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="java"
+                      >
+                        <li
+                          className="platform-tile list-unstyled java java "
+                        >
+                          <span
+                            className="platformicon platformicon-java"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Java
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="javascript-angular"
+                    onClick={[Function]}
+                    platform="javascript-angular"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="javascript-angular"
+                      >
+                        <li
+                          className="platform-tile list-unstyled javascript-angular javascript "
+                        >
+                          <span
+                            className="platformicon platformicon-javascript-angular"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Angular
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="javascript"
+                    onClick={[Function]}
+                    platform="javascript"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="javascript"
+                      >
+                        <li
+                          className="platform-tile list-unstyled javascript javascript "
+                        >
+                          <span
+                            className="platformicon platformicon-javascript"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        JavaScript
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="javascript-react"
+                    onClick={[Function]}
+                    platform="javascript-react"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="javascript-react"
+                      >
+                        <li
+                          className="platform-tile list-unstyled javascript-react javascript "
+                        >
+                          <span
+                            className="platformicon platformicon-javascript-react"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        React
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="node-express"
+                    onClick={[Function]}
+                    platform="node-express"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="node-express"
+                      >
+                        <li
+                          className="platform-tile list-unstyled node-express node "
+                        >
+                          <span
+                            className="platformicon platformicon-node-express"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Express
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="node"
+                    onClick={[Function]}
+                    platform="node"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="node"
+                      >
+                        <li
+                          className="platform-tile list-unstyled node node "
+                        >
+                          <span
+                            className="platformicon platformicon-node"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Node.js
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="php-laravel"
+                    onClick={[Function]}
+                    platform="php-laravel"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="php-laravel"
+                      >
+                        <li
+                          className="platform-tile list-unstyled php-laravel php "
+                        >
+                          <span
+                            className="platformicon platformicon-php-laravel"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Laravel
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="php"
+                    onClick={[Function]}
+                    platform="php"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="php"
+                      >
+                        <li
+                          className="platform-tile list-unstyled php php "
+                        >
+                          <span
+                            className="platformicon platformicon-php"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        PHP
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="php-symfony2"
+                    onClick={[Function]}
+                    platform="php-symfony2"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="php-symfony2"
+                      >
+                        <li
+                          className="platform-tile list-unstyled php-symfony2 php "
+                        >
+                          <span
+                            className="platformicon platformicon-php-symfony2"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Symfony2
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="python-django"
+                    onClick={[Function]}
+                    platform="python-django"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="python-django"
+                      >
+                        <li
+                          className="platform-tile list-unstyled python-django python "
+                        >
+                          <span
+                            className="platformicon platformicon-python-django"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Django
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="python-flask"
+                    onClick={[Function]}
+                    platform="python-flask"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="python-flask"
+                      >
+                        <li
+                          className="platform-tile list-unstyled python-flask python "
+                        >
+                          <span
+                            className="platformicon platformicon-python-flask"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Flask
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="python"
+                    onClick={[Function]}
+                    platform="python"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="python"
+                      >
+                        <li
+                          className="platform-tile list-unstyled python python "
+                        >
+                          <span
+                            className="platformicon platformicon-python"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Python
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="cocoa"
+                    onClick={[Function]}
+                    platform="cocoa"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="cocoa"
+                      >
+                        <li
+                          className="platform-tile list-unstyled cocoa cocoa "
+                        >
+                          <span
+                            className="platformicon platformicon-cocoa"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        React-Native
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="ruby-rails"
+                    onClick={[Function]}
+                    platform="ruby-rails"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="ruby-rails"
+                      >
+                        <li
+                          className="platform-tile list-unstyled ruby-rails ruby "
+                        >
+                          <span
+                            className="platformicon platformicon-ruby-rails"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Rails
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="ruby"
+                    onClick={[Function]}
+                    platform="ruby"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="ruby"
+                      >
+                        <li
+                          className="platform-tile list-unstyled ruby ruby "
+                        >
+                          <span
+                            className="platformicon platformicon-ruby"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Ruby
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                </ul>
+              </div>
+            </PlatformPicker>
+            <div
+              className="create-project-form"
+            >
+              <div
+                className="new-project-name client-platform"
+              >
+                <h4>
+                  Give your project a name:
+                </h4>
+                <div
+                  className="project-name-wrapper"
+                >
+                  <PlatformiconTile
+                    platform=""
+                  >
+                    <li
+                      className="platform-tile list-unstyled   undefined"
+                    >
+                      <span
+                        className="platformicon platformicon-"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <input
+                    autoComplete="off"
+                    label="Project Name"
+                    name="name"
+                    onChange={[Function]}
+                    placeholder="Project name"
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+              <div
+                className="new-project-team"
+              >
+                <h4>
+                  Team:
+                </h4>
+                <div>
+                  <SelectField
+                    clearable={false}
+                    disabled={false}
+                    hideErrorMessage={false}
+                    multiple={false}
+                    name="select-team"
+                    onChange={[Function]}
+                    options={Array []}
+                    required={false}
+                    style={
+                      Object {
+                        "marginBottom": 0,
+                        "width": 180,
+                      }
+                    }
+                    value=""
+                  >
+                    <div
+                      className=""
                       style={
                         Object {
                           "marginBottom": 0,
                           "width": 180,
                         }
                       }
-                      value=""
                     >
                       <div
-                        className=""
-                        style={
-                          Object {
-                            "marginBottom": 0,
-                            "width": 180,
-                          }
-                        }
+                        className="controls"
                       >
-                        <div
-                          className="controls"
+                        <StyledSelectControl
+                          clearable={false}
+                          disabled={false}
+                          id="id-select-team"
+                          multiple={false}
+                          name="select-team"
+                          onChange={[Function]}
+                          options={Array []}
+                          required={false}
+                          value=""
                         >
-                          <StyledSelectControl
+                          <SelectControl
+                            className="css-j6zs66-StyledSelectControl e1qrhqd00"
                             clearable={false}
                             disabled={false}
+                            height={36}
                             id="id-select-team"
                             multiple={false}
                             name="select-team"
@@ -930,9 +912,12 @@ exports[`OnboardingWizard render() should render and respond to click events 1`]
                             required={false}
                             value=""
                           >
-                            <SelectControl
+                            <StyledSelect
+                              arrowRenderer={[Function]}
+                              backspaceRemoves={false}
                               className="css-j6zs66-StyledSelectControl e1qrhqd00"
                               clearable={false}
+                              deleteRemoves={false}
                               disabled={false}
                               height={36}
                               id="id-select-team"
@@ -943,10 +928,10 @@ exports[`OnboardingWizard render() should render and respond to click events 1`]
                               required={false}
                               value=""
                             >
-                              <StyledSelect
+                              <ForwardRef(SelectPicker)
                                 arrowRenderer={[Function]}
                                 backspaceRemoves={false}
-                                className="css-j6zs66-StyledSelectControl e1qrhqd00"
+                                className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
                                 clearable={false}
                                 deleteRemoves={false}
                                 disabled={false}
@@ -959,13 +944,14 @@ exports[`OnboardingWizard render() should render and respond to click events 1`]
                                 required={false}
                                 value=""
                               >
-                                <ForwardRef(SelectPicker)
+                                <SelectPicker
                                   arrowRenderer={[Function]}
                                   backspaceRemoves={false}
                                   className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
                                   clearable={false}
                                   deleteRemoves={false}
                                   disabled={false}
+                                  forwardedRef={null}
                                   height={36}
                                   id="id-select-team"
                                   multiple={false}
@@ -975,190 +961,172 @@ exports[`OnboardingWizard render() should render and respond to click events 1`]
                                   required={false}
                                   value=""
                                 >
-                                  <SelectPicker
+                                  <Select
                                     arrowRenderer={[Function]}
+                                    autosize={true}
                                     backspaceRemoves={false}
+                                    backspaceToRemoveMessage="Press backspace to remove {label}"
                                     className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
+                                    clearAllText="Clear all"
+                                    clearRenderer={[Function]}
+                                    clearValueText="Clear value"
                                     clearable={false}
+                                    closeOnSelect={true}
                                     deleteRemoves={false}
+                                    delimiter=","
                                     disabled={false}
-                                    forwardedRef={null}
+                                    escapeClearsValue={true}
+                                    filterOptions={[Function]}
                                     height={36}
                                     id="id-select-team"
+                                    ignoreAccents={true}
+                                    ignoreCase={true}
+                                    inputProps={Object {}}
+                                    isLoading={false}
+                                    joinValues={false}
+                                    labelKey="label"
+                                    matchPos="any"
+                                    matchProp="any"
+                                    menuBuffer={0}
+                                    menuRenderer={[Function]}
+                                    multi={false}
                                     multiple={false}
                                     name="select-team"
+                                    noResultsText="No results found"
+                                    onBlurResetsInput={true}
                                     onChange={[Function]}
+                                    onCloseResetsInput={true}
+                                    onSelectResetsInput={true}
+                                    openOnClick={true}
+                                    optionComponent={[Function]}
                                     options={Array []}
+                                    pageSize={5}
+                                    placeholder="Select..."
+                                    removeSelected={true}
                                     required={false}
+                                    rtl={false}
+                                    scrollMenuIntoView={true}
+                                    searchable={true}
+                                    simpleValue={false}
+                                    tabSelectsValue={true}
+                                    trimFilter={true}
                                     value=""
+                                    valueComponent={[Function]}
+                                    valueKey="value"
                                   >
-                                    <Select
-                                      arrowRenderer={[Function]}
-                                      autosize={true}
-                                      backspaceRemoves={false}
-                                      backspaceToRemoveMessage="Press backspace to remove {label}"
-                                      className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
-                                      clearAllText="Clear all"
-                                      clearRenderer={[Function]}
-                                      clearValueText="Clear value"
-                                      clearable={false}
-                                      closeOnSelect={true}
-                                      deleteRemoves={false}
-                                      delimiter=","
-                                      disabled={false}
-                                      escapeClearsValue={true}
-                                      filterOptions={[Function]}
-                                      height={36}
-                                      id="id-select-team"
-                                      ignoreAccents={true}
-                                      ignoreCase={true}
-                                      inputProps={Object {}}
-                                      isLoading={false}
-                                      joinValues={false}
-                                      labelKey="label"
-                                      matchPos="any"
-                                      matchProp="any"
-                                      menuBuffer={0}
-                                      menuRenderer={[Function]}
-                                      multi={false}
-                                      multiple={false}
-                                      name="select-team"
-                                      noResultsText="No results found"
-                                      onBlurResetsInput={true}
-                                      onChange={[Function]}
-                                      onCloseResetsInput={true}
-                                      onSelectResetsInput={true}
-                                      openOnClick={true}
-                                      optionComponent={[Function]}
-                                      options={Array []}
-                                      pageSize={5}
-                                      placeholder="Select..."
-                                      removeSelected={true}
-                                      required={false}
-                                      rtl={false}
-                                      scrollMenuIntoView={true}
-                                      searchable={true}
-                                      simpleValue={false}
-                                      tabSelectsValue={true}
-                                      trimFilter={true}
-                                      value=""
-                                      valueComponent={[Function]}
-                                      valueKey="value"
+                                    <div
+                                      className="Select e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
                                     >
                                       <div
-                                        className="Select e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
+                                        className="Select-control"
+                                        onKeyDown={[Function]}
+                                        onMouseDown={[Function]}
+                                        onTouchEnd={[Function]}
+                                        onTouchMove={[Function]}
+                                        onTouchStart={[Function]}
                                       >
-                                        <div
-                                          className="Select-control"
-                                          onKeyDown={[Function]}
-                                          onMouseDown={[Function]}
-                                          onTouchEnd={[Function]}
-                                          onTouchMove={[Function]}
-                                          onTouchStart={[Function]}
+                                        <span
+                                          className="Select-multi-value-wrapper"
+                                          id="react-select-2--value"
                                         >
-                                          <span
-                                            className="Select-multi-value-wrapper"
-                                            id="react-select-2--value"
+                                          <div
+                                            className="Select-placeholder"
+                                          >
+                                            Select...
+                                          </div>
+                                          <AutosizeInput
+                                            aria-activedescendant="react-select-2--value"
+                                            aria-expanded="false"
+                                            aria-haspopup="false"
+                                            aria-owns=""
+                                            className="Select-input"
+                                            id="id-select-team"
+                                            injectStyles={true}
+                                            minWidth="5"
+                                            onBlur={[Function]}
+                                            onChange={[Function]}
+                                            onFocus={[Function]}
+                                            required={false}
+                                            role="combobox"
+                                            value=""
                                           >
                                             <div
-                                              className="Select-placeholder"
-                                            >
-                                              Select...
-                                            </div>
-                                            <AutosizeInput
-                                              aria-activedescendant="react-select-2--value"
-                                              aria-expanded="false"
-                                              aria-haspopup="false"
-                                              aria-owns=""
                                               className="Select-input"
-                                              id="id-select-team"
-                                              injectStyles={true}
-                                              minWidth="5"
-                                              onBlur={[Function]}
-                                              onChange={[Function]}
-                                              onFocus={[Function]}
-                                              required={false}
-                                              role="combobox"
-                                              value=""
+                                              style={
+                                                Object {
+                                                  "display": "inline-block",
+                                                }
+                                              }
                                             >
-                                              <div
-                                                className="Select-input"
+                                              <input
+                                                aria-activedescendant="react-select-2--value"
+                                                aria-expanded="false"
+                                                aria-haspopup="false"
+                                                aria-owns=""
+                                                id="id-select-team"
+                                                onBlur={[Function]}
+                                                onChange={[Function]}
+                                                onFocus={[Function]}
+                                                required={false}
+                                                role="combobox"
                                                 style={
                                                   Object {
-                                                    "display": "inline-block",
+                                                    "boxSizing": "content-box",
+                                                    "width": "5px",
                                                   }
                                                 }
-                                              >
-                                                <input
-                                                  aria-activedescendant="react-select-2--value"
-                                                  aria-expanded="false"
-                                                  aria-haspopup="false"
-                                                  aria-owns=""
-                                                  id="id-select-team"
-                                                  onBlur={[Function]}
-                                                  onChange={[Function]}
-                                                  onFocus={[Function]}
-                                                  required={false}
-                                                  role="combobox"
-                                                  style={
-                                                    Object {
-                                                      "boxSizing": "content-box",
-                                                      "width": "5px",
-                                                    }
+                                                value=""
+                                              />
+                                              <div
+                                                style={
+                                                  Object {
+                                                    "height": 0,
+                                                    "left": 0,
+                                                    "overflow": "scroll",
+                                                    "position": "absolute",
+                                                    "top": 0,
+                                                    "visibility": "hidden",
+                                                    "whiteSpace": "pre",
                                                   }
-                                                  value=""
-                                                />
-                                                <div
-                                                  style={
-                                                    Object {
-                                                      "height": 0,
-                                                      "left": 0,
-                                                      "overflow": "scroll",
-                                                      "position": "absolute",
-                                                      "top": 0,
-                                                      "visibility": "hidden",
-                                                      "whiteSpace": "pre",
-                                                    }
-                                                  }
-                                                />
-                                              </div>
-                                            </AutosizeInput>
-                                          </span>
+                                                }
+                                              />
+                                            </div>
+                                          </AutosizeInput>
+                                        </span>
+                                        <span
+                                          className="Select-arrow-zone"
+                                          onMouseDown={[Function]}
+                                        >
                                           <span
-                                            className="Select-arrow-zone"
-                                            onMouseDown={[Function]}
-                                          >
-                                            <span
-                                              className="icon-arrow-down"
-                                            />
-                                          </span>
-                                        </div>
+                                            className="icon-arrow-down"
+                                          />
+                                        </span>
                                       </div>
-                                    </Select>
-                                  </SelectPicker>
-                                </ForwardRef(SelectPicker)>
-                              </StyledSelect>
-                            </SelectControl>
-                          </StyledSelectControl>
-                        </div>
+                                    </div>
+                                  </Select>
+                                </SelectPicker>
+                              </ForwardRef(SelectPicker)>
+                            </StyledSelect>
+                          </SelectControl>
+                        </StyledSelectControl>
                       </div>
-                    </SelectField>
-                  </div>
+                    </div>
+                  </SelectField>
                 </div>
-                <div>
-                  <button
-                    className="btn btn-primary new-project-submit"
-                    onClick={[Function]}
-                  >
-                    Create Project
-                  </button>
-                </div>
-                <p>
-                  Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
-                </p>
               </div>
+              <div>
+                <button
+                  className="btn btn-primary new-project-submit"
+                  onClick={[Function]}
+                >
+                  Create Project
+                </button>
+              </div>
+              <p>
+                Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
+              </p>
             </div>
-          </Wrapper>
+          </div>
         </OnboardingProject>
       </div>
     </div>
@@ -1284,816 +1252,798 @@ exports[`OnboardingWizard render() should render and respond to click events 2`]
           team=""
           teams={Array []}
         >
-          <Wrapper>
-            <div
-              className="css-a5urgt-Wrapper e1bu5aqa0"
-            >
-              <PageHeading
-                withMargins={true}
-              >
-                <Wrapper
-                  withMargins={true}
-                >
-                  <h1
-                    className="css-wxef79-Wrapper e1f8hk460"
-                  >
-                    Choose a language or framework:
-                  </h1>
-                </Wrapper>
-              </PageHeading>
-              <PlatformPicker
-                name=""
-                next={[MockFunction]}
-                platform=""
-                setName={[MockFunction]}
-                setPlatform={
-                  [MockFunction] {
-                    "calls": Array [
-                      Array [
-                        "csharp",
-                      ],
+          <div
+            className="onboarding-info"
+          >
+            <h4>
+              Choose a language or framework:
+            </h4>
+            <PlatformPicker
+              name=""
+              next={[MockFunction]}
+              platform=""
+              setName={[MockFunction]}
+              setPlatform={
+                [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      "csharp",
                     ],
-                    "results": Array [
-                      Object {
-                        "isThrow": false,
-                        "value": undefined,
-                      },
-                    ],
-                  }
+                  ],
+                  "results": Array [
+                    Object {
+                      "isThrow": false,
+                      "value": undefined,
+                    },
+                  ],
                 }
-                setTeam={[Function]}
-                showOther={true}
-                team=""
-                teams={Array []}
-              >
-                <div
-                  className="platform-picker"
-                >
-                  <NavTabs>
-                    <ul
-                      className="nav nav-tabs"
-                    >
-                      <li
-                        style={
-                          Object {
-                            "float": "right",
-                            "marginRight": 0,
-                          }
-                        }
-                      >
-                        <div
-                          className="platform-filter-container"
-                        >
-                          <span
-                            className="icon icon-search"
-                          />
-                          <input
-                            className="platform-filter"
-                            label="Filter"
-                            onChange={[Function]}
-                            placeholder="Filter"
-                            type="text"
-                            value=""
-                          />
-                        </div>
-                      </li>
-                      <ListLink
-                        activeClassName="active"
-                        index={false}
-                        isActive={[Function]}
-                        key="popular"
-                        onClick={[Function]}
-                        to=""
-                      >
-                        <li
-                          className="active"
-                        >
-                          <Link
-                            onClick={[Function]}
-                            onlyActiveOnIndex={false}
-                            style={Object {}}
-                            to=""
-                          >
-                            <a
-                              onClick={[Function]}
-                              style={Object {}}
-                            >
-                              Popular
-                            </a>
-                          </Link>
-                        </li>
-                      </ListLink>
-                      <ListLink
-                        activeClassName="active"
-                        index={false}
-                        isActive={[Function]}
-                        key="browser"
-                        onClick={[Function]}
-                        to=""
-                      >
-                        <li
-                          className=""
-                        >
-                          <Link
-                            onClick={[Function]}
-                            onlyActiveOnIndex={false}
-                            style={Object {}}
-                            to=""
-                          >
-                            <a
-                              onClick={[Function]}
-                              style={Object {}}
-                            >
-                              Browser
-                            </a>
-                          </Link>
-                        </li>
-                      </ListLink>
-                      <ListLink
-                        activeClassName="active"
-                        index={false}
-                        isActive={[Function]}
-                        key="server"
-                        onClick={[Function]}
-                        to=""
-                      >
-                        <li
-                          className=""
-                        >
-                          <Link
-                            onClick={[Function]}
-                            onlyActiveOnIndex={false}
-                            style={Object {}}
-                            to=""
-                          >
-                            <a
-                              onClick={[Function]}
-                              style={Object {}}
-                            >
-                              Server
-                            </a>
-                          </Link>
-                        </li>
-                      </ListLink>
-                      <ListLink
-                        activeClassName="active"
-                        index={false}
-                        isActive={[Function]}
-                        key="mobile"
-                        onClick={[Function]}
-                        to=""
-                      >
-                        <li
-                          className=""
-                        >
-                          <Link
-                            onClick={[Function]}
-                            onlyActiveOnIndex={false}
-                            style={Object {}}
-                            to=""
-                          >
-                            <a
-                              onClick={[Function]}
-                              style={Object {}}
-                            >
-                              Mobile
-                            </a>
-                          </Link>
-                        </li>
-                      </ListLink>
-                      <ListLink
-                        activeClassName="active"
-                        index={false}
-                        isActive={[Function]}
-                        key="desktop"
-                        onClick={[Function]}
-                        to=""
-                      >
-                        <li
-                          className=""
-                        >
-                          <Link
-                            onClick={[Function]}
-                            onlyActiveOnIndex={false}
-                            style={Object {}}
-                            to=""
-                          >
-                            <a
-                              onClick={[Function]}
-                              style={Object {}}
-                            >
-                              Desktop
-                            </a>
-                          </Link>
-                        </li>
-                      </ListLink>
-                      <ListLink
-                        activeClassName="active"
-                        index={false}
-                        isActive={[Function]}
-                        key="all"
-                        onClick={[Function]}
-                        to=""
-                      >
-                        <li
-                          className=""
-                        >
-                          <Link
-                            onClick={[Function]}
-                            onlyActiveOnIndex={false}
-                            style={Object {}}
-                            to=""
-                          >
-                            <a
-                              onClick={[Function]}
-                              style={Object {}}
-                            >
-                              All
-                            </a>
-                          </Link>
-                        </li>
-                      </ListLink>
-                    </ul>
-                  </NavTabs>
-                  <ul
-                    className="client-platform-list platform-tiles"
-                  >
-                    <PlatformCard
-                      className=""
-                      key="csharp"
-                      onClick={[Function]}
-                      platform="csharp"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="csharp"
-                        >
-                          <li
-                            className="platform-tile list-unstyled csharp csharp "
-                          >
-                            <span
-                              className="platformicon platformicon-csharp"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          C#
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="java"
-                      onClick={[Function]}
-                      platform="java"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="java"
-                        >
-                          <li
-                            className="platform-tile list-unstyled java java "
-                          >
-                            <span
-                              className="platformicon platformicon-java"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Java
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="javascript-angular"
-                      onClick={[Function]}
-                      platform="javascript-angular"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="javascript-angular"
-                        >
-                          <li
-                            className="platform-tile list-unstyled javascript-angular javascript "
-                          >
-                            <span
-                              className="platformicon platformicon-javascript-angular"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Angular
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="javascript"
-                      onClick={[Function]}
-                      platform="javascript"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="javascript"
-                        >
-                          <li
-                            className="platform-tile list-unstyled javascript javascript "
-                          >
-                            <span
-                              className="platformicon platformicon-javascript"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          JavaScript
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="javascript-react"
-                      onClick={[Function]}
-                      platform="javascript-react"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="javascript-react"
-                        >
-                          <li
-                            className="platform-tile list-unstyled javascript-react javascript "
-                          >
-                            <span
-                              className="platformicon platformicon-javascript-react"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          React
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="node-express"
-                      onClick={[Function]}
-                      platform="node-express"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="node-express"
-                        >
-                          <li
-                            className="platform-tile list-unstyled node-express node "
-                          >
-                            <span
-                              className="platformicon platformicon-node-express"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Express
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="node"
-                      onClick={[Function]}
-                      platform="node"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="node"
-                        >
-                          <li
-                            className="platform-tile list-unstyled node node "
-                          >
-                            <span
-                              className="platformicon platformicon-node"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Node.js
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="php-laravel"
-                      onClick={[Function]}
-                      platform="php-laravel"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="php-laravel"
-                        >
-                          <li
-                            className="platform-tile list-unstyled php-laravel php "
-                          >
-                            <span
-                              className="platformicon platformicon-php-laravel"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Laravel
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="php"
-                      onClick={[Function]}
-                      platform="php"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="php"
-                        >
-                          <li
-                            className="platform-tile list-unstyled php php "
-                          >
-                            <span
-                              className="platformicon platformicon-php"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          PHP
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="php-symfony2"
-                      onClick={[Function]}
-                      platform="php-symfony2"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="php-symfony2"
-                        >
-                          <li
-                            className="platform-tile list-unstyled php-symfony2 php "
-                          >
-                            <span
-                              className="platformicon platformicon-php-symfony2"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Symfony2
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="python-django"
-                      onClick={[Function]}
-                      platform="python-django"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="python-django"
-                        >
-                          <li
-                            className="platform-tile list-unstyled python-django python "
-                          >
-                            <span
-                              className="platformicon platformicon-python-django"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Django
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="python-flask"
-                      onClick={[Function]}
-                      platform="python-flask"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="python-flask"
-                        >
-                          <li
-                            className="platform-tile list-unstyled python-flask python "
-                          >
-                            <span
-                              className="platformicon platformicon-python-flask"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Flask
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="python"
-                      onClick={[Function]}
-                      platform="python"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="python"
-                        >
-                          <li
-                            className="platform-tile list-unstyled python python "
-                          >
-                            <span
-                              className="platformicon platformicon-python"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Python
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="cocoa"
-                      onClick={[Function]}
-                      platform="cocoa"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="cocoa"
-                        >
-                          <li
-                            className="platform-tile list-unstyled cocoa cocoa "
-                          >
-                            <span
-                              className="platformicon platformicon-cocoa"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          React-Native
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="ruby-rails"
-                      onClick={[Function]}
-                      platform="ruby-rails"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="ruby-rails"
-                        >
-                          <li
-                            className="platform-tile list-unstyled ruby-rails ruby "
-                          >
-                            <span
-                              className="platformicon platformicon-ruby-rails"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Rails
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                    <PlatformCard
-                      className=""
-                      key="ruby"
-                      onClick={[Function]}
-                      platform="ruby"
-                    >
-                      <span
-                        className="platform-card"
-                        onClick={[Function]}
-                      >
-                        <PlatformiconTile
-                          className=""
-                          onClick={[Function]}
-                          platform="ruby"
-                        >
-                          <li
-                            className="platform-tile list-unstyled ruby ruby "
-                          >
-                            <span
-                              className="platformicon platformicon-ruby"
-                            />
-                          </li>
-                        </PlatformiconTile>
-                        <h5>
-                           
-                          Ruby
-                           
-                        </h5>
-                      </span>
-                    </PlatformCard>
-                  </ul>
-                </div>
-              </PlatformPicker>
+              }
+              setTeam={[Function]}
+              showOther={true}
+              team=""
+              teams={Array []}
+            >
               <div
-                className="create-project-form"
+                className="platform-picker"
               >
-                <div
-                  className="new-project-name client-platform"
-                >
-                  <PageHeading
-                    withMargins={true}
+                <NavTabs>
+                  <ul
+                    className="nav nav-tabs"
                   >
-                    <Wrapper
-                      withMargins={true}
+                    <li
+                      style={
+                        Object {
+                          "float": "right",
+                          "marginRight": 0,
+                        }
+                      }
                     >
-                      <h1
-                        className="css-wxef79-Wrapper e1f8hk460"
-                      >
-                        Give your project a name:
-                      </h1>
-                    </Wrapper>
-                  </PageHeading>
-                  <div
-                    className="project-name-wrapper"
-                  >
-                    <PlatformiconTile
-                      platform=""
-                    >
-                      <li
-                        className="platform-tile list-unstyled   undefined"
+                      <div
+                        className="platform-filter-container"
                       >
                         <span
-                          className="platformicon platformicon-"
+                          className="icon icon-search"
                         />
-                      </li>
-                    </PlatformiconTile>
-                    <input
-                      autoComplete="off"
-                      label="Project Name"
-                      name="name"
-                      onChange={[Function]}
-                      placeholder="Project name"
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </div>
-                <div
-                  className="new-project-team"
-                >
-                  <PageHeading
-                    withMargins={true}
-                  >
-                    <Wrapper
-                      withMargins={true}
+                        <input
+                          className="platform-filter"
+                          label="Filter"
+                          onChange={[Function]}
+                          placeholder="Filter"
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </li>
+                    <ListLink
+                      activeClassName="active"
+                      index={false}
+                      isActive={[Function]}
+                      key="popular"
+                      onClick={[Function]}
+                      to=""
                     >
-                      <h1
-                        className="css-wxef79-Wrapper e1f8hk460"
+                      <li
+                        className="active"
                       >
-                        Team:
-                      </h1>
-                    </Wrapper>
-                  </PageHeading>
-                  <div>
-                    <SelectField
-                      clearable={false}
-                      disabled={false}
-                      hideErrorMessage={false}
-                      multiple={false}
-                      name="select-team"
-                      onChange={[Function]}
-                      options={Array []}
-                      required={false}
+                        <Link
+                          onClick={[Function]}
+                          onlyActiveOnIndex={false}
+                          style={Object {}}
+                          to=""
+                        >
+                          <a
+                            onClick={[Function]}
+                            style={Object {}}
+                          >
+                            Popular
+                          </a>
+                        </Link>
+                      </li>
+                    </ListLink>
+                    <ListLink
+                      activeClassName="active"
+                      index={false}
+                      isActive={[Function]}
+                      key="browser"
+                      onClick={[Function]}
+                      to=""
+                    >
+                      <li
+                        className=""
+                      >
+                        <Link
+                          onClick={[Function]}
+                          onlyActiveOnIndex={false}
+                          style={Object {}}
+                          to=""
+                        >
+                          <a
+                            onClick={[Function]}
+                            style={Object {}}
+                          >
+                            Browser
+                          </a>
+                        </Link>
+                      </li>
+                    </ListLink>
+                    <ListLink
+                      activeClassName="active"
+                      index={false}
+                      isActive={[Function]}
+                      key="server"
+                      onClick={[Function]}
+                      to=""
+                    >
+                      <li
+                        className=""
+                      >
+                        <Link
+                          onClick={[Function]}
+                          onlyActiveOnIndex={false}
+                          style={Object {}}
+                          to=""
+                        >
+                          <a
+                            onClick={[Function]}
+                            style={Object {}}
+                          >
+                            Server
+                          </a>
+                        </Link>
+                      </li>
+                    </ListLink>
+                    <ListLink
+                      activeClassName="active"
+                      index={false}
+                      isActive={[Function]}
+                      key="mobile"
+                      onClick={[Function]}
+                      to=""
+                    >
+                      <li
+                        className=""
+                      >
+                        <Link
+                          onClick={[Function]}
+                          onlyActiveOnIndex={false}
+                          style={Object {}}
+                          to=""
+                        >
+                          <a
+                            onClick={[Function]}
+                            style={Object {}}
+                          >
+                            Mobile
+                          </a>
+                        </Link>
+                      </li>
+                    </ListLink>
+                    <ListLink
+                      activeClassName="active"
+                      index={false}
+                      isActive={[Function]}
+                      key="desktop"
+                      onClick={[Function]}
+                      to=""
+                    >
+                      <li
+                        className=""
+                      >
+                        <Link
+                          onClick={[Function]}
+                          onlyActiveOnIndex={false}
+                          style={Object {}}
+                          to=""
+                        >
+                          <a
+                            onClick={[Function]}
+                            style={Object {}}
+                          >
+                            Desktop
+                          </a>
+                        </Link>
+                      </li>
+                    </ListLink>
+                    <ListLink
+                      activeClassName="active"
+                      index={false}
+                      isActive={[Function]}
+                      key="all"
+                      onClick={[Function]}
+                      to=""
+                    >
+                      <li
+                        className=""
+                      >
+                        <Link
+                          onClick={[Function]}
+                          onlyActiveOnIndex={false}
+                          style={Object {}}
+                          to=""
+                        >
+                          <a
+                            onClick={[Function]}
+                            style={Object {}}
+                          >
+                            All
+                          </a>
+                        </Link>
+                      </li>
+                    </ListLink>
+                  </ul>
+                </NavTabs>
+                <ul
+                  className="client-platform-list platform-tiles"
+                >
+                  <PlatformCard
+                    className=""
+                    key="csharp"
+                    onClick={[Function]}
+                    platform="csharp"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="csharp"
+                      >
+                        <li
+                          className="platform-tile list-unstyled csharp csharp "
+                        >
+                          <span
+                            className="platformicon platformicon-csharp"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        C#
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="java"
+                    onClick={[Function]}
+                    platform="java"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="java"
+                      >
+                        <li
+                          className="platform-tile list-unstyled java java "
+                        >
+                          <span
+                            className="platformicon platformicon-java"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Java
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="javascript-angular"
+                    onClick={[Function]}
+                    platform="javascript-angular"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="javascript-angular"
+                      >
+                        <li
+                          className="platform-tile list-unstyled javascript-angular javascript "
+                        >
+                          <span
+                            className="platformicon platformicon-javascript-angular"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Angular
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="javascript"
+                    onClick={[Function]}
+                    platform="javascript"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="javascript"
+                      >
+                        <li
+                          className="platform-tile list-unstyled javascript javascript "
+                        >
+                          <span
+                            className="platformicon platformicon-javascript"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        JavaScript
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="javascript-react"
+                    onClick={[Function]}
+                    platform="javascript-react"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="javascript-react"
+                      >
+                        <li
+                          className="platform-tile list-unstyled javascript-react javascript "
+                        >
+                          <span
+                            className="platformicon platformicon-javascript-react"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        React
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="node-express"
+                    onClick={[Function]}
+                    platform="node-express"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="node-express"
+                      >
+                        <li
+                          className="platform-tile list-unstyled node-express node "
+                        >
+                          <span
+                            className="platformicon platformicon-node-express"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Express
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="node"
+                    onClick={[Function]}
+                    platform="node"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="node"
+                      >
+                        <li
+                          className="platform-tile list-unstyled node node "
+                        >
+                          <span
+                            className="platformicon platformicon-node"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Node.js
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="php-laravel"
+                    onClick={[Function]}
+                    platform="php-laravel"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="php-laravel"
+                      >
+                        <li
+                          className="platform-tile list-unstyled php-laravel php "
+                        >
+                          <span
+                            className="platformicon platformicon-php-laravel"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Laravel
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="php"
+                    onClick={[Function]}
+                    platform="php"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="php"
+                      >
+                        <li
+                          className="platform-tile list-unstyled php php "
+                        >
+                          <span
+                            className="platformicon platformicon-php"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        PHP
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="php-symfony2"
+                    onClick={[Function]}
+                    platform="php-symfony2"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="php-symfony2"
+                      >
+                        <li
+                          className="platform-tile list-unstyled php-symfony2 php "
+                        >
+                          <span
+                            className="platformicon platformicon-php-symfony2"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Symfony2
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="python-django"
+                    onClick={[Function]}
+                    platform="python-django"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="python-django"
+                      >
+                        <li
+                          className="platform-tile list-unstyled python-django python "
+                        >
+                          <span
+                            className="platformicon platformicon-python-django"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Django
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="python-flask"
+                    onClick={[Function]}
+                    platform="python-flask"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="python-flask"
+                      >
+                        <li
+                          className="platform-tile list-unstyled python-flask python "
+                        >
+                          <span
+                            className="platformicon platformicon-python-flask"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Flask
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="python"
+                    onClick={[Function]}
+                    platform="python"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="python"
+                      >
+                        <li
+                          className="platform-tile list-unstyled python python "
+                        >
+                          <span
+                            className="platformicon platformicon-python"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Python
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="cocoa"
+                    onClick={[Function]}
+                    platform="cocoa"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="cocoa"
+                      >
+                        <li
+                          className="platform-tile list-unstyled cocoa cocoa "
+                        >
+                          <span
+                            className="platformicon platformicon-cocoa"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        React-Native
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="ruby-rails"
+                    onClick={[Function]}
+                    platform="ruby-rails"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="ruby-rails"
+                      >
+                        <li
+                          className="platform-tile list-unstyled ruby-rails ruby "
+                        >
+                          <span
+                            className="platformicon platformicon-ruby-rails"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Rails
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                  <PlatformCard
+                    className=""
+                    key="ruby"
+                    onClick={[Function]}
+                    platform="ruby"
+                  >
+                    <span
+                      className="platform-card"
+                      onClick={[Function]}
+                    >
+                      <PlatformiconTile
+                        className=""
+                        onClick={[Function]}
+                        platform="ruby"
+                      >
+                        <li
+                          className="platform-tile list-unstyled ruby ruby "
+                        >
+                          <span
+                            className="platformicon platformicon-ruby"
+                          />
+                        </li>
+                      </PlatformiconTile>
+                      <h5>
+                         
+                        Ruby
+                         
+                      </h5>
+                    </span>
+                  </PlatformCard>
+                </ul>
+              </div>
+            </PlatformPicker>
+            <div
+              className="create-project-form"
+            >
+              <div
+                className="new-project-name client-platform"
+              >
+                <h4>
+                  Give your project a name:
+                </h4>
+                <div
+                  className="project-name-wrapper"
+                >
+                  <PlatformiconTile
+                    platform=""
+                  >
+                    <li
+                      className="platform-tile list-unstyled   undefined"
+                    >
+                      <span
+                        className="platformicon platformicon-"
+                      />
+                    </li>
+                  </PlatformiconTile>
+                  <input
+                    autoComplete="off"
+                    label="Project Name"
+                    name="name"
+                    onChange={[Function]}
+                    placeholder="Project name"
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+              <div
+                className="new-project-team"
+              >
+                <h4>
+                  Team:
+                </h4>
+                <div>
+                  <SelectField
+                    clearable={false}
+                    disabled={false}
+                    hideErrorMessage={false}
+                    multiple={false}
+                    name="select-team"
+                    onChange={[Function]}
+                    options={Array []}
+                    required={false}
+                    style={
+                      Object {
+                        "marginBottom": 0,
+                        "width": 180,
+                      }
+                    }
+                    value=""
+                  >
+                    <div
+                      className=""
                       style={
                         Object {
                           "marginBottom": 0,
                           "width": 180,
                         }
                       }
-                      value=""
                     >
                       <div
-                        className=""
-                        style={
-                          Object {
-                            "marginBottom": 0,
-                            "width": 180,
-                          }
-                        }
+                        className="controls"
                       >
-                        <div
-                          className="controls"
+                        <StyledSelectControl
+                          clearable={false}
+                          disabled={false}
+                          id="id-select-team"
+                          multiple={false}
+                          name="select-team"
+                          onChange={[Function]}
+                          options={Array []}
+                          required={false}
+                          value=""
                         >
-                          <StyledSelectControl
+                          <SelectControl
+                            className="css-j6zs66-StyledSelectControl e1qrhqd00"
                             clearable={false}
                             disabled={false}
+                            height={36}
                             id="id-select-team"
                             multiple={false}
                             name="select-team"
@@ -2102,9 +2052,12 @@ exports[`OnboardingWizard render() should render and respond to click events 2`]
                             required={false}
                             value=""
                           >
-                            <SelectControl
+                            <StyledSelect
+                              arrowRenderer={[Function]}
+                              backspaceRemoves={false}
                               className="css-j6zs66-StyledSelectControl e1qrhqd00"
                               clearable={false}
+                              deleteRemoves={false}
                               disabled={false}
                               height={36}
                               id="id-select-team"
@@ -2115,10 +2068,10 @@ exports[`OnboardingWizard render() should render and respond to click events 2`]
                               required={false}
                               value=""
                             >
-                              <StyledSelect
+                              <ForwardRef(SelectPicker)
                                 arrowRenderer={[Function]}
                                 backspaceRemoves={false}
-                                className="css-j6zs66-StyledSelectControl e1qrhqd00"
+                                className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
                                 clearable={false}
                                 deleteRemoves={false}
                                 disabled={false}
@@ -2131,13 +2084,14 @@ exports[`OnboardingWizard render() should render and respond to click events 2`]
                                 required={false}
                                 value=""
                               >
-                                <ForwardRef(SelectPicker)
+                                <SelectPicker
                                   arrowRenderer={[Function]}
                                   backspaceRemoves={false}
                                   className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
                                   clearable={false}
                                   deleteRemoves={false}
                                   disabled={false}
+                                  forwardedRef={null}
                                   height={36}
                                   id="id-select-team"
                                   multiple={false}
@@ -2147,190 +2101,172 @@ exports[`OnboardingWizard render() should render and respond to click events 2`]
                                   required={false}
                                   value=""
                                 >
-                                  <SelectPicker
+                                  <Select
                                     arrowRenderer={[Function]}
+                                    autosize={true}
                                     backspaceRemoves={false}
+                                    backspaceToRemoveMessage="Press backspace to remove {label}"
                                     className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
+                                    clearAllText="Clear all"
+                                    clearRenderer={[Function]}
+                                    clearValueText="Clear value"
                                     clearable={false}
+                                    closeOnSelect={true}
                                     deleteRemoves={false}
+                                    delimiter=","
                                     disabled={false}
-                                    forwardedRef={null}
+                                    escapeClearsValue={true}
+                                    filterOptions={[Function]}
                                     height={36}
                                     id="id-select-team"
+                                    ignoreAccents={true}
+                                    ignoreCase={true}
+                                    inputProps={Object {}}
+                                    isLoading={false}
+                                    joinValues={false}
+                                    labelKey="label"
+                                    matchPos="any"
+                                    matchProp="any"
+                                    menuBuffer={0}
+                                    menuRenderer={[Function]}
+                                    multi={false}
                                     multiple={false}
                                     name="select-team"
+                                    noResultsText="No results found"
+                                    onBlurResetsInput={true}
                                     onChange={[Function]}
+                                    onCloseResetsInput={true}
+                                    onSelectResetsInput={true}
+                                    openOnClick={true}
+                                    optionComponent={[Function]}
                                     options={Array []}
+                                    pageSize={5}
+                                    placeholder="Select..."
+                                    removeSelected={true}
                                     required={false}
+                                    rtl={false}
+                                    scrollMenuIntoView={true}
+                                    searchable={true}
+                                    simpleValue={false}
+                                    tabSelectsValue={true}
+                                    trimFilter={true}
                                     value=""
+                                    valueComponent={[Function]}
+                                    valueKey="value"
                                   >
-                                    <Select
-                                      arrowRenderer={[Function]}
-                                      autosize={true}
-                                      backspaceRemoves={false}
-                                      backspaceToRemoveMessage="Press backspace to remove {label}"
-                                      className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
-                                      clearAllText="Clear all"
-                                      clearRenderer={[Function]}
-                                      clearValueText="Clear value"
-                                      clearable={false}
-                                      closeOnSelect={true}
-                                      deleteRemoves={false}
-                                      delimiter=","
-                                      disabled={false}
-                                      escapeClearsValue={true}
-                                      filterOptions={[Function]}
-                                      height={36}
-                                      id="id-select-team"
-                                      ignoreAccents={true}
-                                      ignoreCase={true}
-                                      inputProps={Object {}}
-                                      isLoading={false}
-                                      joinValues={false}
-                                      labelKey="label"
-                                      matchPos="any"
-                                      matchProp="any"
-                                      menuBuffer={0}
-                                      menuRenderer={[Function]}
-                                      multi={false}
-                                      multiple={false}
-                                      name="select-team"
-                                      noResultsText="No results found"
-                                      onBlurResetsInput={true}
-                                      onChange={[Function]}
-                                      onCloseResetsInput={true}
-                                      onSelectResetsInput={true}
-                                      openOnClick={true}
-                                      optionComponent={[Function]}
-                                      options={Array []}
-                                      pageSize={5}
-                                      placeholder="Select..."
-                                      removeSelected={true}
-                                      required={false}
-                                      rtl={false}
-                                      scrollMenuIntoView={true}
-                                      searchable={true}
-                                      simpleValue={false}
-                                      tabSelectsValue={true}
-                                      trimFilter={true}
-                                      value=""
-                                      valueComponent={[Function]}
-                                      valueKey="value"
+                                    <div
+                                      className="Select e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
                                     >
                                       <div
-                                        className="Select e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
+                                        className="Select-control"
+                                        onKeyDown={[Function]}
+                                        onMouseDown={[Function]}
+                                        onTouchEnd={[Function]}
+                                        onTouchMove={[Function]}
+                                        onTouchStart={[Function]}
                                       >
-                                        <div
-                                          className="Select-control"
-                                          onKeyDown={[Function]}
-                                          onMouseDown={[Function]}
-                                          onTouchEnd={[Function]}
-                                          onTouchMove={[Function]}
-                                          onTouchStart={[Function]}
+                                        <span
+                                          className="Select-multi-value-wrapper"
+                                          id="react-select-2--value"
                                         >
-                                          <span
-                                            className="Select-multi-value-wrapper"
-                                            id="react-select-2--value"
+                                          <div
+                                            className="Select-placeholder"
+                                          >
+                                            Select...
+                                          </div>
+                                          <AutosizeInput
+                                            aria-activedescendant="react-select-2--value"
+                                            aria-expanded="false"
+                                            aria-haspopup="false"
+                                            aria-owns=""
+                                            className="Select-input"
+                                            id="id-select-team"
+                                            injectStyles={true}
+                                            minWidth="5"
+                                            onBlur={[Function]}
+                                            onChange={[Function]}
+                                            onFocus={[Function]}
+                                            required={false}
+                                            role="combobox"
+                                            value=""
                                           >
                                             <div
-                                              className="Select-placeholder"
-                                            >
-                                              Select...
-                                            </div>
-                                            <AutosizeInput
-                                              aria-activedescendant="react-select-2--value"
-                                              aria-expanded="false"
-                                              aria-haspopup="false"
-                                              aria-owns=""
                                               className="Select-input"
-                                              id="id-select-team"
-                                              injectStyles={true}
-                                              minWidth="5"
-                                              onBlur={[Function]}
-                                              onChange={[Function]}
-                                              onFocus={[Function]}
-                                              required={false}
-                                              role="combobox"
-                                              value=""
+                                              style={
+                                                Object {
+                                                  "display": "inline-block",
+                                                }
+                                              }
                                             >
-                                              <div
-                                                className="Select-input"
+                                              <input
+                                                aria-activedescendant="react-select-2--value"
+                                                aria-expanded="false"
+                                                aria-haspopup="false"
+                                                aria-owns=""
+                                                id="id-select-team"
+                                                onBlur={[Function]}
+                                                onChange={[Function]}
+                                                onFocus={[Function]}
+                                                required={false}
+                                                role="combobox"
                                                 style={
                                                   Object {
-                                                    "display": "inline-block",
+                                                    "boxSizing": "content-box",
+                                                    "width": "5px",
                                                   }
                                                 }
-                                              >
-                                                <input
-                                                  aria-activedescendant="react-select-2--value"
-                                                  aria-expanded="false"
-                                                  aria-haspopup="false"
-                                                  aria-owns=""
-                                                  id="id-select-team"
-                                                  onBlur={[Function]}
-                                                  onChange={[Function]}
-                                                  onFocus={[Function]}
-                                                  required={false}
-                                                  role="combobox"
-                                                  style={
-                                                    Object {
-                                                      "boxSizing": "content-box",
-                                                      "width": "5px",
-                                                    }
+                                                value=""
+                                              />
+                                              <div
+                                                style={
+                                                  Object {
+                                                    "height": 0,
+                                                    "left": 0,
+                                                    "overflow": "scroll",
+                                                    "position": "absolute",
+                                                    "top": 0,
+                                                    "visibility": "hidden",
+                                                    "whiteSpace": "pre",
                                                   }
-                                                  value=""
-                                                />
-                                                <div
-                                                  style={
-                                                    Object {
-                                                      "height": 0,
-                                                      "left": 0,
-                                                      "overflow": "scroll",
-                                                      "position": "absolute",
-                                                      "top": 0,
-                                                      "visibility": "hidden",
-                                                      "whiteSpace": "pre",
-                                                    }
-                                                  }
-                                                />
-                                              </div>
-                                            </AutosizeInput>
-                                          </span>
+                                                }
+                                              />
+                                            </div>
+                                          </AutosizeInput>
+                                        </span>
+                                        <span
+                                          className="Select-arrow-zone"
+                                          onMouseDown={[Function]}
+                                        >
                                           <span
-                                            className="Select-arrow-zone"
-                                            onMouseDown={[Function]}
-                                          >
-                                            <span
-                                              className="icon-arrow-down"
-                                            />
-                                          </span>
-                                        </div>
+                                            className="icon-arrow-down"
+                                          />
+                                        </span>
                                       </div>
-                                    </Select>
-                                  </SelectPicker>
-                                </ForwardRef(SelectPicker)>
-                              </StyledSelect>
-                            </SelectControl>
-                          </StyledSelectControl>
-                        </div>
+                                    </div>
+                                  </Select>
+                                </SelectPicker>
+                              </ForwardRef(SelectPicker)>
+                            </StyledSelect>
+                          </SelectControl>
+                        </StyledSelectControl>
                       </div>
-                    </SelectField>
-                  </div>
+                    </div>
+                  </SelectField>
                 </div>
-                <div>
-                  <button
-                    className="btn btn-primary new-project-submit"
-                    onClick={[Function]}
-                  >
-                    Create Project
-                  </button>
-                </div>
-                <p>
-                  Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
-                </p>
               </div>
+              <div>
+                <button
+                  className="btn btn-primary new-project-submit"
+                  onClick={[Function]}
+                >
+                  Create Project
+                </button>
+              </div>
+              <p>
+                Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
+              </p>
             </div>
-          </Wrapper>
+          </div>
         </OnboardingProject>
       </div>
     </div>

--- a/tests/js/spec/views/onboarding/project/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/project/__snapshots__/index.spec.jsx.snap
@@ -4,9 +4,11 @@ exports[`Project render() should render NotFound if no matching organization 1`]
 <div
   className="onboarding-info"
 >
-  <h4>
+  <PageHeading
+    withMargins={true}
+  >
     Choose a language or framework:
-  </h4>
+  </PageHeading>
   <PlatformPicker
     location={
       Object {
@@ -34,9 +36,11 @@ exports[`Project render() should render NotFound if no matching organization 1`]
     <div
       className="new-project-name client-platform"
     >
-      <h4>
+      <PageHeading
+        withMargins={true}
+      >
         Give your project a name:
-      </h4>
+      </PageHeading>
       <div
         className="project-name-wrapper"
       >
@@ -57,9 +61,11 @@ exports[`Project render() should render NotFound if no matching organization 1`]
     <div
       className="new-project-team"
     >
-      <h4>
+      <PageHeading
+        withMargins={true}
+      >
         Team:
-      </h4>
+      </PageHeading>
       <div>
         <SelectField
           clearable={false}
@@ -132,9 +138,19 @@ exports[`Project render() should set required class on empty submit 1`] = `
   <div
     className="onboarding-info"
   >
-    <h4>
-      Choose a language or framework:
-    </h4>
+    <PageHeading
+      withMargins={true}
+    >
+      <Wrapper
+        withMargins={true}
+      >
+        <h1
+          className="css-wxef79-Wrapper e1f8hk460"
+        >
+          Choose a language or framework:
+        </h1>
+      </Wrapper>
+    </PageHeading>
     <PlatformPicker
       location={
         Object {
@@ -850,9 +866,19 @@ exports[`Project render() should set required class on empty submit 1`] = `
       <div
         className="new-project-name client-platform"
       >
-        <h4>
-          Give your project a name:
-        </h4>
+        <PageHeading
+          withMargins={true}
+        >
+          <Wrapper
+            withMargins={true}
+          >
+            <h1
+              className="css-wxef79-Wrapper e1f8hk460"
+            >
+              Give your project a name:
+            </h1>
+          </Wrapper>
+        </PageHeading>
         <div
           className="project-name-wrapper"
         >
@@ -881,9 +907,19 @@ exports[`Project render() should set required class on empty submit 1`] = `
       <div
         className="new-project-team"
       >
-        <h4>
-          Team:
-        </h4>
+        <PageHeading
+          withMargins={true}
+        >
+          <Wrapper
+            withMargins={true}
+          >
+            <h1
+              className="css-wxef79-Wrapper e1f8hk460"
+            >
+              Team:
+            </h1>
+          </Wrapper>
+        </PageHeading>
         <div>
           <SelectField
             clearable={false}

--- a/tests/js/spec/views/onboarding/project/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/project/__snapshots__/index.spec.jsx.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Project render() should render NotFound if no matching organization 1`] = `
-<div
-  className="onboarding-info"
->
-  <h4>
+<Wrapper>
+  <PageHeading
+    withMargins={true}
+  >
     Choose a language or framework:
-  </h4>
+  </PageHeading>
   <PlatformPicker
     location={
       Object {
@@ -34,9 +34,11 @@ exports[`Project render() should render NotFound if no matching organization 1`]
     <div
       className="new-project-name client-platform"
     >
-      <h4>
+      <PageHeading
+        withMargins={true}
+      >
         Give your project a name:
-      </h4>
+      </PageHeading>
       <div
         className="project-name-wrapper"
       >
@@ -57,9 +59,11 @@ exports[`Project render() should render NotFound if no matching organization 1`]
     <div
       className="new-project-team"
     >
-      <h4>
+      <PageHeading
+        withMargins={true}
+      >
         Team:
-      </h4>
+      </PageHeading>
       <div>
         <SelectField
           clearable={false}
@@ -92,7 +96,7 @@ exports[`Project render() should render NotFound if no matching organization 1`]
       Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
     </p>
   </div>
-</div>
+</Wrapper>
 `;
 
 exports[`Project render() should set required class on empty submit 1`] = `
@@ -129,807 +133,825 @@ exports[`Project render() should set required class on empty submit 1`] = `
   team=""
   teams={Array []}
 >
-  <div
-    className="onboarding-info"
-  >
-    <h4>
-      Choose a language or framework:
-    </h4>
-    <PlatformPicker
-      location={
-        Object {
-          "query": Object {},
-        }
-      }
-      name="bar"
-      next={
-        [MockFunction] {
-          "calls": Array [
-            Array [],
-          ],
-          "results": Array [
-            Object {
-              "isThrow": false,
-              "value": undefined,
-            },
-          ],
-        }
-      }
-      params={
-        Object {
-          "orgId": "testOrg",
-          "projectId": "",
-        }
-      }
-      platform=""
-      setName={[MockFunction]}
-      setPlatform={[MockFunction]}
-      setTeam={[Function]}
-      showOther={true}
-      team=""
-      teams={Array []}
-    >
-      <div
-        className="platform-picker"
-      >
-        <NavTabs>
-          <ul
-            className="nav nav-tabs"
-          >
-            <li
-              style={
-                Object {
-                  "float": "right",
-                  "marginRight": 0,
-                }
-              }
-            >
-              <div
-                className="platform-filter-container"
-              >
-                <span
-                  className="icon icon-search"
-                />
-                <input
-                  className="platform-filter"
-                  label="Filter"
-                  onChange={[Function]}
-                  placeholder="Filter"
-                  type="text"
-                  value=""
-                />
-              </div>
-            </li>
-            <ListLink
-              activeClassName="active"
-              index={false}
-              isActive={[Function]}
-              key="popular"
-              onClick={[Function]}
-              to=""
-            >
-              <li
-                className="active"
-              >
-                <Link
-                  onClick={[Function]}
-                  onlyActiveOnIndex={false}
-                  style={Object {}}
-                  to=""
-                >
-                  <a
-                    onClick={[Function]}
-                    style={Object {}}
-                  >
-                    Popular
-                  </a>
-                </Link>
-              </li>
-            </ListLink>
-            <ListLink
-              activeClassName="active"
-              index={false}
-              isActive={[Function]}
-              key="browser"
-              onClick={[Function]}
-              to=""
-            >
-              <li
-                className=""
-              >
-                <Link
-                  onClick={[Function]}
-                  onlyActiveOnIndex={false}
-                  style={Object {}}
-                  to=""
-                >
-                  <a
-                    onClick={[Function]}
-                    style={Object {}}
-                  >
-                    Browser
-                  </a>
-                </Link>
-              </li>
-            </ListLink>
-            <ListLink
-              activeClassName="active"
-              index={false}
-              isActive={[Function]}
-              key="server"
-              onClick={[Function]}
-              to=""
-            >
-              <li
-                className=""
-              >
-                <Link
-                  onClick={[Function]}
-                  onlyActiveOnIndex={false}
-                  style={Object {}}
-                  to=""
-                >
-                  <a
-                    onClick={[Function]}
-                    style={Object {}}
-                  >
-                    Server
-                  </a>
-                </Link>
-              </li>
-            </ListLink>
-            <ListLink
-              activeClassName="active"
-              index={false}
-              isActive={[Function]}
-              key="mobile"
-              onClick={[Function]}
-              to=""
-            >
-              <li
-                className=""
-              >
-                <Link
-                  onClick={[Function]}
-                  onlyActiveOnIndex={false}
-                  style={Object {}}
-                  to=""
-                >
-                  <a
-                    onClick={[Function]}
-                    style={Object {}}
-                  >
-                    Mobile
-                  </a>
-                </Link>
-              </li>
-            </ListLink>
-            <ListLink
-              activeClassName="active"
-              index={false}
-              isActive={[Function]}
-              key="desktop"
-              onClick={[Function]}
-              to=""
-            >
-              <li
-                className=""
-              >
-                <Link
-                  onClick={[Function]}
-                  onlyActiveOnIndex={false}
-                  style={Object {}}
-                  to=""
-                >
-                  <a
-                    onClick={[Function]}
-                    style={Object {}}
-                  >
-                    Desktop
-                  </a>
-                </Link>
-              </li>
-            </ListLink>
-            <ListLink
-              activeClassName="active"
-              index={false}
-              isActive={[Function]}
-              key="all"
-              onClick={[Function]}
-              to=""
-            >
-              <li
-                className=""
-              >
-                <Link
-                  onClick={[Function]}
-                  onlyActiveOnIndex={false}
-                  style={Object {}}
-                  to=""
-                >
-                  <a
-                    onClick={[Function]}
-                    style={Object {}}
-                  >
-                    All
-                  </a>
-                </Link>
-              </li>
-            </ListLink>
-          </ul>
-        </NavTabs>
-        <ul
-          className="client-platform-list platform-tiles"
-        >
-          <PlatformCard
-            className=""
-            key="csharp"
-            onClick={[Function]}
-            platform="csharp"
-          >
-            <span
-              className="platform-card"
-              onClick={[Function]}
-            >
-              <PlatformiconTile
-                className=""
-                onClick={[Function]}
-                platform="csharp"
-              >
-                <li
-                  className="platform-tile list-unstyled csharp csharp "
-                >
-                  <span
-                    className="platformicon platformicon-csharp"
-                  />
-                </li>
-              </PlatformiconTile>
-              <h5>
-                 
-                C#
-                 
-              </h5>
-            </span>
-          </PlatformCard>
-          <PlatformCard
-            className=""
-            key="java"
-            onClick={[Function]}
-            platform="java"
-          >
-            <span
-              className="platform-card"
-              onClick={[Function]}
-            >
-              <PlatformiconTile
-                className=""
-                onClick={[Function]}
-                platform="java"
-              >
-                <li
-                  className="platform-tile list-unstyled java java "
-                >
-                  <span
-                    className="platformicon platformicon-java"
-                  />
-                </li>
-              </PlatformiconTile>
-              <h5>
-                 
-                Java
-                 
-              </h5>
-            </span>
-          </PlatformCard>
-          <PlatformCard
-            className=""
-            key="javascript-angular"
-            onClick={[Function]}
-            platform="javascript-angular"
-          >
-            <span
-              className="platform-card"
-              onClick={[Function]}
-            >
-              <PlatformiconTile
-                className=""
-                onClick={[Function]}
-                platform="javascript-angular"
-              >
-                <li
-                  className="platform-tile list-unstyled javascript-angular javascript "
-                >
-                  <span
-                    className="platformicon platformicon-javascript-angular"
-                  />
-                </li>
-              </PlatformiconTile>
-              <h5>
-                 
-                Angular
-                 
-              </h5>
-            </span>
-          </PlatformCard>
-          <PlatformCard
-            className=""
-            key="javascript"
-            onClick={[Function]}
-            platform="javascript"
-          >
-            <span
-              className="platform-card"
-              onClick={[Function]}
-            >
-              <PlatformiconTile
-                className=""
-                onClick={[Function]}
-                platform="javascript"
-              >
-                <li
-                  className="platform-tile list-unstyled javascript javascript "
-                >
-                  <span
-                    className="platformicon platformicon-javascript"
-                  />
-                </li>
-              </PlatformiconTile>
-              <h5>
-                 
-                JavaScript
-                 
-              </h5>
-            </span>
-          </PlatformCard>
-          <PlatformCard
-            className=""
-            key="javascript-react"
-            onClick={[Function]}
-            platform="javascript-react"
-          >
-            <span
-              className="platform-card"
-              onClick={[Function]}
-            >
-              <PlatformiconTile
-                className=""
-                onClick={[Function]}
-                platform="javascript-react"
-              >
-                <li
-                  className="platform-tile list-unstyled javascript-react javascript "
-                >
-                  <span
-                    className="platformicon platformicon-javascript-react"
-                  />
-                </li>
-              </PlatformiconTile>
-              <h5>
-                 
-                React
-                 
-              </h5>
-            </span>
-          </PlatformCard>
-          <PlatformCard
-            className=""
-            key="node-express"
-            onClick={[Function]}
-            platform="node-express"
-          >
-            <span
-              className="platform-card"
-              onClick={[Function]}
-            >
-              <PlatformiconTile
-                className=""
-                onClick={[Function]}
-                platform="node-express"
-              >
-                <li
-                  className="platform-tile list-unstyled node-express node "
-                >
-                  <span
-                    className="platformicon platformicon-node-express"
-                  />
-                </li>
-              </PlatformiconTile>
-              <h5>
-                 
-                Express
-                 
-              </h5>
-            </span>
-          </PlatformCard>
-          <PlatformCard
-            className=""
-            key="node"
-            onClick={[Function]}
-            platform="node"
-          >
-            <span
-              className="platform-card"
-              onClick={[Function]}
-            >
-              <PlatformiconTile
-                className=""
-                onClick={[Function]}
-                platform="node"
-              >
-                <li
-                  className="platform-tile list-unstyled node node "
-                >
-                  <span
-                    className="platformicon platformicon-node"
-                  />
-                </li>
-              </PlatformiconTile>
-              <h5>
-                 
-                Node.js
-                 
-              </h5>
-            </span>
-          </PlatformCard>
-          <PlatformCard
-            className=""
-            key="php-laravel"
-            onClick={[Function]}
-            platform="php-laravel"
-          >
-            <span
-              className="platform-card"
-              onClick={[Function]}
-            >
-              <PlatformiconTile
-                className=""
-                onClick={[Function]}
-                platform="php-laravel"
-              >
-                <li
-                  className="platform-tile list-unstyled php-laravel php "
-                >
-                  <span
-                    className="platformicon platformicon-php-laravel"
-                  />
-                </li>
-              </PlatformiconTile>
-              <h5>
-                 
-                Laravel
-                 
-              </h5>
-            </span>
-          </PlatformCard>
-          <PlatformCard
-            className=""
-            key="php"
-            onClick={[Function]}
-            platform="php"
-          >
-            <span
-              className="platform-card"
-              onClick={[Function]}
-            >
-              <PlatformiconTile
-                className=""
-                onClick={[Function]}
-                platform="php"
-              >
-                <li
-                  className="platform-tile list-unstyled php php "
-                >
-                  <span
-                    className="platformicon platformicon-php"
-                  />
-                </li>
-              </PlatformiconTile>
-              <h5>
-                 
-                PHP
-                 
-              </h5>
-            </span>
-          </PlatformCard>
-          <PlatformCard
-            className=""
-            key="php-symfony2"
-            onClick={[Function]}
-            platform="php-symfony2"
-          >
-            <span
-              className="platform-card"
-              onClick={[Function]}
-            >
-              <PlatformiconTile
-                className=""
-                onClick={[Function]}
-                platform="php-symfony2"
-              >
-                <li
-                  className="platform-tile list-unstyled php-symfony2 php "
-                >
-                  <span
-                    className="platformicon platformicon-php-symfony2"
-                  />
-                </li>
-              </PlatformiconTile>
-              <h5>
-                 
-                Symfony2
-                 
-              </h5>
-            </span>
-          </PlatformCard>
-          <PlatformCard
-            className=""
-            key="python-django"
-            onClick={[Function]}
-            platform="python-django"
-          >
-            <span
-              className="platform-card"
-              onClick={[Function]}
-            >
-              <PlatformiconTile
-                className=""
-                onClick={[Function]}
-                platform="python-django"
-              >
-                <li
-                  className="platform-tile list-unstyled python-django python "
-                >
-                  <span
-                    className="platformicon platformicon-python-django"
-                  />
-                </li>
-              </PlatformiconTile>
-              <h5>
-                 
-                Django
-                 
-              </h5>
-            </span>
-          </PlatformCard>
-          <PlatformCard
-            className=""
-            key="python-flask"
-            onClick={[Function]}
-            platform="python-flask"
-          >
-            <span
-              className="platform-card"
-              onClick={[Function]}
-            >
-              <PlatformiconTile
-                className=""
-                onClick={[Function]}
-                platform="python-flask"
-              >
-                <li
-                  className="platform-tile list-unstyled python-flask python "
-                >
-                  <span
-                    className="platformicon platformicon-python-flask"
-                  />
-                </li>
-              </PlatformiconTile>
-              <h5>
-                 
-                Flask
-                 
-              </h5>
-            </span>
-          </PlatformCard>
-          <PlatformCard
-            className=""
-            key="python"
-            onClick={[Function]}
-            platform="python"
-          >
-            <span
-              className="platform-card"
-              onClick={[Function]}
-            >
-              <PlatformiconTile
-                className=""
-                onClick={[Function]}
-                platform="python"
-              >
-                <li
-                  className="platform-tile list-unstyled python python "
-                >
-                  <span
-                    className="platformicon platformicon-python"
-                  />
-                </li>
-              </PlatformiconTile>
-              <h5>
-                 
-                Python
-                 
-              </h5>
-            </span>
-          </PlatformCard>
-          <PlatformCard
-            className=""
-            key="cocoa"
-            onClick={[Function]}
-            platform="cocoa"
-          >
-            <span
-              className="platform-card"
-              onClick={[Function]}
-            >
-              <PlatformiconTile
-                className=""
-                onClick={[Function]}
-                platform="cocoa"
-              >
-                <li
-                  className="platform-tile list-unstyled cocoa cocoa "
-                >
-                  <span
-                    className="platformicon platformicon-cocoa"
-                  />
-                </li>
-              </PlatformiconTile>
-              <h5>
-                 
-                React-Native
-                 
-              </h5>
-            </span>
-          </PlatformCard>
-          <PlatformCard
-            className=""
-            key="ruby-rails"
-            onClick={[Function]}
-            platform="ruby-rails"
-          >
-            <span
-              className="platform-card"
-              onClick={[Function]}
-            >
-              <PlatformiconTile
-                className=""
-                onClick={[Function]}
-                platform="ruby-rails"
-              >
-                <li
-                  className="platform-tile list-unstyled ruby-rails ruby "
-                >
-                  <span
-                    className="platformicon platformicon-ruby-rails"
-                  />
-                </li>
-              </PlatformiconTile>
-              <h5>
-                 
-                Rails
-                 
-              </h5>
-            </span>
-          </PlatformCard>
-          <PlatformCard
-            className=""
-            key="ruby"
-            onClick={[Function]}
-            platform="ruby"
-          >
-            <span
-              className="platform-card"
-              onClick={[Function]}
-            >
-              <PlatformiconTile
-                className=""
-                onClick={[Function]}
-                platform="ruby"
-              >
-                <li
-                  className="platform-tile list-unstyled ruby ruby "
-                >
-                  <span
-                    className="platformicon platformicon-ruby"
-                  />
-                </li>
-              </PlatformiconTile>
-              <h5>
-                 
-                Ruby
-                 
-              </h5>
-            </span>
-          </PlatformCard>
-        </ul>
-      </div>
-    </PlatformPicker>
+  <Wrapper>
     <div
-      className="create-project-form"
+      className="css-a5urgt-Wrapper e1bu5aqa0"
     >
-      <div
-        className="new-project-name client-platform"
+      <PageHeading
+        withMargins={true}
       >
-        <h4>
-          Give your project a name:
-        </h4>
-        <div
-          className="project-name-wrapper"
+        <Wrapper
+          withMargins={true}
         >
-          <PlatformiconTile
-            platform=""
+          <h1
+            className="css-wxef79-Wrapper e1f8hk460"
           >
-            <li
-              className="platform-tile list-unstyled   undefined"
+            Choose a language or framework:
+          </h1>
+        </Wrapper>
+      </PageHeading>
+      <PlatformPicker
+        location={
+          Object {
+            "query": Object {},
+          }
+        }
+        name="bar"
+        next={
+          [MockFunction] {
+            "calls": Array [
+              Array [],
+            ],
+            "results": Array [
+              Object {
+                "isThrow": false,
+                "value": undefined,
+              },
+            ],
+          }
+        }
+        params={
+          Object {
+            "orgId": "testOrg",
+            "projectId": "",
+          }
+        }
+        platform=""
+        setName={[MockFunction]}
+        setPlatform={[MockFunction]}
+        setTeam={[Function]}
+        showOther={true}
+        team=""
+        teams={Array []}
+      >
+        <div
+          className="platform-picker"
+        >
+          <NavTabs>
+            <ul
+              className="nav nav-tabs"
+            >
+              <li
+                style={
+                  Object {
+                    "float": "right",
+                    "marginRight": 0,
+                  }
+                }
+              >
+                <div
+                  className="platform-filter-container"
+                >
+                  <span
+                    className="icon icon-search"
+                  />
+                  <input
+                    className="platform-filter"
+                    label="Filter"
+                    onChange={[Function]}
+                    placeholder="Filter"
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </li>
+              <ListLink
+                activeClassName="active"
+                index={false}
+                isActive={[Function]}
+                key="popular"
+                onClick={[Function]}
+                to=""
+              >
+                <li
+                  className="active"
+                >
+                  <Link
+                    onClick={[Function]}
+                    onlyActiveOnIndex={false}
+                    style={Object {}}
+                    to=""
+                  >
+                    <a
+                      onClick={[Function]}
+                      style={Object {}}
+                    >
+                      Popular
+                    </a>
+                  </Link>
+                </li>
+              </ListLink>
+              <ListLink
+                activeClassName="active"
+                index={false}
+                isActive={[Function]}
+                key="browser"
+                onClick={[Function]}
+                to=""
+              >
+                <li
+                  className=""
+                >
+                  <Link
+                    onClick={[Function]}
+                    onlyActiveOnIndex={false}
+                    style={Object {}}
+                    to=""
+                  >
+                    <a
+                      onClick={[Function]}
+                      style={Object {}}
+                    >
+                      Browser
+                    </a>
+                  </Link>
+                </li>
+              </ListLink>
+              <ListLink
+                activeClassName="active"
+                index={false}
+                isActive={[Function]}
+                key="server"
+                onClick={[Function]}
+                to=""
+              >
+                <li
+                  className=""
+                >
+                  <Link
+                    onClick={[Function]}
+                    onlyActiveOnIndex={false}
+                    style={Object {}}
+                    to=""
+                  >
+                    <a
+                      onClick={[Function]}
+                      style={Object {}}
+                    >
+                      Server
+                    </a>
+                  </Link>
+                </li>
+              </ListLink>
+              <ListLink
+                activeClassName="active"
+                index={false}
+                isActive={[Function]}
+                key="mobile"
+                onClick={[Function]}
+                to=""
+              >
+                <li
+                  className=""
+                >
+                  <Link
+                    onClick={[Function]}
+                    onlyActiveOnIndex={false}
+                    style={Object {}}
+                    to=""
+                  >
+                    <a
+                      onClick={[Function]}
+                      style={Object {}}
+                    >
+                      Mobile
+                    </a>
+                  </Link>
+                </li>
+              </ListLink>
+              <ListLink
+                activeClassName="active"
+                index={false}
+                isActive={[Function]}
+                key="desktop"
+                onClick={[Function]}
+                to=""
+              >
+                <li
+                  className=""
+                >
+                  <Link
+                    onClick={[Function]}
+                    onlyActiveOnIndex={false}
+                    style={Object {}}
+                    to=""
+                  >
+                    <a
+                      onClick={[Function]}
+                      style={Object {}}
+                    >
+                      Desktop
+                    </a>
+                  </Link>
+                </li>
+              </ListLink>
+              <ListLink
+                activeClassName="active"
+                index={false}
+                isActive={[Function]}
+                key="all"
+                onClick={[Function]}
+                to=""
+              >
+                <li
+                  className=""
+                >
+                  <Link
+                    onClick={[Function]}
+                    onlyActiveOnIndex={false}
+                    style={Object {}}
+                    to=""
+                  >
+                    <a
+                      onClick={[Function]}
+                      style={Object {}}
+                    >
+                      All
+                    </a>
+                  </Link>
+                </li>
+              </ListLink>
+            </ul>
+          </NavTabs>
+          <ul
+            className="client-platform-list platform-tiles"
+          >
+            <PlatformCard
+              className=""
+              key="csharp"
+              onClick={[Function]}
+              platform="csharp"
             >
               <span
-                className="platformicon platformicon-"
-              />
-            </li>
-          </PlatformiconTile>
-          <input
-            autoComplete="off"
-            label="Project Name"
-            name="name"
-            onChange={[Function]}
-            placeholder="Project name"
-            type="text"
-            value="bar"
-          />
-        </div>
-      </div>
-      <div
-        className="new-project-team"
-      >
-        <h4>
-          Team:
-        </h4>
-        <div>
-          <SelectField
-            clearable={false}
-            disabled={false}
-            hideErrorMessage={false}
-            multiple={false}
-            name="select-team"
-            onChange={[Function]}
-            options={Array []}
-            required={false}
-            style={
-              Object {
-                "marginBottom": 0,
-                "width": 180,
-              }
-            }
-            value=""
-          >
-            <div
+                className="platform-card"
+                onClick={[Function]}
+              >
+                <PlatformiconTile
+                  className=""
+                  onClick={[Function]}
+                  platform="csharp"
+                >
+                  <li
+                    className="platform-tile list-unstyled csharp csharp "
+                  >
+                    <span
+                      className="platformicon platformicon-csharp"
+                    />
+                  </li>
+                </PlatformiconTile>
+                <h5>
+                   
+                  C#
+                   
+                </h5>
+              </span>
+            </PlatformCard>
+            <PlatformCard
               className=""
+              key="java"
+              onClick={[Function]}
+              platform="java"
+            >
+              <span
+                className="platform-card"
+                onClick={[Function]}
+              >
+                <PlatformiconTile
+                  className=""
+                  onClick={[Function]}
+                  platform="java"
+                >
+                  <li
+                    className="platform-tile list-unstyled java java "
+                  >
+                    <span
+                      className="platformicon platformicon-java"
+                    />
+                  </li>
+                </PlatformiconTile>
+                <h5>
+                   
+                  Java
+                   
+                </h5>
+              </span>
+            </PlatformCard>
+            <PlatformCard
+              className=""
+              key="javascript-angular"
+              onClick={[Function]}
+              platform="javascript-angular"
+            >
+              <span
+                className="platform-card"
+                onClick={[Function]}
+              >
+                <PlatformiconTile
+                  className=""
+                  onClick={[Function]}
+                  platform="javascript-angular"
+                >
+                  <li
+                    className="platform-tile list-unstyled javascript-angular javascript "
+                  >
+                    <span
+                      className="platformicon platformicon-javascript-angular"
+                    />
+                  </li>
+                </PlatformiconTile>
+                <h5>
+                   
+                  Angular
+                   
+                </h5>
+              </span>
+            </PlatformCard>
+            <PlatformCard
+              className=""
+              key="javascript"
+              onClick={[Function]}
+              platform="javascript"
+            >
+              <span
+                className="platform-card"
+                onClick={[Function]}
+              >
+                <PlatformiconTile
+                  className=""
+                  onClick={[Function]}
+                  platform="javascript"
+                >
+                  <li
+                    className="platform-tile list-unstyled javascript javascript "
+                  >
+                    <span
+                      className="platformicon platformicon-javascript"
+                    />
+                  </li>
+                </PlatformiconTile>
+                <h5>
+                   
+                  JavaScript
+                   
+                </h5>
+              </span>
+            </PlatformCard>
+            <PlatformCard
+              className=""
+              key="javascript-react"
+              onClick={[Function]}
+              platform="javascript-react"
+            >
+              <span
+                className="platform-card"
+                onClick={[Function]}
+              >
+                <PlatformiconTile
+                  className=""
+                  onClick={[Function]}
+                  platform="javascript-react"
+                >
+                  <li
+                    className="platform-tile list-unstyled javascript-react javascript "
+                  >
+                    <span
+                      className="platformicon platformicon-javascript-react"
+                    />
+                  </li>
+                </PlatformiconTile>
+                <h5>
+                   
+                  React
+                   
+                </h5>
+              </span>
+            </PlatformCard>
+            <PlatformCard
+              className=""
+              key="node-express"
+              onClick={[Function]}
+              platform="node-express"
+            >
+              <span
+                className="platform-card"
+                onClick={[Function]}
+              >
+                <PlatformiconTile
+                  className=""
+                  onClick={[Function]}
+                  platform="node-express"
+                >
+                  <li
+                    className="platform-tile list-unstyled node-express node "
+                  >
+                    <span
+                      className="platformicon platformicon-node-express"
+                    />
+                  </li>
+                </PlatformiconTile>
+                <h5>
+                   
+                  Express
+                   
+                </h5>
+              </span>
+            </PlatformCard>
+            <PlatformCard
+              className=""
+              key="node"
+              onClick={[Function]}
+              platform="node"
+            >
+              <span
+                className="platform-card"
+                onClick={[Function]}
+              >
+                <PlatformiconTile
+                  className=""
+                  onClick={[Function]}
+                  platform="node"
+                >
+                  <li
+                    className="platform-tile list-unstyled node node "
+                  >
+                    <span
+                      className="platformicon platformicon-node"
+                    />
+                  </li>
+                </PlatformiconTile>
+                <h5>
+                   
+                  Node.js
+                   
+                </h5>
+              </span>
+            </PlatformCard>
+            <PlatformCard
+              className=""
+              key="php-laravel"
+              onClick={[Function]}
+              platform="php-laravel"
+            >
+              <span
+                className="platform-card"
+                onClick={[Function]}
+              >
+                <PlatformiconTile
+                  className=""
+                  onClick={[Function]}
+                  platform="php-laravel"
+                >
+                  <li
+                    className="platform-tile list-unstyled php-laravel php "
+                  >
+                    <span
+                      className="platformicon platformicon-php-laravel"
+                    />
+                  </li>
+                </PlatformiconTile>
+                <h5>
+                   
+                  Laravel
+                   
+                </h5>
+              </span>
+            </PlatformCard>
+            <PlatformCard
+              className=""
+              key="php"
+              onClick={[Function]}
+              platform="php"
+            >
+              <span
+                className="platform-card"
+                onClick={[Function]}
+              >
+                <PlatformiconTile
+                  className=""
+                  onClick={[Function]}
+                  platform="php"
+                >
+                  <li
+                    className="platform-tile list-unstyled php php "
+                  >
+                    <span
+                      className="platformicon platformicon-php"
+                    />
+                  </li>
+                </PlatformiconTile>
+                <h5>
+                   
+                  PHP
+                   
+                </h5>
+              </span>
+            </PlatformCard>
+            <PlatformCard
+              className=""
+              key="php-symfony2"
+              onClick={[Function]}
+              platform="php-symfony2"
+            >
+              <span
+                className="platform-card"
+                onClick={[Function]}
+              >
+                <PlatformiconTile
+                  className=""
+                  onClick={[Function]}
+                  platform="php-symfony2"
+                >
+                  <li
+                    className="platform-tile list-unstyled php-symfony2 php "
+                  >
+                    <span
+                      className="platformicon platformicon-php-symfony2"
+                    />
+                  </li>
+                </PlatformiconTile>
+                <h5>
+                   
+                  Symfony2
+                   
+                </h5>
+              </span>
+            </PlatformCard>
+            <PlatformCard
+              className=""
+              key="python-django"
+              onClick={[Function]}
+              platform="python-django"
+            >
+              <span
+                className="platform-card"
+                onClick={[Function]}
+              >
+                <PlatformiconTile
+                  className=""
+                  onClick={[Function]}
+                  platform="python-django"
+                >
+                  <li
+                    className="platform-tile list-unstyled python-django python "
+                  >
+                    <span
+                      className="platformicon platformicon-python-django"
+                    />
+                  </li>
+                </PlatformiconTile>
+                <h5>
+                   
+                  Django
+                   
+                </h5>
+              </span>
+            </PlatformCard>
+            <PlatformCard
+              className=""
+              key="python-flask"
+              onClick={[Function]}
+              platform="python-flask"
+            >
+              <span
+                className="platform-card"
+                onClick={[Function]}
+              >
+                <PlatformiconTile
+                  className=""
+                  onClick={[Function]}
+                  platform="python-flask"
+                >
+                  <li
+                    className="platform-tile list-unstyled python-flask python "
+                  >
+                    <span
+                      className="platformicon platformicon-python-flask"
+                    />
+                  </li>
+                </PlatformiconTile>
+                <h5>
+                   
+                  Flask
+                   
+                </h5>
+              </span>
+            </PlatformCard>
+            <PlatformCard
+              className=""
+              key="python"
+              onClick={[Function]}
+              platform="python"
+            >
+              <span
+                className="platform-card"
+                onClick={[Function]}
+              >
+                <PlatformiconTile
+                  className=""
+                  onClick={[Function]}
+                  platform="python"
+                >
+                  <li
+                    className="platform-tile list-unstyled python python "
+                  >
+                    <span
+                      className="platformicon platformicon-python"
+                    />
+                  </li>
+                </PlatformiconTile>
+                <h5>
+                   
+                  Python
+                   
+                </h5>
+              </span>
+            </PlatformCard>
+            <PlatformCard
+              className=""
+              key="cocoa"
+              onClick={[Function]}
+              platform="cocoa"
+            >
+              <span
+                className="platform-card"
+                onClick={[Function]}
+              >
+                <PlatformiconTile
+                  className=""
+                  onClick={[Function]}
+                  platform="cocoa"
+                >
+                  <li
+                    className="platform-tile list-unstyled cocoa cocoa "
+                  >
+                    <span
+                      className="platformicon platformicon-cocoa"
+                    />
+                  </li>
+                </PlatformiconTile>
+                <h5>
+                   
+                  React-Native
+                   
+                </h5>
+              </span>
+            </PlatformCard>
+            <PlatformCard
+              className=""
+              key="ruby-rails"
+              onClick={[Function]}
+              platform="ruby-rails"
+            >
+              <span
+                className="platform-card"
+                onClick={[Function]}
+              >
+                <PlatformiconTile
+                  className=""
+                  onClick={[Function]}
+                  platform="ruby-rails"
+                >
+                  <li
+                    className="platform-tile list-unstyled ruby-rails ruby "
+                  >
+                    <span
+                      className="platformicon platformicon-ruby-rails"
+                    />
+                  </li>
+                </PlatformiconTile>
+                <h5>
+                   
+                  Rails
+                   
+                </h5>
+              </span>
+            </PlatformCard>
+            <PlatformCard
+              className=""
+              key="ruby"
+              onClick={[Function]}
+              platform="ruby"
+            >
+              <span
+                className="platform-card"
+                onClick={[Function]}
+              >
+                <PlatformiconTile
+                  className=""
+                  onClick={[Function]}
+                  platform="ruby"
+                >
+                  <li
+                    className="platform-tile list-unstyled ruby ruby "
+                  >
+                    <span
+                      className="platformicon platformicon-ruby"
+                    />
+                  </li>
+                </PlatformiconTile>
+                <h5>
+                   
+                  Ruby
+                   
+                </h5>
+              </span>
+            </PlatformCard>
+          </ul>
+        </div>
+      </PlatformPicker>
+      <div
+        className="create-project-form"
+      >
+        <div
+          className="new-project-name client-platform"
+        >
+          <PageHeading
+            withMargins={true}
+          >
+            <Wrapper
+              withMargins={true}
+            >
+              <h1
+                className="css-wxef79-Wrapper e1f8hk460"
+              >
+                Give your project a name:
+              </h1>
+            </Wrapper>
+          </PageHeading>
+          <div
+            className="project-name-wrapper"
+          >
+            <PlatformiconTile
+              platform=""
+            >
+              <li
+                className="platform-tile list-unstyled   undefined"
+              >
+                <span
+                  className="platformicon platformicon-"
+                />
+              </li>
+            </PlatformiconTile>
+            <input
+              autoComplete="off"
+              label="Project Name"
+              name="name"
+              onChange={[Function]}
+              placeholder="Project name"
+              type="text"
+              value="bar"
+            />
+          </div>
+        </div>
+        <div
+          className="new-project-team"
+        >
+          <PageHeading
+            withMargins={true}
+          >
+            <Wrapper
+              withMargins={true}
+            >
+              <h1
+                className="css-wxef79-Wrapper e1f8hk460"
+              >
+                Team:
+              </h1>
+            </Wrapper>
+          </PageHeading>
+          <div>
+            <SelectField
+              clearable={false}
+              disabled={false}
+              hideErrorMessage={false}
+              multiple={false}
+              name="select-team"
+              onChange={[Function]}
+              options={Array []}
+              required={false}
               style={
                 Object {
                   "marginBottom": 0,
                   "width": 180,
                 }
               }
+              value=""
             >
               <div
-                className="controls"
+                className=""
+                style={
+                  Object {
+                    "marginBottom": 0,
+                    "width": 180,
+                  }
+                }
               >
-                <StyledSelectControl
-                  clearable={false}
-                  disabled={false}
-                  id="id-select-team"
-                  multiple={false}
-                  name="select-team"
-                  onChange={[Function]}
-                  options={Array []}
-                  required={false}
-                  value=""
+                <div
+                  className="controls"
                 >
-                  <SelectControl
-                    className="css-j6zs66-StyledSelectControl e1qrhqd00"
+                  <StyledSelectControl
                     clearable={false}
                     disabled={false}
-                    height={36}
                     id="id-select-team"
                     multiple={false}
                     name="select-team"
@@ -938,12 +960,9 @@ exports[`Project render() should set required class on empty submit 1`] = `
                     required={false}
                     value=""
                   >
-                    <StyledSelect
-                      arrowRenderer={[Function]}
-                      backspaceRemoves={false}
+                    <SelectControl
                       className="css-j6zs66-StyledSelectControl e1qrhqd00"
                       clearable={false}
-                      deleteRemoves={false}
                       disabled={false}
                       height={36}
                       id="id-select-team"
@@ -954,10 +973,10 @@ exports[`Project render() should set required class on empty submit 1`] = `
                       required={false}
                       value=""
                     >
-                      <ForwardRef(SelectPicker)
+                      <StyledSelect
                         arrowRenderer={[Function]}
                         backspaceRemoves={false}
-                        className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
+                        className="css-j6zs66-StyledSelectControl e1qrhqd00"
                         clearable={false}
                         deleteRemoves={false}
                         disabled={false}
@@ -970,14 +989,13 @@ exports[`Project render() should set required class on empty submit 1`] = `
                         required={false}
                         value=""
                       >
-                        <SelectPicker
+                        <ForwardRef(SelectPicker)
                           arrowRenderer={[Function]}
                           backspaceRemoves={false}
                           className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
                           clearable={false}
                           deleteRemoves={false}
                           disabled={false}
-                          forwardedRef={null}
                           height={36}
                           id="id-select-team"
                           multiple={false}
@@ -987,171 +1005,189 @@ exports[`Project render() should set required class on empty submit 1`] = `
                           required={false}
                           value=""
                         >
-                          <Select
+                          <SelectPicker
                             arrowRenderer={[Function]}
-                            autosize={true}
                             backspaceRemoves={false}
-                            backspaceToRemoveMessage="Press backspace to remove {label}"
                             className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
-                            clearAllText="Clear all"
-                            clearRenderer={[Function]}
-                            clearValueText="Clear value"
                             clearable={false}
-                            closeOnSelect={true}
                             deleteRemoves={false}
-                            delimiter=","
                             disabled={false}
-                            escapeClearsValue={true}
-                            filterOptions={[Function]}
+                            forwardedRef={null}
                             height={36}
                             id="id-select-team"
-                            ignoreAccents={true}
-                            ignoreCase={true}
-                            inputProps={Object {}}
-                            isLoading={false}
-                            joinValues={false}
-                            labelKey="label"
-                            matchPos="any"
-                            matchProp="any"
-                            menuBuffer={0}
-                            menuRenderer={[Function]}
-                            multi={false}
                             multiple={false}
                             name="select-team"
-                            noResultsText="No results found"
-                            onBlurResetsInput={true}
                             onChange={[Function]}
-                            onCloseResetsInput={true}
-                            onSelectResetsInput={true}
-                            openOnClick={true}
-                            optionComponent={[Function]}
                             options={Array []}
-                            pageSize={5}
-                            placeholder="Select..."
-                            removeSelected={true}
                             required={false}
-                            rtl={false}
-                            scrollMenuIntoView={true}
-                            searchable={true}
-                            simpleValue={false}
-                            tabSelectsValue={true}
-                            trimFilter={true}
                             value=""
-                            valueComponent={[Function]}
-                            valueKey="value"
                           >
-                            <div
-                              className="Select e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
+                            <Select
+                              arrowRenderer={[Function]}
+                              autosize={true}
+                              backspaceRemoves={false}
+                              backspaceToRemoveMessage="Press backspace to remove {label}"
+                              className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
+                              clearAllText="Clear all"
+                              clearRenderer={[Function]}
+                              clearValueText="Clear value"
+                              clearable={false}
+                              closeOnSelect={true}
+                              deleteRemoves={false}
+                              delimiter=","
+                              disabled={false}
+                              escapeClearsValue={true}
+                              filterOptions={[Function]}
+                              height={36}
+                              id="id-select-team"
+                              ignoreAccents={true}
+                              ignoreCase={true}
+                              inputProps={Object {}}
+                              isLoading={false}
+                              joinValues={false}
+                              labelKey="label"
+                              matchPos="any"
+                              matchProp="any"
+                              menuBuffer={0}
+                              menuRenderer={[Function]}
+                              multi={false}
+                              multiple={false}
+                              name="select-team"
+                              noResultsText="No results found"
+                              onBlurResetsInput={true}
+                              onChange={[Function]}
+                              onCloseResetsInput={true}
+                              onSelectResetsInput={true}
+                              openOnClick={true}
+                              optionComponent={[Function]}
+                              options={Array []}
+                              pageSize={5}
+                              placeholder="Select..."
+                              removeSelected={true}
+                              required={false}
+                              rtl={false}
+                              scrollMenuIntoView={true}
+                              searchable={true}
+                              simpleValue={false}
+                              tabSelectsValue={true}
+                              trimFilter={true}
+                              value=""
+                              valueComponent={[Function]}
+                              valueKey="value"
                             >
                               <div
-                                className="Select-control"
-                                onKeyDown={[Function]}
-                                onMouseDown={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
+                                className="Select e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
                               >
-                                <span
-                                  className="Select-multi-value-wrapper"
-                                  id="react-select-2--value"
-                                >
-                                  <div
-                                    className="Select-placeholder"
-                                  >
-                                    Select...
-                                  </div>
-                                  <AutosizeInput
-                                    aria-activedescendant="react-select-2--value"
-                                    aria-expanded="false"
-                                    aria-haspopup="false"
-                                    aria-owns=""
-                                    className="Select-input"
-                                    id="id-select-team"
-                                    injectStyles={true}
-                                    minWidth="5"
-                                    onBlur={[Function]}
-                                    onChange={[Function]}
-                                    onFocus={[Function]}
-                                    required={false}
-                                    role="combobox"
-                                    value=""
-                                  >
-                                    <div
-                                      className="Select-input"
-                                      style={
-                                        Object {
-                                          "display": "inline-block",
-                                        }
-                                      }
-                                    >
-                                      <input
-                                        aria-activedescendant="react-select-2--value"
-                                        aria-expanded="false"
-                                        aria-haspopup="false"
-                                        aria-owns=""
-                                        id="id-select-team"
-                                        onBlur={[Function]}
-                                        onChange={[Function]}
-                                        onFocus={[Function]}
-                                        required={false}
-                                        role="combobox"
-                                        style={
-                                          Object {
-                                            "boxSizing": "content-box",
-                                            "width": "5px",
-                                          }
-                                        }
-                                        value=""
-                                      />
-                                      <div
-                                        style={
-                                          Object {
-                                            "height": 0,
-                                            "left": 0,
-                                            "overflow": "scroll",
-                                            "position": "absolute",
-                                            "top": 0,
-                                            "visibility": "hidden",
-                                            "whiteSpace": "pre",
-                                          }
-                                        }
-                                      />
-                                    </div>
-                                  </AutosizeInput>
-                                </span>
-                                <span
-                                  className="Select-arrow-zone"
+                                <div
+                                  className="Select-control"
+                                  onKeyDown={[Function]}
                                   onMouseDown={[Function]}
+                                  onTouchEnd={[Function]}
+                                  onTouchMove={[Function]}
+                                  onTouchStart={[Function]}
                                 >
                                   <span
-                                    className="icon-arrow-down"
-                                  />
-                                </span>
+                                    className="Select-multi-value-wrapper"
+                                    id="react-select-2--value"
+                                  >
+                                    <div
+                                      className="Select-placeholder"
+                                    >
+                                      Select...
+                                    </div>
+                                    <AutosizeInput
+                                      aria-activedescendant="react-select-2--value"
+                                      aria-expanded="false"
+                                      aria-haspopup="false"
+                                      aria-owns=""
+                                      className="Select-input"
+                                      id="id-select-team"
+                                      injectStyles={true}
+                                      minWidth="5"
+                                      onBlur={[Function]}
+                                      onChange={[Function]}
+                                      onFocus={[Function]}
+                                      required={false}
+                                      role="combobox"
+                                      value=""
+                                    >
+                                      <div
+                                        className="Select-input"
+                                        style={
+                                          Object {
+                                            "display": "inline-block",
+                                          }
+                                        }
+                                      >
+                                        <input
+                                          aria-activedescendant="react-select-2--value"
+                                          aria-expanded="false"
+                                          aria-haspopup="false"
+                                          aria-owns=""
+                                          id="id-select-team"
+                                          onBlur={[Function]}
+                                          onChange={[Function]}
+                                          onFocus={[Function]}
+                                          required={false}
+                                          role="combobox"
+                                          style={
+                                            Object {
+                                              "boxSizing": "content-box",
+                                              "width": "5px",
+                                            }
+                                          }
+                                          value=""
+                                        />
+                                        <div
+                                          style={
+                                            Object {
+                                              "height": 0,
+                                              "left": 0,
+                                              "overflow": "scroll",
+                                              "position": "absolute",
+                                              "top": 0,
+                                              "visibility": "hidden",
+                                              "whiteSpace": "pre",
+                                            }
+                                          }
+                                        />
+                                      </div>
+                                    </AutosizeInput>
+                                  </span>
+                                  <span
+                                    className="Select-arrow-zone"
+                                    onMouseDown={[Function]}
+                                  >
+                                    <span
+                                      className="icon-arrow-down"
+                                    />
+                                  </span>
+                                </div>
                               </div>
-                            </div>
-                          </Select>
-                        </SelectPicker>
-                      </ForwardRef(SelectPicker)>
-                    </StyledSelect>
-                  </SelectControl>
-                </StyledSelectControl>
+                            </Select>
+                          </SelectPicker>
+                        </ForwardRef(SelectPicker)>
+                      </StyledSelect>
+                    </SelectControl>
+                  </StyledSelectControl>
+                </div>
               </div>
-            </div>
-          </SelectField>
+            </SelectField>
+          </div>
         </div>
+        <div>
+          <button
+            className="btn btn-primary new-project-submit"
+            onClick={[Function]}
+          >
+            Create Project
+          </button>
+        </div>
+        <p>
+          Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
+        </p>
       </div>
-      <div>
-        <button
-          className="btn btn-primary new-project-submit"
-          onClick={[Function]}
-        >
-          Create Project
-        </button>
-      </div>
-      <p>
-        Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
-      </p>
     </div>
-  </div>
+  </Wrapper>
 </OnboardingProject>
 `;

--- a/tests/js/spec/views/onboarding/project/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/project/__snapshots__/index.spec.jsx.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Project render() should render NotFound if no matching organization 1`] = `
-<Wrapper>
-  <PageHeading
-    withMargins={true}
-  >
+<div
+  className="onboarding-info"
+>
+  <h4>
     Choose a language or framework:
-  </PageHeading>
+  </h4>
   <PlatformPicker
     location={
       Object {
@@ -34,11 +34,9 @@ exports[`Project render() should render NotFound if no matching organization 1`]
     <div
       className="new-project-name client-platform"
     >
-      <PageHeading
-        withMargins={true}
-      >
+      <h4>
         Give your project a name:
-      </PageHeading>
+      </h4>
       <div
         className="project-name-wrapper"
       >
@@ -59,11 +57,9 @@ exports[`Project render() should render NotFound if no matching organization 1`]
     <div
       className="new-project-team"
     >
-      <PageHeading
-        withMargins={true}
-      >
+      <h4>
         Team:
-      </PageHeading>
+      </h4>
       <div>
         <SelectField
           clearable={false}
@@ -96,7 +92,7 @@ exports[`Project render() should render NotFound if no matching organization 1`]
       Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
     </p>
   </div>
-</Wrapper>
+</div>
 `;
 
 exports[`Project render() should set required class on empty submit 1`] = `
@@ -133,825 +129,807 @@ exports[`Project render() should set required class on empty submit 1`] = `
   team=""
   teams={Array []}
 >
-  <Wrapper>
-    <div
-      className="css-a5urgt-Wrapper e1bu5aqa0"
+  <div
+    className="onboarding-info"
+  >
+    <h4>
+      Choose a language or framework:
+    </h4>
+    <PlatformPicker
+      location={
+        Object {
+          "query": Object {},
+        }
+      }
+      name="bar"
+      next={
+        [MockFunction] {
+          "calls": Array [
+            Array [],
+          ],
+          "results": Array [
+            Object {
+              "isThrow": false,
+              "value": undefined,
+            },
+          ],
+        }
+      }
+      params={
+        Object {
+          "orgId": "testOrg",
+          "projectId": "",
+        }
+      }
+      platform=""
+      setName={[MockFunction]}
+      setPlatform={[MockFunction]}
+      setTeam={[Function]}
+      showOther={true}
+      team=""
+      teams={Array []}
     >
-      <PageHeading
-        withMargins={true}
-      >
-        <Wrapper
-          withMargins={true}
-        >
-          <h1
-            className="css-wxef79-Wrapper e1f8hk460"
-          >
-            Choose a language or framework:
-          </h1>
-        </Wrapper>
-      </PageHeading>
-      <PlatformPicker
-        location={
-          Object {
-            "query": Object {},
-          }
-        }
-        name="bar"
-        next={
-          [MockFunction] {
-            "calls": Array [
-              Array [],
-            ],
-            "results": Array [
-              Object {
-                "isThrow": false,
-                "value": undefined,
-              },
-            ],
-          }
-        }
-        params={
-          Object {
-            "orgId": "testOrg",
-            "projectId": "",
-          }
-        }
-        platform=""
-        setName={[MockFunction]}
-        setPlatform={[MockFunction]}
-        setTeam={[Function]}
-        showOther={true}
-        team=""
-        teams={Array []}
-      >
-        <div
-          className="platform-picker"
-        >
-          <NavTabs>
-            <ul
-              className="nav nav-tabs"
-            >
-              <li
-                style={
-                  Object {
-                    "float": "right",
-                    "marginRight": 0,
-                  }
-                }
-              >
-                <div
-                  className="platform-filter-container"
-                >
-                  <span
-                    className="icon icon-search"
-                  />
-                  <input
-                    className="platform-filter"
-                    label="Filter"
-                    onChange={[Function]}
-                    placeholder="Filter"
-                    type="text"
-                    value=""
-                  />
-                </div>
-              </li>
-              <ListLink
-                activeClassName="active"
-                index={false}
-                isActive={[Function]}
-                key="popular"
-                onClick={[Function]}
-                to=""
-              >
-                <li
-                  className="active"
-                >
-                  <Link
-                    onClick={[Function]}
-                    onlyActiveOnIndex={false}
-                    style={Object {}}
-                    to=""
-                  >
-                    <a
-                      onClick={[Function]}
-                      style={Object {}}
-                    >
-                      Popular
-                    </a>
-                  </Link>
-                </li>
-              </ListLink>
-              <ListLink
-                activeClassName="active"
-                index={false}
-                isActive={[Function]}
-                key="browser"
-                onClick={[Function]}
-                to=""
-              >
-                <li
-                  className=""
-                >
-                  <Link
-                    onClick={[Function]}
-                    onlyActiveOnIndex={false}
-                    style={Object {}}
-                    to=""
-                  >
-                    <a
-                      onClick={[Function]}
-                      style={Object {}}
-                    >
-                      Browser
-                    </a>
-                  </Link>
-                </li>
-              </ListLink>
-              <ListLink
-                activeClassName="active"
-                index={false}
-                isActive={[Function]}
-                key="server"
-                onClick={[Function]}
-                to=""
-              >
-                <li
-                  className=""
-                >
-                  <Link
-                    onClick={[Function]}
-                    onlyActiveOnIndex={false}
-                    style={Object {}}
-                    to=""
-                  >
-                    <a
-                      onClick={[Function]}
-                      style={Object {}}
-                    >
-                      Server
-                    </a>
-                  </Link>
-                </li>
-              </ListLink>
-              <ListLink
-                activeClassName="active"
-                index={false}
-                isActive={[Function]}
-                key="mobile"
-                onClick={[Function]}
-                to=""
-              >
-                <li
-                  className=""
-                >
-                  <Link
-                    onClick={[Function]}
-                    onlyActiveOnIndex={false}
-                    style={Object {}}
-                    to=""
-                  >
-                    <a
-                      onClick={[Function]}
-                      style={Object {}}
-                    >
-                      Mobile
-                    </a>
-                  </Link>
-                </li>
-              </ListLink>
-              <ListLink
-                activeClassName="active"
-                index={false}
-                isActive={[Function]}
-                key="desktop"
-                onClick={[Function]}
-                to=""
-              >
-                <li
-                  className=""
-                >
-                  <Link
-                    onClick={[Function]}
-                    onlyActiveOnIndex={false}
-                    style={Object {}}
-                    to=""
-                  >
-                    <a
-                      onClick={[Function]}
-                      style={Object {}}
-                    >
-                      Desktop
-                    </a>
-                  </Link>
-                </li>
-              </ListLink>
-              <ListLink
-                activeClassName="active"
-                index={false}
-                isActive={[Function]}
-                key="all"
-                onClick={[Function]}
-                to=""
-              >
-                <li
-                  className=""
-                >
-                  <Link
-                    onClick={[Function]}
-                    onlyActiveOnIndex={false}
-                    style={Object {}}
-                    to=""
-                  >
-                    <a
-                      onClick={[Function]}
-                      style={Object {}}
-                    >
-                      All
-                    </a>
-                  </Link>
-                </li>
-              </ListLink>
-            </ul>
-          </NavTabs>
-          <ul
-            className="client-platform-list platform-tiles"
-          >
-            <PlatformCard
-              className=""
-              key="csharp"
-              onClick={[Function]}
-              platform="csharp"
-            >
-              <span
-                className="platform-card"
-                onClick={[Function]}
-              >
-                <PlatformiconTile
-                  className=""
-                  onClick={[Function]}
-                  platform="csharp"
-                >
-                  <li
-                    className="platform-tile list-unstyled csharp csharp "
-                  >
-                    <span
-                      className="platformicon platformicon-csharp"
-                    />
-                  </li>
-                </PlatformiconTile>
-                <h5>
-                   
-                  C#
-                   
-                </h5>
-              </span>
-            </PlatformCard>
-            <PlatformCard
-              className=""
-              key="java"
-              onClick={[Function]}
-              platform="java"
-            >
-              <span
-                className="platform-card"
-                onClick={[Function]}
-              >
-                <PlatformiconTile
-                  className=""
-                  onClick={[Function]}
-                  platform="java"
-                >
-                  <li
-                    className="platform-tile list-unstyled java java "
-                  >
-                    <span
-                      className="platformicon platformicon-java"
-                    />
-                  </li>
-                </PlatformiconTile>
-                <h5>
-                   
-                  Java
-                   
-                </h5>
-              </span>
-            </PlatformCard>
-            <PlatformCard
-              className=""
-              key="javascript-angular"
-              onClick={[Function]}
-              platform="javascript-angular"
-            >
-              <span
-                className="platform-card"
-                onClick={[Function]}
-              >
-                <PlatformiconTile
-                  className=""
-                  onClick={[Function]}
-                  platform="javascript-angular"
-                >
-                  <li
-                    className="platform-tile list-unstyled javascript-angular javascript "
-                  >
-                    <span
-                      className="platformicon platformicon-javascript-angular"
-                    />
-                  </li>
-                </PlatformiconTile>
-                <h5>
-                   
-                  Angular
-                   
-                </h5>
-              </span>
-            </PlatformCard>
-            <PlatformCard
-              className=""
-              key="javascript"
-              onClick={[Function]}
-              platform="javascript"
-            >
-              <span
-                className="platform-card"
-                onClick={[Function]}
-              >
-                <PlatformiconTile
-                  className=""
-                  onClick={[Function]}
-                  platform="javascript"
-                >
-                  <li
-                    className="platform-tile list-unstyled javascript javascript "
-                  >
-                    <span
-                      className="platformicon platformicon-javascript"
-                    />
-                  </li>
-                </PlatformiconTile>
-                <h5>
-                   
-                  JavaScript
-                   
-                </h5>
-              </span>
-            </PlatformCard>
-            <PlatformCard
-              className=""
-              key="javascript-react"
-              onClick={[Function]}
-              platform="javascript-react"
-            >
-              <span
-                className="platform-card"
-                onClick={[Function]}
-              >
-                <PlatformiconTile
-                  className=""
-                  onClick={[Function]}
-                  platform="javascript-react"
-                >
-                  <li
-                    className="platform-tile list-unstyled javascript-react javascript "
-                  >
-                    <span
-                      className="platformicon platformicon-javascript-react"
-                    />
-                  </li>
-                </PlatformiconTile>
-                <h5>
-                   
-                  React
-                   
-                </h5>
-              </span>
-            </PlatformCard>
-            <PlatformCard
-              className=""
-              key="node-express"
-              onClick={[Function]}
-              platform="node-express"
-            >
-              <span
-                className="platform-card"
-                onClick={[Function]}
-              >
-                <PlatformiconTile
-                  className=""
-                  onClick={[Function]}
-                  platform="node-express"
-                >
-                  <li
-                    className="platform-tile list-unstyled node-express node "
-                  >
-                    <span
-                      className="platformicon platformicon-node-express"
-                    />
-                  </li>
-                </PlatformiconTile>
-                <h5>
-                   
-                  Express
-                   
-                </h5>
-              </span>
-            </PlatformCard>
-            <PlatformCard
-              className=""
-              key="node"
-              onClick={[Function]}
-              platform="node"
-            >
-              <span
-                className="platform-card"
-                onClick={[Function]}
-              >
-                <PlatformiconTile
-                  className=""
-                  onClick={[Function]}
-                  platform="node"
-                >
-                  <li
-                    className="platform-tile list-unstyled node node "
-                  >
-                    <span
-                      className="platformicon platformicon-node"
-                    />
-                  </li>
-                </PlatformiconTile>
-                <h5>
-                   
-                  Node.js
-                   
-                </h5>
-              </span>
-            </PlatformCard>
-            <PlatformCard
-              className=""
-              key="php-laravel"
-              onClick={[Function]}
-              platform="php-laravel"
-            >
-              <span
-                className="platform-card"
-                onClick={[Function]}
-              >
-                <PlatformiconTile
-                  className=""
-                  onClick={[Function]}
-                  platform="php-laravel"
-                >
-                  <li
-                    className="platform-tile list-unstyled php-laravel php "
-                  >
-                    <span
-                      className="platformicon platformicon-php-laravel"
-                    />
-                  </li>
-                </PlatformiconTile>
-                <h5>
-                   
-                  Laravel
-                   
-                </h5>
-              </span>
-            </PlatformCard>
-            <PlatformCard
-              className=""
-              key="php"
-              onClick={[Function]}
-              platform="php"
-            >
-              <span
-                className="platform-card"
-                onClick={[Function]}
-              >
-                <PlatformiconTile
-                  className=""
-                  onClick={[Function]}
-                  platform="php"
-                >
-                  <li
-                    className="platform-tile list-unstyled php php "
-                  >
-                    <span
-                      className="platformicon platformicon-php"
-                    />
-                  </li>
-                </PlatformiconTile>
-                <h5>
-                   
-                  PHP
-                   
-                </h5>
-              </span>
-            </PlatformCard>
-            <PlatformCard
-              className=""
-              key="php-symfony2"
-              onClick={[Function]}
-              platform="php-symfony2"
-            >
-              <span
-                className="platform-card"
-                onClick={[Function]}
-              >
-                <PlatformiconTile
-                  className=""
-                  onClick={[Function]}
-                  platform="php-symfony2"
-                >
-                  <li
-                    className="platform-tile list-unstyled php-symfony2 php "
-                  >
-                    <span
-                      className="platformicon platformicon-php-symfony2"
-                    />
-                  </li>
-                </PlatformiconTile>
-                <h5>
-                   
-                  Symfony2
-                   
-                </h5>
-              </span>
-            </PlatformCard>
-            <PlatformCard
-              className=""
-              key="python-django"
-              onClick={[Function]}
-              platform="python-django"
-            >
-              <span
-                className="platform-card"
-                onClick={[Function]}
-              >
-                <PlatformiconTile
-                  className=""
-                  onClick={[Function]}
-                  platform="python-django"
-                >
-                  <li
-                    className="platform-tile list-unstyled python-django python "
-                  >
-                    <span
-                      className="platformicon platformicon-python-django"
-                    />
-                  </li>
-                </PlatformiconTile>
-                <h5>
-                   
-                  Django
-                   
-                </h5>
-              </span>
-            </PlatformCard>
-            <PlatformCard
-              className=""
-              key="python-flask"
-              onClick={[Function]}
-              platform="python-flask"
-            >
-              <span
-                className="platform-card"
-                onClick={[Function]}
-              >
-                <PlatformiconTile
-                  className=""
-                  onClick={[Function]}
-                  platform="python-flask"
-                >
-                  <li
-                    className="platform-tile list-unstyled python-flask python "
-                  >
-                    <span
-                      className="platformicon platformicon-python-flask"
-                    />
-                  </li>
-                </PlatformiconTile>
-                <h5>
-                   
-                  Flask
-                   
-                </h5>
-              </span>
-            </PlatformCard>
-            <PlatformCard
-              className=""
-              key="python"
-              onClick={[Function]}
-              platform="python"
-            >
-              <span
-                className="platform-card"
-                onClick={[Function]}
-              >
-                <PlatformiconTile
-                  className=""
-                  onClick={[Function]}
-                  platform="python"
-                >
-                  <li
-                    className="platform-tile list-unstyled python python "
-                  >
-                    <span
-                      className="platformicon platformicon-python"
-                    />
-                  </li>
-                </PlatformiconTile>
-                <h5>
-                   
-                  Python
-                   
-                </h5>
-              </span>
-            </PlatformCard>
-            <PlatformCard
-              className=""
-              key="cocoa"
-              onClick={[Function]}
-              platform="cocoa"
-            >
-              <span
-                className="platform-card"
-                onClick={[Function]}
-              >
-                <PlatformiconTile
-                  className=""
-                  onClick={[Function]}
-                  platform="cocoa"
-                >
-                  <li
-                    className="platform-tile list-unstyled cocoa cocoa "
-                  >
-                    <span
-                      className="platformicon platformicon-cocoa"
-                    />
-                  </li>
-                </PlatformiconTile>
-                <h5>
-                   
-                  React-Native
-                   
-                </h5>
-              </span>
-            </PlatformCard>
-            <PlatformCard
-              className=""
-              key="ruby-rails"
-              onClick={[Function]}
-              platform="ruby-rails"
-            >
-              <span
-                className="platform-card"
-                onClick={[Function]}
-              >
-                <PlatformiconTile
-                  className=""
-                  onClick={[Function]}
-                  platform="ruby-rails"
-                >
-                  <li
-                    className="platform-tile list-unstyled ruby-rails ruby "
-                  >
-                    <span
-                      className="platformicon platformicon-ruby-rails"
-                    />
-                  </li>
-                </PlatformiconTile>
-                <h5>
-                   
-                  Rails
-                   
-                </h5>
-              </span>
-            </PlatformCard>
-            <PlatformCard
-              className=""
-              key="ruby"
-              onClick={[Function]}
-              platform="ruby"
-            >
-              <span
-                className="platform-card"
-                onClick={[Function]}
-              >
-                <PlatformiconTile
-                  className=""
-                  onClick={[Function]}
-                  platform="ruby"
-                >
-                  <li
-                    className="platform-tile list-unstyled ruby ruby "
-                  >
-                    <span
-                      className="platformicon platformicon-ruby"
-                    />
-                  </li>
-                </PlatformiconTile>
-                <h5>
-                   
-                  Ruby
-                   
-                </h5>
-              </span>
-            </PlatformCard>
-          </ul>
-        </div>
-      </PlatformPicker>
       <div
-        className="create-project-form"
+        className="platform-picker"
       >
-        <div
-          className="new-project-name client-platform"
-        >
-          <PageHeading
-            withMargins={true}
+        <NavTabs>
+          <ul
+            className="nav nav-tabs"
           >
-            <Wrapper
-              withMargins={true}
+            <li
+              style={
+                Object {
+                  "float": "right",
+                  "marginRight": 0,
+                }
+              }
             >
-              <h1
-                className="css-wxef79-Wrapper e1f8hk460"
-              >
-                Give your project a name:
-              </h1>
-            </Wrapper>
-          </PageHeading>
-          <div
-            className="project-name-wrapper"
-          >
-            <PlatformiconTile
-              platform=""
-            >
-              <li
-                className="platform-tile list-unstyled   undefined"
+              <div
+                className="platform-filter-container"
               >
                 <span
-                  className="platformicon platformicon-"
+                  className="icon icon-search"
                 />
-              </li>
-            </PlatformiconTile>
-            <input
-              autoComplete="off"
-              label="Project Name"
-              name="name"
-              onChange={[Function]}
-              placeholder="Project name"
-              type="text"
-              value="bar"
-            />
-          </div>
-        </div>
-        <div
-          className="new-project-team"
-        >
-          <PageHeading
-            withMargins={true}
-          >
-            <Wrapper
-              withMargins={true}
+                <input
+                  className="platform-filter"
+                  label="Filter"
+                  onChange={[Function]}
+                  placeholder="Filter"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </li>
+            <ListLink
+              activeClassName="active"
+              index={false}
+              isActive={[Function]}
+              key="popular"
+              onClick={[Function]}
+              to=""
             >
-              <h1
-                className="css-wxef79-Wrapper e1f8hk460"
+              <li
+                className="active"
               >
-                Team:
-              </h1>
-            </Wrapper>
-          </PageHeading>
-          <div>
-            <SelectField
-              clearable={false}
-              disabled={false}
-              hideErrorMessage={false}
-              multiple={false}
-              name="select-team"
-              onChange={[Function]}
-              options={Array []}
-              required={false}
+                <Link
+                  onClick={[Function]}
+                  onlyActiveOnIndex={false}
+                  style={Object {}}
+                  to=""
+                >
+                  <a
+                    onClick={[Function]}
+                    style={Object {}}
+                  >
+                    Popular
+                  </a>
+                </Link>
+              </li>
+            </ListLink>
+            <ListLink
+              activeClassName="active"
+              index={false}
+              isActive={[Function]}
+              key="browser"
+              onClick={[Function]}
+              to=""
+            >
+              <li
+                className=""
+              >
+                <Link
+                  onClick={[Function]}
+                  onlyActiveOnIndex={false}
+                  style={Object {}}
+                  to=""
+                >
+                  <a
+                    onClick={[Function]}
+                    style={Object {}}
+                  >
+                    Browser
+                  </a>
+                </Link>
+              </li>
+            </ListLink>
+            <ListLink
+              activeClassName="active"
+              index={false}
+              isActive={[Function]}
+              key="server"
+              onClick={[Function]}
+              to=""
+            >
+              <li
+                className=""
+              >
+                <Link
+                  onClick={[Function]}
+                  onlyActiveOnIndex={false}
+                  style={Object {}}
+                  to=""
+                >
+                  <a
+                    onClick={[Function]}
+                    style={Object {}}
+                  >
+                    Server
+                  </a>
+                </Link>
+              </li>
+            </ListLink>
+            <ListLink
+              activeClassName="active"
+              index={false}
+              isActive={[Function]}
+              key="mobile"
+              onClick={[Function]}
+              to=""
+            >
+              <li
+                className=""
+              >
+                <Link
+                  onClick={[Function]}
+                  onlyActiveOnIndex={false}
+                  style={Object {}}
+                  to=""
+                >
+                  <a
+                    onClick={[Function]}
+                    style={Object {}}
+                  >
+                    Mobile
+                  </a>
+                </Link>
+              </li>
+            </ListLink>
+            <ListLink
+              activeClassName="active"
+              index={false}
+              isActive={[Function]}
+              key="desktop"
+              onClick={[Function]}
+              to=""
+            >
+              <li
+                className=""
+              >
+                <Link
+                  onClick={[Function]}
+                  onlyActiveOnIndex={false}
+                  style={Object {}}
+                  to=""
+                >
+                  <a
+                    onClick={[Function]}
+                    style={Object {}}
+                  >
+                    Desktop
+                  </a>
+                </Link>
+              </li>
+            </ListLink>
+            <ListLink
+              activeClassName="active"
+              index={false}
+              isActive={[Function]}
+              key="all"
+              onClick={[Function]}
+              to=""
+            >
+              <li
+                className=""
+              >
+                <Link
+                  onClick={[Function]}
+                  onlyActiveOnIndex={false}
+                  style={Object {}}
+                  to=""
+                >
+                  <a
+                    onClick={[Function]}
+                    style={Object {}}
+                  >
+                    All
+                  </a>
+                </Link>
+              </li>
+            </ListLink>
+          </ul>
+        </NavTabs>
+        <ul
+          className="client-platform-list platform-tiles"
+        >
+          <PlatformCard
+            className=""
+            key="csharp"
+            onClick={[Function]}
+            platform="csharp"
+          >
+            <span
+              className="platform-card"
+              onClick={[Function]}
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="csharp"
+              >
+                <li
+                  className="platform-tile list-unstyled csharp csharp "
+                >
+                  <span
+                    className="platformicon platformicon-csharp"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                C#
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            key="java"
+            onClick={[Function]}
+            platform="java"
+          >
+            <span
+              className="platform-card"
+              onClick={[Function]}
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="java"
+              >
+                <li
+                  className="platform-tile list-unstyled java java "
+                >
+                  <span
+                    className="platformicon platformicon-java"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                Java
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            key="javascript-angular"
+            onClick={[Function]}
+            platform="javascript-angular"
+          >
+            <span
+              className="platform-card"
+              onClick={[Function]}
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="javascript-angular"
+              >
+                <li
+                  className="platform-tile list-unstyled javascript-angular javascript "
+                >
+                  <span
+                    className="platformicon platformicon-javascript-angular"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                Angular
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            key="javascript"
+            onClick={[Function]}
+            platform="javascript"
+          >
+            <span
+              className="platform-card"
+              onClick={[Function]}
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="javascript"
+              >
+                <li
+                  className="platform-tile list-unstyled javascript javascript "
+                >
+                  <span
+                    className="platformicon platformicon-javascript"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                JavaScript
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            key="javascript-react"
+            onClick={[Function]}
+            platform="javascript-react"
+          >
+            <span
+              className="platform-card"
+              onClick={[Function]}
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="javascript-react"
+              >
+                <li
+                  className="platform-tile list-unstyled javascript-react javascript "
+                >
+                  <span
+                    className="platformicon platformicon-javascript-react"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                React
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            key="node-express"
+            onClick={[Function]}
+            platform="node-express"
+          >
+            <span
+              className="platform-card"
+              onClick={[Function]}
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="node-express"
+              >
+                <li
+                  className="platform-tile list-unstyled node-express node "
+                >
+                  <span
+                    className="platformicon platformicon-node-express"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                Express
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            key="node"
+            onClick={[Function]}
+            platform="node"
+          >
+            <span
+              className="platform-card"
+              onClick={[Function]}
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="node"
+              >
+                <li
+                  className="platform-tile list-unstyled node node "
+                >
+                  <span
+                    className="platformicon platformicon-node"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                Node.js
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            key="php-laravel"
+            onClick={[Function]}
+            platform="php-laravel"
+          >
+            <span
+              className="platform-card"
+              onClick={[Function]}
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="php-laravel"
+              >
+                <li
+                  className="platform-tile list-unstyled php-laravel php "
+                >
+                  <span
+                    className="platformicon platformicon-php-laravel"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                Laravel
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            key="php"
+            onClick={[Function]}
+            platform="php"
+          >
+            <span
+              className="platform-card"
+              onClick={[Function]}
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="php"
+              >
+                <li
+                  className="platform-tile list-unstyled php php "
+                >
+                  <span
+                    className="platformicon platformicon-php"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                PHP
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            key="php-symfony2"
+            onClick={[Function]}
+            platform="php-symfony2"
+          >
+            <span
+              className="platform-card"
+              onClick={[Function]}
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="php-symfony2"
+              >
+                <li
+                  className="platform-tile list-unstyled php-symfony2 php "
+                >
+                  <span
+                    className="platformicon platformicon-php-symfony2"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                Symfony2
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            key="python-django"
+            onClick={[Function]}
+            platform="python-django"
+          >
+            <span
+              className="platform-card"
+              onClick={[Function]}
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="python-django"
+              >
+                <li
+                  className="platform-tile list-unstyled python-django python "
+                >
+                  <span
+                    className="platformicon platformicon-python-django"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                Django
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            key="python-flask"
+            onClick={[Function]}
+            platform="python-flask"
+          >
+            <span
+              className="platform-card"
+              onClick={[Function]}
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="python-flask"
+              >
+                <li
+                  className="platform-tile list-unstyled python-flask python "
+                >
+                  <span
+                    className="platformicon platformicon-python-flask"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                Flask
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            key="python"
+            onClick={[Function]}
+            platform="python"
+          >
+            <span
+              className="platform-card"
+              onClick={[Function]}
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="python"
+              >
+                <li
+                  className="platform-tile list-unstyled python python "
+                >
+                  <span
+                    className="platformicon platformicon-python"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                Python
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            key="cocoa"
+            onClick={[Function]}
+            platform="cocoa"
+          >
+            <span
+              className="platform-card"
+              onClick={[Function]}
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="cocoa"
+              >
+                <li
+                  className="platform-tile list-unstyled cocoa cocoa "
+                >
+                  <span
+                    className="platformicon platformicon-cocoa"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                React-Native
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            key="ruby-rails"
+            onClick={[Function]}
+            platform="ruby-rails"
+          >
+            <span
+              className="platform-card"
+              onClick={[Function]}
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="ruby-rails"
+              >
+                <li
+                  className="platform-tile list-unstyled ruby-rails ruby "
+                >
+                  <span
+                    className="platformicon platformicon-ruby-rails"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                Rails
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+          <PlatformCard
+            className=""
+            key="ruby"
+            onClick={[Function]}
+            platform="ruby"
+          >
+            <span
+              className="platform-card"
+              onClick={[Function]}
+            >
+              <PlatformiconTile
+                className=""
+                onClick={[Function]}
+                platform="ruby"
+              >
+                <li
+                  className="platform-tile list-unstyled ruby ruby "
+                >
+                  <span
+                    className="platformicon platformicon-ruby"
+                  />
+                </li>
+              </PlatformiconTile>
+              <h5>
+                 
+                Ruby
+                 
+              </h5>
+            </span>
+          </PlatformCard>
+        </ul>
+      </div>
+    </PlatformPicker>
+    <div
+      className="create-project-form"
+    >
+      <div
+        className="new-project-name client-platform"
+      >
+        <h4>
+          Give your project a name:
+        </h4>
+        <div
+          className="project-name-wrapper"
+        >
+          <PlatformiconTile
+            platform=""
+          >
+            <li
+              className="platform-tile list-unstyled   undefined"
+            >
+              <span
+                className="platformicon platformicon-"
+              />
+            </li>
+          </PlatformiconTile>
+          <input
+            autoComplete="off"
+            label="Project Name"
+            name="name"
+            onChange={[Function]}
+            placeholder="Project name"
+            type="text"
+            value="bar"
+          />
+        </div>
+      </div>
+      <div
+        className="new-project-team"
+      >
+        <h4>
+          Team:
+        </h4>
+        <div>
+          <SelectField
+            clearable={false}
+            disabled={false}
+            hideErrorMessage={false}
+            multiple={false}
+            name="select-team"
+            onChange={[Function]}
+            options={Array []}
+            required={false}
+            style={
+              Object {
+                "marginBottom": 0,
+                "width": 180,
+              }
+            }
+            value=""
+          >
+            <div
+              className=""
               style={
                 Object {
                   "marginBottom": 0,
                   "width": 180,
                 }
               }
-              value=""
             >
               <div
-                className=""
-                style={
-                  Object {
-                    "marginBottom": 0,
-                    "width": 180,
-                  }
-                }
+                className="controls"
               >
-                <div
-                  className="controls"
+                <StyledSelectControl
+                  clearable={false}
+                  disabled={false}
+                  id="id-select-team"
+                  multiple={false}
+                  name="select-team"
+                  onChange={[Function]}
+                  options={Array []}
+                  required={false}
+                  value=""
                 >
-                  <StyledSelectControl
+                  <SelectControl
+                    className="css-j6zs66-StyledSelectControl e1qrhqd00"
                     clearable={false}
                     disabled={false}
+                    height={36}
                     id="id-select-team"
                     multiple={false}
                     name="select-team"
@@ -960,9 +938,12 @@ exports[`Project render() should set required class on empty submit 1`] = `
                     required={false}
                     value=""
                   >
-                    <SelectControl
+                    <StyledSelect
+                      arrowRenderer={[Function]}
+                      backspaceRemoves={false}
                       className="css-j6zs66-StyledSelectControl e1qrhqd00"
                       clearable={false}
+                      deleteRemoves={false}
                       disabled={false}
                       height={36}
                       id="id-select-team"
@@ -973,10 +954,10 @@ exports[`Project render() should set required class on empty submit 1`] = `
                       required={false}
                       value=""
                     >
-                      <StyledSelect
+                      <ForwardRef(SelectPicker)
                         arrowRenderer={[Function]}
                         backspaceRemoves={false}
-                        className="css-j6zs66-StyledSelectControl e1qrhqd00"
+                        className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
                         clearable={false}
                         deleteRemoves={false}
                         disabled={false}
@@ -989,13 +970,14 @@ exports[`Project render() should set required class on empty submit 1`] = `
                         required={false}
                         value=""
                       >
-                        <ForwardRef(SelectPicker)
+                        <SelectPicker
                           arrowRenderer={[Function]}
                           backspaceRemoves={false}
                           className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
                           clearable={false}
                           deleteRemoves={false}
                           disabled={false}
+                          forwardedRef={null}
                           height={36}
                           id="id-select-team"
                           multiple={false}
@@ -1005,189 +987,171 @@ exports[`Project render() should set required class on empty submit 1`] = `
                           required={false}
                           value=""
                         >
-                          <SelectPicker
+                          <Select
                             arrowRenderer={[Function]}
+                            autosize={true}
                             backspaceRemoves={false}
+                            backspaceToRemoveMessage="Press backspace to remove {label}"
                             className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
+                            clearAllText="Clear all"
+                            clearRenderer={[Function]}
+                            clearValueText="Clear value"
                             clearable={false}
+                            closeOnSelect={true}
                             deleteRemoves={false}
+                            delimiter=","
                             disabled={false}
-                            forwardedRef={null}
+                            escapeClearsValue={true}
+                            filterOptions={[Function]}
                             height={36}
                             id="id-select-team"
+                            ignoreAccents={true}
+                            ignoreCase={true}
+                            inputProps={Object {}}
+                            isLoading={false}
+                            joinValues={false}
+                            labelKey="label"
+                            matchPos="any"
+                            matchProp="any"
+                            menuBuffer={0}
+                            menuRenderer={[Function]}
+                            multi={false}
                             multiple={false}
                             name="select-team"
+                            noResultsText="No results found"
+                            onBlurResetsInput={true}
                             onChange={[Function]}
+                            onCloseResetsInput={true}
+                            onSelectResetsInput={true}
+                            openOnClick={true}
+                            optionComponent={[Function]}
                             options={Array []}
+                            pageSize={5}
+                            placeholder="Select..."
+                            removeSelected={true}
                             required={false}
+                            rtl={false}
+                            scrollMenuIntoView={true}
+                            searchable={true}
+                            simpleValue={false}
+                            tabSelectsValue={true}
+                            trimFilter={true}
                             value=""
+                            valueComponent={[Function]}
+                            valueKey="value"
                           >
-                            <Select
-                              arrowRenderer={[Function]}
-                              autosize={true}
-                              backspaceRemoves={false}
-                              backspaceToRemoveMessage="Press backspace to remove {label}"
-                              className="e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20"
-                              clearAllText="Clear all"
-                              clearRenderer={[Function]}
-                              clearValueText="Clear value"
-                              clearable={false}
-                              closeOnSelect={true}
-                              deleteRemoves={false}
-                              delimiter=","
-                              disabled={false}
-                              escapeClearsValue={true}
-                              filterOptions={[Function]}
-                              height={36}
-                              id="id-select-team"
-                              ignoreAccents={true}
-                              ignoreCase={true}
-                              inputProps={Object {}}
-                              isLoading={false}
-                              joinValues={false}
-                              labelKey="label"
-                              matchPos="any"
-                              matchProp="any"
-                              menuBuffer={0}
-                              menuRenderer={[Function]}
-                              multi={false}
-                              multiple={false}
-                              name="select-team"
-                              noResultsText="No results found"
-                              onBlurResetsInput={true}
-                              onChange={[Function]}
-                              onCloseResetsInput={true}
-                              onSelectResetsInput={true}
-                              openOnClick={true}
-                              optionComponent={[Function]}
-                              options={Array []}
-                              pageSize={5}
-                              placeholder="Select..."
-                              removeSelected={true}
-                              required={false}
-                              rtl={false}
-                              scrollMenuIntoView={true}
-                              searchable={true}
-                              simpleValue={false}
-                              tabSelectsValue={true}
-                              trimFilter={true}
-                              value=""
-                              valueComponent={[Function]}
-                              valueKey="value"
+                            <div
+                              className="Select e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
                             >
                               <div
-                                className="Select e1qrhqd00 css-1cl3z8x-StyledSelect-StyledSelectControl eho28m20 is-searchable Select--single"
+                                className="Select-control"
+                                onKeyDown={[Function]}
+                                onMouseDown={[Function]}
+                                onTouchEnd={[Function]}
+                                onTouchMove={[Function]}
+                                onTouchStart={[Function]}
                               >
-                                <div
-                                  className="Select-control"
-                                  onKeyDown={[Function]}
-                                  onMouseDown={[Function]}
-                                  onTouchEnd={[Function]}
-                                  onTouchMove={[Function]}
-                                  onTouchStart={[Function]}
+                                <span
+                                  className="Select-multi-value-wrapper"
+                                  id="react-select-2--value"
                                 >
-                                  <span
-                                    className="Select-multi-value-wrapper"
-                                    id="react-select-2--value"
+                                  <div
+                                    className="Select-placeholder"
+                                  >
+                                    Select...
+                                  </div>
+                                  <AutosizeInput
+                                    aria-activedescendant="react-select-2--value"
+                                    aria-expanded="false"
+                                    aria-haspopup="false"
+                                    aria-owns=""
+                                    className="Select-input"
+                                    id="id-select-team"
+                                    injectStyles={true}
+                                    minWidth="5"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onFocus={[Function]}
+                                    required={false}
+                                    role="combobox"
+                                    value=""
                                   >
                                     <div
-                                      className="Select-placeholder"
-                                    >
-                                      Select...
-                                    </div>
-                                    <AutosizeInput
-                                      aria-activedescendant="react-select-2--value"
-                                      aria-expanded="false"
-                                      aria-haspopup="false"
-                                      aria-owns=""
                                       className="Select-input"
-                                      id="id-select-team"
-                                      injectStyles={true}
-                                      minWidth="5"
-                                      onBlur={[Function]}
-                                      onChange={[Function]}
-                                      onFocus={[Function]}
-                                      required={false}
-                                      role="combobox"
-                                      value=""
+                                      style={
+                                        Object {
+                                          "display": "inline-block",
+                                        }
+                                      }
                                     >
-                                      <div
-                                        className="Select-input"
+                                      <input
+                                        aria-activedescendant="react-select-2--value"
+                                        aria-expanded="false"
+                                        aria-haspopup="false"
+                                        aria-owns=""
+                                        id="id-select-team"
+                                        onBlur={[Function]}
+                                        onChange={[Function]}
+                                        onFocus={[Function]}
+                                        required={false}
+                                        role="combobox"
                                         style={
                                           Object {
-                                            "display": "inline-block",
+                                            "boxSizing": "content-box",
+                                            "width": "5px",
                                           }
                                         }
-                                      >
-                                        <input
-                                          aria-activedescendant="react-select-2--value"
-                                          aria-expanded="false"
-                                          aria-haspopup="false"
-                                          aria-owns=""
-                                          id="id-select-team"
-                                          onBlur={[Function]}
-                                          onChange={[Function]}
-                                          onFocus={[Function]}
-                                          required={false}
-                                          role="combobox"
-                                          style={
-                                            Object {
-                                              "boxSizing": "content-box",
-                                              "width": "5px",
-                                            }
+                                        value=""
+                                      />
+                                      <div
+                                        style={
+                                          Object {
+                                            "height": 0,
+                                            "left": 0,
+                                            "overflow": "scroll",
+                                            "position": "absolute",
+                                            "top": 0,
+                                            "visibility": "hidden",
+                                            "whiteSpace": "pre",
                                           }
-                                          value=""
-                                        />
-                                        <div
-                                          style={
-                                            Object {
-                                              "height": 0,
-                                              "left": 0,
-                                              "overflow": "scroll",
-                                              "position": "absolute",
-                                              "top": 0,
-                                              "visibility": "hidden",
-                                              "whiteSpace": "pre",
-                                            }
-                                          }
-                                        />
-                                      </div>
-                                    </AutosizeInput>
-                                  </span>
+                                        }
+                                      />
+                                    </div>
+                                  </AutosizeInput>
+                                </span>
+                                <span
+                                  className="Select-arrow-zone"
+                                  onMouseDown={[Function]}
+                                >
                                   <span
-                                    className="Select-arrow-zone"
-                                    onMouseDown={[Function]}
-                                  >
-                                    <span
-                                      className="icon-arrow-down"
-                                    />
-                                  </span>
-                                </div>
+                                    className="icon-arrow-down"
+                                  />
+                                </span>
                               </div>
-                            </Select>
-                          </SelectPicker>
-                        </ForwardRef(SelectPicker)>
-                      </StyledSelect>
-                    </SelectControl>
-                  </StyledSelectControl>
-                </div>
+                            </div>
+                          </Select>
+                        </SelectPicker>
+                      </ForwardRef(SelectPicker)>
+                    </StyledSelect>
+                  </SelectControl>
+                </StyledSelectControl>
               </div>
-            </SelectField>
-          </div>
+            </div>
+          </SelectField>
         </div>
-        <div>
-          <button
-            className="btn btn-primary new-project-submit"
-            onClick={[Function]}
-          >
-            Create Project
-          </button>
-        </div>
-        <p>
-          Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
-        </p>
       </div>
+      <div>
+        <button
+          className="btn btn-primary new-project-submit"
+          onClick={[Function]}
+        >
+          Create Project
+        </button>
+      </div>
+      <p>
+        Projects allow you to scope events to a specific application in your organization. For example, you might have separate projects for your API server and frontend client.
+      </p>
     </div>
-  </Wrapper>
+  </div>
 </OnboardingProject>
 `;

--- a/tests/js/spec/views/organizationDiscover/result/index.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/result/index.spec.jsx
@@ -212,7 +212,7 @@ describe('Result', function() {
     });
 
     it('renders query name', function() {
-      expect(wrapper.find('Heading').text()).toBe('Saved query #1');
+      expect(wrapper.find('PageHeader').text()).toBe('Saved query #1');
     });
   });
 });

--- a/tests/js/spec/views/organizationDiscover/result/index.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/result/index.spec.jsx
@@ -212,7 +212,7 @@ describe('Result', function() {
     });
 
     it('renders query name', function() {
-      expect(wrapper.find('PageHeader').text()).toBe('Saved query #1');
+      expect(wrapper.find('PageHeading').text()).toBe('Saved query #1');
     });
   });
 });

--- a/tests/js/spec/views/projectInstall/__snapshots__/newProject.spec.jsx.snap
+++ b/tests/js/spec/views/projectInstall/__snapshots__/newProject.spec.jsx.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NewProjectPlatform render() should render 1`] = `
-<Box
-  flex={1}
->
+<Container>
   <div
     className="sub-header flex flex-container flex-vertically-centered"
   >
@@ -39,5 +37,5 @@ exports[`NewProjectPlatform render() should render 1`] = `
       />
     </div>
   </div>
-</Box>
+</Container>
 `;

--- a/tests/js/spec/views/projectInstall/__snapshots__/newProject.spec.jsx.snap
+++ b/tests/js/spec/views/projectInstall/__snapshots__/newProject.spec.jsx.snap
@@ -26,12 +26,14 @@ exports[`NewProjectPlatform render() should render 1`] = `
   <div
     className="container"
   >
-    <SideEffect(DocumentTitle)
-      title="Sentry"
-    />
-    <CreateProject
-      getDocsUrl={[Function]}
-    />
+    <Content>
+      <SideEffect(DocumentTitle)
+        title="Sentry"
+      />
+      <CreateProject
+        getDocsUrl={[Function]}
+      />
+    </Content>
   </div>
 </Container>
 `;

--- a/tests/js/spec/views/projectInstall/__snapshots__/newProject.spec.jsx.snap
+++ b/tests/js/spec/views/projectInstall/__snapshots__/newProject.spec.jsx.snap
@@ -26,16 +26,12 @@ exports[`NewProjectPlatform render() should render 1`] = `
   <div
     className="container"
   >
-    <div
-      className="content"
-    >
-      <SideEffect(DocumentTitle)
-        title="Sentry"
-      />
-      <CreateProject
-        getDocsUrl={[Function]}
-      />
-    </div>
+    <SideEffect(DocumentTitle)
+      title="Sentry"
+    />
+    <CreateProject
+      getDocsUrl={[Function]}
+    />
   </div>
 </Container>
 `;

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -1572,18 +1572,24 @@ exports[`OrganizationUserFeedback renders 1`] = `
               >
                 <div>
                   <div
-                    className="row release-list-header"
+                    className="row"
                   >
                     <div
                       className="col-sm-9"
                     >
-                      <Header>
-                        <h4
-                          className="css-149epof-Header en9t8ev0"
+                      <PageHeading
+                        withMargins={true}
+                      >
+                        <Wrapper
+                          withMargins={true}
                         >
-                          User Feedback
-                        </h4>
-                      </Header>
+                          <h1
+                            className="css-13ev48w-Wrapper e1f8hk460"
+                          >
+                            User Feedback
+                          </h1>
+                        </Wrapper>
+                      </PageHeading>
                     </div>
                     <div
                       className="col-sm-3"

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -1576,6 +1576,11 @@ exports[`OrganizationUserFeedback renders 1`] = `
                   >
                     <div
                       className="col-sm-9"
+                      style={
+                        Object {
+                          "marginBottom": "5px",
+                        }
+                      }
                     >
                       <PageHeading
                         withMargins={true}
@@ -1595,6 +1600,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                       className="col-sm-3"
                       style={
                         Object {
+                          "marginTop": "4px",
                           "textAlign": "right",
                         }
                       }


### PR DESCRIPTION
This pull standardizes page headers and background color for the entire app. It aligns older views with the new standards we are introducing in Discover and Events views:

![2018-12-17 10-57-22 2018-12-17 11_07_48](https://user-images.githubusercontent.com/435981/50117862-f11e5d80-0202-11e9-88fb-1f99c328b3e2.gif)

It also introduces a new component, `PageHeader.

I tried to check every non-settings view while working on this, including `projects/new` and `:project/getting-started`. If there are any secret views I might have missed please let me know (@ckj might be helpful on this one)