### PR TITLE
fix: Use expected tags format

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -318,8 +318,13 @@ class SnubaEventSerializer(Serializer):
         keys = getattr(obj, 'tags.key', None)
         values = getattr(obj, 'tags.value', None)
         if keys and values and len(keys) == len(values):
-            return dict(zip(keys, values))
-        return None
+            return sorted([
+                {
+                    'key': k.split('sentry:', 1)[-1],
+                    'value': v,
+                } for (k, v) in zip(keys, values)
+            ], key=lambda x: x['key'])
+        return []
 
     def serialize(self, obj, attrs, user):
         result = {

--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -265,7 +265,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
             group=group,
             message="foo",
             tags={
-                'logger': 'python',
+                'logger': 'python'
             }
         )
 
@@ -273,7 +273,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        assert response.data[0]['tags']['logger'] == 'python'
+        assert response.data[0]['tags'][0] == {'key': 'logger', 'value': 'python'}
 
     @freeze_time()
     def test_date_filters(self):


### PR DESCRIPTION
UI code expects a list of `{key: ..., value: ...}`dicts for the tags, which is what the old code serializes. Don't ask me why, it just does.

It will all be redundant anyway after https://github.com/getsentry/sentry/pull/11071 which makes them use the same serialization code.