### PR TITLE
fix(help): Remove extra '/' from help-search docs results

### DIFF
--- a/src/sentry/static/sentry/app/components/search/sources/helpSource.jsx
+++ b/src/sentry/static/sentry/app/components/search/sources/helpSource.jsx
@@ -91,7 +91,7 @@ class HelpSource extends React.Component {
           descriptionKey: 'content',
           type: 'doc',
           badge: <DocsBadge />,
-          makeUrl: ({url}) => `https://docs.sentry.io/${url}`,
+          makeUrl: ({url}) => `https://docs.sentry.io${url}`,
         })
       ),
       ...faqResults.hits.map(result =>

--- a/tests/js/spec/components/modals/__snapshots__/helpSearchModal.spec.jsx.snap
+++ b/tests/js/spec/components/modals/__snapshots__/helpSearchModal.spec.jsx.snap
@@ -30,7 +30,7 @@ exports[`Docs Search Modal can open help search modal and complete a search 1`] 
                 "resultType": "doc",
                 "sourceType": "help",
                 "title": "Doc result 1",
-                "to": "https://docs.sentry.io/undefined",
+                "to": "https://docs.sentry.io/doc_result",
               }
             }
             matches={
@@ -57,7 +57,7 @@ exports[`Docs Search Modal can open help search modal and complete a search 1`] 
                   "resultType": "doc",
                   "sourceType": "help",
                   "title": "Doc result 1",
-                  "to": "https://docs.sentry.io/undefined",
+                  "to": "https://docs.sentry.io/doc_result",
                 }
               }
               location={

--- a/tests/js/spec/components/modals/helpSearchModal.spec.jsx
+++ b/tests/js/spec/components/modals/helpSearchModal.spec.jsx
@@ -56,6 +56,7 @@ describe('Docs Search Modal', function() {
       const search = jest.fn(params => {
         const docHits = [
           {
+            url: '/doc_result',
             _highlightResult: {
               title: {value: 'Doc result 1'},
             },
@@ -66,6 +67,7 @@ describe('Docs Search Modal', function() {
         ];
         const faqHits = [
           {
+            url: '/faq_result',
             _highlightResult: {
               title: {value: 'FAQ result 1'},
             },


### PR DESCRIPTION
The extra slash is causing the docs page to not expand the sidebar correctly.