### PR TITLE
feat: Make /issues the default route for Sentry 10

### DIFF
--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -65,7 +65,7 @@ class FeatureManager(object):
         Depending on the Feature class, additional arguments may need to be
         provided to assign organiation or project context to the feature.
 
-        >>> FeatureManager.has('organization:feature', organization, actor=request.user)
+        >>> FeatureManager.has('organizations:feature', organization, actor=request.user)
         """
         actor = kwargs.pop('actor', None)
         feature = self.get(name, *args, **kwargs)

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -797,6 +797,12 @@ function routes() {
               import(/* webpackChunkName: "OrganizationStreamContainer" */ './views/organizationStream/container')}
             component={errorHandler(LazyLoad)}
           >
+            <Redirect from="/organizations/:orgId/" to="/organizations/:orgId/issues/" />
+            <IndexRoute
+              componentPromise={() =>
+                import(/* webpackChunkName: "OrganizationStreamOverview" */ './views/organizationStream/overview')}
+              component={errorHandler(LazyLoad)}
+            />
             <IndexRoute
               componentPromise={() =>
                 import(/* webpackChunkName: "OrganizationStreamOverview" */ './views/organizationStream/overview')}

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -803,11 +803,6 @@ function routes() {
                 import(/* webpackChunkName: "OrganizationStreamOverview" */ './views/organizationStream/overview')}
               component={errorHandler(LazyLoad)}
             />
-            <IndexRoute
-              componentPromise={() =>
-                import(/* webpackChunkName: "OrganizationStreamOverview" */ './views/organizationStream/overview')}
-              component={errorHandler(LazyLoad)}
-            />
             <Route
               path="searches/:searchId/"
               componentPromise={() =>

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -151,7 +151,7 @@ class OrganizationMixin(object):
 
         if organization:
             if features.has('organizations:sentry10', organization, actor=request.user):
-                url = reverse('sentry-organization-index', args=[organization.slug])
+                url = reverse('sentry-organization-issue-list', args=[organization.slug])
             else:
                 url = reverse('sentry-organization-home', args=[organization.slug])
         elif not features.has('organizations:create'):

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -148,9 +148,13 @@ class OrganizationMixin(object):
 
         # TODO(dcramer): deal with case when the user cannot create orgs
         organization = self.get_active_organization(request)
+
         if organization:
-            url = reverse('sentry-organization-home', args=[organization.slug])
-        elif not features.has('organizations:create'):
+            if features.has('organizations:sentry10', organization, actor=request.user):
+                url = reverse('sentry-organization-index', args=[organization.slug])
+            else:
+                url = reverse('sentry-organization-home', args=[organization.slug])
+        elif not features.has('organizations:create', organization, actor=request.user):
             return self.respond('sentry/no-organization-access.html', status=403)
         else:
             url = '/organizations/new/'

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -154,7 +154,7 @@ class OrganizationMixin(object):
                 url = reverse('sentry-organization-index', args=[organization.slug])
             else:
                 url = reverse('sentry-organization-home', args=[organization.slug])
-        elif not features.has('organizations:create', organization, actor=request.user):
+        elif not features.has('organizations:create'):
             return self.respond('sentry/no-organization-access.html', status=403)
         else:
             url = '/organizations/new/'

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -405,6 +405,11 @@ urlpatterns += patterns(
         name='sentry-organization-index'
     ),
     url(
+        r'^organizations/(?P<organization_slug>[\w_-]+)/issues/$',
+        react_page_view,
+        name='sentry-organization-issue-list'
+    ),
+    url(
         r'^organizations/(?P<organization_slug>[\w_-]+)/issues/(?P<issue_id>\d+)/$',
         react_page_view,
         name='sentry-organization-issue-detail'

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -399,7 +399,11 @@ urlpatterns += patterns(
     url(r'^(?P<organization_slug>[\w_-]+)/$',
         react_page_view, name='sentry-organization-home'),
     url(r'^organizations/new/$', generic_react_page_view),
-
+    url(
+        r'^organizations/(?P<organization_slug>[\w_-]+)/$',
+        react_page_view,
+        name='sentry-organization-index'
+    ),
     url(
         r'^organizations/(?P<organization_slug>[\w_-]+)/issues/(?P<issue_id>\d+)/$',
         react_page_view,


### PR DESCRIPTION
Add a route for organizations/:orgid/ which redirects to the issues page. `redirect_to_org` navigates to this page if the sentry10 flag is active