### PR TITLE
fix(banner): Swap out check using onboardingTask with checking projects array

### DIFF
--- a/src/sentry/static/sentry/app/components/installPromptBanner.jsx
+++ b/src/sentry/static/sentry/app/components/installPromptBanner.jsx
@@ -41,10 +41,7 @@ const InstallPromptBanner = createReactClass({
 
   sentFirstEvent() {
     let {projects} = this.props.organization;
-    let hasFirstEvent = projects.find(
-      project => project.firstEvent && project.firstEvent !== null
-    );
-    return hasFirstEvent !== undefined;
+    return !!projects.find(project => project.firstEvent);
   },
 
   getUrl() {

--- a/src/sentry/static/sentry/app/components/installPromptBanner.jsx
+++ b/src/sentry/static/sentry/app/components/installPromptBanner.jsx
@@ -20,14 +20,13 @@ const InstallPromptBanner = createReactClass({
 
   getInitialState() {
     return {
-      sentFirstEvent: false,
+      sentFirstEvent: this.sentFirstEvent(),
     };
   },
 
   componentDidMount() {
     let {href} = window.location;
     let {organization} = this.props;
-    this.sentFirstEvent();
     analytics('install_prompt.banner_viewed', {
       org_id: parseInt(organization.id, 10),
       page: href,
@@ -42,8 +41,10 @@ const InstallPromptBanner = createReactClass({
 
   sentFirstEvent() {
     let {projects} = this.props.organization;
-    let hasFirstEvent = projects.find(project => project.firstEvent !== null);
-    hasFirstEvent && this.setState({sentFirstEvent: true});
+    let hasFirstEvent = projects.find(
+      project => project.firstEvent && project.firstEvent !== null
+    );
+    return hasFirstEvent !== undefined;
   },
 
   getUrl() {

--- a/src/sentry/static/sentry/app/components/installPromptBanner.jsx
+++ b/src/sentry/static/sentry/app/components/installPromptBanner.jsx
@@ -41,11 +41,9 @@ const InstallPromptBanner = createReactClass({
   },
 
   sentFirstEvent() {
-    let {onboardingTasks} = this.props.organization;
-    let firstEventTask = onboardingTasks.find(task => task.task === 2);
-    this.setState({
-      sentFirstEvent: firstEventTask && firstEventTask.status === 'complete',
-    });
+    let {projects} = this.props.organization;
+    let hasFirstEvent = projects.find(project => project.firstEvent !== null);
+    hasFirstEvent && this.setState({sentFirstEvent: true});
   },
 
   getUrl() {

--- a/tests/acceptance/test_project_overview.py
+++ b/tests/acceptance/test_project_overview.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from django.utils import timezone
 
 from sentry.testutils import AcceptanceTestCase
-from sentry.models import OrganizationOnboardingTask, OnboardingTask, OnboardingTaskStatus
 
 
 class ProjectOverviewTest(AcceptanceTestCase):
@@ -28,11 +27,6 @@ class ProjectOverviewTest(AcceptanceTestCase):
         self.create_group(
             project=self.project,
             message='Foo bar',
-        )
-        OrganizationOnboardingTask.objects.create_or_update(
-            organization_id=self.project.organization_id,
-            task=OnboardingTask.FIRST_EVENT,
-            status=OnboardingTaskStatus.COMPLETE,
         )
         self.browser.get(self.path)
         self.browser.wait_until('.chart-wrapper')

--- a/tests/acceptance/test_project_releases.py
+++ b/tests/acceptance/test_project_releases.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 
+from django.utils import timezone
+
 from sentry.testutils import AcceptanceTestCase
-from sentry.models import OrganizationOnboardingTask, OnboardingTask, OnboardingTaskStatus
 
 
 class ProjectReleasesTest(AcceptanceTestCase):
@@ -31,11 +32,7 @@ class ProjectReleasesTest(AcceptanceTestCase):
             project=self.project,
             message='Foo bar',
         )
-        OrganizationOnboardingTask.objects.create_or_update(
-            organization_id=self.project.organization_id,
-            task=OnboardingTask.FIRST_EVENT,
-            status=OnboardingTaskStatus.COMPLETE,
-        )
+        self.project.update(first_event=timezone.now())
         self.browser.get(self.path)
         self.browser.wait_until_not('.loading')
         self.browser.wait_until('.ref-project-releases')
@@ -60,6 +57,7 @@ class ProjectReleaseDetailsTest(AcceptanceTestCase):
             organization=self.org,
             teams=[self.team],
             name='Bengal',
+            first_event=timezone.now(),
         )
         self.release = self.create_release(
             project=self.project,
@@ -69,11 +67,6 @@ class ProjectReleaseDetailsTest(AcceptanceTestCase):
             first_release=self.release,
             project=self.project,
             message='Foo bar',
-        )
-        OrganizationOnboardingTask.objects.create_or_update(
-            organization_id=self.project.organization_id,
-            task=OnboardingTask.FIRST_EVENT,
-            status=OnboardingTaskStatus.COMPLETE,
         )
         self.login_as(self.user)
         self.path = u'/{}/{}/releases/{}/'.format(

--- a/tests/acceptance/test_project_user_feedback.py
+++ b/tests/acceptance/test_project_user_feedback.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from django.utils import timezone
 
 from sentry.testutils import AcceptanceTestCase
-from sentry.models import OrganizationOnboardingTask, OnboardingTask, OnboardingTaskStatus
 
 
 class ProjectUserFeedbackTest(AcceptanceTestCase):
@@ -28,11 +27,6 @@ class ProjectUserFeedbackTest(AcceptanceTestCase):
         self.create_group(
             project=self.project,
             message='Foo bar',
-        )
-        OrganizationOnboardingTask.objects.create_or_update(
-            organization_id=self.project.organization_id,
-            task=OnboardingTask.FIRST_EVENT,
-            status=OnboardingTaskStatus.COMPLETE,
         )
         self.create_userreport(group=self.group, project=self.project, event=self.event)
         self.browser.get(self.path)

--- a/tests/js/spec/components/installPromptBanner.spec.jsx
+++ b/tests/js/spec/components/installPromptBanner.spec.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import InstallPromptBanner from 'app/components/installPromptBanner';
+
+describe('InstallPromptBanner', function() {
+  it('renders', function() {
+    let project1 = TestStubs.Project();
+    let project2 = TestStubs.Project({firstEvent: null});
+    let organization = TestStubs.Organization({projects: [project1, project2]});
+    let wrapper = shallow(
+      <InstallPromptBanner organization={organization} />,
+      TestStubs.routerContext()
+    );
+    expect(wrapper.find('StyledAlert').exists()).toBe(true);
+    expect(wrapper.find('a').text()).toContain('Start capturing errors');
+  });
+
+  it('does not render if first event sent', function() {
+    let project1 = TestStubs.Project();
+    let project2 = TestStubs.Project({firstEvent: '2018-03-18'});
+    let organization = TestStubs.Organization({projects: [project1, project2]});
+    let wrapper = shallow(
+      <InstallPromptBanner organization={organization} />,
+      TestStubs.routerContext()
+    );
+    expect(wrapper.find('StyledAlert').exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
Not sure why but there are cases where the `FirstEvent` `OrganizationOnboardingTask` does not get saved to the db but the org has at least one project with `FirstEvent`. This PR shifts the check to look through the org projects array instead while we dig into whatever is causing the issue with the `Task`.