### PR TITLE
fix(api): Fix has_more in ProcessingIssue.objects.find_resolved

### DIFF
--- a/src/sentry/models/processingissue.py
+++ b/src/sentry/models/processingissue.py
@@ -73,7 +73,7 @@ class ProcessingIssueManager(BaseManager):
         if there are more.
         """
         from sentry.models import RawEvent
-        rv = list(self.find_resolved_queryset([project_id])[:limit])
+        rv = list(self.find_resolved_queryset([project_id]).order_by('id')[:limit + 1])
         if len(rv) > limit:
             rv = rv[:limit]
             has_more = True

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -28,10 +28,12 @@ from sentry.event_manager import EventManager
 from sentry.constants import SentryAppStatus
 from sentry.mediators import sentry_apps, sentry_app_installations, service_hooks
 from sentry.models import (
-    Activity, Environment, Event, EventError, EventMapping, Group, Organization, OrganizationMember,
-    OrganizationMemberTeam, Project, ProjectBookmark, Team, User, UserEmail, Release, Commit, ReleaseCommit,
-    CommitAuthor, Repository, CommitFileChange, ProjectDebugFile, File, UserPermission, EventAttachment,
-    UserReport
+    Activity, Commit, CommitAuthor, CommitFileChange, Environment, Event,
+    EventAttachment, EventError, EventMapping, EventProcessingIssue, File,
+    Group, Organization, OrganizationMember, OrganizationMemberTeam,
+    ProcessingIssue, Project, ProjectBookmark, ProjectDebugFile, RawEvent,
+    Release, ReleaseCommit, Repository, Team, User, UserEmail, UserPermission,
+    UserReport,
 )
 from sentry.utils.canonical import CanonicalKeyDict
 
@@ -778,3 +780,26 @@ class Fixtures(object):
         )
 
         return userreport
+
+    def create_raw_event(self, **kwargs):
+        return RawEvent.objects.create(
+            project=kwargs.get('project', self.project),
+            event_id=kwargs.get('event_id', petname.Generate(1, '', letters=10).title()),
+        )
+
+    def create_processing_issue(self, **kwargs):
+        return ProcessingIssue.objects.create(
+            project=kwargs.get('project', self.project),
+            checksum=kwargs.get('checksum', petname.Generate(1, '', letters=20).title()),
+            type=kwargs.get('type', EventError.NATIVE_MISSING_DSYM),
+        )
+
+    def create_event_processing_issue(self, raw_event=None, processing_issue=None):
+        if raw_event is None:
+            raw_event = self.create_raw_event()
+        if processing_issue is None:
+            processing_issue = self.create_processing_issue()
+        return EventProcessingIssue.objects.create(
+            raw_event=raw_event,
+            processing_issue=processing_issue,
+        )

--- a/tests/sentry/models/test_processingissue.py
+++ b/tests/sentry/models/test_processingissue.py
@@ -25,3 +25,27 @@ class ProcessingIssueTest(TestCase):
         issue.delete()
 
         assert EventProcessingIssue.objects.count() == 0
+
+
+class FindResolvedTest(TestCase):
+    def test_has_processing_issues(self):
+        results, has_more = ProcessingIssue.objects.find_resolved(self.project.id)
+        assert results == []
+        assert not has_more
+
+        self.create_event_processing_issue(
+            raw_event=self.create_raw_event(),
+            processing_issue=self.create_processing_issue(),
+        )
+        results, has_more = ProcessingIssue.objects.find_resolved(self.project.id)
+        assert results == []
+        assert not has_more
+
+    def test_has_more(self):
+        raw_events = [self.create_raw_event() for _ in xrange(3)]
+        results, has_more = ProcessingIssue.objects.find_resolved(self.project.id, limit=2)
+        assert results == raw_events[:2]
+        assert has_more
+        results, has_more = ProcessingIssue.objects.find_resolved(self.project.id, limit=3)
+        assert results == raw_events
+        assert not has_more


### PR DESCRIPTION
Currently, the `has_more` boolean returned from this method is always False.
Just a small fix to make it work as expected.