### PR TITLE
ref(ui): Allow form search source results to be marked

### DIFF
--- a/src/sentry/static/sentry/app/components/search/sources/formSource.jsx
+++ b/src/sentry/static/sentry/app/components/search/sources/formSource.jsx
@@ -53,7 +53,7 @@ class FormSource extends React.Component {
     this.setState({
       fuzzy: await createFuzzySearch(searchMap || [], {
         ...this.props.searchOptions,
-        keys: ['field.label', 'field.help'],
+        keys: ['title', 'description'],
       }),
     });
   }

--- a/tests/js/spec/components/search/sources/formSource.spec.jsx
+++ b/tests/js/spec/components/search/sources/formSource.spec.jsx
@@ -9,6 +9,8 @@ describe('FormSource', function() {
   let wrapper;
   let searchMap = [
     {
+      title: 'Test Field',
+      description: 'test-help',
       route: '/route/',
       field: {
         name: 'test-field',
@@ -17,6 +19,8 @@ describe('FormSource', function() {
       },
     },
     {
+      title: 'Foo Field',
+      description: 'foo-help',
       route: '/foo/',
       field: {
         name: 'foo-field',
@@ -50,6 +54,8 @@ describe('FormSource', function() {
         name: 'test-field',
         help: 'test-help',
       },
+      title: 'Test Field',
+      description: 'test-help',
       route: '/route/',
       resultType: 'field',
       sourceType: 'field',


### PR DESCRIPTION
The search map contains the keys `{title, description}`, as well as a nested `field` object that contains `label` hand `help`. These are two of the same, as the title and description are setup when creating the searchMap from the field object.

This enables the title and description to be marked (the matching portions highlighted) in the SearchResult.