### PR TITLE
fix(user-reports): User report list endpoint handles no projects

### DIFF
--- a/src/sentry/api/endpoints/organization_user_reports.py
+++ b/src/sentry/api/endpoints/organization_user_reports.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import
 
+from rest_framework.response import Response
 from sentry.api.bases.organization import (
     OrganizationEndpoint,
     OrganizationUserReportsPermission,
 )
+from sentry.api.bases import NoProjects
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models import UserReportWithGroupSerializer
@@ -38,11 +40,14 @@ class OrganizationUserReportsEndpoint(OrganizationEndpoint):
         :pparam string project_slug: the slug of the project.
         :auth: required
         """
-        filter_params = self.get_filter_params(
-            request,
-            organization,
-            date_filter_optional=True,
-        )
+        try:
+            filter_params = self.get_filter_params(
+                request,
+                organization,
+                date_filter_optional=True,
+            )
+        except NoProjects:
+            return Response([])
 
         queryset = UserReport.objects.filter(
             project_id__in=filter_params['project_id'],

--- a/tests/sentry/api/endpoints/test_organization_user_reports.py
+++ b/tests/sentry/api/endpoints/test_organization_user_reports.py
@@ -110,3 +110,11 @@ class OrganizationUserReportListTest(APITestCase):
 
     def test_all_reports(self):
         self.run_test([self.report_1, self.report_2, self.report_resolved_1], status='')
+
+    def test_new_project(self):
+        org2 = self.create_organization()
+        self.team = self.create_team(organization=org2)
+        self.create_member(teams=[self.team], user=self.user, organization=org2)
+        response = self.get_response(org2.slug)
+        assert response.status_code == 200, response.content
+        assert response.data == []


### PR DESCRIPTION
The endpoint returns an empty list of reports if the organization
doesn't have any projects yet.