### PR TITLE
fix(invites) Don't display projects on org invite page.

### DIFF
--- a/src/sentry/templates/sentry/accept-organization-invite.html
+++ b/src/sentry/templates/sentry/accept-organization-invite.html
@@ -31,18 +31,7 @@
           </div>
         {% endif %}
 
-        {% if project_count %}
-          <p>{% blocktrans %}You have been invited to join this organization, which manages <strong>{{ project_count }}</strong> project(s), including:{% endblocktrans %}</p>
-          <ul>
-            {% for project in project_list|slice:"5" %}
-              <li>
-                {{ project.slug }}
-              </li>
-            {% endfor %}
-          </ul>
-        {% else %}
-          <p>{% blocktrans %}You have been invited to join this organization.{% endblocktrans %}</p>
-        {% endif %}
+        <p>{% blocktrans %}You have been invited to join this organization.{% endblocktrans %}</p>
 
         {% if needs_authentication %}
           <p>{% trans "To continue, you must either login to your existing account, or create a new one." %}</p>

--- a/src/sentry/web/frontend/accept_organization_invite.py
+++ b/src/sentry/web/frontend/accept_organization_invite.py
@@ -6,7 +6,7 @@ from django.core.urlresolvers import reverse
 from django.utils.crypto import constant_time_compare
 from django.utils.translation import ugettext_lazy as _
 
-from sentry.models import AuditLogEntryEvent, Authenticator, OrganizationMember, Project
+from sentry.models import AuditLogEntryEvent, Authenticator, OrganizationMember
 from sentry.signals import member_joined
 from sentry.utils import auth
 from sentry.web.frontend.base import BaseView
@@ -56,16 +56,8 @@ class AcceptOrganizationInviteView(BaseView):
         om = helper.om
         organization = om.organization
 
-        qs = Project.objects.filter(
-            organization=organization,
-        )
-        project_list = list(qs[:25])
-        project_count = qs.count()
-
         context = {
             'org_name': organization.name,
-            'project_list': project_list,
-            'project_count': project_count,
             'needs_authentication': not helper.user_authenticated,
             'needs_2fa': helper.needs_2fa,
             'logout_url': u'{}?next={}'.format(


### PR DESCRIPTION
Showing the first a list of projects on the organization invite page creates the opportunity to leak information as the invited member may not have access to all the displayed projects. While we could filter down the projects to the only those the member will have access to, it is simpler to not mention projects at all.

Fixes #11528