### PR TITLE
fix(ui): Do not render link for invalid user emails

### DIFF
--- a/src/sentry/static/sentry/app/components/events/contexts/user.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/user.jsx
@@ -7,6 +7,8 @@ import Avatar from 'app/components/avatar';
 import ErrorBoundary from 'app/components/errorBoundary';
 import KeyValueList from 'app/components/events/interfaces/keyValueList';
 
+const EMAIL_REGEX = /[^@]+@[^\.]+\..+/;
+
 class UserContextType extends React.Component {
   static propTypes = {
     data: PropTypes.object.isRequired,
@@ -24,9 +26,11 @@ class UserContextType extends React.Component {
         'Email',
         <pre>
           {user.email}
-          <a href={`mailto:${user.email}`} target="_blank" className="external-icon">
-            <em className="icon-envelope" />
-          </a>
+          {EMAIL_REGEX.test(user.email) && (
+            <a href={`mailto:${user.email}`} target="_blank" className="external-icon">
+              <em className="icon-envelope" />
+            </a>
+          )}
         </pre>,
       ]);
     user.username && builtins.push(['Username', <pre>{user.username}</pre>]);


### PR DESCRIPTION
Checks for an okay-ish looking email value before rendering a `mailto:` link. The Regex is oversimplified, but catches `[email]` or hash values generated during PII stripping.

Ref https://github.com/getsentry/semaphore/pull/161