### PR TITLE
ref(issues): Refactor group header component

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/project/index.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/project/index.jsx
@@ -30,7 +30,7 @@ class ProjectGroupDetails extends React.Component {
   render() {
     // eslint-disable-next-line no-unused-vars
     const {setProjectNavSection, ...props} = this.props;
-    return <GroupDetails {...props} />;
+    return <GroupDetails project={this.context.project} {...props} />;
   }
 }
 

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/actions.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/actions.jsx
@@ -12,7 +12,7 @@ import DropdownLink from 'app/components/dropdownLink';
 import Feature from 'app/components/acl/feature';
 import FeatureDisabled from 'app/components/acl/featureDisabled';
 import GroupActions from 'app/actions/groupActions';
-import GroupState from 'app/mixins/groupState';
+import OrganizationState from 'app/mixins/organizationState';
 import GuideAnchor from 'app/components/assistant/guideAnchor';
 import IgnoreActions from 'app/components/actions/ignore';
 import IndicatorStore from 'app/stores/indicatorStore';
@@ -109,7 +109,12 @@ class DeleteActions extends React.Component {
 const GroupDetailsActions = createReactClass({
   displayName: 'GroupDetailsActions',
 
-  mixins: [ApiMixin, GroupState],
+  propTypes: {
+    group: SentryTypes.Group.isRequired,
+    project: SentryTypes.Project,
+  },
+
+  mixins: [ApiMixin, OrganizationState],
 
   getInitialState() {
     return {ignoreModal: null, shareBusy: false};
@@ -127,8 +132,7 @@ const GroupDetailsActions = createReactClass({
   },
 
   onDelete() {
-    let group = this.getGroup();
-    let project = this.getProject();
+    let {group, project} = this.props;
     let org = this.getOrganization();
     let loadingIndicator = IndicatorStore.add(t('Delete event..'));
 
@@ -149,8 +153,7 @@ const GroupDetailsActions = createReactClass({
   },
 
   onUpdate(data) {
-    let group = this.getGroup();
-    let project = this.getProject();
+    let {group, project} = this.props;
     let org = this.getOrganization();
     let loadingIndicator = IndicatorStore.add(t('Saving changes..'));
 
@@ -170,8 +173,7 @@ const GroupDetailsActions = createReactClass({
   },
 
   onShare(shared) {
-    let group = this.getGroup();
-    let project = this.getProject();
+    let {group, project} = this.props;
     let org = this.getOrganization();
     this.setState({shareBusy: true});
 
@@ -197,17 +199,15 @@ const GroupDetailsActions = createReactClass({
   },
 
   onToggleShare() {
-    let group = this.getGroup();
-    this.onShare(!group.isPublic);
+    this.onShare(!this.props.group.isPublic);
   },
 
   onToggleBookmark() {
-    this.onUpdate({isBookmarked: !this.getGroup().isBookmarked});
+    this.onUpdate({isBookmarked: !this.props.group.isBookmarked});
   },
 
   onDiscard() {
-    let group = this.getGroup();
-    let project = this.getProject();
+    let {group, project} = this.props;
     let org = this.getOrganization();
     let id = uniqueId();
     let loadingIndicator = IndicatorStore.add(t('Discarding event..'));
@@ -231,17 +231,16 @@ const GroupDetailsActions = createReactClass({
   },
 
   render() {
-    let group = this.getGroup();
-    let project = this.getProject();
+    let {group, project} = this.props;
     let org = this.getOrganization();
-    let orgFeatures = new Set(this.getOrganization().features);
+    let orgFeatures = new Set(org.features);
 
     let bookmarkClassName = 'group-bookmark btn btn-default btn-sm';
     if (group.isBookmarked) {
       bookmarkClassName += ' active';
     }
 
-    let hasRelease = this.getProjectFeatures().has('releases');
+    let hasRelease = new Set(project.features).has('releases');
 
     let isResolved = group.status === 'resolved';
     let isIgnored = group.status === 'ignored';

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/groupDetails.jsx
@@ -4,6 +4,7 @@ import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import {browserHistory} from 'react-router';
 import DocumentTitle from 'react-document-title';
+import * as Sentry from '@sentry/browser';
 
 import ApiMixin from 'app/mixins/apiMixin';
 import GroupStore from 'app/stores/groupStore';
@@ -11,6 +12,7 @@ import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import SentryTypes from 'app/sentryTypes';
 import {t} from 'app/locale';
+import ProjectsStore from 'app/stores/projectsStore';
 
 import GroupHeader from '../shared/header';
 import {ERROR_TYPES} from '../shared/constants';
@@ -19,6 +21,8 @@ const GroupDetails = createReactClass({
   displayName: 'GroupDetails',
 
   propTypes: {
+    // Provided in the project version of group details
+    project: SentryTypes.Project,
     environment: SentryTypes.Environment,
   },
 
@@ -96,15 +100,24 @@ const GroupDetails = createReactClass({
           );
         }
 
+        let project = this.props.project || ProjectsStore.getById(data.project.id);
+
+        if (!project) {
+          Sentry.withScope(scope => {
+            Sentry.captureException(new Error('Project not found'));
+          });
+        }
+
         this.setState({
           loading: false,
           error: false,
           errorType: null,
+          project,
         });
 
         return void GroupStore.loadInitialData([data]);
       },
-      error: (_, textStatus, errorThrown) => {
+      error: (_, _textStatus, errorThrown) => {
         let errorType = null;
         switch (errorThrown) {
           case 'NOT FOUND':
@@ -167,8 +180,8 @@ const GroupDetails = createReactClass({
   },
 
   render() {
-    let group = this.state.group;
     let params = this.props.params;
+    let {group, project} = this.state;
 
     if (this.state.error) {
       switch (this.state.errorType) {
@@ -186,7 +199,7 @@ const GroupDetails = createReactClass({
     return (
       <DocumentTitle title={this.getTitle()}>
         <div className={this.props.className}>
-          <GroupHeader orgId={params.orgId} projectId={group.project.id} group={group} />
+          <GroupHeader orgId={params.orgId} project={project} group={group} />
           {React.cloneElement(this.props.children, {
             group,
           })}

--- a/tests/js/spec/views/groupDetails/actions.spec.jsx
+++ b/tests/js/spec/views/groupDetails/actions.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import GroupActions from 'app/views/groupDetails/project/actions';
+import GroupActions from 'app/views/groupDetails/shared/actions';
 import ConfigStore from 'app/stores/configStore';
 
 describe('GroupActions', function() {
@@ -19,28 +19,28 @@ describe('GroupActions', function() {
 
   describe('render()', function() {
     it('renders correctly', function() {
-      let wrapper = shallow(<GroupActions />, {
-        context: {
-          group: TestStubs.Group({
+      let wrapper = shallow(
+        <GroupActions
+          group={TestStubs.Group({
             id: '1337',
             pluginActions: [],
             pluginIssues: [],
-          }),
-          organization: TestStubs.Organization({
-            id: '4660',
-            slug: 'org',
-          }),
-          project: TestStubs.ProjectDetails({
+          })}
+          project={TestStubs.ProjectDetails({
             id: '2448',
             name: 'project name',
             slug: 'project',
-          }),
-          team: TestStubs.Team({
-            id: '3559',
-            slug: 'team',
-          }),
-        },
-      });
+          })}
+        />,
+        {
+          context: {
+            organization: TestStubs.Organization({
+              id: '4660',
+              slug: 'org',
+            }),
+          },
+        }
+      );
       expect(wrapper).toMatchSnapshot();
     });
   });


### PR DESCRIPTION
Make the group header component more reusable for organzation level
issues. Fetches the project from ProjectsStore if we're not in the
context of a single project.