### PR TITLE
fix(minidump): Treat CFI scanned frames like scanned frames

### DIFF
--- a/src/sentry/lang/native/cfi.py
+++ b/src/sentry/lang/native/cfi.py
@@ -19,7 +19,7 @@ from sentry.utils.safe import get_path
 logger = logging.getLogger('sentry.minidumps')
 
 # Frame trust values achieved through the use of CFI
-CFI_TRUSTS = ('cfi', 'cfi-scan')
+CFI_TRUSTS = ('cfi', )
 
 # Minimum frame trust value that we require to omit CFI reprocessing
 MIN_TRUST = FrameTrust.fp

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -318,7 +318,7 @@ const Frame = createReactClass({
     if (this.isInlineFrame()) {
       return t('Inlined frame');
     }
-    if (this.props.data.trust === 'scan') {
+    if (this.props.data.trust === 'scan' || this.props.data.trust === 'cfi-scan') {
       return t('Found by stack scanning');
     }
     if (this.getPlatform() == 'cocoa') {


### PR DESCRIPTION
Frames with trust `cfi-scan` should be treated like `scan` frames. This trust level indicates that CFI was available but did not resolve a usable frame, which is why the stackwalker fell back to stack scanning.