### PR TITLE
fix(ui): Remove "new" badge from issue owners

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx
@@ -39,7 +39,6 @@ export default function getConfiguration({project}) {
           path: `${pathPrefix}/ownership/`,
           title: t('Issue Owners'),
           description: t('Manage issue ownership rules for a project'),
-          badge: () => 'new',
         },
         {
           path: `${pathPrefix}/data-forwarding/`,


### PR DESCRIPTION
It's been in the product since Sentry 9 (~10 months and counting); probably safe to say it's not new anymore.