### PR TITLE
feat(require-2fa): restrict sso with require 2fa 

### DIFF
--- a/src/sentry/api/endpoints/organization_auth_providers.py
+++ b/src/sentry/api/endpoints/organization_auth_providers.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from rest_framework.response import Response
 
 from sentry.auth import manager
-from sentry.auth.providers.saml2 import SAML2Provider
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationAuthProviderPermission
 from sentry.api.serializers import serialize
 
@@ -25,7 +24,6 @@ class OrganizationAuthProvidersEndpoint(OrganizationEndpoint):
                 'key': k,
                 'name': v.name,
                 'requiredFeature': v.required_feature,
-                'disables2FA': issubclass(v, SAML2Provider),
             })
 
         return Response(serialize(provider_list, request.user))

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -26,7 +26,7 @@ from sentry.utils.cache import memoize
 ERR_DEFAULT_ORG = 'You cannot remove the default organization.'
 ERR_NO_USER = 'This request requires an authenticated user.'
 ERR_NO_2FA = 'Cannot require two-factor authentication without personal two-factor enabled.'
-ERR_SSO_ENABLED = 'Cannot require two-factor authentication with SAML SSO enabled'
+ERR_SSO_ENABLED = 'Cannot require two-factor authentication with SSO enabled'
 
 ORG_OPTIONS = (
     # serializer field name, option key name, type, default value

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -859,10 +859,13 @@ class AuthHelper(object):
 
     def disable_2fa_required(self):
         require_2fa = self.organization.flags.require_2fa
-        if require_2fa and require_2fa.is_set:
-            self.organization.update(
-                flags=F('flags').bitand(~Organization.flags.require_2fa)
-            )
+
+        if not require_2fa or not require_2fa.is_set:
+            return
+
+        self.organization.update(
+            flags=F('flags').bitand(~Organization.flags.require_2fa)
+        )
 
         logger.info(
             'Require 2fa disabled during sso setup',

--- a/src/sentry/static/sentry/app/views/settings/organizationAuth/organizationAuthList.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuth/organizationAuthList.jsx
@@ -43,9 +43,8 @@ class OrganizationAuthList extends React.Component {
 
     const warn2FADisable =
       organization.require2FA &&
-      providerList.some(
-        ({requiredFeature, disables2FA}) =>
-          disables2FA && features.includes(descopeFeatureName(requiredFeature))
+      providerList.some(({requiredFeature}) =>
+        features.includes(descopeFeatureName(requiredFeature))
       );
 
     return (
@@ -68,9 +67,7 @@ class OrganizationAuthList extends React.Component {
 
             {warn2FADisable && (
               <PanelAlert m={0} mb={0} type="warning">
-                {t(
-                  'Require 2FA will be disabled if you enable SAML-based SSO (Okta, OneLogin, Auth0, etc.)'
-                )}
+                {t('Require 2FA will be disabled if you enable SSO')}
               </PanelAlert>
             )}
 

--- a/src/sentry/static/sentry/app/views/settings/organizationAuth/organizationAuthList.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuth/organizationAuthList.jsx
@@ -67,7 +67,7 @@ class OrganizationAuthList extends React.Component {
 
             {warn2FADisable && (
               <PanelAlert m={0} mb={0} type="warning">
-                {t('Require 2FA will be disabled if you enable SSO')}
+                {t('Require 2FA will be disabled if you enable SSO.')}
               </PanelAlert>
             )}
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -474,12 +474,14 @@ class TwoFactorAPITestCase(APITestCase):
     def assert_can_enable_org_2fa(self, organization, user, status_code=200):
         self.__helper_enable_organization_2fa(organization, user, status_code)
 
-    def assert_cannot_enable_org_2fa(self, organization, user, status_code):
-        self.__helper_enable_organization_2fa(organization, user, status_code)
+    def assert_cannot_enable_org_2fa(self, organization, user, status_code, err_msg=None):
+        self.__helper_enable_organization_2fa(organization, user, status_code, err_msg)
 
-    def __helper_enable_organization_2fa(self, organization, user, status_code):
+    def __helper_enable_organization_2fa(self, organization, user, status_code, err_msg=None):
         response = self.api_enable_org_2fa(organization, user)
-        assert response.status_code == status_code, response.content
+        assert response.status_code == status_code
+        if err_msg:
+            assert err_msg in response.content
         organization = Organization.objects.get(id=organization.id)
 
         if status_code >= 200 and status_code < 300:

--- a/tests/js/fixtures/authProviders.js
+++ b/tests/js/fixtures/authProviders.js
@@ -1,13 +1,13 @@
 export function AuthProviders(params = []) {
   return [
     {
-      key: 'github',
-      name: 'Github',
+      key: 'dummy',
+      name: 'Dummy',
       requiredFeature: 'organizations:sso-basic',
     },
     {
-      key: 'sam2',
-      name: 'SAML2',
+      key: 'dummy2',
+      name: 'Dummy SAML',
       requiredFeature: 'organizations:sso-saml2',
     },
     ...params,

--- a/tests/js/fixtures/authProviders.js
+++ b/tests/js/fixtures/authProviders.js
@@ -1,15 +1,13 @@
 export function AuthProviders(params = []) {
   return [
     {
-      disables2FA: false,
-      key: 'dummy',
-      name: 'Dummy',
+      key: 'github',
+      name: 'Github',
       requiredFeature: 'organizations:sso-basic',
     },
     {
-      disables2FA: true,
-      key: 'dummy2',
-      name: 'Dummy SAML',
+      key: 'sam2',
+      name: 'SAML2',
       requiredFeature: 'organizations:sso-saml2',
     },
     ...params,

--- a/tests/js/spec/views/settings/__snapshots__/organizationAuthList.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationAuthList.spec.jsx.snap
@@ -68,23 +68,23 @@ exports[`OrganizationAuthList renders 1`] = `
           value="1"
         />
         <ProviderItem
-          key="github"
+          key="dummy"
           onConfigure={[Function]}
           provider={
             Object {
-              "key": "github",
-              "name": "Github",
+              "key": "dummy",
+              "name": "Dummy",
               "requiredFeature": "organizations:sso-basic",
             }
           }
         />
         <ProviderItem
-          key="sam2"
+          key="dummy2"
           onConfigure={[Function]}
           provider={
             Object {
-              "key": "sam2",
-              "name": "SAML2",
+              "key": "dummy2",
+              "name": "Dummy SAML",
               "requiredFeature": "organizations:sso-saml2",
             }
           }

--- a/tests/js/spec/views/settings/__snapshots__/organizationAuthList.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationAuthList.spec.jsx.snap
@@ -68,25 +68,23 @@ exports[`OrganizationAuthList renders 1`] = `
           value="1"
         />
         <ProviderItem
-          key="dummy"
+          key="github"
           onConfigure={[Function]}
           provider={
             Object {
-              "disables2FA": false,
-              "key": "dummy",
-              "name": "Dummy",
+              "key": "github",
+              "name": "Github",
               "requiredFeature": "organizations:sso-basic",
             }
           }
         />
         <ProviderItem
-          key="dummy2"
+          key="sam2"
           onConfigure={[Function]}
           provider={
             Object {
-              "disables2FA": true,
-              "key": "dummy2",
-              "name": "Dummy SAML",
+              "key": "sam2",
+              "name": "SAML2",
               "requiredFeature": "organizations:sso-saml2",
             }
           }

--- a/tests/js/spec/views/settings/organizationAuthList.spec.jsx
+++ b/tests/js/spec/views/settings/organizationAuthList.spec.jsx
@@ -48,9 +48,27 @@ describe('OrganizationAuthList', function() {
 
   describe('with 2fa warning', function() {
     const require2fa = {require2FA: true};
+    const withSSO = {features: ['sso-basic']};
     const withSAML = {features: ['sso-saml2']};
 
     it('renders', function() {
+      let context = TestStubs.routerContext([
+        {organization: TestStubs.Organization({...require2fa, ...withSSO})},
+      ]);
+
+      let wrapper = shallow(
+        <OrganizationAuthList
+          orgId="org-slug"
+          onSendReminders={() => {}}
+          providerList={TestStubs.AuthProviders()}
+        />,
+        context
+      );
+
+      expect(wrapper.find('PanelAlert[type="warning"]').exists()).toBe(true);
+    });
+
+    it('renders with saml available', function() {
       let context = TestStubs.routerContext([
         {organization: TestStubs.Organization({...require2fa, ...withSAML})},
       ]);
@@ -67,7 +85,7 @@ describe('OrganizationAuthList', function() {
       expect(wrapper.find('PanelAlert[type="warning"]').exists()).toBe(true);
     });
 
-    it('does not render warning without saml available', function() {
+    it('does not render without sso available', function() {
       let context = TestStubs.routerContext([
         {organization: TestStubs.Organization({...require2fa})},
       ]);
@@ -84,7 +102,24 @@ describe('OrganizationAuthList', function() {
       expect(wrapper.find('PanelAlert[type="warning"]').exists()).toBe(false);
     });
 
-    it('does not render without require 2fa enabled', function() {
+    it('does not render with sso and require 2fa disabled', function() {
+      let context = TestStubs.routerContext([
+        {organization: TestStubs.Organization({...withSSO})},
+      ]);
+
+      let wrapper = shallow(
+        <OrganizationAuthList
+          orgId="org-slug"
+          onSendReminders={() => {}}
+          providerList={TestStubs.AuthProviders()}
+        />,
+        context
+      );
+
+      expect(wrapper.find('PanelAlert[type="warning"]').exists()).toBe(false);
+    });
+
+    it('does not render with saml and require 2fa disabled', function() {
       let context = TestStubs.routerContext([
         {organization: TestStubs.Organization({...withSAML})},
       ]);

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -131,7 +131,7 @@ class AuthSAML2Test(AuthProviderTestCase):
         assert auth.status_code == 200
         assert auth.context['existing_user'] == self.user
 
-    @mock.patch('sentry.auth.providers.saml2.logger')
+    @mock.patch('sentry.auth.helper.logger')
     def test_auth_setup(self, auth_log):
         self.auth_provider.delete()
         self.login_as(self.user)
@@ -162,9 +162,9 @@ class AuthSAML2Test(AuthProviderTestCase):
             event=AuditLogEntryEvent.ORG_EDIT,
             actor=self.user
         )
-        assert 'require_2fa to False when enabling SAML SSO' in event.get_note()
+        assert 'require_2fa to False when enabling SSO' in event.get_note()
         auth_log.info.assert_called_once_with(
-            'Require 2fa disabled during saml sso setup',
+            'Require 2fa disabled during sso setup',
             extra={
                 'organization_id': self.org.id
             }


### PR DESCRIPTION
Not allowing require 2FA with SSO for now, since users can join an organization via SSO without an invite. If a member was booted out of the organization for not having 2FA, there's a few cases where on rejoining without an invite a new organization member could be created instead of attaching to the previous one. They'd lose their role and teams.