### PR TITLE
feat(integrations): Update Comment Sync 

### DIFF
--- a/src/sentry/api/bases/group.py
+++ b/src/sentry/api/bases/group.py
@@ -7,7 +7,7 @@ from sentry.api.bases.project import ProjectPermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.utils.sdk import configure_scope
 from sentry.models import Group, GroupLink, GroupStatus, get_group_with_redirect
-from sentry.tasks.integrations import delete_comment, post_comment, update_comment
+from sentry.tasks.integrations import delete_comment, create_comment, update_comment
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ class GroupEndpoint(Endpoint):
         return (args, kwargs)
 
     def create_external_comment(self, request, group, group_note):
-        self._sync_comment(self, request, group, group_note, post_comment)
+        self._sync_comment(self, request, group, group_note, create_comment)
 
     def update_external_comment(self, request, group, group_note):
         self._sync_comment(self, request, group, group_note, update_comment)

--- a/src/sentry/api/bases/group.py
+++ b/src/sentry/api/bases/group.py
@@ -7,7 +7,7 @@ from sentry.api.bases.project import ProjectPermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.utils.sdk import configure_scope
 from sentry.models import Group, GroupLink, GroupStatus, get_group_with_redirect
-from sentry.tasks.integrations import delete_comment, create_comment, update_comment
+from sentry.tasks.integrations import create_comment, update_comment
 
 logger = logging.getLogger(__name__)
 
@@ -88,16 +88,6 @@ class GroupEndpoint(Endpoint):
                 kwargs={
                     'external_issue_id': external_issue_id,
                     'group_note_id': group_note.id,
-                    'user_id': request.user.id,
-                }
-            )
-
-    def delete_external_comment(self, request, group, group_note):
-        for external_issue_id in self.get_external_issue_ids(group):
-            delete_comment.apply_async(
-                kwargs={
-                    'external_issue_id': external_issue_id,
-                    'external_comment_id': group_note.data['external_id'],
                     'user_id': request.user.id,
                 }
             )

--- a/src/sentry/api/endpoints/group_notes.py
+++ b/src/sentry/api/endpoints/group_notes.py
@@ -102,5 +102,5 @@ class GroupNotesEndpoint(GroupEndpoint):
 
         activity.send_notification()
 
-        self.sync_comment(request, group, activity, 'create')
+        self.create_external_comment(request, group, activity)
         return Response(serialize(activity, request.user), status=201)

--- a/src/sentry/api/endpoints/group_notes_details.py
+++ b/src/sentry/api/endpoints/group_notes_details.py
@@ -32,6 +32,7 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
 
         note.delete()
 
+        self.sync_comment(request, group, note, 'delete')
         return Response(status=204)
 
     def put(self, request, group, note_id):
@@ -55,6 +56,7 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
             note.data = dict(serializer.object)
             note.save()
 
+            self.sync_comment(request, group, note, 'update')
             return Response(serialize(note, request.user), status=200)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/group_notes_details.py
+++ b/src/sentry/api/endpoints/group_notes_details.py
@@ -32,7 +32,7 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
 
         note.delete()
 
-        self.sync_comment(request, group, note, 'delete')
+        self.delete_external_comment(request, group, note)
         return Response(status=204)
 
     def put(self, request, group, note_id):
@@ -56,7 +56,7 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
             note.data = dict(serializer.object)
             note.save()
 
-            self.sync_comment(request, group, note, 'update')
+            self.update_external_comment(request, group, note)
             return Response(serialize(note, request.user), status=200)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/group_notes_details.py
+++ b/src/sentry/api/endpoints/group_notes_details.py
@@ -53,7 +53,9 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
 
         if serializer.is_valid():
             # Would be nice to have a last_modified timestamp we could bump here
+            external_id = note.data.get('external_id')
             note.data = dict(serializer.object)
+            note.data['external_id'] = external_id
             note.save()
 
             self.update_external_comment(request, group, note)

--- a/src/sentry/api/endpoints/group_notes_details.py
+++ b/src/sentry/api/endpoints/group_notes_details.py
@@ -32,7 +32,6 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
 
         note.delete()
 
-        self.delete_external_comment(request, group, note)
         return Response(status=204)
 
     def put(self, request, group, note_id):

--- a/src/sentry/api/endpoints/group_notes_details.py
+++ b/src/sentry/api/endpoints/group_notes_details.py
@@ -52,12 +52,10 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
 
         if serializer.is_valid():
             # Would be nice to have a last_modified timestamp we could bump here
-            external_id = note.data.get('external_id')
             note.data = dict(serializer.object)
-            note.data['external_id'] = external_id
             note.save()
-
-            self.update_external_comment(request, group, note)
+            if note.data.get('external_id'):
+                self.update_external_comment(request, group, note)
             return Response(serialize(note, request.user), status=200)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/group_notes_details.py
+++ b/src/sentry/api/endpoints/group_notes_details.py
@@ -52,7 +52,7 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
 
         if serializer.is_valid():
             # Would be nice to have a last_modified timestamp we could bump here
-            note.data = dict(serializer.object)
+            note.data.update(dict(serializer.object))
             note.save()
             if note.data.get('external_id'):
                 self.update_external_comment(request, group, note)

--- a/src/sentry/api/serializers/rest_framework/group_notes.py
+++ b/src/sentry/api/serializers/rest_framework/group_notes.py
@@ -25,6 +25,7 @@ def seperate_resolved_actors(actors):
 class NoteSerializer(serializers.Serializer):
     text = serializers.CharField()
     mentions = ListField(child=ActorField(), required=False)
+    external_id = serializers.CharField(allow_none=True, required=False)
 
     def validate_mentions(self, attrs, source):
         if source in attrs and 'group' in self.context:

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -65,7 +65,11 @@ class ExampleIntegration(IntegrationInstallation, IssueSyncMixin):
     def create_comment(self, issue_id, user_id, group_note):
         user = User.objects.get(id=user_id)
         attribution = '%s wrote:\n\n' % user.name
-        return '%s<blockquote>%s</blockquote>' % (attribution, group_note.data['text'])
+        comment = {
+            'id': '123456789',
+            'text': '%s<blockquote>%s</blockquote>' % (attribution, group_note.data['text'])
+        }
+        return comment
 
     def get_persisted_default_config_fields(self):
         return ['project']

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -65,8 +65,7 @@ class ExampleIntegration(IntegrationInstallation, IssueSyncMixin):
     def create_comment(self, issue_id, user_id, group_note):
         user = User.objects.get(id=user_id)
         attribution = '%s wrote:\n\n' % user.name
-        quoted_comment = '%s<blockquote>%s</blockquote>' % (attribution, group_note.data['text'])
-        return quoted_comment
+        return '%s<blockquote>%s</blockquote>' % (attribution, group_note.data['text'])
 
     def get_persisted_default_config_fields(self):
         return ['project']

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -62,10 +62,10 @@ class ExampleIntegration(IntegrationInstallation, IssueSyncMixin):
     def get_issue_url(self, key):
         return u'https://example/issues/{}'.format(key)
 
-    def create_comment(self, issue_id, user_id, comment):
+    def create_comment(self, issue_id, user_id, group_note):
         user = User.objects.get(id=user_id)
         attribution = '%s wrote:\n\n' % user.name
-        quoted_comment = '%s<blockquote>%s</blockquote>' % (attribution, comment)
+        quoted_comment = '%s<blockquote>%s</blockquote>' % (attribution, group_note.data['text'])
         return quoted_comment
 
     def get_persisted_default_config_fields(self):

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -259,6 +259,9 @@ class IssueBasicMixin(object):
 
         return annotations
 
+    def get_comment_id(self, comment):
+        return comment['id']
+
     def create_comment(self, issue_id, user_id, group_note):
         pass
 

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -265,9 +265,6 @@ class IssueBasicMixin(object):
     def update_comment(self, issue_id, user_id, group_note):
         pass
 
-    def delete_comment(self, issue_id, user_id, external_comment_id):
-        pass
-
 
 class IssueSyncMixin(IssueBasicMixin):
     comment_key = None

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -265,7 +265,7 @@ class IssueBasicMixin(object):
     def update_comment(self, issue_id, user_id, group_note):
         pass
 
-    def delete_comment(self, issue_id, user_id, group_note):
+    def delete_comment(self, issue_id, user_id, external_comment_id):
         pass
 
 

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -259,6 +259,15 @@ class IssueBasicMixin(object):
 
         return annotations
 
+    def create_comment(self, issue_id, user_id, comment):
+        pass
+
+    def update_comment(self, issue_id, user_id, external_comment_id, comment_text):
+        pass
+
+    def delete_comment(self, issue_id, user_id, external_comment_id):
+        pass
+
 
 class IssueSyncMixin(IssueBasicMixin):
     comment_key = None

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -259,13 +259,13 @@ class IssueBasicMixin(object):
 
         return annotations
 
-    def create_comment(self, issue_id, user_id, comment):
+    def create_comment(self, issue_id, user_id, group_note):
         pass
 
-    def update_comment(self, issue_id, user_id, external_comment_id, comment_text):
+    def update_comment(self, issue_id, user_id, group_note):
         pass
 
-    def delete_comment(self, issue_id, user_id, external_comment_id):
+    def delete_comment(self, issue_id, user_id, group_note):
         pass
 
 

--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -132,9 +132,6 @@ class JiraApiClient(ApiClient):
     def update_comment(self, issue_key, comment_id, comment):
         return self.put(self.COMMENT_URL % (issue_key, comment_id), data={'body': comment})
 
-    def delete_comment(self, issue_key, comment_id):
-        return self.delete(self.COMMENT_URL % (issue_key, comment_id))
-
     def get_projects_list(self):
         return self.get_cached(self.PROJECT_URL)
 

--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -67,7 +67,8 @@ class JiraCloud(object):
 
 
 class JiraApiClient(ApiClient):
-    COMMENT_URL = '/rest/api/2/issue/%s/comment'
+    COMMENTS_URL = '/rest/api/2/issue/%s/comment'
+    COMMENT_URL = '/rest/api/2/issue/%s/comment/%s'
     STATUS_URL = '/rest/api/2/status'
     CREATE_URL = '/rest/api/2/issue'
     ISSUE_URL = '/rest/api/2/issue/%s'
@@ -126,7 +127,13 @@ class JiraApiClient(ApiClient):
         return self.get(self.SEARCH_URL, params={'jql': jql})
 
     def create_comment(self, issue_key, comment):
-        return self.post(self.COMMENT_URL % issue_key, data={'body': comment})
+        return self.post(self.COMMENTS_URL % issue_key, data={'body': comment})
+
+    def update_comment(self, issue_key, comment_id, comment):
+        return self.put(self.COMMENT_URL % (issue_key, comment_id), data={'body': comment})
+
+    def delete_comment(self, issue_key, comment_id):
+        return self.delete(self.COMMENT_URL % (issue_key, comment_id))
 
     def get_projects_list(self):
         return self.get_cached(self.PROJECT_URL)

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -299,8 +299,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
     def create_comment_attribution(self, user_id, comment_text):
         user = User.objects.get(id=user_id)
         attribution = '%s wrote:\n\n' % user.name
-        quoted_comment = '%s{quote}%s{quote}' % (attribution, comment_text)
-        return quoted_comment
+        return '%s{quote}%s{quote}' % (attribution, comment_text)
 
     def update_comment(self, issue_id, user_id, group_note):
         quoted_comment = self.create_comment_attribution(user_id, group_note.data['text'])

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -289,10 +289,24 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
 
     def create_comment(self, issue_id, user_id, comment):
         # https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=texteffects
+        quoted_comment = self.create_comment_attribution(user_id, comment)
+        return self.get_client().create_comment(issue_id, quoted_comment)
+
+    def get_comment_id(self, comment):
+        return comment['id']
+
+    def create_comment_attribution(self, user_id, comment_text):
         user = User.objects.get(id=user_id)
         attribution = '%s wrote:\n\n' % user.name
-        quoted_comment = '%s{quote}%s{quote}' % (attribution, comment)
-        return self.get_client().create_comment(issue_id, quoted_comment)
+        quoted_comment = '%s{quote}%s{quote}' % (attribution, comment_text)
+        return quoted_comment
+
+    def update_comment(self, issue_id, user_id, external_comment_id, comment_text):
+        quoted_comment = self.create_comment_attribution(user_id, comment_text)
+        return self.get_client().update_comment(issue_id, external_comment_id, quoted_comment)
+
+    def delete_comment(self, issue_id, user_id, external_comment_id):
+        return self.get_client().delete_comment(issue_id, external_comment_id)
 
     def search_issues(self, query):
         try:

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -307,9 +307,6 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             issue_id, group_note.data['external_id'], quoted_comment,
         )
 
-    def delete_comment(self, issue_id, user_id, external_comment_id):
-        return self.get_client().delete_comment(issue_id, external_comment_id)
-
     def search_issues(self, query):
         try:
             return self.get_client().search_issues(query)

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -287,8 +287,9 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             'description': issue['fields']['description'],
         }
 
-    def create_comment(self, issue_id, user_id, comment):
+    def create_comment(self, issue_id, user_id, group_note):
         # https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=texteffects
+        comment = group_note.data['text']
         quoted_comment = self.create_comment_attribution(user_id, comment)
         return self.get_client().create_comment(issue_id, quoted_comment)
 
@@ -301,12 +302,13 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         quoted_comment = '%s{quote}%s{quote}' % (attribution, comment_text)
         return quoted_comment
 
-    def update_comment(self, issue_id, user_id, external_comment_id, comment_text):
-        quoted_comment = self.create_comment_attribution(user_id, comment_text)
-        return self.get_client().update_comment(issue_id, external_comment_id, quoted_comment)
+    def update_comment(self, issue_id, user_id, group_note):
+        quoted_comment = self.create_comment_attribution(user_id, group_note.data['text'])
+        return self.get_client().update_comment(
+            issue_id, group_note.data['external_id'], quoted_comment)
 
-    def delete_comment(self, issue_id, user_id, external_comment_id):
-        return self.get_client().delete_comment(issue_id, external_comment_id)
+    def delete_comment(self, issue_id, user_id, group_note):
+        return self.get_client().delete_comment(issue_id, group_note.data['external_id'])
 
     def search_issues(self, query):
         try:

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -304,10 +304,11 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
     def update_comment(self, issue_id, user_id, group_note):
         quoted_comment = self.create_comment_attribution(user_id, group_note.data['text'])
         return self.get_client().update_comment(
-            issue_id, group_note.data['external_id'], quoted_comment)
+            issue_id, group_note.data['external_id'], quoted_comment,
+        )
 
-    def delete_comment(self, issue_id, user_id, group_note):
-        return self.get_client().delete_comment(issue_id, group_note.data['external_id'])
+    def delete_comment(self, issue_id, user_id, external_comment_id):
+        return self.get_client().delete_comment(issue_id, external_comment_id)
 
     def search_issues(self, query):
         try:

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -293,9 +293,6 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         quoted_comment = self.create_comment_attribution(user_id, comment)
         return self.get_client().create_comment(issue_id, quoted_comment)
 
-    def get_comment_id(self, comment):
-        return comment['id']
-
     def create_comment_attribution(self, user_id, comment_text):
         user = User.objects.get(id=user_id)
         attribution = '%s wrote:\n\n' % user.name

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -10,7 +10,7 @@ from sentry import http, features
 from sentry.constants import ObjectStatus
 from sentry.models import (
     Integration as IntegrationModel, IntegrationExternalProject, Organization,
-    OrganizationIntegration, User
+    OrganizationIntegration
 )
 from sentry.integrations import IntegrationInstallation, IntegrationFeatures, IntegrationProvider, IntegrationMetadata, FeatureDescription
 from sentry.integrations.exceptions import ApiError, IntegrationError
@@ -285,15 +285,6 @@ class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync):
             return self.model.metadata['default_project']
         except KeyError:
             return None
-
-    def create_comment(self, issue_id, user_id, comment):
-        # VSTS uses markdown or xml
-        # https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/bots/bots-text-formats
-        user = User.objects.get(id=user_id)
-        attribution = '%s wrote:\n\n' % user.name
-
-        quoted_comment = '%s<blockquote>%s</blockquote>' % (attribution, comment)
-        self.get_client().update_work_item(self.instance, issue_id, comment=quoted_comment)
 
 
 class VstsIntegrationProvider(IntegrationProvider):

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -276,7 +276,3 @@ class VstsIssueSync(IssueSyncMixin):
     def update_comment(self, issue_id, user_id, external_comment_id, comment_text):
         # Azure does not support updating comments
         pass
-
-    def delete_comment(self, issue_id, user_id, external_comment_id):
-        # Azure does not support deleting comments
-        pass

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -5,7 +5,7 @@ from mistune import markdown
 
 
 from django.core.urlresolvers import reverse
-from sentry.models import IntegrationExternalProject, OrganizationIntegration
+from sentry.models import IntegrationExternalProject, OrganizationIntegration, User
 from sentry.integrations.issues import IssueSyncMixin
 
 from sentry.integrations.exceptions import ApiUnauthorized, ApiError
@@ -256,3 +256,26 @@ class VstsIssueSync(IssueSyncMixin):
         if external_issue.metadata is None:
             return ''
         return external_issue.metadata['display_name']
+
+    def create_comment(self, issue_id, user_id, comment):
+        quoted_comment = self.create_comment_attribution(user_id, comment)
+        self.get_client().update_work_item(self.instance, issue_id, comment=quoted_comment)
+
+    def get_comment_id(self, comment):
+        return comment['id']
+
+    def create_comment_attribution(self, user_id, comment_text):
+        # VSTS uses markdown or xml
+        # https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/bots/bots-text-formats
+        user = User.objects.get(id=user_id)
+        attribution = '%s wrote:\n\n' % user.name
+        quoted_comment = '%s<blockquote>%s</blockquote>' % (attribution, comment_text)
+        return quoted_comment
+
+    def update_comment(self, issue_id, user_id, external_comment_id, comment_text):
+        # Azure does not support updating comments
+        raise NotImplementedError
+
+    def delete_comment(self, issue_id, user_id, external_comment_id):
+        # Azure does not support deleting comments
+        raise NotImplementedError

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -257,7 +257,8 @@ class VstsIssueSync(IssueSyncMixin):
             return ''
         return external_issue.metadata['display_name']
 
-    def create_comment(self, issue_id, user_id, comment):
+    def create_comment(self, issue_id, user_id, group_note):
+        comment = group_note.data['text']
         quoted_comment = self.create_comment_attribution(user_id, comment)
         self.get_client().update_work_item(self.instance, issue_id, comment=quoted_comment)
 

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -262,9 +262,6 @@ class VstsIssueSync(IssueSyncMixin):
         quoted_comment = self.create_comment_attribution(user_id, comment)
         self.get_client().update_work_item(self.instance, issue_id, comment=quoted_comment)
 
-    def get_comment_id(self, comment):
-        return comment['id']
-
     def create_comment_attribution(self, user_id, comment_text):
         # VSTS uses markdown or xml
         # https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/bots/bots-text-formats

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -274,8 +274,8 @@ class VstsIssueSync(IssueSyncMixin):
 
     def update_comment(self, issue_id, user_id, external_comment_id, comment_text):
         # Azure does not support updating comments
-        raise NotImplementedError
+        pass
 
     def delete_comment(self, issue_id, user_id, external_comment_id):
         # Azure does not support deleting comments
-        raise NotImplementedError
+        pass

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -23,7 +23,7 @@ def should_comment_sync(installation, external_issue):
     organization = Organization.objects.get(id=external_issue.organization_id)
     has_issue_sync = features.has('organizations:integrations-issue-sync',
                                   organization)
-    return has_issue_sync and installation.should_sync('comment'), installation
+    return has_issue_sync and installation.should_sync('comment')
 
 
 @instrumented_task(

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -27,6 +27,41 @@ def should_comment_sync(installation, external_issue):
 
 
 @instrumented_task(
+    name='sentry.tasks.integrations.post_comment',
+    queue='integrations',
+    default_retry_delay=60 * 5,
+    max_retries=5
+)
+# TODO(lb): Replaced by create_comment method. Remove once all preexisting jobs have executed.
+# no longer in use
+# TODO(jess): Add more retry exclusions once ApiClients have better error handling
+@retry(exclude=(ExternalIssue.DoesNotExist, Integration.DoesNotExist))
+def post_comment(external_issue_id, data, user_id, **kwargs):
+    # sync Sentry comments to an external issue
+    external_issue = ExternalIssue.objects.get(id=external_issue_id)
+
+    organization = Organization.objects.get(id=external_issue.organization_id)
+    has_issue_sync = features.has('organizations:integrations-issue-sync',
+                                  organization)
+    if not has_issue_sync:
+        return
+
+    integration = Integration.objects.get(id=external_issue.integration_id)
+    installation = integration.get_installation(
+        organization_id=external_issue.organization_id,
+    )
+    if installation.should_sync('comment'):
+        installation.create_comment(external_issue.key, user_id, data['text'])
+        analytics.record(
+            'integration.issue.comments.synced',
+            provider=integration.provider,
+            id=integration.id,
+            organization_id=external_issue.organization_id,
+            user_id=user_id,
+        )
+
+
+@instrumented_task(
     name='sentry.tasks.integrations.create_comment',
     queue='integrations',
     default_retry_delay=60 * 5,

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -512,8 +512,3 @@ class GroupDeleteTest(APITestCase):
         # Now we killed everything with fire
         assert not Group.objects.filter(id=group.id).exists()
         assert not GroupHash.objects.filter(group_id=group.id).exists()
-
-
-class LinkedGroupTest(APITestCase):
-    def setUp(self):
-        pass

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -512,3 +512,8 @@ class GroupDeleteTest(APITestCase):
         # Now we killed everything with fire
         assert not Group.objects.filter(id=group.id).exists()
         assert not GroupHash.objects.filter(group_id=group.id).exists()
+
+
+class LinkedGroupTest(APITestCase):
+    def setUp(self):
+        pass

--- a/tests/sentry/api/endpoints/test_group_notes.py
+++ b/tests/sentry/api/endpoints/test_group_notes.py
@@ -228,4 +228,4 @@ class GroupNoteCreateTest(APITestCase):
                 activity = Activity.objects.get(id=response.data['id'])
                 assert activity.user == self.user
                 assert activity.group == group
-                assert activity.data == {'text': comment}
+                assert activity.data == {'text': comment, 'external_id': '123456789'}

--- a/tests/sentry/api/endpoints/test_group_notes_details.py
+++ b/tests/sentry/api/endpoints/test_group_notes_details.py
@@ -7,6 +7,11 @@ from sentry.testutils import APITestCase
 
 
 class GroupNotesDetailsTest(APITestCase):
+    def setUp(self):
+        super(GroupNotesDetailsTest, self).setUp()
+        self.activity.data['external_id'] = '123'
+        self.activity.save()
+
     @fixture
     def url(self):
         return u'/api/0/issues/{}/comments/{}/'.format(
@@ -45,4 +50,4 @@ class GroupNotesDetailsTest(APITestCase):
         activity = Activity.objects.get(id=response.data['id'])
         assert activity.user == self.user
         assert activity.group == self.group
-        assert activity.data == {'text': 'hi haters'}
+        assert activity.data == {'text': 'hi haters', 'external_id': '123'}

--- a/tests/sentry/api/endpoints/test_group_notes_details.py
+++ b/tests/sentry/api/endpoints/test_group_notes_details.py
@@ -51,3 +51,25 @@ class GroupNotesDetailsTest(APITestCase):
         assert activity.user == self.user
         assert activity.group == self.group
         assert activity.data == {'text': 'hi haters', 'external_id': '123'}
+
+    def test_put_no_external_id(self):
+        del self.activity.data['external_id']
+        self.activity.save()
+        self.login_as(user=self.user)
+
+        url = self.url
+
+        response = self.client.put(url, format='json')
+        assert response.status_code == 400, response.content
+
+        response = self.client.put(
+            url, format='json', data={
+                'text': 'hi haters',
+            }
+        )
+        assert response.status_code == 200, response.content
+
+        activity = Activity.objects.get(id=response.data['id'])
+        assert activity.user == self.user
+        assert activity.group == self.group
+        assert activity.data == {'text': 'hi haters', 'external_id': None}

--- a/tests/sentry/api/endpoints/test_group_notes_details.py
+++ b/tests/sentry/api/endpoints/test_group_notes_details.py
@@ -80,7 +80,7 @@ class GroupNotesDetailsTest(APITestCase):
 
         assert mock_update_comment.call_count == 1
         assert mock_update_comment.call_args[0][0] == u'123'
-        assert mock_update_comment.call_args[0][1] == 2
+        assert mock_update_comment.call_args[0][1] == self.group.id
         assert mock_update_comment.call_args[0][2] == activity
 
     @patch('sentry.integrations.issues.IssueBasicMixin.update_comment')

--- a/tests/sentry/api/endpoints/test_group_notes_details.py
+++ b/tests/sentry/api/endpoints/test_group_notes_details.py
@@ -80,7 +80,7 @@ class GroupNotesDetailsTest(APITestCase):
 
         assert mock_update_comment.call_count == 1
         assert mock_update_comment.call_args[0][0] == u'123'
-        assert mock_update_comment.call_args[0][1] == self.group.id
+        assert mock_update_comment.call_args[0][1] == self.user.id
         assert mock_update_comment.call_args[0][2] == activity
 
     @patch('sentry.integrations.issues.IssueBasicMixin.update_comment')

--- a/tests/sentry/api/endpoints/test_group_notes_details.py
+++ b/tests/sentry/api/endpoints/test_group_notes_details.py
@@ -72,4 +72,4 @@ class GroupNotesDetailsTest(APITestCase):
         activity = Activity.objects.get(id=response.data['id'])
         assert activity.user == self.user
         assert activity.group == self.group
-        assert activity.data == {'text': 'hi haters', 'external_id': None}
+        assert activity.data == {'text': 'hi haters'}

--- a/tests/sentry/api/endpoints/test_group_notes_details.py
+++ b/tests/sentry/api/endpoints/test_group_notes_details.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import
 
-from exam import fixture
+import responses
 
-from sentry.models import Activity, Group
+from exam import fixture
+from mock import patch
+
+from sentry.models import Activity, ExternalIssue, Group, GroupLink, Integration
 from sentry.testutils import APITestCase
 
 
@@ -11,6 +14,25 @@ class GroupNotesDetailsTest(APITestCase):
         super(GroupNotesDetailsTest, self).setUp()
         self.activity.data['external_id'] = '123'
         self.activity.save()
+        self.integration = Integration.objects.create(
+            provider='example',
+            external_id='example12345',
+            name='Example 12345',
+        )
+        org_integration = self.integration.add_organization(self.organization)
+        org_integration.config = {'sync_comments': True}
+        org_integration.save()
+        self.external_issue = ExternalIssue.objects.create(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            key='123'
+        )
+        GroupLink.objects.create(
+            project_id=self.group.project_id,
+            group_id=self.group.id,
+            linked_type=GroupLink.LinkedType.issue,
+            linked_id=self.external_issue.id,
+        )
 
     @fixture
     def url(self):
@@ -32,7 +54,9 @@ class GroupNotesDetailsTest(APITestCase):
 
         assert Group.objects.get(id=self.group.id).num_comments == 0
 
-    def test_put(self):
+    @patch('sentry.integrations.issues.IssueBasicMixin.update_comment')
+    @responses.activate
+    def test_put(self, mock_update_comment):
         self.login_as(user=self.user)
 
         url = self.url
@@ -40,11 +64,13 @@ class GroupNotesDetailsTest(APITestCase):
         response = self.client.put(url, format='json')
         assert response.status_code == 400, response.content
 
-        response = self.client.put(
-            url, format='json', data={
-                'text': 'hi haters',
-            }
-        )
+        with self.tasks():
+            with self.feature('organizations:integrations-issue-sync'):
+                response = self.client.put(
+                    url, format='json', data={
+                        'text': 'hi haters',
+                    }
+                )
         assert response.status_code == 200, response.content
 
         activity = Activity.objects.get(id=response.data['id'])
@@ -52,7 +78,13 @@ class GroupNotesDetailsTest(APITestCase):
         assert activity.group == self.group
         assert activity.data == {'text': 'hi haters', 'external_id': '123'}
 
-    def test_put_no_external_id(self):
+        assert mock_update_comment.call_count == 1
+        assert mock_update_comment.call_args[0][0] == u'123'
+        assert mock_update_comment.call_args[0][1] == 2
+        assert mock_update_comment.call_args[0][2] == activity
+
+    @patch('sentry.integrations.issues.IssueBasicMixin.update_comment')
+    def test_put_no_external_id(self, mock_update_comment):
         del self.activity.data['external_id']
         self.activity.save()
         self.login_as(user=self.user)
@@ -73,3 +105,5 @@ class GroupNotesDetailsTest(APITestCase):
         assert activity.user == self.user
         assert activity.group == self.group
         assert activity.data == {'text': 'hi haters'}
+
+        assert mock_update_comment.call_count == 0

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -838,3 +838,9 @@ class JiraIntegrationTest(APITestCase):
                 installation.create_comment(1, self.user.id, comment)
                 assert mock_create_comment.call_args[0][1] == \
                     'Sentry Admin wrote:\n\n{quote}%s{quote}' % comment
+
+    def test_update_comment(self):
+        pass
+
+    def test_delete_comment(self):
+        pass

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from mock import patch, Mock
 
 from sentry.identity.vsts import VSTSIdentityProvider
 from sentry.integrations.exceptions import IntegrationError
@@ -395,10 +395,14 @@ class VstsIntegrationTest(VstsIntegrationTestCase):
         integration = Integration.objects.get(provider='vsts')
         installation = integration.get_installation(self.organization.id)
 
-        comment = 'hello world\nThis is a comment.\n\n\n    Glad it\'s quoted'
         self.user.name = 'Sentry Admin'
         self.user.save()
+
+        comment_text = 'hello world\nThis is a comment.\n\n\n    Glad it\'s quoted'
+        comment = Mock()
+        comment.data = {'text': comment_text}
+
         installation.create_comment(1, self.user.id, comment)
 
         assert mock_update_work_item.call_args[1]['comment'] == \
-            'Sentry Admin wrote:\n\n<blockquote>%s</blockquote>' % comment
+            'Sentry Admin wrote:\n\n<blockquote>%s</blockquote>' % comment_text


### PR DESCRIPTION
This adds the ability to update comments that are linked to sentry issues. Jira integration was implemented with this new feature. However, Azure DevOps's comments were immutable, and so I was unable to add it to that integration. We did not add the ability to delete comments as it would be necessary to change permissions in Jira. And this was not a big enough feature to warrant it.