### PR TITLE
feat: Silently ignore CFI errors as far as users are concerned

### DIFF
--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -636,8 +636,17 @@ class DIFCache(object):
             return error
 
         _, _, error = self._update_cachefile(dif, filepath, ProjectCfiCacheFile)
+
+        # CFI generation will never fail to the user.  We instead log it here
+        # for reference only.  This is because we have currently limited trust
+        # in our CFI generation and even without CFI information we can
+        # continue processing stacktraces.
         if error is not None:
-            return error
+            logger.warning('dsymfile.cfi-generation-failed', extra=dict(
+                error=error,
+                debug_id=dif.debug_id
+            ))
+            return None
 
         return None
 


### PR DESCRIPTION
If we encounter issues building CFI caches we do not fail the upload.  We are currently
not entirely confident in our CFI code paths and it's better for us to fall back to non
CFI processing than to fail the upload.