### PR TITLE
feat(issues) Add processing issues alerts to issue list

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/processingIssues.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/processingIssues.jsx
@@ -1,0 +1,10 @@
+export function fetchProcessingIssues(api, orgId, projectIds = null) {
+  let query = null;
+  if (projectIds) {
+    query = {project: projectIds};
+  }
+  return api.requestPromise(`/organizations/${orgId}/processingissues/`, {
+    method: 'GET',
+    query,
+  });
+}

--- a/src/sentry/static/sentry/app/views/stream/processingIssueHint.jsx
+++ b/src/sentry/static/sentry/app/views/stream/processingIssueHint.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import {Link} from 'react-router';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import styled from 'react-emotion';
+
+import TimeSince from 'app/components/timeSince';
+import {t, tn, tct} from 'app/locale';
+
+class ProcessingIssueHint extends React.Component {
+  static propTypes = {
+    issue: PropTypes.object.isRequired,
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    showProject: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    showProject: false,
+  };
+
+  render() {
+    let {orgId, projectId, issue, showProject} = this.props;
+    let link = `/settings/${orgId}/${projectId}/processing-issues/`;
+    let showButton = false;
+    let className = {
+      'processing-issues': true,
+      alert: true,
+    };
+    let text = null;
+    let lastEvent = null;
+    let icon = null;
+
+    let project = null;
+    if (showProject) {
+      project = (
+        <span>
+          <strong>{projectId}</strong> &mdash;
+        </span>
+      );
+    }
+
+    if (issue.numIssues > 0) {
+      icon = <span className="icon icon-alert" />;
+      text = tn(
+        'There is %s issue blocking event processing',
+        'There are %s issues blocking event processing',
+        issue.numIssues
+      );
+      lastEvent = (
+        <span className="last-seen">
+          ({tct('last event from [ago]', {
+            ago: <TimeSince date={issue.lastSeen} />,
+          })})
+        </span>
+      );
+      className['alert-error'] = true;
+      showButton = true;
+    } else if (issue.issuesProcessing > 0) {
+      icon = <span className="icon icon-processing play" />;
+      className['alert-info'] = true;
+      text = tn(
+        'Reprocessing %s event …',
+        'Reprocessing %s events …',
+        issue.issuesProcessing
+      );
+    } else if (issue.resolveableIssues > 0) {
+      icon = <span className="icon icon-processing" />;
+      className['alert-warning'] = true;
+      text = tn(
+        'There is %s event pending reprocessing.',
+        'There are %s events pending reprocessing.',
+        issue.resolveableIssues
+      );
+      showButton = true;
+    } else {
+      /* we should not go here but what do we know */
+      return null;
+    }
+    return (
+      <Container className={classNames(className)}>
+        {showButton && (
+          <Link to={link} className="btn btn-default btn-sm pull-right">
+            {t('Show details')}
+          </Link>
+        )}
+        {icon} {project}
+        <strong>{text}</strong> {lastEvent}{' '}
+      </Container>
+    );
+  }
+}
+
+const Container = styled.div`
+  margin: -1px -1px 0;
+  padding: 10px 16px;
+`;
+
+export default ProcessingIssueHint;

--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -1,4 +1,4 @@
-import {Link, browserHistory} from 'react-router';
+import {browserHistory} from 'react-router';
 import {omit, isEqual} from 'lodash';
 import Cookies from 'js-cookie';
 import PropTypes from 'prop-types';
@@ -15,7 +15,7 @@ import {
   setActiveEnvironment,
   setActiveEnvironmentName,
 } from 'app/actionCreators/environments';
-import {t, tn, tct} from 'app/locale';
+import {t, tct} from 'app/locale';
 import ApiMixin from 'app/mixins/apiMixin';
 import ConfigStore from 'app/stores/configStore';
 import EnvironmentStore from 'app/stores/environmentStore';
@@ -24,6 +24,7 @@ import GroupStore from 'app/stores/groupStore';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import Pagination from 'app/components/pagination';
+import ProcessingIssueHint from 'app/views/stream/processingIssueHint';
 import ProjectState from 'app/mixins/projectState';
 import SentryTypes from 'app/sentryTypes';
 import StreamActions from 'app/views/stream/actions';
@@ -31,7 +32,6 @@ import EmptyStateWarning from 'app/components/emptyStateWarning';
 import StreamFilters from 'app/views/stream/filters';
 import StreamGroup from 'app/components/stream/group';
 import StreamSidebar from 'app/views/stream/sidebar';
-import TimeSince from 'app/components/timeSince';
 import parseApiError from 'app/utils/parseApiError';
 import parseLinkHeader from 'app/utils/parseLinkHeader';
 import queryString from 'app/utils/queryString';
@@ -579,67 +579,8 @@ const Stream = createReactClass({
     if (!pi || this.showingProcessingIssues()) {
       return null;
     }
-
     let {orgId, projectId} = this.props.params;
-    let link = `/${orgId}/${projectId}/settings/processing-issues/`;
-    let showButton = false;
-    let className = {
-      'processing-issues': true,
-      alert: true,
-    };
-    let issues = null;
-    let lastEvent = null;
-    let icon = null;
-
-    if (pi.numIssues > 0) {
-      icon = <span className="icon icon-alert" />;
-      issues = tn(
-        'There is %s issue blocking event processing',
-        'There are %s issues blocking event processing',
-        pi.numIssues
-      );
-      lastEvent = (
-        <span className="last-seen">
-          ({tct('last event from [ago]', {
-            ago: <TimeSince date={pi.lastSeen} />,
-          })})
-        </span>
-      );
-      className['alert-error'] = true;
-      showButton = true;
-    } else if (pi.issuesProcessing > 0) {
-      icon = <span className="icon icon-processing play" />;
-      className['alert-info'] = true;
-      issues = tn(
-        'Reprocessing %s event …',
-        'Reprocessing %s events …',
-        pi.issuesProcessing
-      );
-    } else if (pi.resolveableIssues > 0) {
-      icon = <span className="icon icon-processing" />;
-      className['alert-warning'] = true;
-      issues = tn(
-        'There is %s event pending reprocessing.',
-        'There are %s events pending reprocessing.',
-        pi.resolveableIssues
-      );
-      showButton = true;
-    } else {
-      /* we should not go here but what do we know */ return null;
-    }
-    return (
-      <div
-        className={classNames(className)}
-        style={{margin: '-1px -1px 0', padding: '10px 16px'}}
-      >
-        {showButton && (
-          <Link to={link} className="btn btn-default btn-sm pull-right">
-            {t('Show details')}
-          </Link>
-        )}
-        {icon} <strong>{issues}</strong> {lastEvent}{' '}
-      </div>
-    );
+    return <ProcessingIssueHint issue={pi} projectId={projectId} orgId={orgId} />;
   },
 
   renderGroupNodes(ids, statsPeriod) {

--- a/tests/js/spec/views/stream/processingIssueHint.spec.jsx
+++ b/tests/js/spec/views/stream/processingIssueHint.spec.jsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import ProcessingIssueHint from 'app/views/stream/processingIssueHint';
+
+describe('ProcessingIssueHint', function() {
+  let issue, wrapper;
+  let orgId = 'test-org';
+  let projectId = 'test-project';
+
+  beforeEach(() => {
+    issue = {
+      hasIssues: false,
+      hasMoreResolveableIssues: false,
+      issuesProcessing: 0,
+      lastSeen: '2019-01-16T15:38:38Z',
+      numIssues: 0,
+      resolveableIssues: 0,
+      signedLink: null,
+    };
+  });
+
+  describe('numIssues state', function() {
+    beforeEach(() => {
+      issue.numIssues = 9;
+      wrapper = mount(
+        <ProcessingIssueHint issue={issue} orgId={orgId} projectId={projectId} />
+      );
+    });
+
+    it('displays a button', function() {
+      let button = wrapper.find('Link');
+      expect(button.length).toBe(1);
+      expect(button.props().to).toEqual(
+        `/settings/${orgId}/${projectId}/processing-issues/`
+      );
+    });
+
+    it('displays an icon', function() {
+      let icon = wrapper.find('[className*="icon-alert"]');
+      expect(icon.length).toBe(1);
+    });
+
+    it('displays text', function() {
+      let text = wrapper.find('Container').text();
+      expect(text).toEqual(expect.stringContaining('issues blocking'));
+    });
+  });
+
+  describe('issuesProcessing state', function() {
+    beforeEach(() => {
+      issue.issuesProcessing = 9;
+      wrapper = mount(
+        <ProcessingIssueHint issue={issue} orgId={orgId} projectId={projectId} />
+      );
+    });
+
+    it('does not display a button', function() {
+      let button = wrapper.find('Link');
+      expect(button.length).toBe(0);
+    });
+
+    it('displays an icon', function() {
+      let icon = wrapper.find('[className*="icon-processing"]');
+      expect(icon.length).toBe(1);
+    });
+
+    it('displays text', function() {
+      let text = wrapper.find('Container').text();
+      expect(text).toEqual(expect.stringContaining('Reprocessing'));
+    });
+  });
+
+  describe('resolvableIssues state', function() {
+    beforeEach(() => {
+      issue.resolveableIssues = 9;
+      wrapper = mount(
+        <ProcessingIssueHint issue={issue} orgId={orgId} projectId={projectId} />
+      );
+    });
+
+    it('displays a button', function() {
+      let button = wrapper.find('Link');
+      expect(button.length).toBe(1);
+      expect(button.props().to).toEqual(
+        `/settings/${orgId}/${projectId}/processing-issues/`
+      );
+    });
+
+    it('displays an icon', function() {
+      let icon = wrapper.find('[className*="icon-processing"]');
+      expect(icon.length).toBe(1);
+    });
+
+    it('displays text', function() {
+      let text = wrapper.find('Container').text();
+      expect(text).toEqual(expect.stringContaining('pending reprocessing'));
+    });
+  });
+
+  describe('showProject state', function() {
+    beforeEach(() => {
+      issue.numIssues = 9;
+      wrapper = mount(
+        <ProcessingIssueHint
+          showProject
+          issue={issue}
+          orgId={orgId}
+          projectId={projectId}
+        />
+      );
+    });
+    it('displays the project slug', function() {
+      let text = wrapper.find('Container').text();
+      expect(text).toEqual(expect.stringContaining(projectId));
+    });
+  });
+});


### PR DESCRIPTION
Display processing issues on the organization issue list. The processing issue alerts reflect the currently selected projects from the global selection header but not the date/environment selectors. This emulates how processing issues work on the per-project list pages.

![screen shot 2019-01-16 at 4 15 26 pm](https://user-images.githubusercontent.com/24086/51280224-21e1e600-19ad-11e9-8861-cd7412faf2a3.png)


Refs APP-931