### PR TITLE
fix(org-events): Fix chart not using query

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
@@ -1,5 +1,6 @@
 import {Flex} from 'grid-emotion';
 import {isEqual} from 'lodash';
+import {withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
@@ -150,6 +151,7 @@ class OrganizationEvents extends AsyncView {
         {error && super.renderError(new Error('Unable to load all required endpoints'))}
         <Panel>
           <EventsChart
+            query={location.query.query}
             zoom={!!location.query.zoom}
             organization={organization}
             onZoom={this.handleZoom}
@@ -193,5 +195,5 @@ const RowDisplay = styled('div')`
   color: ${p => p.theme.gray6};
 `;
 
-export default withOrganization(OrganizationEvents);
+export default withRouter(withOrganization(OrganizationEvents));
 export {OrganizationEvents, parseRowFromLinks};

--- a/tests/js/helpers/mockRouterPush.jsx
+++ b/tests/js/helpers/mockRouterPush.jsx
@@ -1,3 +1,5 @@
+import qs from 'query-string';
+
 // More closely mocks a router push -- updates wrapper's props/context
 // with updated `router` and calls `wrapper.update()`
 export function mockRouterPush(wrapper, router) {
@@ -5,6 +7,7 @@ export function mockRouterPush(wrapper, router) {
     const location = {
       ...router.location,
       query,
+      search: qs.stringify(query),
     };
     let newRouter = {
       router: {


### PR DESCRIPTION
Fixes the events chart not using search query, adds/updates tests