### PR TITLE
test(user-feedback): Make test fixture non random

### DIFF
--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -774,7 +774,7 @@ class Fixtures(object):
             project=kwargs['project'],
             name='Jane Doe',
             email='jane@example.com',
-            comments=make_sentence()
+            comments="the application crashed"
         )
 
         return userreport


### PR DESCRIPTION
We need the text in this test to be static so we don't trigger Percy
every time