### PR TITLE
fix(ui): Display compact issue link to project for Sentry 10

### DIFF
--- a/src/sentry/static/sentry/app/components/compactIssue.jsx
+++ b/src/sentry/static/sentry/app/components/compactIssue.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import {Flex, Box} from 'grid-emotion';
+import styled from 'react-emotion';
 
 import ApiMixin from 'app/mixins/apiMixin';
 import IndicatorStore from 'app/stores/indicatorStore';
@@ -94,7 +95,13 @@ class CompactIssueHeader extends React.Component {
         </Flex>
         <div className="event-extra">
           <span className="project-name">
-            <ProjectLink to={basePath}>{data.project.slug}</ProjectLink>
+            {hasNewRoutes ? (
+              <ProjectSlug>{data.project.slug}</ProjectSlug>
+            ) : (
+              <ProjectLink to={`/${organization.slug}/${projectId}/`}>
+                {data.project.slug}
+              </ProjectLink>
+            )}
           </span>
           {data.numComments !== 0 && (
             <span>
@@ -264,6 +271,10 @@ const CompactIssue = createReactClass({
     );
   },
 });
+
+const ProjectSlug = styled('span')`
+  font-weight: bold;
+`;
 
 export {CompactIssue};
 export default withOrganization(CompactIssue);

--- a/src/sentry/static/sentry/app/components/compactIssue.jsx
+++ b/src/sentry/static/sentry/app/components/compactIssue.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import {Flex, Box} from 'grid-emotion';
-import styled from 'react-emotion';
 
 import ApiMixin from 'app/mixins/apiMixin';
 import IndicatorStore from 'app/stores/indicatorStore';
@@ -96,7 +95,7 @@ class CompactIssueHeader extends React.Component {
         <div className="event-extra">
           <span className="project-name">
             {hasNewRoutes ? (
-              <ProjectSlug>{data.project.slug}</ProjectSlug>
+              <strong>{data.project.slug}</strong>
             ) : (
               <ProjectLink to={`/${organization.slug}/${projectId}/`}>
                 {data.project.slug}
@@ -271,10 +270,6 @@ const CompactIssue = createReactClass({
     );
   },
 });
-
-const ProjectSlug = styled('span')`
-  font-weight: bold;
-`;
 
 export {CompactIssue};
 export default withOrganization(CompactIssue);

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -229,7 +229,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                         "/org-slug/project-slug/issues/1/",
                       ],
                       Array [
-                        "/org-slug/project-slug/issues/",
+                        "/org-slug/project-slug/",
                       ],
                       Array [
                         "/org-slug/project-slug/issues/1/activity/",
@@ -366,7 +366,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                           "/org-slug/project-slug/issues/1/",
                         ],
                         Array [
-                          "/org-slug/project-slug/issues/",
+                          "/org-slug/project-slug/",
                         ],
                         Array [
                           "/org-slug/project-slug/issues/1/activity/",
@@ -1980,12 +1980,12 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                             className="project-name"
                                           >
                                             <ProjectLink
-                                              to="/org-slug/project-slug/issues/"
+                                              to="/org-slug/project-slug/"
                                             >
                                               <Link
                                                 onlyActiveOnIndex={false}
                                                 style={Object {}}
-                                                to="/org-slug/project-slug/issues/"
+                                                to="/org-slug/project-slug/"
                                               >
                                                 <a
                                                   onClick={[Function]}


### PR DESCRIPTION
We need to disable this link since there isn't a project page in Sentry
10. Also returns the non- Sentry 10 project link to what it was previously.