### PR TITLE
fix(analytics): Add platform only if available in issue banner

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -83,10 +83,10 @@ class EventEntries extends React.Component {
 
     analytics('issue_error_banner.viewed', {
       org_id: parseInt(orgId, 10),
-      platform: project.platform,
       group: event.groupID,
       error_type: errorTypes,
       error_message: errorMessages,
+      ...(platform ? {platform: project.platform}),
     });
   }
 

--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -86,7 +86,7 @@ class EventEntries extends React.Component {
       group: event.groupID,
       error_type: errorTypes,
       error_message: errorMessages,
-      ...(platform ? {platform: project.platform}),
+      ...(platform && {platform: project.platform}),
     });
   }
 

--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -86,7 +86,7 @@ class EventEntries extends React.Component {
       group: event.groupID,
       error_type: errorTypes,
       error_message: errorMessages,
-      ...(platform && {platform: project.platform}),
+      ...(project.platform && {platform: project.platform}),
     });
   }
 

--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -80,13 +80,14 @@ class EventEntries extends React.Component {
   recordIssueError(errorTypes, errorMessages) {
     let {organization, project, event} = this.props;
     let orgId = organization.id;
+    let platform = project.platform;
 
     analytics('issue_error_banner.viewed', {
       org_id: parseInt(orgId, 10),
       group: event.groupID,
       error_type: errorTypes,
       error_message: errorMessages,
-      ...(project.platform && {platform: project.platform}),
+      ...(platform && {platform: project.platform}),
     });
   }
 

--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -87,7 +87,7 @@ class EventEntries extends React.Component {
       group: event.groupID,
       error_type: errorTypes,
       error_message: errorMessages,
-      ...(platform && {platform: project.platform}),
+      ...(platform && {platform}),
     });
   }
 


### PR DESCRIPTION
Not all projects have platform set - sending as part of the data only if available

fixes RELOAD-D