### PR TITLE
feat: Conditionally render single project selector

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled, {css} from 'react-emotion';
 
+import SentryTypes from 'app/sentryTypes';
 import {t} from 'app/locale';
 import ProjectSelector from 'app/components/projectSelector';
 import InlineSvg from 'app/components/inlineSvg';
@@ -14,6 +15,7 @@ const rootContainerStyles = css`
 
 export default class MultipleProjectSelector extends React.PureComponent {
   static propTypes = {
+    organization: SentryTypes.Organization.isRequired,
     value: PropTypes.array,
     projects: PropTypes.array,
     onChange: PropTypes.func,
@@ -85,6 +87,10 @@ export default class MultipleProjectSelector extends React.PureComponent {
     this.setState({hasChanges: true});
   };
 
+  hasMultiSelect = () => {
+    return new Set(this.props.organization.features).has('global-views');
+  };
+
   render() {
     const {value, projects} = this.props;
     const selectedProjectIds = new Set(value);
@@ -96,7 +102,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
     return (
       <StyledProjectSelector
         {...this.props}
-        multi
+        multi={this.hasMultiSelect()}
         selectedProjects={selected}
         projects={projects}
         onSelect={this.handleQuickSelect}

--- a/tests/js/spec/views/releases/list/__snapshots__/organizationReleases.spec.jsx.snap
+++ b/tests/js/spec/views/releases/list/__snapshots__/organizationReleases.spec.jsx.snap
@@ -536,7 +536,7 @@ exports[`OrganizationReleases renders 1`] = `
                               value={Array []}
                             >
                               <StyledProjectSelector
-                                multi={true}
+                                multi={false}
                                 onChange={[Function]}
                                 onClose={[Function]}
                                 onMultiSelect={[Function]}
@@ -600,7 +600,7 @@ exports[`OrganizationReleases renders 1`] = `
                               >
                                 <ProjectSelector
                                   className="css-iw79rr-StyledProjectSelector ewlipse0"
-                                  multi={true}
+                                  multi={false}
                                   onChange={[Function]}
                                   onClose={[Function]}
                                   onMultiSelect={[Function]}

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -484,7 +484,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                             value={Array []}
                           >
                             <StyledProjectSelector
-                              multi={true}
+                              multi={false}
                               onChange={[Function]}
                               onClose={[Function]}
                               onMultiSelect={[Function]}
@@ -526,7 +526,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                             >
                               <ProjectSelector
                                 className="css-iw79rr-StyledProjectSelector ewlipse0"
-                                multi={true}
+                                multi={false}
                                 onChange={[Function]}
                                 onClose={[Function]}
                                 onMultiSelect={[Function]}


### PR DESCRIPTION
Global selection header only allows single project selection if the
`global-views` feature is not active.