### PR TITLE
fix(ui): correct typo in tagDistributionMeter color array

### DIFF
--- a/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
+++ b/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
@@ -231,7 +231,7 @@ const getColor = p => {
     '#bbb7ca',
     '#c5c3d6',
     '#d0cee1',
-    'dad9ed',
+    '#dad9ed',
   ][p.index];
 };
 


### PR DESCRIPTION
resolved this visual bug:

![image](https://user-images.githubusercontent.com/435981/50308189-63837d80-044f-11e9-9644-468d0836e6be.png)
