### PR TITLE
ref(dashboard): Revised Model Deletion

### DIFF
--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -40,7 +40,6 @@ def load_defaults():
     default_manager.register(models.ApiToken, BulkModelDeletionTask)
     default_manager.register(models.CommitAuthor, BulkModelDeletionTask)
     default_manager.register(models.CommitFileChange, BulkModelDeletionTask)
-    # TODO(lb): Create a defaults.DashboardDeletionTask
     default_manager.register(models.Dashboard, ModelDeletionTask)
     default_manager.register(models.DiscoverSavedQuery, BulkModelDeletionTask)
     default_manager.register(models.DiscoverSavedQueryProject, BulkModelDeletionTask)
@@ -79,10 +78,6 @@ def load_defaults():
     default_manager.register(models.SavedSearchUserDefault, BulkModelDeletionTask)
     default_manager.register(models.Team, defaults.TeamDeletionTask)
     default_manager.register(models.UserReport, BulkModelDeletionTask)
-    # TODO(lb): Create a defaults.DashboardDeletionTask
-    default_manager.register(models.Widget, ModelDeletionTask)
-    # TODO(lb): Create a defaults.DashboardDeletionTask
-    default_manager.register(models.WidgetDataSource, BulkModelDeletionTask)
 
 
 load_defaults()


### PR DESCRIPTION
`ModelDeletionTask` follows relations so additional Widget and WidgetDataSource did not originally need to be included. It is the `BulkModelDeletionTask`, that does not. It is not clear to me when to use which, but this currently deletes successfully. 