### PR TITLE
build: Remove 'exports' from sourcemaps sources prefix

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -276,8 +276,6 @@ const appConfig = {
   output: {
     path: distPath,
     filename: '[name].js',
-    libraryTarget: 'var',
-    library: 'exports',
     sourceMapFilename: '[name].js.map',
   },
   optimization: {


### PR DESCRIPTION
The default libraryTarget in webpack is `var`, and we were not explicitly using the 'exports' variable anywhere in the global scope.