### PR TITLE
fix(issue-sync): correct zero-height bug on issue sync hovercards with down placement

### DIFF
--- a/src/sentry/static/sentry/app/components/issueSyncListElement.jsx
+++ b/src/sentry/static/sentry/app/components/issueSyncListElement.jsx
@@ -12,11 +12,6 @@ const hoverCardContainer = css`
   min-width: 0; /* flex-box overflow workaround */
 `;
 
-const hoverCardStyles = css`
-  min-height: 0;
-  bottom: ${28 + 10}px; /* 28px is the current bottom value called in hovercard.less */
-`;
-
 class IssueSyncElement extends React.Component {
   static propTypes = {
     externalIssueLink: PropTypes.string,
@@ -108,7 +103,6 @@ class IssueSyncElement extends React.Component {
           containerClassName={hoverCardContainer}
           header={this.props.hoverCardHeader}
           body={this.props.hoverCardBody}
-          className={hoverCardStyles}
         >
           {this.getIcon()}
           {this.getLink()}

--- a/tests/js/spec/components/__snapshots__/issueSyncListElement.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/issueSyncListElement.spec.jsx.snap
@@ -3,7 +3,6 @@
 exports[`AlertLink renders 1`] = `
 <IssueSyncListElementContainer>
   <Hovercard
-    className="css-17m6soy-hoverCardStyles"
     containerClassName="css-1kx7hlk-hoverCardContainer"
     displayTimeout={100}
   >

--- a/tests/js/spec/components/group/__snapshots__/externalIssueActions.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/externalIssueActions.spec.jsx.snap
@@ -72,7 +72,6 @@ exports[`ExternalIssueActions with an external issue linked renders 1`] = `
             }
           />
         }
-        className="css-17m6soy-hoverCardStyles"
         containerClassName="css-1kx7hlk-hoverCardContainer"
         displayTimeout={100}
         header="Linked GitHub Integration"
@@ -305,7 +304,6 @@ exports[`ExternalIssueActions with no external issues linked renders 1`] = `
               }
             />
           }
-          className="css-17m6soy-hoverCardStyles"
           containerClassName="css-1kx7hlk-hoverCardContainer"
           displayTimeout={100}
           header="Linked GitHub Integration"


### PR DESCRIPTION
And now for a very special episode of _This Old Code_.

![hovercard-height-bug](https://user-images.githubusercontent.com/435981/50994672-be9a1480-14d1-11e9-84ab-338b97073e0f.gif)
