### PR TITLE
ref(discover): Make useTimestamp default

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
@@ -234,6 +234,7 @@ export default class Result extends React.Component {
                 tooltip={tooltipOptions}
                 legend={legendData}
                 renderer="canvas"
+                isGroupedByDate={true}
               />
               {this.renderNote()}
             </ChartWrapper>
@@ -247,6 +248,7 @@ export default class Result extends React.Component {
                 tooltip={tooltipOptions}
                 legend={legendData}
                 renderer="canvas"
+                isGroupedByDate={true}
               />
               {this.renderNote()}
             </ChartWrapper>

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
@@ -1,8 +1,6 @@
 /*eslint no-use-before-define: ["error", { "functions": false }]*/
-
 import React from 'react';
 import styled from 'react-emotion';
-import moment from 'moment';
 import {orderBy} from 'lodash';
 import Papa from 'papaparse';
 
@@ -42,12 +40,9 @@ export function getChartData(data, query, options = {}) {
  * Returns time series data formatted for line and bar charts, with each day
  * along the x-axis
  *
- * TODO(billy): Investigate making `useTimestamps` the default behavior and remove the option
- *
  * @param {Array} data Data returned from Snuba
  * @param {Object} query Query state corresponding to data
  * @param {Object} [options] Options object
- * @param {Boolean} [options.useTimestamps] (default: false) Return raw timestamps instead of formatting dates
  * @param {Boolean} [options.assumeNullAsZero] (default: false) Assume null values as 0
  * @param {Boolean} [options.allSeries] (default: false) Return all series instead of top 10
  * @param {Object} [options.fieldLabelMap] (default: false) Maps value from Snuba to a defined label
@@ -68,9 +63,7 @@ export function getChartDataByDay(rawData, query, options = {}) {
 
   // Reverse to get ascending dates - we request descending to ensure latest
   // day data is compplete in the case of limits being hit
-  const dates = [
-    ...new Set(rawData.map(entry => formatDate(entry.time, !options.useTimestamps))),
-  ].reverse();
+  const dates = [...new Set(rawData.map(entry => formatDate(entry.time)))].reverse();
 
   // Temporarily store series as object with series names as keys
   const seriesHash = getEmptySeriesHash(top10Series, dates, options);
@@ -79,7 +72,7 @@ export function getChartDataByDay(rawData, query, options = {}) {
   data.forEach(row => {
     const key = row[CHART_KEY];
 
-    const dateIdx = dates.indexOf(formatDate(row.time, !options.useTimestamps));
+    const dateIdx = dates.indexOf(formatDate(row.time));
 
     if (top10Series.has(key)) {
       seriesHash[key][dateIdx].value =
@@ -161,14 +154,8 @@ function getDataWithKeys(data, query, options = {}) {
   });
 }
 
-function formatDate(datetime, enabled = true) {
-  const timestamp = datetime * 1000;
-
-  if (!enabled) {
-    return timestamp;
-  }
-
-  return moment.utc(timestamp).format('MMM Do');
+function formatDate(datetime) {
+  return datetime * 1000;
 }
 
 // Converts a value to a string for the chart label. This could

--- a/tests/js/spec/views/organizationDiscover/result/utils.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/result/utils.spec.jsx
@@ -158,45 +158,6 @@ describe('Utils', function() {
       const expected = [
         {
           data: [
-            {name: 'Jul 9th', value: 14},
-            {name: 'Jul 10th', value: null},
-            {name: 'Jul 20th', value: 30},
-          ],
-          seriesName: 'python,SnubaError',
-        },
-        {
-          data: [
-            {name: 'Jul 9th', value: 6},
-            {name: 'Jul 10th', value: null},
-            {name: 'Jul 20th', value: 8},
-          ],
-          seriesName: 'php,Exception',
-        },
-        {
-          data: [
-            {name: 'Jul 9th', value: 6},
-            {name: 'Jul 10th', value: null},
-            {name: 'Jul 20th', value: 5},
-          ],
-          seriesName: 'javascript,Type Error',
-        },
-        {
-          data: [
-            {name: 'Jul 9th', value: 6},
-            {name: 'Jul 10th', value: 20},
-            {name: 'Jul 20th', value: null},
-          ],
-          seriesName: 'python,ZeroDivisionError',
-        },
-      ];
-
-      expect(getChartDataByDay(raw, query)).toEqual(expected);
-    });
-
-    it('returns chart data grouped by timestamp', function() {
-      const expected = [
-        {
-          data: [
             {name: 1531094400000, value: 14},
             {name: 1531180800000, value: null},
             {name: 1532070000000, value: 30},
@@ -228,40 +189,41 @@ describe('Utils', function() {
           seriesName: 'python,ZeroDivisionError',
         },
       ];
-      expect(getChartDataByDay(raw, query, {useTimestamps: true})).toEqual(expected);
+
+      expect(getChartDataByDay(raw, query)).toEqual(expected);
     });
 
     it('assumes null value as 0', function() {
       const expected = [
         {
           data: [
-            {name: 'Jul 9th', value: 14},
-            {name: 'Jul 10th', value: 0},
-            {name: 'Jul 20th', value: 30},
+            {name: 1531094400000, value: 14},
+            {name: 1531180800000, value: 0},
+            {name: 1532070000000, value: 30},
           ],
           seriesName: 'python,SnubaError',
         },
         {
           data: [
-            {name: 'Jul 9th', value: 6},
-            {name: 'Jul 10th', value: 0},
-            {name: 'Jul 20th', value: 8},
+            {name: 1531094400000, value: 6},
+            {name: 1531180800000, value: 0},
+            {name: 1532070000000, value: 8},
           ],
           seriesName: 'php,Exception',
         },
         {
           data: [
-            {name: 'Jul 9th', value: 6},
-            {name: 'Jul 10th', value: 0},
-            {name: 'Jul 20th', value: 5},
+            {name: 1531094400000, value: 6},
+            {name: 1531180800000, value: 0},
+            {name: 1532070000000, value: 5},
           ],
           seriesName: 'javascript,Type Error',
         },
         {
           data: [
-            {name: 'Jul 9th', value: 6},
-            {name: 'Jul 10th', value: 20},
-            {name: 'Jul 20th', value: 0},
+            {name: 1531094400000, value: 6},
+            {name: 1531180800000, value: 20},
+            {name: 1532070000000, value: 0},
           ],
           seriesName: 'python,ZeroDivisionError',
         },
@@ -308,33 +270,33 @@ describe('Utils', function() {
       const expected = [
         {
           data: [
-            {name: 'Jul 9th', value: 14},
-            {name: 'Jul 10th', value: null},
-            {name: 'Jul 20th', value: 30},
+            {name: 1531094400000, value: 14},
+            {name: 1531180800000, value: null},
+            {name: 1532070000000, value: 30},
           ],
           seriesName: 'SNAKES,SnubaError',
         },
         {
           data: [
-            {name: 'Jul 9th', value: 6},
-            {name: 'Jul 10th', value: null},
-            {name: 'Jul 20th', value: 8},
+            {name: 1531094400000, value: 6},
+            {name: 1531180800000, value: null},
+            {name: 1532070000000, value: 8},
           ],
           seriesName: 'PHP,Exception',
         },
         {
           data: [
-            {name: 'Jul 9th', value: 6},
-            {name: 'Jul 10th', value: null},
-            {name: 'Jul 20th', value: 5},
+            {name: 1531094400000, value: 6},
+            {name: 1531180800000, value: null},
+            {name: 1532070000000, value: 5},
           ],
           seriesName: 'NOT JAVA,Type Error',
         },
         {
           data: [
-            {name: 'Jul 9th', value: 6},
-            {name: 'Jul 10th', value: 20},
-            {name: 'Jul 20th', value: null},
+            {name: 1531094400000, value: 6},
+            {name: 1531180800000, value: 20},
+            {name: 1532070000000, value: null},
           ],
           seriesName: 'SNAKES,ZeroDivisionError',
         },


### PR DESCRIPTION
I was trying to avoid breaking discover with this, but ended up breaking discover :facepalm:

The logic for useTimestamp was wrong, so it was, by default, using timestamps (instead of the other way around).
I removed the option and just made it default