### PR TITLE
ref(anaytics): Add cta to progress bar analytics

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/list/projectReleases/releaseProgress.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/projectReleases/releaseProgress.jsx
@@ -86,14 +86,19 @@ class ReleaseProgress extends AsyncComponent {
     let remainingSteps;
     if (setupStatus) {
       remainingSteps = setupStatus.filter(step => step.complete === false);
+
+      let nextStep = remainingSteps[0] && STEPS[remainingSteps[0].step];
+
       this.buildMessage(remainingSteps);
+
       this.setState({
         remainingSteps: Object.keys(remainingSteps).length,
-        nextStep: remainingSteps[0] && STEPS[remainingSteps[0].step],
+        nextStep,
       });
 
       this.recordAnalytics('viewed', {
         steps: setupStatus,
+        ...(nextStep && {cta: nextStep.desc}),
       });
     }
   }


### PR DESCRIPTION
Adds the cta to the progress bar view events. Can be deduced but this makes it easier