### PR TITLE
fix(issues): Prevent unnecessary mount/unmount of group sidebar

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/shared/groupEventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/groupEventDetails.jsx
@@ -14,6 +14,8 @@ import withEnvironment from 'app/utils/withEnvironment';
 import GroupEventToolbar from './eventToolbar';
 import {fetchGroupEventAndMarkSeen} from './utils';
 
+const GroupSidebarWithEnvironment = withEnvironment(GroupSidebar);
+
 class GroupEventDetails extends React.Component {
   static propTypes = {
     group: SentryTypes.Group.isRequired,
@@ -75,7 +77,7 @@ class GroupEventDetails extends React.Component {
     // Sidebar doesn't support multiple environments yet so do not pass an
     // environment in the org level variant of the sidebar
     const SidebarWithEnvironment = params.projectId
-      ? withEnvironment(GroupSidebar)
+      ? GroupSidebarWithEnvironment
       : GroupSidebar;
 
     return (


### PR DESCRIPTION
This fixes a bug introduced in #11484 that caused the group sidebar
component to remount every time the render function in the group events
page was called causing unnecessary API calls / rendering.