### PR TITLE
chore: Unpin sentry-sdk version

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -55,9 +55,7 @@ requests-oauthlib==0.3.3
 requests[security]>=2.20.0,<2.21.0
 selenium==3.11.0
 semaphore>=0.2.0,<0.3.0
-# Temporarily keep this below 0.6.5 since a change to the `Auth` class causes
-# a test to fail
-sentry-sdk>=0.6.0,<0.6.5
+sentry-sdk>=0.6.0,!=0.6.5
 setproctitle>=1.1.7,<1.2.0
 simplejson>=3.2.0,<3.9.0
 six>=1.10.0,<1.11.0


### PR DESCRIPTION
New version of the sdk is released and shouldn't break Sentry mysql tests.