### PR TITLE
feat(2fa): Allow org to reset member 2fa

### DIFF
--- a/src/sentry/api/bases/user.py
+++ b/src/sentry/api/bases/user.py
@@ -2,12 +2,12 @@ from __future__ import absolute_import
 
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.permissions import ScopedPermission
-from sentry.models import User
+from sentry.api.permissions import SentryPermission
+from sentry.models import Organization, OrganizationStatus, User
 from sentry.auth.superuser import is_active_superuser
 
 
-class UserPermission(ScopedPermission):
+class UserPermission(SentryPermission):
     def has_object_permission(self, request, view, user=None):
         if user is None:
             user = request.user
@@ -18,6 +18,37 @@ class UserPermission(ScopedPermission):
         if is_active_superuser(request):
             return True
         return False
+
+
+class RelaxedUserPermission(UserPermission):
+
+    scope_map = {
+        'DELETE': ['member:admin'],
+    }
+
+    def has_org_permission(self, request, user):
+        """
+        Org can act on a user account,
+        if the user is a member of only one org
+        e.g. reset org member's 2FA
+        """
+
+        try:
+            organization = Organization.objects.get(
+                status=OrganizationStatus.VISIBLE,
+                member_set__user=user
+            )
+
+            self.determine_access(request, organization)
+            allowed_scopes = set(self.scope_map.get(request.method, []))
+            return any(request.access.has_scope(s) for s in allowed_scopes)
+        except (Organization.DoesNotExist, Organization.MultipleObjectsReturned):
+            return False
+
+    def has_object_permission(self, request, view, user=None):
+        if super(RelaxedUserPermission, self).has_object_permission(request, view, user):
+            return True
+        return self.has_org_permission(request, user)
 
 
 class UserEndpoint(Endpoint):

--- a/src/sentry/api/bases/user.py
+++ b/src/sentry/api/bases/user.py
@@ -20,7 +20,7 @@ class UserPermission(SentryPermission):
         return False
 
 
-class RelaxedUserPermission(UserPermission):
+class OrganizationUserPermission(UserPermission):
     scope_map = {
         'DELETE': ['member:admin'],
     }
@@ -45,7 +45,7 @@ class RelaxedUserPermission(UserPermission):
             return False
 
     def has_object_permission(self, request, view, user=None):
-        if super(RelaxedUserPermission, self).has_object_permission(request, view, user):
+        if super(OrganizationUserPermission, self).has_object_permission(request, view, user):
             return True
         return self.has_org_permission(request, user)
 

--- a/src/sentry/api/bases/user.py
+++ b/src/sentry/api/bases/user.py
@@ -21,7 +21,6 @@ class UserPermission(SentryPermission):
 
 
 class RelaxedUserPermission(UserPermission):
-
     scope_map = {
         'DELETE': ['member:admin'],
     }

--- a/src/sentry/api/endpoints/organization_member_details.py
+++ b/src/sentry/api/endpoints/organization_member_details.py
@@ -9,7 +9,8 @@ from sentry import roles
 from sentry.api.bases.organization import (
     OrganizationEndpoint, OrganizationPermission)
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.serializers import serialize, RoleSerializer, OrganizationMemberWithTeamsSerializer
+from sentry.api.serializers import (
+    DetailedUserSerializer, serialize, RoleSerializer, OrganizationMemberWithTeamsSerializer)
 from sentry.api.serializers.rest_framework import ListField
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import (
@@ -105,6 +106,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationEndpoint):
 
         if request.access.has_scope('member:admin'):
             context['invite_link'] = member.get_invite_link()
+            context['user'] = serialize(member.user, request.user, DetailedUserSerializer())
 
         context['isOnlyOwner'] = self._is_only_owner(member)
         context['roles'] = serialize(

--- a/src/sentry/api/endpoints/user_authenticator_details.py
+++ b/src/sentry/api/endpoints/user_authenticator_details.py
@@ -4,7 +4,7 @@ from django.db import transaction
 from rest_framework import status
 from rest_framework.response import Response
 
-from sentry.api.bases.user import UserEndpoint
+from sentry.api.bases.user import UserEndpoint, RelaxedUserPermission
 from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize
 from sentry.models import Authenticator
@@ -12,6 +12,8 @@ from sentry.security import capture_security_activity
 
 
 class UserAuthenticatorDetailsEndpoint(UserEndpoint):
+    permission_classes = (RelaxedUserPermission, )
+
     @sudo_required
     def get(self, request, user, auth_id):
         """

--- a/src/sentry/api/endpoints/user_authenticator_details.py
+++ b/src/sentry/api/endpoints/user_authenticator_details.py
@@ -4,7 +4,7 @@ from django.db import transaction
 from rest_framework import status
 from rest_framework.response import Response
 
-from sentry.api.bases.user import UserEndpoint, RelaxedUserPermission
+from sentry.api.bases.user import UserEndpoint, OrganizationUserPermission
 from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize
 from sentry.models import Authenticator
@@ -12,7 +12,7 @@ from sentry.security import capture_security_activity
 
 
 class UserAuthenticatorDetailsEndpoint(UserEndpoint):
-    permission_classes = (RelaxedUserPermission, )
+    permission_classes = (OrganizationUserPermission, )
 
     @sudo_required
     def get(self, request, user, auth_id):

--- a/src/sentry/static/sentry/app/actionCreators/account.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/account.jsx
@@ -29,3 +29,9 @@ export function logout(api) {
     method: 'DELETE',
   });
 }
+
+export function removeAuthenticator(api, userId, authId) {
+  return api.requestPromise(`/users/${userId}/authenticators/${authId}/`, {
+    method: 'DELETE',
+  });
+}

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberDetail.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberDetail.jsx
@@ -1,20 +1,33 @@
+import * as Sentry from '@sentry/browser';
+
 import {browserHistory} from 'react-router';
 import React from 'react';
 
 import {resendMemberInvite, updateMember} from 'app/actionCreators/members';
-import {t} from 'app/locale';
+import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
+import {t, tct} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
 import Button from 'app/components/button';
+import Confirm from 'app/components/confirm';
 import DateTime from 'app/components/dateTime';
+import Field from 'app/views/settings/components/forms/field';
 import IndicatorStore from 'app/stores/indicatorStore';
 import NotFound from 'app/components/errors/notFound';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import SentryTypes from 'app/sentryTypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
+import Tooltip from 'app/components/tooltip';
 import recreateRoute from 'app/utils/recreateRoute';
 
 import RoleSelect from './inviteMember/roleSelect';
 import TeamSelect from './inviteMember/teamSelect';
+
+const NOT_ENROLLED = t('Not enrolled in two-factor authentication');
+const NO_PERMISSION = t('You do not have permission to perform this action');
+const TWO_FACTOR_REQUIRED = t(
+  'Cannot be reset since two-factor is required for this organization'
+);
+const MULTIPLE_ORGS = t('Cannot be reset since user is in more than one organization');
 
 class OrganizationMemberDetail extends AsyncView {
   static contextTypes = {
@@ -142,16 +155,71 @@ class OrganizationMemberDetail extends AsyncView {
     });
   };
 
+  removeAuthenticator = (userId, authId) => {
+    let endpoint = `/users/${userId}/authenticators/${authId}/`;
+
+    return this.api.requestPromise(endpoint, {
+      method: 'DELETE',
+    });
+  };
+
+  handle2faReset = () => {
+    let {member} = this.state;
+    let {slug} = this.getOrganization();
+
+    let user = member.user;
+    let requests = user.authenticators.map(auth =>
+      this.removeAuthenticator(user.id, auth.id)
+    );
+
+    Promise.all(requests)
+      .then(() => {
+        this.props.router.push(`/settings/${slug}/members/`);
+        addSuccessMessage(t('All authenticators have been removed'));
+      })
+      .catch(err => {
+        addErrorMessage(t('Error removing authenticators'));
+        Sentry.captureException(err);
+      });
+  };
+
+  showResetButton = () => {
+    let {member} = this.state;
+    let {require2FA} = this.getOrganization();
+    let {user} = member;
+
+    if (!user || !user.authenticators || require2FA) return false;
+    let hasAuth = user.authenticators.length >= 1;
+    return hasAuth && user.canReset2fa;
+  };
+
+  getTooltip = () => {
+    let {member} = this.state;
+    let {require2FA} = this.getOrganization();
+    let {user} = member;
+
+    if (!user) return '';
+
+    if (!user.authenticators) return NO_PERMISSION;
+    if (!user.authenticators.length) return NOT_ENROLLED;
+    if (!user.canReset2fa) return MULTIPLE_ORGS;
+    if (require2FA) return TWO_FACTOR_REQUIRED;
+
+    return '';
+  };
+
   renderBody() {
     let {error, member} = this.state;
     let {teams, access} = this.getOrganization();
 
     if (!member) return <NotFound />;
 
-    let email = member.email;
     let inviteLink = member.invite_link;
     let canEdit = access.includes('org:write');
-    let canResend = !member.expired;
+
+    let {email, expired, pending} = member;
+    let canResend = !expired;
+    let showAuth = !pending;
 
     return (
       <div>
@@ -245,6 +313,44 @@ class OrganizationMemberDetail extends AsyncView {
             </PanelItem>
           </PanelBody>
         </Panel>
+
+        {showAuth && (
+          <Panel>
+            <PanelHeader>{t('Authentication')}</PanelHeader>
+            <PanelBody>
+              <Field
+                alignRight={true}
+                flexibleControlStateSize={true}
+                label={t('Reset two-factor authentication')}
+                help={t(
+                  'Resetting two-factor authentication will remove all two-factor authentication methods for this member.'
+                )}
+              >
+                <Tooltip
+                  data-test-id="reset-2fa-tooltip"
+                  disabled={this.showResetButton()}
+                  title={this.getTooltip()}
+                >
+                  <span>
+                    <Confirm
+                      disabled={!this.showResetButton()}
+                      message={tct(
+                        'Are you sure you want to disable all two-factor authentication methods for [name]?',
+                        {name: member.name ? member.name : 'this member'}
+                      )}
+                      onConfirm={this.handle2faReset}
+                      data-test-id="reset-2fa-confirm"
+                    >
+                      <Button data-test-id="reset-2fa">
+                        {t('Reset two-factor authentication')}
+                      </Button>
+                    </Confirm>
+                  </span>
+                </Tooltip>
+              </Field>
+            </PanelBody>
+          </Panel>
+        )}
 
         <RoleSelect
           enforceAllowed={false}

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberDetail.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberDetail.jsx
@@ -14,6 +14,7 @@ import Field from 'app/views/settings/components/forms/field';
 import IndicatorStore from 'app/stores/indicatorStore';
 import NotFound from 'app/components/errors/notFound';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
+import {removeAuthenticator} from 'app/actionCreators/account';
 import SentryTypes from 'app/sentryTypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import Tooltip from 'app/components/tooltip';
@@ -155,21 +156,12 @@ class OrganizationMemberDetail extends AsyncView {
     });
   };
 
-  removeAuthenticator = (userId, authId) => {
-    let endpoint = `/users/${userId}/authenticators/${authId}/`;
-
-    return this.api.requestPromise(endpoint, {
-      method: 'DELETE',
-    });
-  };
-
   handle2faReset = () => {
-    let {member} = this.state;
+    let {user} = this.state.member;
     let {slug} = this.getOrganization();
 
-    let user = member.user;
     let requests = user.authenticators.map(auth =>
-      this.removeAuthenticator(user.id, auth.id)
+      removeAuthenticator(this.api, user.id, auth.id)
     );
 
     Promise.all(requests)
@@ -341,7 +333,7 @@ class OrganizationMemberDetail extends AsyncView {
                       onConfirm={this.handle2faReset}
                       data-test-id="reset-2fa-confirm"
                     >
-                      <Button data-test-id="reset-2fa">
+                      <Button data-test-id="reset-2fa" priority="danger">
                         {t('Reset two-factor authentication')}
                       </Button>
                     </Confirm>

--- a/tests/js/spec/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
@@ -268,4 +268,163 @@ describe('OrganizationMemberDetail', function() {
       expect(wrapper.find('Button[data-test-id="resend-invite"]')).toHaveLength(0);
     });
   });
+
+  describe('Reset member 2FA', function() {
+    let fields = {
+      roles: TestStubs.RoleList(),
+      dateCreated: new Date(),
+      teams: [team.slug],
+    };
+
+    let noAccess = TestStubs.Member({
+      ...fields,
+      id: '4',
+      user: TestStubs.User({has2fa: false}),
+    });
+
+    let no2fa = TestStubs.Member({
+      ...fields,
+      id: '5',
+      user: TestStubs.User({has2fa: false, authenticators: [], canReset2fa: true}),
+    });
+
+    let has2fa = TestStubs.Member({
+      ...fields,
+      id: '6',
+      user: TestStubs.User({
+        has2fa: true,
+        authenticators: [
+          TestStubs.Authenticators().Totp(),
+          TestStubs.Authenticators().Sms(),
+          TestStubs.Authenticators().U2f(),
+        ],
+        canReset2fa: true,
+      }),
+    });
+
+    let multipleOrgs = TestStubs.Member({
+      ...fields,
+      id: '7',
+      user: TestStubs.User({
+        has2fa: true,
+        authenticators: [TestStubs.Authenticators().Totp()],
+        canReset2fa: false,
+      }),
+    });
+
+    beforeAll(function() {
+      organization = TestStubs.Organization({teams});
+      routerContext = TestStubs.routerContext([{organization}]);
+
+      MockApiClient.clearMockResponses();
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/members/${pendingMember.id}/`,
+        body: pendingMember,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/members/${noAccess.id}/`,
+        body: noAccess,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/members/${no2fa.id}/`,
+        body: no2fa,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/members/${has2fa.id}/`,
+        body: has2fa,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/members/${multipleOrgs.id}/`,
+        body: multipleOrgs,
+      });
+    });
+
+    let button = 'Button[data-test-id="reset-2fa"]';
+    let tooltip = 'Tooltip[data-test-id="reset-2fa-tooltip"]';
+
+    const expectButtonEnabled = () => {
+      expect(wrapper.find(button).text()).toEqual('Reset two-factor authentication');
+      expect(wrapper.find(button).prop('disabled')).toBe(false);
+
+      expect(wrapper.find(tooltip).prop('title')).toEqual('');
+      expect(wrapper.find(tooltip).prop('disabled')).toBe(true);
+    };
+
+    const expectButtonDisabled = title => {
+      expect(wrapper.find(button).text()).toEqual('Reset two-factor authentication');
+      expect(wrapper.find(button).prop('disabled')).toBe(true);
+
+      expect(wrapper.find(tooltip).prop('title')).toEqual(title);
+      expect(wrapper.find(tooltip).prop('disabled')).toBe(false);
+    };
+
+    it('does not show for pending member', function() {
+      wrapper = mount(
+        <OrganizationMemberDetail params={{memberId: pendingMember.id}} />,
+        routerContext
+      );
+      expect(wrapper.find(button)).toHaveLength(0);
+    });
+
+    it('shows tooltip for joined member without permission to edit', function() {
+      wrapper = mount(
+        <OrganizationMemberDetail params={{memberId: noAccess.id}} />,
+        routerContext
+      );
+      expectButtonDisabled('You do not have permission to perform this action');
+    });
+
+    it('shows tooltip for member without 2fa', function() {
+      wrapper = mount(
+        <OrganizationMemberDetail params={{memberId: no2fa.id}} />,
+        routerContext
+      );
+      expectButtonDisabled('Not enrolled in two-factor authentication');
+    });
+
+    it('can reset member 2FA', function() {
+      let deleteMocks = has2fa.user.authenticators.map(auth => {
+        return MockApiClient.addMockResponse({
+          url: `/users/${has2fa.user.id}/authenticators/${auth.id}/`,
+          method: 'DELETE',
+        });
+      });
+
+      wrapper = mount(
+        <OrganizationMemberDetail params={{memberId: has2fa.id}} />,
+        routerContext
+      );
+
+      expectButtonEnabled();
+      wrapper.find(button).simulate('click');
+      wrapper.find('Button[data-test-id="confirm-modal"]').simulate('click');
+      deleteMocks.map(deleteMock => {
+        expect(deleteMock).toHaveBeenCalled();
+      });
+    });
+
+    it('shows tooltip for member in multiple orgs', function() {
+      wrapper = mount(
+        <OrganizationMemberDetail params={{memberId: multipleOrgs.id}} />,
+        routerContext
+      );
+      expectButtonDisabled('Cannot be reset since user is in more than one organization');
+    });
+
+    it('shows tooltip for member in 2FA required org', function() {
+      organization.require2FA = true;
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/members/${has2fa.id}/`,
+        body: has2fa,
+      });
+
+      wrapper = mount(
+        <OrganizationMemberDetail params={{memberId: has2fa.id}} />,
+        routerContext
+      );
+      expectButtonDisabled(
+        'Cannot be reset since two-factor is required for this organization'
+      );
+    });
+  });
 });

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -2,10 +2,13 @@ from __future__ import absolute_import
 
 from django.core import mail
 from django.core.urlresolvers import reverse
+from django.db.models import F
 from mock import patch
 
 from sentry.models import (
-    AuthProvider, OrganizationMember, OrganizationMemberTeam)
+    Authenticator, AuthProvider, Organization, OrganizationMember, OrganizationMemberTeam,
+    RecoveryCodeInterface, TotpInterface
+)
 from sentry.testutils import APITestCase
 
 
@@ -464,6 +467,167 @@ class UpdateOrganizationMemberTest(APITestCase):
         owner_om = OrganizationMember.objects.get(
             organization=organization, user=owner)
         assert owner_om.role == 'owner'
+
+
+class ResetOrganizationMember2faTest(APITestCase):
+
+    def setUp(self):
+        self.owner = self.create_user()
+        self.org = self.create_organization(owner=self.owner)
+
+        self.member = self.create_user()
+        self.member_om = self.create_member(
+            organization=self.org,
+            user=self.member,
+            role='member',
+            teams=[],
+        )
+        self.login_as(self.member)
+        totp = TotpInterface()
+        totp.enroll(self.member)
+        self.interface_id = totp.authenticator.id
+        assert Authenticator.objects.filter(user=self.member).exists()
+
+    def assert_can_get_user_authenticators(self):
+        path = reverse(
+            'sentry-api-0-organization-member-details', args=[self.org.slug, self.member_om.id]
+        )
+        resp = self.client.get(path)
+        assert resp.status_code == 200
+        data = resp.data
+
+        assert len(data['user']['authenticators']) == 1
+        assert data['user']['has2fa'] is True
+        assert data['user']['canReset2fa'] is True
+
+    def assert_cannot_get_authenticators(self):
+        path = reverse(
+            'sentry-api-0-organization-member-details', args=[self.org.slug, self.member_om.id]
+        )
+        resp = self.client.get(path)
+        assert resp.status_code == 200
+        data = resp.data
+
+        assert 'authenticators' not in data['user']
+        assert 'canReset2fa' not in data['user']
+
+    def assert_can_remove_authenticators(self):
+        path = reverse(
+            'sentry-api-0-user-authenticator-details', args=[self.member.id, self.interface_id]
+        )
+        resp = self.client.delete(path)
+        assert resp.status_code == 204
+        assert not Authenticator.objects.filter(user=self.member).exists()
+
+    def assert_cannot_remove_authenticators(self):
+        path = reverse(
+            'sentry-api-0-user-authenticator-details', args=[self.member.id, self.interface_id]
+        )
+        resp = self.client.delete(path)
+        assert resp.status_code == 403
+        assert Authenticator.objects.filter(user=self.member).exists()
+
+    def test_org_owner_can_reset_member_2fa(self):
+        self.login_as(self.owner)
+
+        self.assert_can_get_user_authenticators()
+        self.assert_can_remove_authenticators()
+
+    def test_owner_must_have_org_membership(self):
+        owner = self.create_user()
+        self.create_organization(owner=owner)
+        self.login_as(owner)
+
+        path = reverse(
+            'sentry-api-0-organization-member-details', args=[self.org.slug, self.member_om.id]
+        )
+        resp = self.client.get(path)
+        assert resp.status_code == 403
+
+        self.assert_cannot_remove_authenticators()
+
+    def test_org_manager_can_reset_member_2fa(self):
+        manager = self.create_user()
+        self.create_member(
+            organization=self.org,
+            user=manager,
+            role='manager',
+            teams=[],
+        )
+        self.login_as(manager)
+
+        self.assert_can_get_user_authenticators()
+        self.assert_can_remove_authenticators()
+
+    def test_org_admin_cannot_reset_member_2fa(self):
+        admin = self.create_user()
+        self.create_member(
+            organization=self.org,
+            user=admin,
+            role='admin',
+            teams=[],
+        )
+        self.login_as(admin)
+
+        self.assert_cannot_get_authenticators()
+        self.assert_cannot_remove_authenticators()
+
+    def test_org_member_cannot_reset_member_2fa(self):
+        member = self.create_user()
+        self.create_member(
+            organization=self.org,
+            user=member,
+            role='member',
+            teams=[],
+        )
+        self.login_as(member)
+
+        self.assert_cannot_get_authenticators()
+        self.assert_cannot_remove_authenticators()
+
+    def test_cannot_reset_member_2fa__has_multiple_org_membership(self):
+        self.create_organization(owner=self.member)
+        self.login_as(self.owner)
+
+        path = reverse(
+            'sentry-api-0-organization-member-details', args=[self.org.slug, self.member_om.id]
+        )
+        resp = self.client.get(path)
+        assert resp.status_code == 200
+        data = resp.data
+
+        assert len(data['user']['authenticators']) == 1
+        assert data['user']['has2fa'] is True
+        assert data['user']['canReset2fa'] is False
+
+        self.assert_cannot_remove_authenticators()
+
+    def test_cannot_reset_member_2fa__org_requires_2fa(self):
+        self.login_as(self.owner)
+        TotpInterface().enroll(self.owner)
+
+        self.org.update(flags=F('flags').bitor(Organization.flags.require_2fa))
+        assert self.org.flags.require_2fa.is_set is True
+
+        self.assert_cannot_remove_authenticators()
+
+    def test_owner_can_only_reset_member_2fa(self):
+        self.login_as(self.owner)
+
+        path = reverse(
+            'sentry-api-0-user-authenticator-details', args=[self.member.id, self.interface_id]
+        )
+        resp = self.client.get(path)
+        assert resp.status_code == 403
+
+        # cannot regenerate recovery codes
+        recovery = RecoveryCodeInterface()
+        recovery.enroll(self.user)
+        path = reverse(
+            'sentry-api-0-user-authenticator-details', args=[self.member.id, recovery.authenticator.id]
+        )
+        resp = self.client.put(path)
+        assert resp.status_code == 403
 
 
 class DeleteOrganizationMemberTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -470,7 +470,6 @@ class UpdateOrganizationMemberTest(APITestCase):
 
 
 class ResetOrganizationMember2faTest(APITestCase):
-
     def setUp(self):
         self.owner = self.create_user()
         self.org = self.create_organization(owner=self.owner)
@@ -488,7 +487,7 @@ class ResetOrganizationMember2faTest(APITestCase):
         self.interface_id = totp.authenticator.id
         assert Authenticator.objects.filter(user=self.member).exists()
 
-    def assert_can_get_user_authenticators(self):
+    def assert_can_get_authenticators(self):
         path = reverse(
             'sentry-api-0-organization-member-details', args=[self.org.slug, self.member_om.id]
         )
@@ -530,7 +529,7 @@ class ResetOrganizationMember2faTest(APITestCase):
     def test_org_owner_can_reset_member_2fa(self):
         self.login_as(self.owner)
 
-        self.assert_can_get_user_authenticators()
+        self.assert_can_get_authenticators()
         self.assert_can_remove_authenticators()
 
     def test_owner_must_have_org_membership(self):
@@ -556,7 +555,7 @@ class ResetOrganizationMember2faTest(APITestCase):
         )
         self.login_as(manager)
 
-        self.assert_can_get_user_authenticators()
+        self.assert_can_get_authenticators()
         self.assert_can_remove_authenticators()
 
     def test_org_admin_cannot_reset_member_2fa(self):

--- a/tests/sentry/api/serializers/test_user.py
+++ b/tests/sentry/api/serializers/test_user.py
@@ -84,3 +84,8 @@ class DetailedUserSerializerTest(TestCase):
         assert len(result['authenticators']) == 1
         assert result['authenticators'][0]['id'] == six.text_type(auth.id)
         assert result['permissions'] == ['foo']
+        assert result['canReset2fa'] is True
+
+        self.create_organization(owner=user)
+        result = serialize(user, user, DetailedUserSerializer())
+        assert result['canReset2fa'] is False


### PR DESCRIPTION
Allows 'member:admin' to reset an org member's 2FA, if the member is only in one org and 2FA isn't required.

<img width="923" alt="screen shot 2018-12-26 at 11 10 29 am" src="https://user-images.githubusercontent.com/16394317/50454852-08460500-08ff-11e9-983b-99ec5372f556.png">
