### PR TITLE
feat(discover): Update fields

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDashboard/data/queries/eventsByRelease.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/data/queries/eventsByRelease.jsx
@@ -2,7 +2,7 @@
  * Events by Release
  */
 const eventsByRelease = {
-  fields: ['sentry:release'],
+  fields: ['release'],
   conditions: [],
   aggregations: [['count()', null, 'Events']],
   limit: 1000,

--- a/src/sentry/static/sentry/app/views/organizationDiscover/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/data.jsx
@@ -23,13 +23,16 @@ export const PROMOTED_TAGS = [
   'os',
   'os.name',
   'os.rooted',
-  'sentry:release',
 ];
 
 // All tags are assumed to be strings, except the following
 export const SPECIAL_TAGS = {
   os_rooted: TYPES.BOOLEAN,
 };
+
+// Hide the following tags if they are returned from Snuba since these are
+// already mapped to user and release attributes
+export const HIDDEN_TAGS = ['sentry:user', 'sentry:release'];
 
 export const COLUMNS = [
   {name: 'id', type: TYPES.STRING},
@@ -39,6 +42,7 @@ export const COLUMNS = [
   {name: 'platform', type: TYPES.STRING},
   {name: 'message', type: TYPES.STRING},
   {name: 'timestamp', type: TYPES.DATETIME},
+  {name: 'release', type: TYPES.STRING},
 
   {name: 'user.id', type: TYPES.STRING},
   {name: 'user.username', type: TYPES.STRING},

--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -10,7 +10,7 @@ import {t} from 'app/locale';
 import {openModal} from 'app/actionCreators/modal';
 
 import MissingProjectWarningModal from './missingProjectWarningModal';
-import {COLUMNS, PROMOTED_TAGS, SPECIAL_TAGS} from './data';
+import {COLUMNS, PROMOTED_TAGS, SPECIAL_TAGS, HIDDEN_TAGS} from './data';
 import {isValidAggregation} from './aggregations/utils';
 
 const DEFAULTS = {
@@ -73,7 +73,7 @@ export default function createQueryBuilder(initial = {}, organization) {
       turbo: true,
     })
       .then(res => {
-        tags = res.data.map(tag => {
+        tags = res.data.filter(tag => !HIDDEN_TAGS.includes(tag.tags_key)).map(tag => {
           const type = SPECIAL_TAGS[tags.tags_key] || 'string';
           return {name: tag.tags_key, type, isTag: true};
         });


### PR DESCRIPTION
Adds "release" field to query builder. Hide sentry:release and
sentry:user from dynamically loaded tags if case they are returned