### PR TITLE
ref(issues): Refactor suggested owners

### DIFF
--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -243,7 +243,7 @@ const GroupSidebar = createReactClass({
 
     return (
       <div className="group-stats">
-        <SuggestedOwners event={this.props.event} />
+        <SuggestedOwners project={project} group={group} event={this.props.event} />
         <GroupReleaseStats
           group={this.props.group}
           allEnvironments={this.state.allEnvironmentsGroupData}

--- a/tests/js/spec/components/group/__snapshots__/sidebar.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/sidebar.spec.jsx.snap
@@ -13,6 +13,75 @@ exports[`GroupSidebar renders with tags renders 1`] = `
         "message": "ApiException",
       }
     }
+    group={
+      Object {
+        "assignedTo": null,
+        "id": "1",
+        "project": Object {
+          "id": "2",
+          "slug": "project-slug",
+        },
+        "stats": Object {
+          "24h": Array [
+            Array [
+              1517281200,
+              2,
+            ],
+            Array [
+              1517310000,
+              1,
+            ],
+          ],
+          "30d": Array [
+            Array [
+              1514764800,
+              1,
+            ],
+            Array [
+              1515024000,
+              122,
+            ],
+          ],
+        },
+        "tags": Array [
+          Object {
+            "canDelete": true,
+            "key": "browser",
+            "name": "Browser",
+            "totalValues": 30,
+          },
+          Object {
+            "canDelete": true,
+            "key": "device",
+            "name": "Device",
+            "totalValues": 5,
+          },
+          Object {
+            "canDelete": true,
+            "key": "url",
+            "name": "URL",
+            "totalValues": 7,
+          },
+          Object {
+            "canDelete": false,
+            "key": "environment",
+            "name": "Environment",
+            "totalValues": 100,
+          },
+        ],
+      }
+    }
+    project={
+      Object {
+        "hasAccess": true,
+        "id": "2",
+        "isBookmarked": false,
+        "isMember": true,
+        "name": "Project Name",
+        "slug": "project-slug",
+        "teams": Array [],
+      }
+    }
   />
   <GroupReleaseStats
     allEnvironments={

--- a/tests/js/spec/components/group/suggestedOwners.spec.jsx
+++ b/tests/js/spec/components/group/suggestedOwners.spec.jsx
@@ -10,11 +10,10 @@ describe('SuggestedOwners', function() {
 
   const organization = TestStubs.Organization();
   const project = TestStubs.Project();
+  const group = TestStubs.Group();
 
   const routerContext = TestStubs.routerContext([
     {
-      group: TestStubs.Group(),
-      project,
       organization,
     },
   ]);
@@ -50,7 +49,10 @@ describe('SuggestedOwners', function() {
       },
     });
 
-    const wrapper = mount(<SuggestedOwners event={event} />, routerContext);
+    const wrapper = mount(
+      <SuggestedOwners project={project} group={group} event={event} />,
+      routerContext
+    );
 
     expect(wrapper.find('ActorAvatar')).toHaveLength(2);
 
@@ -87,7 +89,10 @@ describe('SuggestedOwners', function() {
       },
     });
 
-    const wrapper = mount(<SuggestedOwners event={event} />, routerContext);
+    const wrapper = mount(
+      <SuggestedOwners project={project} group={group} event={event} />,
+      routerContext
+    );
 
     expect(wrapper.find('ActorAvatar')).toHaveLength(1);
 


### PR DESCRIPTION
Suggested owners component gets project and group from props instead of
context. Makes it reusable for organization level issues where project
and group will not be in context.