### PR TITLE
feat(search): WIP Search by External Issue Key 

### DIFF
--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -410,6 +410,9 @@ def parse_query(project, query, user):
                 results.update(get_date_params(value, 'date_from', 'date_to'))
             elif key == 'timesSeen':
                 results.update(get_numeric_field_value('times_seen', value))
+            elif key == 'external_issue_id':
+                # TODO(lb): not sure I should be doing anything special here
+                results['external_issue_id'] = value
             else:
                 results['tags'][key] = value
 


### PR DESCRIPTION
The `ExternalIssue` model has a `key` field that we should be able to leverage for searching groups/issues by `external_issue_id`. The following are examples of what is in the key given the integration:
 
Github = getsentry / sentry #10450 (org/repo#issue_id)
Jira = APP-123
Bitbucket = pringlesprongles/simpsons#2
GitLab = gitlab.com/lauryngroup:lauryngroup/anotherproject#2
VSTS = 1 (issue id)