### PR TITLE
fix(user-reports): Remove broken pagination code

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/shared/groupUserFeedback.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/groupUserFeedback.jsx
@@ -26,7 +26,6 @@ class GroupUserFeedback extends React.Component {
       loading: true,
       error: false,
       reportList: [],
-      pageLinks: '',
     };
   }
 
@@ -47,12 +46,11 @@ class GroupUserFeedback extends React.Component {
     });
 
     fetchGroupUserReports(this.props.group.id, this.props.query)
-      .then((data, _, jqXHR) => {
+      .then(data => {
         this.setState({
           error: false,
           loading: false,
           reportList: data,
-          pageLinks: jqXHR.getResponseHeader('Link'),
         });
       })
       .catch(() => {


### PR DESCRIPTION
Remove broken pagination code on the group user reports view which caused the component to crash upon successfully fetching data.

This component never previously had working pagination though there were some references to pagelinks in there.