### PR TITLE
ref(issues): Refactor group activity

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1083,7 +1083,7 @@ function routes() {
             <Route
               path="activity/"
               componentPromise={() =>
-                import(/* webpackChunkName: "GroupActivity" */ './views/groupDetails/project/groupActivity')}
+                import(/* webpackChunkName: "GroupActivity" */ './views/groupDetails/shared/groupActivity')}
               component={errorHandler(LazyLoad)}
             />
 

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/groupActivity.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/groupActivity.jsx
@@ -28,12 +28,13 @@ class GroupActivityItem extends React.Component {
   static propTypes = {
     author: PropTypes.node,
     item: PropTypes.object,
+    orgId: PropTypes.string,
+    projectId: PropTypes.string,
   };
 
   render() {
-    let {author, item, params} = this.props;
+    let {author, item, orgId, projectId} = this.props;
     let {data} = item;
-    let {orgId, projectId} = params;
 
     switch (item.type) {
       case 'note':
@@ -290,7 +291,8 @@ const GroupActivity = createReactClass({
                     </span>
                   }
                   item={item}
-                  params={this.props.params}
+                  orgId={this.props.params.orgId}
+                  projectId={group.project.slug}
                 />
               </ErrorBoundary>
             </div>

--- a/tests/js/spec/views/groupActivity/index.spec.jsx
+++ b/tests/js/spec/views/groupActivity/index.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import GroupActivity from 'app/views/groupDetails/project/groupActivity';
+import GroupActivity from 'app/views/groupDetails/shared/groupActivity';
 import NoteInput from 'app/components/activity/noteInput';
 import ConfigStore from 'app/stores/configStore';
 import GroupStore from 'app/stores/groupStore';


### PR DESCRIPTION
Group activity component reads projectId from group instead of params.
Makes it reusable at org level routes where project won't be in the URL.