### PR TITLE
ref(processing): Filter for valid debug images in language plugins

### DIFF
--- a/src/sentry/lang/java/plugin.py
+++ b/src/sentry/lang/java/plugin.py
@@ -13,7 +13,9 @@ FRAME_CACHE_VERSION = 2
 
 
 def is_valid_image(image):
-    return bool(image) and image.get('uuid') is not None
+    return bool(image) \
+        and image.get('type') == 'proguard' \
+        and image.get('uuid') is not None
 
 
 class JavaStacktraceProcessor(StacktraceProcessor):
@@ -23,10 +25,9 @@ class JavaStacktraceProcessor(StacktraceProcessor):
         self.images = set()
         self.available = False
 
-        for image in get_path(self.data, 'debug_meta', 'images', filter=True, default=()):
-            if image.get('type') == 'proguard' and image.get('uuid'):
-                self.available = True
-                self.images.add(six.text_type(image['uuid']).lower())
+        for image in get_path(self.data, 'debug_meta', 'images', filter=is_valid_image, default=()):
+            self.available = True
+            self.images.add(six.text_type(image['uuid']).lower())
 
     def handles_frame(self, frame, stacktrace_info):
         platform = frame.get('platform') or self.data.get('platform')

--- a/src/sentry/lang/java/plugin.py
+++ b/src/sentry/lang/java/plugin.py
@@ -12,6 +12,10 @@ from sentry.utils.safe import get_path
 FRAME_CACHE_VERSION = 2
 
 
+def is_valid_image(image):
+    return bool(image) and image.get('uuid') is not None
+
+
 class JavaStacktraceProcessor(StacktraceProcessor):
     def __init__(self, *args, **kwargs):
         StacktraceProcessor.__init__(self, *args, **kwargs)
@@ -20,7 +24,7 @@ class JavaStacktraceProcessor(StacktraceProcessor):
         self.available = False
 
         for image in get_path(self.data, 'debug_meta', 'images', filter=True, default=()):
-            if image.get('type') == 'proguard':
+            if image.get('type') == 'proguard' and image.get('uuid'):
                 self.available = True
                 self.images.add(six.text_type(image['uuid']).lower())
 

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -37,7 +37,7 @@ class NativeStacktraceProcessor(StacktraceProcessor):
         self.difs_referenced = set()
 
         images = get_path(self.data, 'debug_meta', 'images', default=(),
-                          filter=(lambda img: img and img.get('type') in self.supported_images))
+                          filter=self._is_valid_image)
 
         if images:
             self.available = True
@@ -45,6 +45,13 @@ class NativeStacktraceProcessor(StacktraceProcessor):
             self.object_lookup = ObjectLookup(images)
         else:
             self.available = False
+
+    def _is_valid_image(self, image):
+        return bool(image) \
+            and image.get('type') in self.supported_images \
+            and image.get('image_addr') is not None \
+            and image.get('image_size') is not None \
+            and (image.get('id') or image.get('uuid')) is not None
 
     def close(self):
         StacktraceProcessor.close(self)


### PR DESCRIPTION
This makes the access to debug images in our language plugins more robust. With the new normalization, we will be retaining debug image records with missing required data. 

See also: https://github.com/getsentry/symbolic/pull/123
cc @untitaker 