### PR TITLE
fix(ui): Do not crash on certain Breadcrumb data

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/crumbTable.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/crumbTable.jsx
@@ -20,7 +20,7 @@ class CrumbTable extends React.Component {
         <tr key={key}>
           <td className="key">{key}</td>
           <td className="value">
-            <pre>{val + ''}</pre>
+            <pre>{_.isObject(val) ? JSON.stringify(val) : val}</pre>
           </td>
         </tr>
       );

--- a/tests/js/spec/components/events/interfaces/breadcrumbComponents/breadcrumbs.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/breadcrumbComponents/breadcrumbs.spec.jsx
@@ -4,37 +4,42 @@ import BreadcrumbsInterface from 'app/components/events/interfaces/breadcrumbs';
 import Breadcrumb from 'app/components/events/interfaces/breadcrumbs/breadcrumb';
 
 describe('BreadcrumbsInterface', function() {
-  const PROPS = {
-    group: {
-      id: '1',
-    },
-    event: {
-      entries: [],
-      id: '4',
-    },
-    type: 'blah',
-    data: {
-      values: [
-        {message: 'sup', category: 'default', level: 'extreme'},
-        {message: 'hey', category: 'error', level: 'info'},
-        {message: 'hello', category: 'default', level: 'extreme'},
-        {message: 'bye', category: 'default', level: 'extreme'},
-        {message: 'ok', category: 'error', level: 'extreme'},
-        {message: 'sup', category: 'default', level: 'extreme'},
-        {message: 'sup', category: 'default', level: 'extreme'},
-        {message: 'sup', category: 'default', level: 'extreme'},
-        {message: 'sup', category: 'default', level: 'extreme'},
-        {message: 'sup', category: 'default', level: 'extreme'},
-        {message: 'sup', category: 'default', level: 'extreme'},
-        {message: 'sup', category: 'default', level: 'extreme'},
-        {message: 'sup', category: 'default', level: 'extreme'},
-        {message: 'sup', category: 'default', level: 'extreme'},
-        {message: 'sup', category: 'default', level: 'extreme'},
-        {message: 'sup', category: 'default', level: 'extreme'},
-        {message: 'sup', category: 'default', level: 'extreme'},
-      ],
-    },
-  };
+  let PROPS;
+
+  beforeEach(() => {
+    PROPS = {
+      group: {
+        id: '1',
+      },
+      event: {
+        entries: [],
+        id: '4',
+      },
+      type: 'blah',
+      data: {
+        values: [
+          {message: 'sup', category: 'default', level: 'extreme'},
+          {message: 'hey', category: 'error', level: 'info'},
+          {message: 'hello', category: 'default', level: 'extreme'},
+          {message: 'bye', category: 'default', level: 'extreme'},
+          {message: 'ok', category: 'error', level: 'extreme'},
+          {message: 'sup', category: 'default', level: 'extreme'},
+          {message: 'sup', category: 'default', level: 'extreme'},
+          {message: 'sup', category: 'default', level: 'extreme'},
+          {message: 'sup', category: 'default', level: 'extreme'},
+          {message: 'sup', category: 'default', level: 'extreme'},
+          {message: 'sup', category: 'default', level: 'extreme'},
+          {message: 'sup', category: 'default', level: 'extreme'},
+          {message: 'sup', category: 'default', level: 'extreme'},
+          {message: 'sup', category: 'default', level: 'extreme'},
+          {message: 'sup', category: 'default', level: 'extreme'},
+          {message: 'sup', category: 'default', level: 'extreme'},
+          {message: 'sup', category: 'default', level: 'extreme'},
+        ],
+      },
+    };
+  });
+
   describe('filterCrumbs', function() {
     it('should filter crumbs based on crumb message', function() {
       const breadcrumbs = shallow(<BreadcrumbsInterface {...PROPS} />).instance();
@@ -67,6 +72,15 @@ describe('BreadcrumbsInterface', function() {
       expect(wrapper.find(Breadcrumb)).toHaveLength(10);
       wrapper.setState({queryValue: 'sup', collapsed: false});
       expect(wrapper.find(Breadcrumb)).toHaveLength(13);
+    });
+
+    it('should not crash if data contains a toString attribute', () => {
+      // Regression test: A "toString" property in data should not falsely be
+      // used to coerce breadcrumb data to string. This would cause a TypeError.
+      const data = {nested: {toString: 'hello'}};
+      PROPS.data.values = [{message: 'sup', category: 'default', level: 'info', data}];
+      const wrapper = shallow(<BreadcrumbsInterface {...PROPS} />);
+      expect(wrapper.find(Breadcrumb)).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
Explicitly JSON-stringifies complex Breadcrumb data instead of coercing it to String. Complex data now shows correctly rather than `[object Object]`. 

Also, this fixes a bug in an edge case, when the nested object has a `"toString"` key. JavaScript would have tried to invoke it for the conversion to String, but failed since the value was not callable.

Fixes [JAVASCRIPT-50Q](https://sentry.io/sentry/javascript/issues/845776279/)