### PR TITLE
fix(page-heading): resolve hosted setup background color bug

### DIFF
--- a/src/sentry/static/sentry/less/onboarding.less
+++ b/src/sentry/static/sentry/less/onboarding.less
@@ -167,7 +167,6 @@
 
   position: sticky;
   bottom: 0;
-  background: white;
 
   p {
     margin-top: 20px;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/435981/50925127-3c90e980-1406-11e9-87cd-bfdfe3f00aa0.png)

![image](https://user-images.githubusercontent.com/435981/50925175-621df300-1406-11e9-84ab-f1937c5fd06f.png)

the crazy css on this page will make it challenging to switch to a white background here (check onboarding.scss) but I think this is probably ok given the larger type sizes.