### PR TITLE
fix(event_manager): Handle invalid timestamp values gracefully

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -191,7 +191,7 @@ def process_timestamp(value, meta, current_datetime=None):
         except Exception:
             meta.add_error(EventError.INVALID_DATA, original_value)
             return None
-    elif not isinstance(value, datetime):
+    elif isinstance(value, six.string_types):
         # all timestamps are in UTC, but the marker is optional
         if value.endswith('Z'):
             value = value[:-1]
@@ -208,6 +208,9 @@ def process_timestamp(value, meta, current_datetime=None):
         except Exception:
             meta.add_error(EventError.INVALID_DATA, original_value)
             return None
+    elif not isinstance(value, datetime):
+        meta.add_error(EventError.INVALID_DATA, original_value)
+        return None
 
     if current_datetime is None:
         current_datetime = datetime.now()

--- a/tests/sentry/event_manager/test_process_timestamp.py
+++ b/tests/sentry/event_manager/test_process_timestamp.py
@@ -50,3 +50,6 @@ class ProcessTimestampTest(TestCase):
             self.meta,
             current_datetime=datetime(2012, 1, 1, 10, 30, 45),
         ) == 1325413845.0
+
+    def test_invalid_type(self):
+        assert process_timestamp({}, self.meta) is None


### PR DESCRIPTION
Fixes [SENTRY-8QY](https://sentry.io/sentry/sentry/issues/807285378)