### PR TITLE
ref(app-platform): change sentry app webhooks schema

### DIFF
--- a/src/sentry/api/serializers/models/app_platform_event.py
+++ b/src/sentry/api/serializers/models/app_platform_event.py
@@ -56,7 +56,7 @@ class AppPlatformEvent(object):
         return {
             'Content-Type': 'application/json',
             'Request-ID': request_uuid,
-            'Sentry-Hook-Event': self.resource,
+            'Sentry-Hook-Resource': self.resource,
             'Sentry-Hook-Timestamp': six.text_type(int(time())),
             'Sentry-Hook-Signature': self.install.sentry_app.build_signature(body)
         }

--- a/src/sentry/api/serializers/models/app_platform_event.py
+++ b/src/sentry/api/serializers/models/app_platform_event.py
@@ -1,11 +1,62 @@
 from __future__ import absolute_import
 
+import six
+from time import time
+from uuid import uuid4
+from sentry.utils import json
 
-def app_platform_event(action, install, data, actor=None):
-    return {
-        'action': action,
-        'installation': {
-            'uuid': install.uuid,
-        },
-        'data': data,
-    }
+
+class AppPlatformEvent(object):
+    def __init__(self, resource, action, install, data, actor=None):
+        self.resource = resource
+        self.action = action
+        self.install = install
+        self.data = data
+        self.actor = actor
+
+    def get_actor(self):
+        # when sentry auto assigns, auto resolves, etc.
+        # or when an alert rule is triggered
+        if not self.actor:
+            return {
+                'type': 'application',
+                'id': 'sentry',
+                'name': 'Sentry',
+            }
+
+        if self.actor.is_sentry_app:
+            return {
+                'type': 'application',
+                'id': self.install.sentry_app.uuid,
+                'name': self.install.sentry_app.name,
+            }
+
+        return {
+            'type': 'user',
+            'id': self.actor.id,
+            'name': self.actor.name,
+        }
+
+    @property
+    def body(self):
+        return {
+            'action': self.action,
+            'installation': {
+                'uuid': self.install.uuid,
+            },
+            'data': self.data,
+            'actor': self.get_actor(),
+        }
+
+    @property
+    def headers(self):
+        body = json.dumps(self.body)
+        request_uuid = uuid4().hex
+
+        return {
+            'Content-Type': 'application/json',
+            'Request-ID': request_uuid,
+            'Sentry-Hook-Event': self.resource,
+            'Sentry-Hook-Timestamp': six.text_type(int(time())),
+            'Sentry-Hook-Signature': self.install.sentry_app.build_signature(body)
+        }

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -2,11 +2,13 @@ from __future__ import absolute_import
 
 import six
 import uuid
+import hmac
 
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
 from django.template.defaultfilters import slugify
+from hashlib import sha256
 
 from sentry.constants import SentryAppStatus, SENTRY_APP_SLUG_MAX_LENGTH
 from sentry.models import Organization
@@ -127,3 +129,11 @@ class SentryApp(ParanoidModel, HasApiScopes):
         """
         if not self.slug:
             self.slug = slugify(self.name)
+
+    def build_signature(self, body):
+        secret = self.application.client_secret
+        return hmac.new(
+            key=secret.encode('utf-8'),
+            msg=body.encode('utf-8'),
+            digestmod=sha256,
+        ).hexdigest()

--- a/src/sentry/models/signals.py
+++ b/src/sentry/models/signals.py
@@ -12,6 +12,7 @@ def resource_changed(sender, instance, created, **kwargs):
         from sentry.tasks.servicehooks import process_resource_change
 
         process_resource_change.delay(
+            action='created',
             sender=sender.__name__,
             instance_id=instance.id,
         )

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -5,11 +5,39 @@ from requests.exceptions import RequestException
 from sentry.http import safe_urlopen
 from sentry.tasks.base import instrumented_task, retry
 from sentry.utils.http import absolute_uri
-from sentry.models import SentryAppInstallation
+from sentry.models import SentryAppInstallation, SentryApp
 from sentry.api.serializers import AppPlatformEvent
 
 
 def notify_sentry_app(event, futures):
+    for f in futures:
+        sentry_app = f.kwargs['sentry_app']
+
+        send_alert_event.delay(
+            event=event,
+            rule=f.rule.label,
+            sentry_app_id=sentry_app.id,
+        )
+
+
+@instrumented_task(
+    name='sentry.tasks.sentry_apps.send_alert_event', default_retry_delay=60 * 5, max_retries=5
+)
+@retry(on=(RequestException, ))
+def send_alert_event(event, rule, sentry_app_id):
+    try:
+        sentry_app = SentryApp.objects.get(id=sentry_app_id)
+    except SentryApp.DoesNotExist:
+        return
+
+    try:
+        install = SentryAppInstallation.objects.get(
+            organization=event.project.organization_id,
+            sentry_app=sentry_app,
+        )
+    except SentryAppInstallation.DoesNotExist:
+        return
+
     group = event.group
     project = group.project
     project_url_base = absolute_uri(u'/{}/{}'.format(
@@ -36,32 +64,16 @@ def notify_sentry_app(event, futures):
     data = {
         'event': event_context,
     }
-    for f in futures:
-        sentry_app = f.kwargs['sentry_app']
-        try:
-            install = SentryAppInstallation.objects.get(
-                organization=event.project.organization_id,
-                sentry_app=sentry_app,
-            )
-        except SentryAppInstallation.DoesNotExist:
-            continue
 
-        data['triggered_rule'] = f.rule.label
+    data['triggered_rule'] = rule
 
-        request_data = AppPlatformEvent(
-            resource='event_alert',
-            action='triggered',
-            install=install,
-            data=data,
-        )
-        send_alert_event.delay(sentry_app=sentry_app, request_data=request_data)
+    request_data = AppPlatformEvent(
+        resource='event_alert',
+        action='triggered',
+        install=install,
+        data=data,
+    )
 
-
-@instrumented_task(
-    name='sentry.tasks.sentry_apps.send_alert_event', default_retry_delay=60 * 5, max_retries=5
-)
-@retry(on=(RequestException, ))
-def send_alert_event(sentry_app, request_data):
     safe_urlopen(
         url=sentry_app.webhook_url,
         data=request_data.body,

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -23,7 +23,7 @@ def notify_sentry_app(event, futures):
         group.id,
         event.id,
     )
-    event_context['html_url'] = u'{}/issues/{}/events/{}/'.format(
+    event_context['web_url'] = u'{}/issues/{}/events/{}/'.format(
         project_url_base,
         group.id,
         event.id,

--- a/tests/sentry/api/serializers/test_app_platform_event.py
+++ b/tests/sentry/api/serializers/test_app_platform_event.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+from sentry.api.serializers import AppPlatformEvent
+from sentry.testutils import TestCase
+from sentry.utils import json
+
+
+class AppPlatformEventSerializerTest(TestCase):
+    def setUp(self):
+        self.user = self.create_user(username='foo')
+        self.organization = self.create_organization(owner=self.user)
+        self.sentry_app = self.create_sentry_app(organization=self.organization)
+        self.install = self.create_sentry_app_installation(
+            organization=self.organization,
+            slug=self.sentry_app.slug,
+        )
+
+    def test_no_actor(self):
+        result = AppPlatformEvent(
+            resource='event_alert',
+            action='triggered',
+            install=self.install,
+            data={},
+        )
+        assert result.body == {
+            'action': 'triggered',
+            'installation': {
+                'uuid': self.install.uuid,
+            },
+            'data': {},
+            'actor': {
+                'type': 'application',
+                'id': 'sentry',
+                'name': 'Sentry',
+            }
+        }
+        body = json.dumps(result.body)
+        signature = self.sentry_app.build_signature(body)
+
+        assert result.headers['Content-Type'] == 'application/json'
+        assert result.headers['Sentry-Hook-Resource'] == 'event_alert'
+        assert result.headers['Sentry-Hook-Signature'] == signature
+
+    def test_sentry_app_actor(self):
+        result = AppPlatformEvent(
+            resource='issue',
+            action='assigned',
+            install=self.install,
+            data={},
+            actor=self.sentry_app.proxy_user,
+        )
+        assert result.body['actor'] == {
+            'type': 'application',
+            'id': self.sentry_app.uuid,
+            'name': self.sentry_app.name,
+        }
+        body = json.dumps(result.body)
+        signature = self.sentry_app.build_signature(body)
+
+        assert result.headers['Content-Type'] == 'application/json'
+        assert result.headers['Sentry-Hook-Resource'] == 'issue'
+        assert result.headers['Sentry-Hook-Signature'] == signature
+
+    def test_user_actor(self):
+        result = AppPlatformEvent(
+            resource='installation',
+            action='created',
+            install=self.install,
+            data={},
+            actor=self.user,
+        )
+        assert result.body['actor'] == {
+            'type': 'user',
+            'id': self.user.id,
+            'name': self.user.name,
+        }
+        body = json.dumps(result.body)
+        signature = self.sentry_app.build_signature(body)
+
+        assert result.headers['Content-Type'] == 'application/json'
+        assert result.headers['Sentry-Hook-Resource'] == 'installation'
+        assert result.headers['Sentry-Hook-Signature'] == signature

--- a/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
@@ -5,13 +5,22 @@ from mock import patch
 from sentry.mediators import sentry_apps
 from sentry.mediators.sentry_app_installations import Creator, InstallationNotifier
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.faux import faux
+
+
+class DictContaining(object):
+    def __init__(self, *keys):
+        self.keys = keys
+
+    def __eq__(self, other):
+        return all([k in other.keys() for k in self.keys])
 
 
 class TestInstallationNotifier(TestCase):
     def setUp(self):
         super(TestInstallationNotifier, self).setUp()
 
-        self.user = self.create_user()
+        self.user = self.create_user(name='foo')
         self.org = self.create_organization(owner=self.user)
 
         self.sentry_app = sentry_apps.Creator.run(
@@ -34,24 +43,35 @@ class TestInstallationNotifier(TestCase):
             user=self.user,
         )
 
-        safe_urlopen.assert_called_once_with(
-            'https://example.com',
-            json={
-                'action': 'installation',
-                'installation': {
-                    'uuid': self.install.uuid,
-                },
-                'data': {
-                    'app': {
-                        'uuid': self.sentry_app.uuid,
-                        'slug': self.sentry_app.slug,
-                    },
-                    'organization': {
-                        'slug': self.org.slug,
-                    },
-                    'uuid': self.install.uuid,
-                    'code': self.install.api_grant.code,
-                },
+        data = faux(safe_urlopen).kwargs['data']
+
+        assert data == {
+            'action': 'created',
+            'installation': {
+                'uuid': self.install.uuid,
             },
-            timeout=5,
-        )
+            'data': {
+                'app': {
+                    'uuid': self.sentry_app.uuid,
+                    'slug': self.sentry_app.slug,
+                },
+                'organization': {
+                    'slug': self.org.slug,
+                },
+                'uuid': self.install.uuid,
+                'code': self.install.api_grant.code,
+            },
+            'actor': {
+                'id': self.user.id,
+                'name': self.user.name,
+                'type': 'user',
+            },
+        }
+
+        assert faux(safe_urlopen).kwarg_equals('headers', DictContaining(
+            'Content-Type',
+            'Request-ID',
+            'Sentry-Hook-Event',
+            'Sentry-Hook-Timestamp',
+            'Sentry-Hook-Signature',
+        ))

--- a/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
@@ -71,7 +71,7 @@ class TestInstallationNotifier(TestCase):
         assert faux(safe_urlopen).kwarg_equals('headers', DictContaining(
             'Content-Type',
             'Request-ID',
-            'Sentry-Hook-Event',
+            'Sentry-Hook-Resource',
             'Sentry-Hook-Timestamp',
             'Sentry-Hook-Signature',
         ))

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -1,0 +1,122 @@
+from __future__ import absolute_import
+
+from collections import namedtuple
+from django.core.urlresolvers import reverse
+from mock import patch
+
+from sentry.models import Rule
+from sentry.testutils import TestCase
+from sentry.tasks.sentry_apps import notify_sentry_app
+from sentry.testutils.helpers.faux import faux
+from sentry.utils.http import absolute_uri
+
+RuleFuture = namedtuple('RuleFuture', ['rule', 'kwargs'])
+
+
+class DictContaining(object):
+    def __init__(self, *keys):
+        self.keys = keys
+
+    def __eq__(self, other):
+        return all([k in other.keys() for k in self.keys])
+
+
+class TestSentryAppAlertEvent(TestCase):
+    def setUp(self):
+        self.organization = self.create_organization(slug='foo')
+        self.sentry_app = self.create_sentry_app(organization=self.organization)
+        self.project = self.create_project(organization=self.organization)
+        self.rule = Rule.objects.create(project=self.project, label='Issa Rule')
+        self.install = self.create_sentry_app_installation(
+            organization=self.project.organization,
+            slug=self.sentry_app.slug,
+        )
+
+    @patch('sentry.tasks.sentry_apps.safe_urlopen')
+    def test_no_sentry_app(self, safe_urlopen):
+        group = self.create_group(project=self.project)
+        event = self.create_event(group=group)
+        rule_future = RuleFuture(
+            rule=self.rule,
+            kwargs={},
+        )
+
+        with self.tasks():
+            notify_sentry_app(event, [rule_future])
+
+        assert not safe_urlopen.called
+
+    @patch('sentry.tasks.sentry_apps.safe_urlopen')
+    def test_no_installation(self, safe_urlopen):
+        sentry_app = self.create_sentry_app(
+            organization=self.organization
+        )
+        group = self.create_group(project=self.project)
+        event = self.create_event(group=group)
+        rule_future = RuleFuture(
+            rule=self.rule,
+            kwargs={'sentry_app': sentry_app},
+        )
+
+        with self.tasks():
+            notify_sentry_app(event, [rule_future])
+
+        assert not safe_urlopen.called
+
+    @patch('sentry.tasks.sentry_apps.safe_urlopen')
+    def test_send_alert_event(self, safe_urlopen):
+        group = self.create_group(project=self.project)
+        event = self.create_event(group=group)
+        rule_future = RuleFuture(
+            rule=self.rule,
+            kwargs={'sentry_app': self.sentry_app},
+        )
+
+        event_data = self._get_event_data(event)
+
+        with self.tasks():
+            notify_sentry_app(event, [rule_future])
+
+        data = faux(safe_urlopen).kwargs['data']
+        assert data == {
+            'action': 'triggered',
+            'installation': {
+                'uuid': self.install.uuid,
+            },
+            'data': {
+                'event': event_data,
+                'triggered_rule': self.rule.label,
+            },
+            'actor': {
+                'type': 'application',
+                'id': 'sentry',
+                'name': 'Sentry',
+            }
+        }
+
+        assert faux(safe_urlopen).kwarg_equals('headers', DictContaining(
+            'Content-Type',
+            'Request-ID',
+            'Sentry-Hook-Resource',
+            'Sentry-Hook-Timestamp',
+            'Sentry-Hook-Signature',
+        ))
+
+    def _get_event_data(self, event):
+        group = event.group
+        event_data = event.as_dict()
+        event_data['url'] = absolute_uri(reverse('sentry-api-0-project-event-details', args=[
+            self.organization.slug,
+            self.project.slug,
+            event.id,
+        ]))
+        event_data['web_url'] = absolute_uri(reverse('sentry-group-event', args=[
+            self.organization.slug,
+            self.project.slug,
+            group.id,
+            event.id,
+        ]))
+        event_data['issue_url'] = absolute_uri(
+            '/api/0/issues/{}/'.format(group.id),
+        )
+        return event_data


### PR DESCRIPTION
**Mini Overview**
For any given Sentry App, all webhook events are sent to the `webhook_url` specified in the app 
configuration. So far there are three types:
* **[Un]Installation Events**
* **Alerts**
* **Resource Subscriptions**

This PR aims to unify the request data for all these types to make things easier for users.

**Headers**
* `Sentry-Hook-Resource`: resource that received the action (part of the payload) and caused the webhook to trigger.
* `Sentry-Hook-Signature`: hash generated using your Client Secret and the request itself.
```
{
  'Content-Type': 'application/json',
  'Request-ID': <request_uuid>,
  'Sentry-Hook-Resource': <resource>,
  'Sentry-Hook-Timestamp': six.text_type(int(time())),
  'Sentry-Hook-Signature': <generated_signature>
}
```

**Payload**
* `action`: what happened to/changed in the resource
* `data` : specific to the resource and action but should include the representation of the resource (i.e. `issue`) and the related `web_url` and `api_urls`.
* `actor`: who/what triggered the action, type is either `user` or `application`. Default will be sentry (sentry.io) for events that are automatically triggered (i.e. auto-resolved issues)
``` json
{
  "action": "<action>",
  "installation": {
    "uuid": "<uuid>"
  },
  "data": { },
  "actor": {
    "type": "application",
    "id": "sentry",
    "name": "Sentry", 
  },    
}
```

cc @mitsuhiko 