### PR TITLE
feat(issues) Hook assignee control up

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/members.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/members.jsx
@@ -1,8 +1,17 @@
 import MemberActions from 'app/actions/memberActions';
+import MemberListStore from 'app/stores/memberListStore';
 
 export function fetchOrgMembers(api, orgId) {
   let endpoint = `/organizations/${orgId}/users/`;
-  return api.requestPromise(endpoint, {method: 'GET'});
+  let promise = api.requestPromise(endpoint, {method: 'GET'});
+  return promise.then(members => {
+    members = members.filter(m => m.user);
+
+    // Update the store with just the users, as avatars rely on them.
+    MemberListStore.loadInitialData(members.map(m => m.user));
+
+    return members;
+  });
 }
 
 export function updateMember(api, params) {

--- a/src/sentry/static/sentry/app/actionCreators/members.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/members.jsx
@@ -1,5 +1,10 @@
 import MemberActions from 'app/actions/memberActions';
 
+export function fetchOrgMembers(api, orgId) {
+  let endpoint = `/organizations/${orgId}/users/`;
+  return api.requestPromise(endpoint, {method: 'GET'});
+}
+
 export function updateMember(api, params) {
   MemberActions.update(params.memberId, params.data);
 

--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -29,6 +29,7 @@ const StreamGroup = createReactClass({
     canSelect: PropTypes.bool,
     query: PropTypes.string,
     hasGuideAnchor: PropTypes.bool,
+    memberList: PropTypes.array,
   },
 
   mixins: [Reflux.listenTo(GroupStore, 'onGroupChange'), ProjectState],
@@ -86,7 +87,7 @@ const StreamGroup = createReactClass({
 
   render() {
     const {data} = this.state;
-    const {id, orgId, query, hasGuideAnchor, canSelect} = this.props;
+    const {id, orgId, query, hasGuideAnchor, canSelect, memberList} = this.props;
     const projectId = data.project.slug;
 
     return (
@@ -124,7 +125,7 @@ const StreamGroup = createReactClass({
           <StyledCount value={data.userCount} />
         </Flex>
         <Box w={80} mx={2} className="hidden-xs hidden-sm">
-          <AssigneeSelector id={data.id} />
+          <AssigneeSelector id={data.id} memberList={memberList} />
         </Box>
       </Group>
     );

--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -17,7 +17,6 @@ import ApiMixin from 'app/mixins/apiMixin';
 import ConfigStore from 'app/stores/configStore';
 import GlobalSelectionStore from 'app/stores/globalSelectionStore';
 import GroupStore from 'app/stores/groupStore';
-import MemberListStore from 'app/stores/memberListStore';
 import SelectedGroupStore from 'app/stores/selectedGroupStore';
 import TagStore from 'app/stores/tagStore';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
@@ -106,10 +105,6 @@ const OrganizationStream = createReactClass({
       fetchTags(this.props.organization.slug);
 
       fetchOrgMembers(this.api, this.props.organization.slug).then(members => {
-        members = members.filter(m => m.user);
-        // Update the store, as avatars rely on them.
-        MemberListStore.loadInitialData(members.map(m => m.user));
-
         let memberList = members.reduce((acc, member) => {
           for (let project of member.projects) {
             if (acc[project] === undefined) {

--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -12,10 +12,12 @@ import {analytics} from 'app/utils/analytics';
 import {t} from 'app/locale';
 import {fetchProject} from 'app/actionCreators/projects';
 import {fetchTags} from 'app/actionCreators/tags';
+import {fetchOrgMembers} from 'app/actionCreators/members';
 import ApiMixin from 'app/mixins/apiMixin';
 import ConfigStore from 'app/stores/configStore';
 import GlobalSelectionStore from 'app/stores/globalSelectionStore';
 import GroupStore from 'app/stores/groupStore';
+import MemberListStore from 'app/stores/memberListStore';
 import SelectedGroupStore from 'app/stores/selectedGroupStore';
 import TagStore from 'app/stores/tagStore';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
@@ -77,13 +79,14 @@ const OrganizationStream = createReactClass({
       pageLinks: '',
       queryCount: null,
       error: false,
-      query: currentQuery.query || '',
+      query: currentQuery.query || 'is:unresolved',
       sort,
       selection: GlobalSelectionStore.get(),
       isSidebarVisible: false,
       savedSearchList: [],
       processingIssues: null,
       tagsLoading: true,
+      memberList: null,
       tags: TagStore.getAllTags(),
       // the project for the selected issues
       // Will only be set if selected issues all belong
@@ -101,6 +104,23 @@ const OrganizationStream = createReactClass({
     if (!this.state.loading) {
       this.fetchData();
       fetchTags(this.props.organization.slug);
+
+      fetchOrgMembers(this.api, this.props.organization.slug).then(members => {
+        members = members.filter(m => m.user);
+        // Update the store, as avatars rely on them.
+        MemberListStore.loadInitialData(members.map(m => m.user));
+
+        let memberList = members.reduce((acc, member) => {
+          for (let project of member.projects) {
+            if (acc[project] === undefined) {
+              acc[project] = [];
+            }
+            acc[project].push(member.user);
+          }
+          return acc;
+        }, {});
+        this.setState({memberList});
+      });
     }
   },
 
@@ -381,10 +401,15 @@ const OrganizationStream = createReactClass({
     dateCutoff.setDate(dateCutoff.getDate() - 30);
 
     let topIssue = ids[0];
+    let {memberList} = this.state;
 
     let {orgId} = this.props.params;
     let groupNodes = ids.map(id => {
       let hasGuideAnchor = userDateJoined > dateCutoff && id === topIssue;
+
+      let group = GroupStore.get(id);
+      let members = memberList[group.project.slug] || [];
+
       return (
         <StreamGroup
           key={id}
@@ -393,6 +418,7 @@ const OrganizationStream = createReactClass({
           statsPeriod={groupStatsPeriod}
           query={this.state.query}
           hasGuideAnchor={hasGuideAnchor}
+          memberList={members}
         />
       );
     });


### PR DESCRIPTION
Get the Assign to pickers working on the organization issue list. This requires getting all the organization members and preparing per-project lists. Ideally I'd like to defer loading members until the user interacts with the picker, but that requires more invasive changes as rendering an assigned user requires the members to be loaded.

I've had to add the fetched users into the `MemberListStore` to make Avatars work correctly, as they don't use props and just read out of the stores directly.

Refs APP-993