### PR TITLE
fix: Another None in eventtypes

### DIFF
--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -10,7 +10,7 @@ from .base import BaseEvent
 
 def get_crash_file(stacktrace):
     default = None
-    for frame in reversed(stacktrace.get('frames') or ()):
+    for frame in reversed(get_path(stacktrace, 'frames', filter=True) or ()):
         fn = frame.get('filename') or frame.get('abs_path')
         if fn:
             if frame.get('in_app'):


### PR DESCRIPTION
Fix SENTRY-97X