### PR TITLE
ref(api): Temporarily hide certain event errors

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -184,13 +184,15 @@ class EventSerializer(Serializer):
         if not isinstance(name, six.string_types):
             return True
 
-        return not name.startswith('breadcrumbs') and 'frames' not in name
+        return not name.startswith('breadcrumbs.') \
+            and not name.startswith('extra.') \
+            and '.frames.' not in name
 
     def serialize(self, obj, attrs, user):
         errors = [
             EventError(error).get_api_context() for error
             in get_path(obj.data, 'errors', filter=True, default=())
-            # TODO(ja): Temporary hack to hide certain normalization errors.
+            # TODO(ja): Temporary workaround to hide certain normalization errors.
             # Remove this and the test in tests/sentry/api/serializers/test_event.py
             if self.should_display_error(error)
         ]

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -179,10 +179,20 @@ class EventSerializer(Serializer):
             }
         return results
 
+    def should_display_error(self, error):
+        name = error.get('name')
+        if not isinstance(name, six.string_types):
+            return True
+
+        return not name.startswith('breadcrumbs') and 'frames' not in name
+
     def serialize(self, obj, attrs, user):
         errors = [
             EventError(error).get_api_context() for error
             in get_path(obj.data, 'errors', filter=True, default=())
+            # TODO(ja): Temporary hack to hide certain normalization errors.
+            # Remove this and the test in tests/sentry/api/serializers/test_event.py
+            if self.should_display_error(error)
         ]
 
         (message, message_meta) = self._get_legacy_message_with_meta(obj)

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -34,6 +34,19 @@ class EventSerializerTest(TestCase):
         assert result['errors'][0]['type'] == EventError.INVALID_DATA
         assert result['errors'][0]['data'] == {'name': u'ü'}
 
+    def test_hidden_eventerror(self):
+        event = self.create_event(
+            data={
+                'errors': [{
+                    'type': EventError.INVALID_DATA,
+                    'name': u'breadcrumbs.values.42.data',
+                }],
+            }
+        )
+
+        result = serialize(event)
+        assert result['errors'] == []
+
     def test_renamed_attributes(self):
         # Only includes meta for simple top-level attributes
         event = self.create_event(

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -40,6 +40,9 @@ class EventSerializerTest(TestCase):
                 'errors': [{
                     'type': EventError.INVALID_DATA,
                     'name': u'breadcrumbs.values.42.data',
+                }, {
+                    'type': EventError.INVALID_DATA,
+                    'name': u'exception.values.0.stacktrace.frames.42.vars',
                 }],
             }
         )


### PR DESCRIPTION
This implements a workaround to prevent certain verbose errors to show up in the UI, which are generated by the stricter normalization in Rust. The workaround should be removed once a better way of rendering such errors has been implemented.