### PR TITLE
fix(webpack): Do not add staticPrefix into module resolution path

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -279,7 +279,7 @@ const appConfig = {
           ? path.join(__dirname, 'tests/fixtures/integration-docs/_platforms.json')
           : path.join(__dirname, 'src/sentry/integration-docs/_platforms.json'),
     },
-    modules: [path.join(__dirname, staticPrefix), 'node_modules'],
+    modules: ['node_modules'],
     extensions: ['.jsx', '.js', '.json'],
   },
   output: {


### PR DESCRIPTION
This allows us to resolve things directly, without the `app/` prefix. We
should avoid doing this for risk of node_module namespace collisions.

We already do not do this. So this is safe to remove.