### PR TITLE
ref(development): Allow the runner to run as a script

### DIFF
--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -159,3 +159,7 @@ def call_command(name, obj=None, **kwargs):
 
 def main():
     cli(prog_name=get_prog(), obj={}, max_content_width=100)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The runner can be executed directly with `python ./src/sentry/runner/__init__.py`. 
This makes it easier to run the runner from an IDE such as PyCharm.