### PR TITLE
build(dev): Add `yarn dev` script to start sentry devserver

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "test-staged": "yarn test --findRelatedTests $(git diff --name-only --cached)",
     "lint": "node_modules/.bin/eslint tests/js src/sentry/static/sentry/app --ext .js,.jsx",
     "lint:css": "stylelint 'src/sentry/static/sentry/app/**/*.jsx'",
-    "dev": "yarn check --verify-tree && sentry devserver --browser-reload",
+    "dev": "yarn check --verify-tree && sentry devserver --browser-reload --workers",
     "dev-proxy": "node scripts/devproxy.js",
     "dev-server": "webpack-dev-server",
     "storybook": "start-storybook -p 9001 -c .storybook",

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "test-staged": "yarn test --findRelatedTests $(git diff --name-only --cached)",
     "lint": "node_modules/.bin/eslint tests/js src/sentry/static/sentry/app --ext .js,.jsx",
     "lint:css": "stylelint 'src/sentry/static/sentry/app/**/*.jsx'",
+    "dev": "yarn check --verify-tree && sentry devserver --browser-reload",
     "dev-proxy": "node scripts/devproxy.js",
     "dev-server": "webpack-dev-server",
     "storybook": "start-storybook -p 9001 -c .storybook",


### PR DESCRIPTION
This also adds a `yarn check --verify-tree` before starting to make sure that yarn deps are up to date.

![image](https://user-images.githubusercontent.com/79684/50703596-8d20d500-1009-11e9-9cb8-e1261b6192a2.png)
