### PR TITLE
ref(ui-search): Mark any search result with matches

### DIFF
--- a/src/sentry/static/sentry/app/components/search/searchResult.jsx
+++ b/src/sentry/static/sentry/app/components/search/searchResult.jsx
@@ -64,20 +64,27 @@ class SearchResult extends React.Component {
     let {highlighted, item, matches, params} = this.props;
     let {sourceType, title, description, model} = item;
 
-    if (['organization', 'member', 'project', 'team'].includes(sourceType)) {
+    if (matches) {
+      const HighlightedMarker = p => <HighlightMarker highlighted={highlighted} {...p} />;
+
       let matchedTitle = matches && matches.find(({key}) => key === 'title');
       let matchedDescription = matches && matches.find(({key}) => key === 'description');
-      let highlightedTitle = matchedTitle ? highlightFuseMatches(matchedTitle) : title;
-      let highlightedDescription = matchedDescription
-        ? highlightFuseMatches(matchedDescription)
-        : description;
 
+      title = matchedTitle
+        ? highlightFuseMatches(matchedTitle, HighlightedMarker)
+        : title;
+      description = matchedDescription
+        ? highlightFuseMatches(matchedDescription, HighlightedMarker)
+        : description;
+    }
+
+    if (['organization', 'member', 'project', 'team'].includes(sourceType)) {
       let DescriptionNode = (
-        <BadgeDetail highlighted={highlighted}>{highlightedDescription}</BadgeDetail>
+        <BadgeDetail highlighted={highlighted}>{description}</BadgeDetail>
       );
 
       let badgeProps = {
-        displayName: highlightedTitle,
+        displayName: title,
         displayEmail: DescriptionNode,
         description: DescriptionNode,
         useLink: false,
@@ -173,4 +180,11 @@ const ResultTypeIcon = styled(InlineSvg)`
 
 const StyledPluginIcon = styled(PluginIcon)`
   flex-shrink: 0;
+`;
+
+const HighlightMarker = styled('mark')`
+  padding: 0;
+  background: transparent;
+  font-weight: bold;
+  color: inherit;
 `;

--- a/src/sentry/static/sentry/app/utils/highlightFuseMatches.jsx
+++ b/src/sentry/static/sentry/app/utils/highlightFuseMatches.jsx
@@ -65,11 +65,11 @@ const getFuseMatches = ({value, indices}) => {
 /**
  * Given a match object from fuse.js, returns an array of components with "highlighted" (bold) substrings.
  */
-const highlightFuseMatches = matchObj => {
+const highlightFuseMatches = (matchObj, Marker = 'mark') => {
   return getFuseMatches(matchObj).map(({highlight, text}, index) => {
     if (!text) return null;
     if (highlight) {
-      return <strong key={index}>{text}</strong>;
+      return <Marker key={index}>{text}</Marker>;
     }
 
     return <span key={index}>{text}</span>;

--- a/tests/js/spec/utils/__snapshots__/highlightFuseMatches.spec.jsx.snap
+++ b/tests/js/spec/utils/__snapshots__/highlightFuseMatches.spec.jsx.snap
@@ -2,9 +2,9 @@
 
 exports[`highlightFuseMatches matches whole word 1`] = `
 Array [
-  <strong>
+  <mark>
     foo
-  </strong>,
+  </mark>,
 ]
 `;
 
@@ -13,21 +13,21 @@ Array [
   <span>
     Auth
   </span>,
-  <strong>
+  <mark>
     ent
-  </strong>,
+  </mark>,
   <span>
     icati
   </span>,
-  <strong>
+  <mark>
     on
-  </strong>,
+  </mark>,
   <span>
      
   </span>,
-  <strong>
+  <mark>
     to
-  </strong>,
+  </mark>,
   <span>
     kens allow you to perform actions
   </span>,


### PR DESCRIPTION
Allow any search result to be marked with text matches, not just `'organization', 'member', 'project', 'team'`.

Uses the more semantic `<mark>` tag