### PR TITLE
api(feat): Modify OrganizationEnvironmentEndpoint to filter by projects and respect visibility (APP-1035)

### DIFF
--- a/src/sentry/api/endpoints/organization_environments.py
+++ b/src/sentry/api/endpoints/organization_environments.py
@@ -3,14 +3,27 @@ from __future__ import absolute_import
 from rest_framework.response import Response
 
 from sentry.api.bases import OrganizationEndpoint
+from sentry.api.helpers.environments import environment_visibility_filter_options
 from sentry.api.serializers import serialize
-from sentry.models import Environment
+from sentry.models import Environment, EnvironmentProject
 
 
 class OrganizationEnvironmentsEndpoint(OrganizationEndpoint):
     def get(self, request, organization):
+        visibility = request.GET.get('visibility', 'visible')
+        if visibility not in environment_visibility_filter_options:
+            return Response({
+                'detail': u'Invalid value for \'visibility\', valid values are: {!r}'.format(
+                    environment_visibility_filter_options.keys(),
+                ),
+            }, status=400)
+        environment_projects = EnvironmentProject.objects.filter(
+            project__in=self.get_projects(request, organization),
+        )
+        add_visibility_filters = environment_visibility_filter_options[visibility]
+        environment_projects = add_visibility_filters(environment_projects).values('environment')
         queryset = Environment.objects.filter(
-            organization_id=organization.id,
+            id__in=environment_projects,
         ).exclude(
             # HACK(mattrobenolt): We don't want to surface the
             # "No Environment" environment to the UI since it

--- a/src/sentry/api/endpoints/project_environments.py
+++ b/src/sentry/api/endpoints/project_environments.py
@@ -3,15 +3,9 @@ from __future__ import absolute_import
 from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.helpers.environments import environment_visibility_filter_options
 from sentry.api.serializers import serialize
 from sentry.models import EnvironmentProject
-
-
-environment_visibility_filter_options = {
-    'all': lambda queryset: queryset,
-    'hidden': lambda queryset: queryset.filter(is_hidden=True),
-    'visible': lambda queryset: queryset.exclude(is_hidden=True),
-}
 
 
 class ProjectEnvironmentsEndpoint(ProjectEndpoint):

--- a/src/sentry/api/helpers/environments.py
+++ b/src/sentry/api/helpers/environments.py
@@ -3,6 +3,12 @@ from __future__ import absolute_import
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.models import Environment
 
+environment_visibility_filter_options = {
+    'all': lambda queryset: queryset,
+    'hidden': lambda queryset: queryset.filter(is_hidden=True),
+    'visible': lambda queryset: queryset.exclude(is_hidden=True),
+}
+
 
 def get_environments(request, organization):
     requested_environments = set(request.GET.getlist('environment'))

--- a/src/sentry/models/environment.py
+++ b/src/sentry/models/environment.py
@@ -105,13 +105,17 @@ class Environment(Model):
 
         return env
 
-    def add_project(self, project):
+    def add_project(self, project, is_hidden=None):
         cache_key = 'envproj:c:%s:%s' % (self.id, project.id)
 
         if cache.get(cache_key) is None:
             try:
                 with transaction.atomic():
-                    EnvironmentProject.objects.create(project=project, environment=self)
+                    EnvironmentProject.objects.create(
+                        project=project,
+                        environment=self,
+                        is_hidden=is_hidden,
+                    )
                 cache.set(cache_key, 1, 3600)
             except IntegrityError:
                 # We've already created the object, should still cache the action.

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -305,7 +305,7 @@ class Fixtures(object):
             project_id=project.id,
             name=name,
         )
-        env.add_project(project)
+        env.add_project(project, is_hidden=kwargs.get('is_hidden'))
         return env
 
     def create_project(self, **kwargs):

--- a/tests/sentry/api/endpoints/test_organization_environments.py
+++ b/tests/sentry/api/endpoints/test_organization_environments.py
@@ -1,31 +1,69 @@
 from __future__ import absolute_import
 
-from django.core.urlresolvers import reverse
+from exam import fixture
 
+from sentry.api.serializers import serialize
 from sentry.models import Environment
 from sentry.testutils import APITestCase
 
 
 class OrganizationEnvironmentsTest(APITestCase):
-    def test_simple(self):
-        project = self.create_project()
+    endpoint = 'sentry-api-0-organization-environments'
 
-        for name in 'production', 'staging':
-            Environment.objects.create(
-                organization_id=project.organization_id,
-                name=name,
-            )
-
+    def setUp(self):
         self.login_as(user=self.user)
 
-        url = reverse(
-            'sentry-api-0-organization-environments',
-            kwargs={
-                'organization_slug': project.organization.slug,
-            }
+    @fixture
+    def project(self):
+        return self.create_project()
+
+    def test_simple(self):
+        Environment.objects.create(
+            organization_id=self.project.organization_id,
+            name='not project',
         )
-        response = self.client.get(url, format='json')
-        assert response.status_code == 200, response.content
-        assert len(response.data) == 2
-        assert response.data[0]['name'] == 'production'
-        assert response.data[1]['name'] == 'staging'
+        prod = self.create_environment(name='production', project=self.project)
+        staging = self.create_environment(name='staging', project=self.project)
+
+        response = self.get_valid_response(self.project.organization.slug)
+        assert response.data == serialize([prod, staging])
+
+    def test_visibility(self):
+        visible = self.create_environment(name='visible', project=self.project, is_hidden=False)
+        hidden = self.create_environment(name='not visible', project=self.project, is_hidden=True)
+        not_set = self.create_environment(name='null visible', project=self.project)
+        response = self.get_valid_response(self.project.organization.slug, visibility='visible')
+        assert response.data == serialize([not_set, visible])
+        response = self.get_valid_response(self.project.organization.slug, visibility='hidden')
+        assert response.data == serialize([hidden])
+        response = self.get_valid_response(self.project.organization.slug, visibility='all')
+        assert response.data == serialize([hidden, not_set, visible])
+
+    def test_project_filter(self):
+        other_project = self.create_project()
+        project_env = self.create_environment(name='project', project=self.project)
+        other_project_env = self.create_environment(name='other', project=other_project)
+
+        response = self.get_valid_response(
+            self.project.organization.slug,
+            project=[self.project.id],
+        )
+        assert response.data == serialize([project_env])
+        response = self.get_valid_response(
+            self.project.organization.slug,
+            project=[other_project.id],
+        )
+        assert response.data == serialize([other_project_env])
+        response = self.get_valid_response(
+            self.project.organization.slug,
+            project=[self.project.id, other_project.id],
+        )
+        assert response.data == serialize([other_project_env, project_env])
+
+    def test_invalid_visibility(self):
+        response = self.get_response(
+            self.project.organization.slug,
+            visibility='invalid-vis'
+        )
+        assert response.status_code == 400
+        assert response.data['detail'].startswith("Invalid value for 'visibility'")


### PR DESCRIPTION
This endpoint was returning all environments for an `Organization`, which isn't great for orgs with
many environments, and projects that are only associated with a small number of environments. It now
accepts our standard list of project ids and filters based on those, or if not passed then all
projects that the user has access to.

Also added the `visibility` querystring param so that we can filter by visibility in the same way
as the `ProjectEnvironment` endpoint. An environment will be visible if it's not hidden in at least
one of the related projects.