### PR TITLE
fix(issues) Fix incorrectly formatted date strings in URL

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -18,6 +18,7 @@ import {fetchSavedSearches} from 'app/actionCreators/savedSearches';
 import {fetchProcessingIssues} from 'app/actionCreators/processingIssues';
 import ConfigStore from 'app/stores/configStore';
 import GroupStore from 'app/stores/groupStore';
+import {getUtcDateString} from 'app/utils/dates';
 import SelectedGroupStore from 'app/stores/selectedGroupStore';
 import TagStore from 'app/stores/tagStore';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
@@ -171,6 +172,12 @@ const OrganizationStream = createReactClass({
     if (selection.datetime.period) {
       delete params.period;
       params.statsPeriod = selection.datetime.period;
+    }
+    if (params.end) {
+      params.end = getUtcDateString(params.end);
+    }
+    if (params.start) {
+      params.start = getUtcDateString(params.start);
     }
 
     let sort = this.getSort();


### PR DESCRIPTION
Correctly format the start/end dates when making backend requests. Previously the native toString() conversion would be used which results in a value the server cannot parse.

Refs APP-1028