### PR TITLE
(WIP) fix(api): Fix issue where an issue can be resolved in a release that isn't associated with its project (APP-991)

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -219,6 +219,14 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, Environment
                 if created:
                     new_projects.append(project)
 
+            commit_list = result.get('commits')
+            # Only process resolutions when adding a project to a release if
+            # the release already existed, and we're not passing in a new list
+            # of commits. If we're passing in commits we'll process resolutions
+            # as part of that process.
+            if not created and not commit_list:
+                release.resolve_commit_resolutions_for_projects(new_projects)
+
             if release.date_released:
                 for project in new_projects:
                     Activity.objects.create(
@@ -229,7 +237,6 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, Environment
                         datetime=release.date_released,
                     )
 
-            commit_list = result.get('commits')
             if commit_list:
                 release.set_commits(commit_list)
 

--- a/src/sentry/plugins/interfaces/releasehook.py
+++ b/src/sentry/plugins/interfaces/releasehook.py
@@ -27,17 +27,19 @@ class ReleaseHook(object):
 
         try:
             with transaction.atomic():
-                release = Release.objects.create(
+                release, rel_created = Release.objects.create(
                     version=version, organization_id=self.project.organization_id, **values
-                )
+                ), True
         except IntegrityError:
-            release = Release.objects.get(
+            release, rel_created = Release.objects.get(
                 version=version,
                 organization_id=self.project.organization_id,
-            )
+            ), False
             release.update(**values)
 
-        release.add_project(self.project)
+        created = release.add_project(self.project)
+        if not rel_created and created:
+            release.resolve_commit_resolutions_for_projects([self.project])
 
     # TODO(dcramer): this is being used by the release details endpoint, but
     # it'd be ideal if most if not all of this logic lived there, and this
@@ -59,8 +61,9 @@ class ReleaseHook(object):
                 )
         except IntegrityError:
             release = Release.objects.get(organization_id=project.organization_id, version=version)
+        # Explicitly don't process resolutions here since we're setting a new
+        # commit list, which will handle resolution processing.
         release.add_project(project)
-
         release.set_commits(commit_list)
 
     def set_refs(self, release, **values):
@@ -73,17 +76,21 @@ class ReleaseHook(object):
         values.setdefault('date_released', timezone.now())
         try:
             with transaction.atomic():
-                release = Release.objects.create(
-                    version=version, organization_id=self.project.organization_id, **values
-                )
+                release, rel_created = Release.objects.create(
+                    version=version,
+                    organization_id=self.project.organization_id,
+                    **values
+                ), True
         except IntegrityError:
-            release = Release.objects.get(
+            release, rel_created = Release.objects.get(
                 version=version,
                 organization_id=self.project.organization_id,
-            )
+            ), False
             release.update(**values)
 
-        release.add_project(self.project)
+        created = release.add_project(self.project)
+        if not rel_created and created:
+            release.resolve_commit_resolutions_for_projects([self.project])
 
         Activity.objects.create(
             type=Activity.RELEASE,


### PR DESCRIPTION
When resolving issues based on commit/pr, filter the `GroupLinks` to only include projects that
are currently associated with a release. This prevents issues from being incorrectly resolved by
releases that their project isn't related to.

Then, whenever we add a project to a release, resolve any commit resolutions associated with that
release for that project.

Planning on writing some more tests around this, but some feedback on the general approach