### PR TITLE
tests(js): Fail on React-specific console.errors

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,10 @@ module.exports = {
       '<rootDir>/tests/fixtures/integration-docs/_platforms.json',
   },
   modulePaths: ['<rootDir>/src/sentry/static/sentry'],
-  setupFiles: ['<rootDir>/tests/js/setup.js'],
+  setupFiles: [
+    "<rootDir>/tests/js/throw-on-react-error.js",
+    '<rootDir>/tests/js/setup.js'
+  ],
   setupTestFrameworkScriptFile: '<rootDir>/tests/js/setupFramework.js',
   testMatch: ['<rootDir>/tests/js/**/?(*.)(spec|test).js?(x)'],
   testPathIgnorePatterns: ['<rootDir>/tests/sentry/lang/javascript/'],

--- a/src/sentry/static/sentry/app/views/releases/list/shared/releaseList.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/shared/releaseList.jsx
@@ -40,7 +40,7 @@ class ReleaseList extends React.Component {
                 <ReleaseStats release={release} />
               </Box>
               <Box w={2 / 12} pl={2}>
-                <Count className="release-count" value={release.newGroups} />
+                <Count className="release-count" value={release.newGroups || 0} />
               </Box>
               <Box w={2 / 12} pl={2}>
                 {release.lastEvent ? (

--- a/tests/js/spec/views/onboarding/index.spec.jsx
+++ b/tests/js/spec/views/onboarding/index.spec.jsx
@@ -64,7 +64,7 @@ describe('OnboardingWizard', function() {
         childContextTypes: {
           router: PropTypes.object,
           organization: PropTypes.object,
-          location: {pathname: 'http://lol/', query: {}},
+          location: PropTypes.object,
         },
       });
 

--- a/tests/js/spec/views/releases/list/projectReleases.spec.jsx
+++ b/tests/js/spec/views/releases/list/projectReleases.spec.jsx
@@ -4,10 +4,6 @@ import {browserHistory} from 'react-router';
 
 import {Client} from 'app/api';
 import {ProjectReleases} from 'app/views/releases/list/projectReleases';
-import SearchBar from 'app/views/stream/searchBar';
-import Pagination from 'app/components/pagination';
-
-import stubReactComponents from '../../../../helpers/stubReactComponent';
 
 describe('ProjectReleases', function() {
   let sandbox;
@@ -18,8 +14,6 @@ describe('ProjectReleases', function() {
     sandbox = sinon.sandbox.create();
 
     sandbox.stub(Client.prototype, 'request');
-    stubReactComponents(sandbox, [SearchBar, Pagination]);
-    sandbox.stub(browserHistory, 'push');
 
     props = {
       setProjectNavSection: function() {},
@@ -53,10 +47,11 @@ describe('ProjectReleases', function() {
     it('should change query string with new search parameter', function() {
       projectReleases.instance().onSearch('searchquery');
 
-      expect(browserHistory.push.calledOnce).toBeTruthy();
-      expect(browserHistory.push.args[0]).toEqual([
-        {pathname: '/123/456/releases/', query: {query: 'searchquery'}},
-      ]);
+      expect(browserHistory.push).toHaveBeenCalledTimes(1);
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        pathname: '/123/456/releases/',
+        query: {query: 'searchquery'},
+      });
     });
   });
 

--- a/tests/js/throw-on-react-error.js
+++ b/tests/js/throw-on-react-error.js
@@ -1,18 +1,13 @@
 // eslint-disable-next-line no-console
 const originalConsoleError = console.error;
+const BAD_ERRORS = /(Failed prop type|Failed child context type|React does not recognize the `[^`]+` prop on a DOM element)/;
 
 // eslint-disable-next-line no-console
 console.error = (message, ...args) => {
   originalConsoleError(message, ...args);
 
   // List of `console.error` messages to fail on
-  if (
-    /(Failed prop type|Failed child context type|React does not recognize the `[^`]+` prop on a DOM element)/.test(
-      message
-    )
-  ) {
+  if (BAD_ERRORS.test(message)) {
     throw new Error(message);
   }
 };
-
-// projectReleases, onboarding

--- a/tests/js/throw-on-react-error.js
+++ b/tests/js/throw-on-react-error.js
@@ -1,0 +1,18 @@
+// eslint-disable-next-line no-console
+const originalConsoleError = console.error;
+
+// eslint-disable-next-line no-console
+console.error = (message, ...args) => {
+  originalConsoleError(message, ...args);
+
+  // List of `console.error` messages to fail on
+  if (
+    /(Failed prop type|Failed child context type|React does not recognize the `[^`]+` prop on a DOM element)/.test(
+      message
+    )
+  ) {
+    throw new Error(message);
+  }
+};
+
+// projectReleases, onboarding

--- a/tests/js/throw-on-react-error.js
+++ b/tests/js/throw-on-react-error.js
@@ -1,19 +1,25 @@
 // eslint-disable-next-line no-console
 const originalConsoleError = console.error;
+
+// List of `console.error` messages to fail on
 const BAD_ERRORS = [
   'Failed prop type',
   'Failed child context type',
   'React does not recognize the `[^`]+` prop on a DOM element',
 ];
 
+// This is needed because when we throw the captured error message, it will
+// also `console.error` it
+const REPEATED_ERROR = 'Error: Uncaught [Error: Warning: ';
+
 const BAD_ERRORS_REGEX = new RegExp(BAD_ERRORS.join('|'));
 
 // eslint-disable-next-line no-console
 console.error = (message, ...args) => {
-  originalConsoleError(message, ...args);
-
-  // List of `console.error` messages to fail on
-  if (BAD_ERRORS_REGEX.test(message)) {
+  if (message.indexOf(REPEATED_ERROR) !== 0 && BAD_ERRORS_REGEX.test(message)) {
+    originalConsoleError(message, ...args);
     throw new Error(message);
+  } else if (!BAD_ERRORS_REGEX.test(message)) {
+    originalConsoleError(message, ...args);
   }
 };

--- a/tests/js/throw-on-react-error.js
+++ b/tests/js/throw-on-react-error.js
@@ -1,13 +1,19 @@
 // eslint-disable-next-line no-console
 const originalConsoleError = console.error;
-const BAD_ERRORS = /(Failed prop type|Failed child context type|React does not recognize the `[^`]+` prop on a DOM element)/;
+const BAD_ERRORS = [
+  'Failed prop type',
+  'Failed child context type',
+  'React does not recognize the `[^`]+` prop on a DOM element',
+];
+
+const BAD_ERRORS_REGEX = new RegExp(BAD_ERRORS.join('|'));
 
 // eslint-disable-next-line no-console
 console.error = (message, ...args) => {
   originalConsoleError(message, ...args);
 
   // List of `console.error` messages to fail on
-  if (BAD_ERRORS.test(message)) {
+  if (BAD_ERRORS_REGEX.test(message)) {
     throw new Error(message);
   }
 };


### PR DESCRIPTION
In order to keep our test logs clean, this will now throw errors when we get certain React warning messages via `console.error`. These include prop type warnings (as well as context type), and invalid properties on a DOM element.