### PR TITLE
fix(dashboard): Update discover query to have limit of 1000

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDashboard/widget.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/widget.jsx
@@ -62,6 +62,7 @@ class Widget extends React.Component {
         start: datetime.start,
         end: datetime.end,
         range: datetime.period,
+        limit: 1000,
       })}&visual=${visual}`
     );
   };


### PR DESCRIPTION
Dashboard widgets always link to a discover query with a limit of 1000,
since Discover limits are lower that what may be used in widgets.