### PR TITLE
ref(issues): Move EventsChart underneath title

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -600,10 +600,6 @@ const OrganizationStream = createReactClass({
 
     return (
       <div className={classNames(classes)}>
-        <Panel>
-          <EventsChart query="" organization={this.props.organization} />
-        </Panel>
-
         <div className="stream-content">
           <StreamFilters
             access={access}
@@ -621,6 +617,11 @@ const OrganizationStream = createReactClass({
             isSearchDisabled={this.state.isSidebarVisible}
             savedSearchList={this.state.savedSearchList}
           />
+
+          <Panel>
+            <EventsChart query="" organization={this.props.organization} />
+          </Panel>
+
           <Panel>
             <StreamActions
               orgId={params.orgId}


### PR DESCRIPTION
So this is now more similar to Events page

![image](https://user-images.githubusercontent.com/79684/51648233-8b756d80-1f34-11e9-8f19-a08a09fe624d.png)
