### PR TITLE
ref(charts): Remove zoom optimizations

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
+++ b/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
@@ -1,4 +1,3 @@
-import {pick, isEqual} from 'lodash';
 import {withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -7,7 +6,6 @@ import moment from 'moment';
 import {callIfFunction} from 'app/utils/callIfFunction';
 import {getFormattedDate} from 'app/utils/dates';
 import {getInterval, useShortInterval} from 'app/components/charts/utils';
-import {isEqualWithDates} from 'app/utils/isEqualWithDates';
 import {updateParams} from 'app/actionCreators/globalSelection';
 import DataZoom from 'app/components/charts/components/dataZoom';
 import SentryTypes from 'app/sentryTypes';
@@ -34,7 +32,6 @@ class ChartZoom extends React.Component {
     start: PropTypes.instanceOf(Date),
     end: PropTypes.instanceOf(Date),
     utc: PropTypes.bool,
-    zoom: PropTypes.bool,
     disabled: PropTypes.bool,
 
     xAxis: SentryTypes.EChartsXAxis,
@@ -56,36 +53,6 @@ class ChartZoom extends React.Component {
 
     // Initialize current period instance state for zoom history
     this.saveCurrentPeriod(props);
-  }
-
-  // Need to be aggressive about not re-rendering because eCharts handles zoom so we
-  // don't want the component to update (unless parameters besides time period were changed)
-  shouldComponentUpdate(nextProps, nextState) {
-    if (this.props.disabled) {
-      return true;
-    }
-
-    const periodKeys = ['period', 'start', 'end'];
-    const nextPeriod = pick(nextProps, periodKeys);
-    const currentPeriod = pick(this.props, periodKeys);
-    const otherKeys = ['query', 'project', 'environment'];
-    const zoom = nextProps.zoom;
-
-    // Exception for these parameters -- needs to re-render chart
-    if (!zoom && !isEqual(pick(nextProps, otherKeys), pick(this.props, otherKeys))) {
-      return true;
-    }
-
-    if (zoom && useShortInterval(nextProps) !== useShortInterval(this.props)) {
-      return true;
-    }
-
-    // do not update if we are zooming or if period via props does not change
-    if (zoom || isEqualWithDates(currentPeriod, nextPeriod)) {
-      return false;
-    }
-
-    return true;
   }
 
   componentDidUpdate() {
@@ -146,7 +113,6 @@ class ChartZoom extends React.Component {
           period,
           start: startFormatted,
           end: endFormatted,
-          zoom: '1',
         },
         this.props.router
       );

--- a/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
@@ -152,7 +152,6 @@ class OrganizationEvents extends AsyncView {
         <Panel>
           <EventsChart
             query={location.query.query}
-            zoom={!!location.query.zoom}
             organization={organization}
             onZoom={this.handleZoom}
           />

--- a/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
@@ -35,7 +35,6 @@ class OrganizationEventsContainer extends React.Component {
       query: getParams({
         ...(location.query || {}),
         query,
-        zoom: null,
       }),
     });
   };
@@ -47,7 +46,7 @@ class OrganizationEventsContainer extends React.Component {
       <Feature features={['global-views']} renderDisabled>
         <GlobalSelectionHeader
           organization={organization}
-          resetParamsOnChange={['zoom', 'cursor']}
+          resetParamsOnChange={['cursor']}
         />
         <PageContent>
           <Body>

--- a/src/sentry/static/sentry/app/views/organizationEvents/loadingPanel.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/loadingPanel.jsx
@@ -26,3 +26,4 @@ const LoadingPanel = styled(props => (
 `;
 
 export default LoadingPanel;
+export {LoadingMask};

--- a/src/sentry/static/sentry/app/views/organizationEvents/utils/eventsRequest.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/utils/eventsRequest.jsx
@@ -267,7 +267,7 @@ class EventsRequest extends React.PureComponent {
     const {timeseriesData, reloading} = this.state;
 
     // Is "loading" if data is null
-    const loading = this.props.loading || reloading || timeseriesData === null;
+    const loading = this.props.loading || timeseriesData === null;
 
     if (showLoading && loading) {
       return <LoadingPanel data-test-id="events-request-loading" />;
@@ -286,6 +286,7 @@ class EventsRequest extends React.PureComponent {
 
     return children({
       loading,
+      reloading,
 
       // timeseries data
       timeseriesData: transformedTimeseriesData,

--- a/tests/js/spec/views/organizationEvents/events.spec.jsx
+++ b/tests/js/spec/views/organizationEvents/events.spec.jsx
@@ -168,7 +168,6 @@ describe('OrganizationEventsErrors', function() {
         ...router.location,
         query: {
           ...router.location.query,
-          zoom: '1',
         },
       };
 
@@ -195,32 +194,34 @@ describe('OrganizationEventsErrors', function() {
       mockRouterPush(wrapper, router);
 
       // XXX: Note this spy happens AFTER initial render!
-      chartRender = jest.spyOn(wrapper.find('ChartZoom').instance(), 'render');
       tableRender = jest.spyOn(wrapper.find('EventsTable').instance(), 'render');
     });
 
     afterAll(function() {
-      chartRender.mockRestore();
+      if (chartRender) {
+        chartRender.mockRestore();
+      }
+
       tableRender.mockRestore();
     });
 
     it('zooms using chart', async function() {
       expect(tableRender).toHaveBeenCalledTimes(0);
-      expect(chartRender).toHaveBeenCalledTimes(0);
 
       await tick();
       wrapper.update();
+
+      chartRender = jest.spyOn(wrapper.find('LineChart').instance(), 'render');
 
       doZoom(wrapper.find('EventsChart').first(), chart);
       await tick();
       wrapper.update();
 
-      // After zooming, chart should not re-render, but table does
-      expect(chartRender).toHaveBeenCalledTimes(0);
+      // After zooming, line chart should re-render once, but table does
+      expect(chartRender).toHaveBeenCalledTimes(1);
       expect(tableRender).toHaveBeenCalledTimes(3);
 
       newParams = {
-        zoom: '1',
         start: '2018-11-29T00:00:00',
         end: '2018-12-02T00:00:00',
       };

--- a/tests/js/spec/views/organizationEvents/eventsChart.spec.jsx
+++ b/tests/js/spec/views/organizationEvents/eventsChart.spec.jsx
@@ -62,29 +62,6 @@ describe('EventsChart', function() {
     expect(render).toHaveBeenCalledTimes(1);
   });
 
-  it('does not re-render if zoomed', function() {
-    expect(render).toHaveBeenCalledTimes(0);
-    doZoom(wrapper, chart);
-    let newParams = {
-      period: null,
-      start: '2018-11-29T00:00:00',
-      end: '2018-12-02T00:00:00',
-      zoom: '1',
-    };
-    expect(updateParams).toHaveBeenCalledWith(newParams, router);
-    expect(render).toHaveBeenCalledTimes(0);
-    wrapper.setProps({
-      period: newParams.period,
-      start: getLocalDateObject(newParams.start),
-      end: getLocalDateObject(newParams.end),
-      zoom: true,
-    });
-    expect(render).toHaveBeenCalledTimes(0);
-    wrapper.update();
-
-    expect(render).toHaveBeenCalledTimes(0);
-  });
-
   it('has correct history entries when zooming', function() {
     let newParams;
     const chartZoomInstance = wrapper.find('ChartZoom').instance();
@@ -126,18 +103,14 @@ describe('EventsChart', function() {
       period: null,
       start: '2018-11-29T00:00:00',
       end: '2018-12-02T00:00:00',
-      zoom: '1',
     };
     expect(updateParams).toHaveBeenCalledWith(newParams, router);
     wrapper.setProps({
       period: newParams.period,
       start: getLocalDateObject(newParams.start),
       end: getLocalDateObject(newParams.end),
-      zoom: true,
     });
     wrapper.update();
-
-    expect(render).toHaveBeenCalledTimes(0);
   });
 
   it('updates url params when restoring zoom level on chart', function() {
@@ -165,18 +138,15 @@ describe('EventsChart', function() {
       period: '14d',
       start: null,
       end: null,
-      zoom: '1',
     };
     expect(updateParams).toHaveBeenCalledWith(newParams, router);
     wrapper.setProps({
       period: '14d',
       start: null,
       end: null,
-      zoom: true,
     });
     wrapper.update();
 
     expect(chartZoomInstance.history).toHaveLength(0);
-    expect(render).toHaveBeenCalledTimes(0);
   });
 });


### PR DESCRIPTION
We tried to preserve echarts zoom as best we could but it will break dashboard widgets. Instead we re-render chart but dim the chart while its re-rendering