### PR TITLE
feat(settings): Update project settings links

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/settingsProjectItem.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsProjectItem.jsx
@@ -54,6 +54,8 @@ const ProjectItem = createReactClass({
     let {project, organization} = this.props;
     let {isBookmarked} = this.state;
 
+    let hasNewRoutes = new Set(organization.features).has('sentry10');
+
     return (
       <div key={project.id} className={isBookmarked ? 'isBookmarked' : null}>
         <Tooltip title={isBookmarked ? 'Remove from bookmarks' : 'Add to bookmarks'}>
@@ -65,7 +67,13 @@ const ProjectItem = createReactClass({
             )}
           </InlineButton>
         </Tooltip>
-        <Link to={`/${organization.slug}/${project.slug}/`}>
+        <Link
+          to={
+            hasNewRoutes
+              ? `/settings/${organization.slug}/${project.slug}/`
+              : `/${organization.slug}/${project.slug}/`
+          }
+        >
           <ProjectLabel project={project} />
         </Link>
       </div>

--- a/src/sentry/static/sentry/app/views/settings/organizationProjects/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationProjects/index.jsx
@@ -75,6 +75,8 @@ export default class OrganizationProjects extends AsyncView {
       .getAccess()
       .has('project:admin');
 
+    let hasNewRoutes = new Set(organization.features).has('sentry10');
+
     let action = (
       <Button
         priority="primary"
@@ -121,15 +123,17 @@ export default class OrganizationProjects extends AsyncView {
                     stats={projectStats[project.id]}
                   />
                 </Box>
-                <Box p={2} align="right">
-                  <Button
-                    icon="icon-settings"
-                    size="small"
-                    to={`/settings/${organization.slug}/${project.slug}/`}
-                  >
-                    {t('Settings')}
-                  </Button>
-                </Box>
+                {!hasNewRoutes && (
+                  <Box p={2} align="right">
+                    <Button
+                      icon="icon-settings"
+                      size="small"
+                      to={`/settings/${organization.slug}/${project.slug}/`}
+                    >
+                      {t('Settings')}
+                    </Button>
+                  </Box>
+                )}
               </PanelItem>
             ))}
             {projectList.length === 0 && (


### PR DESCRIPTION
Since no project page exists in sentry 10, we should link to the project
settings page instead in organization projects settings.