### PR TITLE
build(webpack): Remove json-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "jed": "^1.1.0",
     "jquery": "2.1.4",
     "js-cookie": "2.0.4",
-    "json-loader": "0.5.3",
     "less": "2.5.3",
     "less-loader": "^4.0.3",
     "lodash": "^4.17.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -114,10 +114,6 @@ var appConfig = {
         },
       },
       {
-        test: /\.json$/,
-        loader: 'json-loader',
-      },
-      {
         test: /app\/icons\/.*\.svg$/,
         use: [
           {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7285,11 +7285,6 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
-json-loader@0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.3.tgz#fde8311d5c3414f608260e3d93135050d17a5593"
-  integrity sha1-/egxHVw0FPYIJg49kxNQUNF6VZM=
-
 json-loader@^0.5.4, json-loader@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"


### PR DESCRIPTION
From the loaders documentation

> Since webpack >= v2.0.0, importing of JSON files will work by default. You might still want to use this if you use a custom file extension.

We don't use a custom extension. The loader is also deprecated and unmaintained.

❄️ Code freeze in place until 2019. Do not merge.