### PR TITLE
fix(ui): activity item contrast

### DIFF
--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -572,7 +572,7 @@
 
       .activity-bubble {
         background: #fff;
-        border: 1px solid @trim;
+        border: 1px solid @trim-dark;
         margin-left: 50px;
         border-radius: 3px;
         font-size: 15px;
@@ -587,7 +587,7 @@
           height: 0;
           border-top: 7px solid transparent;
           border-bottom: 7px solid transparent;
-          border-right: 7px solid @trim;
+          border-right: 7px solid @trim-dark;
           position: absolute;
           left: -7px;
           top: 12px;
@@ -697,7 +697,7 @@
         top: 11px;
         left: 0;
         right: 0;
-        border-top: 1px solid @trim;
+        border-top: 1px solid @trim-dark;
         z-index: -1;
         opacity: 0.6;
       }
@@ -714,7 +714,7 @@
         &.sentry {
           color: @gray-darker;
           font-size: 16px;
-          background: @white;
+          background: @white-dark;
         }
       }
 
@@ -722,7 +722,7 @@
         color: @gray-light;
         margin-left: 5px;
         float: right;
-        background: @white;
+        background: @white-dark;
         padding-left: 8px;
       }
 
@@ -734,7 +734,7 @@
       .activity-item-content {
         display: inline;
         padding-right: 8px;
-        background: @white;
+        background: @white-dark;
       }
     }
   }


### PR DESCRIPTION
This is a quick fix for the mismatched background colors and general contrast for elements on the Comments tab.

<img width="1400" alt="screen shot 2019-01-17 at 3 48 47 pm" src="https://user-images.githubusercontent.com/30713/51356574-e2300280-1a6f-11e9-9dd3-cb2d4d4b4ec9.png">
