### PR TITLE
ref(ui-search): Cleanup minor UI visuals

### DIFF
--- a/src/sentry/static/sentry/app/components/modals/commandPalette.jsx
+++ b/src/sentry/static/sentry/app/components/modals/commandPalette.jsx
@@ -2,11 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled, {css} from 'react-emotion';
 
+import {analytics} from 'app/utils/analytics';
 import {t} from 'app/locale';
 import Search from 'app/components/search';
-import SearchResult from 'app/components/search/searchResult';
-import SearchResultWrapper from 'app/components/search/searchResultWrapper';
-import {analytics} from 'app/utils/analytics';
+import theme from 'app/utils/theme';
 
 const dropdownStyle = css`
   width: 100%;
@@ -15,6 +14,7 @@ const dropdownStyle = css`
   border-top-right-radius: 0;
   position: initial;
   box-shadow: none;
+  border-top: 1px solid ${p => theme.borderLight};
 `;
 
 class CommandPaletteModal extends React.Component {
@@ -59,11 +59,6 @@ class CommandPaletteModal extends React.Component {
               />
             </InputWrapper>
           )}
-          renderItem={({item, matches, itemProps, highlighted}) => (
-            <CommandPaletteSearchResultWrapper {...itemProps} highlighted={highlighted}>
-              <SearchResult highlighted={highlighted} item={item} matches={matches} />
-            </CommandPaletteSearchResultWrapper>
-          )}
         />
       </Body>
     );
@@ -86,18 +81,4 @@ const Input = styled('input')`
   &:focus {
     outline: none;
   }
-`;
-
-const CommandPaletteSearchResultWrapper = styled(SearchResultWrapper)`
-  &:first-child {
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
-  }
-
-  ${p =>
-    p.highlighted &&
-    css`
-      color: ${p.theme.whiteDark};
-      background: ${p.theme.purpleLight};
-    `};
 `;

--- a/src/sentry/static/sentry/app/components/search/index.jsx
+++ b/src/sentry/static/sentry/app/components/search/index.jsx
@@ -220,6 +220,7 @@ const DropdownBox = styled.div`
   right: 0;
   width: 400px;
   border-radius: 5px;
+  overflow: hidden;
 `;
 
 const SearchWrapper = styled.div`

--- a/src/sentry/static/sentry/app/components/search/searchResult.jsx
+++ b/src/sentry/static/sentry/app/components/search/searchResult.jsx
@@ -73,7 +73,7 @@ class SearchResult extends React.Component {
         : description;
 
       let DescriptionNode = (
-        <Description highlighted={highlighted}>{highlightedDescription}</Description>
+        <BadgeDetail highlighted={highlighted}>{highlightedDescription}</BadgeDetail>
       );
 
       let badgeProps = {
@@ -152,12 +152,16 @@ const SearchDetail = styled.div`
   opacity: 0.8;
 `;
 
+const BadgeDetail = styled.div`
+  line-height: 1.3;
+  color: ${p => (p.highlighted ? p.theme.purpleDarkest : null)};
+`;
+
 const Content = styled(props => <Flex direction="column" {...props} />)`
   /* stylelint-disable-next-line no-empty-block */
 `;
 
 const ResultTypeIcon = styled(InlineSvg)`
-  color: ${p => p.theme.offWhite};
   font-size: 1.2em;
   flex-shrink: 0;
 
@@ -169,8 +173,4 @@ const ResultTypeIcon = styled(InlineSvg)`
 
 const StyledPluginIcon = styled(PluginIcon)`
   flex-shrink: 0;
-`;
-
-const Description = styled('div')`
-  ${p => (p.highlighted ? `color: ${p.theme.offWhite};` : '')};
 `;

--- a/src/sentry/static/sentry/app/components/search/searchResultWrapper.jsx
+++ b/src/sentry/static/sentry/app/components/search/searchResultWrapper.jsx
@@ -7,7 +7,6 @@ const SearchResultWrapper = styled(({highlighted, ...props}) => <div {...props} 
   display: block;
   color: ${p => p.theme.gray5};
   padding: 10px;
-  border-top: 1px solid ${p => p.theme.borderLight};
 
   ${p =>
     p.highlighted &&
@@ -16,13 +15,8 @@ const SearchResultWrapper = styled(({highlighted, ...props}) => <div {...props} 
       background: ${p.theme.offWhite};
     `};
 
-  &:first-child {
-    border-radius: 4px 4px 0 0;
-  }
-
-  &:last-child {
-    border-bottom: 0;
-    border-radius: 0 0 4px 4px;
+  &:not(:first-child) {
+    border-top: 1px solid ${p => p.theme.borderLight};
   }
 `;
 

--- a/src/sentry/static/sentry/app/utils/highlightFuseMatches.jsx
+++ b/src/sentry/static/sentry/app/utils/highlightFuseMatches.jsx
@@ -22,7 +22,10 @@ import React from 'react';
  * @return {Array<{highlight: Boolean, text: String}>} Returns an array of {highlight, text} objects.
  */
 const getFuseMatches = ({value, indices}) => {
-  if (!indices.length) return [];
+  if (indices.length === 0) {
+    return [{highlight: false, text: value}];
+  }
+
   let strLength = value.length;
   let result = [];
   let prev = [0, -1];

--- a/tests/js/spec/components/modals/__snapshots__/docsSearchModal.spec.jsx.snap
+++ b/tests/js/spec/components/modals/__snapshots__/docsSearchModal.spec.jsx.snap
@@ -5,7 +5,7 @@ exports[`Docs Search Modal can open docs search modal and search 1`] = `
   className="css-rrcdsm-dropdownStyle"
 >
   <div
-    className="css-1k2nl5d-DropdownBox-dropdownStyle ed7560h0"
+    className="css-1gdmenf-DropdownBox-dropdownStyle ed7560h0"
   >
     <a
       href="https://help.sentry.io/100"

--- a/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
+++ b/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
@@ -95,14 +95,14 @@ describe('Command Palette Modal', function() {
 
     expect(
       wrapper
-        .find('ModalDialog CommandPaletteSearchResultWrapper')
+        .find('ModalDialog SearchResultWrapper')
         .first()
         .prop('highlighted')
     ).toBe(true);
 
     expect(
       wrapper
-        .find('ModalDialog CommandPaletteSearchResultWrapper')
+        .find('ModalDialog SearchResultWrapper')
         .at(1)
         .prop('highlighted')
     ).toBe(false);

--- a/tests/js/spec/utils/highlightFuseMatches.spec.jsx
+++ b/tests/js/spec/utils/highlightFuseMatches.spec.jsx
@@ -7,7 +7,9 @@ describe('highlightFuseMatches', function() {
   };
 
   it('handles no matches', function() {
-    expect(getFuseMatches({value: 'My long string', indices: []})).toEqual([]);
+    expect(getFuseMatches({value: 'My long string', indices: []})).toEqual([
+      {highlight: false, text: 'My long string'},
+    ]);
   });
 
   it('gets the correct tokens', function() {


### PR DESCRIPTION
* Use a consistent highlight color for omnisearch and the settings search dropdown box.

 * Use overflow: hidden to crop the borders of search results in the search dropdown box, instead of rounding the first and last result corners and then having to removing this styling for the omni box.

 * Be consisntent about colors of the description text for IdBadges and normal results.

 * Ensure text is rendered even when the text contains no fuzzy matches.