### PR TITLE
fix(ui): Render message params

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/message.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/message.jsx
@@ -21,9 +21,10 @@ class MessageInterface extends React.Component {
       return null;
     }
 
-    // NB: Always render params, regardless whether they appear in the formatted
-    // string or not. The reason is for structured logging frameworks, like
-    // serilog. They only format some parameters into the formatted string.
+    // NB: Always render params, regardless of whether they appear in the
+    // formatted string due to structured logging frameworks, like Serilog. They
+    // only format some parameters into the formatted string, but we want to
+    // display all of them.
 
     if (Array.isArray(params)) {
       params = params.map((value, i) => [`#${i}`, value]);
@@ -38,14 +39,12 @@ class MessageInterface extends React.Component {
     let {data, group, event} = this.props;
 
     return (
-      <React.Fragment>
-        <EventDataSection group={group} event={event} type="message" title={t('Message')}>
-          <pre className="plain">
-            <Annotated object={data} prop="formatted" />
-          </pre>
-          {this.renderParams()}
-        </EventDataSection>
-      </React.Fragment>
+      <EventDataSection group={group} event={event} type="message" title={t('Message')}>
+        <pre className="plain">
+          <Annotated object={data} prop="formatted" />
+        </pre>
+        {this.renderParams()}
+      </EventDataSection>
     );
   }
 }

--- a/src/sentry/static/sentry/app/components/events/interfaces/message.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/message.jsx
@@ -1,10 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import KeyValueList from 'app/components/events/interfaces/keyValueList';
 import Annotated from 'app/components/events/meta/annotated';
 import EventDataSection from 'app/components/events/eventDataSection';
 import SentryTypes from 'app/sentryTypes';
 import {t} from 'app/locale';
+import {objectIsEmpty} from 'app/utils';
 
 class MessageInterface extends React.Component {
   static propTypes = {
@@ -13,30 +15,37 @@ class MessageInterface extends React.Component {
     data: PropTypes.object.isRequired,
   };
 
+  renderParams() {
+    let { params } = this.props.data;
+    if (objectIsEmpty(params)) {
+      return null;
+    }
+
+    // NB: Always render params, regardless whether they appear in the formatted
+    // string or not. The reason is for structured logging frameworks, like
+    // serilog. They only format some parameters into the formatted string.
+
+    if (Array.isArray(params)) {
+      params = params.map((value, i) => [`#${i}`, value]);
+    }
+
+    return (
+      <KeyValueList data={params} isSorted={false} isContextData />
+    );
+  }
+
   render() {
     let {data, group, event} = this.props;
 
     return (
-      <EventDataSection group={group} event={event} type="message" title={t('Message')}>
-        <pre className="plain">
-          <Annotated object={data} prop="formatted">
-            {formatted =>
-              typeof formatted !== 'undefined' ? (
-                formatted
-              ) : (
-                <Annotated object={data} prop="message" />
-              )}
-          </Annotated>
-        </pre>
-
-        {data.params &&
-          !data.formatted && (
-            <div>
-              <h5>{t('Params')}</h5>
-              <pre className="plain">{JSON.stringify(data.params, null, 2)}</pre>
-            </div>
-          )}
-      </EventDataSection>
+      <React.Fragment>
+        <EventDataSection group={group} event={event} type="message" title={t('Message')}>
+          <pre className="plain">
+            <Annotated object={data} prop="formatted" />
+          </pre>
+          {this.renderParams()}
+        </EventDataSection>
+      </React.Fragment>
     );
   }
 }

--- a/src/sentry/static/sentry/app/components/events/interfaces/message.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/message.jsx
@@ -16,7 +16,7 @@ class MessageInterface extends React.Component {
   };
 
   renderParams() {
-    let { params } = this.props.data;
+    let {params} = this.props.data;
     if (objectIsEmpty(params)) {
       return null;
     }
@@ -30,9 +30,7 @@ class MessageInterface extends React.Component {
       params = params.map((value, i) => [`#${i}`, value]);
     }
 
-    return (
-      <KeyValueList data={params} isSorted={false} isContextData />
-    );
+    return <KeyValueList data={params} isSorted={false} isContextData />;
   }
 
   render() {


### PR DESCRIPTION
We broke rendering of message params with #11078. See https://sentry.zendesk.com/agent/tickets/18273 for context.  

`logentry.formatted` is now guaranteed to always be present. Thus, we can remove the fallback to rendering `logentry.message`.

Ref #11417

<hr/>

<img width="675" alt="screenshot 2019-01-09 at 10 32 01" src="https://user-images.githubusercontent.com/1433023/50890120-e0c06380-13f9-11e9-8af6-ba4c0db238a7.png">
