### PR TITLE
feat(discover): Add support for relative date ranges

### DIFF
--- a/src/sentry/api/endpoints/organization_discover_query.py
+++ b/src/sentry/api/endpoints/organization_discover_query.py
@@ -32,12 +32,12 @@ class DiscoverQuerySerializer(serializers.Serializer):
         required=True,
         allow_null=False,
     )
-    start = serializers.CharField(required=False)
-    end = serializers.CharField(required=False)
-    range = serializers.CharField(required=False)
-    statsPeriod = serializers.CharField(required=False)
-    statsPeriodStart = serializers.CharField(required=False)
-    statsPeriodEnd = serializers.CharField(required=False)
+    start = serializers.CharField(required=False, allow_none=True)
+    end = serializers.CharField(required=False, allow_none=True)
+    range = serializers.CharField(required=False, allow_none=True)
+    statsPeriod = serializers.CharField(required=False, allow_none=True)
+    statsPeriodStart = serializers.CharField(required=False, allow_none=True)
+    statsPeriodEnd = serializers.CharField(required=False, allow_none=True)
     fields = ListField(
         child=serializers.CharField(),
         required=False,

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -26,7 +26,7 @@ def get_datetime_from_stats_period(stats_period, now=None):
     return now - stats_period
 
 
-def get_date_range_from_params(params, optional=False):
+def get_date_range_from_params(params, optional=False, validate_window=True):
     """
     Gets a date range from standard date range params we pass to the api.
 
@@ -43,6 +43,7 @@ def get_date_range_from_params(params, optional=False):
     If `start` end `end` are passed, validate them, convert to `datetime` and
     returns them if valid.
     :param optional: When True, if no params passed then return `(None, None)`.
+    :param validate_window: When True, validate against min / max time delta.
     :return: A length 2 tuple containing start/end or raises an `InvalidParams`
     exception
     """
@@ -78,8 +79,9 @@ def get_date_range_from_params(params, optional=False):
     if start > end:
         raise InvalidParams('start must be before end')
 
-    delta = end - start
-    if delta < MIN_STATS_PERIOD or delta > MAX_STATS_PERIOD:
-        raise InvalidParams(INVALID_PERIOD_ERROR)
+    if validate_window:
+        delta = end - start
+        if delta < MIN_STATS_PERIOD or delta > MAX_STATS_PERIOD:
+            raise InvalidParams(INVALID_PERIOD_ERROR)
 
     return start, end

--- a/tests/snuba/test_organization_discover_query.py
+++ b/tests/snuba/test_organization_discover_query.py
@@ -91,20 +91,6 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
         assert response.data['data'][0]['message'] == 'message!'
         assert response.data['data'][0]['platform'] == 'python'
 
-    def test_invalid_date_request(self):
-        with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
-            response = self.client.post(url, {
-                'projects': [self.project.id],
-                'fields': ['message', 'platform'],
-                'range': '1d',
-                'start': (datetime.now() - timedelta(seconds=10)).strftime('%Y-%m-%dT%H:%M:%S'),
-                'end': (datetime.now()).strftime('%Y-%m-%dT%H:%M:%S'),
-                'orderby': '-timestamp',
-            })
-
-        assert response.status_code == 400, response.content
-
     def test_invalid_range_value(self):
         with self.feature('organizations:discover'):
             url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])

--- a/tests/snuba/test_organization_discover_query.py
+++ b/tests/snuba/test_organization_discover_query.py
@@ -69,6 +69,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
                 'start': (datetime.now() - timedelta(seconds=10)).strftime('%Y-%m-%dT%H:%M:%S'),
                 'end': (datetime.now()).strftime('%Y-%m-%dT%H:%M:%S'),
                 'orderby': '-timestamp',
+                'range': None,
             })
 
         assert response.status_code == 200, response.content
@@ -84,6 +85,8 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
                 'fields': ['message', 'platform'],
                 'range': '1d',
                 'orderby': '-timestamp',
+                'start': None,
+                'end': None,
             })
 
         assert response.status_code == 200, response.content
@@ -127,6 +130,8 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
                 'fields': ['message', 'platform'],
                 'range': '1x',
                 'orderby': '-timestamp',
+                'start': None,
+                'end': None,
             })
 
         assert response.status_code == 400, response.content
@@ -140,6 +145,8 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
                 'aggregations': [['test', 'test', 'test']],
                 'range': '14d',
                 'orderby': '-timestamp',
+                'start': None,
+                'end': None,
             })
 
         assert response.status_code == 400, response.content
@@ -154,6 +161,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
                 'start': (datetime.now() - timedelta(seconds=10)).strftime('%Y-%m-%dT%H:%M:%S'),
                 'end': (datetime.now()).strftime('%Y-%m-%dT%H:%M:%S'),
                 'orderby': '-timestamp',
+                'range': None,
             })
 
         assert response.status_code == 200, response.content
@@ -170,6 +178,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
                 'start': (datetime.now() - timedelta(seconds=10)).strftime('%Y-%m-%dT%H:%M:%S'),
                 'end': (datetime.now() + timedelta(seconds=10)).strftime('%Y-%m-%dT%H:%M:%S'),
                 'orderby': '-timestamp',
+                'range': None,
             })
         assert response.status_code == 200, response.content
         assert len(response.data['data']) == 1
@@ -185,6 +194,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
                 'start': (datetime.now() - timedelta(seconds=10)).strftime('%Y-%m-%dT%H:%M:%S'),
                 'end': (datetime.now()).strftime('%Y-%m-%dT%H:%M:%S'),
                 'orderby': '-timestamp',
+                'range': None,
             })
         assert response.status_code == 200, response.content
         assert len(response.data['data']) == 1
@@ -199,6 +209,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
                 'start': (datetime.now() - timedelta(seconds=10)).strftime('%Y-%m-%dT%H:%M:%S'),
                 'end': (datetime.now()).strftime('%Y-%m-%dT%H:%M:%S'),
                 'orderby': '-timestamp',
+                'range': None,
             })
 
         assert response.status_code == 200, response.content
@@ -212,6 +223,8 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
                 'fields': ['project.name'],
                 'range': '14d',
                 'orderby': '-timestamp',
+                'start': None,
+                'end': None,
             })
         assert response.status_code == 200, response.content
         assert len(response.data['data']) == 1
@@ -226,6 +239,8 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
                 'fields': ['project.name'],
                 'range': '14d',
                 'orderby': '-count',
+                'start': None,
+                'end': None,
             })
         assert response.status_code == 200, response.content
         assert len(response.data['data']) == 1
@@ -243,6 +258,8 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
                 'orderby': 'time',
                 'range': '5d',
                 'rollup': 86400,
+                'start': None,
+                'end': None,
             })
         assert response.status_code == 200, response.content
         assert len(response.data['data']) == 6
@@ -262,6 +279,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
                 'start': (self.now - timedelta(seconds=300)).strftime('%Y-%m-%dT%H:%M:%S'),
                 'end': self.now.strftime('%Y-%m-%dT%H:%M:%S'),
                 'rollup': 60,
+                'range': None,
             })
 
         assert response.status_code == 200, response.content
@@ -278,6 +296,8 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
                 'aggregations': [['uniq', 'project.name', 'uniq_project_name']],
                 'range': '14d',
                 'orderby': '-uniq_project_name',
+                'start': None,
+                'end': None,
             })
         assert response.status_code == 200, response.content
         assert len(response.data['data']) == 1
@@ -292,6 +312,8 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
                 'aggregations': [['count()', '', 'count']],
                 'range': '14d',
                 'orderby': '-count',
+                'start': None,
+                'end': None,
             })
         assert response.status_code == 200, response.content
         assert response.data['meta'] == [
@@ -307,6 +329,8 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
             'fields': ['message', 'platform'],
             'range': '14d',
             'orderby': '-timestamp',
+            'start': None,
+            'end': None,
         })
 
         assert response.status_code == 404, response.content
@@ -320,6 +344,8 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
                 'fields': ['message', 'platform'],
                 'range': '14d',
                 'orderby': '-timestamp',
+                'start': None,
+                'end': None,
             })
 
         assert response.status_code == 403, response.content


### PR DESCRIPTION
This adds support for specifying a range like "14 days ago to 7 days ago".

This changes the behavior slightly in that it won't error if you provide multiple time filters (which is what we do for events, etc). Let me know if that's a problem for discover.

cc @billyvg 