### PR TITLE
fix(webpack): Correct bad chunkname in routes

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -464,7 +464,7 @@ function routes() {
         path="auth/"
         name="Auth Providers"
         componentPromise={() =>
-          import(/*webpackChunkName: OrganizationAuth*/ './views/settings/organizationAuth')}
+          import(/*webpackChunkName: "OrganizationAuth"*/ './views/settings/organizationAuth')}
         component={errorHandler(LazyLoad)}
       />
 


### PR DESCRIPTION
The quotes were missing.

❄️ Code freeze in place until 2019. Do not merge.