### PR TITLE
fix(issues) Stack global search bar on top of other search ui

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/header.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/header.jsx
@@ -6,7 +6,7 @@ const Header = styled(Flex)`
   box-shadow: ${p => p.theme.dropShadowLight};
   font-size: ${p => p.theme.fontSizeExtraLarge};
   height: 60px;
-  z-index: ${p => p.theme.zIndex.header};
+  z-index: ${p => p.theme.zIndex.sidebar};
   position: relative;
   width: 100%;
   background: #fff;

--- a/tests/js/spec/views/releases/list/__snapshots__/organizationReleases.spec.jsx.snap
+++ b/tests/js/spec/views/releases/list/__snapshots__/organizationReleases.spec.jsx.snap
@@ -468,10 +468,10 @@ exports[`OrganizationReleases renders 1`] = `
                 >
                   <Header>
                     <Base
-                      className="css-1651jh1-Header e10yv9i90"
+                      className="css-14hw0r3-Header e10yv9i90"
                     >
                       <div
-                        className="css-1651jh1-Header e10yv9i90"
+                        className="css-14hw0r3-Header e10yv9i90"
                         is={null}
                       >
                         <HeaderItemPosition>

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -438,10 +438,10 @@ exports[`OrganizationUserFeedback renders 1`] = `
               >
                 <Header>
                   <Base
-                    className="css-1651jh1-Header e10yv9i90"
+                    className="css-14hw0r3-Header e10yv9i90"
                   >
                     <div
-                      className="css-1651jh1-Header e10yv9i90"
+                      className="css-14hw0r3-Header e10yv9i90"
                       is={null}
                     >
                       <HeaderItemPosition>


### PR DESCRIPTION
The global search bar should not stack underneath the issue search controls.

## Old
![screen shot 2019-01-10 at 4 04 36 pm](https://user-images.githubusercontent.com/24086/50996993-74289000-14f1-11e9-9d8c-2ec0e71b286b.png)

## New
![screen shot 2019-01-10 at 4 05 54 pm](https://user-images.githubusercontent.com/24086/50997068-a33f0180-14f1-11e9-9ade-0bf931f9c5d9.png)

Refs APP-990