### PR TITLE
fix(unreal): remove legacy callstack

### DIFF
--- a/src/sentry/lang/native/unreal.py
+++ b/src/sentry/lang/native/unreal.py
@@ -7,10 +7,8 @@ from sentry.utils.safe import set_path, setdefault_path
 import re
 import uuid
 
-_frame_regexp = re.compile(
-    r'^(?P<package>[\w]+)(!(?P<function>[^\[\n]+)?(\[(?P<filename>.*):(?P<lineno>\d+)\])?)?$')
 _portable_callstack_regexp = re.compile(
-    r'(?P<module>[\w]+) (?P<baseaddr>0x[\da-fA-F]+) \+ (?P<offset>[\da-fA-F]+)')
+    r'((?P<package>[\w]+) )?(?P<baseaddr>0x[\da-fA-F]+) \+ (?P<offset>[\da-fA-F]+)')
 
 
 def process_unreal_crash(data):
@@ -68,36 +66,28 @@ def merge_unreal_context_event(unreal_context, event, project):
             comments=user_desc,
         )
 
-    portable_callstack_list = []
     portable_callstack = runtime_prop.pop('portable_call_stack', None)
     if portable_callstack is not None:
-        for match in _portable_callstack_regexp.finditer(portable_callstack):
-            addr = hex(int(match.group('baseaddr'), 16) + int(match.group('offset'), 16))
-            portable_callstack_list.append(addr)
-
-    legacy_callstack = runtime_prop.pop('legacy_call_stack', None)
-    if legacy_callstack is not None:
-        traces = legacy_callstack.split('\n')
-
         frames = []
-        for i, trace in enumerate(traces):
-            match = _frame_regexp.match(trace)
-            if not match:
+
+        for match in _portable_callstack_regexp.finditer(portable_callstack):
+            baseaddr = int(match.group('baseaddr'), 16)
+            offset = int(match.group('offset'), 16)
+            # Crashes without PDB in the client report: 0x00000000ffffffff + ffffffff
+            if baseaddr == 0xffffffff and offset == 0xffffffff:
                 continue
 
             frames.append({
                 'package': match.group('package'),
-                'lineno': match.group('lineno'),
-                'filename': match.group('filename'),
-                'function': match.group('function'),
-                'in_app': match.group('function') is not None,
-                'instruction_addr': portable_callstack_list[i],
+                'instruction_addr': hex(baseaddr + offset),
             })
 
-        frames.reverse()
-        event['stacktrace'] = {
-            'frames': frames
-        }
+            frames.reverse()
+
+        if len(frames) > 0:
+            event['stacktrace'] = {
+                'frames': frames
+            }
 
     # drop modules. minidump processing adds 'images loaded'
     runtime_prop.pop('modules', None)

--- a/tests/sentry/lang/native/test_unreal.py
+++ b/tests/sentry/lang/native/test_unreal.py
@@ -172,9 +172,8 @@ class UnrealIntegrationTest(TestCase):
         bt = event.interfaces['exception'].values[0].stacktrace
         frames = bt.frames
         main = frames[-1]
-        assert main.function == 'AActor::IsPendingKillPending()'
         assert main.errors is None
-        assert main.instruction_addr == '0x54be3394'
+        assert main.instruction_addr == '0xfd53034'
 
         attachments = sorted(
             EventAttachment.objects.filter(


### PR DESCRIPTION
Epic games removed legacy callstack in 4.21.
We're removing it as it also doesn't match the portable one sometimes.