### PR TITLE
ref(app-platform): Remove service hooks on app uninstall

### DIFF
--- a/src/sentry/mediators/sentry_app_installations/destroyer.py
+++ b/src/sentry/mediators/sentry_app_installations/destroyer.py
@@ -23,13 +23,11 @@ class Destroyer(Mediator):
 
     def _destroy_service_hooks(self):
         hooks = ServiceHook.objects.filter(
-            application=self.install.sentry_app.application,
+            application_id=self.install.sentry_app.application_id,
             actor_id=self.install.id,
         )
         for hook in hooks:
-            service_hooks.Destroyer.run(
-                service_hook=hook,
-            )
+            service_hooks.Destroyer.run(service_hook=hook)
 
     def _destroy_installation(self):
         self.install.delete()

--- a/src/sentry/mediators/sentry_app_installations/destroyer.py
+++ b/src/sentry/mediators/sentry_app_installations/destroyer.py
@@ -24,6 +24,7 @@ class Destroyer(Mediator):
     def _destroy_service_hooks(self):
         hooks = ServiceHook.objects.filter(
             application=self.install.sentry_app.application,
+            actor_id=self.install.id,
         )
         for hook in hooks:
             service_hooks.Destroyer.run(

--- a/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
@@ -43,9 +43,10 @@ class TestDestroyer(TestCase):
         assert not ApiGrant.objects.filter(pk=grant.id).exists()
 
     def test_deletes_service_hooks(self):
-        hook = ServiceHook.objects.get(
+        hook = self.create_service_hook(
             application=self.sentry_app.application,
-            actor_id=self.install.id,
+            project=self.project,
+            actor=self.install,
         )
 
         self.destroyer.call()

--- a/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
@@ -45,6 +45,7 @@ class TestDestroyer(TestCase):
     def test_deletes_service_hooks(self):
         hook = ServiceHook.objects.get(
             application=self.sentry_app.application,
+            actor_id=self.install.id,
         )
 
         self.destroyer.call()

--- a/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.db import connection
 
 from sentry.mediators.sentry_app_installations import Creator, Destroyer
-from sentry.models import ApiAuthorization, ApiGrant, SentryAppInstallation
+from sentry.models import ApiAuthorization, ApiGrant, SentryAppInstallation, ServiceHook
 from sentry.testutils import TestCase
 
 
@@ -11,11 +11,13 @@ class TestDestroyer(TestCase):
     def setUp(self):
         self.user = self.create_user()
         self.org = self.create_organization()
+        self.project = self.create_project(organization=self.org)
 
         self.sentry_app = self.create_sentry_app(
             name='nulldb',
             organization=self.org,
-            scopes=('project:read',),
+            scopes=('project:read', 'event:read'),
+            events=('issue',),
         )
 
         self.install = Creator.run(
@@ -39,6 +41,15 @@ class TestDestroyer(TestCase):
         self.destroyer.call()
 
         assert not ApiGrant.objects.filter(pk=grant.id).exists()
+
+    def test_deletes_service_hooks(self):
+        hook = ServiceHook.objects.get(
+            application=self.sentry_app.application,
+        )
+
+        self.destroyer.call()
+
+        assert not ServiceHook.objects.filter(pk=hook.id).exists()
 
     def test_soft_deletes_installation(self):
         self.destroyer.call()


### PR DESCRIPTION
When an app is uninstalled we want to remove all the service hooks associated with the install. 