### PR TITLE
ref(ui): Eliminate implicit jQuery usage

### DIFF
--- a/src/sentry/static/sentry/app/components/contextData.jsx
+++ b/src/sentry/static/sentry/app/components/contextData.jsx
@@ -1,6 +1,6 @@
+import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
-import jQuery from 'jquery';
 import _ from 'lodash';
 
 import {isUrl} from 'app/utils';
@@ -81,7 +81,7 @@ class ContextData extends React.Component {
 
   renderValue = value => {
     function toggle(evt) {
-      jQuery(evt.target)
+      $(evt.target)
         .parent()
         .toggleClass('val-toggle-open');
       evt.preventDefault();

--- a/src/sentry/static/sentry/app/components/customResolutionModal.jsx
+++ b/src/sentry/static/sentry/app/components/customResolutionModal.jsx
@@ -1,7 +1,7 @@
+import $ from 'jquery';
+import Modal, {Header, Body, Footer} from 'react-bootstrap/lib/Modal';
 import PropTypes from 'prop-types';
 import React from 'react';
-import jQuery from 'jquery';
-import Modal, {Header, Body, Footer} from 'react-bootstrap/lib/Modal';
 
 import {SelectAsyncField} from 'app/components/forms';
 import {t} from 'app/locale';
@@ -26,7 +26,7 @@ export default class CustomResolutionModal extends React.Component {
   componentDidUpdate(prevProps, prevState) {
     if (!prevProps.show && this.props.show) {
       // XXX(cramer): this is incorrect but idgaf
-      jQuery('.modal').attr('tabindex', null);
+      $('.modal').attr('tabindex', null);
     }
   }
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/utils.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/utils.jsx
@@ -1,5 +1,6 @@
 import {isString} from 'lodash';
 import * as Sentry from '@sentry/browser';
+import queryString from 'query-string';
 
 import {defined} from 'app/utils';
 
@@ -38,7 +39,7 @@ export function getCurlCommand(data) {
         result += ' \\\n --data "' + escapeQuotes(JSON.stringify(data.data)) + '"';
         break;
       case 'application/x-www-form-urlencoded':
-        result += ' \\\n --data "' + escapeQuotes(jQuery.param(data.data)) + '"';
+        result += ' \\\n --data "' + escapeQuotes(queryString.stringify(data.data)) + '"';
         break;
       default:
         if (isString(data.data)) {

--- a/src/sentry/static/sentry/app/components/forms/inputField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/inputField.jsx
@@ -1,7 +1,8 @@
-import jQuery from 'jquery';
+import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
+
 import FormField from 'app/components/forms/formField';
 
 export default class InputField extends FormField {
@@ -17,16 +18,16 @@ export default class InputField extends FormField {
 
   componentWillUnmount() {
     this.removeTooltips();
-    jQuery(ReactDOM.findDOMNode(this)).unbind();
+    $(ReactDOM.findDOMNode(this)).unbind();
     super.componentWillUnmount();
   }
 
   attachTooltips() {
-    jQuery('.tip', ReactDOM.findDOMNode(this)).tooltip();
+    $('.tip', ReactDOM.findDOMNode(this)).tooltip();
   }
 
   removeTooltips() {
-    jQuery('.tip', ReactDOM.findDOMNode(this)).tooltip('destroy');
+    $('.tip', ReactDOM.findDOMNode(this)).tooltip('destroy');
   }
 
   getAttributes() {

--- a/src/sentry/static/sentry/app/components/forms/rangeField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/rangeField.jsx
@@ -1,5 +1,5 @@
+import $ from 'jquery';
 import PropTypes from 'prop-types';
-import jQuery from 'jquery';
 import ReactDOM from 'react-dom';
 
 import InputField from 'app/components/forms/inputField';
@@ -40,12 +40,12 @@ export default class RangeField extends InputField {
   }
 
   attachSlider() {
-    let $value = jQuery('<span class="value" />');
+    let $value = $('<span class="value" />');
     let suffixClassNames = '';
     if (this.props.disabled) {
       suffixClassNames += ' disabled';
     }
-    jQuery(ReactDOM.findDOMNode(this.refs.input))
+    $(ReactDOM.findDOMNode(this.refs.input))
       .on('slider:ready', (e, data) => {
         let value = parseInt(data.value, 10);
         $value.appendTo(data.el);

--- a/src/sentry/static/sentry/app/components/narrowLayout.jsx
+++ b/src/sentry/static/sentry/app/components/narrowLayout.jsx
@@ -1,4 +1,4 @@
-import jQuery from 'jquery';
+import $ from 'jquery';
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -14,12 +14,12 @@ class NarrowLayout extends React.Component {
 
   componentWillMount() {
     this.api = new Client();
-    jQuery(document.body).addClass('narrow');
+    $(document.body).addClass('narrow');
   }
 
   componentWillUnmount() {
     this.api.clear();
-    jQuery(document.body).removeClass('narrow');
+    $(document.body).removeClass('narrow');
   }
 
   handleLogout = () => {

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -1,31 +1,32 @@
+import $ from 'jquery';
+import {ThemeProvider} from 'emotion-theming';
 import {isEqual, pick} from 'lodash';
 import {withRouter, browserHistory} from 'react-router';
-import {ThemeProvider} from 'emotion-theming';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 import styled, {css, cx} from 'react-emotion';
 
+import {URL_PARAM} from 'app/components/organizations/globalSelectionHeader/constants';
 import {hideSidebar, showSidebar} from 'app/actionCreators/preferences';
 import {load as loadIncidents} from 'app/actionCreators/incidents';
 import {t} from 'app/locale';
 import ConfigStore from 'app/stores/configStore';
-import InlineSvg from 'app/components/inlineSvg';
 import Feature from 'app/components/acl/feature';
-import SentryTypes from 'app/sentryTypes';
+import InlineSvg from 'app/components/inlineSvg';
 import PreferencesStore from 'app/stores/preferencesStore';
-import theme from 'app/utils/theme';
+import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
+import theme from 'app/utils/theme';
 import withLatestContext from 'app/utils/withLatestContext';
-import {URL_PARAM} from 'app/components/organizations/globalSelectionHeader/constants';
 
 import Broadcasts from './broadcasts';
 import Incidents from './incidents';
+import OnboardingStatus from './onboardingStatus';
 import SidebarDropdown from './sidebarDropdown';
 import SidebarHelp from './help';
 import SidebarItem from './sidebarItem';
-import OnboardingStatus from './onboardingStatus';
 
 class Sidebar extends React.Component {
   static propTypes = {
@@ -52,8 +53,8 @@ class Sidebar extends React.Component {
 
   componentDidMount() {
     let {router} = this.props;
-    jQuery(document.body).addClass('body-sidebar');
-    jQuery(document).on('click', this.documentClickHandler);
+    $(document.body).addClass('body-sidebar');
+    $(document).on('click', this.documentClickHandler);
 
     loadIncidents();
 
@@ -99,8 +100,8 @@ class Sidebar extends React.Component {
   }
 
   componentWillUnmount() {
-    jQuery(document).off('click', this.documentClickHandler);
-    jQuery(document.body).removeClass('body-sidebar');
+    $(document).off('click', this.documentClickHandler);
+    $(document.body).removeClass('body-sidebar');
 
     if (this.mq) {
       this.mq.removeListener(this.handleMediaQueryChange);
@@ -115,9 +116,9 @@ class Sidebar extends React.Component {
 
   doCollapse(collapsed) {
     if (collapsed) {
-      jQuery(document.body).addClass('collapsed');
+      $(document.body).addClass('collapsed');
     } else {
-      jQuery(document.body).removeClass('collapsed');
+      $(document.body).removeClass('collapsed');
     }
   }
 

--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
-import jQuery from 'jquery';
+import $ from 'jquery';
 import styled from 'react-emotion';
 
 import {PanelItem} from 'app/components/panels';
@@ -79,7 +79,7 @@ const StreamGroup = createReactClass({
   toggleSelect(evt) {
     if (evt.target.tagName === 'A') return;
     if (evt.target.tagName === 'INPUT') return;
-    if (jQuery(evt.target).parents('a').length !== 0) return;
+    if ($(evt.target).parents('a').length !== 0) return;
 
     SelectedGroupStore.toggleSelect(this.state.data.id);
   },

--- a/src/sentry/static/sentry/app/stores/eventStore.jsx
+++ b/src/sentry/static/sentry/app/stores/eventStore.jsx
@@ -1,4 +1,4 @@
-import jQuery from 'jquery';
+import $ from 'jquery';
 import Reflux from 'reflux';
 import _ from 'lodash';
 
@@ -37,7 +37,7 @@ const EventStore = Reflux.createStore({
 
     items.forEach((item, idx) => {
       if (itemsById[item.id]) {
-        this.items[idx] = jQuery.extend(true, {}, item, itemsById[item.id]);
+        this.items[idx] = $.extend(true, {}, item, itemsById[item.id]);
         delete itemsById[item.id];
       }
     });

--- a/src/sentry/static/sentry/app/utils/getCookie.jsx
+++ b/src/sentry/static/sentry/app/utils/getCookie.jsx
@@ -3,7 +3,7 @@ export default function getCookie(name) {
   if (document.cookie && document.cookie !== '') {
     let cookies = document.cookie.split(';');
     for (let i = 0; i < cookies.length; i++) {
-      let cookie = jQuery.trim(cookies[i]);
+      let cookie = cookies[i].trim();
       // Does this cookie string begin with the name we want?
       if (cookie.substring(0, name.length + 1) == name + '=') {
         cookieValue = decodeURIComponent(cookie.substring(name.length + 1));

--- a/src/sentry/static/sentry/app/views/groupDetails/project/groupMerged/index.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/project/groupMerged/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
+import createReactClass from 'create-react-class';
+import queryString from 'query-string';
 
 import {t} from 'app/locale';
 import ApiMixin from 'app/mixins/apiMixin';
@@ -63,7 +64,7 @@ const GroupMergedView = createReactClass({
       query: this.state.query,
     };
 
-    return `/issues/${params.groupId}/${type}/?${jQuery.param(queryParams)}`;
+    return `/issues/${params.groupId}/${type}/?${queryString.stringify(queryParams)}`;
   },
 
   fetchData() {

--- a/src/sentry/static/sentry/app/views/groupDetails/project/groupSimilar/index.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/project/groupSimilar/index.jsx
@@ -1,8 +1,9 @@
+import {browserHistory} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
-import {browserHistory} from 'react-router';
 import Reflux from 'reflux';
+import createReactClass from 'create-react-class';
+import queryString from 'query-string';
 
 import {t} from 'app/locale';
 import GroupingActions from 'app/actions/groupingActions';
@@ -10,6 +11,7 @@ import GroupingStore from 'app/stores/groupingStore';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import ProjectState from 'app/mixins/projectState';
+
 import SimilarList from './similarList';
 
 const GroupGroupingView = createReactClass({
@@ -75,7 +77,7 @@ const GroupGroupingView = createReactClass({
       ...this.props.location.query,
       limit: 50,
     };
-    return `/issues/${params.groupId}/${type}/?${jQuery.param(queryParams)}`;
+    return `/issues/${params.groupId}/${type}/?${queryString.stringify(queryParams)}`;
   },
 
   fetchData() {

--- a/src/sentry/static/sentry/app/views/installWizard.jsx
+++ b/src/sentry/static/sentry/app/views/installWizard.jsx
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 import DocumentTitle from 'react-document-title';
@@ -15,12 +16,12 @@ export default class InstallWizard extends AsyncView {
 
   componentWillMount() {
     super.componentWillMount();
-    jQuery(document.body).addClass('install-wizard');
+    $(document.body).addClass('install-wizard');
   }
 
   componentWillUnmount() {
     super.componentWillUnmount();
-    jQuery(document.body).removeClass('install-wizard');
+    $(document.body).removeClass('install-wizard');
   }
 
   getEndpoints() {

--- a/src/sentry/static/sentry/app/views/newsletterConsent.jsx
+++ b/src/sentry/static/sentry/app/views/newsletterConsent.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import $ from 'jquery';
 import PropTypes from 'prop-types';
-import jQuery from 'jquery';
+import React from 'react';
 import createReactClass from 'create-react-class';
 
 import {ApiForm, RadioBooleanField} from 'app/components/forms';
@@ -14,11 +14,11 @@ export default createReactClass({
   },
 
   componentWillMount() {
-    jQuery(document.body).addClass('auth');
+    $(document.body).addClass('auth');
   },
 
   componentWillUnmount() {
-    jQuery(document.body).removeClass('auth');
+    $(document.body).removeClass('auth');
   },
 
   onSubmitSuccess() {

--- a/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {Flex} from 'grid-emotion';
 import {browserHistory} from 'react-router';
 import DocumentTitle from 'react-document-title';
-import jQuery from 'jquery';
+import $ from 'jquery';
 import SentryTypes from 'app/sentryTypes';
 
 import {updateProjects, updateDateTime} from 'app/actionCreators/globalSelection';
@@ -69,7 +69,7 @@ class OrganizationDiscoverContainer extends React.Component {
   }
 
   componentDidMount() {
-    jQuery(document.body).addClass('body-discover');
+    $(document.body).addClass('body-discover');
 
     const {savedQueryId} = this.props.params;
 
@@ -101,7 +101,7 @@ class OrganizationDiscoverContainer extends React.Component {
   }
 
   componentWillUnmount() {
-    jQuery(document.body).removeClass('body-discover');
+    $(document.body).removeClass('body-discover');
   }
 
   loadTags = () => {

--- a/src/sentry/static/sentry/app/views/projectDashboard/eventList.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/eventList.jsx
@@ -1,13 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import jQuery from 'jquery';
-import SentryTypes from 'app/sentryTypes';
+import queryString from 'query-string';
+
+import {Panel, PanelHeader, PanelBody} from 'app/components/panels';
+import {t, tct} from 'app/locale';
 import ApiMixin from 'app/mixins/apiMixin';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
-import {t, tct} from 'app/locale';
-import {Panel, PanelHeader, PanelBody} from 'app/components/panels';
+import SentryTypes from 'app/sentryTypes';
 
 import EventNode from './eventNode';
 
@@ -61,7 +62,9 @@ const EventList = createReactClass({
       qs.query = `${qs.query} environment:${environment.name}`;
     }
 
-    return `/projects/${params.orgId}/${params.projectId}/issues/?${jQuery.param(qs)}`;
+    return `/projects/${params.orgId}/${params.projectId}/issues/?${queryString.stringify(
+      qs
+    )}`;
   },
 
   getMinutes() {

--- a/src/sentry/static/sentry/app/views/sharedGroupDetails/index.jsx
+++ b/src/sentry/static/sentry/app/views/sharedGroupDetails/index.jsx
@@ -1,7 +1,7 @@
 import DocumentTitle from 'react-document-title';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import {t} from 'app/locale';
 import ApiMixin from 'app/mixins/apiMixin';
@@ -38,11 +38,11 @@ const SharedGroupDetails = createReactClass({
 
   componentWillMount() {
     this.fetchData();
-    jQuery(document.body).addClass('shared-group');
+    $(document.body).addClass('shared-group');
   },
 
   componentWillUnmount() {
-    jQuery(document.body).removeClass('shared-group');
+    $(document.body).removeClass('shared-group');
   },
 
   getTitle() {

--- a/tests/js/spec/components/dropdownLink.spec.jsx
+++ b/tests/js/spec/components/dropdownLink.spec.jsx
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import React from 'react';
 
 import {mount} from 'enzyme';
@@ -128,7 +129,7 @@ describe('DropdownLink', function() {
       });
 
       it('does not close when document is clicked', function() {
-        jQuery(document).click();
+        $(document).click();
         // State does not change
         expect(wrapper.find('.dropdown-menu')).toHaveLength(1);
       });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -233,25 +233,39 @@ const appConfig = {
     ],
   },
   plugins: [
+    /**
+     * Used to make our lodash modules even smaller
+     */
     new LodashModuleReplacementPlugin({
       collections: true,
       currying: true, // these are enabled to support lodash/fp/ features
       flattening: true, // used by a dependency of react-mentions
       shorthands: true,
     }),
-    new webpack.ProvidePlugin({
-      $: 'jquery',
-      jQuery: 'jquery',
-      'window.jQuery': 'jquery',
-      'root.jQuery': 'jquery',
-    }),
+    /**
+     * jQuery must be provided in the global scope specifically and only for
+     * bootstrap, as it will not import jQuery itself.
+     *
+     * We discourage the use of global jQuery through eslint rules
+     */
+    new webpack.ProvidePlugin({jQuery: 'jquery'}),
+    /**
+     * Extract CSS into separate files.
+     */
     new ExtractTextPlugin(),
+    /**
+     * Defines environemnt specific flags.
+     */
     new webpack.DefinePlugin({
       'process.env': {
         NODE_ENV: JSON.stringify(env.NODE_ENV),
         IS_PERCY: JSON.stringify(env.CI && !!env.PERCY_TOKEN && !!env.TRAVIS),
       },
     }),
+    /**
+     * See above for locale chunks. These plugins help with that
+     * funcationality.
+     */
     new OptionalLocaleChunkPlugin(),
     ...localeRestrictionPlugins,
   ],


### PR DESCRIPTION
Reopening of #11472 

Ensurers jQuery is imported as '$' when it is used. Do not support implicitly using jQuery within modles

Removes some usage of jQuery.parmas.

It's important to note that jQuery is *still* made available on the `window` as it is exported by the sentry app/index entrypoint.