### PR TITLE
fix(issues): Fix group event details refetching

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/shared/groupEventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/groupEventDetails.jsx
@@ -34,6 +34,12 @@ class GroupEventDetails extends React.Component {
     this.fetchData();
   }
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.params.eventId !== this.props.params.eventId) {
+      this.fetchData();
+    }
+  }
+
   fetchData() {
     const {group, project, organization, params} = this.props;
     const eventId = params.eventId || 'latest';


### PR DESCRIPTION
This fixes a bug introduced in
https://github.com/getsentry/sentry/pull/11445 which causes the group
event details component to not refetch the event when the forward and
backward buttons are used.