### PR TITLE
fix(project-settings): Fix legacy browser project filters

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.jsx
@@ -266,7 +266,7 @@ class ProjectFiltersSettings extends AsyncComponent {
                           <FormField
                             inline={false}
                             {...fieldProps}
-                            getData={data => ({subfilters: data[filter.id]})}
+                            getData={data => ({subfilters: [...data[filter.id]]})}
                           >
                             {({onChange, onBlur}) => (
                               <LegacyBrowserFilterRow


### PR DESCRIPTION
This was broken because data was a `Set` -- cast to an `Array`.