### PR TITLE
feat(dashboard): Update discover query limits for widgets (APP-1008)

### DIFF
--- a/src/sentry/api/endpoints/organization_discover_query.py
+++ b/src/sentry/api/endpoints/organization_discover_query.py
@@ -44,7 +44,7 @@ class DiscoverQuerySerializer(serializers.Serializer):
         required=False,
         allow_null=True,
     )
-    limit = serializers.IntegerField(min_value=0, max_value=1000, required=False)
+    limit = serializers.IntegerField(min_value=0, max_value=10000, required=False)
     rollup = serializers.IntegerField(required=False)
     orderby = serializers.CharField(required=False)
     conditions = ListField(

--- a/src/sentry/static/sentry/app/views/organizationDashboard/data/queries/anonymousUsersAffected.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/data/queries/anonymousUsersAffected.jsx
@@ -5,7 +5,7 @@ const anonymousUsersAffectedQuery = {
   fields: [],
   conditions: [['user.email', 'IS NULL', null]],
   aggregations: [['count()', null, 'Anonymous Users']],
-  limit: 1000,
+  limit: 2000,
 
   orderby: '-time',
   groupby: ['time'],

--- a/src/sentry/static/sentry/app/views/organizationDashboard/data/queries/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/data/queries/events.jsx
@@ -5,7 +5,7 @@ const events = {
   fields: [],
   conditions: [],
   aggregations: [['count()', null, 'Events']],
-  limit: 1000,
+  limit: 2000,
 
   orderby: '-time',
   groupby: ['time'],

--- a/src/sentry/static/sentry/app/views/organizationDashboard/data/queries/eventsByRelease.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/data/queries/eventsByRelease.jsx
@@ -5,7 +5,7 @@ const eventsByRelease = {
   fields: ['sentry:release'],
   conditions: [],
   aggregations: [['count()', null, 'Events']],
-  limit: 1000,
+  limit: 2000,
 
   orderby: '-time',
   groupby: ['time'],

--- a/src/sentry/static/sentry/app/views/organizationDashboard/data/queries/handledVsUnhandled.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/data/queries/handledVsUnhandled.jsx
@@ -5,7 +5,7 @@ const handledVsUnhandledQuery = {
   fields: ['error.handled'],
   conditions: [],
   aggregations: [['count()', null, 'count']],
-  limit: 1000,
+  limit: 2000,
 
   orderby: '-time',
   groupby: ['time'],

--- a/src/sentry/static/sentry/app/views/organizationDashboard/data/queries/knownUsersAffected.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/data/queries/knownUsersAffected.jsx
@@ -5,7 +5,7 @@ const knownUsersAffectedQuery = {
   fields: [],
   conditions: [['user.email', 'IS NOT NULL', null]],
   aggregations: [['uniq', 'user.email', 'Known Users']],
-  limit: 1000,
+  limit: 2000,
 
   orderby: '-time',
   groupby: ['time'],

--- a/src/sentry/static/sentry/app/views/organizationDashboard/data/queries/topTransactions.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/data/queries/topTransactions.jsx
@@ -5,7 +5,7 @@ const eventsQuery = {
   fields: ['url'],
   conditions: [],
   aggregations: [['count()', null, 'count']],
-  limit: 1000,
+  limit: 2000,
 
   orderby: '-time',
   groupby: ['time'],

--- a/src/sentry/static/sentry/app/views/organizationDashboard/discoverQuery.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/discoverQuery.jsx
@@ -84,7 +84,7 @@ class DiscoverQuery extends React.Component {
     this.resetQueries();
 
     // Fetch
-    const promises = this.queryBuilders.map(builder => builder.fetchForWidget());
+    const promises = this.queryBuilders.map(builder => builder.fetchWithoutLimit());
     let results = await Promise.all(promises);
     let previousData = null;
     let data = null;

--- a/src/sentry/static/sentry/app/views/organizationDashboard/discoverQuery.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/discoverQuery.jsx
@@ -84,7 +84,7 @@ class DiscoverQuery extends React.Component {
     this.resetQueries();
 
     // Fetch
-    const promises = this.queryBuilders.map(builder => builder.fetch());
+    const promises = this.queryBuilders.map(builder => builder.fetchForWidget());
     let results = await Promise.all(promises);
     let previousData = null;
     let data = null;

--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -13,7 +13,7 @@ import MissingProjectWarningModal from './missingProjectWarningModal';
 import {COLUMNS, PROMOTED_TAGS, SPECIAL_TAGS} from './data';
 import {isValidAggregation} from './aggregations/utils';
 
-const WIDGET_LIMIT = 10000;
+const API_LIMIT = 10000;
 
 const DEFAULTS = {
   projects: [],
@@ -52,7 +52,7 @@ export default function createQueryBuilder(initial = {}, organization) {
     getExternal,
     updateField,
     fetch,
-    fetchForWidget,
+    fetchWithoutLimit,
     getQueryByType,
     getColumns,
     load,
@@ -212,10 +212,12 @@ export default function createQueryBuilder(initial = {}, organization) {
    * Fetches either the query provided as an argument or the current query state
    * if this is not provided and returns the result wrapped in a promise
    *
+   * This is similar to `fetch` but does not support pagination and mirrors the API limit
+   *
    * @param {Object} [data] Optional field to provide data to fetch
    * @returns {Promise<Object|Error>}
    */
-  function fetchForWidget(data = getExternal()) {
+  function fetchWithoutLimit(data = getExternal()) {
     const api = new Client();
     const endpoint = `/organizations/${organization.slug}/discover/query/`;
 
@@ -225,7 +227,7 @@ export default function createQueryBuilder(initial = {}, organization) {
     }
 
     if (typeof data.limit === 'number') {
-      if (data.limit < 1 || data.limit > WIDGET_LIMIT) {
+      if (data.limit < 1 || data.limit > API_LIMIT) {
         return Promise.reject(new Error(t('Invalid limit parameter')));
       }
     }

--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -13,6 +13,8 @@ import MissingProjectWarningModal from './missingProjectWarningModal';
 import {COLUMNS, PROMOTED_TAGS, SPECIAL_TAGS} from './data';
 import {isValidAggregation} from './aggregations/utils';
 
+const WIDGET_LIMIT = 10000;
+
 const DEFAULTS = {
   projects: [],
   fields: ['id', 'issue.id', 'project.name', 'platform', 'timestamp'],
@@ -50,6 +52,7 @@ export default function createQueryBuilder(initial = {}, organization) {
     getExternal,
     updateField,
     fetch,
+    fetchForWidget,
     getQueryByType,
     getColumns,
     load,
@@ -203,6 +206,37 @@ export default function createQueryBuilder(initial = {}, organization) {
       .catch(err => {
         throw new Error(t('An error occurred'));
       });
+  }
+
+  /**
+   * Fetches either the query provided as an argument or the current query state
+   * if this is not provided and returns the result wrapped in a promise
+   *
+   * @param {Object} [data] Optional field to provide data to fetch
+   * @returns {Promise<Object|Error>}
+   */
+  function fetchForWidget(data = getExternal()) {
+    const api = new Client();
+    const endpoint = `/organizations/${organization.slug}/discover/query/`;
+
+    // Reject immediately if no projects are available
+    if (!data.projects.length) {
+      return Promise.reject(new Error(t('No projects selected')));
+    }
+
+    if (typeof data.limit === 'number') {
+      if (data.limit < 1 || data.limit > WIDGET_LIMIT) {
+        return Promise.reject(new Error(t('Invalid limit parameter')));
+      }
+    }
+
+    if (moment.utc(data.start).isAfter(moment.utc(data.end))) {
+      return Promise.reject(new Error('Start date cannot be after end date'));
+    }
+
+    return api.requestPromise(endpoint, {method: 'POST', data}).catch(() => {
+      throw new Error(t('Error with query'));
+    });
   }
 
   /**

--- a/tests/js/spec/views/organizationDashboard/dashboard.spec.jsx
+++ b/tests/js/spec/views/organizationDashboard/dashboard.spec.jsx
@@ -34,7 +34,7 @@ describe('OrganizationDashboard', function() {
       body: TestStubs.Environments(),
     });
     discoverMock = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/discover/query/?per_page=1000&cursor=0:0:1',
+      url: '/organizations/org-slug/discover/query/',
       method: 'POST',
       body: {
         data: [],


### PR DESCRIPTION
This updates the limit for discover queries from 1000 to 10,000. However we restrict the discover UI itself to remain at 1,000.