### PR TITLE
fix(settings): Change Weekly Reports UI to default to "On" (ISSUE-274)

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/accountNotificationSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/accountNotificationSettings.jsx
@@ -23,10 +23,10 @@ export const fields = {
   weeklyReports: {
     // Form is not visible because currently not implemented
     name: 'weeklyReports',
-    // type: 'boolean',
+    type: 'boolean',
     label: t('Send Me Weekly Reports'),
     help: t("Reports contain a summary of what's happened within your organization."),
-    // disabled: true,
+    disabled: true,
   },
   deployNotifications: {
     name: 'deployNotifications',
@@ -67,7 +67,7 @@ const formGroups = [
 
   {
     title: t('Weekly Reports'),
-    fields: [fields.weeklyReports],
+    fields: [],
   },
 
   {

--- a/src/sentry/static/sentry/app/views/settings/account/accountNotificationFineTuning.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountNotificationFineTuning.jsx
@@ -62,6 +62,7 @@ const ACCOUNT_NOTIFICATION_FIELDS = {
       "Reports contain a summary of what's happened within the organization."
     ),
     type: 'select',
+    defaultValue: 1,
     choices: [[1, t('On')], [0, t('Off')]],
     defaultFieldName: 'weeklyReports',
   },

--- a/src/sentry/static/sentry/app/views/settings/account/accountNotificationFineTuning.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountNotificationFineTuning.jsx
@@ -62,6 +62,7 @@ const ACCOUNT_NOTIFICATION_FIELDS = {
       "Reports contain a summary of what's happened within the organization."
     ),
     type: 'select',
+    // API only saves organizations that have this disabled, so we should default to "On"
     defaultValue: 1,
     choices: [[1, t('On')], [0, t('Off')]],
     defaultFieldName: 'weeklyReports',

--- a/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
@@ -220,7 +220,7 @@ class FormField extends React.Component {
     flexibleControlStateSize: PropTypes.bool,
 
     // Default value to use for form field if value is not specified in `<Form>` parent
-    defaultValue: PropTypes.string,
+    defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
     // the following should only be used without form context
     onChange: PropTypes.func,


### PR DESCRIPTION
API only saves organizations which have weekly reports disabled, this means default should be "On"