### PR TITLE
chore(lint): Fix various warnings

### DIFF
--- a/src/sentry/static/sentry/app/components/activity/item.jsx
+++ b/src/sentry/static/sentry/app/components/activity/item.jsx
@@ -35,19 +35,18 @@ class ActivityItem extends React.Component {
     this.state = {
       clipped: this.props.defaultClipped,
     };
+    this.activityBubbleRef = React.createRef();
   }
 
   componentDidMount() {
-    if (this.refs.activityBubble) {
-      let bubbleHeight = this.refs.activityBubble.offsetHeight;
+    if (this.activityBubbleRef.current) {
+      let bubbleHeight = this.activityBubbleRef.current.offsetHeight;
 
       if (bubbleHeight > this.props.clipHeight) {
-        /*eslint react/no-did-mount-set-state:0*/
         // okay if this causes re-render; cannot determine until
         // rendered first anyways
-        this.setState({
-          clipped: true,
-        });
+        // eslint-disable-next-line react/no-did-mount-set-state
+        this.setState({clipped: true});
       }
     }
   }
@@ -330,7 +329,7 @@ class ActivityItem extends React.Component {
             )}
             <div
               className={bubbleClassName}
-              ref="activityBubble"
+              ref={this.activityBubbleRef}
               dangerouslySetInnerHTML={{__html: noteBody}}
             />
             <div className="activity-meta">

--- a/src/sentry/static/sentry/app/components/contextPickerModal.jsx
+++ b/src/sentry/static/sentry/app/components/contextPickerModal.jsx
@@ -175,7 +175,6 @@ class ContextPickerModal extends React.Component {
   focusProjectSelector = () => {
     if (!this.projectSelect || this.state.loading) return;
 
-    // eslint-disable-next-line react/no-find-dom-node
     ReactDOM.findDOMNode(this.projectSelect)
       .querySelector('input')
       .focus();
@@ -184,7 +183,6 @@ class ContextPickerModal extends React.Component {
   focusOrganizationSelector = () => {
     if (!this.orgSelect || this.state.loading) return;
 
-    // eslint-disable-next-line react/no-find-dom-node
     ReactDOM.findDOMNode(this.orgSelect)
       .querySelector('input')
       .focus();

--- a/src/sentry/static/sentry/app/components/customIgnoreDurationModal.jsx
+++ b/src/sentry/static/sentry/app/components/customIgnoreDurationModal.jsx
@@ -22,11 +22,13 @@ export default class CustomIgnoreDurationModal extends React.Component {
     this.state = {
       dateWarning: false,
     };
+    this.snoozeDateInputRef = React.createRef();
+    this.snoozeTimeInputRef = React.createRef();
   }
 
   selectedIgnoreMinutes = () => {
-    const dateStr = this.refs.snoozeDateInput.value; // YYYY-MM-DD
-    const timeStr = this.refs.snoozeTimeInput.value; // HH:MM
+    const dateStr = this.snoozeDateInputRef.current.value; // YYYY-MM-DD
+    const timeStr = this.snoozeTimeInputRef.current.value; // HH:MM
     if (dateStr && timeStr) {
       const selectedDate = new Date(dateStr + 'T' + timeStr); // poor man's ISO datetime
       if (!isNaN(selectedDate)) {
@@ -82,7 +84,7 @@ export default class CustomIgnoreDurationModal extends React.Component {
                 type="date"
                 id="snooze-until-date"
                 defaultValue={defaultDateVal}
-                ref="snoozeDateInput"
+                ref={this.snoozeDateInputRef}
                 required={true}
                 style={{padding: '0 10px'}}
               />
@@ -94,7 +96,7 @@ export default class CustomIgnoreDurationModal extends React.Component {
                 type="time"
                 id="snooze-until-time"
                 defaultValue={defaultTimeVal}
-                ref="snoozeTimeInput"
+                ref={this.snoozeTimeInputRef}
                 style={{padding: '0 10px'}}
                 required={true}
               />

--- a/src/sentry/static/sentry/app/components/forms/inputField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/inputField.jsx
@@ -43,7 +43,6 @@ export default class InputField extends FormField {
         placeholder={this.props.placeholder}
         onChange={this.onChange}
         disabled={this.props.disabled}
-        ref="input"
         name={this.props.name}
         required={this.props.required}
         value={this.state.value}

--- a/src/sentry/static/sentry/app/components/forms/textareaField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/textareaField.jsx
@@ -6,7 +6,6 @@ export default class TextareaField extends InputField {
     return (
       <textarea
         id={this.getId()}
-        ref="input"
         className="form-control"
         value={this.state.value}
         disabled={this.props.disabled}

--- a/src/sentry/static/sentry/app/components/resultGrid.jsx
+++ b/src/sentry/static/sentry/app/components/resultGrid.jsx
@@ -326,7 +326,6 @@ const ResultGrid = createReactClass({
                     placeholder="search"
                     style={{width: 300}}
                     name="query"
-                    ref="searchInput"
                     autoComplete="off"
                     value={this.state.query}
                     onChange={this.onQueryChange}

--- a/src/sentry/static/sentry/app/components/searchBar.jsx
+++ b/src/sentry/static/sentry/app/components/searchBar.jsx
@@ -21,6 +21,7 @@ class SearchBar extends React.PureComponent {
     this.state = {
       query: this.props.query || this.props.defaultQuery,
     };
+    this.searchInputRef = React.createRef();
   }
 
   componentWillReceiveProps(nextProps) {
@@ -32,7 +33,7 @@ class SearchBar extends React.PureComponent {
   }
 
   blur = () => {
-    this.searchInput.blur();
+    this.searchInputRef.current.blur();
   };
 
   onSubmit = evt => {
@@ -72,7 +73,7 @@ class SearchBar extends React.PureComponent {
               className="search-input form-control"
               placeholder={this.props.placeholder}
               name="query"
-              ref={el => (this.searchInput = el)}
+              ref={this.searchInputRef}
               autoComplete="off"
               value={this.state.query}
               onBlur={this.onQueryBlur}

--- a/src/sentry/static/sentry/app/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/tooltip.jsx
@@ -38,7 +38,6 @@ class Tooltip extends React.Component {
 
   handleMount = ref => {
     if (ref && !this.ref) {
-      // eslint-disable-next-line react/no-find-dom-node
       this.attachTooltips(ref);
     } else if (!ref && this.ref) {
       this.removeTooltips(ref);

--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -1,9 +1,8 @@
 /* global module */
 import 'babel-polyfill';
 import 'bootstrap/js/alert';
-import 'bootstrap/js/dropdown';
 import 'bootstrap/js/tab';
-import 'bootstrap/js/tooltip';
+import 'bootstrap/js/dropdown';
 
 import 'app/utils/emotion-setup';
 

--- a/src/sentry/static/sentry/app/views/organizationProjectsDashboard/newIssues.jsx
+++ b/src/sentry/static/sentry/app/views/organizationProjectsDashboard/newIssues.jsx
@@ -11,6 +11,8 @@ export default class NewIssues extends React.Component {
     pageSize: PropTypes.number,
   };
 
+  issueListRef = React.createRef();
+
   getEndpoint = () => {
     return `/organizations/${this.props.params.orgId}/issues/new/`;
   };
@@ -28,7 +30,7 @@ export default class NewIssues extends React.Component {
   };
 
   refresh = () => {
-    this.refs.issueList.remountComponent();
+    this.issueListRef.current.remountComponent();
   };
 
   render() {
@@ -53,7 +55,7 @@ export default class NewIssues extends React.Component {
           }}
           pagination={false}
           renderEmpty={this.renderEmpty}
-          ref="issueList"
+          ref={this.issueListRef}
           {...this.props}
         />
       </div>

--- a/src/sentry/static/sentry/app/views/releases/detail/project/releaseOverview.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/project/releaseOverview.jsx
@@ -216,7 +216,6 @@ const ReleaseOverview = createReactClass({
                   </PanelBody>
                 </Panel>
               )}
-              ref="issueList"
               showActions={false}
               params={{orgId}}
               className="m-b-2"
@@ -238,7 +237,6 @@ const ReleaseOverview = createReactClass({
                   </PanelBody>
                 </Panel>
               )}
-              ref="issueList"
               showActions={false}
               params={{orgId}}
               className="m-b-2"

--- a/src/sentry/static/sentry/app/views/settings/components/forms/textCopyInput.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/textCopyInput.jsx
@@ -56,11 +56,12 @@ class TextCopyInput extends React.Component {
 
   constructor(props) {
     super(props);
+    this.textRef = React.createRef();
   }
 
   // Select text when copy button is clicked
   handleCopyClick = e => {
-    if (!this.textRef) return;
+    if (!this.textRef.current) return;
 
     let {onCopy} = this.props;
 
@@ -72,16 +73,11 @@ class TextCopyInput extends React.Component {
   };
 
   handleSelectText = () => {
-    if (!this.textRef) return;
+    if (!this.textRef.current) return;
 
     // We use findDOMNode here because `this.textRef` is not a dom node,
     // it's a ref to AutoSelectText
-    // eslint-disable-next-line react/no-find-dom-node
-    selectText(ReactDOM.findDOMNode(this.textRef));
-  };
-
-  handleAutoMount = ref => {
-    this.textRef = ref;
+    selectText(ReactDOM.findDOMNode(this.textRef.current));
   };
 
   render() {
@@ -92,7 +88,7 @@ class TextCopyInput extends React.Component {
         <OverflowContainer>
           <StyledInput
             readOnly
-            ref={this.handleAutoMount}
+            ref={this.textRef}
             style={style}
             value={children}
             onClick={this.handleSelectText}

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/selectOwners.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/selectOwners.jsx
@@ -203,7 +203,6 @@ export default class SelectOwners extends React.Component {
   closeSelectMenu() {
     // Close select menu
     if (this.selectRef) {
-      // eslint-disable-next-line react/no-find-dom-node
       let input = ReactDOM.findDOMNode(this.selectRef).querySelector(
         '.Select-input input'
       );

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
@@ -68,7 +68,7 @@ describe('Sentry Application Details', function() {
           isAlertable: false,
         };
 
-        expect(response).toBeCalledWith(
+        expect(response).toHaveBeenCalledWith(
           '/sentry-apps/',
           expect.objectContaining({
             data,


### PR DESCRIPTION
* Remove usage of string refs, replace appropriately with createRef or another function style ref.

 * Removes comments on `findDOMNode` warnings, since we want to aim to remove usage of this.