### PR TITLE
fix(issues) Fix duplicate requests in org issues

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -17,7 +17,6 @@ import {extractSelectionParameters} from 'app/components/organizations/globalSel
 import Pagination from 'app/components/pagination';
 import {Panel, PanelBody} from 'app/components/panels';
 import StreamGroup from 'app/components/stream/group';
-import {updateProjects} from 'app/actionCreators/globalSelection';
 import {fetchTags} from 'app/actionCreators/tags';
 import {fetchOrgMembers} from 'app/actionCreators/members';
 import {fetchSavedSearches} from 'app/actionCreators/savedSearches';

--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -70,7 +70,7 @@ const OrganizationStream = createReactClass({
 
     return {
       groupIds: [],
-      loading: false,
+      loading: true,
       selectAllActive: false,
       realtimeActive,
       pageLinks: '',
@@ -113,7 +113,14 @@ const OrganizationStream = createReactClass({
 
     // Start by getting searches first so if the user is on a saved search
     // we load the correct data the first time.
+    this.fetchProcessingIssues();
     this.fetchSavedSearches();
+
+    // If we don't have a searchId there won't be more chained requests
+    // so we should fetch groups
+    if (!this.props.params.searchId) {
+      this.fetchData();
+    }
   },
 
   componentDidUpdate(prevProps, prevState) {
@@ -125,12 +132,29 @@ const OrganizationStream = createReactClass({
         this._poller.disable();
       }
     }
-    if (prevProps.params.searchId != this.props.params.searchId) {
-      this.onSavedSearchChange();
-    } else if (
-      prevProps.location.search != this.props.location.search ||
-      !isEqual(prevProps.selection, this.props.selection)
+
+    // If project selections have changed we need to get new processing issues.
+    if (!isEqual(prevProps.selection.projects, this.props.selection.projects)) {
+      this.fetchProcessingIssues();
+    }
+
+    let prevQuery = prevProps.location.query;
+    let newQuery = this.props.location.query;
+
+    // If any important url parameter changed or saved search changed
+    // reload data.
+    if (
+      !isEqual(prevProps.selection, this.props.selection) ||
+      prevQuery.sort != newQuery.sort ||
+      prevQuery.query != newQuery.query ||
+      prevQuery.statsPeriod !== newQuery.statsPeriod ||
+      prevQuery.groupStatsPeriod !== newQuery.groupStatsPeriod ||
+      prevState.savedSearch !== this.state.savedSearch
     ) {
+      this.fetchData();
+    } else if (!this.lastRequest && prevState.loading === false && this.state.loading) {
+      // Reload if we went from not loading to loading.
+      // This can happen when transitionTo is called
       this.fetchData();
     }
   },
@@ -211,7 +235,6 @@ const OrganizationStream = createReactClass({
   },
 
   fetchData() {
-    this.fetchProcessingIssues();
     GroupStore.loadInitialData([]);
 
     this.setState({
@@ -223,7 +246,7 @@ const OrganizationStream = createReactClass({
     let requestParams = {
       ...this.getEndpointParams(),
       limit: MAX_ITEMS,
-      shortIdLookup: '1',
+      shortIdLookup: 1,
     };
 
     let currentQuery = this.props.location.query || {};
@@ -332,25 +355,8 @@ const OrganizationStream = createReactClass({
     return `/organizations/${params.orgId}/issues/`;
   },
 
-  onSavedSearchChange() {
-    if (!this.state.savedSearchList) {
-      return;
-    }
-
-    let {searchId} = this.props.params;
-    let match = this.state.savedSearchList.find(search => search.id === searchId);
-    if (match) {
-      let projects = [];
-      if (match.projectId) {
-        projects = [parseInt(match.projectId, 10)];
-      }
-
-      // Will trigger a transition if the projects changed
-      updateProjects(projects);
-      this.setState({savedSearch: match}, this.transitionTo);
-    } else {
-      this.setState({savedSearch: null}, this.transitionTo);
-    }
+  onSavedSearchSelect(search) {
+    this.setState({savedSearch: search, loading: true}, this.transitionTo);
   },
 
   onRealtimeChange(realtime) {
@@ -453,10 +459,12 @@ const OrganizationStream = createReactClass({
     let {savedSearch} = this.state;
     let path;
 
-    if (savedSearch && query.query == savedSearch.query) {
+    if (savedSearch && savedSearch.query === query.query) {
       path = `/organizations/${organization.slug}/issues/searches/${savedSearch.id}/`;
-      // Drop query and add project so we endup in the right place.
+      // Drop query and project, adding the search project if available.
       delete query.query;
+      delete query.project;
+
       if (savedSearch.projectId) {
         query.project = [savedSearch.projectId];
       }
@@ -469,10 +477,7 @@ const OrganizationStream = createReactClass({
         pathname: path,
         query,
       });
-
-      // Refetch data as simply pushing browserHistory doesn't
-      // update props.
-      this.fetchData();
+      this.setState({loading: true});
     }
   },
 
@@ -539,12 +544,20 @@ const OrganizationStream = createReactClass({
   },
 
   fetchSavedSearches() {
-    let {orgId} = this.props.params;
-    this.setState({loading: true});
+    let {orgId, searchId} = this.props.params;
 
     fetchSavedSearches(this.api, orgId).then(
       savedSearchList => {
-        this.setState({savedSearchList}, this.onSavedSearchChange);
+        let newState = {
+          savedSearchList,
+          loading: true,
+        };
+
+        if (searchId) {
+          let match = savedSearchList.find(search => search.id === searchId);
+          newState.savedSearch = match ? match : null;
+        }
+        this.setState(newState);
       },
       error => {
         logAjaxError(error);
@@ -559,7 +572,7 @@ const OrganizationStream = createReactClass({
     this.setState({
       savedSearchList: sortBy(savedSearchList, ['name', 'projectId']),
     });
-    this.setState({savedSearch: data}, this.transitionTo);
+    this.setState({savedSearch: data, loading: true}, this.transitionTo);
   },
 
   renderProcessingIssuesHints() {
@@ -644,6 +657,7 @@ const OrganizationStream = createReactClass({
             onSortChange={this.onSortChange}
             onSearch={this.onSearch}
             onSavedSearchCreate={this.onSavedSearchCreate}
+            onSavedSearchSelect={this.onSavedSearchSelect}
             onSidebarToggle={this.onSidebarToggle}
             isSearchDisabled={this.state.isSidebarVisible}
             savedSearchList={this.state.savedSearchList}

--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -145,8 +145,8 @@ const OrganizationStream = createReactClass({
     // reload data.
     if (
       !isEqual(prevProps.selection, this.props.selection) ||
-      prevQuery.sort != newQuery.sort ||
-      prevQuery.query != newQuery.query ||
+      prevQuery.sort !== newQuery.sort ||
+      prevQuery.query !== newQuery.query ||
       prevQuery.statsPeriod !== newQuery.statsPeriod ||
       prevQuery.groupStatsPeriod !== newQuery.groupStatsPeriod ||
       prevState.savedSearch !== this.state.savedSearch

--- a/src/sentry/static/sentry/app/views/stream/filters.jsx
+++ b/src/sentry/static/sentry/app/views/stream/filters.jsx
@@ -25,6 +25,7 @@ class StreamFilters extends React.Component {
     onSearch: PropTypes.func,
     onSidebarToggle: PropTypes.func,
     onSavedSearchCreate: PropTypes.func.isRequired,
+    onSavedSearchSelect: PropTypes.func.isRequired,
   };
 
   static contextTypes = {
@@ -56,6 +57,7 @@ class StreamFilters extends React.Component {
       onSidebarToggle,
       onSearch,
       onSavedSearchCreate,
+      onSavedSearchSelect,
       onSortChange,
     } = this.props;
 
@@ -72,6 +74,7 @@ class StreamFilters extends React.Component {
               queryMaxCount={queryMaxCount}
               query={query}
               onSavedSearchCreate={onSavedSearchCreate}
+              onSavedSearchSelect={onSavedSearchSelect}
               savedSearchList={savedSearchList}
             />
           </div>

--- a/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
@@ -10,7 +10,6 @@ import DropdownLink from 'app/components/dropdownLink';
 import QueryCount from 'app/components/queryCount';
 import MenuItem from 'app/components/menuItem';
 import Tooltip from 'app/components/tooltip';
-import SentryTypes from 'app/sentryTypes';
 import {BooleanField, FormState, TextField} from 'app/components/forms';
 import withApi from 'app/utils/withApi';
 import space from 'app/styles/space';
@@ -220,7 +219,6 @@ const SavedSearchSelector = withApi(
       queryMaxCount: PropTypes.number,
       onSavedSearchCreate: PropTypes.func.isRequired,
       onSavedSearchSelect: PropTypes.func.isRequired,
-      selection: SentryTypes.GlobalSelection,
     };
 
     getTitle() {

--- a/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
@@ -10,6 +10,7 @@ import DropdownLink from 'app/components/dropdownLink';
 import QueryCount from 'app/components/queryCount';
 import MenuItem from 'app/components/menuItem';
 import Tooltip from 'app/components/tooltip';
+import SentryTypes from 'app/sentryTypes';
 import {BooleanField, FormState, TextField} from 'app/components/forms';
 import withApi from 'app/utils/withApi';
 import space from 'app/styles/space';
@@ -218,6 +219,8 @@ const SavedSearchSelector = withApi(
       queryCount: PropTypes.number,
       queryMaxCount: PropTypes.number,
       onSavedSearchCreate: PropTypes.func.isRequired,
+      onSavedSearchSelect: PropTypes.func.isRequired,
+      selection: SentryTypes.GlobalSelection,
     };
 
     getTitle() {
@@ -230,16 +233,14 @@ const SavedSearchSelector = withApi(
     }
 
     render() {
-      let {orgId, projectId, queryCount, queryMaxCount} = this.props;
+      let {orgId, projectId, queryCount, queryMaxCount, onSavedSearchSelect} = this.props;
       let hasProject = !!projectId;
 
       let children = this.props.savedSearchList.map(search => {
-        let url = hasProject
-          ? `/${orgId}/${projectId}/searches/${search.id}/`
-          : `/organizations/${orgId}/issues/searches/${search.id}/`;
+        // let url = this.createUrl(search, hasProject);
 
         return (
-          <StyledMenuItem to={url} key={search.id}>
+          <StyledMenuItem onSelect={() => onSavedSearchSelect(search)} key={search.id}>
             <strong>{search.name}</strong>
             <code>{search.query}</code>
           </StyledMenuItem>

--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -125,7 +125,7 @@ const Stream = createReactClass({
 
     let searchIdChanged = this.state.isDefaultSearch
       ? nextSearchId !== null
-      : nextSearchId !== this.state.searchId;
+      : nextSearchId !== this.props.params.searchId;
 
     // We are using qs.parse with location.search since this.props.location.query
     // returns the same value as nextProps.location.query
@@ -252,14 +252,20 @@ const Stream = createReactClass({
   },
 
   onSavedSearchCreate(data) {
-    let {orgId, projectId} = this.props.params;
     let savedSearchList = this.state.savedSearchList;
     savedSearchList.push(data);
 
-    this.setState({
-      savedSearchList: sortBy(savedSearchList, ['name']),
-    });
-    browserHistory.push(`/${orgId}/${projectId}/searches/${data.id}/`);
+    this.setState(
+      {
+        savedSearchList: sortBy(savedSearchList, ['name']),
+        searchId: data.id,
+      },
+      this.transitionTo
+    );
+  },
+
+  onSavedSearchSelect(search) {
+    this.setState({searchId: search.id}, this.transitionTo);
   },
 
   getQueryState(props) {
@@ -691,6 +697,7 @@ const Stream = createReactClass({
             onSortChange={this.onSortChange}
             onSearch={this.onSearch}
             onSavedSearchCreate={this.onSavedSearchCreate}
+            onSavedSearchSelect={this.onSavedSearchSelect}
             onSidebarToggle={this.onSidebarToggle}
             isSearchDisabled={this.state.isSidebarVisible}
             savedSearchList={this.state.savedSearchList}

--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -121,10 +121,10 @@ const Stream = createReactClass({
 
     // you cannot apply both a query and a saved search (our routes do not
     // support it), so the searchId takes priority
-    let nextSearchId = nextProps.params.searchId || null;
+    let nextSearchId = nextProps.params.searchId;
 
     let searchIdChanged = this.state.isDefaultSearch
-      ? nextSearchId !== null
+      ? nextSearchId !== undefined
       : nextSearchId !== this.props.params.searchId;
 
     // We are using qs.parse with location.search since this.props.location.query

--- a/tests/js/spec/views/organizationStream/overview.spec.jsx
+++ b/tests/js/spec/views/organizationStream/overview.spec.jsx
@@ -1,0 +1,297 @@
+import React from 'react';
+import {browserHistory} from 'react-router';
+import {shallow} from 'enzyme';
+
+import TagStore from 'app/stores/tagStore';
+import GroupStore from 'app/stores/groupStore';
+import {OrganizationStream} from 'app/views/organizationStream/overview';
+
+const DEFAULT_LINKS_HEADER =
+  '<http://127.0.0.1:8000/api/0/organizations/org-slug/issues/?cursor=1443575731:0:1>; rel="previous"; results="false"; cursor="1443575731:0:1", ' +
+  '<http://127.0.0.1:8000/api/0/organizations/org-slug/issues/?cursor=1443575731:0:0>; rel="next"; results="true"; cursor="1443575731:0:0';
+
+describe('OrganizationStream', function() {
+  let sandbox;
+  let wrapper;
+  let props;
+
+  let organization;
+  let project;
+  let group;
+  let savedSearch;
+
+  let fetchTagsRequest;
+
+  beforeEach(function() {
+    sandbox = sinon.sandbox.create();
+
+    project = TestStubs.ProjectDetails({
+      id: '3559',
+      name: 'Foo Project',
+      slug: 'project-slug',
+      firstEvent: true,
+    });
+    organization = TestStubs.Organization({
+      id: '1337',
+      slug: 'org-slug',
+      access: ['releases'],
+      projects: [project],
+    });
+    savedSearch = {
+      id: '789',
+      query: 'is:unresolved',
+      name: 'test',
+      projectId: project.id,
+    };
+
+    group = TestStubs.Group({project});
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/',
+      body: [group],
+      headers: {
+        Link: DEFAULT_LINKS_HEADER,
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/searches/',
+      body: [savedSearch],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/processingissues/',
+      method: 'GET',
+      body: [
+        {
+          project: 'test-project',
+          numIssues: 1,
+          hasIssues: true,
+          lastSeen: '2019-01-16T15:39:11.081Z',
+        },
+      ],
+    });
+    fetchTagsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/tags/',
+      method: 'GET',
+      body: TestStubs.Tags(),
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/users/',
+      method: 'GET',
+      body: [TestStubs.Member({projects: [project.slug]})],
+    });
+
+    sandbox.stub(browserHistory, 'push');
+    TagStore.init();
+
+    props = {
+      selection: {
+        projects: [parseInt(organization.projects[0].id, 10)],
+        environments: [],
+        datetime: {period: '14d'},
+      },
+      location: {query: {query: 'is:unresolved'}, search: 'query=is:unresolved'},
+      params: {orgId: organization.slug},
+      organization,
+    };
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+    MockApiClient.clearMockResponses();
+  });
+
+  describe('getEndpointParams', function() {
+    beforeEach(function() {
+      wrapper = shallow(<OrganizationStream {...props} />);
+    });
+
+    it('omits null values', function() {
+      wrapper.setProps({
+        selection: {
+          projects: null,
+          environments: null,
+          datetime: {period: '14d'},
+        },
+      });
+      let value = wrapper.instance().getEndpointParams();
+
+      expect(value.project).toBeUndefined();
+      expect(value.projects).toBeUndefined();
+      expect(value.environment).toBeUndefined();
+      expect(value.environments).toBeUndefined();
+      expect(value.statsPeriod).toEqual('14d');
+    });
+
+    it('omits defaults', function() {
+      wrapper.setProps({
+        location: {
+          query: {
+            sort: 'date',
+            groupStatsPeriod: '24h',
+          },
+        },
+      });
+      let value = wrapper.instance().getEndpointParams();
+
+      expect(value.groupStatsPeriod).toBeUndefined();
+      expect(value.sort).toBeUndefined();
+    });
+
+    it('uses saved search data', function() {
+      wrapper.setState({savedSearch});
+      let value = wrapper.instance().getEndpointParams();
+
+      expect(value.query).toEqual(savedSearch.query);
+      expect(value.project).toEqual([parseInt(savedSearch.projectId, 10)]);
+    });
+  });
+
+  describe('componentDidMount', function() {
+    beforeEach(function() {
+      wrapper = shallow(<OrganizationStream {...props} />);
+    });
+
+    it('fetches tags and sets state', async function() {
+      let instance = wrapper.instance();
+      await instance.componentDidMount();
+
+      expect(fetchTagsRequest).toHaveBeenCalled();
+      expect(instance.state.tags.assigned).toBeTruthy();
+    });
+
+    it('fetches members and sets state', async function() {
+      let instance = wrapper.instance();
+      await instance.componentDidMount();
+      await wrapper.update();
+
+      let members = instance.state.memberList;
+      // Spot check the resulting structure as we munge it a bit.
+      expect(members).toBeTruthy();
+      expect(members[project.slug]).toBeTruthy();
+      expect(members[project.slug][0].email).toBeTruthy();
+    });
+
+    it('fetches groups when there is no searchid', async function() {
+      await wrapper.instance().componentDidMount();
+    });
+  });
+
+  describe('componentDidMount with a valid saved search', function() {
+    beforeEach(function() {
+      props.params.searchId = '789';
+      wrapper = shallow(<OrganizationStream {...props} />);
+    });
+
+    it('fetches searches and sets the savedSearch', async function() {
+      wrapper.setState({loading: false});
+      let instance = wrapper.instance();
+      await instance.componentDidMount();
+      await wrapper.update();
+
+      expect(instance.state.savedSearch).toBeTruthy();
+    });
+
+    it('uses the saved search query', async function() {
+      let instance = wrapper.instance();
+      await instance.componentDidMount();
+      await wrapper.update();
+
+      expect(instance.getQuery()).toEqual(savedSearch.query);
+    });
+  });
+
+  describe('componentDidMount with an invalid saved search', function() {
+    beforeEach(function() {
+      props.params.searchId = '999';
+      wrapper = shallow(<OrganizationStream {...props} />);
+      wrapper.setState({loading: false});
+    });
+
+    it('resets the savedSearch state', async function() {
+      let instance = wrapper.instance();
+      await instance.componentDidMount();
+      await wrapper.update();
+
+      expect(instance.state.savedSearch).toBeNull();
+    });
+  });
+
+  describe('processingIssues', function() {
+    beforeEach(function() {
+      wrapper = shallow(<OrganizationStream {...props} />);
+    });
+
+    it('fetches and displays processing issues', async function() {
+      let instance = wrapper.instance();
+      instance.componentDidMount();
+      await wrapper.update();
+
+      GroupStore.add([group]);
+      wrapper.setState({
+        groupIds: ['1'],
+        loading: false,
+      });
+
+      let issues = wrapper.find('ProcessingIssueHint');
+      expect(issues).toHaveLength(1);
+    });
+  });
+
+  describe('render states', function() {
+    beforeEach(function() {
+      wrapper = shallow(<OrganizationStream {...props} />);
+    });
+
+    it('displays the loading icon', function() {
+      wrapper.setState({loading: true});
+      expect(wrapper.find('LoadingIndicator')).toHaveLength(1);
+    });
+
+    it('displays an error', function() {
+      wrapper.setState({error: 'Things broke', loading: false});
+
+      let error = wrapper.find('LoadingError');
+      expect(error).toHaveLength(1);
+      expect(error.props().message).toEqual('Things broke');
+    });
+
+    it('displays an empty resultset', function() {
+      wrapper.setState({
+        loading: false,
+        error: false,
+        groupIds: [],
+      });
+      expect(wrapper.find('EmptyStateWarning')).toHaveLength(1);
+    });
+
+    it('displays the getting started state', function() {
+      let proj = TestStubs.ProjectDetails({
+        firstEvent: false,
+      });
+      let org = TestStubs.Organization({
+        access: ['releases'],
+        projects: [proj],
+      });
+      wrapper.setProps({
+        organization: org,
+        selection: {
+          projects: [parseInt(proj.id, 10)],
+          environments: [],
+          datetime: {period: '14d'},
+        },
+      });
+      wrapper.setState({loading: false});
+      expect(wrapper.find('ErrorRobot')).toHaveLength(1);
+    });
+
+    it('displays group rows', function() {
+      GroupStore.add([group]);
+      wrapper.setState({
+        error: false,
+        loading: false,
+        groupIds: ['1'],
+      });
+      let groups = wrapper.find('StreamGroup');
+      expect(groups).toHaveLength(1);
+    });
+  });
+});

--- a/tests/js/spec/views/stream/__snapshots__/stream.spec.jsx.snap
+++ b/tests/js/spec/views/stream/__snapshots__/stream.spec.jsx.snap
@@ -23,6 +23,7 @@ exports[`Stream render() displays the group list 1`] = `
       }
       isSearchDisabled={false}
       onSavedSearchCreate={[Function]}
+      onSavedSearchSelect={[Function]}
       onSearch={[Function]}
       onSidebarToggle={[Function]}
       onSortChange={[Function]}
@@ -196,6 +197,7 @@ exports[`Stream toggles environment select all environments 1`] = `
       }
       isSearchDisabled={false}
       onSavedSearchCreate={[Function]}
+      onSavedSearchSelect={[Function]}
       onSearch={[Function]}
       onSidebarToggle={[Function]}
       onSortChange={[Function]}


### PR DESCRIPTION
Changing a search term shouldn't re-fetch the processing issues unless the projects involved have changed. I've also removed a bunch of aborted requests when changing between saved searches. I've not been able to remove them all though.

Currently when moving between saved searches that have different projects there is one aborted request which comes from the selection projects being updated after the savedSearch state is updated. I tried a bunch of different ways to solve this but each solution that resulted
in 0 aborted requests broke a different use case.

I've moved the saved search selection to be an action instead of a direct link as this helps cut down on the aborted requests and allows each issue list to generate the appropriate URLs without having to embed that logic in the SavedSearchSelector component.

Refs APP-1028