### PR TITLE
fix(django-rest-framework): Improve ListField Test coverage.

### DIFF
--- a/tests/sentry/api/serializers/rest_framework/test_list.py
+++ b/tests/sentry/api/serializers/rest_framework/test_list.py
@@ -1,0 +1,103 @@
+from __future__ import absolute_import
+from sentry.api.serializers.rest_framework import ListField
+
+from rest_framework import serializers
+
+from sentry.testutils import TestCase
+
+
+class ListFieldTest(TestCase):
+    def assert_success(self, serializer, value):
+        assert serializer.is_valid()
+        assert not serializer.errors
+        assert serializer.object == value
+
+    def assert_unsuccessful(self, serializer, errors):
+        assert not serializer.is_valid()
+        assert serializer.errors == errors
+        assert serializer.object is None
+
+    def test_simple(self):
+        class DummySerializer(serializers.Serializer):
+            list_field = ListField(child=serializers.IntegerField())
+        serializer = DummySerializer(data={'list_field': [1, 2, 3]})
+        self.assert_success(serializer, {'list_field': [1, 2, 3]})
+
+    def test_single_element_list(self):
+        class DummySerializer(serializers.Serializer):
+            list_field = ListField(child=serializers.IntegerField())
+        serializer = DummySerializer(data={'list_field': [1]})
+        self.assert_success(serializer, {'list_field': [1]})
+
+    def test_empty_list_child_required(self):
+        class DummySerializer(serializers.Serializer):
+            list_field = ListField(required=False, child=serializers.IntegerField())
+        serializer = DummySerializer(data={'list_field': []})
+        self.assert_success(serializer, {'list_field': []})
+
+    def test_empty_list_child_required_default_value(self):
+        class DummySerializer(serializers.Serializer):
+            list_field = ListField(default=[], required=False, child=serializers.IntegerField())
+        serializer = DummySerializer(data={'list_field': []})
+        self.assert_success(serializer, {'list_field': []})
+
+    def test_empty_list_child_required_complex_object(self):
+        class DummyChildSerializer(serializers.Serializer):
+            name = serializers.CharField()
+            age = serializers.IntegerField()
+
+        class DummySerializer(serializers.Serializer):
+            list_field = ListField(required=False, child=DummyChildSerializer())
+        serializer = DummySerializer(data={'list_field': []})
+        self.assert_unsuccessful(serializer,
+                                 {'list_field': ['non_field_errors: No input provided']})
+
+    def test_empty_list_child_not_required_complex_object(self):
+        class DummyChildSerializer(serializers.Serializer):
+            name = serializers.CharField()
+            age = serializers.IntegerField()
+
+        class DummySerializer(serializers.Serializer):
+            list_field = ListField(required=False, child=DummyChildSerializer(required=False))
+        serializer = DummySerializer(data={'list_field': []})
+        self.assert_unsuccessful(serializer,
+                                 {'list_field': ['non_field_errors: No input provided']})
+
+    def test_empty_list_child_not_required_complex_object_with_default(self):
+        class DummyChildSerializer(serializers.Serializer):
+            name = serializers.CharField()
+            age = serializers.IntegerField()
+
+        class DummySerializer(serializers.Serializer):
+            list_field = ListField(
+                default=[],
+                required=False,
+                child=DummyChildSerializer(
+                    required=False))
+        serializer = DummySerializer(data={'list_field': []})
+        self.assert_unsuccessful(serializer,
+                                 {'list_field': ['non_field_errors: No input provided']})
+
+    def test_empty_list(self):
+        class DummySerializer(serializers.Serializer):
+            list_field = ListField(required=False, child=serializers.IntegerField(required=False))
+        serializer = DummySerializer(data={'list_field': []})
+        self.assert_success(serializer, {'list_field': []})
+
+    def test_checks_required(self):
+        class DummySerializer(serializers.Serializer):
+            list_field = ListField(child=serializers.IntegerField())
+        serializer = DummySerializer(data={})
+        self.assert_unsuccessful(serializer, {'list_field': [u'This field is required.']})
+
+    def test_allows_no_object_with_not_required(self):
+        class DummySerializer(serializers.Serializer):
+            list_field = ListField(child=serializers.IntegerField(), required=False)
+        serializer = DummySerializer(data={})
+        self.assert_success(serializer, {})
+
+    def test_allows_object_with_not_required(self):
+        class DummySerializer(serializers.Serializer):
+            list_field = ListField(child=serializers.IntegerField(), required=False)
+        serializer = DummySerializer(data={'list_field': [1, 2, 3]})
+        self.assert_success(serializer, {'list_field': [1, 2, 3]})


### PR DESCRIPTION
Wrote tests in the ListField as they were missing. 

This highlights a bug I have encountered where the empty list is not allowed depending on what kind of child is given to the list. 

```python
class DummySerializer(serializers.Serializer):
            list_field = ListField(required=False, child=serializers.IntegerField())
serializer = DummySerializer(data={'list_field': []})
```
In this case, `serializer.is_valid()` is `True`.

```python
class DummySerializer(serializers.Serializer):
            list_field = ListField(required=False, child=DummyChildSerializer())
serializer = DummySerializer(data={'list_field': []})
```
But in this case `serializer.is_valid()` is `False`. 

Also changing `child=DummyChildSerializer(required=False)` does not solve the problem and `serializer.is_valid()` is still `False`.


I wanted to get some guidance prior to making a change. I have a preference for it to work similarly to how the [ListField in the current django rest framework works](https://github.com/encode/django-rest-framework/blob/master/rest_framework/fields.py#L1612). But I had fears of breaking existing code.