### PR TITLE
feat(discover): Add formatting options for `getChartData`

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
@@ -16,9 +16,11 @@ const CHART_KEY = '__CHART_KEY__';
  *
  * @param {Array} data Data returned from Snuba
  * @param {Object} query Query state corresponding to data
+ * @param {Object} [options] Options object
+ * @param {Boolean} [options.hideFieldName] (default: false) Hide field name in results set
  * @returns {Array}
  */
-export function getChartData(data, query) {
+export function getChartData(data, query, options = {}) {
   const {fields} = query;
 
   return query.aggregations.map(aggregation => {
@@ -27,7 +29,9 @@ export function getChartData(data, query) {
       data: data.map(res => {
         return {
           value: res[aggregation[2]],
-          name: fields.map(field => `${field} ${res[field]}`).join(' '),
+          name: fields
+            .map(field => `${options.hideFieldName ? '' : `${field} `}${res[field]}`)
+            .join(options.separator || ' '),
         };
       }),
     };

--- a/tests/js/spec/views/organizationDiscover/result/utils.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/result/utils.spec.jsx
@@ -9,41 +9,92 @@ import {
 } from 'app/views/organizationDiscover/result/utils';
 
 describe('Utils', function() {
-  it('getChartData()', function() {
+  describe('getChartData()', function() {
     const raw = [
       {count: 2, uniq_id: 1, 'project.id': 5, environment: null},
       {count: 2, uniq_id: 3, 'project.id': 5, environment: 'staging'},
       {count: 2, uniq_id: 4, 'project.id': 5, environment: 'alpha'},
       {count: 6, uniq_id: 10, 'project.id': 5, environment: 'production'},
     ];
-
     const query = {
       aggregations: [['count()', null, 'count'], ['uniq', 'id', 'uniq_id']],
       fields: ['project.id', 'environment'],
     };
 
-    const expected = [
-      {
-        seriesName: 'count',
-        data: [
-          {value: 2, name: 'project.id 5 environment null'},
-          {value: 2, name: 'project.id 5 environment staging'},
-          {value: 2, name: 'project.id 5 environment alpha'},
-          {value: 6, name: 'project.id 5 environment production'},
-        ],
-      },
-      {
-        seriesName: 'uniq_id',
-        data: [
-          {value: 1, name: 'project.id 5 environment null'},
-          {value: 3, name: 'project.id 5 environment staging'},
-          {value: 4, name: 'project.id 5 environment alpha'},
-          {value: 10, name: 'project.id 5 environment production'},
-        ],
-      },
-    ];
+    it('returns chart data', function() {
+      const expected = [
+        {
+          seriesName: 'count',
+          data: [
+            {value: 2, name: 'project.id 5 environment null'},
+            {value: 2, name: 'project.id 5 environment staging'},
+            {value: 2, name: 'project.id 5 environment alpha'},
+            {value: 6, name: 'project.id 5 environment production'},
+          ],
+        },
+        {
+          seriesName: 'uniq_id',
+          data: [
+            {value: 1, name: 'project.id 5 environment null'},
+            {value: 3, name: 'project.id 5 environment staging'},
+            {value: 4, name: 'project.id 5 environment alpha'},
+            {value: 10, name: 'project.id 5 environment production'},
+          ],
+        },
+      ];
 
-    expect(getChartData(raw, query)).toEqual(expected);
+      expect(getChartData(raw, query)).toEqual(expected);
+    });
+
+    it('customizes separator', function() {
+      const expected = [
+        {
+          seriesName: 'count',
+          data: [
+            {value: 2, name: 'project.id 5, environment null'},
+            {value: 2, name: 'project.id 5, environment staging'},
+            {value: 2, name: 'project.id 5, environment alpha'},
+            {value: 6, name: 'project.id 5, environment production'},
+          ],
+        },
+        {
+          seriesName: 'uniq_id',
+          data: [
+            {value: 1, name: 'project.id 5, environment null'},
+            {value: 3, name: 'project.id 5, environment staging'},
+            {value: 4, name: 'project.id 5, environment alpha'},
+            {value: 10, name: 'project.id 5, environment production'},
+          ],
+        },
+      ];
+
+      expect(getChartData(raw, query, {separator: ', '})).toEqual(expected);
+    });
+
+    it('hides field name for series label', function() {
+      const expected = [
+        {
+          seriesName: 'count',
+          data: [
+            {value: 2, name: '5 null'},
+            {value: 2, name: '5 staging'},
+            {value: 2, name: '5 alpha'},
+            {value: 6, name: '5 production'},
+          ],
+        },
+        {
+          seriesName: 'uniq_id',
+          data: [
+            {value: 1, name: '5 null'},
+            {value: 3, name: '5 staging'},
+            {value: 4, name: '5 alpha'},
+            {value: 10, name: '5 production'},
+          ],
+        },
+      ];
+
+      expect(getChartData(raw, query, {hideFieldName: true})).toEqual(expected);
+    });
   });
 
   it('getChartDataByDay()', function() {


### PR DESCRIPTION
This adds two formatting options for `getChartData()`:

* `hideFieldName` - hides field name and only displays value for the label
* `separator` - Adds separator for labels (default is space)