### PR TITLE
test: Pin  mysqlclient to 1.3.13 and sentry-sdk to < 0.6.5 to fix test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,9 @@ matrix:
       install:
         - python setup.py install_egg_info
         - pip install -e ".[dev,tests,optional]"
-        - pip install mysqlclient
+        # 1.3.14 causes test failures. Pinning to 1.3.13 for now, hopefully
+        # a later release resolves this.
+        - pip install mysqlclient==1.3.13
       before_script:
         - mysql -u root -e 'create database sentry;'
 

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -55,7 +55,9 @@ requests-oauthlib==0.3.3
 requests[security]>=2.20.0,<2.21.0
 selenium==3.11.0
 semaphore>=0.2.0,<0.3.0
-sentry-sdk>=0.6.0,<0.7
+# Temporarily keep this below 0.6.5 since a change to the `Auth` class causes
+# a test to fail
+sentry-sdk>=0.6.0,<0.6.5
 setproctitle>=1.1.7,<1.2.0
 simplejson>=3.2.0,<3.9.0
 six>=1.10.0,<1.11.0


### PR DESCRIPTION
1.3.14 causes tests/sentry/lang/java/test_plugin.py to fail. We can try later versions in a while and see if the issue still occurs.