### PR TITLE
fix(ui) Fix 'other' tag bucket to have a proper tooltip

### DIFF
--- a/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
+++ b/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
@@ -134,21 +134,24 @@ const TagDistributionMeter = createReactClass({
           );
         })}
         {hasOther && (
-          <Segment
+          <Tooltip
             key="other"
-            index={9}
-            first={!topValues.length}
-            last={true}
-            css={{width: otherPct + '%'}}
-            to={`/${orgId}/${projectId}/issues/${this.props.group.id}/tags/${this.props
-              .tag}/`}
-            title={'Other<br/>' + otherPctLabel + '%'}
+            title={`Other<br/>${otherPctLabel}%`}
+            tooltipOptions={{html: true}}
           >
-            <Description first={!topValues.length}>
-              <Percentage>{otherPctLabel}%</Percentage>
-              <Label>{t('Other')}</Label>
-            </Description>
-          </Segment>
+            <Segment
+              index={9}
+              first={!topValues.length}
+              last={true}
+              css={{width: otherPct + '%'}}
+              to={`/${orgId}/${projectId}/issues/${group.id}/tags/${tag}/`}
+            >
+              <Description first={!topValues.length}>
+                <Percentage>{otherPctLabel}%</Percentage>
+                <Label>{t('Other')}</Label>
+              </Description>
+            </Segment>
+          </Tooltip>
         )}
       </React.Fragment>
     );


### PR DESCRIPTION
The 'other' bucket was missing a react tooltip and only had a browser title based tooltip. Now 'other' is like all the other tag values.

## New
![screen shot 2019-01-09 at 10 56 54 am](https://user-images.githubusercontent.com/24086/50911201-5b3eb280-13fd-11e9-9681-414a5f80839a.png)

## Old

![screen shot 2019-01-09 at 10 58 04 am](https://user-images.githubusercontent.com/24086/50911240-75789080-13fd-11e9-855f-f339ede0ec8e.png)

Fixes #11418