### PR TITLE
fix(integrations) Fix jira server failure on invalid key

### DIFF
--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 import logging
 import six
 
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from cryptography.hazmat.backends import default_backend
 from django import forms
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
@@ -95,13 +97,24 @@ class InstallationForm(forms.Form):
     private_key = forms.CharField(
         label=_('Jira Consumer Private Key'),
         widget=forms.Textarea(
-            attrs={'placeholder': _('--PRIVATE KEY--')}
+            attrs={'placeholder': _(
+                '-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----')}
         )
     )
 
     def clean_url(self):
         """Strip off trailing / as they cause invalid URLs downstream"""
         return self.cleaned_data['url'].rstrip('/')
+
+    def clean_private_key(self):
+        data = self.cleaned_data['private_key']
+
+        try:
+            load_pem_private_key(data.encode('utf-8'), None, default_backend())
+        except Exception:
+            raise forms.ValidationError(
+                'Private key must be a valid SSH private key encoded in a PEM format.')
+        return data
 
 
 class InstallationConfigView(PipelineView):


### PR DESCRIPTION
We should validate the uploaded private key so we can avoid hard failures later.

Fixes APP-997