### PR TITLE
fix(events): Correct event time tooltip sizing

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/eventToolbar.jsx
@@ -169,7 +169,10 @@ let GroupEventToolbar = createReactClass({
           </Link>
         </h4>
         <span>
-          <Tooltip title={this.getDateTooltip()} tooltipOptions={{html: true}}>
+          <Tooltip
+            title={this.getDateTooltip()}
+            tooltipOptions={{html: true, container: false}}
+          >
             <span>
               <DateTime
                 date={getDynamicText({value: evt.dateCreated, fixed: 'Dummy timestamp'})}


### PR DESCRIPTION
The tooltip was partially hiding the date time within it, this inserts the tooltip to it's parent container instead of at the body level.

This is how the tooltip used to render before 67ad02531ac4b6d4fd02274565e37f387edd01b7 was applied, causing all tooltips to render on the body.

I don't know exactly why having the tooltip within the parent container fixes the overflow, but this is somewhat of a bandaid until we can improve tooltips.

Fixes [ISSUE-252](https://getsentry.atlassian.net/browse/ISSUE-252)