### PR TITLE
fix(issues) Don't index into null

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -78,7 +78,7 @@ const OrganizationStream = createReactClass({
       savedSearchList: [],
       processingIssues: null,
       tagsLoading: true,
-      memberList: null,
+      memberList: [],
       tags: TagStore.getAllTags(),
       // the project for the selected issues
       // Will only be set if selected issues all belong

--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -78,7 +78,7 @@ const OrganizationStream = createReactClass({
       savedSearchList: [],
       processingIssues: null,
       tagsLoading: true,
-      memberList: [],
+      memberList: {},
       tags: TagStore.getAllTags(),
       // the project for the selected issues
       // Will only be set if selected issues all belong
@@ -442,7 +442,7 @@ const OrganizationStream = createReactClass({
       let hasGuideAnchor = userDateJoined > dateCutoff && id === topIssue;
 
       let group = GroupStore.get(id);
-      let members = memberList[group.project.slug] || [];
+      let members = memberList[group.project.slug] || null;
 
       return (
         <StreamGroup


### PR DESCRIPTION
Instead of using null for a default value using an Array gives us a consistent type that we can use elsewhere in the component more safely.

Fixes JAVASCRIPT-52T