### PR TITLE
feat: Persist global selections in local storage

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/constants.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/constants.jsx
@@ -15,3 +15,5 @@ export const DATE_TIME = {
 };
 
 export const DATE_TIME_KEYS = Object.values(DATE_TIME);
+
+export const LOCAL_STORAGE_KEY = 'global-selection';

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
@@ -9,7 +9,6 @@ import {
 } from 'app/components/organizations/globalSelectionHeader/constants';
 import {callIfFunction} from 'app/utils/callIfFunction';
 import {defined} from 'app/utils';
-import {getLocalDateObject} from 'app/utils/dates';
 import {isEqualWithDates} from 'app/utils/isEqualWithDates';
 import {
   updateDateTime,
@@ -25,6 +24,8 @@ import MultipleProjectSelector from 'app/components/organizations/multipleProjec
 import SentryTypes from 'app/sentryTypes';
 import TimeRangeSelector from 'app/components/organizations/timeRangeSelector';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
+
+import {getStateFromQuery} from './utils';
 
 class GlobalSelectionHeader extends React.Component {
   static propTypes = {
@@ -76,46 +77,6 @@ class GlobalSelectionHeader extends React.Component {
     resetParamsOnChange: [],
   };
 
-  // Parses URL query parameters for values relevant to global selection header
-  static getStateFromRouter(props) {
-    const {query} = props.location;
-    let start = query[URL_PARAM.START] !== 'null' && query[URL_PARAM.START];
-    let end = query[URL_PARAM.END] !== 'null' && query[URL_PARAM.END];
-    let project = query[URL_PARAM.PROJECT];
-    let environment = query[URL_PARAM.ENVIRONMENT];
-    let period = query[URL_PARAM.PERIOD];
-    let utc = query[URL_PARAM.UTC];
-
-    const hasAbsolute = !!start && !!end;
-
-    if (defined(project) && Array.isArray(project)) {
-      project = project.map(p => parseInt(p, 10));
-    } else if (defined(project)) {
-      const projectIdInt = parseInt(project, 10);
-      project = isNaN(projectIdInt) ? [] : [projectIdInt];
-    }
-
-    if (defined(environment) && !Array.isArray(environment)) {
-      environment = [environment];
-    }
-
-    if (hasAbsolute) {
-      start = getLocalDateObject(start);
-      end = getLocalDateObject(end);
-    }
-
-    return {
-      project,
-      environment,
-      period: period || null,
-      start: start || null,
-      end: end || null,
-
-      // params from URL will be a string
-      utc: typeof utc !== 'undefined' ? utc === 'true' : null,
-    };
-  }
-
   constructor(props) {
     super(props);
     this.state = {};
@@ -128,7 +89,7 @@ class GlobalSelectionHeader extends React.Component {
 
     const hasMultipleProjectFeature = this.hasMultipleProjectSelection();
 
-    const stateFromRouter = GlobalSelectionHeader.getStateFromRouter(this.props);
+    const stateFromRouter = getStateFromQuery(this.props.location.query);
     // We should update store if there are any relevant URL parameters when component
     // is mounted
     if (Object.values(stateFromRouter).some(i => !!i)) {
@@ -159,7 +120,7 @@ class GlobalSelectionHeader extends React.Component {
       // update URL parameters to reflect current store
       const {datetime, environments, projects} = this.props.selection;
 
-      if (hasMultipleProjectFeature) {
+      if (hasMultipleProjectFeature || projects.length === 1) {
         updateParams(
           {project: projects, environment: environments, ...datetime},
           this.getRouter()
@@ -235,14 +196,9 @@ class GlobalSelectionHeader extends React.Component {
       return;
     }
 
-    const {
-      project,
-      environment,
-      period,
-      start,
-      end,
-      utc,
-    } = GlobalSelectionHeader.getStateFromRouter(nextProps);
+    const {project, environment, period, start, end, utc} = getStateFromQuery(
+      nextProps.location.query
+    );
 
     if (start || end || period || utc) {
       // Don't attempt to update date if all of these values are empty

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/utils.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/utils.jsx
@@ -1,0 +1,42 @@
+import {defined} from 'app/utils';
+import {getLocalDateObject} from 'app/utils/dates';
+import {URL_PARAM} from './constants';
+
+// Parses URL query parameters for values relevant to global selection header
+export function getStateFromQuery(query) {
+  let start = query[URL_PARAM.START] !== 'null' && query[URL_PARAM.START];
+  let end = query[URL_PARAM.END] !== 'null' && query[URL_PARAM.END];
+  let project = query[URL_PARAM.PROJECT];
+  let environment = query[URL_PARAM.ENVIRONMENT];
+  let period = query[URL_PARAM.PERIOD];
+  let utc = query[URL_PARAM.UTC];
+
+  const hasAbsolute = !!start && !!end;
+
+  if (defined(project) && Array.isArray(project)) {
+    project = project.map(p => parseInt(p, 10));
+  } else if (defined(project)) {
+    const projectIdInt = parseInt(project, 10);
+    project = isNaN(projectIdInt) ? [] : [projectIdInt];
+  }
+
+  if (defined(environment) && !Array.isArray(environment)) {
+    environment = [environment];
+  }
+
+  if (hasAbsolute) {
+    start = getLocalDateObject(start);
+    end = getLocalDateObject(end);
+  }
+
+  return {
+    project,
+    environment,
+    period: period || null,
+    start: start || null,
+    end: end || null,
+
+    // params from URL will be a string
+    utc: typeof utc !== 'undefined' ? utc === 'true' : null,
+  };
+}

--- a/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
+++ b/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
@@ -1,11 +1,17 @@
-import {isEqual} from 'lodash';
+import {isEqual, pick} from 'lodash';
 import Reflux from 'reflux';
 
-import {DATE_TIME} from 'app/components/organizations/globalSelectionHeader/constants';
+import {
+  DATE_TIME,
+  URL_PARAM,
+  LOCAL_STORAGE_KEY,
+} from 'app/components/organizations/globalSelectionHeader/constants';
+import {getStateFromQuery} from 'app/components/organizations/globalSelectionHeader/utils';
 import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import {isEqualWithDates} from 'app/utils/isEqualWithDates';
 import ConfigStore from 'app/stores/configStore';
 import GlobalSelectionActions from 'app/actions/globalSelectionActions';
+import localStorage from 'app/utils/localStorage';
 
 const getDefaultSelection = () => {
   const user = ConfigStore.get('user');
@@ -24,7 +30,7 @@ const getDefaultSelection = () => {
 
 const GlobalSelectionStore = Reflux.createStore({
   init() {
-    this.reset();
+    this.reset(this.selection);
     this.listenTo(GlobalSelectionActions.updateProjects, this.updateProjects);
     this.listenTo(GlobalSelectionActions.updateDateTime, this.updateDateTime);
     this.listenTo(GlobalSelectionActions.updateEnvironments, this.updateEnvironments);
@@ -32,6 +38,40 @@ const GlobalSelectionStore = Reflux.createStore({
 
   reset(state) {
     this.selection = state || getDefaultSelection();
+  },
+
+  /**
+   * Initializes the global selection store
+   * If there are query params apply these, otherwise check local storage
+  */
+  loadInitialData(queryParams) {
+    const query = pick(queryParams, Object.values(URL_PARAM));
+    const hasQuery = Object.keys(query).length > 0;
+
+    let globalSelection = getDefaultSelection();
+
+    if (hasQuery) {
+      const parsed = getStateFromQuery(queryParams);
+      globalSelection = {
+        projects: parsed.project || [],
+        environments: parsed.environment || [],
+        datetime: {
+          [DATE_TIME.START]: parsed.start || null,
+          [DATE_TIME.END]: parsed.end || null,
+          [DATE_TIME.PERIOD]: parsed.period || null,
+          [DATE_TIME.UTC]: parsed.utc || undefined,
+        },
+      };
+    } else {
+      try {
+        globalSelection = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY));
+      } catch (ex) {
+        // use default if invalid
+      }
+    }
+
+    this.selection = globalSelection;
+    this.trigger(this.selection);
   },
 
   get() {
@@ -47,6 +87,7 @@ const GlobalSelectionStore = Reflux.createStore({
       ...this.selection,
       projects,
     };
+    this.updateLocalStorage();
     this.trigger(this.selection);
   },
 
@@ -62,6 +103,7 @@ const GlobalSelectionStore = Reflux.createStore({
         ...datetime,
       },
     };
+    this.updateLocalStorage();
     this.trigger(this.selection);
   },
 
@@ -74,7 +116,12 @@ const GlobalSelectionStore = Reflux.createStore({
       ...this.selection,
       environments,
     };
+    this.updateLocalStorage();
     this.trigger(this.selection);
+  },
+
+  updateLocalStorage() {
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(this.selection));
   },
 });
 

--- a/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
+++ b/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
@@ -121,7 +121,9 @@ const GlobalSelectionStore = Reflux.createStore({
   },
 
   updateLocalStorage() {
-    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(this.selection));
+    try {
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(this.selection));
+    } catch (ex) {}
   },
 });
 

--- a/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
+++ b/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
@@ -44,7 +44,8 @@ const GlobalSelectionStore = Reflux.createStore({
    * Initializes the global selection store
    * If there are query params apply these, otherwise check local storage
   */
-  loadInitialData(queryParams) {
+  loadInitialData(orgId, queryParams) {
+    this.orgId = orgId;
     const query = pick(queryParams, Object.values(URL_PARAM));
     const hasQuery = Object.keys(query).length > 0;
 
@@ -64,7 +65,11 @@ const GlobalSelectionStore = Reflux.createStore({
       };
     } else {
       try {
-        globalSelection = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY));
+        const localStorageKey = `${LOCAL_STORAGE_KEY}:${orgId}`;
+        const storedValue = JSON.parse(localStorage.getItem(localStorageKey));
+        if (storedValue) {
+          globalSelection = storedValue;
+        }
       } catch (ex) {
         // use default if invalid
       }
@@ -122,8 +127,11 @@ const GlobalSelectionStore = Reflux.createStore({
 
   updateLocalStorage() {
     try {
-      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(this.selection));
-    } catch (ex) {}
+      const localStorageKey = `${LOCAL_STORAGE_KEY}:${this.orgId}`;
+      localStorage.setItem(localStorageKey, JSON.stringify(this.selection));
+    } catch (ex) {
+      // Do nothing
+    }
   },
 });
 

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -56,10 +56,6 @@ const OrganizationContext = createReactClass({
 
   componentWillMount() {
     this.fetchData();
-    GlobalSelectionStore.loadInitialData(
-      this.props.params.orgId,
-      this.props.location.query
-    );
   },
 
   componentWillReceiveProps(nextProps) {
@@ -99,6 +95,7 @@ const OrganizationContext = createReactClass({
 
         TeamStore.loadInitialData(data.teams);
         ProjectsStore.loadInitialData(data.projects);
+        GlobalSelectionStore.loadInitialData(data, this.props.location.query);
 
         this.setState({
           organization: data,

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -20,6 +20,7 @@ import SentryTypes from 'app/sentryTypes';
 import Sidebar from 'app/components/sidebar';
 import TeamStore from 'app/stores/teamStore';
 import space from 'app/styles/space';
+import GlobalSelectionStore from 'app/stores/globalSelectionStore';
 
 let ERROR_TYPES = {
   ORG_NOT_FOUND: 'ORG_NOT_FOUND',
@@ -55,6 +56,7 @@ const OrganizationContext = createReactClass({
 
   componentWillMount() {
     this.fetchData();
+    GlobalSelectionStore.loadInitialData(this.props.location.query);
   },
 
   componentWillReceiveProps(nextProps) {

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -56,7 +56,10 @@ const OrganizationContext = createReactClass({
 
   componentWillMount() {
     this.fetchData();
-    GlobalSelectionStore.loadInitialData(this.props.location.query);
+    GlobalSelectionStore.loadInitialData(
+      this.props.params.orgId,
+      this.props.location.query
+    );
   },
 
   componentWillReceiveProps(nextProps) {

--- a/tests/js/spec/stores/globalSelectionStore.spec.jsx
+++ b/tests/js/spec/stores/globalSelectionStore.spec.jsx
@@ -7,12 +7,21 @@ import {
 
 jest.mock('app/utils/localStorage', () => {
   return {
-    getItem: () => JSON.stringify({projects: [2], environments: ['staging']}),
+    getItem: () => JSON.stringify({projects: [5], environments: ['staging']}),
     setItem: jest.fn(),
   };
 });
 
 describe('GlobalSelectionStore', function() {
+  const organization = TestStubs.Organization({
+    features: ['global-views'],
+    projects: [TestStubs.Project({id: '5'})],
+  });
+
+  afterEach(function() {
+    GlobalSelectionStore.reset();
+  });
+
   it('get()', function() {
     expect(GlobalSelectionStore.get()).toEqual({
       projects: [],
@@ -48,19 +57,30 @@ describe('GlobalSelectionStore', function() {
   });
 
   it('loadInitialData() - queryParams', async function() {
-    GlobalSelectionStore.loadInitialData({project: ['2'], environment: ['staging']});
+    GlobalSelectionStore.loadInitialData(organization, {
+      project: '5',
+      environment: ['staging'],
+    });
 
     await tick();
 
-    expect(GlobalSelectionStore.get().projects).toEqual([2]);
+    expect(GlobalSelectionStore.get().projects).toEqual([5]);
     expect(GlobalSelectionStore.get().environments).toEqual(['staging']);
   });
 
   it('loadInitialData() - localStorage', async function() {
-    GlobalSelectionStore.loadInitialData({});
+    GlobalSelectionStore.loadInitialData(organization, {});
     await tick();
 
-    expect(GlobalSelectionStore.get().projects).toEqual([2]);
+    expect(GlobalSelectionStore.get().projects).toEqual([5]);
     expect(GlobalSelectionStore.get().environments).toEqual(['staging']);
+  });
+
+  it('loadInitialData() - defaults used if invalid', async function() {
+    GlobalSelectionStore.loadInitialData(organization, {project: [2]});
+    await tick();
+
+    expect(GlobalSelectionStore.get().projects).toEqual([]);
+    expect(GlobalSelectionStore.get().environments).toEqual([]);
   });
 });

--- a/tests/js/spec/stores/globalSelectionStore.spec.jsx
+++ b/tests/js/spec/stores/globalSelectionStore.spec.jsx
@@ -5,6 +5,13 @@ import {
   updateEnvironments,
 } from 'app/actionCreators/globalSelection';
 
+jest.mock('app/utils/localStorage', () => {
+  return {
+    getItem: () => JSON.stringify({projects: [2], environments: ['staging']}),
+    setItem: jest.fn(),
+  };
+});
+
 describe('GlobalSelectionStore', function() {
   it('get()', function() {
     expect(GlobalSelectionStore.get()).toEqual({
@@ -38,5 +45,22 @@ describe('GlobalSelectionStore', function() {
     updateEnvironments(['alpha']);
     await tick();
     expect(GlobalSelectionStore.get().environments).toEqual(['alpha']);
+  });
+
+  it('loadInitialData() - queryParams', async function() {
+    GlobalSelectionStore.loadInitialData({project: ['2'], environment: ['staging']});
+
+    await tick();
+
+    expect(GlobalSelectionStore.get().projects).toEqual([2]);
+    expect(GlobalSelectionStore.get().environments).toEqual(['staging']);
+  });
+
+  it('loadInitialData() - localStorage', async function() {
+    GlobalSelectionStore.loadInitialData({});
+    await tick();
+
+    expect(GlobalSelectionStore.get().projects).toEqual([2]);
+    expect(GlobalSelectionStore.get().environments).toEqual(['staging']);
   });
 });

--- a/tests/js/spec/views/organizationContext.spec.jsx
+++ b/tests/js/spec/views/organizationContext.spec.jsx
@@ -6,6 +6,7 @@ import ConfigStore from 'app/stores/configStore';
 import OrganizationContext from 'app/views/organizationContext';
 import ProjectsStore from 'app/stores/projectsStore';
 import TeamStore from 'app/stores/teamStore';
+import GlobalSelectionStore from 'app/stores/globalSelectionStore';
 
 jest.mock('app/stores/configStore', () => ({
   get: jest.fn(),
@@ -32,8 +33,12 @@ describe('OrganizationContext', function() {
     });
     jest.spyOn(TeamStore, 'loadInitialData');
     jest.spyOn(ProjectsStore, 'loadInitialData');
+    jest.spyOn(GlobalSelectionStore, 'loadInitialData');
+
     wrapper = mount(
-      <OrganizationContext params={{orgId: 'org-slug'}}>{<div />}</OrganizationContext>
+      <OrganizationContext params={{orgId: 'org-slug'}} location={{query: {}}}>
+        {<div />}
+      </OrganizationContext>
     );
   });
 
@@ -54,6 +59,7 @@ describe('OrganizationContext', function() {
 
     expect(TeamStore.loadInitialData).toHaveBeenCalledWith(org.teams);
     expect(ProjectsStore.loadInitialData).toHaveBeenCalledWith(org.projects);
+    expect(GlobalSelectionStore.loadInitialData).toHaveBeenCalledWith({});
   });
 
   it('resets TeamStore when unmounting', function() {
@@ -91,7 +97,9 @@ describe('OrganizationContext', function() {
       statusCode: 403,
     });
     wrapper = mount(
-      <OrganizationContext params={{orgId: 'org-slug'}}>{<div />}</OrganizationContext>
+      <OrganizationContext params={{orgId: 'org-slug'}} location={{}}>
+        {<div />}
+      </OrganizationContext>
     );
 
     expect(wrapper.find('LoadingError')).toHaveLength(1);
@@ -106,7 +114,9 @@ describe('OrganizationContext', function() {
       statusCode: 403,
     });
     wrapper = mount(
-      <OrganizationContext params={{orgId: 'org-slug'}}>{<div />}</OrganizationContext>
+      <OrganizationContext params={{orgId: 'org-slug'}} location={{}}>
+        {<div />}
+      </OrganizationContext>
     );
 
     expect(openSudo).toHaveBeenCalled();

--- a/tests/js/spec/views/organizationContext.spec.jsx
+++ b/tests/js/spec/views/organizationContext.spec.jsx
@@ -59,7 +59,7 @@ describe('OrganizationContext', function() {
 
     expect(TeamStore.loadInitialData).toHaveBeenCalledWith(org.teams);
     expect(ProjectsStore.loadInitialData).toHaveBeenCalledWith(org.projects);
-    expect(GlobalSelectionStore.loadInitialData).toHaveBeenCalledWith('org-slug', {});
+    expect(GlobalSelectionStore.loadInitialData).toHaveBeenCalledWith(org, {});
   });
 
   it('resets TeamStore when unmounting', function() {

--- a/tests/js/spec/views/organizationContext.spec.jsx
+++ b/tests/js/spec/views/organizationContext.spec.jsx
@@ -59,7 +59,7 @@ describe('OrganizationContext', function() {
 
     expect(TeamStore.loadInitialData).toHaveBeenCalledWith(org.teams);
     expect(ProjectsStore.loadInitialData).toHaveBeenCalledWith(org.projects);
-    expect(GlobalSelectionStore.loadInitialData).toHaveBeenCalledWith({});
+    expect(GlobalSelectionStore.loadInitialData).toHaveBeenCalledWith('org-slug', {});
   });
 
   it('resets TeamStore when unmounting', function() {

--- a/tests/js/spec/views/organizationsDetails.spec.jsx
+++ b/tests/js/spec/views/organizationsDetails.spec.jsx
@@ -26,7 +26,7 @@ describe('OrganizationDetails', function() {
           }),
         });
         let tree = render(
-          <OrganizationDetails params={{orgId: 'org-slug'}} />,
+          <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} />,
           TestStubs.routerContext()
         );
         expect(tree).toMatchSnapshot();
@@ -45,7 +45,7 @@ describe('OrganizationDetails', function() {
           }),
         });
         let tree = render(
-          <OrganizationDetails params={{orgId: 'org-slug'}} />,
+          <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} />,
           TestStubs.routerContext()
         );
         expect(tree).toMatchSnapshot();
@@ -68,7 +68,7 @@ describe('OrganizationDetails', function() {
 
       it('should render a deletion in progress prompt', function() {
         let tree = render(
-          <OrganizationDetails params={{orgId: 'org-slug'}} />,
+          <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} />,
           TestStubs.routerContext()
         );
         expect(tree).toMatchSnapshot();


### PR DESCRIPTION
Persist latest project, environment and time selections in local storage.
These will be applied unless a querystring is provided.