### PR TITLE
fix: Collect missing metrics for store-like endpoints

### DIFF
--- a/src/sentry/middleware/stats.py
+++ b/src/sentry/middleware/stats.py
@@ -21,7 +21,10 @@ class ResponseCodeMiddleware(object):
 
 class RequestTimingMiddleware(object):
     allowed_methods = ('POST', 'GET')
-    allowed_paths = ('sentry.web.api.StoreView', 'sentry.api.endpoints', )
+    allowed_paths = (
+        'sentry.web.api',  # Store endpoints
+        'sentry.api.endpoints',
+    )
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         if request.method not in self.allowed_methods:


### PR DESCRIPTION
Only `StoreView` responses are measured at the moment.
This will collect `view.response/view.duration` metrics for the rest of store-compatible endpoints (minidumps, unreal crashes, etc.)  