### PR TITLE
feat(discover): Use URL parameters for each visualization

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -22,7 +22,8 @@ import {
   SavedQueryWrapper,
 } from './styles';
 import {
-  getQueryStringFromQuery,
+  areQueriesEqual,
+  getQueryObjectFromQuery,
   getQueryFromQueryString,
   deleteSavedQuery,
   updateSavedQuery,
@@ -74,12 +75,12 @@ export default class OrganizationDiscover extends React.Component {
   componentWillReceiveProps(nextProps) {
     const {
       queryBuilder,
-      location: {search},
+      location: {search, query},
       savedQuery,
       isEditingSavedQuery,
       params,
     } = nextProps;
-    const currentSearch = this.props.location.search;
+    const currentQuery = this.props.location.query;
     const {resultManager} = this.state;
 
     if (savedQuery && savedQuery !== this.props.savedQuery) {
@@ -94,12 +95,7 @@ export default class OrganizationDiscover extends React.Component {
 
     // Don't compare `visual` since there is no need to re-query if queries are equal
     // but views are changing
-    const visualRegex = /&?visual=[^&]+/;
-    if (
-      currentSearch &&
-      search &&
-      currentSearch.replace(visualRegex, '') === search.replace(visualRegex, '')
-    ) {
+    if (areQueriesEqual(currentQuery, query)) {
       return;
     }
 
@@ -220,11 +216,12 @@ export default class OrganizationDiscover extends React.Component {
         const shouldRedirect = !this.props.params.savedQueryId;
 
         if (shouldRedirect) {
-          const visual =
-            keepVisual && location.query.visual ? `&visual=${location.query.visual}` : '';
           browserHistory.push({
             pathname: `/organizations/${organization.slug}/discover/`,
-            search: `${getQueryStringFromQuery(queryBuilder.getInternal())}${visual}`,
+            query: {
+              ...getQueryObjectFromQuery(queryBuilder.getInternal()),
+              visual: keepVisual && location.query.visual,
+            },
           });
         }
 

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/visualizationsToggle.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/visualizationsToggle.jsx
@@ -1,9 +1,11 @@
+import {Link, withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+
+import {t} from 'app/locale';
 import DropdownLink from 'app/components/dropdownLink';
 import MenuItem from 'app/components/menuItem';
-import {t} from 'app/locale';
 
 import {
   ResultViewActions,
@@ -20,18 +22,31 @@ class VisualizationsToggle extends React.Component {
         name: PropTypes.string,
       })
     ).isRequired,
-    handleChange: PropTypes.func.isRequired,
     handleCsvDownload: PropTypes.func.isRequired,
     visualization: PropTypes.string.isRequired,
   };
 
+  getUrl = id => {
+    const {location} = this.props;
+
+    return {
+      ...location,
+      query: {
+        ...location.query,
+        visual: id,
+      },
+    };
+  };
+
   getMenuItem = opt => {
+    const {location, visualization} = this.props;
     return (
       <MenuItem
         key={opt.id}
-        onSelect={this.props.handleChange}
+        to={location.pathname}
+        query={{...location.query, visual: opt.id}}
         eventKey={opt.id}
-        isActive={opt.id === this.props.visualization}
+        isActive={opt.id === visualization}
       >
         {opt.name}
       </MenuItem>
@@ -42,7 +57,7 @@ class VisualizationsToggle extends React.Component {
     const active = opt.id === this.props.visualization;
     return (
       <li key={opt.id} className={classNames({active})}>
-        <a onClick={() => this.props.handleChange(opt.id)}>{opt.name}</a>
+        <Link to={this.getUrl(opt.id)}>{opt.name}</Link>
       </li>
     );
   };
@@ -81,4 +96,4 @@ class VisualizationsToggle extends React.Component {
   }
 }
 
-export default VisualizationsToggle;
+export default withRouter(VisualizationsToggle);

--- a/tests/js/spec/views/organizationDiscover/discover.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/discover.spec.jsx
@@ -1,5 +1,6 @@
 import {browserHistory} from 'react-router';
 import React from 'react';
+import qs from 'query-string';
 
 import {mount} from 'enzyme';
 import ConfigStore from 'app/stores/configStore';
@@ -69,7 +70,7 @@ describe('Discover', function() {
     });
   });
 
-  describe('componentWillRecieveProps()', function() {
+  describe('componentWillReceiveProps()', function() {
     it('handles navigating to saved query', function() {
       const wrapper = mount(
         <Discover
@@ -102,7 +103,7 @@ describe('Discover', function() {
           queryBuilder={queryBuilder}
           organization={organization}
           updateSavedQueryData={jest.fn()}
-          location={{search: ''}}
+          location={{search: '', query: {}}}
           params={{}}
           toggleEditMode={jest.fn()}
           isLoading={false}
@@ -111,10 +112,12 @@ describe('Discover', function() {
       );
 
       expect(wrapper.find('TimeRangeSelector').text()).toEqual('Last 14 days');
+      const search =
+        'projects=%5B%5D&fields=%5B%22id%22%2C%22issue.id%22%2C%22project.name%22%2C%22platform%22%2C%22timestamp%22%5D&conditions=%5B%5D&aggregations=%5B%5D&range=%227d%22&orderby=%22-timestamp%22&limit=1000&start=null&end=null';
       wrapper.setProps({
         location: {
-          search:
-            'projects=%5B%5D&fields=%5B%22id%22%2C%22issue.id%22%2C%22project.name%22%2C%22platform%22%2C%22timestamp%22%5D&conditions=%5B%5D&aggregations=%5B%5D&range=%227d%22&orderby=%22-timestamp%22&limit=1000&start=null&end=null',
+          query: qs.parse(search),
+          search,
         },
       });
       await tick();
@@ -346,10 +349,11 @@ describe('Discover', function() {
       let wrapper;
       beforeEach(function() {
         const mockResponse = {timing: {}, data: [], meta: []};
-        browserHistory.push.mockImplementation(function({search}) {
+        browserHistory.push.mockImplementation(function({search, query}) {
           wrapper.setProps({
             location: {
-              search: search || '',
+              search: search || qs.stringify(query),
+              query,
             },
           });
         });
@@ -361,7 +365,7 @@ describe('Discover', function() {
           <Discover
             queryBuilder={queryBuilder}
             organization={organization}
-            location={{location: '?fields=something'}}
+            location={{}}
             params={{}}
             updateSavedQueryData={jest.fn()}
             toggleEditMode={jest.fn()}
@@ -420,6 +424,9 @@ describe('Discover', function() {
         wrapper.setProps({
           location: {
             search: '?fields=[]',
+            query: {
+              fields: [],
+            },
           },
         });
         expect(queryBuilder.reset.mock.calls).toHaveLength(prevCallCount);

--- a/tests/js/spec/views/organizationDiscover/discover.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/discover.spec.jsx
@@ -123,6 +123,46 @@ describe('Discover', function() {
 
       // TODO: check that query is run with correct params
     });
+
+    it('does not runquery if queries are equal and visual changes in url params', async function() {
+      queryBuilder.fetch = jest.fn(() =>
+        Promise.resolve({
+          timing: {},
+          data: [{foo: 'bar', 'project.id': project.id}],
+          meta: [{name: 'foo'}],
+        })
+      );
+      const wrapper = mount(
+        <Discover
+          queryBuilder={queryBuilder}
+          organization={organization}
+          updateSavedQueryData={jest.fn()}
+          location={{search: ''}}
+          params={{}}
+          toggleEditMode={jest.fn()}
+          isLoading={false}
+        />,
+        TestStubs.routerContext([{organization}])
+      );
+      wrapper.setProps({
+        location: {
+          search:
+            'projects=%5B%5D&fields=%5B%22id%22%2C%22issue.id%22%2C%22project.name%22%2C%22platform%22%2C%22timestamp%22%5D&conditions=%5B%5D&aggregations=%5B%5D&range=%2214d%22&orderby=%22-timestamp%22&limit=1000&start=null&end=null',
+        },
+      });
+      await tick();
+      wrapper.update();
+      queryBuilder.fetch.mockClear();
+      wrapper.setProps({
+        location: {
+          search:
+            'projects=%5B%5D&fields=%5B%22id%22%2C%22issue.id%22%2C%22project.name%22%2C%22platform%22%2C%22timestamp%22%5D&conditions=%5B%5D&aggregations=%5B%5D&range=%2214d%22&orderby=%22-timestamp%22&limit=1000&start=null&end=null&visual=bar',
+        },
+      });
+      await tick();
+      wrapper.update();
+      expect(queryBuilder.fetch).not.toHaveBeenCalled();
+    });
   });
 
   describe('Pagination', function() {

--- a/tests/js/spec/views/organizationDiscover/result/index.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/result/index.spec.jsx
@@ -1,7 +1,9 @@
-import React from 'react';
 import {mount, shallow} from 'enzyme';
+import React from 'react';
 
-import Result from 'app/views/organizationDiscover/result';
+import {mockRouterPush} from 'app-test/helpers/mockRouterPush';
+import {initializeOrg} from 'app-test/helpers/initializeOrg';
+import Result, {Result as ResultShallow} from 'app/views/organizationDiscover/result';
 import createQueryBuilder from 'app/views/organizationDiscover/queryBuilder';
 
 describe('Result', function() {
@@ -25,7 +27,12 @@ describe('Result', function() {
         },
       };
       wrapper = shallow(
-        <Result data={data} organization={organization} onFetchPage={jest.fn()} />,
+        <ResultShallow
+          location={{query: {}}}
+          data={data}
+          organization={organization}
+          onFetchPage={jest.fn()}
+        />,
         {
           context: {organization},
           disableLifecycleMethods: false,
@@ -140,11 +147,23 @@ describe('Result', function() {
     });
 
     describe('Toggles Visualizations', function() {
+      organization = TestStubs.Organization();
+      const {routerContext, router} = initializeOrg({
+        organization,
+        router: {
+          location: {
+            pathname: `/organizations/${organization.slug}/discover/`,
+            query: {},
+          },
+        },
+      });
+
       beforeEach(function() {
         wrapper = mount(
           <Result data={data} organization={organization} onFetchPage={jest.fn()} />,
-          TestStubs.routerContext([{organization}])
+          routerContext
         );
+        mockRouterPush(wrapper, router);
       });
 
       it('displays options', function() {
@@ -158,9 +177,14 @@ describe('Result', function() {
 
         wrapper
           .find('ResultViewButtons')
-          .find('a')
+          .find('Link a')
           .at(1)
-          .simulate('click');
+          .simulate('click', {button: 0});
+
+        expect(router.push).toHaveBeenCalledWith({
+          pathname: '/organizations/org-slug/discover/',
+          query: {visual: 'line'},
+        });
         wrapper.update();
 
         expect(wrapper.find('ResultTable')).toHaveLength(0);
@@ -175,7 +199,7 @@ describe('Result', function() {
           .find('ul.dropdown-menu')
           .find('a')
           .at(1)
-          .simulate('click');
+          .simulate('click', {button: 0});
 
         expect(wrapper.find('ResultTable')).toHaveLength(0);
         expect(wrapper.find('LineChart')).toHaveLength(1);

--- a/tests/js/spec/views/organizationDiscover/utils.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/utils.spec.jsx
@@ -1,6 +1,6 @@
 import {
   getQueryFromQueryString,
-  getQueryStringFromQuery,
+  getQueryObjectFromQuery,
   getOrderbyFields,
   parseSavedQuery,
   generateQueryName,
@@ -40,9 +40,18 @@ describe('getQueryFromQueryString()', function() {
   });
 });
 
-describe('getQueryStringFromQuery()', function() {
+describe('getQueryObjectFromQuery()', function() {
   it('parses query from query string', function() {
-    expect(getQueryStringFromQuery(query)).toEqual(queryString);
+    expect(getQueryObjectFromQuery(query)).toEqual({
+      aggregations: '[["count()",null,"count"],["uniq","os_build","uniq_os_build"]]',
+      conditions: '[]',
+      end: '"2018-07-10T01:18:04"',
+      fields: '["id","timestamp"]',
+      limit: '1000',
+      orderby: '"-timestamp"',
+      projects: '[8]',
+      start: '"2018-06-26T01:18:04"',
+    });
   });
 });
 


### PR DESCRIPTION
Instead of using component state, use url parameters as data source for which chart gets displayed. This will be helpful when navigating from other parts of the application to a discover query.