### PR TITLE
feat: Add wildcard for gpu context

### DIFF
--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -945,12 +945,14 @@
       background-size: contain;
     }
 
-    &.amd .context-item-icon {
+    &.amd .context-item-icon,
+    &[class*='amd-'] .context-item-icon {
       background-image: url(../images/icons/context/amd.png);
       background-size: contain;
     }
 
-    &.nvidia .context-item-icon {
+    &.nvidia .context-item-icon,
+    &[class*='nvidia-'] .context-item-icon {
       background-image: url(../images/icons/context/nvidia.png);
       background-size: contain;
     }


### PR DESCRIPTION
Also shows the `nvidia` icon whenever there is a more specific identifier is available.
Same goes for `amd`.

![screenshot 2018-12-18 12 50 54](https://user-images.githubusercontent.com/363802/50152361-b6c8c500-02c3-11e9-8b50-496f9534f4f4.png)
