### PR TITLE
fix: Skip too large events in workerrelay

### DIFF
--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -93,7 +93,7 @@ def get_task_kwargs_for_message(value):
     dispatched.
     """
 
-    if len(value) > 2000000:
+    if len(value) > 10000000:
         logger.debug("Event payload too large: %d", len(value))
         return None
 

--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -92,6 +92,11 @@ def get_task_kwargs_for_message(value):
     can be applied to a post-processing task, or ``None`` if no task should be
     dispatched.
     """
+
+    if len(value) > 2000000:
+        logger.debug("Event payload too large: %d", len(value))
+        return None
+
     payload = json.loads(value)
 
     try:


### PR DESCRIPTION
The backlog is currently full of poorly trunchated events (sometimes even bloated through metadata). This is the workaround.