### PR TITLE
fix(webhooks): Include event ID (autoincrementing) in request body

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -76,6 +76,7 @@ default_manager.add('organizations:unreleased-changes', OrganizationFeature)  # 
 default_manager.add('organizations:gitlab-integration', OrganizationFeature)  # NOQA
 default_manager.add('organizations:jira-server-integration', OrganizationFeature)  # NOQA
 default_manager.add('organizations:large-debug-files', OrganizationFeature)  # NOQA
+default_manager.add('organizations:legacy-event-id', OrganizationFeature)  # NOQA
 
 # Project scoped features
 default_manager.add('projects:similarity-view', ProjectFeature)  # NOQA

--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -8,6 +8,7 @@ from django import forms
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
+from sentry import features
 from sentry.exceptions import PluginError
 from sentry.models import Event
 from sentry.plugins.bases import notify
@@ -91,10 +92,11 @@ class WebHooksPlugin(notify.NotificationPlugin):
         data['event'] = dict(event.data or {})
         data['event']['tags'] = event.get_tags()
         data['event']['event_id'] = event.event_id
-        data['event']['id'] = Event.objects.filter(
-            project_id=event.project_id,
-            event_id=event.event_id,
-        ).values_list('id', flat=True).get()
+        if features.has('organizations:legacy-event-id', group.project.organization):
+            data['event']['id'] = Event.objects.filter(
+                project_id=event.project_id,
+                event_id=event.event_id,
+            ).values_list('id', flat=True).get()
         return data
 
     def get_webhook_urls(self, project):

--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 from sentry.exceptions import PluginError
+from sentry.models import Event
 from sentry.plugins.bases import notify
 from sentry.http import is_valid_url, safe_urlopen
 from sentry.utils.safe import safe_execute
@@ -90,7 +91,10 @@ class WebHooksPlugin(notify.NotificationPlugin):
         data['event'] = dict(event.data or {})
         data['event']['tags'] = event.get_tags()
         data['event']['event_id'] = event.event_id
-        data['event']['id'] = event.id
+        data['event']['id'] = Event.objects.filter(
+            project_id=event.project_id,
+            event_id=event.event_id,
+        ).values_list('id', flat=True).get()
         return data
 
     def get_webhook_urls(self, project):

--- a/tests/sentry/plugins/sentry_webhooks/test_plugin.py
+++ b/tests/sentry/plugins/sentry_webhooks/test_plugin.py
@@ -31,7 +31,8 @@ class WebHooksPluginTest(TestCase):
         notification = Notification(event=event, rule=rule)
         self.project.update_option('webhooks:urls', 'http://example.com')
 
-        self.plugin.notify(notification)
+        with self.feature('organizations:legacy-event-id'):
+            self.plugin.notify(notification)
 
         assert len(responses.calls) == 1
 


### PR DESCRIPTION
See ISSUE-237 for a lot more context. From that ticket:

> This was "broken" as a result of post-processing changes that switched to using a Kafka consumer of the event stream as the mechanism for events being dispatched. 