### PR TITLE
fix(api): Correctly filter for environments in org group index

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -12,7 +12,7 @@ from sentry.api.helpers.group_index import build_query_params_from_request, get_
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializerSnuba
 from sentry.api.utils import get_date_range_from_params, InvalidParams
-from sentry.models import Environment, Group, GroupStatus
+from sentry.models import Group, GroupStatus
 from sentry.search.snuba.backend import SnubaSearchBackend
 
 
@@ -85,10 +85,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
             # disable stats
             stats_period = None
 
-        environments = list(Environment.objects.filter(
-            organization_id=organization.id,
-            name__in=self.get_environments(request, organization),
-        ))
+        environments = self.get_environments(request, organization)
 
         serializer = functools.partial(
             StreamGroupSerializerSnuba,

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -141,10 +141,21 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
     def test_environment(self):
         self.create_environment(name='production', organization=self.project.organization)
+        self.create_environment(name='staging', organization=self.project.organization)
         group = self.create_group(
             project=self.project,
         )
+        group2 = self.create_group(
+            project=self.project,
+        )
         self.create_event(tags={'environment': 'production'}, group=group, datetime=self.min_ago)
+        self.create_event(
+            tags={
+                'environment': 'staging'},
+            group=group2,
+            datetime=self.min_ago,
+            stacktrace=[
+                ['foo.py']])
 
         self.login_as(user=self.user)
 

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -141,12 +141,16 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
     def test_environment(self):
         self.create_environment(name='production', organization=self.project.organization)
-        self.create_event(tags={'environment': 'production'})
+        group = self.create_group(
+            project=self.project,
+        )
+        self.create_event(tags={'environment': 'production'}, group=group, datetime=self.min_ago)
 
         self.login_as(user=self.user)
 
         response = self.client.get(self.path + '?environment=production', format='json')
         assert response.status_code == 200
+        assert len(response.data) == 1
 
         response = self.client.get(self.path + '?environment=garbage', format='json')
         assert response.status_code == 404


### PR DESCRIPTION
i must have messed this up after the `get_environments` refactor. improved the test so it would have failed in the incorrect case