### PR TITLE
fix(sidebar): Fix sidebar navigation

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import {ThemeProvider} from 'emotion-theming';
-import {isEqual, pick, identity} from 'lodash';
+import {isEqual, pick, pickBy, identity} from 'lodash';
 import {withRouter, browserHistory} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -157,7 +157,10 @@ class Sidebar extends React.Component {
 
   // Keep the global selection querystring values in the path
   navigateWithGlobalSelection = (pathname, evt) => {
-    const query = pick(this.props.location.query, Object.values(URL_PARAM) && identity);
+    const query = pickBy(
+      pick(this.props.location.query, Object.values(URL_PARAM)),
+      identity
+    );
 
     // Handle cmd-click (mac) and meta-click (linux)
     if (evt.metaKey) {


### PR DESCRIPTION
Fixes a bug introduced in  https://github.com/getsentry/sentry/pull/11612
that causes the sidebar to set an incorrect query string on navigation.
This also broke back button behavior.