### PR TITLE
fix(stacktraces): Ignore suffix in Java generated classes

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -36,6 +36,17 @@ _filename_version_re = re.compile(
 )/""", re.X | re.I
 )
 
+# OpenJDK auto-generated classes for reflection access:
+#   sun.reflect.GeneratedSerializationConstructorAccessor123
+#   sun.reflect.GeneratedConstructorAccessor456
+# Note that this doesn't cover the following pattern for the sake of
+# backward compatibility (to not to change the existing grouping):
+#   sun.reflect.GeneratedMethodAccessor789
+_java_reflect_enhancer_re = re.compile(
+    r'''(sun\.reflect\.Generated(?:Serialization)?ConstructorAccessor)\d+''',
+    re.X
+)
+
 # Java Spring specific anonymous classes.
 # see: http://mydailyjava.blogspot.co.at/2013/11/cglib-missing-manual.html
 _java_cglib_enhancer_re = re.compile(r'''(\$\$[\w_]+?CGLIB\$\$)[a-fA-F0-9]+(_[0-9]+)?''', re.X)
@@ -198,6 +209,7 @@ def remove_module_outliers(module, platform=None):
     if platform == 'java':
         if module[:35] == 'sun.reflect.GeneratedMethodAccessor':
             return 'sun.reflect.GeneratedMethodAccessor'
+        module = _java_reflect_enhancer_re.sub(r'\1<auto>', module)
         module = _java_cglib_enhancer_re.sub(r'\1<auto>', module)
         module = _java_assist_enhancer_re.sub(r'\1<auto>', module)
         module = _clojure_enhancer_re.sub(r'\1<auto>', module)

--- a/tests/sentry/interfaces/test_stacktrace.py
+++ b/tests/sentry/interfaces/test_stacktrace.py
@@ -392,6 +392,31 @@ class StacktraceTest(TestCase):
             ]
         )
 
+    def test_get_hash_ignores_sun_java_generated_constructors(self):
+        interface = Frame.to_python(
+            {
+                'module': 'sun.reflect.GeneratedSerializationConstructorAccessor1',
+                'function': 'invoke',
+            }
+        )
+        result = interface.get_hash(platform='java')
+        self.assertEquals(result, [
+            'sun.reflect.GeneratedSerializationConstructorAccessor<auto>',
+            'invoke',
+        ])
+
+        interface = Frame.to_python(
+            {
+                'module': 'sun.reflect.GeneratedConstructorAccessor2',
+                'function': 'invoke',
+            }
+        )
+        result = interface.get_hash(platform='java')
+        self.assertEquals(result, [
+            'sun.reflect.GeneratedConstructorAccessor<auto>',
+            'invoke',
+        ])
+
     def test_get_hash_ignores_sun_java_generated_methods(self):
         interface = Frame.to_python(
             {


### PR DESCRIPTION
OpenJDK reflection generates classes with unpredictable suffix which should not be considered when calculating a hash for a frame in Sentry stack trace.

One of the cases was supported earlier, this change _makes matching stricter_, i.e. not just by "startsWith" but by full name pattern match:

* `sun.reflect.GeneratedMethodAccessor`

And also adds two more patterns for auto-generated classes from `sun.reflect`:

* `sun.reflect.GeneratedSerializationConstructorAccessor`
* `sun.reflect.GeneratedConstructorAccessor`

[Here's a link](https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/999dbd4192d0f819cb5224f26e9e7fa75ca6f289/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java#L756-L763) to OpenJDK source where classes with these names are generated (link is for a mirror of JDK 11 but the code is same up to at least JDK 7).

