### PR TITLE
fix(integrations): Bitbucket no description issue.

### DIFF
--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -99,6 +99,9 @@ class BitbucketIssueBasicMixin(IssueBasicMixin):
         if not data.get('repo'):
             raise IntegrationFormError({'repo': ['Repository is required']})
 
+        data['content'] = {'raw': data['description']}
+        del data['description']
+
         try:
             issue = client.create_issue(data.get('repo'), data)
         except ApiError as e:

--- a/tests/sentry/integrations/bitbucket/test_issues.py
+++ b/tests/sentry/integrations/bitbucket/test_issues.py
@@ -260,3 +260,27 @@ class BitbucketIssueTest(APITestCase):
                 'help': ('Leave blank if you don\'t want to '
                          'add a comment to the Bitbucket issue.'),
             }]
+
+    @responses.activate
+    def test_get_issue(self):
+        repo = 'myaccount/repo1'
+        id = '112'
+        title = 'hello'
+        content = {'html': 'This is the description'}
+
+        responses.add(
+            responses.POST,
+            u'https://api.bitbucket.org/2.0/repositories/{repo}/issues'.format(repo=repo),
+            json={
+                'id': id, 'title': title, 'content': {'html': content},
+            }
+        )
+        installation = self.integration.get_installation(self.organization.id)
+        result = installation.create_issue(
+            {'id': id, 'title': title, 'description': content, 'repo': repo})
+        assert result == {
+            'key': id,
+            'title': title,
+            'description': content,
+            'repo': repo,
+        }

--- a/tests/sentry/integrations/bitbucket/test_issues.py
+++ b/tests/sentry/integrations/bitbucket/test_issues.py
@@ -262,7 +262,7 @@ class BitbucketIssueTest(APITestCase):
             }]
 
     @responses.activate
-    def test_get_issue(self):
+    def test_create_issue(self):
         repo = 'myaccount/repo1'
         id = '112'
         title = 'hello'


### PR DESCRIPTION
The Bitbucket integration was failing to populate the descriptions of created issues. This was due to the fact that Bitbucket calls their description content instead. Added a test to the `create_issue` method.

ISSUE-270