### PR TITLE
fix(discover): Hide primary hash column

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/data.jsx
@@ -38,7 +38,6 @@ export const COLUMNS = [
   {name: 'project.name', type: TYPES.STRING},
   {name: 'platform', type: TYPES.STRING},
   {name: 'message', type: TYPES.STRING},
-  {name: 'primary_hash', type: TYPES.STRING},
   {name: 'timestamp', type: TYPES.DATETIME},
 
   {name: 'user.id', type: TYPES.STRING},


### PR DESCRIPTION
End users should not use this column since we have group.id now