### PR TITLE
fix(api): Don't return groups from another project when looking up by short id

### DIFF
--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -374,9 +374,6 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                     else:
                         Event.objects.bind_nodes([matching_event], 'data')
 
-            # If the query looks like a short id, we want to provide some
-            # information about where that is.  Note that this can return
-            # results for another project.  The UI deals with this.
             elif request.GET.get('shortIdLookup') == '1' and \
                     looks_like_short_id(query):
                 try:
@@ -385,6 +382,9 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                     )
                 except Group.DoesNotExist:
                     matching_group = None
+                else:
+                    if matching_group.project_id != project.id:
+                        matching_group = None
 
             if matching_group is not None:
                 matching_event_environment = None

--- a/tests/sentry/api/endpoints/test_project_group_index.py
+++ b/tests/sentry/api/endpoints/test_project_group_index.py
@@ -269,6 +269,41 @@ class GroupListTest(APITestCase):
         assert response.status_code == 200
         assert len(response.data) == 0
 
+    def test_lookup_by_short_id(self):
+        group = self.group
+        short_id = group.qualified_short_id
+
+        self.login_as(user=self.user)
+        response = self.client.get(
+            u'{}?query={}&shortIdLookup=1'.format(
+                self.path, short_id), format='json')
+        assert response.status_code == 200
+        assert len(response.data) == 1
+
+    def test_lookup_by_short_id_no_perms(self):
+        organization = self.create_organization()
+        project = self.create_project(organization=organization)
+        project2 = self.create_project(organization=organization)
+        team = self.create_team(organization=organization)
+        project2.add_team(team)
+        group = self.create_group(project=project)
+        user = self.create_user()
+        self.create_member(organization=organization, user=user, teams=[team])
+
+        short_id = group.qualified_short_id
+
+        self.login_as(user=user)
+
+        path = u'/api/0/projects/{}/{}/issues/'.format(
+            organization.slug,
+            project2.slug,
+        )
+        response = self.client.get(
+            u'{}?query={}&shortIdLookup=1'.format(
+                path, short_id), format='json')
+        assert response.status_code == 200
+        assert len(response.data) == 0
+
     def test_lookup_by_first_release(self):
         self.login_as(self.user)
         project = self.project


### PR DESCRIPTION
i'm not really sure why we are doing this, but it seems wrong as it will return a group that the user doesn't necessarily have access to. found while working on https://github.com/getsentry/sentry/pull/11133