### PR TITLE
ref(interfaces): Reduce grouping score of the stacktrace interface

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -720,7 +720,7 @@ class Stacktrace(Interface):
     .. note:: This interface can be passed as the 'stacktrace' key in addition
               to the full interface path.
     """
-    score = 2000
+    score = 1950
 
     def __iter__(self):
         return iter(self.frames)


### PR DESCRIPTION
This lowers grouping score of the `Stacktrace` interface from 2000 to 1950 to force it after the `Exception` interface. Otherwise, the grouping precedence depends on field order in the input data if both interfaces are given.

This only applies to events with a stacktrace and more than one exception, which is an infrequent edge case.