### PR TITLE
feat(issues) Allow AssigneeSelector to take members via props

### DIFF
--- a/src/sentry/static/sentry/app/components/assigneeSelector.jsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.jsx
@@ -29,6 +29,10 @@ const AssigneeSelectorComponent = createReactClass({
   propTypes: {
     id: PropTypes.string.isRequired,
     size: PropTypes.number,
+    // Either a list of users, or null. If null, members will
+    // be read from the MemberListStore. The prop is useful when the
+    // store contains more/different users than you need to show
+    // in an individual component, eg. Org Issue list
     memberList: PropTypes.array,
   },
 

--- a/tests/js/spec/components/assigneeSelector.spec.jsx
+++ b/tests/js/spec/components/assigneeSelector.spec.jsx
@@ -86,6 +86,28 @@ describe('AssigneeSelector', function() {
     Client.clearMockResponses();
   });
 
+  describe('render with props', function() {
+    it('renders members from the prop when present', async function() {
+      assigneeSelector = mount(
+        <AssigneeSelectorComponent id={GROUP_1.id} memberList={[USER_2, USER_3]} />,
+        TestStubs.routerContext()
+      );
+      MemberListStore.loadInitialData([USER_1]);
+      openMenu();
+
+      assigneeSelector.update();
+      expect(assigneeSelector.find('LoadingIndicator')).toHaveLength(0);
+      expect(assigneeSelector.find('Avatar')).toHaveLength(3);
+      expect(assigneeSelector.find('UserAvatar')).toHaveLength(2);
+      expect(assigneeSelector.find('TeamAvatar')).toHaveLength(1);
+
+      let names = assigneeSelector
+        .find('MenuItemWrapper Label Highlight')
+        .map(el => el.text());
+      expect(names).toEqual([`#${TEAM_1.slug}`, USER_2.name, USER_3.name]);
+    });
+  });
+
   describe('putSessionUserFirst()', function() {
     const putSessionUserFirst = AssigneeSelectorComponent.putSessionUserFirst;
     it('should place the session user at the top of the member list if present', function() {


### PR DESCRIPTION
The MemberListStore has some single-project assumptions baked into it. Instead of trying to rejig that store and update it to work in a multi-project world I thought it would be simpler to have AssigneeSelector accept the member list in its props.

Refs APP-993