### PR TITLE
fix: sentry-plugins is in_app

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1334,6 +1334,7 @@ def get_sentry_sdk_config():
         'environment': ENVIRONMENT,
         'in_app_include': [
             'sentry',
+            'sentry_plugins',
         ],
         'debug': True,
         'send_default_pii': True


### PR DESCRIPTION
The reason why `include_paths = ["sentry"]` worked in the old SDK was
because Raven checks for `module.startswith("sentry")` while the new SDK
checks for `module.startswith("sentry.") or module == "sentry"`