### PR TITLE
feat(releases): Basic organization release overview page

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -798,9 +798,15 @@ function routes() {
           <Route
             path="/organizations/:orgId/releases/:version/"
             componentPromise={() =>
-              import(/* webpackChunkName: "OrganizationReleasesDetail" */ './views/releases/detail/organization')}
+              import(/*webpackChunkName: "OrganizationReleaseDetail"*/ './views/releases/detail/organization')}
             component={errorHandler(LazyLoad)}
-          />
+          >
+            <IndexRoute
+              componentPromise={() =>
+                import(/*webpackChunkName:"OrganizationReleaseOverview"*/ './views/releases/detail/organization/releaseOverview')}
+              component={errorHandler(LazyLoad)}
+            />
+          </Route>
 
           <Route
             path="/organizations/:orgId/teams/new/"
@@ -893,19 +899,19 @@ function routes() {
           <Route
             path="releases/:version/"
             componentPromise={() =>
-              import(/* webpackChunkName: "ReleaseDetails" */ './views/releases/detail/project')}
+              import(/*webpackChunkName:"ProjectReleaseDetails"*/ './views/releases/detail/project')}
             component={errorHandler(LazyLoad)}
           >
             <IndexRoute
               componentPromise={() =>
-                import(/* webpackChunkName: "ReleaseOverview" */ './views/releases/detail/project/releaseOverview')}
+                import(/*webpackChunkName:"ProjectReleaseOverview"*/ './views/releases/detail/project/releaseOverview')}
               component={errorHandler(LazyLoad)}
             />
 
             <Route
               path="new-events/"
               componentPromise={() =>
-                import(/* webpackChunkName: "ReleaseNewEvents" */ './views/releases/detail/project/releaseNewEvents')}
+                import(/*webpackChunkName:"ProjectReleaseNewEvents"*/ './views/releases/detail/project/releaseNewEvents')}
               component={errorHandler(LazyLoad)}
             />
 

--- a/src/sentry/static/sentry/app/views/releases/detail/organization/releaseOverview.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/organization/releaseOverview.jsx
@@ -1,0 +1,212 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import {Box} from 'grid-emotion';
+import Button from 'app/components/button';
+import IconOpen from 'app/icons/icon-open';
+import HeroIcon from 'app/components/heroIcon';
+import LastCommit from 'app/components/lastCommit';
+// import IssueList from 'app/components/issueList';
+import CommitAuthorStats from 'app/components/commitAuthorStats';
+import ReleaseProjectStatSparkline from 'app/components/releaseProjectStatSparkline';
+import RepositoryFileSummary from 'app/components/repositoryFileSummary';
+import TimeSince from 'app/components/timeSince';
+import AsyncView from 'app/views/asyncView';
+import {t} from 'app/locale';
+// import {Panel, PanelBody, PanelItem} from 'app/components/panels';
+import Well from 'app/components/well';
+
+export default class OrganizationReleaseOverview extends AsyncView {
+  static contextTypes = {
+    release: PropTypes.object,
+  };
+
+  getEndpoints() {
+    const {orgId, version} = this.props.params;
+    const basePath = `/organizations/${orgId}/releases/${encodeURIComponent(version)}/`;
+    return [
+      ['fileList', `${basePath}commitfiles/`],
+      ['deploys', `${basePath}deploys/`],
+      ['repos', `/organizations/${orgId}/repos/`],
+    ];
+  }
+
+  renderEmpty() {
+    return <div className="box empty">{t('None')}</div>;
+  }
+
+  renderBody() {
+    const {orgId, version} = this.props.params;
+    const {release} = this.context;
+
+    const {fileList, repos} = this.state;
+
+    const hasRepos = repos.length > 0;
+
+    // convert list of individual file changes (can be
+    // multiple changes to a single file) into a per-file
+    // summary grouped by repository
+    const filesByRepository = fileList.reduce(function(fbr, file) {
+      const {filename, repoName, author, type} = file;
+      if (!fbr.hasOwnProperty(repoName)) {
+        fbr[repoName] = {};
+      }
+      if (!fbr[repoName].hasOwnProperty(filename)) {
+        fbr[repoName][filename] = {
+          authors: {},
+          types: new Set(),
+          repos: new Set(),
+        };
+      }
+
+      fbr[repoName][filename].authors[author.email] = author;
+      fbr[repoName][filename].types.add(type);
+
+      return fbr;
+    }, {});
+
+    const deploys = this.state.deploys;
+
+    // TODO: Issue lists depend on organization issues endpoint
+    // const query = {};
+
+    return (
+      <div>
+        <div className="row" style={{paddingTop: 10}}>
+          <div className="col-sm-8">
+            {/**<h5>{t('Issues Resolved in this Release')}</h5>
+            <IssueList
+              endpoint={`/organizations/${orgId}/releases/${encodeURIComponent(
+                version
+              )}/resolved/`}
+              query={query}
+              pagination={false}
+              renderEmpty={() => (
+                <Panel>
+                  <PanelBody>
+                    <PanelItem key="none" justify="center">
+                      {t('No issues resolved')}
+                    </PanelItem>
+                  </PanelBody>
+                </Panel>
+              )}
+              showActions={false}
+              params={{orgId}}
+              className="m-b-2"
+            />
+            <h5>{t('New Issues in this Release')}</h5>
+            <IssueList
+              endpoint={`/organizations/${orgId}/issues/`}
+              query={{
+                ...query,
+                query: 'first-release:"' + version + '"',
+                limit: 5,
+              }}
+              statsPeriod="0"
+              pagination={false}
+              renderEmpty={() => (
+                <Panel>
+                  <PanelBody>
+                    <PanelItem justify="center">{t('No new issues')}</PanelItem>
+                  </PanelBody>
+                </Panel>
+              )}
+              showActions={false}
+              params={{orgId}}
+              className="m-b-2"
+              />**/}
+            {hasRepos && (
+              <div>
+                {Object.keys(filesByRepository).map((repository, i) => {
+                  return (
+                    <RepositoryFileSummary
+                      key={i}
+                      repository={repository}
+                      fileChangeSummary={filesByRepository[repository]}
+                    />
+                  );
+                })}
+              </div>
+            )}
+          </div>
+          <div className="col-sm-4">
+            {hasRepos ? (
+              <div>
+                {release.lastCommit && (
+                  <LastCommit commit={release.lastCommit} headerClass="nav-header" />
+                )}
+                <CommitAuthorStats orgId={orgId} version={version} />
+                <h6 className="nav-header m-b-1">{t('Projects Affected')}</h6>
+                <ul className="nav nav-stacked">
+                  {release.projects.length === 0
+                    ? this.renderEmpty()
+                    : release.projects.map(project => {
+                        return (
+                          <ReleaseProjectStatSparkline
+                            key={project.id}
+                            orgId={orgId}
+                            project={project}
+                            version={version}
+                          />
+                        );
+                      })}
+                </ul>
+              </div>
+            ) : (
+              <Well centered className="m-t-2">
+                <HeroIcon src="icon-commit" />
+                <h5>Releases are better with commit data!</h5>
+                <p>
+                  Connect a repository to see commit info, files changed, and authors
+                  involved in future releases.
+                </p>
+                <Box mb={1}>
+                  <Button priority="primary" href={`/organizations/${orgId}/repos/`}>
+                    Connect a repository
+                  </Button>
+                </Box>
+              </Well>
+            )}
+            <h6 className="nav-header m-b-1">{t('Deploys')}</h6>
+            <ul className="nav nav-stacked">
+              {!deploys.length
+                ? this.renderEmpty()
+                : deploys.map(deploy => {
+                    const href = `/organizations/${orgId}/issues/?query=release:${version}&environment=${encodeURIComponent(
+                      deploy.environment
+                    )}`;
+
+                    return (
+                      <li key={deploy.id}>
+                        <a href={href} title={t('View in stream')}>
+                          <div className="row row-flex row-center-vertically">
+                            <div className="col-xs-6">
+                              <span
+                                className="repo-label"
+                                style={{verticalAlign: 'bottom'}}
+                              >
+                                {deploy.environment}
+                                <IconOpen
+                                  className="icon-open"
+                                  size={11}
+                                  style={{marginLeft: 6}}
+                                />
+                              </span>
+                            </div>
+                            <div className="col-xs-6 align-right">
+                              <small>
+                                <TimeSince date={deploy.dateFinished} />
+                              </small>
+                            </div>
+                          </div>
+                        </a>
+                      </li>
+                    );
+                  })}
+            </ul>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/sentry/static/sentry/app/views/releases/detail/organization/releaseOverview.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/organization/releaseOverview.jsx
@@ -1,7 +1,7 @@
-import PropTypes from 'prop-types';
 import React from 'react';
-
 import {Box} from 'grid-emotion';
+
+import SentryTypes from 'app/sentryTypes';
 import Button from 'app/components/button';
 import IconOpen from 'app/icons/icon-open';
 import HeroIcon from 'app/components/heroIcon';
@@ -18,7 +18,7 @@ import Well from 'app/components/well';
 
 export default class OrganizationReleaseOverview extends AsyncView {
   static contextTypes = {
-    release: PropTypes.object,
+    release: SentryTypes.Release,
   };
 
   getEndpoints() {

--- a/src/sentry/static/sentry/app/views/releases/detail/organization/releaseOverview.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/organization/releaseOverview.jsx
@@ -3,7 +3,7 @@ import {Box} from 'grid-emotion';
 
 import SentryTypes from 'app/sentryTypes';
 import Button from 'app/components/button';
-import IconOpen from 'app/icons/icon-open';
+import InlineSvg from 'app/components/inlineSvg';
 import HeroIcon from 'app/components/heroIcon';
 import LastCommit from 'app/components/lastCommit';
 // import IssueList from 'app/components/issueList';
@@ -186,8 +186,8 @@ export default class OrganizationReleaseOverview extends AsyncView {
                                 style={{verticalAlign: 'bottom'}}
                               >
                                 {deploy.environment}
-                                <IconOpen
-                                  className="icon-open"
+                                <InlineSvg
+                                  src="icon-open"
                                   size={11}
                                   style={{marginLeft: 6}}
                                 />

--- a/src/sentry/static/sentry/app/views/releases/detail/shared/releaseHeader.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/shared/releaseHeader.jsx
@@ -30,7 +30,7 @@ export default class ReleaseHeader extends React.Component {
 
     const releasePath = projectId
       ? `/${orgId}/${projectId}/releases/${encodeURIComponent(release.version)}`
-      : `/organizations/releases/${encodeURIComponent(release.version)}`;
+      : `/organizations/${orgId}/releases/${encodeURIComponent(release.version)}`;
 
     return (
       <div className="release-details">

--- a/src/sentry/static/sentry/app/views/releases/detail/shared/utils.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/shared/utils.jsx
@@ -17,22 +17,3 @@ export function deleteRelease(orgId, version) {
     }
   );
 }
-
-/**
- * Get release version
- *
- * @param {String} orgId Organization slug
- * @param {String} version Version
- * @param {Object} query Query params
- * @returns {Promise}
- */
-export function getRelease(orgId, version, query = {}) {
-  const api = new Client();
-
-  return api.requestPromise(
-    `/organizations/${orgId}/releases/${encodeURIComponent(version)}/`,
-    {
-      query,
-    }
-  );
-}


### PR DESCRIPTION
Basic implementation of an organization release overview page.
Mostly copied from project releases.

This currently excludes:
- issues in this release (depends on org issue endpoints)
- project/environment/date filtering