### PR TITLE
ref(releases): Make release artifacts component work for org releases

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -914,7 +914,7 @@ function routes() {
             <Route
               path="artifacts/"
               componentPromise={() =>
-                import(/*webpackChunkName:"ReleaseArtifacts"*/ './views/releases/detail/project/releaseArtifacts')}
+                import(/*webpackChunkName:"ReleaseArtifacts"*/ './views/releases/detail/shared/releaseArtifacts')}
               component={errorHandler(LazyLoad)}
             />
             <Route

--- a/src/sentry/static/sentry/app/views/releases/detail/shared/releaseArtifacts.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/shared/releaseArtifacts.jsx
@@ -46,10 +46,12 @@ const ReleaseArtifacts = createReactClass({
   },
 
   getFilesEndpoint() {
-    let params = this.props.params;
-    return `/projects/${params.orgId}/${params.projectId}/releases/${encodeURIComponent(
-      params.version
-    )}/files/`;
+    let {orgId, projectId, version} = this.props.params;
+    let encodedVersion = encodeURIComponent(version);
+
+    return projectId
+      ? `/projects/${orgId}/${projectId}/releases/${encodedVersion}/files/`
+      : `/organizations/${orgId}/releases/${encodedVersion}/files/`;
   },
 
   fetchData() {

--- a/tests/js/spec/views/releases/detail/releaseArtifacts.spec.jsx
+++ b/tests/js/spec/views/releases/detail/releaseArtifacts.spec.jsx
@@ -147,11 +147,20 @@ describe('ReleaseArtifacts', function() {
   });
 
   describe('fetchData()', function() {
-    it('should append the location query string to the request URL', function() {
+    it('fetches data for project releases', function() {
       wrapper.instance().fetchData();
 
       let apiArgs = stubbedApiRequest.lastCall.args;
       expect(apiArgs[0]).toEqual('/projects/123/456/releases/abcdef/files/');
+      expect(apiArgs[1].data).toHaveProperty('cursor', '0:0:100');
+    });
+
+    it('fetches data for orgazniation releases', function() {
+      wrapper.setProps({params: {orgId: '123', version: 'abcdef'}});
+      wrapper.instance().fetchData();
+
+      let apiArgs = stubbedApiRequest.lastCall.args;
+      expect(apiArgs[0]).toEqual('/organizations/123/releases/abcdef/files/');
       expect(apiArgs[1].data).toHaveProperty('cursor', '0:0:100');
     });
   });

--- a/tests/js/spec/views/releases/detail/releaseArtifacts.spec.jsx
+++ b/tests/js/spec/views/releases/detail/releaseArtifacts.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import {Client} from 'app/api';
-import ReleaseArtifacts from 'app/views/releases/detail/project/releaseArtifacts';
+import ReleaseArtifacts from 'app/views/releases/detail/shared/releaseArtifacts';
 
 describe('ReleaseArtifacts', function() {
   let sandbox;


### PR DESCRIPTION
Release artifacts component fetches data from org release artifacts
component if a projectId is not present in the route.