### PR TITLE
feat(user-feedback): Implement basic version of org user feedback

### DIFF
--- a/src/sentry/static/sentry/app/components/events/userFeedback.jsx
+++ b/src/sentry/static/sentry/app/components/events/userFeedback.jsx
@@ -5,6 +5,8 @@ import TimeSince from 'app/components/timeSince';
 import utils from 'app/utils';
 import Link from 'app/components/link';
 
+import {t} from 'app/locale';
+
 class EventUserFeedback extends React.Component {
   static propTypes = {
     report: PropTypes.object.isRequired,
@@ -35,7 +37,7 @@ class EventUserFeedback extends React.Component {
                           to={`/${orgId}/${projectId}/issues/${issueId}/events/${report
                             .event.id}`}
                         >
-                          View event
+                          {t('View event')}
                         </Link>
                       </small>
                     )}

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -225,6 +225,13 @@ class Sidebar extends React.Component {
                     label={t('Releases')}
                     to={`/organizations/${organization.slug}/releases/`}
                   />
+                  <SidebarItem
+                    {...sidebarItemProps}
+                    onClick={this.hidePanel}
+                    icon={<InlineSvg src="icon-support" />}
+                    label={t('User Feedback')}
+                    to={`/organizations/${organization.slug}/user-feedback/`}
+                  />
                 </Feature>
                 <Feature features={['global-views']}>
                   <SidebarItem

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -783,6 +783,13 @@ function routes() {
           </Route>
 
           <Route
+            path="/organizations/:orgId/user-feedback/"
+            componentPromise={() =>
+              import(/*webpackChunkName: "OrganizationUserFeedback"*/ './views/userFeedback/organizationUserFeedback')}
+            component={errorHandler(LazyLoad)}
+          />
+
+          <Route
             path="/organizations/:orgId/releases/"
             componentPromise={() =>
               import(/*webpackChunkName: "OrganizationReleases"*/ './views/releases/list/organizationReleases')}

--- a/src/sentry/static/sentry/app/views/userFeedback/organizationUserFeedback.jsx
+++ b/src/sentry/static/sentry/app/views/userFeedback/organizationUserFeedback.jsx
@@ -7,6 +7,7 @@ import {t} from 'app/locale';
 import withOrganization from 'app/utils/withOrganization';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import SentryTypes from 'app/sentryTypes';
+import Feature from 'app/components/acl/feature';
 import Alert from 'app/components/alert';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
@@ -70,10 +71,6 @@ class OrganizationUserFeedback extends React.Component {
   }
 
   renderList() {
-    if (!new Set(this.props.organization.features).has('sentry10')) {
-      return this.renderNoAccess();
-    }
-
     if (this.state.loading) {
       return <LoadingIndicator />;
     }
@@ -120,13 +117,19 @@ class OrganizationUserFeedback extends React.Component {
     const {status} = getQuery(this.props.location.search);
     return (
       <Content>
-        <UserFeedbackContainer
-          location={this.props.location}
-          pageLinks={this.state.pageLinks}
-          status={status}
+        <Feature
+          features={['organizations:sentry10']}
+          organization={this.props.organization}
+          renderDisabled={this.renderNoAccess}
         >
-          {this.renderList()}
-        </UserFeedbackContainer>
+          <UserFeedbackContainer
+            location={this.props.location}
+            pageLinks={this.state.pageLinks}
+            status={status}
+          >
+            {this.renderList()}
+          </UserFeedbackContainer>
+        </Feature>
       </Content>
     );
   }

--- a/src/sentry/static/sentry/app/views/userFeedback/organizationUserFeedback.jsx
+++ b/src/sentry/static/sentry/app/views/userFeedback/organizationUserFeedback.jsx
@@ -1,17 +1,144 @@
 import React from 'react';
+// import PropTypes from 'prop-types';
+import styled from 'react-emotion';
+import {isEqual} from 'lodash';
+
+import {t} from 'app/locale';
+import withOrganization from 'app/utils/withOrganization';
+import withGlobalSelection from 'app/utils/withGlobalSelection';
+import SentryTypes from 'app/sentryTypes';
+import Alert from 'app/components/alert';
+import LoadingError from 'app/components/loadingError';
+import LoadingIndicator from 'app/components/loadingIndicator';
+import EmptyStateWarning from 'app/components/emptyStateWarning';
+import CompactIssue from 'app/components/compactIssue';
+import EventUserFeedback from 'app/components/events/userFeedback';
+import space from 'app/styles/space';
 
 import UserFeedbackContainer from './container';
+import {fetchUserFeedback, getQuery} from './utils';
 
-export default class OrganizationUserFeedback extends React.Component {
+class OrganizationUserFeedback extends React.Component {
+  static propTypes = {
+    organization: SentryTypes.Organization,
+    // selection: PropTypes.object,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {reportList: [], loading: true, error: false, pageLinks: ''};
+  }
+
+  componentDidMount() {
+    this.fetchData();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (
+      !isEqual(getQuery(prevProps.location.search), getQuery(this.props.location.search))
+    ) {
+      this.fetchData();
+    }
+  }
+
+  fetchData = () => {
+    this.setState({loading: true, error: false});
+
+    const query = getQuery(this.props.location.search);
+
+    fetchUserFeedback(this.props.organization, query)
+      .then(([reportList, _, jqXHR]) => {
+        this.setState({
+          reportList,
+          loading: false,
+          pageLinks: jqXHR.getResponseHeader('Link'),
+        });
+      })
+      .catch(() => this.setState({error: true, loading: false}));
+  };
+
+  renderNoAccess() {
+    return <Alert type="warning">{t("You don't have access to this feature")}</Alert>;
+  }
+
+  renderEmpty() {
+    return (
+      <EmptyStateWarning>
+        <p>{t('Sorry, no results match your serch query.')}</p>
+      </EmptyStateWarning>
+    );
+  }
+
   renderList() {
-    // TODO: implement this
+    if (!new Set(this.props.organization.features).has('sentry10')) {
+      return this.renderNoAccess();
+    }
+
+    if (this.state.loading) {
+      return <LoadingIndicator />;
+    }
+
+    if (this.state.error) {
+      return <LoadingError onRetry={this.fetchData} />;
+    }
+
+    if (this.state.reportList.length === 0) {
+      return this.renderEmpty();
+    }
+
+    return this.renderResults();
+  }
+
+  renderResults() {
+    const {orgId} = this.props.params;
+
+    const children = this.state.reportList.map(item => {
+      const issue = item.issue;
+      const projectId = issue.project.slug;
+      return (
+        <CompactIssue
+          key={item.id}
+          id={issue.id}
+          data={issue}
+          orgId={orgId}
+          projectId={projectId}
+        >
+          <EventUserFeedback
+            report={item}
+            orgId={orgId}
+            projectId={projectId}
+            issueId={issue.id}
+          />
+        </CompactIssue>
+      );
+    });
+
+    return children;
   }
 
   render() {
+    const {status} = getQuery(this.props.location.search);
     return (
-      <UserFeedbackContainer location={this.props.location} pageLinks={''} status={''}>
-        {this.renderList()}
-      </UserFeedbackContainer>
+      <Content>
+        <UserFeedbackContainer
+          location={this.props.location}
+          pageLinks={this.state.pageLinks}
+          status={status}
+        >
+          {this.renderList()}
+        </UserFeedbackContainer>
+      </Content>
     );
   }
 }
+
+const Content = styled('div')`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+  padding: ${space(2)} ${space(4)} ${space(3)};
+  margin-bottom: -20px; /* <footer> has margin-top: 20px; */
+`;
+
+export default withOrganization(withGlobalSelection(OrganizationUserFeedback));

--- a/src/sentry/static/sentry/app/views/userFeedback/utils.jsx
+++ b/src/sentry/static/sentry/app/views/userFeedback/utils.jsx
@@ -1,0 +1,49 @@
+import {Client} from 'app/api';
+import qs from 'query-string';
+
+const DEFAULT_STATUS = 'unresolved';
+
+/**
+ * Fetch user feedback for organization filtered by the query provided.
+ * Either statsPeriod or start, end and utc values should be provided.
+ *
+ * @param {Object} organization
+ * @param {Object} query
+ * @param {Number[]} query.projects
+ * @param {String[]} query.environments
+ * @param {String} [query.statsPeriod]
+ * @param {String} [query.start]
+ * @param {String} [query.end]
+ * @param {Boolean} [query.utc]
+ * @returns {Promise<Array>}
+ */
+export function fetchUserFeedback(organization, query = {}) {
+  const api = new Client();
+
+  return api.requestPromise(`/organizations/${organization.slug}/user-feedback/`, {
+    includeAllArgs: true,
+    query: {
+      per_page: 50,
+      ...query,
+    },
+  });
+}
+
+/**
+ * Get query for API given the current location.search string
+ * We are using qs.parse since location.query re-uses the same object making it
+ * incorrectly seem like the query string has not changed
+ *
+ * @param {String} search
+ * @returns {Object}
+ */
+export function getQuery(search) {
+  const query = qs.parse(search);
+
+  const status = typeof query.status !== 'undefined' ? query.status : DEFAULT_STATUS;
+  const cursor = query.cursor;
+
+  const queryParams = {status, cursor};
+
+  return queryParams;
+}


### PR DESCRIPTION
Implement basic version of org user feedback page behind sentry10
feature flag. This doesn't currently include the org header. Only currently
supports filtering by status, not environments, projects or datetime.