### PR TITLE
feat(events): Events access is controlled by by events flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -789,8 +789,10 @@ SENTRY_FEATURES = {
     'organizations:discover': False,
     # Enable attaching arbitrary files to events.
     'organizations:event-attachments': False,
-    # Enable the organization wide events stream interface.
+    # Enable multi project selection
     'organizations:global-views': False,
+    # Enable the events stream interface.
+    'organizations:events': False,
     # Enable integration functionality to create and link groups to issues on
     # external services.
     'organizations:integrations-issue-basic': False,

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -52,6 +52,7 @@ default_manager.add('organizations:create')
 # Organization scoped features
 default_manager.add('organizations:api-keys', OrganizationFeature)  # NOQA
 default_manager.add('organizations:discover', OrganizationFeature)  # NOQA
+default_manager.add('organizations:events', OrganizationFeature)  # NOQA
 default_manager.add('organizations:event-attachments', OrganizationFeature)  # NOQA
 default_manager.add('organizations:global-views', OrganizationFeature)  # NOQA
 default_manager.add('organizations:integrations-issue-basic', OrganizationFeature)  # NOQA

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -258,7 +258,7 @@ class Sidebar extends React.Component {
                   />
                 </Feature>
 
-                <Feature features={['global-views']}>
+                <Feature features={['events']}>
                   <SidebarItem
                     {...sidebarItemProps}
                     onClick={(_id, evt) =>

--- a/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
@@ -44,7 +44,7 @@ class OrganizationEventsContainer extends React.Component {
     const {organization, location, children} = this.props;
 
     return (
-      <Feature features={['global-views']} renderDisabled>
+      <Feature features={['events']} renderDisabled>
         <GlobalSelectionHeader
           organization={organization}
           resetParamsOnChange={['zoom', 'cursor']}

--- a/tests/acceptance/test_organization_events.py
+++ b/tests/acceptance/test_organization_events.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from sentry.testutils import AcceptanceTestCase
 
-FEATURE_NAME = 'organizations:global-views'
+FEATURE_NAME = 'organizations:events'
 
 
 class OrganizationEventsTest(AcceptanceTestCase):

--- a/tests/js/spec/views/organizationEvents/events.spec.jsx
+++ b/tests/js/spec/views/organizationEvents/events.spec.jsx
@@ -22,7 +22,7 @@ describe('OrganizationEventsErrors', function() {
   const {organization, router, routerContext} = initializeOrg({
     projects: [{isMember: true}, {isMember: true, slug: 'new-project', id: 3}],
     organization: {
-      features: ['global-views'],
+      features: ['events'],
     },
     router: {
       location: {

--- a/tests/js/spec/views/organizationEvents/index.spec.jsx
+++ b/tests/js/spec/views/organizationEvents/index.spec.jsx
@@ -12,7 +12,7 @@ describe('OrganizationEvents', function() {
   const {organization, router, routerContext} = initializeOrg({
     projects: [{isMember: true}, {isMember: true, slug: 'new-project', id: 3}],
     organization: {
-      features: ['global-views'],
+      features: ['events', 'global-views'],
     },
     router: {
       location: {


### PR DESCRIPTION
Previously this was linked to global views, however we want to give more
users (even those without multi project access) access to this view.

Depends on https://github.com/getsentry/getsentry/pull/2528