### PR TITLE
fix(sidebar): Fetch org details in user settings

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/organizations.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/organizations.jsx
@@ -78,7 +78,7 @@ export function fetchOrganizationByMember(memberId, {addOrg, fetchOrgDetails}) {
 
       if (fetchOrgDetails) {
         // load SidebarDropdown with org details including `access`
-        fetchOrganizationDetails(data[0].name, {setActive: true, loadProjects: true});
+        fetchOrganizationDetails(data[0].slug, {setActive: true, loadProjects: true});
       }
     }
   });

--- a/src/sentry/static/sentry/app/actionCreators/organizations.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/organizations.jsx
@@ -1,7 +1,6 @@
 import {browserHistory} from 'react-router';
 
 import {Client} from 'app/api';
-import ConfigStore from 'app/stores/configStore';
 import IndicatorStore from 'app/stores/indicatorStore';
 import OrganizationsActions from 'app/actions/organizationsActions';
 import OrganizationsStore from 'app/stores/organizationsStore';
@@ -50,10 +49,6 @@ export function removeAndRedirectToRemainingOrganization(api, params) {
 }
 
 export function setActiveOrganization(org) {
-  if (org && org.slug) {
-    // update lastOrganization without page load
-    ConfigStore.set('lastOrganization', org.slug);
-  }
   OrganizationsActions.setActive(org);
 }
 

--- a/src/sentry/static/sentry/app/components/sidebar/onboardingStatus.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/onboardingStatus.jsx
@@ -35,7 +35,8 @@ class OnboardingStatus extends React.Component {
 
   render() {
     let {collapsed, org, currentPanel, hidePanel, showPanel, onShowPanel} = this.props;
-    if (org.features && org.features.indexOf('onboarding') === -1) return null;
+    if (typeof org.features === 'undefined' || org.features.indexOf('onboarding') === -1)
+      return null;
 
     let doneTasks = (org.onboardingTasks || []).filter(
       task => task.status === 'complete' || task.status === 'skipped'

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
@@ -82,15 +82,17 @@ const SidebarDropdown = withApi(
                 >
                   <div style={{display: 'flex', alignItems: 'flex-start'}}>
                     {avatar}
-                    {hasOrganization &&
-                      !collapsed &&
+                    {!collapsed &&
                       orientation !== 'top' && (
-                        <NameAndOrgWrapper>
-                          <DropdownOrgName>
-                            {org.name} <i className="icon-arrow-down" />
-                          </DropdownOrgName>
-                          <DropdownUserName>{user.name}</DropdownUserName>
-                        </NameAndOrgWrapper>
+                        <OrgAndUserWrapper>
+                          <OrgOrUserName>
+                            {hasOrganization ? org.name : user.name}{' '}
+                            <i className="icon-arrow-down" />
+                          </OrgOrUserName>
+                          <UserNameOrEmail>
+                            {hasOrganization ? user.name : user.email}
+                          </UserNameOrEmail>
+                        </OrgAndUserWrapper>
                       )}
                   </div>
                 </SidebarDropdownActor>
@@ -194,10 +196,10 @@ const SidebarDropdownRoot = styled('div')`
 `;
 
 // So that long org names and user names do not overflow
-const NameAndOrgWrapper = styled('div')`
+const OrgAndUserWrapper = styled('div')`
   overflow: hidden;
 `;
-const DropdownOrgName = styled(TextOverflow)`
+const OrgOrUserName = styled(TextOverflow)`
   font-size: 16px;
   line-height: 1.2;
   font-weight: bold;
@@ -206,7 +208,7 @@ const DropdownOrgName = styled(TextOverflow)`
   transition: 0.15s text-shadow linear;
 `;
 
-const DropdownUserName = styled(TextOverflow)`
+const UserNameOrEmail = styled(TextOverflow)`
   font-size: 14px;
   line-height: 16px;
   transition: 0.15s color linear;
@@ -217,11 +219,11 @@ const SidebarDropdownActor = styled('div')`
 
   &:hover {
     /* stylelint-disable-next-line no-duplicate-selectors */
-    ${DropdownOrgName} {
+    ${OrgOrUserName} {
       text-shadow: 0 0 6px rgba(255, 255, 255, 0.1);
     }
     /* stylelint-disable-next-line no-duplicate-selectors */
-    ${DropdownUserName} {
+    ${UserNameOrEmail} {
       color: ${p => p.theme.gray1};
     }
   }

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.jsx
@@ -165,8 +165,8 @@ class AccountSecurityEnroll extends AsyncView {
   loadOrganizationContext = () => {
     if (this.invite && this.invite.memberId) {
       fetchOrganizationByMember(this.invite.memberId, {
-        loadOrg: true,
-        setActive: true,
+        addOrg: true,
+        fetchOrgDetails: true,
       });
     }
   };

--- a/src/sentry/static/sentry/app/views/settings/account/accountSettingsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSettingsLayout.jsx
@@ -1,9 +1,41 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import AccountSettingsNavigation from 'app/views/settings/account/accountSettingsNavigation';
+import ConfigStore from 'app/stores/configStore';
+import {fetchOrganizationDetails} from 'app/actionCreators/organizations';
+import SentryTypes from 'app/sentryTypes';
 import SettingsLayout from 'app/views/settings/components/settingsLayout';
+import withOrganizations from 'app/utils/withOrganizations';
 
 class AccountSettingsLayout extends React.Component {
+  static propTypes = {
+    organizations: PropTypes.arrayOf(SentryTypes.Organization),
+  };
+
+  componentWillMount() {
+    let lastOrg = ConfigStore.get('lastOrganization');
+    if (lastOrg) {
+      // load SidebarDropdown with org details including `access`
+      fetchOrganizationDetails(lastOrg, {setActive: true, loadProjects: true});
+    }
+  }
+
+  componentDidUpdate() {
+    let lastOrg = ConfigStore.get('lastOrganization');
+    if (lastOrg) return;
+
+    // if there's no lastOrganization in session, wait for orgs to load
+    // in OrganizationsStore and then fetch details for SidebarDropdown
+    let {organizations} = this.props;
+    if (organizations.length) {
+      fetchOrganizationDetails(organizations[0].name, {
+        setActive: true,
+        loadProjects: true,
+      });
+    }
+  }
+
   render() {
     return (
       <div className="app">
@@ -18,4 +50,4 @@ class AccountSettingsLayout extends React.Component {
   }
 }
 
-export default AccountSettingsLayout;
+export default withOrganizations(AccountSettingsLayout);

--- a/src/sentry/static/sentry/app/views/settings/account/accountSettingsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSettingsLayout.jsx
@@ -29,7 +29,7 @@ class AccountSettingsLayout extends React.Component {
     // in OrganizationsStore and then fetch details for SidebarDropdown
     let {organizations} = this.props;
     if (organizations.length) {
-      fetchOrganizationDetails(organizations[0].name, {
+      fetchOrganizationDetails(organizations[0].slug, {
         setActive: true,
         loadProjects: true,
       });

--- a/src/sentry/static/sentry/app/views/settings/account/accountSettingsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSettingsLayout.jsx
@@ -1,35 +1,25 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import AccountSettingsNavigation from 'app/views/settings/account/accountSettingsNavigation';
-import ConfigStore from 'app/stores/configStore';
 import {fetchOrganizationDetails} from 'app/actionCreators/organizations';
 import SentryTypes from 'app/sentryTypes';
 import SettingsLayout from 'app/views/settings/components/settingsLayout';
-import withOrganizations from 'app/utils/withOrganizations';
+import withLatestContext from 'app/utils/withLatestContext';
 
 class AccountSettingsLayout extends React.Component {
   static propTypes = {
-    organizations: PropTypes.arrayOf(SentryTypes.Organization),
+    organization: SentryTypes.Organization,
   };
 
-  componentWillMount() {
-    let lastOrg = ConfigStore.get('lastOrganization');
-    if (lastOrg) {
-      // load SidebarDropdown with org details including `access`
-      fetchOrganizationDetails(lastOrg, {setActive: true, loadProjects: true});
-    }
-  }
+  componentDidUpdate(prevProps) {
+    let {organization} = this.props;
+    if (prevProps.organization === organization) return;
 
-  componentDidUpdate() {
-    let lastOrg = ConfigStore.get('lastOrganization');
-    if (lastOrg) return;
-
-    // if there's no lastOrganization in session, wait for orgs to load
-    // in OrganizationsStore and then fetch details for SidebarDropdown
-    let {organizations} = this.props;
-    if (organizations.length) {
-      fetchOrganizationDetails(organizations[0].slug, {
+    // if there is no org in context, SidebarDropdown uses an org from `withLatestContext`
+    // (which queries the org index endpoint instead of org details)
+    // and does not have `access` info
+    if (organization && !organization.access) {
+      fetchOrganizationDetails(organization.slug, {
         setActive: true,
         loadProjects: true,
       });
@@ -50,4 +40,4 @@ class AccountSettingsLayout extends React.Component {
   }
 }
 
-export default withOrganizations(AccountSettingsLayout);
+export default withLatestContext(AccountSettingsLayout);

--- a/src/sentry/static/sentry/app/views/settings/account/accountSettingsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSettingsLayout.jsx
@@ -18,7 +18,7 @@ class AccountSettingsLayout extends React.Component {
     // if there is no org in context, SidebarDropdown uses an org from `withLatestContext`
     // (which queries the org index endpoint instead of org details)
     // and does not have `access` info
-    if (organization && !organization.access) {
+    if (organization && typeof organization.access === 'undefined') {
       fetchOrganizationDetails(organization.slug, {
         setActive: true,
         loadProjects: true,

--- a/src/sentry/static/sentry/app/views/settings/settingsIndex.jsx
+++ b/src/sentry/static/sentry/app/views/settings/settingsIndex.jsx
@@ -8,6 +8,7 @@ import {t} from 'app/locale';
 import Avatar from 'app/components/avatar';
 import ConfigStore from 'app/stores/configStore';
 import ExternalLink from 'app/components/externalLink';
+import {fetchOrganizationDetails} from 'app/actionCreators/organizations';
 import InlineSvg from 'app/components/inlineSvg';
 import Link from 'app/components/link';
 import LoadingIndicator from 'app/components/loadingIndicator';
@@ -43,6 +44,21 @@ class SettingsIndex extends React.Component {
   static propTypes = {
     organization: SentryTypes.Organization,
   };
+
+  componentDidUpdate(prevProps) {
+    let {organization} = this.props;
+    if (prevProps.organization === organization) return;
+
+    // if there is no org in context, SidebarDropdown uses an org from `withLatestContext`
+    // (which queries the org index endpoint instead of org details)
+    // and does not have `access` info
+    if (organization && typeof organization.access === 'undefined') {
+      fetchOrganizationDetails(organization.slug, {
+        setActive: true,
+        loadProjects: true,
+      });
+    }
+  }
 
   render() {
     let {organization} = this.props;

--- a/tests/acceptance/test_account_settings.py
+++ b/tests/acceptance/test_account_settings.py
@@ -13,7 +13,9 @@ class AccountSettingsTest(AcceptanceTestCase):
             name='Rowdy Tiger Rowdy Tiger Rowdy Tiger',
             owner=None,
         )
-        self.team = self.create_team(organization=self.org, name='Mariachi Band Mariachi Band Mariachi Band')
+        self.team = self.create_team(
+            organization=self.org,
+            name='Mariachi Band Mariachi Band Mariachi Band')
         self.project = self.create_project(
             organization=self.org,
             teams=[self.team],
@@ -37,85 +39,95 @@ class AccountSettingsTest(AcceptanceTestCase):
         self.login_as(self.user)
 
     # TODO(billy): Enable this and remove the slower tests below
-    @pytest.mark.skip(reason="This will be faster but does not check if old django routes are redirecting")
+    @pytest.mark.skip(
+        reason="This will be faster but does not check if old django routes are redirecting")
     def test_account_settings(self):
-        path = '/account/settings/'
-        self.browser.get(path)
-        self.browser.wait_until_not('.loading-indicator')
-        self.browser.snapshot('account settings')
+        with self.feature('organizations:onboarding'):
+            path = '/account/settings/'
+            self.browser.get(path)
+            self.browser.wait_until_not('.loading-indicator')
+            self.browser.snapshot('account settings')
 
-        self.browser.click('[href="/settings/account/security/"]')
-        self.browser.wait_until_not('.loading-indicator')
-        self.browser.snapshot('account security settings')
+            self.browser.click('[href="/settings/account/security/"]')
+            self.browser.wait_until_not('.loading-indicator')
+            self.browser.snapshot('account security settings')
 
-        self.browser.click('[href="/settings/account/notifications/"]')
-        self.browser.wait_until_not('.loading-indicator')
-        self.browser.snapshot('account notification settings')
+            self.browser.click('[href="/settings/account/notifications/"]')
+            self.browser.wait_until_not('.loading-indicator')
+            self.browser.snapshot('account notification settings')
 
-        self.browser.click_when_visible('#Alerts a')
-        self.browser.wait_until_not('.loading-indicator')
-        self.browser.snapshot('account notification - fine tune "Alerts"')
+            self.browser.click_when_visible('#Alerts a')
+            self.browser.wait_until_not('.loading-indicator')
+            self.browser.snapshot('account notification - fine tune "Alerts"')
 
-        self.browser.click('[href="/settings/account/emails/"]')
-        self.browser.wait_until_not('.loading-indicator')
-        self.browser.snapshot('account emails settings')
+            self.browser.click('[href="/settings/account/emails/"]')
+            self.browser.wait_until_not('.loading-indicator')
+            self.browser.snapshot('account emails settings')
 
-        self.browser.click('[href="/settings/account/subscriptions/"]')
-        self.browser.wait_until_not('.loading-indicator')
-        self.browser.snapshot('account subscriptions settings')
+            self.browser.click('[href="/settings/account/subscriptions/"]')
+            self.browser.wait_until_not('.loading-indicator')
+            self.browser.snapshot('account subscriptions settings')
 
-        self.browser.click('[href="/settings/account/authorizations/"]')
-        self.browser.wait_until_not('.loading-indicator')
-        self.browser.snapshot('account authorizations settings')
+            self.browser.click('[href="/settings/account/authorizations/"]')
+            self.browser.wait_until_not('.loading-indicator')
+            self.browser.snapshot('account authorizations settings')
 
-        self.browser.click('[href="/settings/account/identities/"]')
-        self.browser.wait_until_not('.loading-indicator')
-        self.browser.snapshot('account identities settings')
+            self.browser.click('[href="/settings/account/identities/"]')
+            self.browser.wait_until_not('.loading-indicator')
+            self.browser.snapshot('account identities settings')
 
-        self.browser.click('[href="/settings/account/close-account/"]')
-        self.browser.wait_until_not('.loading-indicator')
-        self.browser.snapshot('account settings - close account')
+            self.browser.click('[href="/settings/account/close-account/"]')
+            self.browser.wait_until_not('.loading-indicator')
+            self.browser.snapshot('account settings - close account')
 
     def test_account_appearance_settings(self):
-        self.browser.get('/account/settings/appearance/')
-        self.browser.wait_until_not('.loading-indicator')
-        self.browser.snapshot('account appearance settings')
+        with self.feature('organizations:onboarding'):
+            self.browser.get('/account/settings/appearance/')
+            self.browser.wait_until_not('.loading-indicator')
+            self.browser.snapshot('account appearance settings')
 
     def test_account_security_settings(self):
-        self.browser.get('/account/settings/security/')
-        self.browser.wait_until_not('.loading-indicator')
-        self.browser.snapshot('account security settings')
+        with self.feature('organizations:onboarding'):
+            self.browser.get('/account/settings/security/')
+            self.browser.wait_until_not('.loading-indicator')
+            self.browser.snapshot('account security settings')
 
     def test_account_notifications(self):
-        self.browser.get('/account/settings/notifications/')
-        self.browser.wait_until_not('.loading-indicator')
-        self.browser.snapshot('account notification settings')
+        with self.feature('organizations:onboarding'):
+            self.browser.get('/account/settings/notifications/')
+            self.browser.wait_until_not('.loading-indicator')
+            self.browser.snapshot('account notification settings')
 
-        self.browser.click_when_visible('#Alerts a')
-        self.browser.wait_until_not('.loading-indicator')
-        self.browser.snapshot('account notification - fine tune "Alerts"')
+            self.browser.click_when_visible('#Alerts a')
+            self.browser.wait_until_not('.loading-indicator')
+            self.browser.snapshot('account notification - fine tune "Alerts"')
 
     def test_account_emails_settings(self):
-        self.browser.get('/account/settings/emails/')
-        self.browser.wait_until_not('.loading-indicator')
-        self.browser.snapshot('account emails settings')
+        with self.feature('organizations:onboarding'):
+            self.browser.get('/account/settings/emails/')
+            self.browser.wait_until_not('.loading-indicator')
+            self.browser.snapshot('account emails settings')
 
     def test_account_subscriptions_settings(self):
-        self.browser.get('/account/settings/subscriptions/')
-        self.browser.wait_until_not('.loading-indicator')
-        self.browser.snapshot('account subscriptions settings')
+        with self.feature('organizations:onboarding'):
+            self.browser.get('/account/settings/subscriptions/')
+            self.browser.wait_until_not('.loading-indicator')
+            self.browser.snapshot('account subscriptions settings')
 
     def test_account_authorizations_settings(self):
-        self.browser.get('/account/authorizations/')
-        self.browser.wait_until_not('.loading-indicator')
-        self.browser.snapshot('account authorizations settings')
+        with self.feature('organizations:onboarding'):
+            self.browser.get('/account/authorizations/')
+            self.browser.wait_until_not('.loading-indicator')
+            self.browser.snapshot('account authorizations settings')
 
     def test_account_identities_settings(self):
-        self.browser.get('/account/settings/identities/')
-        self.browser.wait_until_not('.loading-indicator')
-        self.browser.snapshot('account identities settings')
+        with self.feature('organizations:onboarding'):
+            self.browser.get('/account/settings/identities/')
+            self.browser.wait_until_not('.loading-indicator')
+            self.browser.snapshot('account identities settings')
 
     def test_close_account(self):
-        self.browser.get('/account/remove/')
-        self.browser.wait_until_not('.loading-indicator')
-        self.browser.snapshot('account settings - close account')
+        with self.feature('organizations:onboarding'):
+            self.browser.get('/account/remove/')
+            self.browser.wait_until_not('.loading-indicator')
+            self.browser.snapshot('account settings - close account')

--- a/tests/acceptance/test_api.py
+++ b/tests/acceptance/test_api.py
@@ -6,7 +6,7 @@ from sentry.testutils import AcceptanceTestCase
 class ApiTokensTest(AcceptanceTestCase):
     def setUp(self):
         super(ApiTokensTest, self).setUp()
-        self.user = self.create_user('foo@example.com')
+        self.user = self.create_user(email='foo@example.com', name='User Name')
         self.login_as(self.user)
         self.path = '/api/'
 
@@ -27,7 +27,7 @@ class ApiTokensTest(AcceptanceTestCase):
 class ApiApplicationTest(AcceptanceTestCase):
     def setUp(self):
         super(ApiApplicationTest, self).setUp()
-        self.user = self.create_user('foo@example.com')
+        self.user = self.create_user(email='foo@example.com', name='User Name')
         self.login_as(self.user)
         self.path = '/api/applications/'
 

--- a/tests/acceptance/test_new_settings.py
+++ b/tests/acceptance/test_new_settings.py
@@ -6,12 +6,16 @@ from sentry.testutils import AcceptanceTestCase
 class NewSettingsTest(AcceptanceTestCase):
     def setUp(self):
         super(NewSettingsTest, self).setUp()
-        self.user = self.create_user(name="A Very Very Very Very Long Username", email='foo@example.com')
-        self.org = self.create_organization(name="A Very Very Very Very Long Organization", owner=self.user)
+        self.user = self.create_user(
+            name="A Very Very Very Very Long Username",
+            email='foo@example.com')
+        self.org = self.create_organization(
+            name="A Very Very Very Very Long Organization", owner=self.user)
         self.login_as(self.user)
         self.path = '/settings/'
 
     def test_settings_index(self):
-        self.browser.get(self.path)
-        self.browser.wait_until_not('.loading-indicator')
-        self.browser.snapshot('new settings index')
+        with self.feature('organizations:onboarding'):
+            self.browser.get(self.path)
+            self.browser.wait_until_not('.loading-indicator')
+            self.browser.snapshot('new settings index')

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -50,6 +50,10 @@ describe('Sidebar', function() {
       router: null,
     });
 
+    // no org displays user details
+    expect(wrapper.find('OrgOrUserName').text()).toContain(user.name);
+    expect(wrapper.find('UserNameOrEmail').text()).toContain(user.email);
+
     wrapper.find('SidebarDropdownActor').simulate('click');
     expect(wrapper.find('OrgAndUserMenu')).toMatchSnapshot();
   });
@@ -59,6 +63,9 @@ describe('Sidebar', function() {
       <SidebarContainer organization={organization} user={user} router={router} />,
       routerContext
     );
+
+    expect(wrapper.find('OrgOrUserName').text()).toContain(organization.name);
+    expect(wrapper.find('UserNameOrEmail').text()).toContain(user.name);
 
     wrapper.find('SidebarCollapseItem').simulate('click');
     await tick();

--- a/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationsDetails.spec.jsx.snap
@@ -55,10 +55,10 @@ exports[`OrganizationDetails render() deletion in progress should render a delet
                 </svg>
               </span>
               <div
-                class="css-a5a05a-NameAndOrgWrapper e1fowdfw4"
+                class="css-1mzb71u-OrgAndUserWrapper e1fowdfw4"
               >
                 <div
-                  class="css-1cbli9p-TextOverflow-DropdownOrgName e1fowdfw5"
+                  class="css-df1voe-TextOverflow-OrgOrUserName e1fowdfw5"
                 >
                   Organization Name 
                   <i
@@ -66,7 +66,7 @@ exports[`OrganizationDetails render() deletion in progress should render a delet
                   />
                 </div>
                 <div
-                  class="css-1djvv1k-TextOverflow-DropdownUserName e1fowdfw6"
+                  class="css-1b3lkmg-TextOverflow-UserNameOrEmail e1fowdfw6"
                 >
                   Foo Bar
                 </div>
@@ -531,10 +531,10 @@ exports[`OrganizationDetails render() pending deletion should render a restorati
                 </svg>
               </span>
               <div
-                class="css-a5a05a-NameAndOrgWrapper e1fowdfw4"
+                class="css-1mzb71u-OrgAndUserWrapper e1fowdfw4"
               >
                 <div
-                  class="css-1cbli9p-TextOverflow-DropdownOrgName e1fowdfw5"
+                  class="css-df1voe-TextOverflow-OrgOrUserName e1fowdfw5"
                 >
                   Organization Name 
                   <i
@@ -542,7 +542,7 @@ exports[`OrganizationDetails render() pending deletion should render a restorati
                   />
                 </div>
                 <div
-                  class="css-1djvv1k-TextOverflow-DropdownUserName e1fowdfw6"
+                  class="css-1b3lkmg-TextOverflow-UserNameOrEmail e1fowdfw6"
                 >
                   Foo Bar
                 </div>
@@ -1034,10 +1034,10 @@ exports[`OrganizationDetails render() pending deletion should render a restorati
                 </svg>
               </span>
               <div
-                class="css-a5a05a-NameAndOrgWrapper e1fowdfw4"
+                class="css-1mzb71u-OrgAndUserWrapper e1fowdfw4"
               >
                 <div
-                  class="css-1cbli9p-TextOverflow-DropdownOrgName e1fowdfw5"
+                  class="css-df1voe-TextOverflow-OrgOrUserName e1fowdfw5"
                 >
                   Organization Name 
                   <i
@@ -1045,7 +1045,7 @@ exports[`OrganizationDetails render() pending deletion should render a restorati
                   />
                 </div>
                 <div
-                  class="css-1djvv1k-TextOverflow-DropdownUserName e1fowdfw6"
+                  class="css-1b3lkmg-TextOverflow-UserNameOrEmail e1fowdfw6"
                 >
                   Foo Bar
                 </div>

--- a/tests/js/spec/views/organizationContext.spec.jsx
+++ b/tests/js/spec/views/organizationContext.spec.jsx
@@ -9,6 +9,7 @@ import TeamStore from 'app/stores/teamStore';
 
 jest.mock('app/stores/configStore', () => ({
   get: jest.fn(),
+  set: jest.fn(),
 }));
 jest.mock('app/actionCreators/modal', () => ({
   openSudo: jest.fn(),

--- a/tests/js/spec/views/organizationContext.spec.jsx
+++ b/tests/js/spec/views/organizationContext.spec.jsx
@@ -9,7 +9,6 @@ import TeamStore from 'app/stores/teamStore';
 
 jest.mock('app/stores/configStore', () => ({
   get: jest.fn(),
-  set: jest.fn(),
 }));
 jest.mock('app/actionCreators/modal', () => ({
   openSudo: jest.fn(),

--- a/tests/js/spec/views/settings/accountSettingsLayout.spec.jsx
+++ b/tests/js/spec/views/settings/accountSettingsLayout.spec.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import * as OrgActions from 'app/actionCreators/organizations';
+import AccountSettingsLayout from 'app/views/settings/account/accountSettingsLayout';
+
+describe('AccountSettingsLayout', function() {
+  let wrapper;
+  let spy;
+  let api;
+
+  let organization = {
+    id: '44',
+    name: 'Org Index',
+    slug: 'org-index',
+  };
+
+  beforeEach(function() {
+    spy = jest.spyOn(OrgActions, 'fetchOrganizationDetails');
+    api = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+    });
+    wrapper = mount(<AccountSettingsLayout params={{}} />, TestStubs.routerContext());
+  });
+
+  it('fetches org details for SidebarDropdown', function() {
+    // org from index endpoint, no `access` info
+    wrapper.setProps({organization});
+    wrapper.update();
+
+    expect(spy).toHaveBeenCalledWith(organization.slug, {
+      setActive: true,
+      loadProjects: true,
+    });
+    expect(api).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fetch org details for SidebarDropdown', function() {
+    // org already has details
+    wrapper.setProps({organization: TestStubs.Organization()});
+    wrapper.update();
+
+    expect(spy).not.toHaveBeenCalledWith();
+    expect(api).not.toHaveBeenCalled();
+  });
+});

--- a/tests/js/spec/views/settings/settingsIndex.spec.jsx
+++ b/tests/js/spec/views/settings/settingsIndex.spec.jsx
@@ -1,17 +1,20 @@
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
 import React from 'react';
 
+import * as OrgActions from 'app/actionCreators/organizations';
 import {SettingsIndex} from 'app/views/settings/settingsIndex';
 import ConfigStore from 'app/stores/configStore';
 
 describe('SettingsIndex', function() {
+  let wrapper;
+
   it('renders', function() {
-    let wrapper = shallow(<SettingsIndex organization={TestStubs.Organization()} />);
+    wrapper = shallow(<SettingsIndex organization={TestStubs.Organization()} />);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('has loading when there is no organization', function() {
-    let wrapper = shallow(<SettingsIndex organization={null} />);
+    wrapper = shallow(<SettingsIndex organization={null} />);
 
     expect(wrapper.find('LoadingIndicator')).toHaveLength(1);
   });
@@ -19,7 +22,7 @@ describe('SettingsIndex', function() {
   it('has different links for on premise users', function() {
     ConfigStore.set('isOnPremise', true);
 
-    let wrapper = shallow(<SettingsIndex organization={TestStubs.Organization()} />);
+    wrapper = shallow(<SettingsIndex organization={TestStubs.Organization()} />);
 
     expect(
       wrapper.find(
@@ -32,5 +35,45 @@ describe('SettingsIndex', function() {
         .find('HomePanelBody SupportLinkComponent[href="https://forum.sentry.io/"]')
         .prop('children')
     ).toBe('Community Forums');
+  });
+
+  describe('Fetch org details for Sidebar', function() {
+    let spy;
+    let api;
+    let organization = {
+      id: '44',
+      name: 'Org Index',
+      slug: 'org-index',
+    };
+
+    beforeEach(function() {
+      spy = jest.spyOn(OrgActions, 'fetchOrganizationDetails');
+      api = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/`,
+      });
+      ConfigStore.config.isOnPremise = false;
+      wrapper = mount(<SettingsIndex params={{}} />, TestStubs.routerContext());
+    });
+
+    it('fetches org details for SidebarDropdown', function() {
+      // org from index endpoint, no `access` info
+      wrapper.setProps({organization});
+      wrapper.update();
+
+      expect(spy).toHaveBeenCalledWith(organization.slug, {
+        setActive: true,
+        loadProjects: true,
+      });
+      expect(api).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fetch org details for SidebarDropdown', function() {
+      // org already has details
+      wrapper.setProps({organization: TestStubs.Organization()});
+      wrapper.update();
+
+      expect(spy).not.toHaveBeenCalledWith();
+      expect(api).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
- During the require 2FA flow, if the user doesn't have an organization and needs to setup 2FA, display the user name and email at the top of the sidebar dropdown.
- In account settings, organization can be pulled from the index endpoint instead of details. Fetch organization details so the sidebar dropdown has `access` information and displays `Members`, `Teams`, etc. tabs.