### PR TITLE
ref(issues): Refactor group sidebar

### DIFF
--- a/src/sentry/static/sentry/app/components/group/releaseStats.jsx
+++ b/src/sentry/static/sentry/app/components/group/releaseStats.jsx
@@ -2,11 +2,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
+import SentryTypes from 'app/sentryTypes';
 import ApiMixin from 'app/mixins/apiMixin';
 import EnvironmentStore from 'app/stores/environmentStore';
 import LatestContextStore from 'app/stores/latestContextStore';
 import LoadingIndicator from 'app/components/loadingIndicator';
-import GroupState from 'app/mixins/groupState';
+import OrganizationState from 'app/mixins/organizationState';
 import GroupReleaseChart from 'app/components/group/releaseChart';
 import SeenInfo from 'app/components/group/seenInfo';
 import {t} from 'app/locale';
@@ -15,7 +16,8 @@ const GroupReleaseStats = createReactClass({
   displayName: 'GroupReleaseStats',
 
   propTypes: {
-    group: PropTypes.object,
+    group: SentryTypes.Group,
+    project: SentryTypes.Project,
     allEnvironments: PropTypes.object,
   },
 
@@ -25,7 +27,7 @@ const GroupReleaseStats = createReactClass({
 
   mixins: [
     ApiMixin,
-    GroupState,
+    OrganizationState,
     Reflux.listenTo(LatestContextStore, 'onLatestContextChange'),
   ],
 
@@ -50,13 +52,13 @@ const GroupReleaseStats = createReactClass({
   },
 
   render() {
-    let {group, allEnvironments} = this.props;
+    let {group, project, allEnvironments} = this.props;
     let {environment} = this.state;
 
     let envName = environment ? environment.displayName : t('All Environments');
-    let projectId = this.getProject().slug;
+    let projectId = project.slug;
     let orgId = this.getOrganization().slug;
-    let hasRelease = this.getProjectFeatures().has('releases');
+    let hasRelease = new Set(project.features).has('releases');
     let isLoading = !group || !allEnvironments;
 
     return (

--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -9,12 +9,11 @@ import ApiMixin from 'app/mixins/apiMixin';
 import SuggestedOwners from 'app/components/group/suggestedOwners';
 import GroupParticipants from 'app/components/group/participants';
 import GroupReleaseStats from 'app/components/group/releaseStats';
-import ProjectState from 'app/mixins/projectState';
+import OrganizationState from 'app/mixins/organizationState';
 import IndicatorStore from 'app/stores/indicatorStore';
 import TagDistributionMeter from 'app/components/group/tagDistributionMeter';
 import LoadingError from 'app/components/loadingError';
 import {t, tct} from 'app/locale';
-import withEnvironment from 'app/utils/withEnvironment';
 
 import ExternalIssueList from 'app/components/group/externalIssuesList';
 
@@ -22,8 +21,10 @@ const GroupSidebar = createReactClass({
   displayName: 'GroupSidebar',
 
   propTypes: {
-    group: PropTypes.object.isRequired,
-    event: PropTypes.object,
+    project: SentryTypes.Project,
+    group: SentryTypes.Group,
+    event: SentryTypes.Event,
+    // Currently only provided in the project version of the issue page
     environment: SentryTypes.Environment,
   },
 
@@ -31,7 +32,7 @@ const GroupSidebar = createReactClass({
     location: PropTypes.object,
   },
 
-  mixins: [ApiMixin, ProjectState],
+  mixins: [ApiMixin, OrganizationState],
 
   getInitialState() {
     return {participants: [], environment: this.props.environment};
@@ -111,8 +112,7 @@ const GroupSidebar = createReactClass({
   },
 
   toggleSubscription() {
-    let group = this.props.group;
-    let project = this.getProject();
+    let {group, project} = this.props;
     let org = this.getOrganization();
     let loadingIndicator = IndicatorStore.add(t('Saving changes..'));
 
@@ -232,8 +232,7 @@ const GroupSidebar = createReactClass({
   },
 
   render() {
-    let {group} = this.props;
-    let project = this.getProject();
+    let {group, project} = this.props;
     let projectId = project.slug;
     let orgId = this.getOrganization().slug;
 
@@ -246,6 +245,7 @@ const GroupSidebar = createReactClass({
         <SuggestedOwners event={this.props.event} />
         <GroupReleaseStats
           group={this.props.group}
+          project={project}
           allEnvironments={this.state.allEnvironmentsGroupData}
         />
         <ExternalIssueList group={this.props.group} project={project} orgId={orgId} />
@@ -301,5 +301,4 @@ const GroupSidebar = createReactClass({
   },
 });
 
-export {GroupSidebar};
-export default withEnvironment(GroupSidebar);
+export default GroupSidebar;

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/groupEventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/groupEventDetails.jsx
@@ -9,6 +9,7 @@ import LoadingIndicator from 'app/components/loadingIndicator';
 import ResolutionBox from 'app/components/resolutionBox';
 import MutedBox from 'app/components/mutedBox';
 import withOrganization from 'app/utils/withOrganization';
+import withEnvironment from 'app/utils/withEnvironment';
 
 import GroupEventToolbar from './eventToolbar';
 import {fetchGroupEventAndMarkSeen} from './utils';
@@ -62,8 +63,14 @@ class GroupEventDetails extends React.Component {
       });
   }
   render() {
-    const {group, project, organization} = this.props;
+    const {group, project, organization, params} = this.props;
     const evt = withMeta(this.state.event);
+
+    // Sidebar doesn't support multiple environments yet so do not pass an
+    // environment in the org level variant of the sidebar
+    const SidebarWithEnvironment = params.projectId
+      ? withEnvironment(GroupSidebar)
+      : GroupSidebar;
 
     return (
       <div>
@@ -105,7 +112,7 @@ class GroupEventDetails extends React.Component {
             )}
           </div>
           <div className="secondary">
-            <GroupSidebar group={group} event={evt} />
+            <SidebarWithEnvironment project={project} group={group} event={evt} />
           </div>
         </div>
       </div>

--- a/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
@@ -74,6 +74,17 @@ exports[`GroupReleaseStats renders 1`] = `
       "query": Object {},
     }
   }
+  project={
+    Object {
+      "hasAccess": true,
+      "id": "2",
+      "isBookmarked": false,
+      "isMember": true,
+      "name": "Project Name",
+      "slug": "project-slug",
+      "teams": Array [],
+    }
+  }
 >
   <div
     className="env-stats"

--- a/tests/js/spec/components/group/__snapshots__/sidebar.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/sidebar.spec.jsx.snap
@@ -131,6 +131,17 @@ exports[`GroupSidebar renders with tags renders 1`] = `
         ],
       }
     }
+    project={
+      Object {
+        "hasAccess": true,
+        "id": "2",
+        "isBookmarked": false,
+        "isMember": true,
+        "name": "Project Name",
+        "slug": "project-slug",
+        "teams": Array [],
+      }
+    }
   />
   <ExternalIssueList
     group={

--- a/tests/js/spec/components/group/releaseStats.spec.jsx
+++ b/tests/js/spec/components/group/releaseStats.spec.jsx
@@ -20,14 +20,13 @@ describe('GroupReleaseStats', function() {
     component = mount(
       <GroupReleaseStats
         group={TestStubs.Group()}
+        project={TestStubs.Project()}
         allEnvironments={TestStubs.Group()}
         location={TestStubs.location()}
       />,
       {
         context: {
           organization: TestStubs.Organization(),
-          project: TestStubs.Project(),
-          group: TestStubs.Group(),
         },
       }
     );

--- a/tests/js/spec/components/group/sidebar.spec.jsx
+++ b/tests/js/spec/components/group/sidebar.spec.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import {GroupSidebar} from 'app/components/group/sidebar';
+import GroupSidebar from 'app/components/group/sidebar';
 
 describe('GroupSidebar', function() {
   let group = TestStubs.Group({tags: TestStubs.Tags()});
+  let project = TestStubs.Project();
   let environment = {name: 'production', displayName: 'Production', id: '1'};
   let wrapper;
   let tagValuesMock;
@@ -26,7 +27,12 @@ describe('GroupSidebar', function() {
     });
 
     wrapper = shallow(
-      <GroupSidebar group={group} event={TestStubs.Event()} environment={environment} />,
+      <GroupSidebar
+        group={group}
+        project={project}
+        event={TestStubs.Event()}
+        environment={environment}
+      />,
       TestStubs.routerContext()
     );
   });
@@ -67,6 +73,7 @@ describe('GroupSidebar', function() {
       wrapper = shallow(
         <GroupSidebar
           group={group}
+          project={project}
           event={TestStubs.Event()}
           environment={environment}
         />,


### PR DESCRIPTION
Refactor group sidebar to take project from props instead of reading
from context. Group sidebar component only filters by environment in the
project version of the issues page, not the org one since multiple
environments are not currently supported in this component.