### PR TITLE
fix(api): Handle invalid date params in org user feedback endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_user_reports.py
+++ b/src/sentry/api/endpoints/organization_user_reports.py
@@ -5,7 +5,7 @@ from sentry.api.bases.organization import (
     OrganizationEndpoint,
     OrganizationUserReportsPermission,
 )
-from sentry.api.bases import NoProjects
+from sentry.api.bases import NoProjects, OrganizationEventsError
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models import UserReportWithGroupSerializer
@@ -48,6 +48,8 @@ class OrganizationUserReportsEndpoint(OrganizationEndpoint):
             )
         except NoProjects:
             return Response([])
+        except OrganizationEventsError as exc:
+            return Response({'detail': exc.message}, status=400)
 
         queryset = UserReport.objects.filter(
             project_id__in=filter_params['project_id'],

--- a/tests/sentry/api/endpoints/test_organization_user_reports.py
+++ b/tests/sentry/api/endpoints/test_organization_user_reports.py
@@ -118,3 +118,10 @@ class OrganizationUserReportListTest(APITestCase):
         response = self.get_response(org2.slug)
         assert response.status_code == 200, response.content
         assert response.data == []
+
+    def test_invalid_date_params(self):
+        response = self.get_response(
+            self.project_1.organization.slug,
+            **{'start': 'null', 'end': 'null'}
+        )
+        assert response.status_code == 400


### PR DESCRIPTION
fixes SENTRY-943