### PR TITLE
feat(events-stream): Disable Sentry user feedback dialog

### DIFF
--- a/src/sentry/static/sentry/app/__mocks__/api.jsx
+++ b/src/sentry/static/sentry/app/__mocks__/api.jsx
@@ -97,7 +97,7 @@ class Client {
           responseText: JSON.stringify(body),
           responseJSON: body,
         };
-        this.handleError(
+        this.handleRequestError(
           {
             path: url,
             requestOptions: options,
@@ -122,7 +122,7 @@ class Client {
   }
 }
 
-Client.prototype.handleError = RealClient.Client.prototype.handleRequestError;
+Client.prototype.handleRequestError = RealClient.Client.prototype.handleRequestError;
 Client.prototype.uniqueId = RealClient.Client.prototype.uniqueId;
 Client.prototype.bulkUpdate = RealClient.Client.prototype.bulkUpdate;
 Client.prototype._chain = RealClient.Client.prototype._chain;

--- a/src/sentry/static/sentry/app/__mocks__/api.jsx
+++ b/src/sentry/static/sentry/app/__mocks__/api.jsx
@@ -97,7 +97,7 @@ class Client {
           responseText: JSON.stringify(body),
           responseJSON: body,
         };
-        this.handleRequestError(
+        this.handleError(
           {
             path: url,
             requestOptions: options,
@@ -122,7 +122,7 @@ class Client {
   }
 }
 
-Client.prototype.handleRequestError = RealClient.Client.prototype.handleRequestError;
+Client.prototype.handleError = RealClient.Client.prototype.handleRequestError;
 Client.prototype.uniqueId = RealClient.Client.prototype.uniqueId;
 Client.prototype.bulkUpdate = RealClient.Client.prototype.bulkUpdate;
 Client.prototype._chain = RealClient.Client.prototype._chain;

--- a/src/sentry/static/sentry/app/components/asyncComponent.jsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.jsx
@@ -200,6 +200,10 @@ export default class AsyncComponent extends React.Component {
     // Allow children to implement this
   }
 
+  onRequestError({stateKey, data, jqXHR}) {
+    // Allow children to implement this
+  }
+
   handleRequestSuccess = ({stateKey, data, jqXHR}, initialRequest) => {
     this.setState(prevState => {
       let state = {
@@ -219,7 +223,8 @@ export default class AsyncComponent extends React.Component {
     this.onRequestSuccess({stateKey, data, jqXHR});
   };
 
-  handleError(error, [stateKey]) {
+  handleError(error, args) {
+    let [stateKey] = args;
     if (error && error.responseText) {
       Sentry.addBreadcrumb({
         message: error.responseText,
@@ -243,6 +248,7 @@ export default class AsyncComponent extends React.Component {
 
       return state;
     });
+    this.onRequestError(error, args);
   }
 
   // DEPRECATED: use getEndpoints()
@@ -298,7 +304,7 @@ export default class AsyncComponent extends React.Component {
     return <LoadingIndicator />;
   }
 
-  renderError(error, disableLog = false) {
+  renderError(error, disableLog = false, disableReport = false) {
     // 401s are captured by SudaModal, but may be passed back to AsyncComponent if they close the modal without identifying
     let unauthorizedErrors = Object.values(this.state.errors).find(
       resp => resp && resp.status === 401
@@ -343,6 +349,7 @@ export default class AsyncComponent extends React.Component {
         error={error}
         component={this}
         disableLogSentry={!shouldLogSentry}
+        disableReport={disableReport}
         onRetry={this.remountComponent}
       />
     );

--- a/src/sentry/static/sentry/app/components/asyncComponent.jsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.jsx
@@ -200,7 +200,7 @@ export default class AsyncComponent extends React.Component {
     // Allow children to implement this
   }
 
-  onRequestError({stateKey, data, jqXHR}) {
+  onRequestError(resp, args) {
     // Allow children to implement this
   }
 

--- a/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
@@ -61,7 +61,7 @@ class TotalEventCount extends AsyncComponent {
     Sentry.captureException(new Error('Unable to fetch "total event count"'));
   }
 
-  renderError(error) {
+  renderError(error, disableLog = false, disableReport = false) {
     // Don't show an error message, handle it in `onRequestError`
     return null;
   }

--- a/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/browser';
 import {Flex} from 'grid-emotion';
 import {isEqual} from 'lodash';
 import {withRouter} from 'react-router';
@@ -56,15 +57,20 @@ class TotalEventCount extends AsyncComponent {
     ];
   }
 
+  onRequestError(error) {
+    Sentry.captureException(new Error('Unable to fetch "total event count"'));
+  }
+
+  renderError(error) {
+    // Don't show an error message, handle it in `onRequestError`
+    return null;
+  }
+
   renderBody() {
     let {eventsMeta} = this.state;
-    let {isAllResults, organization, numRows} = this.props;
+    let {isAllResults, numRows} = this.props;
     let count = isAllResults ? numRows : eventsMeta.count;
-    return (
-      <Feature features={['internal-catchall']} organization={organization}>
-        {t(` of ${count.toLocaleString()}${isAllResults ? '' : ' (estimated)'}`)}
-      </Feature>
-    );
+    return t(` of ${count.toLocaleString()}${isAllResults ? '' : ' (estimated)'}`);
   }
 }
 
@@ -148,7 +154,12 @@ class OrganizationEvents extends AsyncView {
 
     return (
       <React.Fragment>
-        {error && super.renderError(new Error('Unable to load all required endpoints'))}
+        {error &&
+          super.renderError(
+            new Error('Unable to load all required endpoints'),
+            false,
+            true
+          )}
         <Panel>
           <EventsChart
             query={location.query.query}
@@ -172,14 +183,16 @@ class OrganizationEvents extends AsyncView {
               <RowDisplay>
                 {events.length ? t(`Results ${this.renderRowCounts()}`) : t('No Results')}
                 {!!events.length && (
-                  <TotalEventCount
-                    organization={organization}
-                    location={location}
-                    isAllResults={
-                      !parsedLinks.previous.results && !parsedLinks.next.results
-                    }
-                    numRows={events.length}
-                  />
+                  <Feature features={['internal-catchall']}>
+                    <TotalEventCount
+                      organization={organization}
+                      location={location}
+                      isAllResults={
+                        !parsedLinks.previous.results && !parsedLinks.next.results
+                      }
+                      numRows={events.length}
+                    />
+                  </Feature>
                 )}
               </RowDisplay>
               <Pagination pageLinks={eventsPageLinks} className="" />

--- a/src/sentry/static/sentry/app/views/routeError.jsx
+++ b/src/sentry/static/sentry/app/views/routeError.jsx
@@ -12,6 +12,7 @@ class RouteError extends React.Component {
      * Disable logging to Sentry
      */
     disableLogSentry: PropTypes.bool,
+    disableReport: PropTypes.bool,
     error: PropTypes.object.isRequired,
     routes: PropTypes.array,
   };
@@ -22,7 +23,7 @@ class RouteError extends React.Component {
   };
 
   componentWillMount() {
-    let {disableLogSentry, routes, error} = this.props;
+    let {disableLogSentry, disableReport, routes, error} = this.props;
     let {organization, project} = this.context;
 
     if (disableLogSentry) return;
@@ -43,7 +44,10 @@ class RouteError extends React.Component {
         scope.setExtra('projectFeatures', (project && project.features) || []);
         Sentry.captureException(error);
       });
-      Sentry.showReportDialog();
+
+      if (!disableReport) {
+        Sentry.showReportDialog();
+      }
     });
   }
 

--- a/tests/js/spec/views/organizationEvents/events.spec.jsx
+++ b/tests/js/spec/views/organizationEvents/events.spec.jsx
@@ -98,9 +98,24 @@ describe('OrganizationEventsErrors', function() {
     await tick();
     wrapper.update();
     expect(eventsStatsMock).toHaveBeenCalled();
-    expect(eventsMetaMock).toHaveBeenCalled();
+    expect(eventsMetaMock).not.toHaveBeenCalled();
     expect(wrapper.find('LoadingIndicator')).toHaveLength(0);
     expect(wrapper.find('IdBadge')).toHaveLength(2);
+  });
+
+  it('renders TotalEventCount with internal flag', async function() {
+    const newOrg = TestStubs.Organization({
+      ...org,
+      features: [...org.features, 'internal-catchall'],
+    });
+    const wrapper = mount(
+      <OrganizationEvents organization={newOrg} location={{query: {}}} />,
+      {...routerContext, context: {...routerContext.context, organization: newOrg}}
+    );
+    await tick();
+    wrapper.update();
+    expect(eventsMetaMock).toHaveBeenCalled();
+    expect(wrapper.find('Feature').text()).toEqual(' of 5 (estimated)');
   });
 
   // This tests the component's `shouldComponentUpdate`


### PR DESCRIPTION
* disables Sentry user feedback dialog on the events stream view.
* disables the error view when `events-meta` endpoint has errors.
* does not make `events-meta` request unless you have `internal-catchall` flag