### PR TITLE
fix(integrations) Remove internal-integrations setting

### DIFF
--- a/src/sentry/api/endpoints/organization_config_integrations.py
+++ b/src/sentry/api/endpoints/organization_config_integrations.py
@@ -7,7 +7,6 @@ from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize, IntegrationProviderSerializer
 
 from sentry import features
-from django.conf import settings
 
 
 class OrganizationConfigIntegrationsEndpoint(OrganizationEndpoint):
@@ -15,17 +14,10 @@ class OrganizationConfigIntegrationsEndpoint(OrganizationEndpoint):
         has_jira_server = features.has('organizations:jira-server-integration',
                                        organization,
                                        actor=request.user)
-
-        has_catchall = features.has('organizations:internal-catchall',
-                                    organization,
-                                    actor=request.user)
         providers = []
         for provider in integrations.all():
             if not has_jira_server and provider.key == 'jira_server':
                 continue
-            if not has_catchall and provider.key in settings.SENTRY_INTERNAL_INTEGRATIONS:
-                continue
-
             providers.append(provider)
 
         providers.sort(key=lambda i: i.key)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1328,10 +1328,6 @@ SENTRY_DEFAULT_INTEGRATIONS = (
     'sentry.integrations.vsts_extension.VstsExtensionIntegrationProvider',
 )
 
-SENTRY_INTERNAL_INTEGRATIONS = (
-    'jira_server',
-)
-
 
 def get_sentry_sdk_config():
     return {


### PR DESCRIPTION
With Jira-Server going out to Early adopters there are no more internal-integrations that need to stay hidden. This setting is also causing jira-server to not be visible to early-adopters.