### PR TITLE
feat(Releases): OrganizationReleases accept commit ranges.

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -280,18 +280,11 @@ class Release(Model):
                 'commit': 'previous_commit..commit',
             }
         ]
+        Note: Overwrites 'previousCommit' and 'commit'
         """
-        def is_commit_range(commit):
-            return COMMIT_RANGE_DELIMITER in commit
-
-        def parse_commit_range(commit_range):
-            previous_commit, commit = commit_range.split(COMMIT_RANGE_DELIMITER)
-            return previous_commit, commit
-
         for ref in refs:
-            if is_commit_range(ref['commit']):
-                # TODO(lb): I'm just going to assume previous commit is None
-                ref['previousCommit'], ref['commit'] = parse_commit_range(ref['commit'])
+            if COMMIT_RANGE_DELIMITER in ref['commit']:
+                ref['previousCommit'], ref['commit'] = ref['commit'].split(COMMIT_RANGE_DELIMITER)
 
     def set_refs(self, refs, user, fetch=False):
         from sentry.api.exceptions import InvalidRepository

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -11,7 +11,8 @@ from __future__ import absolute_import
 __all__ = (
     'TestCase', 'TransactionTestCase', 'APITestCase', 'TwoFactorAPITestCase', 'AuthProviderTestCase', 'RuleTestCase',
     'PermissionTestCase', 'PluginTestCase', 'CliTestCase', 'AcceptanceTestCase',
-    'IntegrationTestCase', 'UserReportEnvironmentTestCase', 'SnubaTestCase', 'IntegrationRepositoryTestCase', 'ReleaseCommitPatchTest'
+    'IntegrationTestCase', 'UserReportEnvironmentTestCase', 'SnubaTestCase', 'IntegrationRepositoryTestCase',
+    'ReleaseCommitPatchTest', 'SetRefsTestCase'
 )
 
 import base64
@@ -54,7 +55,7 @@ from sentry.auth.superuser import (
 )
 from sentry.constants import MODULE_ROOT
 from sentry.models import (
-    GroupEnvironment, GroupHash, GroupMeta, ProjectOption, DeletedOrganization,
+    GroupEnvironment, GroupHash, GroupMeta, ProjectOption, Repository, DeletedOrganization,
     Environment, GroupStatus, Organization, TotpInterface, UserReport,
 )
 from sentry.plugins import plugins
@@ -963,3 +964,45 @@ class ReleaseCommitPatchTest(APITestCase):
         assert file_change.type == type
         assert file_change.filename == filename
         assert file_change.commit_id == commit_id
+
+
+class SetRefsTestCase(APITestCase):
+    def setUp(self):
+        super(SetRefsTestCase, self).setUp()
+        self.user = self.create_user(is_staff=False, is_superuser=False)
+        self.org = self.create_organization()
+
+        self.team = self.create_team(organization=self.org)
+        self.project = self.create_project(name='foo', organization=self.org, teams=[self.team])
+        self.create_member(teams=[self.team], user=self.user, organization=self.org)
+        self.login_as(user=self.user)
+
+        self.group = self.create_group(project=self.project)
+        self.repo = Repository.objects.create(
+            organization_id=self.org.id,
+            name='test/repo',
+        )
+
+    def assert_fetch_commits(self, mock_fetch_commit, prev_release_id, release_id, refs):
+        assert len(mock_fetch_commit.method_calls) == 1
+        kwargs = mock_fetch_commit.method_calls[0][2]['kwargs']
+        assert kwargs == {
+            'prev_release_id': prev_release_id,
+            'refs': refs,
+            'release_id': release_id,
+            'user_id': self.user.id,
+        }
+
+    def assert_head_commit(self, head_commit, commit_key, release_id=None):
+        assert self.org.id == head_commit.organization_id
+        assert self.repo.id == head_commit.repository_id
+        if release_id:
+            assert release_id == head_commit.release_id
+        else:
+            assert self.release.id == head_commit.release_id
+        self.assert_commit(head_commit.commit, commit_key)
+
+    def assert_commit(self, commit, key):
+        assert self.org.id == commit.organization_id
+        assert self.repo.id == commit.repository_id
+        assert commit.key == key

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -543,3 +543,85 @@ class SetCommitsTestCase(TestCase):
         assert resolution.actor_id is None
 
         assert Group.objects.get(id=group.id).status == GroupStatus.RESOLVED
+
+
+class SetRefsTestCase(TestCase):
+    def setUp(self):
+        super(SetRefsTestCase, self).setUp()
+        self.org = self.create_organization()
+        self.project = self.create_project(organization=self.org, name='foo')
+        self.group = self.create_group(project=self.project)
+
+        self.repo = Repository.objects.create(
+            organization_id=self.org.id,
+            name='test/repo',
+        )
+        self.release = Release.objects.create(version='abcdabc', organization=self.org)
+        self.release.add_project(self.project)
+
+    @patch('sentry.tasks.commits.fetch_commits')
+    def test_simple(self):
+        refs = [
+            {
+                'repository': 'repository-name',
+                'previousCommit': 'previous-commit-id',
+                'commit': 'current-commit-id',
+            },
+            {
+                'repository': 'repository-name',
+                'previousCommit': 'previous-commit-id-2',
+                'commit': 'current-commit-id-2',
+            }
+        ]
+
+        self.release.set_refs(refs)
+
+    @patch('sentry.tasks.commits.fetch_commits')
+    def test_invalid_repos(self):
+        refs = [
+            {
+                'repository': 'repository-name',
+                'previousCommit': 'previous-commit-id',
+                'commit': 'current-commit-id',
+            },
+            {
+                'repository': 'repository-name',
+                'previousCommit': 'previous-commit-id-2',
+                'commit': 'current-commit-id-2',
+            }
+        ]
+
+        self.release.set_refs(refs)
+
+    @patch('sentry.tasks.commits.fetch_commits')
+    def test_handle_commit_ranges(self):
+        refs = [
+            {
+                'repository': 'repository-name',
+                'previousCommit': 'previous-commit-id',
+                'commit': 'current-commit-id',
+            },
+            {
+                'repository': 'repository-name',
+                'previousCommit': 'previous-commit-id-2',
+                'commit': 'current-commit-id-2',
+            }
+        ]
+
+        self.release.set_refs(refs)
+
+    def test_fetch_false(self):
+        refs = [
+            {
+                'repository': 'repository-name',
+                'previousCommit': 'previous-commit-id',
+                'commit': 'current-commit-id',
+            },
+            {
+                'repository': 'repository-name',
+                'previousCommit': 'previous-commit-id-2',
+                'commit': 'current-commit-id-2',
+            }
+        ]
+
+        self.release.set_refs(refs)


### PR DESCRIPTION
From the comments here: https://github.com/getsentry/sentry/issues/5728

The commit range is specified by `previousCommitSha..commitSha` and placed in the `['refs']['commit']` field of `OrganizationReleases`. I made the deprecated `headCommit` field also compatible with this format. Note that anything in `['refs']['previousCommit']` when the `[commit]` field has the commit range format will be overwritten.
