### PR TITLE
fix(charts): Fix re-render on charts after zooming

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
+++ b/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
@@ -151,6 +151,20 @@ class ChartZoom extends React.Component {
         this.props.router
       );
 
+      setTimeout(() => {
+        // Hacky but we want to replace the zoom url param so that if we zoom again
+        // and use browser back button to go back, zoom is not in the URL params (and
+        // thus will re-render the chart)
+        const {
+          router,
+          location: {query: {zoom, ...query}, ...restLocation}, // eslint-disable-line no-unused-vars
+        } = this.props;
+        router.replace({
+          ...restLocation,
+          query,
+        });
+      }, 1);
+
       this.saveCurrentPeriod({period, start, end});
     };
   };


### PR DESCRIPTION
This fixes charts not re-rendering after zooming multiple times. Steps to reproduce on prod: zoom (make sure you stay > 24h), zoom again (> 24h), then hit back on browser, chart should re-render.

Zooming should not re-render charts because we want to preserve the zooming animation (unless you go from > 24h to < 24h).
It is more difficult to do this when user hits back on the browser, so re-render is acceptable.