### PR TITLE
fix(ui): Don't use mdash w/o both provider & url

### DIFF
--- a/src/sentry/static/sentry/app/components/repositoryRow.jsx
+++ b/src/sentry/static/sentry/app/components/repositoryRow.jsx
@@ -88,9 +88,8 @@ class RepositoryRow extends React.Component {
                 )}
               </RepositoryTitle>
               <Box>
-                {showProvider && (
-                  <small>{repository.provider.name}&nbsp;&mdash;&nbsp;</small>
-                )}
+                {showProvider && <small>{repository.provider.name}</small>}
+                {showProvider && repository.url && <span>&nbsp;&mdash;&nbsp;</span>}
                 {repository.url && (
                   <small>
                     <a href={repository.url}>{repository.url.replace('https://', '')}</a>


### PR DESCRIPTION
It's possible to have a provider name without a URL, e.g. when there is no hosted repo ("Unknown Provider").