### PR TITLE
tests(js): Fix throw on console.error when message is not string

### DIFF
--- a/tests/js/throw-on-react-error.js
+++ b/tests/js/throw-on-react-error.js
@@ -16,7 +16,11 @@ const BAD_ERRORS_REGEX = new RegExp(BAD_ERRORS.join('|'));
 
 // eslint-disable-next-line no-console
 console.error = (message, ...args) => {
-  if (message.indexOf(REPEATED_ERROR) !== 0 && BAD_ERRORS_REGEX.test(message)) {
+  if (
+    typeof message === 'string' &&
+    message.indexOf(REPEATED_ERROR) !== 0 &&
+    BAD_ERRORS_REGEX.test(message)
+  ) {
     originalConsoleError(message, ...args);
     throw new Error(message);
   } else if (!BAD_ERRORS_REGEX.test(message)) {


### PR DESCRIPTION
Not sure when we call console.error with an object, but it can happen, make sure we only evaluate strings