### PR TITLE
feat(ui-search): Support external links in `to`

### DIFF
--- a/src/sentry/static/sentry/app/components/search/index.jsx
+++ b/src/sentry/static/sentry/app/components/search/index.jsx
@@ -92,6 +92,13 @@ class Search extends React.Component {
 
     if (!to) return;
 
+    if (to.startsWith('http')) {
+      const open = window.open();
+      open.opener = null;
+      open.location = to;
+      return;
+    }
+
     let {params, router} = this.props;
     let nextPath = replaceRouterParams(to, params);
 


### PR DESCRIPTION
Selecting an external link opens it in a new tab