### PR TITLE
feat(dashboard): Add error boundary for widgets

### DIFF
--- a/src/sentry/static/sentry/app/components/errorBoundary.jsx
+++ b/src/sentry/static/sentry/app/components/errorBoundary.jsx
@@ -18,6 +18,7 @@ class ErrorBoundary extends React.Component {
   static propTypes = {
     mini: PropTypes.bool,
     message: PropTypes.node,
+    renderer: PropTypes.node,
   };
 
   static defaultProps = {
@@ -52,7 +53,11 @@ class ErrorBoundary extends React.Component {
 
   render() {
     if (this.state.error) {
-      let {mini, message, className} = this.props;
+      let {renderer, mini, message, className} = this.props;
+
+      if (renderer) {
+        return renderer;
+      }
 
       if (mini) {
         return (

--- a/src/sentry/static/sentry/app/components/errorBoundary.jsx
+++ b/src/sentry/static/sentry/app/components/errorBoundary.jsx
@@ -18,7 +18,7 @@ class ErrorBoundary extends React.Component {
   static propTypes = {
     mini: PropTypes.bool,
     message: PropTypes.node,
-    renderer: PropTypes.node,
+    customComponent: PropTypes.node,
   };
 
   static defaultProps = {
@@ -53,10 +53,10 @@ class ErrorBoundary extends React.Component {
 
   render() {
     if (this.state.error) {
-      let {renderer, mini, message, className} = this.props;
+      let {customComponent, mini, message, className} = this.props;
 
-      if (renderer) {
-        return renderer;
+      if (customComponent) {
+        return customComponent;
       }
 
       if (mini) {

--- a/src/sentry/static/sentry/app/views/organizationDashboard/widget.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/widget.jsx
@@ -31,7 +31,7 @@ class Widget extends React.Component {
     const isTable = type === WIDGET_DISPLAY.TABLE;
 
     return (
-      <ErrorBoundary renderer={<ErrorCard>{t('Error loading widget')}</ErrorCard>}>
+      <ErrorBoundary customComponent={<ErrorCard>{t('Error loading widget')}</ErrorCard>}>
         <DiscoverQuery
           organization={organization}
           selection={selection}


### PR DESCRIPTION
If widgets fail to render, display an error card. This allows user to see widgets that did not error and not completely crash dashboard.

![image](https://user-images.githubusercontent.com/79684/51767142-529edb00-2091-11e9-87f2-b2ddcecf5fa6.png)

Depends on https://github.com/getsentry/sentry/pull/11709 and https://github.com/getsentry/sentry/pull/11669