### PR TITLE
tools(dev): Run `yarn install` when check fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "test-staged": "yarn test --findRelatedTests $(git diff --name-only --cached)",
     "lint": "node_modules/.bin/eslint tests/js src/sentry/static/sentry/app --ext .js,.jsx",
     "lint:css": "stylelint 'src/sentry/static/sentry/app/**/*.jsx'",
-    "dev": "yarn check --verify-tree && sentry devserver --browser-reload --workers",
+    "dev": "(yarn check --verify-tree || yarn) && sentry devserver --browser-reload",
     "dev-proxy": "node scripts/devproxy.js",
     "dev-server": "webpack-dev-server",
     "storybook": "start-storybook -p 9001 -c .storybook",


### PR DESCRIPTION
We could only just run `yarn` on every call, but I think the check is useful to see what actually has been updated? Removed `--workers` because it conflicts with `CELERY_ALWAYS_EAGER`