### PR TITLE
fix(issues) Fix warnings emitted on browser navigation

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar.jsx
@@ -124,6 +124,13 @@ class SmartSearchBar extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    if (this.blurTimeout) {
+      clearTimeout(this.blurTimeout);
+      this.blurTimeout = null;
+    }
+  }
+
   DROPDOWN_BLUR_DURATION = 200;
 
   blur = () => {
@@ -273,12 +280,12 @@ class SmartSearchBar extends React.Component {
         this.setState({
           searchTerm: query,
         });
-        return void this.updateAutoCompleteState(this.getTagKeys(''), '');
+        return this.updateAutoCompleteState(this.getTagKeys(''), '');
       }
 
       // cursor on whitespace
       // show default "help" search terms
-      return void this.setState({
+      return this.setState({
         searchTerm: '',
         searchItems: defaultSearchItems,
         activeSearchItem: 0,
@@ -332,7 +339,7 @@ class SmartSearchBar extends React.Component {
         return undefined;
       }
 
-      return void (tag.predefined ? this.getPredefinedTagValues : this.getTagValues)(
+      return (tag.predefined ? this.getPredefinedTagValues : this.getTagValues)(
         tag,
         preparedQuery,
         this.updateAutoCompleteState

--- a/src/sentry/static/sentry/app/utils/stream.jsx
+++ b/src/sentry/static/sentry/app/utils/stream.jsx
@@ -35,7 +35,10 @@ export function queryToObj(queryStr) {
     {}
   );
 
-  if (text.length) queryObj.__text = text.join(' ');
+  queryObj.__text = '';
+  if (text.length) {
+    queryObj.__text = text.join(' ');
+  }
 
   return queryObj;
 }

--- a/tests/js/spec/utils/stream.spec.jsx
+++ b/tests/js/spec/utils/stream.spec.jsx
@@ -4,10 +4,12 @@ describe('utils/stream', function() {
   describe('queryToObj()', function() {
     it('should convert a basic query string to a query object', function() {
       expect(queryToObj('is:unresolved')).toEqual({
+        __text: '',
         is: 'unresolved',
       });
 
       expect(queryToObj('is:unresolved browser:"Chrome 36"')).toEqual({
+        __text: '',
         is: 'unresolved',
         browser: 'Chrome 36',
       });


### PR DESCRIPTION
When using the back/fwd buttons the StreamSidebar and SmartSearchBar would emit warnings about components moving from controlled to uncontrolled and having state changed while unmounted. This resolves those problems by cancelling timeouts and ensuring that the nested input element never has it's value set to `undefined`.

Fixes APP-990