### PR TITLE
fix(api): Use _error prop for child serializer in list field

### DIFF
--- a/src/sentry/api/serializers/rest_framework/list.py
+++ b/src/sentry/api/serializers/rest_framework/list.py
@@ -56,7 +56,7 @@ class ListField(WritableField):
         if self.child:
             # the `self.child.from_native` call might have already
             # validated/changed data so check for child errors first
-            if self.child.errors:
+            if self.child._errors:
                 raise ValidationError(self.format_child_errors())
             for item in value:
                 if item is None and not self.allow_null:

--- a/tests/sentry/api/serializers/rest_framework/test_list.py
+++ b/tests/sentry/api/serializers/rest_framework/test_list.py
@@ -49,8 +49,7 @@ class ListFieldTest(TestCase):
         class DummySerializer(serializers.Serializer):
             list_field = ListField(required=False, child=DummyChildSerializer())
         serializer = DummySerializer(data={'list_field': []})
-        self.assert_unsuccessful(serializer,
-                                 {'list_field': ['non_field_errors: No input provided']})
+        self.assert_success(serializer, {'list_field': []})
 
     def test_empty_list_child_not_required_complex_object(self):
         class DummyChildSerializer(serializers.Serializer):
@@ -60,8 +59,7 @@ class ListFieldTest(TestCase):
         class DummySerializer(serializers.Serializer):
             list_field = ListField(required=False, child=DummyChildSerializer(required=False))
         serializer = DummySerializer(data={'list_field': []})
-        self.assert_unsuccessful(serializer,
-                                 {'list_field': ['non_field_errors: No input provided']})
+        self.assert_success(serializer, {'list_field': []})
 
     def test_empty_list_child_not_required_complex_object_with_default(self):
         class DummyChildSerializer(serializers.Serializer):
@@ -75,8 +73,7 @@ class ListFieldTest(TestCase):
                 child=DummyChildSerializer(
                     required=False))
         serializer = DummySerializer(data={'list_field': []})
-        self.assert_unsuccessful(serializer,
-                                 {'list_field': ['non_field_errors: No input provided']})
+        self.assert_success(serializer, {'list_field': []})
 
     def test_empty_list(self):
         class DummySerializer(serializers.Serializer):


### PR DESCRIPTION
This was incorrectly triggering validation when there were no child items because of:
https://github.com/encode/django-rest-framework/blob/2.4.8/rest_framework/serializers.py#L501