### PR TITLE
ref(interfaces): Update the Http interface (request)

### DIFF
--- a/src/sentry/interfaces/http.py
+++ b/src/sentry/interfaces/http.py
@@ -88,7 +88,7 @@ def fix_broken_encoding(value):
 
 
 def jsonify(value):
-    return value if isinstance(value, six.string_types) else json.dumps(value)
+    return to_bytes(value) if isinstance(value, six.string_types) else json.dumps(value)
 
 
 class Http(Interface):

--- a/src/sentry/interfaces/http.py
+++ b/src/sentry/interfaces/http.py
@@ -19,6 +19,7 @@ from six.moves.urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from sentry.interfaces.base import Interface, InterfaceValidationError, prune_empty_keys
 from sentry.interfaces.schemas import validate_and_default_interface
+from sentry.utils import json
 from sentry.utils.safe import trim, trim_dict, trim_pairs
 from sentry.utils.http import heuristic_decode
 from sentry.utils.validators import validate_ip
@@ -84,6 +85,10 @@ def fix_broken_encoding(value):
     if isinstance(value, six.binary_type):
         value = value.decode('utf8', errors='replace')
     return value
+
+
+def jsonify(value):
+    return value if isinstance(value, six.string_types) else json.dumps(value)
 
 
 class Http(Interface):
@@ -152,7 +157,7 @@ class Http(Interface):
                     query_string = query_string[1:]
                 query_string = parse_qsl(query_string, keep_blank_values=True)
             elif isinstance(query_string, dict):
-                query_string = [(to_bytes(k), to_bytes(v)) for k, v in six.iteritems(query_string)]
+                query_string = [(to_bytes(k), jsonify(v)) for k, v in six.iteritems(query_string)]
             elif isinstance(query_string, list):
                 query_string = [
                     tuple(tup) for tup in query_string

--- a/src/sentry/interfaces/http.py
+++ b/src/sentry/interfaces/http.py
@@ -190,7 +190,7 @@ class Http(Interface):
         inferred_content_type = data.get('inferred_content_type', content_type)
 
         if 'inferred_content_type' not in data and not isinstance(body, dict):
-            body, inferred_content_type = heuristic_decode(body, content_type)
+            inferred_content_type = heuristic_decode(body, content_type)
 
         if body:
             body = trim(body, settings.SENTRY_MAX_HTTP_BODY_SIZE)

--- a/src/sentry/interfaces/http.py
+++ b/src/sentry/interfaces/http.py
@@ -147,18 +147,22 @@ class Http(Interface):
 
         query_string = data.get('query_string') or query_bit
         if query_string:
-            # if querystring was a dict, convert it to a string
-            if isinstance(query_string, dict):
-                query_string = urlencode(
-                    [(to_bytes(k), to_bytes(v)) for k, v in query_string.items()]
-                )
-            else:
+            if isinstance(query_string, six.string_types):
                 if query_string[0] == '?':
-                    # remove '?' prefix
                     query_string = query_string[1:]
+                query_string = parse_qsl(query_string, keep_blank_values=True)
+            elif isinstance(query_string, dict):
+                query_string = [(to_bytes(k), to_bytes(v)) for k, v in six.iteritems(query_string)]
+            elif isinstance(query_string, list):
+                query_string = [
+                    tuple(tup) for tup in query_string
+                    if isinstance(tup, (tuple, list)) and len(tup) == 2
+                ]
+            else:
+                query_string = []
             kwargs['query_string'] = trim(query_string, 4096)
         else:
-            kwargs['query_string'] = ''
+            kwargs['query_string'] = []
 
         fragment = data.get('fragment') or fragment_bit
 
@@ -230,7 +234,7 @@ class Http(Interface):
     def full_url(self):
         url = self.url
         if self.query_string:
-            url = url + '?' + self.query_string
+            url = url + '?' + urlencode(self.query_string)
         if self.fragment:
             url = url + '#' + self.fragment
         return url
@@ -242,7 +246,7 @@ class Http(Interface):
                 'url': self.full_url,
                 'short_url': self.url,
                 'method': self.method,
-                'query_string': self.query_string,
+                'query_string': urlencode(self.query_string),
                 'fragment': self.fragment,
             }
         )

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -63,7 +63,16 @@ HTTP_INTERFACE_SCHEMA = {
             'minLength': 1,
         },
         'method': {'type': 'string'},
-        'query_string': {'type': ['string', 'object']},
+        'query_string': {
+            'anyOf': [
+                {'type': ['string', 'object']},
+                {'type': 'array', 'items': {
+                    'type': 'array',
+                    'maxItems': 2,
+                    'minItems': 2,
+                }},
+            ],
+        },
         'inferred_content_type': {'type': 'string'},
         'cookies': {
             'anyOf': [

--- a/src/sentry/static/sentry/app/components/events/interfaces/richHttpContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/richHttpContent.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import queryString from 'query-string';
 
 import {objectIsEmpty} from 'app/utils';
 import {objectToSortedTupleArray} from 'app/components/events/interfaces/utils';
@@ -33,12 +32,7 @@ class RichHttpContent extends React.Component {
     try {
       // Sentry API abbreviates long query string values, sometimes resulting in
       // an un-parsable querystring ... stay safe kids
-      return (
-        <KeyValueList
-          data={objectToSortedTupleArray(queryString.parse(data))}
-          isContextData={true}
-        />
-      );
+      return <KeyValueList data={data} isContextData={true} />;
     } catch (e) {
       return <pre>{data}</pre>;
     }
@@ -48,7 +42,7 @@ class RichHttpContent extends React.Component {
     let data = this.props.data;
     return (
       <div>
-        {data.query && (
+        {!objectIsEmpty(data.query) && (
           <ClippedBox title={t('Query String')}>
             <ErrorBoundary mini>{this.getQueryStringOrRaw(data.query)}</ErrorBoundary>
           </ClippedBox>

--- a/src/sentry/utils/data_scrubber.py
+++ b/src/sentry/utils/data_scrubber.py
@@ -104,8 +104,8 @@ class SensitiveDataFilter(object):
                 data['contexts'][key] = varmap(self.sanitize, value)
 
     def sanitize(self, key, value):
-        if value is None:
-            return
+        if value is None or value == '':
+            return value
 
         if isinstance(key, six.string_types):
             key = key.lower()

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -256,12 +256,13 @@ def heuristic_decode(data, possible_content_type=None):
 
     for decoding_type, decoder in decoders:
         try:
-            return (decoder(data), decoding_type)
+            decoder(data)
         except Exception:
             # Try another decoder
             continue
+        return decoding_type
 
-    return (data, inferred_content_type)
+    return inferred_content_type
 
 
 def percent_encode(val):

--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -90,6 +90,8 @@ def trim(
             _size += len(force_text(trim_v))
             if _size >= max_size:
                 break
+        if isinstance(value, tuple):
+            result = tuple(result)
 
     elif isinstance(value, six.string_types):
         result = truncatechars(value, max_size - _size)

--- a/tests/sentry/interfaces/test_http.py
+++ b/tests/sentry/interfaces/test_http.py
@@ -79,7 +79,7 @@ class HttpTest(TestCase):
         ))
         assert result.data == {'foo': 'bar'}
 
-    def test_form_encoded_data(self):
+    def test_urlencoded_data(self):
         result = Http.to_python(
             dict(
                 url='http://example.com',
@@ -87,7 +87,43 @@ class HttpTest(TestCase):
                 data='foo=bar',
             )
         )
-        assert result.data == {'foo': ['bar']}
+
+        assert result.data == 'foo=bar'
+        assert result.inferred_content_type == 'application/x-www-form-urlencoded'
+
+    def test_infer_urlencoded_content_type(self):
+        result = Http.to_python(
+            dict(
+                url='http://example.com',
+                data='foo=bar',
+            )
+        )
+
+        assert result.data == 'foo=bar'
+        assert result.inferred_content_type == 'application/x-www-form-urlencoded'
+
+    def test_json_data(self):
+        result = Http.to_python(
+            dict(
+                url='http://example.com',
+                headers={'Content-Type': 'application/json'},
+                data='{"foo":"bar"}',
+            )
+        )
+
+        assert result.data == '{"foo":"bar"}'
+        assert result.inferred_content_type == 'application/json'
+
+    def test_infer_json_content_type(self):
+        result = Http.to_python(
+            dict(
+                url='http://example.com',
+                data='{"foo":"bar"}',
+            )
+        )
+
+        assert result.data == '{"foo":"bar"}'
+        assert result.inferred_content_type == 'application/json'
 
     def test_cookies_as_string(self):
         result = Http.to_python(dict(

--- a/tests/sentry/interfaces/test_http.py
+++ b/tests/sentry/interfaces/test_http.py
@@ -28,7 +28,7 @@ class HttpTest(TestCase):
         assert result.url == 'http://example.com'
         assert result.method is None
         assert result.fragment == ''
-        assert result.query_string == ''
+        assert result.query_string == []
         assert result.data is None
         assert result.cookies == []
         assert result.headers == []
@@ -49,7 +49,7 @@ class HttpTest(TestCase):
             )
         )
         assert result.method == 'GET'
-        assert result.query_string == 'foo=bar'
+        assert result.query_string == [('foo', 'bar')]
         assert result.fragment == 'foobar'
         assert result.cookies == [('foo', 'bar')]
         assert result.headers == [('X-Foo-Bar', 'baz')]
@@ -61,7 +61,14 @@ class HttpTest(TestCase):
             url='http://example.com',
             query_string={'foo': 'bar'},
         ))
-        assert result.query_string == 'foo=bar'
+        assert result.query_string == [('foo', 'bar')]
+
+    def test_query_string_as_pairlist(self):
+        result = Http.to_python(dict(
+            url='http://example.com',
+            query_string=[['foo', 'bar']],
+        ))
+        assert result.query_string == [('foo', 'bar')]
 
     def test_query_string_as_dict_unicode(self):
         result = Http.to_python(
@@ -70,7 +77,7 @@ class HttpTest(TestCase):
                 query_string={'foo': u'\N{SNOWMAN}'},
             )
         )
-        assert result.query_string == 'foo=%E2%98%83'
+        assert result.query_string == [('foo', '\xe2\x98\x83')]
 
     def test_data_as_dict(self):
         result = Http.to_python(dict(

--- a/tests/sentry/utils/http/tests.py
+++ b/tests/sentry/utils/http/tests.py
@@ -351,30 +351,24 @@ class HeuristicDecodeTestCase(TestCase):
     url_body = 'key=value&key2=value2'
 
     def test_json(self):
-        data, content_type = heuristic_decode(self.json_body, 'application/json')
-        assert data == {'key': 'value', 'key2': 'value2'}
+        content_type = heuristic_decode(self.json_body, 'application/json')
         assert content_type == 'application/json'
 
     def test_url_encoded(self):
-        data, content_type = heuristic_decode(self.url_body, 'application/x-www-form-urlencoded')
-        assert data == {'key': ['value'], 'key2': ['value2']}
+        content_type = heuristic_decode(self.url_body, 'application/x-www-form-urlencoded')
         assert content_type == 'application/x-www-form-urlencoded'
 
     def test_possible_type_mismatch(self):
-        data, content_type = heuristic_decode(self.json_body, 'application/x-www-form-urlencoded')
-        assert data == {'key': 'value', 'key2': 'value2'}
+        content_type = heuristic_decode(self.json_body, 'application/x-www-form-urlencoded')
         assert content_type == 'application/json'
 
-        data, content_type = heuristic_decode(self.url_body, 'application/json')
-        assert data == {'key': ['value'], 'key2': ['value2']}
+        content_type = heuristic_decode(self.url_body, 'application/json')
         assert content_type == 'application/x-www-form-urlencoded'
 
     def test_no_possible_type(self):
-        data, content_type = heuristic_decode(self.json_body)
-        assert data == {'key': 'value', 'key2': 'value2'}
+        content_type = heuristic_decode(self.json_body)
         assert content_type == 'application/json'
 
     def test_unable_to_decode(self):
-        data, content_type = heuristic_decode('string body', 'text/plain')
-        assert data == 'string body'
+        content_type = heuristic_decode('string body', 'text/plain')
         assert content_type == 'text/plain'

--- a/tests/sentry/utils/test_data_scrubber.py
+++ b/tests/sentry/utils/test_data_scrubber.py
@@ -164,6 +164,32 @@ class SensitiveDataFilterTest(TestCase):
             }
         )
 
+    def test_querystring_as_pairlist(self):
+        data = {
+            'request': {
+                'query_string': [
+                    ['foo', 'bar'],
+                    ['password', 'hello'],
+                    ['the_secret', 'hello'],
+                    ['a_password_here', 'hello'],
+                    ['api_key', 'secret_key'],
+                ],
+            }
+        }
+
+        proc = SensitiveDataFilter()
+        proc.apply(data)
+
+        assert 'request' in data
+        http = data['request']
+        assert http['query_string'] == [
+            ['foo', 'bar'],
+            ['password', FILTER_MASK],
+            ['the_secret', FILTER_MASK],
+            ['a_password_here', FILTER_MASK],
+            ['api_key', FILTER_MASK],
+        ]
+
     def test_querystring_as_string_with_partials(self):
         data = {
             'request': {
@@ -177,6 +203,28 @@ class SensitiveDataFilterTest(TestCase):
         assert 'request' in data
         http = data['request']
         assert http['query_string'] == 'foo=bar&password&baz=bar'
+
+    def test_querystring_as_pairlist_with_partials(self):
+        data = {
+            'request': {
+                'query_string': [
+                    ['foo', 'bar'],
+                    ['password', ''],
+                    ['baz', 'bar'],
+                ]
+            }
+        }
+
+        proc = SensitiveDataFilter()
+        proc.apply(data)
+
+        assert 'request' in data
+        http = data['request']
+        assert http['query_string'] == [
+            ['foo', 'bar'],
+            ['password', ''],
+            ['baz', 'bar'],
+        ]
 
     def test_sanitize_additional_sensitive_fields(self):
         additional_sensitive_dict = {'fieldy_field': 'value', 'moar_other_field': 'another value'}

--- a/tests/sentry/web/api/tests.py
+++ b/tests/sentry/web/api/tests.py
@@ -464,12 +464,7 @@ class StoreViewTest(TestCase):
         assert resp.status_code == 200, (resp.status_code, resp.content)
 
         call_data = mock_insert_data_to_database.call_args[0][0]
-        assert call_data['request']['data'] == {
-            'password': ['lol'],
-            'foo': ['1'],
-            'bar': ['2'],
-            'baz': ['3']
-        }
+        assert call_data['request']['data'] == "password=lol&foo=1&bar=2&baz=3"
 
     @mock.patch('sentry.coreapi.ClientApiHelper.insert_data_to_database')
     def test_scrub_data_on(self, mock_insert_data_to_database):
@@ -490,12 +485,7 @@ class StoreViewTest(TestCase):
         assert resp.status_code == 200, (resp.status_code, resp.content)
 
         call_data = mock_insert_data_to_database.call_args[0][0]
-        assert call_data['request']['data'] == {
-            'password': ['lol'],
-            'foo': ['1'],
-            'bar': ['2'],
-            'baz': ['3']
-        }
+        assert call_data['request']['data'] == "password=lol&foo=1&bar=2&baz=3"
 
     @mock.patch('sentry.coreapi.ClientApiHelper.insert_data_to_database')
     def test_scrub_data_defaults(self, mock_insert_data_to_database):
@@ -516,12 +506,7 @@ class StoreViewTest(TestCase):
         assert resp.status_code == 200, (resp.status_code, resp.content)
 
         call_data = mock_insert_data_to_database.call_args[0][0]
-        assert call_data['request']['data'] == {
-            'password': ['[Filtered]'],
-            'foo': ['1'],
-            'bar': ['2'],
-            'baz': ['3']
-        }
+        assert call_data['request']['data'] == "password=[Filtered]&foo=1&bar=2&baz=3"
 
     @mock.patch('sentry.coreapi.ClientApiHelper.insert_data_to_database')
     def test_scrub_data_sensitive_fields(self, mock_insert_data_to_database):
@@ -543,12 +528,7 @@ class StoreViewTest(TestCase):
         assert resp.status_code == 200, (resp.status_code, resp.content)
 
         call_data = mock_insert_data_to_database.call_args[0][0]
-        assert call_data['request']['data'] == {
-            'password': ['[Filtered]'],
-            'foo': ['[Filtered]'],
-            'bar': ['[Filtered]'],
-            'baz': ['3']
-        }
+        assert call_data['request']['data'] == "password=[Filtered]&foo=[Filtered]&bar=[Filtered]&baz=3"
 
     @mock.patch('sentry.coreapi.ClientApiHelper.insert_data_to_database')
     def test_scrub_data_org_override(self, mock_insert_data_to_database):
@@ -571,12 +551,7 @@ class StoreViewTest(TestCase):
         assert resp.status_code == 200, (resp.status_code, resp.content)
 
         call_data = mock_insert_data_to_database.call_args[0][0]
-        assert call_data['request']['data'] == {
-            'password': ['[Filtered]'],
-            'foo': ['1'],
-            'bar': ['2'],
-            'baz': ['3']
-        }
+        assert call_data['request']['data'] == "password=[Filtered]&foo=1&bar=2&baz=3"
 
     @mock.patch('sentry.coreapi.ClientApiHelper.insert_data_to_database')
     def test_scrub_data_org_override_sensitive_fields(self, mock_insert_data_to_database):
@@ -599,12 +574,7 @@ class StoreViewTest(TestCase):
         assert resp.status_code == 200, (resp.status_code, resp.content)
 
         call_data = mock_insert_data_to_database.call_args[0][0]
-        assert call_data['request']['data'] == {
-            'password': ['[Filtered]'],
-            'foo': ['[Filtered]'],
-            'bar': ['[Filtered]'],
-            'baz': ['[Filtered]']
-        }
+        assert call_data['request']['data'] == "password=[Filtered]&foo=[Filtered]&bar=[Filtered]&baz=[Filtered]"
 
     @mock.patch('sentry.coreapi.ClientApiHelper.insert_data_to_database')
     def test_uses_client_as_sdk(self, mock_insert_data_to_database):


### PR DESCRIPTION
Changes normalization of the Http interface (`request`):

 - Content type inference still happens, but the body is left as it was ingested.
 - Query strings are now stored as pair lists internally, not as string.