### PR TITLE
feat(discover): Auto-run when there is a query string present

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -1,5 +1,4 @@
 import {browserHistory} from 'react-router';
-import {isEqual, pick} from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
@@ -28,7 +27,6 @@ import {
   deleteSavedQuery,
   updateSavedQuery,
 } from './utils';
-import {DEFAULTS as DEFAULT_QUERY} from './queryBuilder';
 import {isValidAggregation} from './aggregations/utils';
 import {isValidCondition} from './conditions/utils';
 import {trackQuery} from './analytics';
@@ -68,15 +66,10 @@ export default class OrganizationDiscover extends React.Component {
   }
 
   componentDidMount() {
-    const {savedQuery, queryBuilder} = this.props;
+    const {savedQuery, location} = this.props;
 
-    const keys = ['fields', 'conditions', 'aggregations', 'orderby'];
-    const isDefaultQuery = isEqual(
-      pick(queryBuilder.getInternal(), keys),
-      pick(DEFAULT_QUERY, keys)
-    );
-
-    if (savedQuery || !isDefaultQuery) {
+    // Run query if there is *any* querystring
+    if (savedQuery || (location && !!location.search)) {
       this.runQuery();
     }
   }

--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -1,4 +1,5 @@
 import {browserHistory} from 'react-router';
+import {isEqual, pick} from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
@@ -27,6 +28,7 @@ import {
   deleteSavedQuery,
   updateSavedQuery,
 } from './utils';
+import {DEFAULTS as DEFAULT_QUERY} from './queryBuilder';
 import {isValidAggregation} from './aggregations/utils';
 import {isValidCondition} from './conditions/utils';
 import {trackQuery} from './analytics';
@@ -66,7 +68,15 @@ export default class OrganizationDiscover extends React.Component {
   }
 
   componentDidMount() {
-    if (this.props.savedQuery) {
+    const {savedQuery, queryBuilder} = this.props;
+
+    const keys = ['fields', 'conditions', 'aggregations', 'orderby'];
+    const isDefaultQuery = isEqual(
+      pick(queryBuilder.getInternal(), keys),
+      pick(DEFAULT_QUERY, keys)
+    );
+
+    if (savedQuery || !isDefaultQuery) {
       this.runQuery();
     }
   }

--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -13,7 +13,7 @@ import MissingProjectWarningModal from './missingProjectWarningModal';
 import {COLUMNS, PROMOTED_TAGS, SPECIAL_TAGS} from './data';
 import {isValidAggregation} from './aggregations/utils';
 
-const DEFAULTS = {
+export const DEFAULTS = {
   projects: [],
   fields: ['id', 'issue.id', 'project.name', 'platform', 'timestamp'],
   conditions: [],

--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -13,7 +13,7 @@ import MissingProjectWarningModal from './missingProjectWarningModal';
 import {COLUMNS, PROMOTED_TAGS, SPECIAL_TAGS} from './data';
 import {isValidAggregation} from './aggregations/utils';
 
-export const DEFAULTS = {
+const DEFAULTS = {
   projects: [],
   fields: ['id', 'issue.id', 'project.name', 'platform', 'timestamp'],
   conditions: [],

--- a/tests/js/spec/views/organizationDiscover/discover.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/discover.spec.jsx
@@ -52,7 +52,28 @@ describe('Discover', function() {
       );
     });
 
-    it('does not auto run non-saved query', async function() {
+    it('auto-runs non-saved, non-default query', async function() {
+      const newQueryBuilder = createQueryBuilder({fields: ['id']}, organization);
+      newQueryBuilder.fetch = jest.fn(() => Promise.resolve(mockResponse));
+
+      wrapper = mount(
+        <Discover
+          queryBuilder={newQueryBuilder}
+          organization={organization}
+          updateSavedQueryData={jest.fn()}
+          toggleEditMode={jest.fn()}
+          isLoading={false}
+        />,
+        TestStubs.routerContext([{organization}])
+      );
+      await tick();
+      expect(wrapper.state().data.baseQuery.query).toEqual(newQueryBuilder.getExternal());
+      expect(wrapper.state().data.baseQuery.data).toEqual(
+        expect.objectContaining({data: mockResponse.data})
+      );
+    });
+
+    it('does not auto run non-saved, default query', async function() {
       wrapper = mount(
         <Discover
           queryBuilder={queryBuilder}

--- a/tests/js/spec/views/organizationDiscover/discover.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/discover.spec.jsx
@@ -52,13 +52,14 @@ describe('Discover', function() {
       );
     });
 
-    it('auto-runs non-saved, non-default query', async function() {
-      const newQueryBuilder = createQueryBuilder({fields: ['id']}, organization);
-      newQueryBuilder.fetch = jest.fn(() => Promise.resolve(mockResponse));
-
+    it('auto-runs when there is a query string', async function() {
       wrapper = mount(
         <Discover
-          queryBuilder={newQueryBuilder}
+          location={{
+            search:
+              'projects=%5B%5D&fields=%5B%22id%22%2C%22issue.id%22%2C%22project.name%22%2C%22platform%22%2C%22timestamp%22%5D&conditions=%5B%5D&aggregations=%5B%5D&range=%227d%22&orderby=%22-timestamp%22&limit=1000&start=null&end=null',
+          }}
+          queryBuilder={queryBuilder}
           organization={organization}
           updateSavedQueryData={jest.fn()}
           toggleEditMode={jest.fn()}
@@ -67,15 +68,18 @@ describe('Discover', function() {
         TestStubs.routerContext([{organization}])
       );
       await tick();
-      expect(wrapper.state().data.baseQuery.query).toEqual(newQueryBuilder.getExternal());
+      expect(wrapper.state().data.baseQuery.query).toEqual(queryBuilder.getExternal());
       expect(wrapper.state().data.baseQuery.data).toEqual(
         expect.objectContaining({data: mockResponse.data})
       );
     });
 
-    it('does not auto run non-saved, default query', async function() {
+    it('does not auto run when there is no query string', async function() {
       wrapper = mount(
         <Discover
+          location={{
+            search: '',
+          }}
           queryBuilder={queryBuilder}
           organization={organization}
           updateSavedQueryData={jest.fn()}


### PR DESCRIPTION
This will autorun queries if it is not the default query from `queryBuilder`, this way we still have the help screen. Otherwise will autorun queries, which is helpful when navigating to discover via a link (whether it is via in-app or outside w/ direct link).