### PR TITLE
fix(charts): Fix world map tooltips [APP-1043]

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/worldMapChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/worldMapChart.jsx
@@ -103,8 +103,9 @@ export default class WorldMapChart extends React.Component {
               return '';
             }
 
+            // `value` should be a number
             const formattedValue =
-              typeof value === 'number' ? value.toLocaleString() : value;
+              typeof value === 'number' ? value.toLocaleString() : '';
             const countryOrCode = this.state.codeToCountryMap[name] || name;
 
             return `<div>${marker} ${countryOrCode}: ${formattedValue}</div>`;

--- a/src/sentry/static/sentry/app/components/charts/worldMapChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/worldMapChart.jsx
@@ -15,21 +15,28 @@ export default class WorldMapChart extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      countryCodesMap: null,
+      countryToCodeMap: null,
     };
   }
 
   async componentDidMount() {
-    const countryCodesMap = await import(/* webpackChunkName: "countryCodesMap" */ 'app/data/countryCodesMap');
+    const countryToCodeMap = await import(/* webpackChunkName: "countryCodesMap" */ 'app/data/countryCodesMap');
 
     // eslint-disable-next-line
     this.setState({
-      countryCodesMap: countryCodesMap.default,
+      countryToCodeMap: countryToCodeMap.default,
+      codeToCountryMap: Object.entries(countryToCodeMap.default).reduce(
+        (acc, [country, code]) => ({
+          ...acc,
+          [code]: country,
+        }),
+        {}
+      ),
     });
   }
 
   render() {
-    if (this.state.countryCodesMap === null) {
+    if (this.state.countryToCodeMap === null) {
       return null;
     }
 
@@ -40,7 +47,7 @@ export default class WorldMapChart extends React.Component {
         ...options,
         mapType: 'world',
         name: seriesName,
-        nameMap: this.state.countryCodesMap,
+        nameMap: this.state.countryToCodeMap,
         aspectScale: 0.85,
         zoom: 1.3,
         center: [10.97, 9.71],
@@ -48,6 +55,14 @@ export default class WorldMapChart extends React.Component {
           normal: {
             areaColor: theme.gray1,
             borderColor: theme.borderLighter,
+          },
+          emphasis: {
+            areaColor: theme.yellowOrange,
+          },
+        },
+        label: {
+          emphasis: {
+            show: false,
           },
         },
         data,
@@ -71,13 +86,30 @@ export default class WorldMapChart extends React.Component {
               color: [theme.purpleLightest, theme.purpleDarkest],
             },
             text: ['High', 'Low'],
-            calculable: true,
+
+            // Whether show handles, which can be dragged to adjust "selected range".
+            // False because the handles are pretty ugly
+            calculable: false,
           },
         }}
         {...props}
         yAxis={null}
         xAxis={null}
         series={processedSeries}
+        tooltip={{
+          formatter: ({marker, name, value, seriesName}) => {
+            // If value is NaN, don't show anything because we won't have a country code either
+            if (isNaN(value)) {
+              return '';
+            }
+
+            const formattedValue =
+              typeof value === 'number' ? value.toLocaleString() : value;
+            const countryOrCode = this.state.codeToCountryMap[name] || name;
+
+            return `<div>${marker} ${countryOrCode}: ${formattedValue}</div>`;
+          },
+        }}
       />
     );
   }


### PR DESCRIPTION
* Define own tooltip formatter for WorldMap - `data` is an object with {name, value} keys.
* Hide country codes on hover, instead just show tooltip
* Hide the "legend" handles -- these also allowed you to filter the chart by dragging the handles
* Show full country names instead of just country code (when possible)

![image](https://user-images.githubusercontent.com/79684/51871975-c567ba80-230c-11e9-844a-67b4e66c32b8.png)
