### PR TITLE
fix(alerts): Fixed spacing in event alert tags.

### DIFF
--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -7,6 +7,7 @@ sentry.models.event
 """
 from __future__ import absolute_import
 
+import re
 import six
 import string
 import warnings
@@ -327,6 +328,21 @@ class Event(Model):
 
 class EventSubjectTemplate(string.Template):
     idpattern = r'(tag:)?[_a-z][_a-z0-9]*'
+
+    def __init__(self, template):
+        super(EventSubjectTemplate, self).__init__(template)
+        self._space_tags()
+
+    def _space_tags(self):
+        """
+        Tags that are not followed by a space are not displayed correctly when shown as
+        the subject in the email. This adds an additional space between the tag and the
+        extra character that follows it.
+        """
+        self.template = re.sub(
+            r'(?P<tag>\$\{tag:[^}]+\})(?P<extra_char>\S)',
+            '\g<tag> \g<extra_char>',
+            self.template)
 
 
 class EventSubjectTemplateData(object):

--- a/tests/sentry/models/test_event.py
+++ b/tests/sentry/models/test_event.py
@@ -85,7 +85,7 @@ class EventTest(TestCase):
     def test_email_subject_with_template(self):
         self.project.update_option(
             'mail:subject_template',
-            '$shortID - ${tag:environment}@${tag:release} $$ $title ${tag:invalid} $invalid'
+            '$shortID - ${tag:environment} @${tag:release} $$ $title ${tag:invalid} $invalid'
         )
 
         event1 = self.create_event(
@@ -97,7 +97,24 @@ class EventTest(TestCase):
             message='baz',
         )
 
-        assert event1.get_email_subject() == 'BAR-1 - production@0 $ baz ${tag:invalid} $invalid'
+        assert event1.get_email_subject() == 'BAR-1 - production @0 $ baz ${tag:invalid} $invalid'
+
+    def test_email_subject_with_template_space_needed(self):
+        self.project.update_option(
+            'mail:subject_template',
+            '${tag:environment}- $title ${tag:release}12345'
+        )
+
+        event1 = self.create_event(
+            event_id='a' * 32,
+            group=self.group,
+            tags={'level': 'info',
+                  'environment': 'production',
+                  'sentry:release': '0'},
+            message='baz',
+        )
+
+        assert event1.get_email_subject() == 'production - baz 0 12345'
 
     def test_as_dict_hides_client_ip(self):
         event = self.create_event(


### PR DESCRIPTION
See Jira ISSUE-223 for the reason for the fix.