### PR TITLE
feat(sentry10): Single project selection mode

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -20,6 +20,11 @@ export default class MultipleProjectSelector extends React.PureComponent {
     projects: PropTypes.array,
     onChange: PropTypes.func,
     onUpdate: PropTypes.func,
+    multi: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    multi: true,
   };
 
   constructor() {
@@ -87,12 +92,8 @@ export default class MultipleProjectSelector extends React.PureComponent {
     this.setState({hasChanges: true});
   };
 
-  hasMultiSelect = () => {
-    return new Set(this.props.organization.features).has('global-views');
-  };
-
   render() {
-    const {value, projects} = this.props;
+    const {value, projects, multi} = this.props;
     const selectedProjectIds = new Set(value);
 
     const selected = projects.filter(project =>
@@ -102,7 +103,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
     return (
       <StyledProjectSelector
         {...this.props}
-        multi={this.hasMultiSelect()}
+        multi={multi}
         selectedProjects={selected}
         projects={projects}
         onSelect={this.handleQuickSelect}
@@ -132,6 +133,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
               isOpen={isOpen}
               onSubmit={() => this.handleUpdate(actions)}
               onClear={this.handleClear}
+              allowClear={multi}
               {...getActorProps()}
             >
               {title}

--- a/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
+++ b/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
@@ -17,10 +17,6 @@ const DEFAULT_SELECTION = {
   },
 };
 
-/**
- * Store for global selections
- * Currently stores active project ids for Discover and EventStream
- */
 const GlobalSelectionStore = Reflux.createStore({
   init() {
     this.reset();

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -21,6 +21,7 @@ const changeQuery = (routerContext, query) => ({
 
 describe('GlobalSelectionHeader', function() {
   const {organization, router, routerContext} = initializeOrg({
+    organization: TestStubs.Organization({features: ['global-views']}),
     router: {
       location: {query: {}},
     },
@@ -175,6 +176,41 @@ describe('GlobalSelectionHeader', function() {
       },
       environments: [],
       projects: [],
+    });
+  });
+
+  describe('Single project selection mode', function() {
+    it('selects first project if more than one is requested', function() {
+      const initializationObj = initializeOrg({
+        router: {
+          location: {query: {project: [1, 2]}},
+        },
+      });
+
+      mount(
+        <GlobalSelectionHeader organization={initializationObj.organization} />,
+        initializationObj.routerContext
+      );
+
+      expect(globalActions.updateProjects).toHaveBeenCalledWith([1]);
+    });
+
+    it('selects first project if none (i.e. all) is requested', function() {
+      const project = TestStubs.Project({id: '3'});
+      const org = TestStubs.Organization({projects: [project]});
+      const initializationObj = initializeOrg({
+        organization: org,
+        router: {
+          location: {query: {}},
+        },
+      });
+
+      mount(
+        <GlobalSelectionHeader organization={initializationObj.organization} />,
+        initializationObj.routerContext
+      );
+
+      expect(globalActions.updateProjects).toHaveBeenCalledWith([3]);
     });
   });
 });

--- a/tests/js/spec/views/organizationDashboard/dashboard.spec.jsx
+++ b/tests/js/spec/views/organizationDashboard/dashboard.spec.jsx
@@ -13,7 +13,7 @@ describe('OrganizationDashboard', function() {
   const {organization, router, routerContext} = initializeOrg({
     projects: [{isMember: true}, {isMember: true, slug: 'new-project', id: 3}],
     organization: {
-      features: ['sentry10'],
+      features: ['sentry10', 'global-views'],
     },
     router: {
       location: {

--- a/tests/js/spec/views/releases/list/__snapshots__/organizationReleases.spec.jsx.snap
+++ b/tests/js/spec/views/releases/list/__snapshots__/organizationReleases.spec.jsx.snap
@@ -25,6 +25,7 @@ exports[`OrganizationReleases renders 1`] = `
       ],
       "features": Array [
         "sentry10",
+        "global-views",
       ],
       "id": "3",
       "name": "Organization Name",
@@ -79,6 +80,7 @@ exports[`OrganizationReleases renders 1`] = `
         ],
         "features": Array [
           "sentry10",
+          "global-views",
         ],
         "id": "3",
         "name": "Organization Name",
@@ -136,6 +138,7 @@ exports[`OrganizationReleases renders 1`] = `
               ],
               "features": Array [
                 "sentry10",
+                "global-views",
               ],
               "id": "3",
               "name": "Organization Name",
@@ -184,6 +187,7 @@ exports[`OrganizationReleases renders 1`] = `
                 ],
                 "features": Array [
                   "sentry10",
+                  "global-views",
                 ],
                 "id": "3",
                 "name": "Organization Name",
@@ -238,6 +242,7 @@ exports[`OrganizationReleases renders 1`] = `
                   ],
                   "features": Array [
                     "sentry10",
+                    "global-views",
                   ],
                   "id": "3",
                   "name": "Organization Name",
@@ -284,6 +289,7 @@ exports[`OrganizationReleases renders 1`] = `
                     ],
                     "features": Array [
                       "sentry10",
+                      "global-views",
                     ],
                     "id": "3",
                     "name": "Organization Name",
@@ -379,6 +385,7 @@ exports[`OrganizationReleases renders 1`] = `
                       ],
                       "features": Array [
                         "sentry10",
+                        "global-views",
                       ],
                       "id": "3",
                       "name": "Organization Name",
@@ -479,6 +486,7 @@ exports[`OrganizationReleases renders 1`] = `
                             className="css-5udiwc-HeaderItemPosition e165b9e40"
                           >
                             <MultipleProjectSelector
+                              multi={true}
                               onChange={[Function]}
                               onUpdate={[Function]}
                               organization={
@@ -496,6 +504,7 @@ exports[`OrganizationReleases renders 1`] = `
                                   ],
                                   "features": Array [
                                     "sentry10",
+                                    "global-views",
                                   ],
                                   "id": "3",
                                   "name": "Organization Name",
@@ -536,7 +545,7 @@ exports[`OrganizationReleases renders 1`] = `
                               value={Array []}
                             >
                               <StyledProjectSelector
-                                multi={false}
+                                multi={true}
                                 onChange={[Function]}
                                 onClose={[Function]}
                                 onMultiSelect={[Function]}
@@ -557,6 +566,7 @@ exports[`OrganizationReleases renders 1`] = `
                                     ],
                                     "features": Array [
                                       "sentry10",
+                                      "global-views",
                                     ],
                                     "id": "3",
                                     "name": "Organization Name",
@@ -600,7 +610,7 @@ exports[`OrganizationReleases renders 1`] = `
                               >
                                 <ProjectSelector
                                   className="css-iw79rr-StyledProjectSelector ewlipse0"
-                                  multi={false}
+                                  multi={true}
                                   onChange={[Function]}
                                   onClose={[Function]}
                                   onMultiSelect={[Function]}
@@ -621,6 +631,7 @@ exports[`OrganizationReleases renders 1`] = `
                                       ],
                                       "features": Array [
                                         "sentry10",
+                                        "global-views",
                                       ],
                                       "id": "3",
                                       "name": "Organization Name",
@@ -806,6 +817,7 @@ exports[`OrganizationReleases renders 1`] = `
                                                   >
                                                     <StyledHeaderItem
                                                       active={false}
+                                                      allowClear={true}
                                                       hasChanges={false}
                                                       hasSelected={false}
                                                       icon={
@@ -829,6 +841,7 @@ exports[`OrganizationReleases renders 1`] = `
                                                     >
                                                       <ForwardRef
                                                         active={false}
+                                                        allowClear={true}
                                                         className="css-22y332-StyledHeaderItem ewlipse1"
                                                         hasChanges={false}
                                                         hasSelected={false}
@@ -1032,6 +1045,7 @@ exports[`OrganizationReleases renders 1`] = `
                                   ],
                                   "features": Array [
                                     "sentry10",
+                                    "global-views",
                                   ],
                                   "id": "3",
                                   "name": "Organization Name",
@@ -1077,6 +1091,7 @@ exports[`OrganizationReleases renders 1`] = `
                                     ],
                                     "features": Array [
                                       "sentry10",
+                                      "global-views",
                                     ],
                                     "id": "3",
                                     "name": "Organization Name",
@@ -1119,6 +1134,7 @@ exports[`OrganizationReleases renders 1`] = `
                                       ],
                                       "features": Array [
                                         "sentry10",
+                                        "global-views",
                                       ],
                                       "id": "3",
                                       "name": "Organization Name",
@@ -1161,6 +1177,7 @@ exports[`OrganizationReleases renders 1`] = `
                                         ],
                                         "features": Array [
                                           "sentry10",
+                                          "global-views",
                                         ],
                                         "id": "3",
                                         "name": "Organization Name",

--- a/tests/js/spec/views/releases/list/organizationReleases.spec.jsx
+++ b/tests/js/spec/views/releases/list/organizationReleases.spec.jsx
@@ -10,7 +10,7 @@ describe('OrganizationReleases', function() {
   beforeEach(function() {
     const organization = TestStubs.Organization({
       projects: [TestStubs.Project()],
-      features: ['sentry10'],
+      features: ['sentry10', 'global-views'],
     });
 
     MockApiClient.addMockResponse({

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -449,6 +449,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                           className="css-5udiwc-HeaderItemPosition e165b9e40"
                         >
                           <MultipleProjectSelector
+                            multi={false}
                             onChange={[Function]}
                             onUpdate={[Function]}
                             organization={
@@ -678,6 +679,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                 >
                                                   <StyledHeaderItem
                                                     active={false}
+                                                    allowClear={false}
                                                     hasChanges={false}
                                                     hasSelected={false}
                                                     icon={
@@ -701,6 +703,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                   >
                                                     <ForwardRef
                                                       active={false}
+                                                      allowClear={false}
                                                       className="css-22y332-StyledHeaderItem ewlipse1"
                                                       hasChanges={false}
                                                       hasSelected={false}
@@ -725,7 +728,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                     >
                                                       <HeaderItem
                                                         active={false}
-                                                        allowClear={true}
+                                                        allowClear={false}
                                                         className="css-22y332-StyledHeaderItem ewlipse1"
                                                         hasChanges={false}
                                                         hasSelected={false}


### PR DESCRIPTION
Enforce single project selection mode via the GlobalSelectionHeader if
users do not have the "global-views" feature. If no project is specified
in the query users will be automatically directed to their first one.