### PR TITLE
fix(charts): Fix charts tooltip formatter to ignore non-numbers

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
@@ -12,7 +12,11 @@ function defaultFormatAxisLabel(value, isTimestamp, utc) {
 }
 
 function valueFormatter(value) {
-  return value.toLocaleString();
+  if (typeof value === 'number') {
+    return value.toLocaleString();
+  }
+
+  return value;
 }
 
 function getFormatter({filter, isGroupedByDate, truncate, formatAxisLabel, utc}) {


### PR DESCRIPTION
Do not attempt to call `toLocaleString()` on non-numbers