### PR TITLE
ref(charts): Refactor Event Handling for Charts

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/baseChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/baseChart.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import ReactEchartsCore from 'echarts-for-react/lib/core';
 import echarts from 'echarts/lib/echarts';
 
+import {callIfFunction} from 'app/utils/callIfFunction';
 import SentryTypes from 'app/sentryTypes';
 import theme from 'app/utils/theme';
 
@@ -78,9 +79,6 @@ class BaseChart extends React.Component {
 
     devicePixelRatio: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
-    // callback when chart is ready
-    onChartReady: PropTypes.func,
-
     // theme name
     // example theme: https://github.com/apache/incubator-echarts/blob/master/theme/dark.js
     theme: PropTypes.string,
@@ -94,11 +92,20 @@ class BaseChart extends React.Component {
     // states whether not to update chart immediately
     lazyUpdate: PropTypes.bool,
 
-    // Map of eventName -> function for echarts events
-    onEvents: PropTypes.shape({
-      highlight: PropTypes.func,
-      mouseover: PropTypes.func,
-    }),
+    // eCharts Event Handlers
+    // callback when chart is ready
+    onChartReady: PropTypes.func,
+    onHighlight: PropTypes.func,
+    onMouseOver: PropTypes.func,
+    onClick: PropTypes.func,
+
+    // Zoom on chart
+    onDataZoom: PropTypes.func,
+
+    // One example of when this is called is restoring chart from zoom levels
+    onRestore: PropTypes.func,
+
+    onFinished: PropTypes.func,
 
     // Forwarded Ref
     forwardedRef: PropTypes.object,
@@ -136,13 +143,40 @@ class BaseChart extends React.Component {
     interval: 'day',
   };
 
+  getEventsMap = () => {
+    return {
+      click: (...args) => {
+        this.handleClick(...args);
+        callIfFunction(this.props.onClick, ...args);
+      },
+      highlight: (...args) => callIfFunction(this.props.onHighlight, ...args),
+      mouseover: (...args) => callIfFunction(this.props.onMouseOver, ...args),
+      datazoom: (...args) => callIfFunction(this.props.onDataZoom, ...args),
+      restore: (...args) => callIfFunction(this.props.onRestore, ...args),
+      finished: (...args) => callIfFunction(this.props.onFinished, ...args),
+    };
+  };
+
   handleChartReady = (...args) => {
-    let {onChartReady} = this.props;
+    const {onChartReady} = this.props;
     onChartReady(...args);
   };
 
+  /**
+   * Handle series item clicks (e.g. Releases mark line or a single series item)
+   * This is different than when you hover over an "axis" line on a chart (e.g.
+   * if there are 2 series for an axis and you're not directly hovered over an item)
+   *
+   * Calls "onClick" inside of series data
+   */
+  handleClick = (series, chart) => {
+    if (series.data) {
+      callIfFunction(series.data.onClick, series, chart);
+    }
+  };
+
   getColorPalette = () => {
-    let {series} = this.props;
+    const {series} = this.props;
 
     return series && series.length
       ? theme.charts.getColorPalette(series.length)
@@ -150,7 +184,7 @@ class BaseChart extends React.Component {
   };
 
   render() {
-    let {
+    const {
       options,
       colors,
       grid,
@@ -176,7 +210,6 @@ class BaseChart extends React.Component {
       lazyUpdate,
       silent,
       style,
-      onEvents,
       forwardedRef,
     } = this.props;
 
@@ -193,7 +226,7 @@ class BaseChart extends React.Component {
         silent={silent}
         theme={this.props.theme}
         onChartReady={this.handleChartReady}
-        onEvents={onEvents}
+        onEvents={this.getEventsMap()}
         opts={{
           height,
           width,

--- a/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
+++ b/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
@@ -292,11 +292,9 @@ class ChartZoom extends React.Component {
           },
         }
       ),
-      onEvents: {
-        datazoom: this.handleDataZoom,
-        restore: this.handleZoomRestore,
-        finished: this.handleChartFinished,
-      },
+      onDataZoom: this.handleDataZoom,
+      onRestore: this.handleZoomRestore,
+      onFinished: this.handleChartFinished,
       ...props,
       xAxis: xAxisOptions,
     };

--- a/src/sentry/static/sentry/app/components/charts/pieChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/pieChart.jsx
@@ -103,29 +103,26 @@ class PieChart extends React.Component {
           firstSeries.data &&
           theme.charts.getColorPalette(firstSeries.data.length)
         }
-        onEvents={{
-          // when legend highlights it does NOT pass dataIndex :(
-          highlight: ({name}) => {
-            if (
-              !this.isInitialSelected ||
-              !name ||
-              firstSeries.data[this.selected].name === name
-            )
-              return;
+        // when legend highlights it does NOT pass dataIndex :(
+        onHighlight={({name}) => {
+          if (
+            !this.isInitialSelected ||
+            !name ||
+            firstSeries.data[this.selected].name === name
+          )
+            return;
 
-            // Unhighlight if not initial "highlight" event and
-            // if name exists (i.e. not dispatched from cDM) and
-            // highlighted series name is different than the initially selected series name
-            this.downplay(this.selected);
-            this.isInitialSelected = false;
-          },
-
-          mouseover: ({dataIndex}) => {
-            if (!this.isInitialSelected) return;
-            if (dataIndex === this.selected) return;
-            this.downplay(this.selected);
-            this.isInitialSelected = false;
-          },
+          // Unhighlight if not initial "highlight" event and
+          // if name exists (i.e. not dispatched from cDM) and
+          // highlighted series name is different than the initially selected series name
+          this.downplay(this.selected);
+          this.isInitialSelected = false;
+        }}
+        onMouseOver={({dataIndex}) => {
+          if (!this.isInitialSelected) return;
+          if (dataIndex === this.selected) return;
+          this.downplay(this.selected);
+          this.isInitialSelected = false;
         }}
         {...props}
         options={{


### PR DESCRIPTION
Previously `BaseChart` would take a map of event name to handler. Refactor to expose specific event handler callback functions. This allows us to more easily define event handlers in `BaseChart` as well as having a more familiar event system.