### PR TITLE
conf: Provide a way to override the frontend DSN

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -882,6 +882,9 @@ SENTRY_PROJECT_KEY = None
 
 # Project ID for recording frontend (javascript) exceptions
 SENTRY_FRONTEND_PROJECT = None
+# DSN for the frontend to use explicitly, which takes priority
+# over SENTRY_FRONTEND_PROJECT or SENTRY_PROJECT
+SENTRY_FRONTEND_DSN = None
 
 # Only store a portion of all messages per unique group.
 SENTRY_SAMPLE_DATA = True

--- a/src/sentry/templatetags/sentry_dsn.py
+++ b/src/sentry/templatetags/sentry_dsn.py
@@ -21,6 +21,9 @@ def _get_project_key(project_id):
 
 
 def get_public_dsn():
+    if settings.SENTRY_FRONTEND_DSN:
+        return settings.SENTRY_FRONTEND_DSN
+
     project_id = settings.SENTRY_FRONTEND_PROJECT or settings.SENTRY_PROJECT
     cache_key = 'dsn:%s' % (project_id, )
 


### PR DESCRIPTION
This allows an install to report frontend errors to another Sentry
install