### PR TITLE
fix(api): Handle invalid date params in org releases endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -4,7 +4,7 @@ from django.db import IntegrityError, transaction
 
 from rest_framework.response import Response
 
-from sentry.api.bases import NoProjects
+from sentry.api.bases import NoProjects, OrganizationEventsError
 from .project_releases import ReleaseSerializer
 from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
@@ -102,6 +102,8 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, Environment
             )
         except NoProjects:
             return Response([])
+        except OrganizationEventsError as exc:
+            return Response({'detail': exc.message}, status=400)
 
         queryset = Release.objects.filter(
             organization=organization,

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -1237,6 +1237,19 @@ class OrganizationReleaseListEnvironmentsTest(APITestCase):
         )
         self.assert_releases(response, [self.release4, self.release5])
 
+    def test_invalid_date_range(self):
+        url = reverse('sentry-api-0-organization-releases',
+                      kwargs={'organization_slug': self.org.slug})
+        response = self.client.get(
+            url,
+            format='json',
+            data={
+                'start': 'null',
+                'end': 'null',
+            },
+        )
+        assert response.status_code == 400
+
 
 class OrganizationReleaseCreateCommitPatch(ReleaseCommitPatchTest):
     @fixture


### PR DESCRIPTION
fixes SENTRY-956