### PR TITLE
feat(charts): Add props to customize TableChart header and body height

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/percentageTableChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/percentageTableChart.jsx
@@ -46,8 +46,19 @@ const StyledDelta = styled('div')`
 
 class PercentageTableChart extends React.Component {
   static propTypes = {
+    // Height of body
+    height: PropTypes.string,
+
+    // props to pass to PanelHeader
+    headerProps: PropTypes.object,
+
+    // Main title (left most column) should
     title: PropTypes.node,
+
+    // Label for the "count" title
     countTitle: PropTypes.node,
+
+    extraTitle: PropTypes.node,
     onRowClick: PropTypes.func,
     data: PropTypes.arrayOf(
       PropTypes.shape({
@@ -62,20 +73,23 @@ class PercentageTableChart extends React.Component {
   static defaultProps = {
     title: '',
     countTitle: t('Count'),
+    extraTitle: null,
     onRowClick: () => {},
   };
 
-  handleRowClick = ({specifier}, e) => {
+  handleRowClick = (obj, e) => {
     const {onRowClick} = this.props;
-    onRowClick(specifier, e);
+    onRowClick(obj, e);
   };
 
   render() {
-    const {title, countTitle, data} = this.props;
+    const {height, headerProps, title, countTitle, extraTitle, data} = this.props;
 
     return (
       <TableChart
-        headers={[title, countTitle, t('Percentage')]}
+        headerProps={headerProps}
+        bodyHeight={height}
+        headers={[title, countTitle, t('Percentage'), extraTitle]}
         data={data.map(({value, lastValue, name, percentage}) => [
           <Name key="name">{name}</Name>,
           <CountColumn key="count">
@@ -97,6 +111,7 @@ class PercentageTableChart extends React.Component {
             </NameAndCountContainer>
             <PercentageContainer justify="space-between" align="center">
               <PercentageLabel>{items[2]}</PercentageLabel>
+              {items[3]}
             </PercentageContainer>
           </Row>
         )}

--- a/src/sentry/static/sentry/app/components/charts/tableChart/index.jsx
+++ b/src/sentry/static/sentry/app/components/charts/tableChart/index.jsx
@@ -17,6 +17,8 @@ export const TableChart = styled(
        */
       dataStartIndex: PropTypes.number,
       widths: PropTypes.arrayOf(PropTypes.number),
+      // Height of body
+      bodyHeight: PropTypes.string,
       getValue: PropTypes.func,
       renderTableHeader: PropTypes.func,
       renderBody: PropTypes.func,
@@ -27,12 +29,15 @@ export const TableChart = styled(
       showColumnTotal: PropTypes.bool,
       rowTotalLabel: PropTypes.string,
       columnTotalLabel: PropTypes.string,
+      // props to pass to PanelHeader
+      headerProps: PropTypes.object,
     };
 
     static get defaultProps() {
       // Default renderer for Table Header
       const defaultRenderTableHeader = ({
         headers,
+        headerProps,
         renderRow,
         rowTotalLabel,
         showRowTotal,
@@ -44,7 +49,7 @@ export const TableChart = styled(
         ];
 
         return (
-          <PanelHeader>
+          <PanelHeader {...headerProps}>
             {renderRow({
               isTableHeader: true,
               items: headersWithTotalColumn,
@@ -65,39 +70,43 @@ export const TableChart = styled(
         renderRow,
         shadeRowPercentage,
         showRowTotal,
+        bodyHeight,
         ...props
-      }) =>
-        dataMaybeWithTotals.map((row, rowIndex) => {
-          let lastRowIndex = dataMaybeWithTotals.length - 1;
-          let isLastRow = rowIndex === lastRowIndex;
-          let showBar = !isLastRow && shadeRowPercentage;
+      }) => (
+        <TableBody height={bodyHeight}>
+          {dataMaybeWithTotals.map((row, rowIndex) => {
+            let lastRowIndex = dataMaybeWithTotals.length - 1;
+            let isLastRow = rowIndex === lastRowIndex;
+            let showBar = !isLastRow && shadeRowPercentage;
 
-          // rowTotals does not include the grand total of data
-          let rowTotal =
-            showRowTotal && rowIndex < data.length
-              ? [dataTotals.rowTotals[rowIndex]]
-              : [];
+            // rowTotals does not include the grand total of data
+            let rowTotal =
+              showRowTotal && rowIndex < data.length
+                ? [dataTotals.rowTotals[rowIndex]]
+                : [];
 
-          return (
-            <TableChartRow
-              key={rowIndex}
-              showBar={showBar}
-              value={dataTotals.rowTotals[rowIndex]}
-              total={dataTotals.total}
-              widths={widths}
-            >
-              {renderRow({
-                css: {zIndex: showBar ? '2' : undefined},
-                ...props,
-                data,
-                widths,
-                items: [...row, ...rowTotal],
-                rowIndex,
-                showRowTotal,
-              })}
-            </TableChartRow>
-          );
-        });
+            return (
+              <TableChartRow
+                key={rowIndex}
+                showBar={showBar}
+                value={dataTotals.rowTotals[rowIndex]}
+                total={dataTotals.total}
+                widths={widths}
+              >
+                {renderRow({
+                  css: {zIndex: showBar ? '2' : undefined},
+                  ...props,
+                  data,
+                  widths,
+                  items: [...row, ...rowTotal],
+                  rowIndex,
+                  showRowTotal,
+                })}
+              </TableChartRow>
+            );
+          })}
+        </TableBody>
+      );
 
       // Default renderer for ALL rows (including header + body so that both can share the same DOM structure + styles)
       const defaultRenderRow = ({
@@ -396,4 +405,9 @@ const DataGroup = styled(Flex)`
 const Row = styled(Flex)`
   flex: 1;
   overflow: hidden;
+`;
+
+const TableBody = styled('div')`
+  height: ${p => p.height};
+  overflow-y: auto;
 `;


### PR DESCRIPTION
* Adds another title: `extraTitle` to add title for rightmost column
* Adds `headerProps` to customize PanelHeader (e.g. `hasButtons`)
* Adds `height` to set height on table body

This will allow you to set a height on PercentageTableChart and have the body be scrollable