### PR TITLE
fix: Don't discard event when breadcrumb level is not hashable

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -58,6 +58,7 @@ from sentry.utils.dates import to_timestamp
 from sentry.utils.db import is_postgres, is_mysql
 from sentry.utils.meta import Meta
 from sentry.utils.safe import ENABLE_TRIMMING, safe_execute, trim, trim_dict, get_path, set_path, setdefault_path
+from sentry.utils.sdk import capture_exception
 from sentry.utils.strings import truncatechars
 from sentry.utils.geo import rust_geoip
 from sentry.utils.validators import is_float
@@ -546,7 +547,12 @@ class EventManager(object):
                 meta.enter(k).add_error(EventError.INVALID_ATTRIBUTE)
                 continue
 
-            normalized = interface.normalize(value, meta.enter(k))
+            try:
+                normalized = interface.normalize(value, meta.enter(k))
+            except Exception:
+                capture_exception()
+                continue
+
             if normalized:
                 data[interface.path] = normalized
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -58,7 +58,6 @@ from sentry.utils.dates import to_timestamp
 from sentry.utils.db import is_postgres, is_mysql
 from sentry.utils.meta import Meta
 from sentry.utils.safe import ENABLE_TRIMMING, safe_execute, trim, trim_dict, get_path, set_path, setdefault_path
-from sentry.utils.sdk import capture_exception
 from sentry.utils.strings import truncatechars
 from sentry.utils.geo import rust_geoip
 from sentry.utils.validators import is_float
@@ -547,12 +546,7 @@ class EventManager(object):
                 meta.enter(k).add_error(EventError.INVALID_ATTRIBUTE)
                 continue
 
-            try:
-                normalized = interface.normalize(value, meta.enter(k))
-            except Exception:
-                capture_exception()
-                continue
-
+            normalized = interface.normalize(value, meta.enter(k))
             if normalized:
                 data[interface.path] = normalized
 

--- a/src/sentry/interfaces/breadcrumbs.py
+++ b/src/sentry/interfaces/breadcrumbs.py
@@ -15,6 +15,7 @@ import six
 from sentry.constants import LOG_LEVELS_MAP
 from sentry.interfaces.base import Interface, InterfaceValidationError, prune_empty_keys
 from sentry.utils.safe import get_path, trim
+from sentry.utils.sdk import capture_exception
 from sentry.utils.dates import to_timestamp, to_datetime, parse_timestamp
 
 
@@ -49,6 +50,8 @@ class Breadcrumbs(Interface):
                 # when one breadcrumb errors, but it'd be nice if we could still
                 # record an error
                 pass
+            except Exception:
+                capture_exception()
 
         return cls(values=values)
 

--- a/src/sentry/interfaces/breadcrumbs.py
+++ b/src/sentry/interfaces/breadcrumbs.py
@@ -15,7 +15,6 @@ import six
 from sentry.constants import LOG_LEVELS_MAP
 from sentry.interfaces.base import Interface, InterfaceValidationError, prune_empty_keys
 from sentry.utils.safe import get_path, trim
-from sentry.utils.sdk import capture_exception
 from sentry.utils.dates import to_timestamp, to_datetime, parse_timestamp
 
 
@@ -45,13 +44,11 @@ class Breadcrumbs(Interface):
 
             try:
                 values.append(cls.normalize_crumb(crumb))
-            except InterfaceValidationError:
+            except Exception:
                 # TODO(dcramer): we dont want to discard the entirety of data
                 # when one breadcrumb errors, but it'd be nice if we could still
                 # record an error
                 pass
-            except Exception:
-                capture_exception()
 
         return cls(values=values)
 

--- a/src/sentry/interfaces/breadcrumbs.py
+++ b/src/sentry/interfaces/breadcrumbs.py
@@ -74,7 +74,8 @@ class Breadcrumbs(Interface):
     def normalize_crumb(cls, crumb):
         ty = crumb.get('type') or 'default'
         level = crumb.get('level')
-        if level not in LOG_LEVELS_MAP and level != 'critical':
+        if not isinstance(level, six.string_types) or \
+           (level not in LOG_LEVELS_MAP and level != 'critical'):
             level = 'info'
 
         ts = parse_timestamp(crumb.get('timestamp'))


### PR DESCRIPTION
Fixes SENTRY-934