### PR TITLE
fix(issues) Allow selection of a single project to enable saved search

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -630,6 +630,13 @@ const OrganizationStream = createReactClass({
       hasReleases = features.has('releases');
       latestRelease = selectedProject.latestRelease;
       projectId = selectedProject.slug;
+    } else {
+      // If the user has filtered down to a single project
+      // we can hint the autocomplete/savedsearch picker with that.
+      let projects = this.getGlobalSearchProjects();
+      if (projects.length === 1) {
+        projectId = projects[0].slug;
+      }
     }
 
     return (

--- a/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
@@ -191,6 +191,7 @@ const SaveSearchButton = withApi(
                   size="small"
                   disabled={isSaving}
                   onClick={this.onToggle.bind(this)}
+                  style={{marginRight: space(1)}}
                 >
                   {t('Cancel')}
                 </Button>


### PR DESCRIPTION
Requiring the user to select an issue via the checkbox is a strange workflow requirement for saving a new search. Instead we can use the global selector to know if only a single project is being operated on.

I've also fixed a missing margin between buttons in the saved search modal.

Fixes APP-1034