### PR TITLE
feat(issues) Add skeleton for Org wide issues

### DIFF
--- a/src/sentry/static/sentry/app/components/groupList.jsx
+++ b/src/sentry/static/sentry/app/components/groupList.jsx
@@ -163,7 +163,6 @@ const GroupList = createReactClass({
                 key={id}
                 id={id}
                 orgId={orgId}
-                projectId={project.slug}
                 canSelect={this.props.canSelectGroups}
               />
             );

--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -25,7 +25,6 @@ const StreamGroup = createReactClass({
   propTypes: {
     id: PropTypes.string.isRequired,
     orgId: PropTypes.string.isRequired,
-    projectId: PropTypes.string.isRequired,
     statsPeriod: PropTypes.string.isRequired,
     canSelect: PropTypes.bool,
     query: PropTypes.string,
@@ -87,7 +86,8 @@ const StreamGroup = createReactClass({
 
   render() {
     const {data} = this.state;
-    const {id, orgId, projectId, query, hasGuideAnchor, canSelect} = this.props;
+    const {id, orgId, query, hasGuideAnchor, canSelect} = this.props;
+    const projectId = data.project.slug;
 
     return (
       <Group onClick={this.toggleSelect} py={1} px={0} align="center">

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -803,8 +803,8 @@ function routes() {
               component={errorHandler(LazyLoad)}
             />
           </Route>
-          /* Once org issues is complete, these routes can be nested under
-          /organizations/:orgId/issues */
+          {/* Once org issues is complete, these routes can be nested under
+          /organizations/:orgId/issues */}
           <Route
             path="/organizations/:orgId/issues/assigned/"
             component={errorHandler(MyIssuesAssignedToMe)}

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -754,7 +754,6 @@ function routes() {
       <Route path="/:orgId/" component={errorHandler(OrganizationDetails)}>
         <Route component={errorHandler(OrganizationRoot)}>
           <IndexRoute component={errorHandler(OrganizationDashboard)} />
-
           <Route
             path="/organizations/:orgId/dashboards/"
             componentPromise={() =>
@@ -767,7 +766,6 @@ function routes() {
               component={errorHandler(LazyLoad)}
             />
           </Route>
-
           <Route
             path="/organizations/:orgId/discover/"
             componentPromise={() =>
@@ -777,12 +775,10 @@ function routes() {
             <Redirect path="saved/" to="/organizations/:orgId/discover/" />
             <Route path="saved/:savedQueryId/" />
           </Route>
-
           <Route
             path="/organizations/:orgId/activity/"
             component={errorHandler(OrganizationActivity)}
           />
-
           <Route
             path="/organizations/:orgId/events/"
             componentPromise={() =>
@@ -795,14 +791,38 @@ function routes() {
               component={errorHandler(LazyLoad)}
             />
           </Route>
-
+          <Route
+            path="/organizations/:orgId/issues/"
+            componentPromise={() =>
+              import(/* webpackChunkName: "OrganizationStreamContainer" */ './views/organizationStream/container')}
+            component={errorHandler(LazyLoad)}
+          >
+            <IndexRoute
+              componentPromise={() =>
+                import(/* webpackChunkName: "OrganizationStreamOverview" */ './views/organizationStream/overview')}
+              component={errorHandler(LazyLoad)}
+            />
+          </Route>
+          /* Once org issues is complete, these routes can be nested under
+          /organizations/:orgId/issues */
+          <Route
+            path="/organizations/:orgId/issues/assigned/"
+            component={errorHandler(MyIssuesAssignedToMe)}
+          />
+          <Route
+            path="/organizations/:orgId/issues/bookmarks/"
+            component={errorHandler(MyIssuesBookmarked)}
+          />
+          <Route
+            path="/organizations/:orgId/issues/history/"
+            component={errorHandler(MyIssuesViewed)}
+          />
           <Route
             path="/organizations/:orgId/user-feedback/"
             componentPromise={() =>
               import(/* webpackChunkName: "OrganizationUserFeedback" */ './views/userFeedback/organizationUserFeedback')}
             component={errorHandler(LazyLoad)}
           />
-
           <Route
             path="/organizations/:orgId/releases/"
             componentPromise={() =>
@@ -821,14 +841,12 @@ function routes() {
               component={errorHandler(LazyLoad)}
             />
           </Route>
-
           <Route
             path="/organizations/:orgId/teams/new/"
             componentPromise={() =>
               import(/* webpackChunkName: "TeamCreate" */ './views/teamCreate')}
             component={errorHandler(LazyLoad)}
           />
-
           <Route path="/organizations/:orgId/" component={OrganizationHomeContainer}>
             <Redirect from="projects/" to="/:orgId/" />
             {hooksOrgRoutes}
@@ -861,25 +879,10 @@ function routes() {
             <Redirect path="repos/" to="/settings/:orgId/repos/" />
             <Route path="stats/" component={errorHandler(OrganizationStats)} />
           </Route>
-
-          <Route
-            path="/organizations/:orgId/issues/assigned/"
-            component={errorHandler(MyIssuesAssignedToMe)}
-          />
-          <Route
-            path="/organizations/:orgId/issues/bookmarks/"
-            component={errorHandler(MyIssuesBookmarked)}
-          />
-          <Route
-            path="/organizations/:orgId/issues/history/"
-            component={errorHandler(MyIssuesViewed)}
-          />
-
           <Route
             path="/organizations/:orgId/projects/new/"
             component={errorHandler(NewProject)}
           />
-
           <Route
             path="/organizations/:orgId/projects/choose/"
             component={errorHandler(ProjectChooser)}

--- a/src/sentry/static/sentry/app/views/organizationStream/container.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/container.jsx
@@ -1,0 +1,35 @@
+import {withRouter} from 'react-router';
+import React from 'react';
+
+import {HeaderTitle, PageContent, PageHeader} from 'app/styles/organization';
+import {t} from 'app/locale';
+import Feature from 'app/components/acl/feature';
+import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
+import SentryTypes from 'app/sentryTypes';
+import withOrganization from 'app/utils/withOrganization';
+
+class OrganizationStreamContainer extends React.Component {
+  static propTypes = {
+    organization: SentryTypes.Organization,
+  };
+
+  render() {
+    const {organization, children} = this.props;
+
+    return (
+      <Feature features={['sentry10']} renderDisabled>
+        <GlobalSelectionHeader organization={organization} />
+
+        <PageContent>
+          <PageHeader>
+            <HeaderTitle>{t('Issues')}</HeaderTitle>
+          </PageHeader>
+
+          {children}
+        </PageContent>
+      </Feature>
+    );
+  }
+}
+export default withRouter(withOrganization(OrganizationStreamContainer));
+export {OrganizationStreamContainer};

--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -23,6 +23,7 @@ import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import Pagination from 'app/components/pagination';
 import SentryTypes from 'app/sentryTypes';
+import StreamGroup from 'app/components/stream/group';
 import parseApiError from 'app/utils/parseApiError';
 import parseLinkHeader from 'app/utils/parseLinkHeader';
 import queryString from 'app/utils/queryString';
@@ -527,11 +528,6 @@ const OrganizationStream = createReactClass({
 const StreamFilters = props => <p>Stream filters are coming soon</p>;
 const StreamActions = props => <p>Stream actions are coming soon</p>;
 const StreamSidebar = props => <p>Stream sidebar is coming soon</p>;
-
-const StreamGroup = ({id}) => <p>Issue {id}</p>;
-StreamGroup.propTypes = {
-  id: PropTypes.string,
-};
 
 export default withOrganization(OrganizationStream);
 export {OrganizationStream};

--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -1,0 +1,537 @@
+import {browserHistory} from 'react-router';
+import {omit, isEqual} from 'lodash';
+import Cookies from 'js-cookie';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Reflux from 'reflux';
+import classNames from 'classnames';
+import createReactClass from 'create-react-class';
+import qs from 'query-string';
+
+import {Panel, PanelBody} from 'app/components/panels';
+import {analytics} from 'app/utils/analytics';
+import {
+  setActiveEnvironment,
+  setActiveEnvironmentName,
+} from 'app/actionCreators/environments';
+import {t, tct} from 'app/locale';
+import ApiMixin from 'app/mixins/apiMixin';
+import ConfigStore from 'app/stores/configStore';
+import EnvironmentStore from 'app/stores/environmentStore';
+import GroupStore from 'app/stores/groupStore';
+import LoadingError from 'app/components/loadingError';
+import LoadingIndicator from 'app/components/loadingIndicator';
+import Pagination from 'app/components/pagination';
+import SentryTypes from 'app/sentryTypes';
+import parseApiError from 'app/utils/parseApiError';
+import parseLinkHeader from 'app/utils/parseLinkHeader';
+import queryString from 'app/utils/queryString';
+import utils from 'app/utils';
+import withOrganization from 'app/utils/withOrganization';
+
+const MAX_ITEMS = 25;
+const DEFAULT_SORT = 'date';
+const DEFAULT_STATS_PERIOD = '24h';
+const STATS_PERIODS = new Set(['14d', '24h']);
+
+const OrganizationStream = createReactClass({
+  displayName: 'OrganizationStream',
+
+  propTypes: {
+    organization: SentryTypes.Organization,
+    environment: SentryTypes.Environment,
+    tags: PropTypes.object,
+    tagsLoading: PropTypes.bool,
+  },
+
+  mixins: [Reflux.listenTo(GroupStore, 'onGroupChange'), ApiMixin],
+
+  getInitialState() {
+    let realtimeActiveCookie = Cookies.get('realtimeActive');
+    let realtimeActive =
+      typeof realtimeActiveCookie === 'undefined'
+        ? false
+        : realtimeActiveCookie === 'true';
+
+    let currentQuery = this.props.location.query || {};
+    let sort = 'sort' in currentQuery ? currentQuery.sort : DEFAULT_SORT;
+
+    let statsPeriod = STATS_PERIODS.has(currentQuery.statsPeriod)
+      ? currentQuery.statsPeriod
+      : DEFAULT_STATS_PERIOD;
+
+    return {
+      groupIds: [],
+      isDefaultSearch: false,
+      loading: false,
+      selectAllActive: false,
+      multiSelected: false,
+      anySelected: false,
+      statsPeriod,
+      realtimeActive,
+      pageLinks: '',
+      queryCount: null,
+      error: false,
+      query: currentQuery.query || '',
+      sort,
+      isSidebarVisible: false,
+      processingIssues: null,
+      environment: this.props.environment,
+    };
+  },
+
+  componentWillMount() {
+    this._streamManager = new utils.StreamManager(GroupStore);
+    this._poller = new utils.CursorPoller({
+      success: this.onRealtimePoll,
+    });
+
+    if (!this.state.loading) {
+      this.fetchData();
+    }
+  },
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.environment !== this.props.environment) {
+      this.setState(
+        {
+          environment: nextProps.environment,
+        },
+        this.fetchData
+      );
+    }
+
+    // We are using qs.parse with location.search since this.props.location.query
+    // returns the same value as nextProps.location.query
+    let currentSearchTerm = qs.parse(this.props.location.search);
+    let nextSearchTerm = qs.parse(nextProps.location.search);
+
+    let searchTermChanged = !isEqual(
+      omit(currentSearchTerm, 'environment'),
+      omit(nextSearchTerm, 'environment')
+    );
+
+    if (searchTermChanged) {
+      this.setState(this.getQueryState(nextProps), this.fetchData);
+    }
+  },
+
+  componentDidUpdate(prevProps, prevState) {
+    if (prevState.realtimeActive !== this.state.realtimeActive) {
+      // User toggled realtime button
+      if (this.state.realtimeActive) {
+        this.resumePolling();
+      } else {
+        this._poller.disable();
+      }
+    }
+  },
+
+  componentWillUnmount() {
+    this._poller.disable();
+    GroupStore.reset();
+  },
+
+  getAccess() {
+    return new Set(this.props.organization.access);
+  },
+
+  getQueryState(props) {
+    let currentQuery = props.location.query || {};
+    let hasQuery = 'query' in currentQuery;
+    let sort = 'sort' in currentQuery ? currentQuery.sort : DEFAULT_SORT;
+    let statsPeriod = STATS_PERIODS.has(currentQuery.statsPeriod)
+      ? currentQuery.statsPeriod
+      : DEFAULT_STATS_PERIOD;
+
+    let newState = {
+      sort,
+      statsPeriod,
+      query: hasQuery ? currentQuery.query : '',
+      isDefaultSearch: false,
+    };
+    newState.loading = false;
+
+    return newState;
+  },
+
+  hasQuery(props) {
+    props = props || this.props;
+    let currentQuery = props.location.query || {};
+    return 'query' in currentQuery;
+  },
+
+  fetchData() {
+    GroupStore.loadInitialData([]);
+
+    this.setState({
+      loading: true,
+      queryCount: null,
+      error: false,
+    });
+
+    let url = this.getGroupListEndpoint();
+
+    // Remove leading and trailing whitespace
+    let query = queryString.formatQueryString(this.state.query);
+
+    let {environment} = this.state;
+
+    let requestParams = {
+      query,
+      limit: MAX_ITEMS,
+      sort: this.state.sort,
+      statsPeriod: this.state.statsPeriod,
+      shortIdLookup: '1',
+    };
+
+    // Always keep the global active environment in sync with the queried environment
+    // The global environment wins unless there one is specified by the saved search
+    const queryEnvironment = queryString.getQueryEnvironment(query);
+
+    if (queryEnvironment !== null) {
+      requestParams.environment = queryEnvironment;
+    } else if (environment) {
+      requestParams.environment = environment.name;
+    }
+
+    let currentQuery = this.props.location.query || {};
+    if ('cursor' in currentQuery) {
+      requestParams.cursor = currentQuery.cursor;
+    }
+
+    if (this.lastRequest) {
+      this.lastRequest.cancel();
+    }
+
+    this._poller.disable();
+
+    this.lastRequest = this.api.request(url, {
+      method: 'GET',
+      data: requestParams,
+      success: (data, ignore, jqXHR) => {
+        // if this is a direct hit, we redirect to the intended result directly.
+        // we have to use the project slug from the result data instead of the
+        // the current props one as the shortIdLookup can return results for
+        // different projects.
+        if (jqXHR.getResponseHeader('X-Sentry-Direct-Hit') === '1') {
+          if (data && data[0].matchingEventId) {
+            let {project, id, matchingEventId, matchingEventEnvironment} = data[0];
+            let redirect = `/${this.props.params
+              .orgId}/${project.slug}/issues/${id}/events/${matchingEventId}/`;
+            // Also direct to the environment of this specific event if this
+            // key exists. We need to explicitly check against undefined becasue
+            // an environment name may be an empty string, which is perfectly valid.
+            if (typeof matchingEventEnvironment !== 'undefined') {
+              setActiveEnvironmentName(matchingEventEnvironment);
+              redirect = `${redirect}?${qs.stringify({
+                environment: matchingEventEnvironment,
+              })}`;
+            }
+            browserHistory.replace(redirect);
+            return;
+          }
+        }
+
+        this._streamManager.push(data);
+
+        let queryCount = jqXHR.getResponseHeader('X-Hits');
+        let queryMaxCount = jqXHR.getResponseHeader('X-Max-Hits');
+
+        this.setState({
+          error: false,
+          loading: false,
+          query,
+          queryCount:
+            typeof queryCount !== 'undefined' ? parseInt(queryCount, 10) || 0 : 0,
+          queryMaxCount:
+            typeof queryMaxCount !== 'undefined' ? parseInt(queryMaxCount, 10) || 0 : 0,
+          pageLinks: jqXHR.getResponseHeader('Link'),
+        });
+      },
+      error: err => {
+        this.setState({
+          error: parseApiError(err),
+          loading: false,
+        });
+      },
+      complete: jqXHR => {
+        this.lastRequest = null;
+
+        this.resumePolling();
+      },
+    });
+  },
+
+  resumePolling() {
+    if (!this.state.pageLinks) return;
+
+    // Only resume polling if we're on the first page of results
+    let links = parseLinkHeader(this.state.pageLinks);
+    if (links && !links.previous.results && this.state.realtimeActive) {
+      this._poller.setEndpoint(links.previous.href);
+      this._poller.enable();
+    }
+  },
+
+  getGroupListEndpoint() {
+    let params = this.props.params;
+
+    return '/organizations/' + params.orgId + '/issues/';
+  },
+
+  onRealtimeChange(realtime) {
+    Cookies.set('realtimeActive', realtime.toString());
+    this.setState({
+      realtimeActive: realtime,
+    });
+  },
+
+  onSelectStatsPeriod(period) {
+    if (period != this.state.statsPeriod) {
+      // TODO(dcramer): all charts should now suggest "loading"
+      this.setState(
+        {
+          statsPeriod: period,
+        },
+        function() {
+          this.transitionTo();
+        }
+      );
+    }
+  },
+
+  onRealtimePoll(data, links) {
+    this._streamManager.unshift(data);
+    if (!utils.valueIsEqual(this.state.pageLinks, links, true)) {
+      this.setState({
+        pageLinks: links,
+      });
+    }
+  },
+
+  onGroupChange() {
+    let groupIds = this._streamManager.getAllItems().map(item => item.id);
+    if (!utils.valueIsEqual(groupIds, this.state.groupIds)) {
+      this.setState({
+        groupIds,
+      });
+    }
+  },
+
+  onSearch(query) {
+    if (query === this.state.query) {
+      // if query is the same, just re-fetch data
+      this.fetchData();
+    } else {
+      // We no longer want to support environments specified in the querystring
+      // To keep this aligned with old behavior though we'll update the global environment
+      // and remove it from the query if someone does provide it this way
+      const queryEnvironment = queryString.getQueryEnvironment(query);
+      if (queryEnvironment !== null) {
+        const env = EnvironmentStore.getByName(queryEnvironment);
+        setActiveEnvironment(env);
+      }
+      query = queryString.getQueryStringWithoutEnvironment(query);
+
+      this.setState(
+        {
+          query,
+        },
+        this.transitionTo
+      );
+    }
+  },
+
+  onSortChange(sort) {
+    this.setState(
+      {
+        sort,
+      },
+      this.transitionTo
+    );
+  },
+
+  onSidebarToggle() {
+    let {organization} = this.props;
+    this.setState({
+      isSidebarVisible: !this.state.isSidebarVisible,
+    });
+    analytics('issue.search_sidebar_clicked', {
+      org_id: parseInt(organization.id, 10),
+    });
+  },
+
+  /**
+   * Returns true if all results in the current query are visible/on this page
+   */
+  allResultsVisible() {
+    if (!this.state.pageLinks) return false;
+
+    let links = parseLinkHeader(this.state.pageLinks);
+    return links && !links.previous.results && !links.next.results;
+  },
+
+  transitionTo() {
+    let queryParams = {};
+
+    if (this.props.location.query.environment) {
+      queryParams.environment = this.props.location.query.environment;
+    }
+
+    queryParams.query = this.state.query;
+
+    if (this.state.sort !== DEFAULT_SORT) {
+      queryParams.sort = this.state.sort;
+    }
+
+    if (this.state.statsPeriod !== DEFAULT_STATS_PERIOD) {
+      queryParams.statsPeriod = this.state.statsPeriod;
+    }
+
+    let params = this.props.params;
+
+    let path = `/${params.orgId}/issues/`;
+    browserHistory.push({
+      pathname: path,
+      query: queryParams,
+    });
+  },
+
+  renderGroupNodes(ids, statsPeriod) {
+    // Restrict this guide to only show for new users (joined<30 days) and add guide anhor only to the first issue
+    let userDateJoined = new Date(ConfigStore.get('user').dateJoined);
+    let dateCutoff = new Date();
+    dateCutoff.setDate(dateCutoff.getDate() - 30);
+
+    let topIssue = ids[0];
+
+    let {orgId} = this.props.params;
+    let groupNodes = ids.map(id => {
+      let hasGuideAnchor = userDateJoined > dateCutoff && id === topIssue;
+      return (
+        <StreamGroup
+          key={id}
+          id={id}
+          orgId={orgId}
+          statsPeriod={statsPeriod}
+          query={this.state.query}
+          hasGuideAnchor={hasGuideAnchor}
+        />
+      );
+    });
+    return <PanelBody className="ref-group-list">{groupNodes}</PanelBody>;
+  },
+
+  renderEmpty() {
+    const {environment} = this.state;
+    const message = environment
+      ? tct('Sorry no events match your filters in the [env] environment.', {
+          env: environment.displayName,
+        })
+      : t('Sorry, no events match your filters.');
+
+    // TODO(lyn): Extract empty state to a separate component
+    return (
+      <div className="empty-stream" style={{border: 0}}>
+        <span className="icon icon-exclamation" />
+        <p>{message}</p>
+      </div>
+    );
+  },
+
+  renderLoading() {
+    return <LoadingIndicator />;
+  },
+
+  renderStreamBody() {
+    let body;
+
+    if (this.state.loading) {
+      body = this.renderLoading();
+    } else if (this.state.error) {
+      body = <LoadingError message={this.state.error} onRetry={this.fetchData} />;
+    } else if (this.state.groupIds.length > 0) {
+      body = this.renderGroupNodes(this.state.groupIds, this.state.statsPeriod);
+    } else {
+      body = this.renderEmpty();
+    }
+    return body;
+  },
+
+  render() {
+    // global loading
+    if (this.state.loading) {
+      return this.renderLoading();
+    }
+    let params = this.props.params;
+    let classes = ['stream-row'];
+    if (this.state.isSidebarVisible) classes.push('show-sidebar');
+    let {orgId} = this.props.params;
+    let access = this.getAccess();
+
+    // In the project mode this reads from the project feature.
+    // There is no analogous property for organizations yet.
+    let hasReleases = false;
+    let latestRelease = '';
+
+    return (
+      <div className={classNames(classes)}>
+        <div className="stream-content">
+          <StreamFilters
+            access={access}
+            orgId={orgId}
+            query={this.state.query}
+            sort={this.state.sort}
+            queryCount={this.state.queryCount}
+            queryMaxCount={this.state.queryMaxCount}
+            onSortChange={this.onSortChange}
+            onSearch={this.onSearch}
+            onSavedSearchCreate={this.onSavedSearchCreate}
+            onSidebarToggle={this.onSidebarToggle}
+            isSearchDisabled={this.state.isSidebarVisible}
+            savedSearchList={this.state.savedSearchList}
+          />
+          <Panel>
+            <StreamActions
+              orgId={params.orgId}
+              hasReleases={hasReleases}
+              latestRelease={latestRelease}
+              environment={this.state.environment}
+              query={this.state.query}
+              queryCount={this.state.queryCount}
+              onSelectStatsPeriod={this.onSelectStatsPeriod}
+              onRealtimeChange={this.onRealtimeChange}
+              realtimeActive={this.state.realtimeActive}
+              statsPeriod={this.state.statsPeriod}
+              groupIds={this.state.groupIds}
+              allResultsVisible={this.allResultsVisible()}
+            />
+            <PanelBody>{this.renderStreamBody()}</PanelBody>
+          </Panel>
+          <Pagination pageLinks={this.state.pageLinks} />
+        </div>
+        <StreamSidebar
+          loading={this.props.tagsLoading}
+          tags={this.props.tags}
+          query={this.state.query}
+          onQueryChange={this.onSearch}
+          orgId={params.orgId}
+        />
+      </div>
+    );
+  },
+});
+
+// Placeholder components to keep pull requests manageable.
+const StreamFilters = props => <p>Stream filters are coming soon</p>;
+const StreamActions = props => <p>Stream actions are coming soon</p>;
+const StreamSidebar = props => <p>Stream sidebar is coming soon</p>;
+
+const StreamGroup = ({id}) => <p>Issue {id}</p>;
+StreamGroup.propTypes = {
+  id: PropTypes.string,
+};
+
+export default withOrganization(OrganizationStream);
+export {OrganizationStream};

--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -649,7 +649,7 @@ const Stream = createReactClass({
 
     let topIssue = ids[0];
 
-    let {orgId, projectId} = this.props.params;
+    let {orgId} = this.props.params;
     let groupNodes = ids.map(id => {
       let hasGuideAnchor = userDateJoined > dateCutoff && id === topIssue;
       return (
@@ -657,7 +657,6 @@ const Stream = createReactClass({
           key={id}
           id={id}
           orgId={orgId}
-          projectId={projectId}
           statsPeriod={statsPeriod}
           query={this.state.query}
           hasGuideAnchor={hasGuideAnchor}

--- a/tests/js/spec/components/__snapshots__/streamGroup.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/streamGroup.spec.jsx.snap
@@ -67,7 +67,7 @@ exports[`StreamGroup renders with anchors 1`] = `
       }
       includeLink={true}
       orgId="orgId"
-      projectId="projectId"
+      projectId="test"
     />
     <EventOrGroupExtraDetails
       assignedTo={null}
@@ -81,7 +81,7 @@ exports[`StreamGroup renders with anchors 1`] = `
           "slug": "test",
         }
       }
-      projectId="projectId"
+      projectId="test"
       stats={
         Object {
           "24h": Array [

--- a/tests/js/spec/components/streamGroup.spec.jsx
+++ b/tests/js/spec/components/streamGroup.spec.jsx
@@ -32,7 +32,6 @@ describe('StreamGroup', function() {
       <StreamGroup
         id="1L"
         orgId="orgId"
-        projectId="projectId"
         groupId="groupId"
         lastSeen="2017-07-25T22:56:12Z"
         firstSeen="2017-07-01T02:06:02Z"

--- a/tests/js/spec/views/stream/__snapshots__/stream.spec.jsx.snap
+++ b/tests/js/spec/views/stream/__snapshots__/stream.spec.jsx.snap
@@ -79,7 +79,6 @@ exports[`Stream render() displays the group list 1`] = `
             id="1"
             key="1"
             orgId="org-slug"
-            projectId="project-slug"
             query="is:unresolved"
             statsPeriod="24h"
           />
@@ -253,7 +252,6 @@ exports[`Stream toggles environment select all environments 1`] = `
             id="1"
             key="1"
             orgId="org-slug"
-            projectId="project-slug"
             query="is:unresolved"
             statsPeriod="24h"
           />


### PR DESCRIPTION
Its a place to start. I wanted to get feedback on the name `organizationStream`.

At a high level I was thinking of duplicating most of the stream components as there are subtle shifts in requirements like:

* Bulk operations will only work if issues from a single project are selected.
* Search context comes from both the global filter bar and other search controls.
* Saved Searches come from different endpoints and behave differently in the search query input.

I've added a few placeholder components that I plan on replacing individually as the APIs for them become available. Notably absent from these changes are saved searches and processing issues which will be added later as they have their own tasks in Jira.

Refs APP-990