### PR TITLE
ref(ui): Refactor short ID

### DIFF
--- a/src/sentry/static/sentry/app/components/shortId.jsx
+++ b/src/sentry/static/sentry/app/components/shortId.jsx
@@ -1,25 +1,18 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
-import ProjectState from 'app/mixins/projectState';
 
 import AutoSelectText from 'app/components/autoSelectText';
 
-const ShortId = createReactClass({
-  displayName: 'ShortId',
-
-  propTypes: {
+export default class ShortId extends React.Component {
+  static propTypes = {
     shortId: PropTypes.string,
-  },
-
-  mixins: [ProjectState],
-
+  };
   preventPropagation(e) {
     // this is a hack for the stream so the click handler doesn't
     // affect this element
     e.stopPropagation();
-  },
+  }
 
   render() {
     let shortId = this.props.shortId;
@@ -31,11 +24,9 @@ const ShortId = createReactClass({
         <AutoSelectText>{shortId}</AutoSelectText>
       </StyledShortId>
     );
-  },
-});
+  }
+}
 
 const StyledShortId = styled.div`
   font-family: ${p => p.theme.text.familyMono};
 `;
-
-export default ShortId;


### PR DESCRIPTION
Remove reference to ProjectState since it wasn't being used and won't be
valid when this component is used in organization group details. Convert
to es6 component.