### PR TITLE
fix(releases): Organization releases endpoint handles no projects

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -4,6 +4,7 @@ from django.db import IntegrityError, transaction
 
 from rest_framework.response import Response
 
+from sentry.api.bases import NoProjects
 from .project_releases import ReleaseSerializer
 from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
@@ -93,11 +94,14 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, Environment
         """
         query = request.GET.get('query')
 
-        filter_params = self.get_filter_params(
-            request,
-            organization,
-            date_filter_optional=True,
-        )
+        try:
+            filter_params = self.get_filter_params(
+                request,
+                organization,
+                date_filter_optional=True,
+            )
+        except NoProjects:
+            return Response([])
 
         queryset = Release.objects.filter(
             organization=organization,

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -171,6 +171,18 @@ class OrganizationReleaseListTest(APITestCase):
         assert response.data[0]['version'] == release3.version
         assert response.data[1]['version'] == release1.version
 
+    def test_new_org(self):
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.organization
+        team = self.create_team(organization=org)
+        self.create_member(teams=[team], user=user, organization=org)
+        self.login_as(user=user)
+        url = reverse('sentry-api-0-organization-releases', kwargs={'organization_slug': org.slug})
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 0
+
 
 class OrganizationReleaseCreateTest(APITestCase):
     def test_minimal(self):


### PR DESCRIPTION
Fixes a bug where the org releases endpoint errors if the organization didn't have any projects