### PR TITLE
bug(ui): remove code that overrides sidebar collapsed state prefs

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -186,10 +186,7 @@ class Sidebar extends React.Component {
     let hasOrganization = !!organization;
 
     return (
-      <StyledSidebar
-        innerRef={ref => (this.sidebar = ref)}
-        collapsed={hasOrganization ? collapsed : true}
-      >
+      <StyledSidebar innerRef={ref => (this.sidebar = ref)} collapsed={collapsed}>
         <SidebarSectionGroup>
           <SidebarSection>
             <SidebarDropdown

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -65,6 +65,8 @@ class Sidebar extends React.Component {
       router.listen(() => {
         $('.tooltip').tooltip('hide');
       });
+
+    this.doCollapse(this.props.collapsed);
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -51,7 +51,7 @@ class Sidebar extends React.Component {
   }
 
   componentDidMount() {
-    let {organization, router} = this.props;
+    let {router} = this.props;
     jQuery(document.body).addClass('body-sidebar');
     jQuery(document).on('click', this.documentClickHandler);
 
@@ -65,10 +65,6 @@ class Sidebar extends React.Component {
       router.listen(() => {
         $('.tooltip').tooltip('hide');
       });
-
-    // If there is no organization (i.e. no org in context, or error loading org)
-    // then sidebar should default to collapsed state
-    this.doCollapse(!!organization ? this.props.collapsed : true);
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
This fixes an error where a user's sidebar prefs are overridden when organization context isn't present. In some cases like in #11155, the sidebar can cover up navigation.

Fixes #11155 and ISSUE-243