### PR TITLE
ref(webhooks): Use as_dict() instead of unstable data access

### DIFF
--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -89,7 +89,7 @@ class WebHooksPlugin(notify.NotificationPlugin):
             'url': group.get_absolute_url(params={'referrer': 'webhooks_plugin'}),
             'triggering_rules': triggering_rules,
         }
-        data['event'] = dict(event.data or {})
+        data['event'] = event.as_dict()
         data['event']['tags'] = event.get_tags()
         data['event']['event_id'] = event.event_id
         if features.has('organizations:legacy-event-id', group.project.organization):


### PR DESCRIPTION
Ensure that webhooks do no longer use the unstable internal data representation. It has changed its canonical representation a couple of times recently (e.g. the `sentry.interfaces.*` rename) and carries internal keys (e.g. `_ref_node`).

With #10740 the same change lands for Snuba.
