### PR TITLE
fix(build) Update urllib3 as safety is failing

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -68,5 +68,5 @@ toronado>=0.0.11,<0.1.0
 ua-parser>=0.6.1,<0.8.0
 # for bitbucket client
 unidiff>=0.5.4
-urllib3>=1.22,<1.23
+urllib3==1.24.1
 uwsgi>2.0.0,<2.1.0


### PR DESCRIPTION
My latest merge failed because urllib3 contains a vulnerability which is fixed in 1.23