### PR TITLE
build(storybook): Temp fix for storybook issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "dev-proxy": "node scripts/devproxy.js",
     "dev-server": "webpack-dev-server",
     "storybook": "start-storybook -p 9001 -c .storybook",
-    "storybook-build": "build-storybook -c .storybook -o .storybook-out",
+    "storybook-build": "build-storybook -c .storybook -o .storybook-out && sed -i -e 's/\\\/sb_dll/sb_dll/g' .storybook-out/index.html",
     "snapshot": "build-storybook && PERCY_TOKEN=$STORYBOOK_PERCY_TOKEN PERCY_PROJECT=$STORYBOOK_PERCY_PROJECT percy-storybook --widths=1280",
     "webpack-profile": "yarn -s webpack --profile --json > stats.json"
   }


### PR DESCRIPTION
storybook DLL was not being loaded because of absolute path

Fixed in https://github.com/storybooks/storybook/issues/5055 but not merged into their stable branch yet.