### PR TITLE
fix: Only render dsn if it's a valid dsn

### DIFF
--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -153,6 +153,10 @@ class ProjectKey(Model):
         else:
             urlparts = urlparse(options.get('system.url-prefix'))
 
+        # If we do not have a scheme or domain/hostname, dsn is never valid
+        if not urlparts.netloc or not urlparts.scheme:
+            return ''
+
         return '%s://%s@%s/%s' % (
             urlparts.scheme, key, urlparts.netloc + urlparts.path, self.project_id,
         )

--- a/src/sentry/templatetags/sentry_dsn.py
+++ b/src/sentry/templatetags/sentry_dsn.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-import re
-
 from django import template
 from django.conf import settings
 from django.db.models import F
@@ -9,7 +7,6 @@ from django.db.models import F
 from sentry.cache import default_cache
 from sentry.models import ProjectKey
 
-_dsn_re = re.compile(r'^(?:(\w+):)\/\/(?:(\w+)(?::(\w+))?@)([\w\.-]+)(?::(\d+))?\/(.+)')
 register = template.Library()
 
 
@@ -30,7 +27,7 @@ def get_public_dsn():
     result = default_cache.get(cache_key)
     if result is None:
         key = _get_project_key(project_id)
-        if key and bool(_dsn_re.match(key.dsn_public)):
+        if key:
             result = key.dsn_public
         else:
             result = ''

--- a/src/sentry/templatetags/sentry_react.py
+++ b/src/sentry/templatetags/sentry_react.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import logging
 import sentry
 
 from django import template
@@ -12,12 +11,12 @@ from pkg_resources import parse_version
 from sentry import features, options
 from sentry.api.serializers.base import serialize
 from sentry.api.serializers.models.user import DetailedUserSerializer
-from sentry.models import ProjectKey
 from sentry.utils import auth, json
 from sentry.utils.email import is_smtp_enabled
 from sentry.utils.assets import get_asset_url
 from sentry.utils.functional import extract_lazy_object
 from sentry.utils.support import get_support_mail
+from sentry.templatetags.sentry_dsn import get_public_dsn
 
 register = template.Library()
 
@@ -59,17 +58,6 @@ def _needs_upgrade():
         options.set('sentry:version-configured', sentry.get_version())
 
     return False
-
-
-def _get_public_dsn():
-    try:
-        projectkey = ProjectKey.objects.filter(
-            project=settings.SENTRY_FRONTEND_PROJECT or settings.SENTRY_PROJECT,
-        )[0]
-    except Exception:
-        logging.exception('Unable to fetch ProjectKey for internal project')
-        return
-    return projectkey.dsn_public
 
 
 def _get_statuspage():
@@ -120,7 +108,7 @@ def get_react_config(context):
         'features': enabled_features,
         'mediaUrl': get_asset_url('sentry', ''),
         'needsUpgrade': needs_upgrade,
-        'dsn': _get_public_dsn(),
+        'dsn': get_public_dsn(),
         'statuspage': _get_statuspage(),
         'messages': [{
             'message': msg.message,

--- a/tests/sentry/templatetags/test_sentry_dsn.py
+++ b/tests/sentry/templatetags/test_sentry_dsn.py
@@ -1,0 +1,27 @@
+from __future__ import absolute_import
+
+from django.conf import settings
+from django.template import Context, Template
+
+from sentry.models import ProjectKey
+from sentry.testutils import TestCase
+
+
+class DsnTest(TestCase):
+    TEMPLATE = Template("{% load sentry_dsn %}{% public_dsn %}")
+
+    def test_valid_dsn(self):
+        self.key = ProjectKey.objects.get_or_create(id=1)[0]
+        result = self.TEMPLATE.render(Context())
+
+        assert self.key.dsn_public in result
+
+    def test_no_system_url(self):
+        self.key = ProjectKey.objects.get_or_create(id=1)[0]
+
+        new_options = settings.SENTRY_OPTIONS.copy()
+        new_options['system.url-prefix'] = ''
+        with self.settings(SENTRY_OPTIONS=new_options):
+            result = self.TEMPLATE.render(Context())
+            assert self.key.dsn_public not in result
+            assert result == ''

--- a/tests/sentry/templatetags/test_sentry_dsn.py
+++ b/tests/sentry/templatetags/test_sentry_dsn.py
@@ -17,18 +17,16 @@ class DsnTest(TestCase):
             result = self.TEMPLATE.render(Context())
 
             assert key.dsn_public in result
+            assert len(result) > 0
 
     def test_no_system_url(self):
         project = self.create_project()
-        with self.settings(SENTRY_PROJECT=project.id):
-            key = ProjectKey.objects.get_or_create(project=project)[0]
 
-            new_options = settings.SENTRY_OPTIONS.copy()
-            new_options['system.url-prefix'] = ''
-            new_options['SENTRY_FRONTEND_PROJECT'] = project.id
+        new_options = settings.SENTRY_OPTIONS.copy()
+        new_options['system.url-prefix'] = ''
 
-            with self.settings(SENTRY_OPTIONS=new_options):
-                result = self.TEMPLATE.render(Context())
+        with self.settings(SENTRY_PROJECT=project.id, SENTRY_OPTIONS=new_options):
+            result = self.TEMPLATE.render(Context())
 
-                assert key.dsn_public not in result
-                assert result == ''
+            assert not result
+            assert len(result) == 0


### PR DESCRIPTION
Tested it in a clean Sentry setup + also added test for template tag `{% load sentry_dsn %}{% public_dsn %}`.

Fixes https://github.com/getsentry/sentry/issues/11105
Fixes https://github.com/getsentry/sentry/issues/11337