### PR TITLE
feat(ui): Add docs search command to command palette

### DIFF
--- a/src/sentry/static/sentry/app/components/search/sources/commandSource.jsx
+++ b/src/sentry/static/sentry/app/components/search/sources/commandSource.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {createFuzzySearch} from 'app/utils/createFuzzySearch';
-import {openSudo} from 'app/actionCreators/modal';
+import {openSudo, openDocsSearchModal} from 'app/actionCreators/modal';
 import Access from 'app/components/acl/access';
 
 const ACTIONS = [
@@ -23,6 +23,12 @@ const ACTIONS = [
       openSudo({
         superuser: true,
       }),
+  },
+
+  {
+    title: 'Search Documentation and FAQ',
+    description: 'Open the Documentation and FAQ search modal.',
+    action: () => openDocsSearchModal(),
   },
 ];
 


### PR DESCRIPTION
Kinda useful since we improve the documentation / FAQ search in some upcoming PRs.