### PR TITLE
fix(ui) Move robot eye animation to use GPU when possible

### DIFF
--- a/src/sentry/static/sentry/less/onboarding.less
+++ b/src/sentry/static/sentry/less/onboarding.less
@@ -57,6 +57,7 @@
       position: absolute;
       top: 21px;
       left: 26px;
+      transform: translateZ(0);
 
       -webkit-animation: blink-eye 0.6s infinite;
       -moz-animation: blink-eye 0.6s infinite;

--- a/src/sentry/static/sentry/less/stream.less
+++ b/src/sentry/static/sentry/less/stream.less
@@ -523,6 +523,7 @@
       position: absolute;
       top: 70px;
       left: 82px;
+      transform: translateZ(0);
 
       -webkit-animation: blink-eye 0.6s infinite;
       -moz-animation: blink-eye 0.6s infinite;


### PR DESCRIPTION
Attempt to reduce the CPU load that the blinking eye creates by shifting the rendering onto the GPU where possible.

Fixes #10381