### PR TITLE
fix(discover): Fix extra rollup bucket

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -237,6 +237,8 @@ def zerofill(data, start, end, rollup, orderby):
         (end, start) = (start, end)
         rollup = rollup * -1
 
+    start = start + rollup
+
     for obj in data:
         if obj['time'] in data_by_time:
             data_by_time[obj['time']].append(obj)

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -229,15 +229,9 @@ def to_naive_timestamp(value):
 
 def zerofill(data, start, end, rollup, orderby):
     rv = []
-    start = ((int(to_naive_timestamp(naiveify_datetime(start))) / rollup) * rollup) - rollup
-    end = ((int(to_naive_timestamp(naiveify_datetime(end))) / rollup) * rollup) + rollup
+    start = (int(to_naive_timestamp(naiveify_datetime(start)) / rollup) * rollup)
+    end = (int(to_naive_timestamp(naiveify_datetime(end)) / rollup) * rollup) + rollup
     data_by_time = {}
-
-    if orderby.startswith('-'):
-        (end, start) = (start, end)
-        rollup = rollup * -1
-
-    start = start + rollup
 
     for obj in data:
         if obj['time'] in data_by_time:
@@ -251,6 +245,9 @@ def zerofill(data, start, end, rollup, orderby):
             data_by_time[key] = []
         else:
             rv.append({'time': key})
+
+    if orderby.startswith('-'):
+        return list(reversed(rv))
 
     return rv
 

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -5,7 +5,7 @@ import pytz
 
 from sentry.models import GroupRelease, Release
 from sentry.testutils import TestCase
-from sentry.utils.snuba import get_snuba_translators
+from sentry.utils.snuba import get_snuba_translators, zerofill
 
 
 class SnubaUtilsTest(TestCase):
@@ -165,3 +165,21 @@ class SnubaUtilsTest(TestCase):
                 'count': 3
             },
         ]
+
+    def test_zerofill(self):
+        results = zerofill(
+            {}, datetime(
+                2019, 1, 2, 0, 0), datetime(
+                2019, 1, 9, 23, 59, 59), 86400, 'time')
+        results_desc = zerofill(
+            {}, datetime(
+                2019, 1, 2, 0, 0), datetime(
+                2019, 1, 9, 23, 59, 59), 86400, '-time')
+
+        assert results == list(reversed(results_desc))
+
+        # Bucket for the 2, 3, 4, 5, 6, 7, 8, 9
+        assert len(results) == 8
+
+        assert results[0]['time'] == 1546387200
+        assert results[7]['time'] == 1546992000

--- a/tests/snuba/test_organization_discover_query.py
+++ b/tests/snuba/test_organization_discover_query.py
@@ -11,7 +11,8 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
     def setUp(self):
         super(OrganizationDiscoverQueryTest, self).setUp()
 
-        one_second_ago = datetime.now() - timedelta(seconds=1)
+        self.now = datetime.now()
+        one_second_ago = self.now - timedelta(seconds=1)
 
         self.login_as(user=self.user)
 
@@ -230,10 +231,10 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
                 'rollup': 86400,
             })
         assert response.status_code == 200, response.content
-        assert len(response.data['data']) == 7
-        assert(response.data['data'][6]['time']) > response.data['data'][5]['time']
-        assert(response.data['data'][6]['project.name']) == 'bar'
-        assert(response.data['data'][6]['count']) == 1
+        assert len(response.data['data']) == 6
+        assert(response.data['data'][5]['time']) > response.data['data'][4]['time']
+        assert(response.data['data'][5]['project.name']) == 'bar'
+        assert(response.data['data'][5]['count']) == 1
 
     def test_zerofilled_dates_when_rollup_absolute(self):
         with self.feature('organizations:discover'):
@@ -244,16 +245,16 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
                 'fields': ['project.name'],
                 'groupby': ['time'],
                 'orderby': '-time',
-                'start': (datetime.now() - timedelta(seconds=60)).strftime('%Y-%m-%dT%H:%M:%S'),
-                'end': (datetime.now()).strftime('%Y-%m-%dT%H:%M:%S'),
-                'rollup': 10,
+                'start': (self.now - timedelta(seconds=300)).strftime('%Y-%m-%dT%H:%M:%S'),
+                'end': self.now.strftime('%Y-%m-%dT%H:%M:%S'),
+                'rollup': 60,
             })
 
         assert response.status_code == 200, response.content
-        assert len(response.data['data']) == 8
-        assert(response.data['data'][1]['time']) > response.data['data'][2]['time']
-        assert(response.data['data'][1]['project.name']) == 'bar'
-        assert(response.data['data'][1]['count']) == 1
+        assert len(response.data['data']) == 6
+        assert(response.data['data'][0]['time']) > response.data['data'][2]['time']
+        assert(response.data['data'][0]['project.name']) == 'bar'
+        assert(response.data['data'][0]['count']) == 1
 
     def test_uniq_project_name(self):
         with self.feature('organizations:discover'):


### PR DESCRIPTION
There was an extra rollup bucket. e.g. if today was jan 8th, last 7 days would fetch jan 1->9th.
This may also fix some test flakiness since `now` is saved in setup so should always be in the most recent bucket