### PR TITLE
feat(discover): Add visualization to query string

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -212,7 +212,12 @@ export default class OrganizationDiscover extends React.Component {
         if (shouldRedirect) {
           browserHistory.push({
             pathname: `/organizations/${organization.slug}/discover/`,
-            search: getQueryStringFromQuery(queryBuilder.getInternal(), location.query),
+            // Don't drop "visualization" from querystring
+            search: getQueryStringFromQuery(queryBuilder.getInternal(), {
+              ...(location.query.visualization && {
+                visualization: location.query.visualization,
+              }),
+            }),
           });
         }
 

--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -26,6 +26,7 @@ import {
   getQueryFromQueryString,
   deleteSavedQuery,
   updateSavedQuery,
+  queryHasChanged,
 } from './utils';
 import {isValidAggregation} from './aggregations/utils';
 import {isValidCondition} from './conditions/utils';
@@ -79,7 +80,6 @@ export default class OrganizationDiscover extends React.Component {
       isEditingSavedQuery,
       params,
     } = nextProps;
-    const currentSearch = this.props.location.search;
     const {resultManager} = this.state;
 
     if (savedQuery && savedQuery !== this.props.savedQuery) {
@@ -92,7 +92,7 @@ export default class OrganizationDiscover extends React.Component {
       return;
     }
 
-    if (currentSearch === search) {
+    if (!queryHasChanged(this.props.location.search, nextProps.location.search)) {
       return;
     }
 
@@ -178,7 +178,7 @@ export default class OrganizationDiscover extends React.Component {
   };
 
   runQuery = () => {
-    const {queryBuilder, organization} = this.props;
+    const {queryBuilder, organization, location} = this.props;
     const {resultManager} = this.state;
 
     // Track query for analytics
@@ -212,7 +212,7 @@ export default class OrganizationDiscover extends React.Component {
         if (shouldRedirect) {
           browserHistory.push({
             pathname: `/organizations/${organization.slug}/discover/`,
-            search: getQueryStringFromQuery(queryBuilder.getInternal()),
+            search: getQueryStringFromQuery(queryBuilder.getInternal(), location.query),
           });
         }
 

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
@@ -32,7 +32,11 @@ import {
   ResultSummaryAndButtons,
 } from '../styles';
 import {NUMBER_OF_SERIES_BY_DAY} from '../data';
-import {queryHasChanged} from '../utils';
+import {
+  queryHasChanged,
+  getQueryFromQueryString,
+  getQueryStringFromQuery,
+} from '../utils';
 
 class Result extends React.Component {
   static propTypes = {
@@ -60,10 +64,14 @@ class Result extends React.Component {
     const visualization = getVisualization(data, location.query.visualization);
 
     if (queryHasChanged(this.props.location.search, nextProps.location.search)) {
+      const search = getQueryStringFromQuery(getQueryFromQueryString(location.search), {
+        visualization,
+      });
+
       this.setState({view: visualization});
       browserHistory.replace({
         pathname: location.pathname,
-        query: {...location.query, visualization},
+        search,
       });
     }
   }
@@ -95,9 +103,14 @@ class Result extends React.Component {
     this.setState({
       view: opt,
     });
+
+    const search = getQueryStringFromQuery(getQueryFromQueryString(location.search), {
+      visualization: opt,
+    });
+
     browserHistory.push({
       pathname: location.pathname,
-      query: {...location.query, visualization: opt},
+      search,
     });
   };
 

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
@@ -143,7 +143,7 @@ export function getVisualization(data, current = 'table') {
     return 'table';
   }
 
-  return current in ['table', 'line', 'bar', 'line-by-day', 'bar-by-day']
+  return ['table', 'line', 'bar', 'line-by-day', 'bar-by-day'].includes(current)
     ? current
     : 'table';
 }

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
@@ -127,6 +127,28 @@ export function getChartDataByDay(rawData, query, options = {}) {
 }
 
 /**
+ * Given result data and the location query, return the correct visualization
+ * @param {Object} data data object for result
+ * @param {String} current visualization from querystring
+ * @returns {String}
+ */
+export function getVisualization(data, current = 'table') {
+  const {baseQuery, byDayQuery} = data;
+
+  if (!byDayQuery.data && ['line-by-day', 'bar-by-day'].includes(current)) {
+    return 'table';
+  }
+
+  if (!baseQuery.query.aggregations.length && ['line', 'bar'].includes(current)) {
+    return 'table';
+  }
+
+  return current in ['table', 'line', 'bar', 'line-by-day', 'bar-by-day']
+    ? current
+    : 'table';
+}
+
+/**
  * Returns the page ranges of paginated tables, i.e. Results 1-100
  * @param {Object} baseQuery data
  * @returns {String}

--- a/src/sentry/static/sentry/app/views/organizationDiscover/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/utils.jsx
@@ -33,15 +33,14 @@ export function getQueryFromQueryString(queryString) {
   return result;
 }
 
-export function getQueryStringFromQuery(query, locationQuery = {}) {
+export function getQueryStringFromQuery(query, queryParams = {}) {
   const queryProperties = Object.entries(query).map(([key, value]) => {
     return key + '=' + encodeURIComponent(JSON.stringify(value));
   });
 
-  // Don't drop "visualization" from querystring
-  if (locationQuery.visualization) {
-    queryProperties.push(`visualization=${locationQuery.visualization}`);
-  }
+  Object.entries(queryParams).forEach(([key, value]) => {
+    queryProperties.push(`${key}=${value}`);
+  });
 
   return `?${queryProperties.sort().join('&')}`;
 }

--- a/src/sentry/static/sentry/app/views/organizationDiscover/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/utils.jsx
@@ -1,5 +1,7 @@
 import moment from 'moment';
 import {Client} from 'app/api';
+import {isEqual, omit} from 'lodash';
+import qs from 'query-string';
 import {isValidAggregation} from './aggregations/utils';
 import {NON_SNUBA_FIELDS} from './data';
 
@@ -31,10 +33,15 @@ export function getQueryFromQueryString(queryString) {
   return result;
 }
 
-export function getQueryStringFromQuery(query) {
+export function getQueryStringFromQuery(query, locationQuery = {}) {
   const queryProperties = Object.entries(query).map(([key, value]) => {
     return key + '=' + encodeURIComponent(JSON.stringify(value));
   });
+
+  // Don't drop "visualization" from querystring
+  if (locationQuery.visualization) {
+    queryProperties.push(`visualization=${locationQuery.visualization}`);
+  }
 
   return `?${queryProperties.join('&')}`;
 }
@@ -97,6 +104,21 @@ export function getView(params, requestedView) {
     default:
       return 'query';
   }
+}
+
+/**
+ * Returns true if the underlying discover query has changed based on the querystring,
+ * otherwise false. Omit "visualization" since it's not part of the query.
+ *
+ * @param {String} prev previous location.search string
+ * @param {String} next next location.search string
+ * @returns {Boolean}
+ */
+export function queryHasChanged(prev, next) {
+  return !isEqual(
+    omit(qs.parse(prev), 'visualization'),
+    omit(qs.parse(next), 'visualization')
+  );
 }
 
 /**

--- a/src/sentry/static/sentry/app/views/organizationDiscover/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/utils.jsx
@@ -43,7 +43,7 @@ export function getQueryStringFromQuery(query, locationQuery = {}) {
     queryProperties.push(`visualization=${locationQuery.visualization}`);
   }
 
-  return `?${queryProperties.join('&')}`;
+  return `?${queryProperties.sort().join('&')}`;
 }
 
 export function getOrderbyFields(queryBuilder) {

--- a/tests/js/spec/views/organizationDiscover/discover.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/discover.spec.jsx
@@ -321,7 +321,11 @@ describe('Discover', function() {
           <Discover
             queryBuilder={queryBuilder}
             organization={organization}
-            location={{location: '?fields=something'}}
+            location={{
+              location: '?fields=something',
+              query: {fields: 'something'},
+              search: '?fields=something',
+            }}
             params={{}}
             updateSavedQueryData={jest.fn()}
             toggleEditMode={jest.fn()}

--- a/tests/js/spec/views/organizationDiscover/result/index.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/result/index.spec.jsx
@@ -29,7 +29,10 @@ describe('Result', function() {
           data={data}
           organization={organization}
           onFetchPage={jest.fn()}
-          location={{query: {}}}
+          location={{
+            query: {},
+            search: '',
+          }}
         />,
         {
           context: {organization},
@@ -151,7 +154,7 @@ describe('Result', function() {
             data={data}
             organization={organization}
             onFetchPage={jest.fn()}
-            location={{query: {}}}
+            location={{query: {}, search: ''}}
           />,
           TestStubs.routerContext([{organization}])
         );

--- a/tests/js/spec/views/organizationDiscover/result/index.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/result/index.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mount, shallow} from 'enzyme';
 
-import Result from 'app/views/organizationDiscover/result';
+import {Result} from 'app/views/organizationDiscover/result';
 import createQueryBuilder from 'app/views/organizationDiscover/queryBuilder';
 
 describe('Result', function() {
@@ -25,7 +25,12 @@ describe('Result', function() {
         },
       };
       wrapper = shallow(
-        <Result data={data} organization={organization} onFetchPage={jest.fn()} />,
+        <Result
+          data={data}
+          organization={organization}
+          onFetchPage={jest.fn()}
+          location={{query: {}}}
+        />,
         {
           context: {organization},
           disableLifecycleMethods: false,
@@ -142,7 +147,12 @@ describe('Result', function() {
     describe('Toggles Visualizations', function() {
       beforeEach(function() {
         wrapper = mount(
-          <Result data={data} organization={organization} onFetchPage={jest.fn()} />,
+          <Result
+            data={data}
+            organization={organization}
+            onFetchPage={jest.fn()}
+            location={{query: {}}}
+          />,
           TestStubs.routerContext([{organization}])
         );
       });
@@ -206,6 +216,7 @@ describe('Result', function() {
           organization={organization}
           savedQuery={TestStubs.DiscoverSavedQuery()}
           onFetchPage={jest.fn()}
+          location={{query: {}}}
         />,
         TestStubs.routerContext()
       );

--- a/tests/js/spec/views/organizationDiscover/utils.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/utils.spec.jsx
@@ -44,6 +44,12 @@ describe('getQueryStringFromQuery()', function() {
   it('parses query from query string', function() {
     expect(getQueryStringFromQuery(query)).toEqual(queryString);
   });
+
+  it('keeps location in query string if provided', function() {
+    expect(getQueryStringFromQuery(query, {visualization: 'table'})).toEqual(
+      `${queryString}&visualization=table`
+    );
+  });
 });
 
 describe('getOrderbyFields()', function() {


### PR DESCRIPTION
Discover visualization type can be defined via the URL, visualization
name persists when switching Discover tabs.