### PR TITLE
ref(app-platform):add events validation check for associated permissions

### DIFF
--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -34,3 +34,18 @@ class SentryAppSerializer(Serializer):
     redirectUrl = serializers.URLField(required=False)
     isAlertable = serializers.BooleanField(required=False)
     overview = serializers.CharField(required=False)
+
+    def validate_events(self, attrs, source):
+        resources = [s.split(':')[0] for s in attrs['scopes']]
+        for event in attrs[source]:
+            if event == 'issue':
+                resource = 'event'
+            else:
+                resource = event
+
+            if resource not in resources:
+                raise ValidationError(
+                    u"resource type '{}' does not have the correct permissions.".format(event),
+                )
+
+        return attrs

--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -36,6 +36,8 @@ class SentryAppSerializer(Serializer):
     overview = serializers.CharField(required=False)
 
     def validate_events(self, attrs, source):
+        if not attrs.get('scopes'):
+            return attrs
         resources = [s.split(':')[0] for s in attrs['scopes']]
         for event in attrs[source]:
             if event == 'issue':

--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -4,7 +4,7 @@ from rest_framework import serializers
 from rest_framework.serializers import Serializer, ValidationError
 
 from sentry.models import ApiScopes
-from sentry.models.sentryapp import VALID_EVENTS, VALID_EVENT_PERMISSIONS
+from sentry.models.sentryapp import VALID_EVENT_RESOURCES, REQUIRED_EVENT_PERMISSIONS
 
 
 class ApiScopesField(serializers.WritableField):
@@ -20,9 +20,9 @@ class ApiScopesField(serializers.WritableField):
 
 class EventListField(serializers.WritableField):
     def validate(self, data):
-        if not set(data).issubset(VALID_EVENTS):
+        if not set(data).issubset(VALID_EVENT_RESOURCES):
             raise ValidationError(u'Invalid event subscription: {}'.format(
-                ', '.join(set(data).difference(VALID_EVENTS))
+                ', '.join(set(data).difference(VALID_EVENT_RESOURCES))
             ))
 
 
@@ -40,7 +40,7 @@ class SentryAppSerializer(Serializer):
             return attrs
 
         for resource in attrs.get(source):
-            needed_scope = VALID_EVENT_PERMISSIONS[resource]
+            needed_scope = REQUIRED_EVENT_PERMISSIONS[resource]
             if needed_scope not in attrs['scopes']:
                 raise ValidationError(
                     u'{} webhooks require the {} permission.'.format(resource, needed_scope),

--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -29,7 +29,7 @@ class EventListField(serializers.WritableField):
 class SentryAppSerializer(Serializer):
     name = serializers.CharField()
     scopes = ApiScopesField()
-    events = EventListField()
+    events = EventListField(required=False)
     webhookUrl = serializers.URLField()
     redirectUrl = serializers.URLField(required=False)
     isAlertable = serializers.BooleanField(required=False)
@@ -39,7 +39,7 @@ class SentryAppSerializer(Serializer):
         if not attrs.get('scopes'):
             return attrs
 
-        for resource in attrs[source]:
+        for resource in attrs.get(source):
             needed_scope = VALID_EVENT_PERMISSIONS[resource]
             if needed_scope not in attrs['scopes']:
                 raise ValidationError(

--- a/src/sentry/mediators/sentry_apps/updater.py
+++ b/src/sentry/mediators/sentry_apps/updater.py
@@ -8,7 +8,7 @@ from sentry.coreapi import APIError
 from sentry.constants import SentryAppStatus
 from sentry.mediators import Mediator, Param
 from sentry.mediators.param import if_param
-from sentry.models.sentryapp import VALID_EVENT_PERMISSIONS
+from sentry.models.sentryapp import REQUIRED_EVENT_PERMISSIONS
 
 
 class Updater(Mediator):
@@ -45,7 +45,7 @@ class Updater(Mediator):
     @if_param('events')
     def _update_events(self):
         for event in self.events:
-            needed_scope = VALID_EVENT_PERMISSIONS[event]
+            needed_scope = REQUIRED_EVENT_PERMISSIONS[event]
             if needed_scope not in self.sentry_app.scope_list:
                 raise APIError(
                     u'{} webhooks require the {} permission.'.format(event, needed_scope),

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -24,6 +24,14 @@ VALID_EVENTS = (
     'issue',
 )
 
+VALID_EVENT_PERMISSIONS = {
+    'issue': 'event:read',
+    'project': 'project:read',
+    'member': 'member:read',
+    'organization': 'org:read',
+    'team': 'team:read',
+}
+
 
 def default_uuid():
     return six.binary_type(uuid.uuid4())

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -20,11 +20,11 @@ from sentry.db.models import (
     ParanoidModel,
 )
 
-VALID_EVENTS = (
+VALID_EVENT_RESOURCES = (
     'issue',
 )
 
-VALID_EVENT_PERMISSIONS = {
+REQUIRED_EVENT_PERMISSIONS = {
     'issue': 'event:read',
     'project': 'project:read',
     'member': 'member:read',

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.jsx
@@ -23,6 +23,7 @@ export default class Subscriptions extends React.Component {
   constructor(...args) {
     super(...args);
     this.state = {events: this.props.events};
+    this.context.form.setValue('events', this.props.events);
   }
 
   componentDidUpdate(prevProps) {

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
@@ -82,7 +82,7 @@ export default class SentryApplicationDetails extends AsyncView {
 
   onSubmitSuccess = data => {
     const {orgId} = this.props.params;
-    addSuccessMessage(t(`${this.state.app.name} successfully saved.`));
+    addSuccessMessage(t(`${data.name} successfully saved.`));
     browserHistory.push(`/settings/${orgId}/developer-settings/`);
   };
 

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/sentryApplicationDetails.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/sentryApplicationDetails.spec.jsx.snap
@@ -418,7 +418,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                   "overflow": true,
                 },
               },
-              "fieldState": Object {},
+              "fieldState": Object {
+                "events": Object {
+                  "Saving": false,
+                  "showSave": true,
+                },
+              },
               "fields": Object {
                 "Event--permission": "no-access",
                 "Member--permission": "no-access",
@@ -442,7 +447,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                 "uuid": "123456123456123456123456",
                 "webhookUrl": "https://example.com/webhook",
               },
-              "formState": undefined,
+              "formState": "Ready",
               "initialData": Object {
                 "Event--permission": "no-access",
                 "Member--permission": "no-access",
@@ -1136,7 +1141,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "overflow": true,
                                                                   },
                                                                 },
-                                                                "fieldState": Object {},
+                                                                "fieldState": Object {
+                                                                  "events": Object {
+                                                                    "Saving": false,
+                                                                    "showSave": true,
+                                                                  },
+                                                                },
                                                                 "fields": Object {
                                                                   "Event--permission": "no-access",
                                                                   "Member--permission": "no-access",
@@ -1160,7 +1170,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                   "uuid": "123456123456123456123456",
                                                                   "webhookUrl": "https://example.com/webhook",
                                                                 },
-                                                                "formState": undefined,
+                                                                "formState": "Ready",
                                                                 "initialData": Object {
                                                                   "Event--permission": "no-access",
                                                                   "Member--permission": "no-access",
@@ -1690,7 +1700,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "overflow": true,
                                                                                               },
                                                                                             },
-                                                                                            "fieldState": Object {},
+                                                                                            "fieldState": Object {
+                                                                                              "events": Object {
+                                                                                                "Saving": false,
+                                                                                                "showSave": true,
+                                                                                              },
+                                                                                            },
                                                                                             "fields": Object {
                                                                                               "Event--permission": "no-access",
                                                                                               "Member--permission": "no-access",
@@ -1714,7 +1729,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "uuid": "123456123456123456123456",
                                                                                               "webhookUrl": "https://example.com/webhook",
                                                                                             },
-                                                                                            "formState": undefined,
+                                                                                            "formState": "Ready",
                                                                                             "initialData": Object {
                                                                                               "Event--permission": "no-access",
                                                                                               "Member--permission": "no-access",
@@ -2254,7 +2269,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "overflow": true,
                                                                   },
                                                                 },
-                                                                "fieldState": Object {},
+                                                                "fieldState": Object {
+                                                                  "events": Object {
+                                                                    "Saving": false,
+                                                                    "showSave": true,
+                                                                  },
+                                                                },
                                                                 "fields": Object {
                                                                   "Event--permission": "no-access",
                                                                   "Member--permission": "no-access",
@@ -2278,7 +2298,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                   "uuid": "123456123456123456123456",
                                                                   "webhookUrl": "https://example.com/webhook",
                                                                 },
-                                                                "formState": undefined,
+                                                                "formState": "Ready",
                                                                 "initialData": Object {
                                                                   "Event--permission": "no-access",
                                                                   "Member--permission": "no-access",
@@ -2808,7 +2828,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "overflow": true,
                                                                                               },
                                                                                             },
-                                                                                            "fieldState": Object {},
+                                                                                            "fieldState": Object {
+                                                                                              "events": Object {
+                                                                                                "Saving": false,
+                                                                                                "showSave": true,
+                                                                                              },
+                                                                                            },
                                                                                             "fields": Object {
                                                                                               "Event--permission": "no-access",
                                                                                               "Member--permission": "no-access",
@@ -2832,7 +2857,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "uuid": "123456123456123456123456",
                                                                                               "webhookUrl": "https://example.com/webhook",
                                                                                             },
-                                                                                            "formState": undefined,
+                                                                                            "formState": "Ready",
                                                                                             "initialData": Object {
                                                                                               "Event--permission": "no-access",
                                                                                               "Member--permission": "no-access",
@@ -3363,7 +3388,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "overflow": true,
                                                                   },
                                                                 },
-                                                                "fieldState": Object {},
+                                                                "fieldState": Object {
+                                                                  "events": Object {
+                                                                    "Saving": false,
+                                                                    "showSave": true,
+                                                                  },
+                                                                },
                                                                 "fields": Object {
                                                                   "Event--permission": "no-access",
                                                                   "Member--permission": "no-access",
@@ -3387,7 +3417,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                   "uuid": "123456123456123456123456",
                                                                   "webhookUrl": "https://example.com/webhook",
                                                                 },
-                                                                "formState": undefined,
+                                                                "formState": "Ready",
                                                                 "initialData": Object {
                                                                   "Event--permission": "no-access",
                                                                   "Member--permission": "no-access",
@@ -3915,7 +3945,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "overflow": true,
                                                                                               },
                                                                                             },
-                                                                                            "fieldState": Object {},
+                                                                                            "fieldState": Object {
+                                                                                              "events": Object {
+                                                                                                "Saving": false,
+                                                                                                "showSave": true,
+                                                                                              },
+                                                                                            },
                                                                                             "fields": Object {
                                                                                               "Event--permission": "no-access",
                                                                                               "Member--permission": "no-access",
@@ -3939,7 +3974,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "uuid": "123456123456123456123456",
                                                                                               "webhookUrl": "https://example.com/webhook",
                                                                                             },
-                                                                                            "formState": undefined,
+                                                                                            "formState": "Ready",
                                                                                             "initialData": Object {
                                                                                               "Event--permission": "no-access",
                                                                                               "Member--permission": "no-access",
@@ -4570,7 +4605,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "overflow": true,
                                                                   },
                                                                 },
-                                                                "fieldState": Object {},
+                                                                "fieldState": Object {
+                                                                  "events": Object {
+                                                                    "Saving": false,
+                                                                    "showSave": true,
+                                                                  },
+                                                                },
                                                                 "fields": Object {
                                                                   "Event--permission": "no-access",
                                                                   "Member--permission": "no-access",
@@ -4594,7 +4634,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                   "uuid": "123456123456123456123456",
                                                                   "webhookUrl": "https://example.com/webhook",
                                                                 },
-                                                                "formState": undefined,
+                                                                "formState": "Ready",
                                                                 "initialData": Object {
                                                                   "Event--permission": "no-access",
                                                                   "Member--permission": "no-access",
@@ -5156,7 +5196,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "overflow": true,
                                                                                               },
                                                                                             },
-                                                                                            "fieldState": Object {},
+                                                                                            "fieldState": Object {
+                                                                                              "events": Object {
+                                                                                                "Saving": false,
+                                                                                                "showSave": true,
+                                                                                              },
+                                                                                            },
                                                                                             "fields": Object {
                                                                                               "Event--permission": "no-access",
                                                                                               "Member--permission": "no-access",
@@ -5180,7 +5225,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "uuid": "123456123456123456123456",
                                                                                               "webhookUrl": "https://example.com/webhook",
                                                                                             },
-                                                                                            "formState": undefined,
+                                                                                            "formState": "Ready",
                                                                                             "initialData": Object {
                                                                                               "Event--permission": "no-access",
                                                                                               "Member--permission": "no-access",
@@ -5711,7 +5756,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "overflow": true,
                                                                   },
                                                                 },
-                                                                "fieldState": Object {},
+                                                                "fieldState": Object {
+                                                                  "events": Object {
+                                                                    "Saving": false,
+                                                                    "showSave": true,
+                                                                  },
+                                                                },
                                                                 "fields": Object {
                                                                   "Event--permission": "no-access",
                                                                   "Member--permission": "no-access",
@@ -5735,7 +5785,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                   "uuid": "123456123456123456123456",
                                                                   "webhookUrl": "https://example.com/webhook",
                                                                 },
-                                                                "formState": undefined,
+                                                                "formState": "Ready",
                                                                 "initialData": Object {
                                                                   "Event--permission": "no-access",
                                                                   "Member--permission": "no-access",
@@ -6290,7 +6340,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "overflow": true,
                                                                                               },
                                                                                             },
-                                                                                            "fieldState": Object {},
+                                                                                            "fieldState": Object {
+                                                                                              "events": Object {
+                                                                                                "Saving": false,
+                                                                                                "showSave": true,
+                                                                                              },
+                                                                                            },
                                                                                             "fields": Object {
                                                                                               "Event--permission": "no-access",
                                                                                               "Member--permission": "no-access",
@@ -6314,7 +6369,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "uuid": "123456123456123456123456",
                                                                                               "webhookUrl": "https://example.com/webhook",
                                                                                             },
-                                                                                            "formState": undefined,
+                                                                                            "formState": "Ready",
                                                                                             "initialData": Object {
                                                                                               "Event--permission": "no-access",
                                                                                               "Member--permission": "no-access",
@@ -7006,7 +7061,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                             "overflow": true,
                                                           },
                                                         },
-                                                        "fieldState": Object {},
+                                                        "fieldState": Object {
+                                                          "events": Object {
+                                                            "Saving": false,
+                                                            "showSave": true,
+                                                          },
+                                                        },
                                                         "fields": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -7030,7 +7090,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                           "uuid": "123456123456123456123456",
                                                           "webhookUrl": "https://example.com/webhook",
                                                         },
-                                                        "formState": undefined,
+                                                        "formState": "Ready",
                                                         "initialData": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -8029,7 +8089,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "overflow": true,
                                                                                       },
                                                                                     },
-                                                                                    "fieldState": Object {},
+                                                                                    "fieldState": Object {
+                                                                                      "events": Object {
+                                                                                        "Saving": false,
+                                                                                        "showSave": true,
+                                                                                      },
+                                                                                    },
                                                                                     "fields": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -8053,7 +8118,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "uuid": "123456123456123456123456",
                                                                                       "webhookUrl": "https://example.com/webhook",
                                                                                     },
-                                                                                    "formState": undefined,
+                                                                                    "formState": "Ready",
                                                                                     "initialData": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -8674,7 +8739,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                             "overflow": true,
                                                           },
                                                         },
-                                                        "fieldState": Object {},
+                                                        "fieldState": Object {
+                                                          "events": Object {
+                                                            "Saving": false,
+                                                            "showSave": true,
+                                                          },
+                                                        },
                                                         "fields": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -8698,7 +8768,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                           "uuid": "123456123456123456123456",
                                                           "webhookUrl": "https://example.com/webhook",
                                                         },
-                                                        "formState": undefined,
+                                                        "formState": "Ready",
                                                         "initialData": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -9697,7 +9767,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "overflow": true,
                                                                                       },
                                                                                     },
-                                                                                    "fieldState": Object {},
+                                                                                    "fieldState": Object {
+                                                                                      "events": Object {
+                                                                                        "Saving": false,
+                                                                                        "showSave": true,
+                                                                                      },
+                                                                                    },
                                                                                     "fields": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -9721,7 +9796,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "uuid": "123456123456123456123456",
                                                                                       "webhookUrl": "https://example.com/webhook",
                                                                                     },
-                                                                                    "formState": undefined,
+                                                                                    "formState": "Ready",
                                                                                     "initialData": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -10310,7 +10385,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                             "overflow": true,
                                                           },
                                                         },
-                                                        "fieldState": Object {},
+                                                        "fieldState": Object {
+                                                          "events": Object {
+                                                            "Saving": false,
+                                                            "showSave": true,
+                                                          },
+                                                        },
                                                         "fields": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -10334,7 +10414,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                           "uuid": "123456123456123456123456",
                                                           "webhookUrl": "https://example.com/webhook",
                                                         },
-                                                        "formState": undefined,
+                                                        "formState": "Ready",
                                                         "initialData": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -11285,7 +11365,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "overflow": true,
                                                                                       },
                                                                                     },
-                                                                                    "fieldState": Object {},
+                                                                                    "fieldState": Object {
+                                                                                      "events": Object {
+                                                                                        "Saving": false,
+                                                                                        "showSave": true,
+                                                                                      },
+                                                                                    },
                                                                                     "fields": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -11309,7 +11394,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "uuid": "123456123456123456123456",
                                                                                       "webhookUrl": "https://example.com/webhook",
                                                                                     },
-                                                                                    "formState": undefined,
+                                                                                    "formState": "Ready",
                                                                                     "initialData": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -11930,7 +12015,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                             "overflow": true,
                                                           },
                                                         },
-                                                        "fieldState": Object {},
+                                                        "fieldState": Object {
+                                                          "events": Object {
+                                                            "Saving": false,
+                                                            "showSave": true,
+                                                          },
+                                                        },
                                                         "fields": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -11954,7 +12044,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                           "uuid": "123456123456123456123456",
                                                           "webhookUrl": "https://example.com/webhook",
                                                         },
-                                                        "formState": undefined,
+                                                        "formState": "Ready",
                                                         "initialData": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -12953,7 +13043,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "overflow": true,
                                                                                       },
                                                                                     },
-                                                                                    "fieldState": Object {},
+                                                                                    "fieldState": Object {
+                                                                                      "events": Object {
+                                                                                        "Saving": false,
+                                                                                        "showSave": true,
+                                                                                      },
+                                                                                    },
                                                                                     "fields": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -12977,7 +13072,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "uuid": "123456123456123456123456",
                                                                                       "webhookUrl": "https://example.com/webhook",
                                                                                     },
-                                                                                    "formState": undefined,
+                                                                                    "formState": "Ready",
                                                                                     "initialData": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -13598,7 +13693,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                             "overflow": true,
                                                           },
                                                         },
-                                                        "fieldState": Object {},
+                                                        "fieldState": Object {
+                                                          "events": Object {
+                                                            "Saving": false,
+                                                            "showSave": true,
+                                                          },
+                                                        },
                                                         "fields": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -13622,7 +13722,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                           "uuid": "123456123456123456123456",
                                                           "webhookUrl": "https://example.com/webhook",
                                                         },
-                                                        "formState": undefined,
+                                                        "formState": "Ready",
                                                         "initialData": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -14621,7 +14721,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "overflow": true,
                                                                                       },
                                                                                     },
-                                                                                    "fieldState": Object {},
+                                                                                    "fieldState": Object {
+                                                                                      "events": Object {
+                                                                                        "Saving": false,
+                                                                                        "showSave": true,
+                                                                                      },
+                                                                                    },
                                                                                     "fields": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -14645,7 +14750,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "uuid": "123456123456123456123456",
                                                                                       "webhookUrl": "https://example.com/webhook",
                                                                                     },
-                                                                                    "formState": undefined,
+                                                                                    "formState": "Ready",
                                                                                     "initialData": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -15266,7 +15371,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                             "overflow": true,
                                                           },
                                                         },
-                                                        "fieldState": Object {},
+                                                        "fieldState": Object {
+                                                          "events": Object {
+                                                            "Saving": false,
+                                                            "showSave": true,
+                                                          },
+                                                        },
                                                         "fields": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -15290,7 +15400,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                           "uuid": "123456123456123456123456",
                                                           "webhookUrl": "https://example.com/webhook",
                                                         },
-                                                        "formState": undefined,
+                                                        "formState": "Ready",
                                                         "initialData": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -16289,7 +16399,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "overflow": true,
                                                                                       },
                                                                                     },
-                                                                                    "fieldState": Object {},
+                                                                                    "fieldState": Object {
+                                                                                      "events": Object {
+                                                                                        "Saving": false,
+                                                                                        "showSave": true,
+                                                                                      },
+                                                                                    },
                                                                                     "fields": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -16313,7 +16428,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "uuid": "123456123456123456123456",
                                                                                       "webhookUrl": "https://example.com/webhook",
                                                                                     },
-                                                                                    "formState": undefined,
+                                                                                    "formState": "Ready",
                                                                                     "initialData": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -16984,7 +17099,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                     "overflow": true,
                                                   },
                                                 },
-                                                "fieldState": Object {},
+                                                "fieldState": Object {
+                                                  "events": Object {
+                                                    "Saving": false,
+                                                    "showSave": true,
+                                                  },
+                                                },
                                                 "fields": Object {
                                                   "Event--permission": "no-access",
                                                   "Member--permission": "no-access",
@@ -17008,7 +17128,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                   "uuid": "123456123456123456123456",
                                                   "webhookUrl": "https://example.com/webhook",
                                                 },
-                                                "formState": undefined,
+                                                "formState": "Ready",
                                                 "initialData": Object {
                                                   "Event--permission": "no-access",
                                                   "Member--permission": "no-access",
@@ -17528,7 +17648,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                 "overflow": true,
                                                                               },
                                                                             },
-                                                                            "fieldState": Object {},
+                                                                            "fieldState": Object {
+                                                                              "events": Object {
+                                                                                "Saving": false,
+                                                                                "showSave": true,
+                                                                              },
+                                                                            },
                                                                             "fields": Object {
                                                                               "Event--permission": "no-access",
                                                                               "Member--permission": "no-access",
@@ -17552,7 +17677,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                               "uuid": "123456123456123456123456",
                                                                               "webhookUrl": "https://example.com/webhook",
                                                                             },
-                                                                            "formState": undefined,
+                                                                            "formState": "Ready",
                                                                             "initialData": Object {
                                                                               "Event--permission": "no-access",
                                                                               "Member--permission": "no-access",
@@ -18034,7 +18159,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                     "overflow": true,
                                                   },
                                                 },
-                                                "fieldState": Object {},
+                                                "fieldState": Object {
+                                                  "events": Object {
+                                                    "Saving": false,
+                                                    "showSave": true,
+                                                  },
+                                                },
                                                 "fields": Object {
                                                   "Event--permission": "no-access",
                                                   "Member--permission": "no-access",
@@ -18058,7 +18188,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                   "uuid": "123456123456123456123456",
                                                   "webhookUrl": "https://example.com/webhook",
                                                 },
-                                                "formState": undefined,
+                                                "formState": "Ready",
                                                 "initialData": Object {
                                                   "Event--permission": "no-access",
                                                   "Member--permission": "no-access",
@@ -18578,7 +18708,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                 "overflow": true,
                                                                               },
                                                                             },
-                                                                            "fieldState": Object {},
+                                                                            "fieldState": Object {
+                                                                              "events": Object {
+                                                                                "Saving": false,
+                                                                                "showSave": true,
+                                                                              },
+                                                                            },
                                                                             "fields": Object {
                                                                               "Event--permission": "no-access",
                                                                               "Member--permission": "no-access",
@@ -18602,7 +18737,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                               "uuid": "123456123456123456123456",
                                                                               "webhookUrl": "https://example.com/webhook",
                                                                             },
-                                                                            "formState": undefined,
+                                                                            "formState": "Ready",
                                                                             "initialData": Object {
                                                                               "Event--permission": "no-access",
                                                                               "Member--permission": "no-access",
@@ -19149,7 +19284,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                   "value": "no-access",
                 },
               },
-              "fieldState": Object {},
+              "fieldState": Object {
+                "events": Object {
+                  "Saving": false,
+                  "showSave": true,
+                },
+              },
               "fields": Object {
                 "Event--permission": "no-access",
                 "Member--permission": "no-access",
@@ -19157,10 +19297,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                 "Project--permission": "no-access",
                 "Release--permission": "no-access",
                 "Team--permission": "no-access",
+                "events": Array [],
                 "isAlertable": false,
                 "organization": "org-slug",
               },
-              "formState": undefined,
+              "formState": "Ready",
               "initialData": Object {
                 "Event--permission": "no-access",
                 "Member--permission": "no-access",
@@ -19812,7 +19953,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                     "value": "no-access",
                                                                   },
                                                                 },
-                                                                "fieldState": Object {},
+                                                                "fieldState": Object {
+                                                                  "events": Object {
+                                                                    "Saving": false,
+                                                                    "showSave": true,
+                                                                  },
+                                                                },
                                                                 "fields": Object {
                                                                   "Event--permission": "no-access",
                                                                   "Member--permission": "no-access",
@@ -19820,10 +19966,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                   "Project--permission": "no-access",
                                                                   "Release--permission": "no-access",
                                                                   "Team--permission": "no-access",
+                                                                  "events": Array [],
                                                                   "isAlertable": false,
                                                                   "organization": "org-slug",
                                                                 },
-                                                                "formState": undefined,
+                                                                "formState": "Ready",
                                                                 "initialData": Object {
                                                                   "Event--permission": "no-access",
                                                                   "Member--permission": "no-access",
@@ -20298,7 +20445,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                                 "value": "no-access",
                                                                                               },
                                                                                             },
-                                                                                            "fieldState": Object {},
+                                                                                            "fieldState": Object {
+                                                                                              "events": Object {
+                                                                                                "Saving": false,
+                                                                                                "showSave": true,
+                                                                                              },
+                                                                                            },
                                                                                             "fields": Object {
                                                                                               "Event--permission": "no-access",
                                                                                               "Member--permission": "no-access",
@@ -20306,10 +20458,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                               "Project--permission": "no-access",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "events": Array [],
                                                                                               "isAlertable": false,
                                                                                               "organization": "org-slug",
                                                                                             },
-                                                                                            "formState": undefined,
+                                                                                            "formState": "Ready",
                                                                                             "initialData": Object {
                                                                                               "Event--permission": "no-access",
                                                                                               "Member--permission": "no-access",
@@ -20807,7 +20960,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                     "value": "no-access",
                                                                   },
                                                                 },
-                                                                "fieldState": Object {},
+                                                                "fieldState": Object {
+                                                                  "events": Object {
+                                                                    "Saving": false,
+                                                                    "showSave": true,
+                                                                  },
+                                                                },
                                                                 "fields": Object {
                                                                   "Event--permission": "no-access",
                                                                   "Member--permission": "no-access",
@@ -20815,10 +20973,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                   "Project--permission": "no-access",
                                                                   "Release--permission": "no-access",
                                                                   "Team--permission": "no-access",
+                                                                  "events": Array [],
                                                                   "isAlertable": false,
                                                                   "organization": "org-slug",
                                                                 },
-                                                                "formState": undefined,
+                                                                "formState": "Ready",
                                                                 "initialData": Object {
                                                                   "Event--permission": "no-access",
                                                                   "Member--permission": "no-access",
@@ -21293,7 +21452,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                                 "value": "no-access",
                                                                                               },
                                                                                             },
-                                                                                            "fieldState": Object {},
+                                                                                            "fieldState": Object {
+                                                                                              "events": Object {
+                                                                                                "Saving": false,
+                                                                                                "showSave": true,
+                                                                                              },
+                                                                                            },
                                                                                             "fields": Object {
                                                                                               "Event--permission": "no-access",
                                                                                               "Member--permission": "no-access",
@@ -21301,10 +21465,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                               "Project--permission": "no-access",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "events": Array [],
                                                                                               "isAlertable": false,
                                                                                               "organization": "org-slug",
                                                                                             },
-                                                                                            "formState": undefined,
+                                                                                            "formState": "Ready",
                                                                                             "initialData": Object {
                                                                                               "Event--permission": "no-access",
                                                                                               "Member--permission": "no-access",
@@ -21793,7 +21958,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                     "value": "no-access",
                                                                   },
                                                                 },
-                                                                "fieldState": Object {},
+                                                                "fieldState": Object {
+                                                                  "events": Object {
+                                                                    "Saving": false,
+                                                                    "showSave": true,
+                                                                  },
+                                                                },
                                                                 "fields": Object {
                                                                   "Event--permission": "no-access",
                                                                   "Member--permission": "no-access",
@@ -21801,10 +21971,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                   "Project--permission": "no-access",
                                                                   "Release--permission": "no-access",
                                                                   "Team--permission": "no-access",
+                                                                  "events": Array [],
                                                                   "isAlertable": false,
                                                                   "organization": "org-slug",
                                                                 },
-                                                                "formState": undefined,
+                                                                "formState": "Ready",
                                                                 "initialData": Object {
                                                                   "Event--permission": "no-access",
                                                                   "Member--permission": "no-access",
@@ -22277,7 +22448,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                                 "value": "no-access",
                                                                                               },
                                                                                             },
-                                                                                            "fieldState": Object {},
+                                                                                            "fieldState": Object {
+                                                                                              "events": Object {
+                                                                                                "Saving": false,
+                                                                                                "showSave": true,
+                                                                                              },
+                                                                                            },
                                                                                             "fields": Object {
                                                                                               "Event--permission": "no-access",
                                                                                               "Member--permission": "no-access",
@@ -22285,10 +22461,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                               "Project--permission": "no-access",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "events": Array [],
                                                                                               "isAlertable": false,
                                                                                               "organization": "org-slug",
                                                                                             },
-                                                                                            "formState": undefined,
+                                                                                            "formState": "Ready",
                                                                                             "initialData": Object {
                                                                                               "Event--permission": "no-access",
                                                                                               "Member--permission": "no-access",
@@ -22877,7 +23054,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                     "value": "no-access",
                                                                   },
                                                                 },
-                                                                "fieldState": Object {},
+                                                                "fieldState": Object {
+                                                                  "events": Object {
+                                                                    "Saving": false,
+                                                                    "showSave": true,
+                                                                  },
+                                                                },
                                                                 "fields": Object {
                                                                   "Event--permission": "no-access",
                                                                   "Member--permission": "no-access",
@@ -22885,10 +23067,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                   "Project--permission": "no-access",
                                                                   "Release--permission": "no-access",
                                                                   "Team--permission": "no-access",
+                                                                  "events": Array [],
                                                                   "isAlertable": false,
                                                                   "organization": "org-slug",
                                                                 },
-                                                                "formState": undefined,
+                                                                "formState": "Ready",
                                                                 "initialData": Object {
                                                                   "Event--permission": "no-access",
                                                                   "Member--permission": "no-access",
@@ -23395,7 +23578,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                                 "value": "no-access",
                                                                                               },
                                                                                             },
-                                                                                            "fieldState": Object {},
+                                                                                            "fieldState": Object {
+                                                                                              "events": Object {
+                                                                                                "Saving": false,
+                                                                                                "showSave": true,
+                                                                                              },
+                                                                                            },
                                                                                             "fields": Object {
                                                                                               "Event--permission": "no-access",
                                                                                               "Member--permission": "no-access",
@@ -23403,10 +23591,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                               "Project--permission": "no-access",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "events": Array [],
                                                                                               "isAlertable": false,
                                                                                               "organization": "org-slug",
                                                                                             },
-                                                                                            "formState": undefined,
+                                                                                            "formState": "Ready",
                                                                                             "initialData": Object {
                                                                                               "Event--permission": "no-access",
                                                                                               "Member--permission": "no-access",
@@ -23895,7 +24084,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                     "value": "no-access",
                                                                   },
                                                                 },
-                                                                "fieldState": Object {},
+                                                                "fieldState": Object {
+                                                                  "events": Object {
+                                                                    "Saving": false,
+                                                                    "showSave": true,
+                                                                  },
+                                                                },
                                                                 "fields": Object {
                                                                   "Event--permission": "no-access",
                                                                   "Member--permission": "no-access",
@@ -23903,10 +24097,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                   "Project--permission": "no-access",
                                                                   "Release--permission": "no-access",
                                                                   "Team--permission": "no-access",
+                                                                  "events": Array [],
                                                                   "isAlertable": false,
                                                                   "organization": "org-slug",
                                                                 },
-                                                                "formState": undefined,
+                                                                "formState": "Ready",
                                                                 "initialData": Object {
                                                                   "Event--permission": "no-access",
                                                                   "Member--permission": "no-access",
@@ -24406,7 +24601,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                                 "value": "no-access",
                                                                                               },
                                                                                             },
-                                                                                            "fieldState": Object {},
+                                                                                            "fieldState": Object {
+                                                                                              "events": Object {
+                                                                                                "Saving": false,
+                                                                                                "showSave": true,
+                                                                                              },
+                                                                                            },
                                                                                             "fields": Object {
                                                                                               "Event--permission": "no-access",
                                                                                               "Member--permission": "no-access",
@@ -24414,10 +24614,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                               "Project--permission": "no-access",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "events": Array [],
                                                                                               "isAlertable": false,
                                                                                               "organization": "org-slug",
                                                                                             },
-                                                                                            "formState": undefined,
+                                                                                            "formState": "Ready",
                                                                                             "initialData": Object {
                                                                                               "Event--permission": "no-access",
                                                                                               "Member--permission": "no-access",
@@ -25063,7 +25264,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                             "value": "no-access",
                                                           },
                                                         },
-                                                        "fieldState": Object {},
+                                                        "fieldState": Object {
+                                                          "events": Object {
+                                                            "Saving": false,
+                                                            "showSave": true,
+                                                          },
+                                                        },
                                                         "fields": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -25071,10 +25277,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                           "Project--permission": "no-access",
                                                           "Release--permission": "no-access",
                                                           "Team--permission": "no-access",
+                                                          "events": Array [],
                                                           "isAlertable": false,
                                                           "organization": "org-slug",
                                                         },
-                                                        "formState": undefined,
+                                                        "formState": "Ready",
                                                         "initialData": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -25966,7 +26173,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                         "value": "no-access",
                                                                                       },
                                                                                     },
-                                                                                    "fieldState": Object {},
+                                                                                    "fieldState": Object {
+                                                                                      "events": Object {
+                                                                                        "Saving": false,
+                                                                                        "showSave": true,
+                                                                                      },
+                                                                                    },
                                                                                     "fields": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -25974,10 +26186,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                       "Project--permission": "no-access",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "events": Array [],
                                                                                       "isAlertable": false,
                                                                                       "organization": "org-slug",
                                                                                     },
-                                                                                    "formState": undefined,
+                                                                                    "formState": "Ready",
                                                                                     "initialData": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -26556,7 +26769,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                             "value": "no-access",
                                                           },
                                                         },
-                                                        "fieldState": Object {},
+                                                        "fieldState": Object {
+                                                          "events": Object {
+                                                            "Saving": false,
+                                                            "showSave": true,
+                                                          },
+                                                        },
                                                         "fields": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -26564,10 +26782,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                           "Project--permission": "no-access",
                                                           "Release--permission": "no-access",
                                                           "Team--permission": "no-access",
+                                                          "events": Array [],
                                                           "isAlertable": false,
                                                           "organization": "org-slug",
                                                         },
-                                                        "formState": undefined,
+                                                        "formState": "Ready",
                                                         "initialData": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -27459,7 +27678,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                         "value": "no-access",
                                                                                       },
                                                                                     },
-                                                                                    "fieldState": Object {},
+                                                                                    "fieldState": Object {
+                                                                                      "events": Object {
+                                                                                        "Saving": false,
+                                                                                        "showSave": true,
+                                                                                      },
+                                                                                    },
                                                                                     "fields": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -27467,10 +27691,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                       "Project--permission": "no-access",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "events": Array [],
                                                                                       "isAlertable": false,
                                                                                       "organization": "org-slug",
                                                                                     },
-                                                                                    "formState": undefined,
+                                                                                    "formState": "Ready",
                                                                                     "initialData": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -28017,7 +28242,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                             "value": "no-access",
                                                           },
                                                         },
-                                                        "fieldState": Object {},
+                                                        "fieldState": Object {
+                                                          "events": Object {
+                                                            "Saving": false,
+                                                            "showSave": true,
+                                                          },
+                                                        },
                                                         "fields": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -28025,10 +28255,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                           "Project--permission": "no-access",
                                                           "Release--permission": "no-access",
                                                           "Team--permission": "no-access",
+                                                          "events": Array [],
                                                           "isAlertable": false,
                                                           "organization": "org-slug",
                                                         },
-                                                        "formState": undefined,
+                                                        "formState": "Ready",
                                                         "initialData": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -28872,7 +29103,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                         "value": "no-access",
                                                                                       },
                                                                                     },
-                                                                                    "fieldState": Object {},
+                                                                                    "fieldState": Object {
+                                                                                      "events": Object {
+                                                                                        "Saving": false,
+                                                                                        "showSave": true,
+                                                                                      },
+                                                                                    },
                                                                                     "fields": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -28880,10 +29116,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                       "Project--permission": "no-access",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "events": Array [],
                                                                                       "isAlertable": false,
                                                                                       "organization": "org-slug",
                                                                                     },
-                                                                                    "formState": undefined,
+                                                                                    "formState": "Ready",
                                                                                     "initialData": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -29462,7 +29699,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                             "value": "no-access",
                                                           },
                                                         },
-                                                        "fieldState": Object {},
+                                                        "fieldState": Object {
+                                                          "events": Object {
+                                                            "Saving": false,
+                                                            "showSave": true,
+                                                          },
+                                                        },
                                                         "fields": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -29470,10 +29712,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                           "Project--permission": "no-access",
                                                           "Release--permission": "no-access",
                                                           "Team--permission": "no-access",
+                                                          "events": Array [],
                                                           "isAlertable": false,
                                                           "organization": "org-slug",
                                                         },
-                                                        "formState": undefined,
+                                                        "formState": "Ready",
                                                         "initialData": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -30365,7 +30608,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                         "value": "no-access",
                                                                                       },
                                                                                     },
-                                                                                    "fieldState": Object {},
+                                                                                    "fieldState": Object {
+                                                                                      "events": Object {
+                                                                                        "Saving": false,
+                                                                                        "showSave": true,
+                                                                                      },
+                                                                                    },
                                                                                     "fields": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -30373,10 +30621,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                       "Project--permission": "no-access",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "events": Array [],
                                                                                       "isAlertable": false,
                                                                                       "organization": "org-slug",
                                                                                     },
-                                                                                    "formState": undefined,
+                                                                                    "formState": "Ready",
                                                                                     "initialData": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -30955,7 +31204,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                             "value": "no-access",
                                                           },
                                                         },
-                                                        "fieldState": Object {},
+                                                        "fieldState": Object {
+                                                          "events": Object {
+                                                            "Saving": false,
+                                                            "showSave": true,
+                                                          },
+                                                        },
                                                         "fields": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -30963,10 +31217,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                           "Project--permission": "no-access",
                                                           "Release--permission": "no-access",
                                                           "Team--permission": "no-access",
+                                                          "events": Array [],
                                                           "isAlertable": false,
                                                           "organization": "org-slug",
                                                         },
-                                                        "formState": undefined,
+                                                        "formState": "Ready",
                                                         "initialData": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -31858,7 +32113,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                         "value": "no-access",
                                                                                       },
                                                                                     },
-                                                                                    "fieldState": Object {},
+                                                                                    "fieldState": Object {
+                                                                                      "events": Object {
+                                                                                        "Saving": false,
+                                                                                        "showSave": true,
+                                                                                      },
+                                                                                    },
                                                                                     "fields": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -31866,10 +32126,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                       "Project--permission": "no-access",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "events": Array [],
                                                                                       "isAlertable": false,
                                                                                       "organization": "org-slug",
                                                                                     },
-                                                                                    "formState": undefined,
+                                                                                    "formState": "Ready",
                                                                                     "initialData": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -32448,7 +32709,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                             "value": "no-access",
                                                           },
                                                         },
-                                                        "fieldState": Object {},
+                                                        "fieldState": Object {
+                                                          "events": Object {
+                                                            "Saving": false,
+                                                            "showSave": true,
+                                                          },
+                                                        },
                                                         "fields": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -32456,10 +32722,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                           "Project--permission": "no-access",
                                                           "Release--permission": "no-access",
                                                           "Team--permission": "no-access",
+                                                          "events": Array [],
                                                           "isAlertable": false,
                                                           "organization": "org-slug",
                                                         },
-                                                        "formState": undefined,
+                                                        "formState": "Ready",
                                                         "initialData": Object {
                                                           "Event--permission": "no-access",
                                                           "Member--permission": "no-access",
@@ -33351,7 +33618,12 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                         "value": "no-access",
                                                                                       },
                                                                                     },
-                                                                                    "fieldState": Object {},
+                                                                                    "fieldState": Object {
+                                                                                      "events": Object {
+                                                                                        "Saving": false,
+                                                                                        "showSave": true,
+                                                                                      },
+                                                                                    },
                                                                                     "fields": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",
@@ -33359,10 +33631,11 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                       "Project--permission": "no-access",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "events": Array [],
                                                                                       "isAlertable": false,
                                                                                       "organization": "org-slug",
                                                                                     },
-                                                                                    "formState": undefined,
+                                                                                    "formState": "Ready",
                                                                                     "initialData": Object {
                                                                                       "Event--permission": "no-access",
                                                                                       "Member--permission": "no-access",

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -164,7 +164,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
 
         assert response.status_code == 400
         assert response.data == \
-            {'events': [u"resource type 'issue' does not have the correct permissions."]}
+            {'events': ['issue webhooks require the event:read permission.']}
 
     @with_feature('organizations:internal-catchall')
     def test_cannot_update_scopes_published_app(self):

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -136,7 +136,7 @@ class PostSentryAppsTest(SentryAppsTest):
 
         assert response.status_code == 422
         assert response.data['errors'] == \
-            {"events": ["resource type 'issue' does not have the correct permissions."]}
+            {'events': ['issue webhooks require the event:read permission.']}
 
     @with_feature('organizations:internal-catchall')
     def test_missing_name(self):

--- a/tests/sentry/mediators/sentry_apps/test_updater.py
+++ b/tests/sentry/mediators/sentry_apps/test_updater.py
@@ -41,6 +41,17 @@ class TestUpdater(TestCase):
         with self.assertRaises(APIError):
             updater.call()
 
+    def test_doesnt_update_app_with_invalid_event_permissions(self):
+        sentry_app = self.create_sentry_app(
+            name='sentry',
+            organization=self.org,
+            scopes=('project:read',),
+        )
+        updater = Updater(sentry_app=sentry_app)
+        updater.events = ('issue',)
+        with self.assertRaises(APIError):
+            updater.call()
+
     def test_updates_webhook_url(self):
         self.updater.webhook_url = 'http://example.com/hooks'
         self.updater.call()


### PR DESCRIPTION
When a sentry app is created or updated, we must check the resource subscriptions (i.e. `issue`) to see if the corresponding permissions are there. The permissions (aka scopes) needed are `read` or above for any given resource.

Backend piece to https://github.com/getsentry/sentry/pull/11510.

Keeping the logic isolated in the serializer (`SentryAppSerializer`) for now but maybe in the future would be useful to add to the `sentry_apps.mediators`.

