### PR TITLE
feat(issues) Fix unknown error on missing inferred content type

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/utils.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/utils.jsx
@@ -41,9 +41,12 @@ export function getCurlCommand(data) {
       case 'application/x-www-form-urlencoded':
         result += ' \\\n --data "' + escapeQuotes(queryString.stringify(data.data)) + '"';
         break;
+
       default:
         if (isString(data.data)) {
           result += ' \\\n --data "' + escapeQuotes(data.data) + '"';
+        } else if (Object.keys(data.data).length === 0) {
+          // Do nothing with empty object data.
         } else {
           Sentry.withScope(scope => {
             scope.setExtra('data', data);

--- a/tests/js/spec/components/events/interfaces/utils.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/utils.spec.jsx
@@ -76,6 +76,21 @@ describe('components/interfaces/utils', function() {
           method: 'GET',
         })
       ).toEqual('curl \\\n "http://example.com/foo?foo=bar"');
+
+      // Do not add data if data is empty object
+      expect(
+        getCurlCommand({
+          url: 'http://example.com/foo',
+          headers: [],
+          env: {
+            ENV: 'prod',
+          },
+          inferredContentType: null,
+          fragment: '',
+          data: {},
+          method: 'GET',
+        })
+      ).toEqual('curl \\\n "http://example.com/foo"');
     });
 
     it('works with a Proxy', function() {


### PR DESCRIPTION
If the user SDK does not send a content-type and we cannot infer one during ingestion, and the data is empty we should skip emitting an error as there isn't anything *wrong* with the http request it just has no data.

This mostly avoids sending events for data that look like reasonable data to me.

Fixes JAVASCRIPT-4T9