### PR TITLE
fix(issues): Fix tooltip placement

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
@@ -143,6 +143,7 @@ const GroupHeader = createReactClass({
                       title={t(
                         'This identifier is unique across your organization, and can be used to reference an issue in various places, like commit messages.'
                       )}
+                      tooltipOptions={{placement: 'bottom'}}
                     >
                       <a
                         className="help-link"


### PR DESCRIPTION
Since the new headers are shorter than the old ones, we need to render
the header tooltips below otherwise they will be cut off.