### PR TITLE
fix(plugins) Catch more errors when sending notifications.

### DIFF
--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, print_function
 
 import logging
 import six
+import urllib2
 from six.moves.urllib.parse import (
     urlparse,
     urlencode,
@@ -18,7 +19,6 @@ from six.moves.urllib.parse import (
 
 from django import forms
 from requests.exceptions import SSLError, HTTPError
-from urllib2 import HTTPError as Urllib2HTTPError
 
 from sentry import digests, ratelimits
 from sentry.digests import get_option_key as get_digest_option_key
@@ -74,7 +74,7 @@ class NotificationPlugin(Plugin):
         try:
             return self.notify_users(event.group, event, triggering_rules=[
                                      r.label for r in notification.rules])
-        except (SSLError, HTTPError, ApiError, PluginError, Urllib2HTTPError) as err:
+        except (SSLError, HTTPError, ApiError, PluginError, urllib2.HTTPError) as err:
             self.logger.info('notification-plugin.notify-failed.', extra={
                 'error': six.text_type(err),
                 'plugin': self.slug

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -18,6 +18,7 @@ from six.moves.urllib.parse import (
 
 from django import forms
 from requests.exceptions import SSLError, HTTPError
+from urllib2 import HTTPError as Urllib2HTTPError
 
 from sentry import digests, ratelimits
 from sentry.digests import get_option_key as get_digest_option_key
@@ -73,7 +74,7 @@ class NotificationPlugin(Plugin):
         try:
             return self.notify_users(event.group, event, triggering_rules=[
                                      r.label for r in notification.rules])
-        except (SSLError, HTTPError, ApiError, PluginError) as err:
+        except (SSLError, HTTPError, ApiError, PluginError, Urllib2HTTPError) as err:
             self.logger.info('notification-plugin.notify-failed.', extra={
                 'error': six.text_type(err),
                 'plugin': self.slug


### PR DESCRIPTION
The old hipchat plugin uses urllib2 which has a different HTTPError than urllib3.

Fixes SENTRY-8en