### PR TITLE
feat: snuba version of group events

### DIFF
--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -11,12 +11,17 @@ from sentry import quotas, tagstore
 from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases import GroupEndpoint
 from sentry.api.serializers import serialize
-from sentry.api.paginator import DateTimePaginator
+from sentry.api.paginator import DateTimePaginator, GenericOffsetPaginator, Paginator
 from sentry.models import Environment, Event, Group
 from sentry.search.utils import parse_query
 from sentry.utils.apidocs import scenario, attach_scenarios
 from sentry.search.utils import InvalidQuery
+from sentry.utils.validators import is_event_id
 
+class NoResults(Exception):
+    pass
+
+EMPTY_RESULT = Response([])
 
 @scenario('ListAvailableSamples')
 def list_available_samples_scenario(runner):
@@ -38,36 +43,127 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
         :pparam string issue_id: the ID of the issue to retrieve.
         :auth: required
         """
+        backend = 'legacy'
+        return {
+            'legacy': self._get_events_legacy,
+            'snuba': self._get_events_snuba,
+        }[backend](request, group)
 
-        def respond(queryset):
-            return self.paginate(
-                request=request,
-                queryset=queryset,
-                order_by='-datetime',
-                on_results=lambda x: serialize(x, request.user),
-                paginator_cls=DateTimePaginator,
-            )
+
+    def _get_events_snuba(self, request, group):
+        from functools32 import partial
+        from sentry.api.paginator import GenericOffsetPaginator
+        from sentry.api.serializers.models.event import SnubaEvent
+        from sentry.utils.snuba import raw_query
+
+        try:
+            environment = self._get_environment(request, group)
+            query, tags = self._get_search_query_and_tags(request, group, environment)
+        except InvalidQuery as exc:
+            return Response({'detail': six.text_type(exc)}, status=400)
+        except NoResults:
+            return EMPTY_RESULT
+
+        conditions = []
+        if query:
+            message_condition = [['positionCaseInsensitive', ['message', "'%s'" % (query,)]], '!=', 0]
+            if is_event_id(query):
+                or_condition = [message_condition, ['event_id', '=', query]]
+                conditions.append(or_condition)
+            else:
+                conditions.append(message_condition)
+
+        if tags:
+            tag_conditions = [[u'tags[{}]'.format(k), '=', v] for (k, v) in tags.items()]
+
+        # TODO do we need to add a retention filter, or does snuba util already do that for us
+        now = timezone.now()
+        data_fn = partial(
+            # extract 'data' from raw_query result
+            lambda *args, **kwargs: raw_query(*args, **kwargs)['data'],
+            start=now - timedelta(days=90),
+            end=now,
+            conditions=conditions,
+            filter_keys={
+                'project_id': [group.project_id],
+                'issue': [group.id]
+            },
+            selected_columns=SnubaEvent.selected_columns,
+            orderby='-timestamp',
+            referrer='api.group-events',
+        )
+
+        return self.paginate(
+            request=request,
+            on_results=lambda results: serialize(
+                [SnubaEvent(row) for row in results], request.user),
+            paginator=GenericOffsetPaginator(data_fn=data_fn)
+        )
+
+
+    def _get_events_legacy(self, request, group):
+        try:
+            environment = self._get_environment(request, group)
+            query, tags = self._get_search_query_and_tags(request, group, environment)
+        except InvalidQuery as exc:
+            return Response({'detail': six.text_type(exc)}, status=400)
+        except NoResults:
+            return EMPTY_RESULT
 
         events = Event.objects.filter(group_id=group.id)
 
+        if query:
+            q = Q(message__icontains=query)
+
+            if is_event_id(query):
+                q |= Q(event_id__exact=query)
+
+            events = events.filter(q)
+
+        if tags:
+            event_filter = tagstore.get_group_event_filter(
+                group.project_id,
+                group.id,
+                environment.id if environment is not None else None,
+                tags,
+            )
+
+            if not event_filter:
+                return EMPTY_RESULT
+
+            events = events.filter(**event_filter)
+
+        # filter out events which are beyond the retention period
+        retention = quotas.get_event_retention(organization=group.project.organization)
+        if retention:
+            events = events.filter(
+                datetime__gte=timezone.now() - timedelta(days=retention)
+            )
+
+        return self.paginate(
+            request=request,
+            queryset=events,
+            order_by='-datetime',
+            on_results=lambda x: serialize(x, request.user),
+            paginator_cls=DateTimePaginator,
+        )
+
+    def _get_environment(self, request, group):
         try:
-            environment = self._get_environment_from_request(
+            return self._get_environment_from_request(
                 request,
                 group.project.organization_id,
             )
         except Environment.DoesNotExist:
-            return respond(events.none())
+            raise NoResults
 
+    def _get_search_query_and_tags(self, request, group, environment=None):
         raw_query = request.GET.get('query')
 
         if raw_query:
-            try:
-                query_kwargs = parse_query([group.project], raw_query, request.user)
-            except InvalidQuery as exc:
-                return Response({'detail': six.text_type(exc)}, status=400)
-            else:
-                query = query_kwargs.pop('query', None)
-                tags = query_kwargs.pop('tags', {})
+            query_kwargs = parse_query([group.project], raw_query, request.user)
+            query = query_kwargs.pop('query', None)
+            tags = query_kwargs.pop('tags', {})
         else:
             query = None
             tags = {}
@@ -79,40 +175,8 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
                 # the request is different than the environment
                 # provided as a tag lookup, the query cannot contain
                 # any valid results.
-                return respond(events.none())
+                raise NoResults
             else:
                 tags['environment'] = environment.name
 
-        if query:
-            q = Q(message__icontains=query)
-
-            if len(query) == 32:
-                q |= Q(event_id__exact=query)
-
-            events = events.filter(q)
-
-        # TODO currently snuba can be used to get this filter of event_ids matching
-        # the search tags, which is then used to further filter a postgres QuerySet
-        # Ideally we would just use snuba to completely replace the fetching of the
-        # events.
-        if tags:
-            event_filter = tagstore.get_group_event_filter(
-                group.project_id,
-                group.id,
-                environment.id if environment is not None else None,
-                tags,
-            )
-
-            if not event_filter:
-                return respond(events.none())
-
-            events = events.filter(**event_filter)
-
-        # filter out events which are beyond the retention period
-        retention = quotas.get_event_retention(organization=group.project.organization)
-        if retention:
-            events = events.filter(
-                datetime__gte=timezone.now() - timedelta(days=retention)
-            )
-
-        return respond(events)
+        return query, tags

--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -85,7 +85,7 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
                 'project_id': [group.project_id],
                 'issue': [group.id]
             },
-            selected_columns=SnubaEvent.selected_columns,
+            selected_columns=SnubaEvent.selected_columns + ['tags.key', 'tags.value'],
             orderby='-timestamp',
             referrer='api.group-events',
         )

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -243,6 +243,7 @@ class DetailedEventSerializer(EventSerializer):
     """
     Adds release and user report info to the serialized event.
     """
+
     def serialize(self, obj, attrs, user):
         result = super(DetailedEventSerializer, self).serialize(obj, attrs, user)
         result['release'] = self._get_release_info(user, obj)
@@ -285,6 +286,8 @@ class SnubaEvent(object):
         'ip_address',
         'email',
         'timestamp',
+        'tags.key',
+        'tags.value',
     ]
 
     def __init__(self, kv):
@@ -300,6 +303,9 @@ class SnubaEventSerializer(Serializer):
         serialization returned by EventSerializer.
     """
 
+    def get_tags_dict(self, obj):
+        return dict(zip(getattr(obj, 'tags.key'), getattr(obj, 'tags.value')))
+
     def serialize(self, obj, attrs, user):
         return {
             'eventID': six.text_type(obj.event_id),
@@ -311,5 +317,6 @@ class SnubaEventSerializer(Serializer):
                 'email': obj.email,
                 'username': obj.username,
                 'ipAddress': obj.ip_address,
-            }
+            },
+            'tags': self.get_tags_dict(obj)
         }

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -145,6 +145,7 @@ register('snuba.search.max-pre-snuba-candidates', default=5000)
 register('snuba.search.chunk-growth-rate', default=1.5)
 register('snuba.search.max-chunk-size', default=2000)
 register('snuba.search.max-total-chunk-time-seconds', default=30.0)
+register('snuba.events-queries.enabled', type=Bool, default=False)
 
 # Kafka Publisher
 register('kafka-publisher.raw-event-sample-rate', default=0.0)

--- a/tests/sentry/api/endpoints/test_group_events.py
+++ b/tests/sentry/api/endpoints/test_group_events.py
@@ -5,15 +5,15 @@ import six
 from datetime import timedelta
 from django.utils import timezone
 
-from sentry import tagstore
+from sentry import options, tagstore
 from sentry.models import Environment
 from sentry.testutils import APITestCase
 
 
 class GroupEventsTest(APITestCase):
     def setUp(self):
-        super(ProjectEventsTest, self).setUp()
-        self.client.cookies['eventstream'] = 'legacy'
+        super(GroupEventsTest, self).setUp()
+        options.set('snuba.events-queries.enabled', False)
 
     def test_simple(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_project_events.py
+++ b/tests/sentry/api/endpoints/test_project_events.py
@@ -6,10 +6,15 @@ from datetime import timedelta
 from django.utils import timezone
 from django.core.urlresolvers import reverse
 
+from sentry import options
 from sentry.testutils import APITestCase
 
 
 class ProjectEventsTest(APITestCase):
+    def setUp(self):
+        super(ProjectEventsTest, self).setUp()
+        options.set('snuba.events-queries.enabled', False)
+
     def test_simple(self):
         self.login_as(user=self.user)
 

--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -5,6 +5,7 @@ import six
 from datetime import timedelta
 from django.utils import timezone
 
+from sentry import options
 from sentry.models import Environment
 from sentry.testutils import APITestCase, SnubaTestCase
 
@@ -21,7 +22,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
     def setUp(self):
         super(GroupEventsTest, self).setUp()
         self.min_ago = timezone.now() - timedelta(minutes=1)
-        self.client.cookies['eventstream'] = 'snuba'
+        options.set('snuba.events-queries.enabled', True)
 
     def test_simple(self):
         self.login_as(user=self.user)

--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -249,7 +249,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         group = self.create_group()
-        event_1 = self.create_event(
+        self.create_event(
             event_id='a' * 32,
             datetime=self.min_ago,
             group=group,

--- a/tests/snuba/api/endpoints/test_project_events.py
+++ b/tests/snuba/api/endpoints/test_project_events.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from django.utils import timezone
 from django.core.urlresolvers import reverse
 
+from sentry import options
 from sentry.testutils import APITestCase, SnubaTestCase
 
 
@@ -11,7 +12,7 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
     def setUp(self):
         super(ProjectEventsTest, self).setUp()
         self.min_ago = timezone.now() - timedelta(minutes=1)
-        self.client.cookies['eventstream'] = 'snuba'
+        options.set('snuba.events-queries.enabled', True)
 
     def test_simple(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
This provides a snuba implementation of the group events api that should maybe be faster than the django based version, and allow some of our larger customers to use the group events tab. 

The queries it makes should benefit from the `split_query` optimization for reverse-time-sorted data that snuba does. 