### PR TITLE
fix(members): Redirect after leaving org

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/index.jsx
@@ -14,6 +14,8 @@ import Pagination from 'app/components/pagination';
 import SentryTypes from 'app/sentryTypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import recreateRoute from 'app/utils/recreateRoute';
+import OrganizationsStore from 'app/stores/organizationsStore';
+import {redirectToRemainingOrganization} from 'app/actionCreators/organizations';
 
 import OrganizationAccessRequests from './organizationAccessRequests';
 import OrganizationMemberRow from './organizationMemberRow';
@@ -160,12 +162,17 @@ class OrganizationMembersView extends AsyncView {
     let {slug: orgName} = organization;
 
     this.removeMember(id).then(
-      () =>
+      () => {
+        // Remove org from dropdown and redirect to remaining org
+        OrganizationsStore.remove(orgName);
+        redirectToRemainingOrganization({orgId: orgName});
+
         addSuccessMessage(
           tct('You left [orgName]', {
             orgName,
           })
-        ),
+        );
+      },
       () =>
         addErrorMessage(
           tct('Error leaving [orgName]', {

--- a/tests/js/spec/views/settings/organizationMembers/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/index.spec.jsx
@@ -83,7 +83,7 @@ describe('OrganizationMembers', function() {
         require_link: true,
       },
     });
-    browserHistory.push = jest.fn();
+    browserHistory.push.mockReset();
     OrganizationsStore.load([organization]);
   });
 

--- a/tests/js/spec/views/settings/organizationMembers/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/index.spec.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import {browserHistory} from 'react-router';
 
 import {Client} from 'app/api';
 import {mount} from 'enzyme';
 import ConfigStore from 'app/stores/configStore';
 import OrganizationMembers from 'app/views/settings/organizationMembers';
+import OrganizationsStore from 'app/stores/organizationsStore';
 import {addSuccessMessage, addErrorMessage} from 'app/actionCreators/indicator';
 
 jest.mock('app/api');
@@ -28,6 +30,9 @@ describe('OrganizationMembers', function() {
   };
   let organization = TestStubs.Organization({
     access: ['member:admin', 'org:admin'],
+    status: {
+      id: 'active',
+    },
   });
   let getStub;
 
@@ -78,6 +83,8 @@ describe('OrganizationMembers', function() {
         require_link: true,
       },
     });
+    browserHistory.push = jest.fn();
+    OrganizationsStore.load([organization]);
   });
 
   it('can remove a member', async function() {
@@ -109,6 +116,9 @@ describe('OrganizationMembers', function() {
 
     expect(deleteMock).toHaveBeenCalled();
     expect(addSuccessMessage).toHaveBeenCalled();
+
+    expect(browserHistory.push).not.toHaveBeenCalled();
+    expect(OrganizationsStore.getAll()).toEqual([organization]);
   });
 
   it('displays error message when failing to remove member', async function() {
@@ -141,6 +151,9 @@ describe('OrganizationMembers', function() {
     expect(deleteMock).toHaveBeenCalled();
     await tick();
     expect(addErrorMessage).toHaveBeenCalled();
+
+    expect(browserHistory.push).not.toHaveBeenCalled();
+    expect(OrganizationsStore.getAll()).toEqual([organization]);
   });
 
   it('can leave org', async function() {
@@ -172,6 +185,52 @@ describe('OrganizationMembers', function() {
 
     expect(deleteMock).toHaveBeenCalled();
     expect(addSuccessMessage).toHaveBeenCalled();
+
+    expect(browserHistory.push).toHaveBeenCalledTimes(1);
+    expect(browserHistory.push).toHaveBeenCalledWith('/organizations/new/');
+    expect(OrganizationsStore.getAll()).toEqual([]);
+  });
+
+  it('can redirect to remaining org after leaving', async function() {
+    let deleteMock = Client.addMockResponse({
+      url: `/organizations/org-id/members/${members[1].id}/`,
+      method: 'DELETE',
+    });
+    let secondOrg = TestStubs.Organization({
+      slug: 'org-two',
+      status: {
+        id: 'active',
+      },
+    });
+    OrganizationsStore.add(secondOrg);
+
+    let wrapper = mount(
+      <OrganizationMembers
+        {...defaultProps}
+        params={{
+          orgId: 'org-id',
+        }}
+      />,
+      TestStubs.routerContext([{organization}])
+    );
+
+    wrapper
+      .find('Button[priority="danger"]')
+      .at(0)
+      .simulate('click');
+
+    await tick();
+
+    // Confirm modal
+    wrapper.find('ModalDialog Button[priority="primary"]').simulate('click');
+    await tick();
+
+    expect(deleteMock).toHaveBeenCalled();
+    expect(addSuccessMessage).toHaveBeenCalled();
+
+    expect(browserHistory.push).toHaveBeenCalledTimes(1);
+    expect(browserHistory.push).toHaveBeenCalledWith(`/${secondOrg.slug}/`);
+    expect(OrganizationsStore.getAll()).toEqual([secondOrg]);
   });
 
   it('displays error message when failing to leave org', async function() {
@@ -204,6 +263,9 @@ describe('OrganizationMembers', function() {
     expect(deleteMock).toHaveBeenCalled();
     await tick();
     expect(addErrorMessage).toHaveBeenCalled();
+
+    expect(browserHistory.push).not.toHaveBeenCalled();
+    expect(OrganizationsStore.getAll()).toEqual([organization]);
   });
 
   it('can re-send invite to member', async function() {


### PR DESCRIPTION
After successfully leaving an org, the user isn't redirected to a remaining organization, leading to some `permissionDenied` errors. Related to JAVASCRIPT-3VH.