### PR TITLE
fix(interfaces): Try to decode request as JSON first

### DIFF
--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -247,8 +247,8 @@ def heuristic_decode(data, possible_content_type=None):
     )
 
     decoders = [
-        ('application/x-www-form-urlencoded', form_encoded_parser),
         ('application/json', json.loads),
+        ('application/x-www-form-urlencoded', form_encoded_parser),
     ]
 
     # Prioritize the decoder which supports the possible content type first.


### PR DESCRIPTION
The urlencoded parser is very lenient and returns a lot of false positives. Try JSON first, since it sometimes even detects valid JSON as urlencoded. This behavior already matches Rust normalization.