### PR TITLE
feat(discover): Add option to discover results to not format dates

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
@@ -40,9 +40,11 @@ export function getChartData(data, query) {
  *
  * @param {Array} data Data returned from Snuba
  * @param {Object} query Query state corresponding to data
+ * @param {Object} [options] Options object
+ * @param {Boolean} [options.useTimestamps] (default: false) Return raw timestamps instead of formatting dates
  * @returns {Array}
  */
-export function getChartDataByDay(rawData, query) {
+export function getChartDataByDay(rawData, query, options = {}) {
   // We only chart the first aggregation for now
   const aggregate = query.aggregations[0][2];
 
@@ -53,7 +55,9 @@ export function getChartDataByDay(rawData, query) {
 
   // Reverse to get ascending dates - we request descending to ensure latest
   // day data is compplete in the case of limits being hit
-  const dates = [...new Set(rawData.map(entry => formatDate(entry.time)))].reverse();
+  const dates = [
+    ...new Set(rawData.map(entry => formatDate(entry.time, !options.useTimestamps))),
+  ].reverse();
 
   // Temporarily store series as object with series names as keys
   const seriesHash = getEmptySeriesHash(top10Series, dates);
@@ -62,7 +66,7 @@ export function getChartDataByDay(rawData, query) {
   data.forEach(row => {
     const key = row[CHART_KEY];
 
-    const dateIdx = dates.indexOf(formatDate(row.time));
+    const dateIdx = dates.indexOf(formatDate(row.time, !options.useTimestamps));
 
     if (top10Series.has(key)) {
       seriesHash[key][dateIdx].value = row[aggregate];
@@ -143,8 +147,14 @@ function getDataWithKeys(data, query) {
   });
 }
 
-function formatDate(datetime) {
-  return moment.utc(datetime * 1000).format('MMM Do');
+function formatDate(datetime, enabled = true) {
+  const timestamp = datetime * 1000;
+
+  if (!enabled) {
+    return timestamp;
+  }
+
+  return moment.utc(timestamp).format('MMM Do');
 }
 
 // Converts a value to a string for the chart label. This could

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
@@ -38,6 +38,8 @@ export function getChartData(data, query) {
  * Returns time series data formatted for line and bar charts, with each day
  * along the x-axis
  *
+ * TODO(billy): Investigate making `useTimestamps` the default behavior and remove the option
+ *
  * @param {Array} data Data returned from Snuba
  * @param {Object} query Query state corresponding to data
  * @param {Object} [options] Options object

--- a/tests/js/spec/views/organizationDiscover/result/utils.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/result/utils.spec.jsx
@@ -46,7 +46,7 @@ describe('Utils', function() {
     expect(getChartData(raw, query)).toEqual(expected);
   });
 
-  it('getChartDataByDay()', function() {
+  describe('getChartDataByDay()', function() {
     const raw = [
       {
         'error.type': 'Type Error',
@@ -103,42 +103,82 @@ describe('Utils', function() {
       fields: ['platform', 'error.type'],
     };
 
-    const expected = [
-      {
-        data: [
-          {name: 'Jul 9th', value: 14},
-          {name: 'Jul 10th', value: null},
-          {name: 'Jul 20th', value: 30},
-        ],
-        seriesName: 'python,SnubaError',
-      },
-      {
-        data: [
-          {name: 'Jul 9th', value: 6},
-          {name: 'Jul 10th', value: null},
-          {name: 'Jul 20th', value: 8},
-        ],
-        seriesName: 'php,Exception',
-      },
-      {
-        data: [
-          {name: 'Jul 9th', value: 6},
-          {name: 'Jul 10th', value: null},
-          {name: 'Jul 20th', value: 5},
-        ],
-        seriesName: 'javascript,Type Error',
-      },
-      {
-        data: [
-          {name: 'Jul 9th', value: 6},
-          {name: 'Jul 10th', value: 20},
-          {name: 'Jul 20th', value: null},
-        ],
-        seriesName: 'python,ZeroDivisionError',
-      },
-    ];
+    it('returns chart data grouped by day', function() {
+      const expected = [
+        {
+          data: [
+            {name: 'Jul 9th', value: 14},
+            {name: 'Jul 10th', value: null},
+            {name: 'Jul 20th', value: 30},
+          ],
+          seriesName: 'python,SnubaError',
+        },
+        {
+          data: [
+            {name: 'Jul 9th', value: 6},
+            {name: 'Jul 10th', value: null},
+            {name: 'Jul 20th', value: 8},
+          ],
+          seriesName: 'php,Exception',
+        },
+        {
+          data: [
+            {name: 'Jul 9th', value: 6},
+            {name: 'Jul 10th', value: null},
+            {name: 'Jul 20th', value: 5},
+          ],
+          seriesName: 'javascript,Type Error',
+        },
+        {
+          data: [
+            {name: 'Jul 9th', value: 6},
+            {name: 'Jul 10th', value: 20},
+            {name: 'Jul 20th', value: null},
+          ],
+          seriesName: 'python,ZeroDivisionError',
+        },
+      ];
 
-    expect(getChartDataByDay(raw, query)).toEqual(expected);
+      expect(getChartDataByDay(raw, query)).toEqual(expected);
+    });
+
+    it('returns chart data grouped by timestamp', function() {
+      const expected = [
+        {
+          data: [
+            {name: 1531094400000, value: 14},
+            {name: 1531180800000, value: null},
+            {name: 1532070000000, value: 30},
+          ],
+          seriesName: 'python,SnubaError',
+        },
+        {
+          data: [
+            {name: 1531094400000, value: 6},
+            {name: 1531180800000, value: null},
+            {name: 1532070000000, value: 8},
+          ],
+          seriesName: 'php,Exception',
+        },
+        {
+          data: [
+            {name: 1531094400000, value: 6},
+            {name: 1531180800000, value: null},
+            {name: 1532070000000, value: 5},
+          ],
+          seriesName: 'javascript,Type Error',
+        },
+        {
+          data: [
+            {name: 1531094400000, value: 6},
+            {name: 1531180800000, value: 20},
+            {name: 1532070000000, value: null},
+          ],
+          seriesName: 'python,ZeroDivisionError',
+        },
+      ];
+      expect(getChartDataByDay(raw, query, {useTimestamps: true})).toEqual(expected);
+    });
   });
 
   it('getDisplayValue()', function() {


### PR DESCRIPTION
Adds option to return chart data by timestamp instead of formatted date