### PR TITLE
fix(ui): Fix z-index of global selection header

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/header.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/header.jsx
@@ -6,7 +6,7 @@ const Header = styled(Flex)`
   box-shadow: ${p => p.theme.dropShadowLight};
   font-size: ${p => p.theme.fontSizeExtraLarge};
   height: 60px;
-  z-index: 1;
+  z-index: 3;
   position: relative;
   width: 100%;
   background: #fff;

--- a/src/sentry/static/sentry/app/components/organizations/header.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/header.jsx
@@ -6,7 +6,7 @@ const Header = styled(Flex)`
   box-shadow: ${p => p.theme.dropShadowLight};
   font-size: ${p => p.theme.fontSizeExtraLarge};
   height: 60px;
-  z-index: 3;
+  z-index: ${p => p.theme.zIndex.header};
   position: relative;
   width: 100%;
   background: #fff;


### PR DESCRIPTION
This component needs a higher z-index to ensure that the project,
environment and time dropdowns get rendered on top of various other
content that might be on the page.