### PR TITLE
ref(issues): Refactor group seen by component

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
@@ -17,7 +17,7 @@ import {t} from 'app/locale';
 import SentryTypes from 'app/sentryTypes';
 
 import GroupActions from './actions';
-import GroupSeenBy from '../project/seenBy';
+import GroupSeenBy from './seenBy';
 
 const GroupHeader = createReactClass({
   displayName: 'GroupHeader',
@@ -174,7 +174,7 @@ const GroupHeader = createReactClass({
             </div>
           </div>
         </div>
-        <GroupSeenBy />
+        <GroupSeenBy group={group} />
         <GroupActions group={group} project={project} />
         <NavTabs>
           <ListLink

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/seenBy.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/seenBy.jsx
@@ -1,24 +1,23 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import moment from 'moment';
 import _ from 'lodash';
 import styled from 'react-emotion';
 
+import SentryTypes from 'app/sentryTypes';
 import ConfigStore from 'app/stores/configStore';
 import AvatarList from 'app/components/avatar/avatarList';
-import GroupState from 'app/mixins/groupState';
 import {userDisplayName} from 'app/utils/formatters';
 import Tooltip from 'app/components/tooltip';
 import {t} from 'app/locale';
 
-const GroupSeenBy = createReactClass({
-  displayName: 'GroupSeenBy',
-
-  mixins: [GroupState],
+export default class GroupSeenBy extends React.Component {
+  static propTypes = {
+    group: SentryTypes.Group.isRequired,
+  };
 
   render() {
-    let activeUser = ConfigStore.get('user');
-    let group = this.getGroup();
+    const activeUser = ConfigStore.get('user');
+    const group = this.props.group;
 
     // NOTE: Sometimes group.seenBy is undefined, even though the /groups/{id} API
     //       endpoint guarantees an array. We haven't figured out HOW GroupSeenBy
@@ -27,7 +26,7 @@ const GroupSeenBy = createReactClass({
     //
     // See: https://github.com/getsentry/sentry/issues/2387
 
-    let seenBy = group.seenBy || [];
+    const seenBy = group.seenBy || [];
     if (seenBy.length === 0) {
       return null;
     }
@@ -50,10 +49,8 @@ const GroupSeenBy = createReactClass({
         </IconWrapper>
       </SeenByWrapper>
     );
-  },
-});
-
-export default GroupSeenBy;
+  }
+}
 
 const SeenByWrapper = styled('div')`
   display: flex;

--- a/tests/js/spec/views/groupDetails/seenBy.spec.jsx
+++ b/tests/js/spec/views/groupDetails/seenBy.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import GroupSeenBy from 'app/views/groupDetails/project/seenBy';
+import GroupSeenBy from 'app/views/groupDetails/shared/seenBy';
 import ConfigStore from 'app/stores/configStore';
 
 describe('GroupSeenBy', function() {
@@ -19,29 +19,21 @@ describe('GroupSeenBy', function() {
 
   describe('render()', function() {
     it('should return null if seenBy is falsy', function() {
-      let wrapper = shallow(<GroupSeenBy />, {
-        context: {
-          group: TestStubs.Group({seenBy: undefined}),
-          project: TestStubs.Project(),
-          team: TestStubs.Team(),
-        },
-      });
+      let wrapper = shallow(<GroupSeenBy group={TestStubs.Group({seenBy: undefined})} />);
       expect(wrapper.children()).toHaveLength(0);
     });
 
     it('should return a list of each user that saw', function() {
-      let wrapper = shallow(<GroupSeenBy />, {
-        context: {
-          group: TestStubs.Group({
+      let wrapper = shallow(
+        <GroupSeenBy
+          group={TestStubs.Group({
             seenBy: [
               {id: '1', email: 'jane@example.com'},
               {id: '2', email: 'john@example.com'},
             ],
-          }),
-          project: TestStubs.Project(),
-          team: TestStubs.Team(),
-        },
-      });
+          })}
+        />
+      );
 
       expect(wrapper.find('EyeIcon')).toHaveLength(1);
       expect(wrapper.find('AvatarList')).toHaveLength(1);


### PR DESCRIPTION
Refactor group seen by component to use group from props instead of
context. Ensures this component will be usable outside of a project
context.