### PR TITLE
fix(assign): Show loading indicator when assigning teams

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/group.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/group.jsx
@@ -74,6 +74,9 @@ export function assignToActor({id, actor}) {
 
   let guid = uniqueId();
   let actorId;
+
+  GroupActions.assignTo(guid, id, {email: ''});
+
   switch (actor.type) {
     case 'user':
       actorId = buildUserId(actor.id);


### PR DESCRIPTION
The other assign actions do this to show the loading indicator while the
assign request is being made.