### PR TITLE
ref(integrations): Bitbucket scopes reduction

### DIFF
--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -61,11 +61,11 @@ metadata = IntegrationMetadata(
     source_url='https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/bitbucket',
     aspects={},
 )
-# see https://developer.atlassian.com/bitbucket/api/2/reference/meta/authentication
+# see https://developer.atlassian.com/bitbucket/api/2/reference/meta/authentication#scopes-bbc
 scopes = (
     # 'account', #not sure this is necessary
     # 'email',#we don't appear to be using it; included in account it looks like
-    'issue:write',  # looks like repo is enough
+    'issue:write',  # necessary
     'pullrequest',
     # 'repository',  # pullrequest implies repository
     'repository:admin',

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -65,7 +65,6 @@ metadata = IntegrationMetadata(
 scopes = (
     'issue:write',
     'pullrequest',
-    # 'repository:admin',
     'webhook',
 )
 

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -61,14 +61,15 @@ metadata = IntegrationMetadata(
     source_url='https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/bitbucket',
     aspects={},
 )
+# see https://developer.atlassian.com/bitbucket/api/2/reference/meta/authentication
 scopes = (
-    'account',
-    'email',
-    'issue:write',
+    # 'account', #not sure this is necessary
+    # 'email',#we don't appear to be using it; included in account it looks like
+    'issue:write',  # looks like repo is enough
     'pullrequest',
-    'repository',
+    # 'repository',  # pullrequest implies repository
     'repository:admin',
-    'team',
+    # 'team',
     'webhook',
 )
 

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -63,13 +63,9 @@ metadata = IntegrationMetadata(
 )
 # see https://developer.atlassian.com/bitbucket/api/2/reference/meta/authentication#scopes-bbc
 scopes = (
-    # 'account', #not sure this is necessary
-    # 'email',#we don't appear to be using it; included in account it looks like
-    'issue:write',  # necessary
+    'issue:write',
     'pullrequest',
-    # 'repository',  # pullrequest implies repository
-    'repository:admin',
-    # 'team',
+    # 'repository:admin',
     'webhook',
 )
 


### PR DESCRIPTION
Because we never implemented login/identity with Bitbucket, we do not need `account`, `email` or `team` scopes. The `repository` scope is included in the `pullrequest` scope.