### PR TITLE
ref(issues): Refactor plugin actions

### DIFF
--- a/src/sentry/static/sentry/app/components/group/externalIssuesList.jsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssuesList.jsx
@@ -13,6 +13,7 @@ import {t} from 'app/locale';
 class ExternalIssueList extends AsyncComponent {
   static propTypes = {
     group: SentryTypes.Group.isRequired,
+    project: SentryTypes.Project.isRequired,
     orgId: PropTypes.string,
   };
 
@@ -40,11 +41,13 @@ class ExternalIssueList extends AsyncComponent {
   }
 
   renderPluginIssues() {
-    const {group} = this.props;
+    const {group, project} = this.props;
 
     return group.pluginIssues && group.pluginIssues.length
       ? group.pluginIssues.map((plugin, i) => {
-          return <PluginActions group={group} plugin={plugin} key={i} />;
+          return (
+            <PluginActions group={group} project={project} plugin={plugin} key={i} />
+          );
         })
       : null;
   }

--- a/src/sentry/static/sentry/app/components/group/pluginActions.jsx
+++ b/src/sentry/static/sentry/app/components/group/pluginActions.jsx
@@ -4,7 +4,7 @@ import createReactClass from 'create-react-class';
 import Modal from 'react-bootstrap/lib/Modal';
 import ApiMixin from 'app/mixins/apiMixin';
 import {addSuccessMessage, addErrorMessage} from 'app/actionCreators/indicator';
-import GroupState from 'app/mixins/groupState';
+import OrganizationState from 'app/mixins/organizationState';
 import NavTabs from 'app/components/navTabs';
 import plugins from 'app/plugins';
 import {t} from 'app/locale';
@@ -16,10 +16,11 @@ const PluginActions = createReactClass({
 
   propTypes: {
     group: SentryTypes.Group.isRequired,
+    project: SentryTypes.Project.isRequired,
     plugin: PropTypes.object.isRequired,
   },
 
-  mixins: [ApiMixin, GroupState],
+  mixins: [ApiMixin, OrganizationState],
 
   getInitialState() {
     return {
@@ -133,8 +134,8 @@ const PluginActions = createReactClass({
               <Modal.Body key={actionType}>
                 {plugins.get(plugin).renderGroupActions({
                   plugin,
-                  group: this.getGroup(),
-                  project: this.getProject(),
+                  group: this.props.group,
+                  project: this.props.project,
                   organization: this.getOrganization(),
                   actionType,
                   onSuccess: this.closeModal,

--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -248,7 +248,7 @@ const GroupSidebar = createReactClass({
           group={this.props.group}
           allEnvironments={this.state.allEnvironmentsGroupData}
         />
-        <ExternalIssueList group={this.props.group} orgId={orgId} />
+        <ExternalIssueList group={this.props.group} project={project} orgId={orgId} />
 
         {this.renderPluginIssue()}
 

--- a/tests/js/spec/components/group/__snapshots__/sidebar.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/sidebar.spec.jsx.snap
@@ -192,6 +192,17 @@ exports[`GroupSidebar renders with tags renders 1`] = `
       }
     }
     orgId="org-slug"
+    project={
+      Object {
+        "hasAccess": true,
+        "id": "2",
+        "isBookmarked": false,
+        "isMember": true,
+        "name": "Project Name",
+        "slug": "project-slug",
+        "teams": Array [],
+      }
+    }
   />
   <h6>
     <span>


### PR DESCRIPTION
Refactor plugin actions to get project as a prop instead of from
context. This will help reuse this component where a project context is
not defined in future.