### PR TITLE
fix(search) Don't 500 on environment tag values

### DIFF
--- a/tests/sentry/search/django/tests.py
+++ b/tests/sentry/search/django/tests.py
@@ -301,6 +301,15 @@ class DjangoSearchBackendTest(TestCase):
                   'server': 'bar.example.com'})
         assert set(results) == set([])
 
+    def test_environment_tag_not_matching_project(self):
+        project = self.create_project(name='other')
+        results = self.backend.query(
+            [project],
+            environments=[self.environments['production']],
+            tags={'environment': 'production'},
+            query='')
+        assert set(results) == set([])
+
     def test_tags_with_environment(self):
         results = self.backend.query(
             [self.project],


### PR DESCRIPTION
When a user makes a request for an environment that isn't assigned to the selected project via tags we should not 500. Instead the request should succeed with an empty result set.

This alters the changes made in #8523 and takes the other approach mentioned in the TODO.

Fixes SENTRY-6PP