### PR TITLE
ref: Update the logentry interface

### DIFF
--- a/src/sentry/data/samples/invalid-interfaces.json
+++ b/src/sentry/data/samples/invalid-interfaces.json
@@ -87,7 +87,9 @@
         ]
     },
     "logentry": {
-        "formatted": "without message attribute"
+        "params": [
+            "missing message or formatted"
+        ]
     },
     "request": {
         "method": "unknown"

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -497,29 +497,6 @@ class EventManager(object):
         data['timestamp'] = process_timestamp(data.get('timestamp'),
                                               meta.enter('timestamp'))
 
-        # raw 'message' is coerced to the Message interface.  Longer term
-        # we want to treat 'message' as a pure alias for 'logentry' but
-        # for now that won't be the case.
-        #
-        # TODO(mitsuhiko): the logic we want to apply here long term is
-        # to
-        #
-        # 1. make logentry.message optional
-        # 2. make logentry.formatted the primary value
-        # 3. always treat a string as an alias for `logentry.formatted`
-        # 4. remove the custom coercion logic here
-        msg_str = data.pop('message', None)
-        if msg_str:
-            msg_if = data.get('logentry')
-
-            if not msg_if:
-                msg_if = data['logentry'] = {'message': msg_str}
-                meta.enter('logentry', 'message').merge(meta.enter('message'))
-
-            if msg_if.get('message') != msg_str and not msg_if.get('formatted'):
-                msg_if['formatted'] = msg_str
-                meta.enter('logentry', 'formatted').merge(meta.enter('message'))
-
         # Fill in ip addresses marked as {{auto}}
         if self._client_ip:
             if get_path(data, 'request', 'env', 'REMOTE_ADDR') == '{{auto}}':

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -474,7 +474,7 @@ class EventManager(object):
             'time_spent': lambda v: int(v) if v is not None else v,
             'tags': lambda v: [(text(v_k).replace(' ', '-').strip(), text(v_v).strip()) for (v_k, v_v) in dict(v).items()],
             'platform': lambda v: v if v in VALID_PLATFORMS else 'other',
-            'logentry': lambda v: v if isinstance(v, dict) else {'message': v},
+            'logentry': lambda v: {'message': v} if (v and not isinstance(v, dict)) else (v or None),
 
             # These can be sent as lists and need to be converted to {'values': [...]}
             'exception': to_values,

--- a/src/sentry/interfaces/message.py
+++ b/src/sentry/interfaces/message.py
@@ -18,14 +18,6 @@ from sentry.interfaces.base import Interface, InterfaceValidationError, prune_em
 from sentry.utils.safe import trim
 
 
-def is_primitive(value):
-    return isinstance(value, bool) or \
-        isinstance(value, int) or \
-        isinstance(value, float) or \
-        isinstance(value, six.string_types) or \
-        value is None
-
-
 class Message(Interface):
     """
     A message consisting of either a ``formatted`` arg, or an optional
@@ -59,9 +51,9 @@ class Message(Interface):
 
         params = data.get('params')
         if isinstance(params, (list, tuple)):
-            params = tuple(p for p in params if is_primitive(p))
+            params = tuple(p for p in params)
         elif isinstance(params, dict):
-            params = {k: v for k, v in six.iteritems(params) if is_primitive(v)}
+            params = {k: v for k, v in six.iteritems(params)}
         else:
             params = ()
 

--- a/src/sentry/interfaces/message.py
+++ b/src/sentry/interfaces/message.py
@@ -38,7 +38,6 @@ class Message(Interface):
 
     @classmethod
     def to_python(cls, data):
-        # TODO(ja): Verify the following validation against incoming events
         formatted = data.get('formatted')
         if not isinstance(formatted, six.string_types):
             formatted = None
@@ -46,12 +45,6 @@ class Message(Interface):
         message = data.get('message')
         if not isinstance(message, six.string_types):
             message = None
-
-        # TODO(ja): Old coercion
-        # if formatted and not isinstance(formatted, six.string_types):
-        #     formatted = json.dumps(formatted)
-        # if message and not isinstance(message, six.string_types):
-        #     message = json.dumps(message)
 
         if not formatted and not message:
             raise InterfaceValidationError("No message present")

--- a/src/sentry/interfaces/message.py
+++ b/src/sentry/interfaces/message.py
@@ -15,7 +15,18 @@ import six
 from django.conf import settings
 
 from sentry.interfaces.base import Interface, InterfaceValidationError, prune_empty_keys
+from sentry.utils import json
 from sentry.utils.safe import trim
+
+
+def stringify(value):
+    if isinstance(value, six.string_types):
+        return value
+
+    if isinstance(value, (int, float, bool)):
+        return json.dumps(value)
+
+    return None
 
 
 class Message(Interface):
@@ -38,14 +49,8 @@ class Message(Interface):
 
     @classmethod
     def to_python(cls, data):
-        formatted = data.get('formatted')
-        if not isinstance(formatted, six.string_types):
-            formatted = None
-
-        message = data.get('message')
-        if not isinstance(message, six.string_types):
-            message = None
-
+        formatted = stringify(data.get('formatted'))
+        message = stringify(data.get('message'))
         if formatted is None and message is None:
             raise InterfaceValidationError("No message present")
 

--- a/src/sentry/interfaces/message.py
+++ b/src/sentry/interfaces/message.py
@@ -65,9 +65,13 @@ class Message(Interface):
         else:
             params = ()
 
-        if formatted is None and params and '%' in message:
+        if formatted is None and params:
             try:
-                formatted = message % params
+                if '%' in message:
+                    formatted = message % params
+                elif '{}' in message and isinstance(params, tuple):
+                    formatted = message.format(*params)
+                # NB: Named newstyle arguments were never supported
             except Exception:
                 pass
 

--- a/src/sentry/utils/canonical.py
+++ b/src/sentry/utils/canonical.py
@@ -16,30 +16,44 @@ import six
 
 __all__ = ('CanonicalKeyDict', 'CanonicalKeyView', 'get_canonical_name')
 
-CANONICAL_KEY_MAPPING = {
-    'message': 'logentry',
-    'sentry.interfaces.Exception': 'exception',
-    'sentry.interfaces.Message': 'logentry',
-    'sentry.interfaces.Stacktrace': 'stacktrace',
-    'sentry.interfaces.Template': 'template',
-    'sentry.interfaces.Http': 'request',
-    'sentry.interfaces.User': 'user',
-    'sentry.interfaces.Csp': 'csp',
-    'sentry.interfaces.Breadcrumbs': 'breadcrumbs',
-    'sentry.interfaces.Contexts': 'contexts',
-    'sentry.interfaces.Threads': 'threads',
-    'sentry.interfaces.DebugMeta': 'debug_meta',
+
+LEGACY_KEY_MAPPING = {
+    'exception': ('sentry.interfaces.Exception',),
+    'logentry': ('sentry.interfaces.Message', 'message',),
+    'stacktrace': ('sentry.interfaces.Stacktrace',),
+    'template': ('sentry.interfaces.Template',),
+    'request': ('sentry.interfaces.Http',),
+    'user': ('sentry.interfaces.User',),
+    'csp': ('sentry.interfaces.Csp',),
+    'breadcrumbs': ('sentry.interfaces.Breadcrumbs',),
+    'contexts': ('sentry.interfaces.Contexts',),
+    'threads': ('sentry.interfaces.Threads',),
+    'debug_meta': ('sentry.interfaces.DebugMeta',),
 }
 
-LEGACY_KEY_MAPPING = {CANONICAL_KEY_MAPPING[k]: k for k in CANONICAL_KEY_MAPPING}
+
+CANONICAL_KEY_MAPPING = {
+    'message': ('logentry', 'sentry.interfaces.Message',),
+    'sentry.interfaces.Exception': ('exception',),
+    'sentry.interfaces.Message': ('logentry',),
+    'sentry.interfaces.Stacktrace': ('stacktrace',),
+    'sentry.interfaces.Template': ('template',),
+    'sentry.interfaces.Http': ('request',),
+    'sentry.interfaces.User': ('user',),
+    'sentry.interfaces.Csp': ('csp',),
+    'sentry.interfaces.Breadcrumbs': ('breadcrumbs',),
+    'sentry.interfaces.Contexts': ('contexts',),
+    'sentry.interfaces.Threads': ('threads',),
+    'sentry.interfaces.DebugMeta': ('debug_meta',),
+}
 
 
 def get_canonical_name(key):
-    return CANONICAL_KEY_MAPPING.get(key, key)
+    return CANONICAL_KEY_MAPPING.get(key, (key,))[0]
 
 
 def get_legacy_name(key):
-    return LEGACY_KEY_MAPPING.get(key, key)
+    return LEGACY_KEY_MAPPING.get(key, (key,))[0]
 
 
 class CanonicalKeyView(collections.Mapping):
@@ -59,18 +73,17 @@ class CanonicalKeyView(collections.Mapping):
         # Preserve the order of iteration while prioritizing canonical keys
         keys = list(self.data)
         for key in keys:
-            canonical = get_canonical_name(key)
-            if canonical == key or canonical not in keys:
-                yield canonical
+            canonicals = CANONICAL_KEY_MAPPING.get(key, ())
+            if not canonicals:
+                yield key
+            elif all(k not in keys for k in canonicals):
+                yield canonicals[0]
 
     def __getitem__(self, key):
         canonical = get_canonical_name(key)
-        if canonical in self.data:
-            return self.data[canonical]
-
-        legacy = get_legacy_name(key)
-        if legacy in self.data:
-            return self.data[legacy]
+        for k in (canonical,) + LEGACY_KEY_MAPPING.get(canonical, ()):
+            if k in self.data:
+                return self.data[k]
 
         raise KeyError(key)
 

--- a/src/sentry/utils/canonical.py
+++ b/src/sentry/utils/canonical.py
@@ -17,6 +17,7 @@ import six
 __all__ = ('CanonicalKeyDict', 'CanonicalKeyView', 'get_canonical_name')
 
 CANONICAL_KEY_MAPPING = {
+    'message': 'logentry',
     'sentry.interfaces.Exception': 'exception',
     'sentry.interfaces.Message': 'logentry',
     'sentry.interfaces.Stacktrace': 'stacktrace',

--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -143,7 +143,9 @@ def load_data(platform, default=None, sample_name=None):
         return data
 
     data['platform'] = platform
-    data['message'] = 'This is an example %s exception' % (sample_name or platform, )
+    # XXX: Message is a legacy alias for logentry. Do not overwrite if set.
+    if 'message' not in data:
+        data['message'] = 'This is an example %s exception' % (sample_name or platform, )
     data['user'] = generate_user(
         ip_address='127.0.0.1',
         username='sentry',

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -176,7 +176,7 @@ class RavenIntegrationTest(TransactionTestCase):
         group = Group.objects.get()
         assert group.event_set.count() == 1
         instance = group.event_set.get()
-        assert instance.data['logentry']['message'] == 'foo'
+        assert instance.data['logentry']['formatted'] == 'foo'
 
 
 class SentryRemoteTest(TestCase):
@@ -503,7 +503,7 @@ class CspReportTest(TestCase):
         assert Event.objects.count() == 1
         e = Event.objects.all()[0]
         Event.objects.bind_nodes([e], 'data')
-        assert output['message'] == e.data['logentry']['message']
+        assert output['message'] == e.data['logentry']['formatted']
         for key, value in six.iteritems(output['tags']):
             assert e.get_tag(key) == value
         for key, value in six.iteritems(output['data']):

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -56,10 +56,10 @@ class EventSerializerTest(TestCase):
     def test_message_interface(self):
         event = self.create_event(
             data={
-                'logentry': {'message': 'bar'},
+                'logentry': {'formatted': 'bar'},
                 '_meta': {
                     'logentry': {
-                        'message': {'': {'err': ['some error']}},
+                        'formatted': {'': {'err': ['some error']}},
                     },
                 },
             }

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1111,10 +1111,21 @@ class EventManagerTest(TransactionTestCase):
 
         assert event.message == 'hello world'
 
+    def test_stringified_message(self):
+        manager = EventManager(make_event(**{
+            'message': 1234,
+        }))
+        manager.normalize()
+        event = manager.save(self.project.id)
+
+        assert event.data['logentry'] == {
+            'formatted': '1234',
+        }
+
     def test_bad_message(self):
         # test that invalid messages are rejected
         manager = EventManager(make_event(**{
-            'message': 1234,
+            'message': ['asdf'],
         }))
         manager.normalize()
         event = manager.save(self.project.id)

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1112,17 +1112,15 @@ class EventManagerTest(TransactionTestCase):
         assert event.message == 'hello world'
 
     def test_bad_message(self):
-        # test that the message is handled gracefully
+        # test that invalid messages are rejected
         manager = EventManager(make_event(**{
             'message': 1234,
         }))
         manager.normalize()
         event = manager.save(self.project.id)
 
-        assert event.message == '1234'
-        assert event.data['logentry'] == {
-            'message': '1234',
-        }
+        assert event.message == '<unlabeled event>'
+        assert 'logentry' not in event.data
 
     def test_message_attribute_goes_to_interface(self):
         manager = EventManager(make_event(**{
@@ -1131,13 +1129,11 @@ class EventManagerTest(TransactionTestCase):
         manager.normalize()
         event = manager.save(self.project.id)
         assert event.data['logentry'] == {
-            'message': 'hello world',
+            'formatted': 'hello world',
         }
 
-    def test_message_attribute_goes_to_formatted(self):
-        # The combining of 'message' and 'logentry' is a bit
-        # of a compatibility hack, and ideally we would just enforce a stricter
-        # schema instead of combining them like this.
+    def test_message_attribute_shadowing(self):
+        # Logentry shadows the legacy message attribute.
         manager = EventManager(
             make_event(
                 **{
@@ -1151,8 +1147,7 @@ class EventManagerTest(TransactionTestCase):
         manager.normalize()
         event = manager.save(self.project.id)
         assert event.data['logentry'] == {
-            'message': 'hello world',
-            'formatted': 'world hello',
+            'formatted': 'hello world',
         }
 
     def test_message_attribute_interface_both_strings(self):
@@ -1167,8 +1162,7 @@ class EventManagerTest(TransactionTestCase):
         manager.normalize()
         event = manager.save(self.project.id)
         assert event.data['logentry'] == {
-            'message': 'a plain string',
-            'formatted': 'another string',
+            'formatted': 'a plain string',
         }
 
     def test_throws_when_matches_discarded_hash(self):

--- a/tests/sentry/event_manager/test_normalization.py
+++ b/tests/sentry/event_manager/test_normalization.py
@@ -180,6 +180,13 @@ def test_long_message():
         settings.SENTRY_MAX_MESSAGE_LENGTH
 
 
+def test_empty_message():
+    manager = EventManager(make_event(message=''))
+    manager.normalize()
+    data = manager.get_data()
+    assert 'logentry' not in data
+
+
 def test_default_version():
     manager = EventManager(make_event())
     manager.normalize()

--- a/tests/sentry/event_manager/test_normalization.py
+++ b/tests/sentry/event_manager/test_normalization.py
@@ -176,7 +176,7 @@ def test_long_message():
     )
     manager.normalize()
     data = manager.get_data()
-    assert len(data['logentry']['message']) == \
+    assert len(data['logentry']['formatted']) == \
         settings.SENTRY_MAX_MESSAGE_LENGTH
 
 

--- a/tests/sentry/event_manager/test_validate_data.py
+++ b/tests/sentry/event_manager/test_validate_data.py
@@ -363,8 +363,7 @@ def test_fingerprints():
 def test_messages():
     # Just 'message': wrap it in interface
     data = validate_and_normalize({"message": "foo is bar"})
-    assert "message" not in data
-    assert data["logentry"] == {"message": "foo is bar"}
+    assert data["logentry"] == {"formatted": "foo is bar"}
 
     # both 'message' and interface with no 'formatted' value, put 'message'
     # into 'formatted'.
@@ -374,10 +373,8 @@ def test_messages():
             "logentry": {"message": "something else"},
         }
     )
-    assert "message" not in data
     assert data["logentry"] == {
-        "message": "something else",
-        "formatted": "foo is bar",
+        "formatted": "something else",
     }
 
     # both 'message' and complete interface, 'message' is discarded
@@ -390,7 +387,6 @@ def test_messages():
             },
         }
     )
-    assert "message" not in data
     assert "errors" not in data
     assert data["logentry"] == {
         "message": "something else",

--- a/tests/sentry/interfaces/test_message.py
+++ b/tests/sentry/interfaces/test_message.py
@@ -59,6 +59,11 @@ class MessageTest(TestCase):
             'formatted': 'Hello there world!'
         }
 
+    def test_stringify_primitives(self):
+        assert Message.to_python({'formatted': 42}).formatted == '42'
+        assert Message.to_python({'formatted': True}).formatted == 'true'
+        assert Message.to_python({'formatted': 4.2}).formatted == '4.2'
+
     def test_serialize_unserialize_behavior(self):
         result = type(self.interface).to_python(self.interface.to_json())
         assert result.to_json() == self.interface.to_json()

--- a/tests/sentry/interfaces/test_message.py
+++ b/tests/sentry/interfaces/test_message.py
@@ -39,9 +39,19 @@ class MessageTest(TestCase):
 
     def test_format_kwargs(self):
         interface = Message.to_python(dict(
-            message='Hello there %(name)!',
+            message='Hello there %(name)s!',
             params={'name': 'world'},
-            formatted='Hello there world!',
+        ))
+        assert interface.to_json() == {
+            'message': interface.message,
+            'params': interface.params,
+            'formatted': 'Hello there world!'
+        }
+
+    def test_format_braces(self):
+        interface = Message.to_python(dict(
+            message='Hello there {}!',
+            params=('world', ),
         ))
         assert interface.to_json() == {
             'message': interface.message,

--- a/tests/sentry/interfaces/test_message.py
+++ b/tests/sentry/interfaces/test_message.py
@@ -26,20 +26,20 @@ class MessageTest(TestCase):
             'formatted': 'Hello there world!'
         }
 
-    def test_get_hash_uses_message(self):
+    def test_get_hash_prefers_message(self):
         assert self.interface.get_hash() == [self.interface.message]
+
+    def test_get_hash_uses_formatted(self):
+        interface = Message.to_python(dict(
+            message=None,
+            params=(),
+            formatted='Hello there world!'
+        ))
+        assert interface.get_hash() == [interface.formatted]
 
     def test_serialize_unserialize_behavior(self):
         result = type(self.interface).to_python(self.interface.to_json())
         assert result.to_json() == self.interface.to_json()
-
-    def test_serialize_non_string_for_message(self):
-        result = type(self.interface).to_python({
-            'message': {
-                'foo': 'bar'
-            },
-        })
-        assert result.message == '{"foo":"bar"}'
 
     # we had a regression which was throwing this data away
     def test_retains_formatted(self):
@@ -47,7 +47,7 @@ class MessageTest(TestCase):
         assert result.message == 'foo bar'
         assert result.formatted == 'foo bar baz'
 
-    def test_discards_dupe_formatted(self):
+    def test_discards_dupe_message(self):
         result = type(self.interface).to_python({'message': 'foo bar', 'formatted': 'foo bar'})
-        assert result.message == 'foo bar'
-        assert result.formatted is None
+        assert result.message is None
+        assert result.formatted == 'foo bar'

--- a/tests/sentry/interfaces/test_message.py
+++ b/tests/sentry/interfaces/test_message.py
@@ -37,6 +37,18 @@ class MessageTest(TestCase):
         ))
         assert interface.get_hash() == [interface.formatted]
 
+    def test_format_kwargs(self):
+        interface = Message.to_python(dict(
+            message='Hello there %(name)!',
+            params={'name': 'world'},
+            formatted='Hello there world!',
+        ))
+        assert interface.to_json() == {
+            'message': interface.message,
+            'params': interface.params,
+            'formatted': 'Hello there world!'
+        }
+
     def test_serialize_unserialize_behavior(self):
         result = type(self.interface).to_python(self.interface.to_json())
         assert result.to_json() == self.interface.to_json()

--- a/tests/sentry/lang/javascript/test_plugin.py
+++ b/tests/sentry/lang/javascript/test_plugin.py
@@ -265,7 +265,7 @@ class JavascriptIntegrationTest(TestCase):
             'message': 'hello',
             'platform': 'javascript',
             'logentry': {
-                'message': u'ReferenceError: Impossible de d\xe9finir une propri\xe9t\xe9 \xab foo \xbb : objet non extensible'
+                'formatted': u'ReferenceError: Impossible de d\xe9finir une propri\xe9t\xe9 \xab foo \xbb : objet non extensible',
             },
             'exception': {
                 'values': [
@@ -287,7 +287,7 @@ class JavascriptIntegrationTest(TestCase):
         event = Event.objects.get()
 
         message = event.interfaces['logentry']
-        assert message.message == 'ReferenceError: Cannot define property \'foo\': object is not extensible'
+        assert message.formatted == 'ReferenceError: Cannot define property \'foo\': object is not extensible'
 
         exception = event.interfaces['exception']
         assert exception.values[0].value == 'Too many files'

--- a/tests/sentry/models/test_event.py
+++ b/tests/sentry/models/test_event.py
@@ -60,14 +60,14 @@ class EventTest(TestCase):
         event = self.create_event(
             data={
                 'logentry': {
-                    'message': 'Hello World!',
+                    'formatted': 'Hello World!',
                 },
             }
         )
 
         d = event.as_dict()
         assert d['logentry'] == {
-            'message': 'Hello World!',
+            'formatted': 'Hello World!',
         }
 
     def test_email_subject(self):

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -48,7 +48,9 @@ class StoreTasksTest(PluginTestCase):
         data = {
             'project': project.id,
             'platform': 'mattlang',
-            'message': 'test',
+            'logentry': {
+                'formatted': 'test',
+            },
             'extra': {
                 'foo': 'bar'
             },
@@ -67,7 +69,9 @@ class StoreTasksTest(PluginTestCase):
         data = {
             'project': project.id,
             'platform': 'NOTMATTLANG',
-            'message': 'test',
+            'logentry': {
+                'formatted': 'test',
+            },
             'extra': {
                 'foo': 'bar'
             },
@@ -86,7 +90,9 @@ class StoreTasksTest(PluginTestCase):
         data = {
             'project': project.id,
             'platform': 'mattlang',
-            'message': 'test',
+            'logentry': {
+                'formatted': 'test',
+            },
             'extra': {
                 'foo': 'bar'
             },
@@ -102,7 +108,9 @@ class StoreTasksTest(PluginTestCase):
             {
                 'project': project.id,
                 'platform': 'mattlang',
-                'message': 'test',
+                'logentry': {
+                    'formatted': 'test',
+                },
             },
             3600,
         )
@@ -120,7 +128,9 @@ class StoreTasksTest(PluginTestCase):
         data = {
             'project': project.id,
             'platform': 'noop',
-            'message': 'test',
+            'logentry': {
+                'formatted': 'test',
+            },
             'extra': {
                 'foo': 'bar'
             },
@@ -146,7 +156,9 @@ class StoreTasksTest(PluginTestCase):
         data = {
             'project': project.id,
             'platform': 'holdmeclose',
-            'message': 'test',
+            'logentry': {
+                'formatted': 'test',
+            },
             'extra': {
                 'foo': 'bar'
             },
@@ -160,7 +172,9 @@ class StoreTasksTest(PluginTestCase):
             'e:1', {
                 'project': project.id,
                 'platform': 'holdmeclose',
-                'message': 'test',
+                'logentry': {
+                    'formatted': 'test',
+                },
                 'extra': {
                     'foo': 'bar'
                 },
@@ -181,7 +195,9 @@ class StoreTasksTest(PluginTestCase):
         data = {
             'project': project.id,
             'platform': 'NOTMATTLANG',
-            'message': 'test',
+            'logentry': {
+                'formatted': 'test',
+            },
             'event_id': uuid.uuid4().hex,
             'extra': {
                 'foo': 'bar'

--- a/tests/sentry/test_canonical.py
+++ b/tests/sentry/test_canonical.py
@@ -163,3 +163,70 @@ class LegacyCanonicalKeyDictTests(TestCase):
         d['sentry.interfaces.User'] = {'id': 'other'}
         assert d['user'] == {'id': 'other'}
         assert d['sentry.interfaces.User'] == {'id': 'other'}
+
+
+class DoubleAliasingTests(TestCase):
+    def test_canonical(self):
+        view = CanonicalKeyView({'logentry': 'foo'})
+        assert len(view) == 1
+        assert view.keys() == ['logentry']
+
+        assert 'logentry' in view
+        assert 'sentry.interfaces.Message' in view
+        assert 'message' in view
+
+        assert view['logentry'] == 'foo'
+        assert view['sentry.interfaces.Message'] == 'foo'
+        assert view['message'] == 'foo'
+
+    def test_legacy_first(self):
+        view = CanonicalKeyView({'sentry.interfaces.Message': 'foo'})
+        assert len(view) == 1
+        assert view.keys() == ['logentry']
+
+        assert 'logentry' in view
+        assert 'sentry.interfaces.Message' in view
+        assert 'message' in view
+
+        assert view['logentry'] == 'foo'
+        assert view['sentry.interfaces.Message'] == 'foo'
+        assert view['message'] == 'foo'
+
+    def test_legacy_second(self):
+        view = CanonicalKeyView({'message': 'foo'})
+        assert len(view) == 1
+        assert view.keys() == ['logentry']
+
+        assert 'logentry' in view
+        assert 'sentry.interfaces.Message' in view
+        assert 'message' in view
+
+        assert view['logentry'] == 'foo'
+        assert view['sentry.interfaces.Message'] == 'foo'
+        assert view['message'] == 'foo'
+
+    def test_override(self):
+        view = CanonicalKeyView({'logentry': 'foo', 'sentry.interfaces.Message': 'bar'})
+        assert len(view) == 1
+        assert view.keys() == ['logentry']
+
+        assert 'logentry' in view
+        assert 'sentry.interfaces.Message' in view
+        assert 'message' in view
+
+        assert view['logentry'] == 'foo'
+        assert view['sentry.interfaces.Message'] == 'foo'
+        assert view['message'] == 'foo'
+
+    def test_two_legacy(self):
+        view = CanonicalKeyView({'message': 'bar', 'sentry.interfaces.Message': 'foo'})
+        assert len(view) == 1
+        assert view.keys() == ['logentry']
+
+        assert 'logentry' in view
+        assert 'sentry.interfaces.Message' in view
+        assert 'message' in view
+
+        assert view['logentry'] == 'foo'
+        assert view['sentry.interfaces.Message'] == 'foo'
+        assert view['message'] == 'foo'

--- a/tests/sentry/utils/test_rust.py
+++ b/tests/sentry/utils/test_rust.py
@@ -37,7 +37,7 @@ def get_event(stacktrace):
         'level': 'error',
         'platform': 'python',
         'logentry': {
-            'message': 'invalid debug identifier\n\n%s' % stacktrace,
+            'formatted': 'invalid debug identifier\n\n%s' % stacktrace,
         },
         'exception': {
             'values': [{
@@ -74,7 +74,7 @@ def test_merge_rust_info():
     merge_rust_info_frames(event, {'exc_info': exc_info})
 
     assert event['platform'] == 'native'
-    assert event['logentry']['message'] == 'invalid debug identifier'
+    assert event['logentry']['formatted'] == 'invalid debug identifier'
 
     exception = event['exception']['values'][0]
     assert exception['value'] == 'invalid debug identifier'
@@ -122,7 +122,7 @@ def test_without_stacktrace():
     merge_rust_info_frames(event, {'exc_info': exc_info})
 
     assert event['platform'] == 'native'
-    assert event['logentry']['message'] == 'invalid debug identifier'
+    assert event['logentry']['formatted'] == 'invalid debug identifier'
 
     exception = event['exception']['values'][0]
     assert exception['value'] == 'invalid debug identifier'

--- a/tests/sentry/utils/test_sdk.py
+++ b/tests/sentry/utils/test_sdk.py
@@ -21,7 +21,7 @@ class SentryInternalClientTest(TestCase):
         event = Event.objects.get()
         assert event.project_id == settings.SENTRY_PROJECT
         assert event.event_id == event_id
-        assert event.data['logentry']['message'] == \
+        assert event.data['logentry']['formatted'] == \
             'internal client test'
 
     def test_encoding(self):
@@ -38,5 +38,5 @@ class SentryInternalClientTest(TestCase):
 
         event = Event.objects.get()
         assert event.project_id == settings.SENTRY_PROJECT
-        assert event.data['logentry']['message'] == 'check the req'
+        assert event.data['logentry']['formatted'] == 'check the req'
         assert 'NotJSONSerializable' in event.data['extra']['request']


### PR DESCRIPTION
Updates the logentry interface and removes some deprecated behavior.

**Changes to the interface**

- Make `logentry.message` optional, and require one of {`message`, `formatted`}
- Make `logentry.formatted` the canonical key, remove `logentry.message` if they are the same
- Only support python-style interpolation (`%s` and `%(key)`)
- Trim everything at the end, after interpolating

**Changes to normalization**

- `logentry`, `sentry.interfaces.Message` and `message` are all aliases in ascending priority
- `message` is no longer written to `logentry.formatted`

**Note**:
- There is still **no difference between missing and empty params**.
- Empty `logentry.message` used to generate an error while empty `message` did not. This behavior is preserved.

#sync-getsentry
