### PR TITLE
feat(ui): Change UTC default to use user preference (APP-858)

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/baseChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/baseChart.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import ReactEchartsCore from 'echarts-for-react/lib/core';
 import echarts from 'echarts/lib/echarts';
 
-import {DEFAULT_USE_UTC} from 'app/constants';
 import SentryTypes from 'app/sentryTypes';
 import theme from 'app/utils/theme';
 
@@ -135,7 +134,6 @@ class BaseChart extends React.Component {
     yAxis: {},
     isGroupedByDate: false,
     interval: 'day',
-    utc: DEFAULT_USE_UTC,
   };
 
   handleChartReady = (...args) => {
@@ -209,6 +207,7 @@ class BaseChart extends React.Component {
         }}
         option={{
           ...options,
+          useUTC: utc,
           color: colors || this.getColorPalette(),
           grid: Grid(grid),
           tooltip:

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
@@ -157,7 +157,10 @@ class TimeRangeSelector extends React.PureComponent {
   };
 
   handleUseUtc = () => {
-    const {onChange, start, end} = this.props;
+    let {onChange, start, end} = this.props;
+
+    start = start || this.state.start;
+    end = end || this.state.end;
 
     this.setState(state => {
       const utc = !state.utc;

--- a/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
+++ b/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
@@ -2,19 +2,24 @@ import {isEqual} from 'lodash';
 import Reflux from 'reflux';
 
 import {DATE_TIME} from 'app/components/organizations/globalSelectionHeader/constants';
-import {DEFAULT_STATS_PERIOD, DEFAULT_USE_UTC} from 'app/constants';
+import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import {isEqualWithDates} from 'app/utils/isEqualWithDates';
+import ConfigStore from 'app/stores/configStore';
 import GlobalSelectionActions from 'app/actions/globalSelectionActions';
 
-const DEFAULT_SELECTION = {
-  projects: [],
-  environments: [],
-  datetime: {
-    [DATE_TIME.START]: null,
-    [DATE_TIME.END]: null,
-    [DATE_TIME.PERIOD]: DEFAULT_STATS_PERIOD,
-    [DATE_TIME.UTC]: DEFAULT_USE_UTC,
-  },
+const getDefaultSelection = () => {
+  const user = ConfigStore.get('user');
+
+  return {
+    projects: [],
+    environments: [],
+    datetime: {
+      [DATE_TIME.START]: null,
+      [DATE_TIME.END]: null,
+      [DATE_TIME.PERIOD]: DEFAULT_STATS_PERIOD,
+      [DATE_TIME.UTC]: user?.options?.timezone === 'UTC' ? true : undefined,
+    },
+  };
 };
 
 /**
@@ -30,7 +35,7 @@ const GlobalSelectionStore = Reflux.createStore({
   },
 
   reset(state) {
-    this.selection = state || DEFAULT_SELECTION;
+    this.selection = state || getDefaultSelection();
   },
 
   get() {

--- a/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/discover.jsx
@@ -51,6 +51,11 @@ export default class OrganizationDiscover extends React.Component {
     view: PropTypes.oneOf(['query', 'saved']),
     toggleEditMode: PropTypes.func.isRequired,
     isLoading: PropTypes.bool.isRequired,
+    utc: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    utc: true,
   };
 
   constructor(props) {
@@ -347,6 +352,7 @@ export default class OrganizationDiscover extends React.Component {
       savedQuery,
       toggleEditMode,
       isLoading,
+      utc,
     } = this.props;
 
     const currentQuery = queryBuilder.getInternal();
@@ -404,7 +410,7 @@ export default class OrganizationDiscover extends React.Component {
           relative={currentQuery.range}
           start={start}
           end={end}
-          utc={true}
+          utc={utc}
           showEnvironmentSelector={false}
           onChangeProjects={this.updateProjects}
           onUpdateProjects={this.runQuery}
@@ -416,6 +422,7 @@ export default class OrganizationDiscover extends React.Component {
           <BodyContent>
             {shouldDisplayResult && (
               <Result
+                utc={utc}
                 data={data}
                 savedQuery={savedQuery}
                 onToggleEdit={toggleEditMode}

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
@@ -44,6 +44,7 @@ class Result extends React.Component {
     savedQuery: SentryTypes.DiscoverSavedQuery, // Provided if it's a saved search
     onFetchPage: PropTypes.func.isRequired,
     onToggleEdit: PropTypes.func,
+    utc: PropTypes.bool,
   };
 
   constructor(props) {
@@ -187,7 +188,7 @@ class Result extends React.Component {
   }
 
   render() {
-    const {data: {baseQuery, byDayQuery}, savedQuery, onFetchPage} = this.props;
+    const {data: {baseQuery, byDayQuery}, savedQuery, onFetchPage, utc} = this.props;
 
     const {view} = this.state;
 
@@ -255,6 +256,7 @@ class Result extends React.Component {
                 legend={legendData}
                 renderer="canvas"
                 isGroupedByDate={true}
+                utc={utc}
               />
               {this.renderNote()}
             </ChartWrapper>
@@ -269,6 +271,7 @@ class Result extends React.Component {
                 legend={legendData}
                 renderer="canvas"
                 isGroupedByDate={true}
+                utc={utc}
               />
               {this.renderNote()}
             </ChartWrapper>

--- a/src/sentry/static/sentry/app/views/organizationEvents/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/eventsChart.jsx
@@ -15,10 +15,11 @@ class EventsChart extends React.Component {
   static propTypes = {
     period: PropTypes.string,
     query: PropTypes.string,
+    utc: PropTypes.bool,
   };
 
   render() {
-    const {period, query} = this.props;
+    const {period, utc, query} = this.props;
 
     return (
       <ChartZoom {...this.props}>
@@ -35,6 +36,7 @@ class EventsChart extends React.Component {
               return (
                 <LineChart
                   {...zoomRenderProps}
+                  utc={utc}
                   series={timeseriesData}
                   seriesOptions={{
                     showSymbol: false,

--- a/tests/js/spec/components/organizations/timeRangeSelector/index.spec.jsx
+++ b/tests/js/spec/components/organizations/timeRangeSelector/index.spec.jsx
@@ -139,6 +139,38 @@ describe('TimeRangeSelector', function() {
     });
   });
 
+  it('switches from relative to absolute and then toggling UTC', async function() {
+    wrapper = createWrapper({
+      relative: '7d',
+      utc: true,
+    });
+    await wrapper.find('HeaderItem').simulate('click');
+
+    wrapper.find('SelectorItem[value="absolute"]').simulate('click');
+    expect(onChange).toHaveBeenCalledWith({
+      relative: null,
+      start: new Date('2017-10-10T02:41:20.000Z'),
+      end: new Date('2017-10-17T02:41:20.000Z'),
+      utc: true,
+    });
+
+    wrapper.find('UtcPicker Checkbox').simulate('change');
+    expect(onChange).toHaveBeenLastCalledWith({
+      relative: null,
+      start: new Date('2017-10-10T06:41:20.000Z'),
+      end: new Date('2017-10-17T06:41:20.000Z'),
+      utc: false,
+    });
+
+    wrapper.find('UtcPicker Checkbox').simulate('change');
+    expect(onChange).toHaveBeenLastCalledWith({
+      relative: null,
+      start: new Date('2017-10-10T02:41:20.000Z'),
+      end: new Date('2017-10-17T02:41:20.000Z'),
+      utc: true,
+    });
+  });
+
   it('maintains time when switching UTC to local time', async function() {
     let state;
     wrapper = createWrapper({


### PR DESCRIPTION
This changes the `<GlobalSelectionHeader>` to use user preference for default UTC param. Discover does not support UTC switching (even though it is in the absolute date checker), so pass `utc=true` as default to charts in Discover to maintain its current functionality.

Additionally, we pass `echarts` the `useUTC` prop so that in the future, if we use their `time` axes, the dates won't be wrong.

This partially addresses [APP-858](https://getsentry.atlassian.net/browse/APP-858).