### PR TITLE
feat(api): Make Org Version of ProjectMemberIndexEndpoint (APP-967)

### DIFF
--- a/src/sentry/api/endpoints/organization_users.py
+++ b/src/sentry/api/endpoints/organization_users.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import
+
+from rest_framework.response import Response
+
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models import OrganizationMemberWithProjectsSerializer
+from sentry.models import OrganizationMember
+
+
+class OrganizationUsersEndpoint(OrganizationEndpoint):
+    def get(self, request, organization):
+        project_ids = self.get_project_ids(request, organization)
+        qs = OrganizationMember.objects.filter(
+            user__is_active=True,
+            organization=organization,
+            teams__projectteam__project_id__in=project_ids,
+        ).select_related('user').prefetch_related(
+            'teams',
+            'teams__projectteam_set',
+            'teams__projectteam_set__project',
+        ).order_by('user__email').distinct()
+
+        return Response(serialize(
+            list(qs),
+            request.user,
+            serializer=OrganizationMemberWithProjectsSerializer(project_ids=project_ids),
+        ))

--- a/src/sentry/api/serializers/models/organization_member.py
+++ b/src/sentry/api/serializers/models/organization_member.py
@@ -78,3 +78,45 @@ class OrganizationMemberWithTeamsSerializer(OrganizationMemberSerializer):
         d['teams'] = attrs.get('teams', [])
 
         return d
+
+
+class OrganizationMemberWithProjectsSerializer(OrganizationMemberSerializer):
+    def __init__(self, *args, **kwargs):
+        self.project_ids = set(kwargs.pop('project_ids', []))
+        super(OrganizationMemberWithProjectsSerializer, self).__init__(*args, **kwargs)
+
+    def get_attrs(self, item_list, user):
+        attrs = super(OrganizationMemberWithProjectsSerializer, self).get_attrs(
+            item_list,
+            user,
+        )
+        # Note: For this to be efficient, call
+        # `.prefetch_related(
+        #       'teams',
+        #       'teams__projectteam_set',
+        #       'teams__projectteam_set__project',
+        # )` on your queryset before using this serializer
+        for org_member in item_list:
+            projects = set()
+            for team in org_member.teams.all():
+                # Filter in python here so that we don't break the prefetch
+                if team.status != TeamStatus.VISIBLE:
+                    continue
+
+                for project_team in team.projectteam_set.all():
+                    if (
+                        project_team.project_id in self.project_ids
+                        and project_team.project.status == TeamStatus.VISIBLE
+                    ):
+                        projects.add(project_team.project.slug)
+
+            projects = list(projects)
+            projects.sort()
+            attrs[org_member]['projects'] = projects
+
+        return attrs
+
+    def serialize(self, obj, attrs, user):
+        d = super(OrganizationMemberWithProjectsSerializer, self).serialize(obj, attrs, user)
+        d['projects'] = attrs.get('projects', [])
+        return d

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -98,6 +98,7 @@ from .endpoints.organization_sentry_apps import OrganizationSentryAppsEndpoint
 from .endpoints.organization_tagkey_values import OrganizationTagKeyValuesEndpoint
 from .endpoints.organization_tags import OrganizationTagsEndpoint
 from .endpoints.organization_user_reports import OrganizationUserReportsEndpoint
+from .endpoints.organization_users import OrganizationUsersEndpoint
 from .endpoints.sentry_app_installations import SentryAppInstallationsEndpoint
 from .endpoints.sentry_app_installation_details import SentryAppInstallationDetailsEndpoint
 from .endpoints.organization_stats import OrganizationStatsEndpoint
@@ -645,6 +646,11 @@ urlpatterns = patterns(
         r'^organizations/(?P<organization_slug>[^\/]+)/user-feedback/$',
         OrganizationUserReportsEndpoint.as_view(),
         name='sentry-api-0-organization-user-feedback'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/users/$',
+        OrganizationUsersEndpoint.as_view(),
+        name='sentry-api-0-organization-users'
     ),
     url(
         r'^organizations/(?P<organization_slug>[^\/]+)/sentry-app-installations/$',

--- a/tests/sentry/api/endpoints/test_organization_users.py
+++ b/tests/sentry/api/endpoints/test_organization_users.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import
+
+from sentry.api.serializers import (
+    OrganizationMemberWithProjectsSerializer,
+    serialize,
+)
+from sentry.testutils import APITestCase
+
+
+class OrganizationMemberListTest(APITestCase):
+    endpoint = 'sentry-api-0-organization-users'
+
+    def setUp(self):
+        self.owner_user = self.create_user('foo@localhost', username='foo')
+        self.user_2 = self.create_user('bar@localhost', username='bar')
+        self.user_3 = self.create_user('unrelated@localhost', username='unrelated')
+
+        self.org = self.create_organization(owner=self.owner_user)
+        self.org.member_set.create(user=self.user_2)
+        self.team = self.create_team(organization=self.org, members=[self.owner_user, self.user_2])
+        self.team_2 = self.create_team(organization=self.org, members=[self.user_2])
+        self.team_3 = self.create_team(organization=self.org, members=[self.user_3])
+        self.project = self.create_project(teams=[self.team])
+        self.project_2 = self.create_project(teams=[self.team_2])
+        self.project_3 = self.create_project(teams=[self.team_3])
+
+        self.login_as(user=self.user_2)
+
+    def test_simple(self):
+        projects_ids = [self.project.id, self.project_2.id]
+        response = self.get_valid_response(self.org.slug, project=projects_ids)
+        expected = serialize(
+            list(
+                self.org.member_set.filter(
+                    user__in=[
+                        self.owner_user,
+                        self.user_2]).order_by('user__email')),
+            self.user_2,
+            OrganizationMemberWithProjectsSerializer(project_ids=projects_ids),
+        )
+        assert response.data == expected
+
+        projects_ids = [self.project_2.id]
+        response = self.get_valid_response(self.org.slug, project=projects_ids)
+        expected = serialize(
+            list(self.org.member_set.filter(user__in=[self.user_2]).order_by('user__email')),
+            self.user_2,
+            OrganizationMemberWithProjectsSerializer(project_ids=projects_ids),
+        )
+        assert response.data == expected

--- a/tests/sentry/api/serializers/test_organization_member.py
+++ b/tests/sentry/api/serializers/test_organization_member.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+from sentry.api.serializers import (
+    OrganizationMemberWithProjectsSerializer,
+    serialize,
+)
+from sentry.testutils import TestCase
+
+
+class OrganizationMemberWithProjectsSerializerTest(TestCase):
+    def setUp(self):
+        self.owner_user = self.create_user('foo@localhost', username='foo')
+        self.user_2 = self.create_user('bar@localhost', username='bar')
+
+        self.org = self.create_organization(owner=self.owner_user)
+        self.org.member_set.create(user=self.user_2)
+        self.team = self.create_team(organization=self.org, members=[self.owner_user, self.user_2])
+        self.team_2 = self.create_team(organization=self.org, members=[self.user_2])
+        self.project = self.create_project(teams=[self.team])
+        self.project_2 = self.create_project(teams=[self.team_2])
+
+    def test_simple(self):
+        projects_ids = [self.project.id, self.project_2.id]
+        org_members = list(self.org.member_set.filter(
+            user__in=[
+                self.owner_user,
+                self.user_2,
+            ],
+        ).order_by('user__email'))
+        result = serialize(
+            org_members,
+            self.user_2,
+            OrganizationMemberWithProjectsSerializer(project_ids=projects_ids),
+        )
+        expected_projects = [
+            [self.project.slug, self.project_2.slug],
+            [self.project.slug]
+        ]
+        expected_projects[0].sort()
+        assert [r['projects'] for r in result] == expected_projects
+
+        projects_ids = [self.project_2.id]
+        result = serialize(
+            org_members,
+            self.user_2,
+            OrganizationMemberWithProjectsSerializer(project_ids=projects_ids),
+        )
+        expected_projects = [
+            [self.project_2.slug],
+            [],
+        ]
+        assert [r['projects'] for r in result] == expected_projects


### PR DESCRIPTION
Implement endpoint for getting a list of organization members and their associated projects. For use in the org level issues list.

We already have OrganizationMemberIndexEndpoint, but it's used for a different purpose, so called this `OrganizationUsersEndpoint`. Open to better names.