### PR TITLE
feat(api): Implement organization level saved searches endpoint (APP-913)

### DIFF
--- a/src/sentry/api/endpoints/organization_searches.py
+++ b/src/sentry/api/endpoints/organization_searches.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import
+
+from rest_framework.response import Response
+from django.db.models import Q
+
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.serializers import serialize
+from sentry.models.savedsearch import (
+    DEFAULT_SAVED_SEARCH_QUERIES,
+    SavedSearch,
+)
+
+
+class OrganizationSearchesEndpoint(OrganizationEndpoint):
+
+    def get(self, request, organization):
+        """
+        List an Organization's saved searches
+        `````````````````````````````````````
+        Retrieve a list of saved searches for a given Organization. For custom
+        saved searches, return them for all projects even if we have duplicates.
+        For default searches, just return one of each search
+
+        :auth: required
+
+        """
+        org_searches = Q(
+            Q(owner=request.user) | Q(owner__isnull=True),
+            ~Q(query__in=DEFAULT_SAVED_SEARCH_QUERIES),
+            project__in=self.get_projects(request, organization),
+        )
+        global_searches = Q(is_global=True)
+        saved_searches = SavedSearch.objects.filter(
+            org_searches | global_searches
+        ).order_by('name', 'project')
+
+        return Response(serialize(list(saved_searches), request.user))

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -28,7 +28,7 @@ from sentry.models import (
     Release, UserOption, User
 )
 from sentry.models.event import Event
-from sentry.receivers import DEFAULT_SAVED_SEARCHES
+from sentry.models.savedsearch import DEFAULT_SAVED_SEARCH_QUERIES
 from sentry.signals import advanced_search, issue_ignored, issue_resolved_in_release, resolved_with_commit
 from sentry.tasks.integrations import kick_off_status_syncs
 from sentry.tasks.merge import merge_groups
@@ -39,7 +39,6 @@ from sentry.utils.functional import extract_lazy_object
 
 
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', and '14d'"
-SAVED_SEARCH_QUERIES = set([s['query'] for s in DEFAULT_SAVED_SEARCHES])
 
 
 @scenario('BulkUpdateIssues')
@@ -228,7 +227,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
 
         self.add_cursor_headers(request, response, cursor_result)
 
-        if results and query not in SAVED_SEARCH_QUERIES:
+        if results and query not in DEFAULT_SAVED_SEARCH_QUERIES:
             advanced_search.send(project=project, sender=request.user)
             analytics.record('project_issue.searched', user_id=request.user.id,
                              organization_id=project.organization_id, project_id=project.id,

--- a/src/sentry/api/serializers/models/savedsearch.py
+++ b/src/sentry/api/serializers/models/savedsearch.py
@@ -29,10 +29,12 @@ class SavedSearchSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         return {
             'id': six.text_type(obj.id),
+            'projectId': six.text_type(obj.project_id) if obj.project_id else None,
             'name': obj.name,
             'query': obj.query,
             'isDefault': obj.is_default,
             'isUserDefault': attrs['isUserDefault'],
             'dateCreated': obj.date_added,
             'isPrivate': bool(obj.owner),
+            'isGlobal': obj.is_global,
         }

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -96,6 +96,7 @@ from .endpoints.organization_config_integrations import OrganizationConfigIntegr
 from .endpoints.organization_config_repositories import OrganizationConfigRepositoriesEndpoint
 from .endpoints.organization_repository_commits import OrganizationRepositoryCommitsEndpoint
 from .endpoints.organization_repository_details import OrganizationRepositoryDetailsEndpoint
+from .endpoints.organization_searches import OrganizationSearchesEndpoint
 from .endpoints.organization_sentry_apps import OrganizationSentryAppsEndpoint
 from .endpoints.organization_tagkey_values import OrganizationTagKeyValuesEndpoint
 from .endpoints.organization_tags import OrganizationTagsEndpoint
@@ -543,6 +544,11 @@ urlpatterns = patterns(
         r'^organizations/(?P<organization_slug>[^\/]+)/members/$',
         OrganizationMemberIndexEndpoint.as_view(),
         name='sentry-api-0-organization-member-index'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/searches/$',
+        OrganizationSearchesEndpoint.as_view(),
+        name='sentry-api-0-organization-searches'
     ),
     url(
         r'^organizations/(?P<organization_slug>[^\/]+)/users/issues/$',

--- a/src/sentry/models/savedsearch.py
+++ b/src/sentry/models/savedsearch.py
@@ -6,6 +6,32 @@ from django.utils import timezone
 from sentry.db.models import FlexibleForeignKey, Model, sane_repr
 
 
+DEFAULT_SAVED_SEARCHES = [
+    {
+        'name': 'Unresolved Issues',
+        'query': 'is:unresolved',
+        'is_default': True
+    },
+    {
+        'name': 'Needs Triage',
+        'query': 'is:unresolved is:unassigned'
+    },
+    {
+        'name': 'Assigned To Me',
+        'query': 'is:unresolved assigned:me'
+    },
+    {
+        'name': 'My Bookmarks',
+        'query': 'is:unresolved bookmarks:me'
+    },
+    {
+        'name': 'New Today',
+        'query': 'is:unresolved age:-24h'
+    },
+]
+DEFAULT_SAVED_SEARCH_QUERIES = set(search['query'] for search in DEFAULT_SAVED_SEARCHES)
+
+
 class SavedSearch(Model):
     """
     A saved search query.

--- a/src/sentry/receivers/savedsearch.py
+++ b/src/sentry/receivers/savedsearch.py
@@ -3,30 +3,7 @@ from __future__ import absolute_import, print_function
 from django.db.models.signals import post_save
 
 from sentry.models import Project, SavedSearch
-
-DEFAULT_SAVED_SEARCHES = [
-    {
-        'name': 'Unresolved Issues',
-        'query': 'is:unresolved',
-        'is_default': True
-    },
-    {
-        'name': 'Needs Triage',
-        'query': 'is:unresolved is:unassigned'
-    },
-    {
-        'name': 'Assigned To Me',
-        'query': 'is:unresolved assigned:me'
-    },
-    {
-        'name': 'My Bookmarks',
-        'query': 'is:unresolved bookmarks:me'
-    },
-    {
-        'name': 'New Today',
-        'query': 'is:unresolved age:-24h'
-    },
-]
+from sentry.models.savedsearch import DEFAULT_SAVED_SEARCHES
 
 
 def create_default_saved_searches(instance, created=True, **kwargs):

--- a/tests/sentry/api/endpoints/test_organization_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_searches.py
@@ -1,0 +1,60 @@
+from __future__ import absolute_import
+
+from django.utils import timezone
+from exam import fixture
+
+from sentry.api.serializers import serialize
+from sentry.models import SavedSearch
+from sentry.models.savedsearch import DEFAULT_SAVED_SEARCHES
+from sentry.testutils import APITestCase
+
+
+class OrganizationSearchesListTest(APITestCase):
+    endpoint = 'sentry-api-0-organization-searches'
+
+    @fixture
+    def user(self):
+        return self.create_user('test@test.com')
+
+    def test_simple(self):
+        self.login_as(user=self.user)
+        team = self.create_team(members=[self.user])
+        project1 = self.create_project(teams=[team], name='foo')
+        project2 = self.create_project(teams=[team], name='bar')
+
+        SavedSearch.objects.create(
+            project=project1,
+            name='bar',
+            query=DEFAULT_SAVED_SEARCHES[0]['query'],
+        )
+        included = [
+            SavedSearch.objects.create(
+                name='Global Query',
+                query=DEFAULT_SAVED_SEARCHES[0]['query'],
+                is_global=True,
+                date_added=timezone.now().replace(microsecond=0)
+            ),
+            SavedSearch.objects.create(
+                project=project1,
+                name='foo',
+                query='some test',
+                date_added=timezone.now().replace(microsecond=0)
+            ),
+            SavedSearch.objects.create(
+                project=project1,
+                name='wat',
+                query='is:unassigned is:unresolved',
+                date_added=timezone.now().replace(microsecond=0)
+            ),
+            SavedSearch.objects.create(
+                project=project2,
+                name='foo',
+                query='some test',
+                date_added=timezone.now().replace(microsecond=0)
+            ),
+        ]
+
+        included.sort(key=lambda search: (search.name, search.id))
+        response = self.get_valid_response(self.organization.slug)
+        response.data.sort(key=lambda search: (search['name'], search['projectId']))
+        assert response.data == serialize(included)

--- a/tests/sentry/api/serializers/test_saved_search.py
+++ b/tests/sentry/api/serializers/test_saved_search.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+import six
+
+from sentry.api.serializers import serialize
+from sentry.models import SavedSearch
+from sentry.models.savedsearch import DEFAULT_SAVED_SEARCHES
+from sentry.testutils import TestCase
+
+
+class SavedSearchSerializerTest(TestCase):
+    def test_simple(self):
+        search = SavedSearch.objects.create(
+            project=self.project,
+            name='Something',
+            query='some query'
+        )
+        result = serialize(search)
+
+        assert result['id'] == six.text_type(search.id)
+        assert result['projectId'] == six.text_type(search.project_id)
+        assert result['name'] == search.name
+        assert result['query'] == search.query
+        assert result['isDefault'] == search.is_default
+        assert result['isUserDefault'] == search.is_default
+        assert result['dateCreated'] == search.date_added
+        assert not result['isPrivate']
+        assert not result['isGlobal']
+
+    def test_global(self):
+        default_saved_search = DEFAULT_SAVED_SEARCHES[0]
+        search = SavedSearch(
+            name=default_saved_search['name'],
+            query=default_saved_search['query'],
+            is_global=True,
+        )
+        result = serialize(search)
+
+        assert result['id'] == six.text_type(search.id)
+        assert result['projectId'] is None
+        assert result['name'] == search.name
+        assert result['query'] == search.query
+        assert not result['isDefault']
+        assert not result['isUserDefault']
+        assert result['dateCreated'] == search.date_added
+        assert not result['isPrivate']
+        assert result['isGlobal']


### PR DESCRIPTION
Implements org level searches. Returns saved searches that users actually created, and filters out the default searches we automatically created. Then returns our global searches so that they can be displayed just once.