### PR TITLE
feat(sidebar): Remove sidebar items for Sentry 10

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -216,6 +216,8 @@ class Sidebar extends React.Component {
     };
     let hasOrganization = !!organization;
 
+    let hasSentry10 = hasOrganization && new Set(organization.features).has('sentry10');
+
     let projectsSidebarItem = () => (
       <SidebarItem
         {...sidebarItemProps}
@@ -316,46 +318,50 @@ class Sidebar extends React.Component {
                 </Feature>
               </SidebarSection>
 
-              <SidebarSection>
-                <SidebarItem
-                  {...sidebarItemProps}
-                  onClick={this.hidePanel}
-                  icon={<InlineSvg src="icon-user" />}
-                  label={t('Assigned to me')}
-                  to={`/organizations/${organization.slug}/issues/assigned/`}
-                />
-                <SidebarItem
-                  {...sidebarItemProps}
-                  onClick={this.hidePanel}
-                  icon={<InlineSvg src="icon-star" />}
-                  label={t('Bookmarked issues')}
-                  to={`/organizations/${organization.slug}/issues/bookmarks/`}
-                />
-                <SidebarItem
-                  {...sidebarItemProps}
-                  onClick={this.hidePanel}
-                  icon={<InlineSvg src="icon-history" />}
-                  label={t('Recently viewed')}
-                  to={`/organizations/${organization.slug}/issues/history/`}
-                />
-              </SidebarSection>
+              {!hasSentry10 && (
+                <React.Fragment>
+                  <SidebarSection>
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      onClick={this.hidePanel}
+                      icon={<InlineSvg src="icon-user" />}
+                      label={t('Assigned to me')}
+                      to={`/organizations/${organization.slug}/issues/assigned/`}
+                    />
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      onClick={this.hidePanel}
+                      icon={<InlineSvg src="icon-star" />}
+                      label={t('Bookmarked issues')}
+                      to={`/organizations/${organization.slug}/issues/bookmarks/`}
+                    />
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      onClick={this.hidePanel}
+                      icon={<InlineSvg src="icon-history" />}
+                      label={t('Recently viewed')}
+                      to={`/organizations/${organization.slug}/issues/history/`}
+                    />
+                  </SidebarSection>
 
-              <SidebarSection>
-                <SidebarItem
-                  {...sidebarItemProps}
-                  onClick={this.hidePanel}
-                  icon={<InlineSvg src="icon-activity" />}
-                  label={t('Activity')}
-                  to={`/organizations/${organization.slug}/activity/`}
-                />
-                <SidebarItem
-                  {...sidebarItemProps}
-                  onClick={this.hidePanel}
-                  icon={<InlineSvg src="icon-stats" />}
-                  label={t('Stats')}
-                  to={`/organizations/${organization.slug}/stats/`}
-                />
-              </SidebarSection>
+                  <SidebarSection>
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      onClick={this.hidePanel}
+                      icon={<InlineSvg src="icon-activity" />}
+                      label={t('Activity')}
+                      to={`/organizations/${organization.slug}/activity/`}
+                    />
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      onClick={this.hidePanel}
+                      icon={<InlineSvg src="icon-stats" />}
+                      label={t('Stats')}
+                      to={`/organizations/${organization.slug}/stats/`}
+                    />
+                  </SidebarSection>
+                </React.Fragment>
+              )}
 
               <SidebarSection>
                 <SidebarItem

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -279,5 +279,19 @@ describe('Sidebar', function() {
       wrapper.update();
       expect(wrapper.find('SidebarPanel')).toHaveLength(0);
     });
+
+    it('hides assigned, bookmarks, history, activity and stats for sentry10', function() {
+      const sentry10Org = TestStubs.Organization({features: ['sentry10']});
+      wrapper = createWrapper();
+      wrapper.setProps({organization: sentry10Org});
+      wrapper.update();
+      const labels = wrapper.find('SidebarItemLabel').map(node => node.text());
+      expect(labels).toHaveLength(5);
+      expect(labels).not.toContain('Assigned to me');
+      expect(labels).not.toContain('Bookmarked issues');
+      expect(labels).not.toContain('Recently viewed');
+      expect(labels).not.toContain('Activity');
+      expect(labels).not.toContain('Stats');
+    });
   });
 });


### PR DESCRIPTION
The following sidebar items are hidden in Sentry 10:
- Assigned to me
- Bookmarked issues
- Recently viewed
- Activity
- Stats