### PR TITLE
ur'strings' are syntax errors in Python 3

### DIFF
--- a/src/sentry/management/commands/backfill_eventstream.py
+++ b/src/sentry/management/commands/backfill_eventstream.py
@@ -9,6 +9,8 @@ from __future__ import absolute_import, print_function
 
 import sys
 
+import six
+
 from django.core.management.base import BaseCommand, CommandError, make_option
 from django.utils.dateparse import parse_datetime
 
@@ -82,8 +84,8 @@ class Command(BaseCommand):
             sys.exit(0)
 
         if not options['no_input']:
-            proceed = raw_input('Do you want to continue? [y/N] ')
-            if proceed.lower() not in ['yes', 'y']:
+            proceed = six.moves.input('Do you want to continue? [y/N] ')
+            if proceed.strip().lower() not in ['yes', 'y']:
                 raise CommandError('Aborted.')
 
         for event in RangeQuerySetWrapper(events, step=100, callbacks=(_attach_related,)):

--- a/src/sentry/utils/strings.py
+++ b/src/sentry/utils/strings.py
@@ -93,7 +93,7 @@ def soft_break(value, length, process=lambda chunk: chunk):
     zero-width spaces after common delimeters, as well as soft-hyphenating long
     identifiers.
     """
-    delimiters = re.compile(ur'([{}]+)'.format(''.join(map(re.escape, ',.$:/+@!?()<>[]{}'))))
+    delimiters = re.compile(six.text_type(r'([{}]+)').format(''.join(map(re.escape, ',.$:/+@!?()<>[]{}'))))
 
     def soft_break_delimiter(match):
         results = []
@@ -108,7 +108,7 @@ def soft_break(value, length, process=lambda chunk: chunk):
 
         return u''.join(results).rstrip(u'\u200b')
 
-    return re.sub(ur'\S{{{},}}'.format(length), soft_break_delimiter, value)
+    return re.sub(six.text_type(r'\S{{{},}}').format(length), soft_break_delimiter, value)
 
 
 def to_unicode(value):


### PR DESCRIPTION
$ ___python3 -c "ur'string'"___  # --> SyntaxError: invalid syntax
* In Python 3, you can have u'strings' or r'strings' but not ur'strings'.

Also __raw_input()__ --> __six.moves.input()__ for compatibility with both Python 2 and Python 3.