### PR TITLE
feat(api): Get rid of minimum time window for event endpoints

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -7,10 +7,10 @@ from django.utils import timezone
 from sentry.search.utils import parse_datetime_string, InvalidQuery
 from sentry.utils.dates import parse_stats_period
 
-MIN_STATS_PERIOD = timedelta(hours=1)
+
 MAX_STATS_PERIOD = timedelta(days=90)
-# make sure to update this message if you are changing the min/max period
-INVALID_PERIOD_ERROR = 'Time window must be greater than an hour and less than or equal to 90 days'
+# make sure to update this message if you are changing the max period
+INVALID_PERIOD_ERROR = 'Time window must be less than or equal to 90 days'
 
 
 class InvalidParams(Exception):
@@ -81,7 +81,7 @@ def get_date_range_from_params(params, optional=False, validate_window=True):
 
     if validate_window:
         delta = end - start
-        if delta < MIN_STATS_PERIOD or delta > MAX_STATS_PERIOD:
+        if delta > MAX_STATS_PERIOD:
             raise InvalidParams(INVALID_PERIOD_ERROR)
 
     return start, end

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -28,7 +28,7 @@ class GetDateRangeFromParamsTest(TestCase):
         assert end - datetime.timedelta(seconds=3600) == start
 
         with self.assertRaises(InvalidParams):
-            get_date_range_from_params({'statsPeriod': '1s'})
+            get_date_range_from_params({'statsPeriod': '91d'})
 
     def test_date_range(self):
         start, end = get_date_range_from_params({


### PR DESCRIPTION
I honestly can't remember why I added the min window -- might have been a relic of the health project. Getting rid of it because it's problematic for zooming.

Also, I thought about raising something like a `NoTimeDelta` error so that various endpoints can optimize and return without querying, but I kinda felt like that was overly complicating the code for what's likely to be pretty minimal efficiency gains.