### PR TITLE
Revert "fix: Skip too large events in workerrelay"

### DIFF
--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -92,11 +92,6 @@ def get_task_kwargs_for_message(value):
     can be applied to a post-processing task, or ``None`` if no task should be
     dispatched.
     """
-
-    if len(value) > 10000000:
-        logger.debug("Event payload too large: %d", len(value))
-        return None
-
     payload = json.loads(value)
 
     try:


### PR DESCRIPTION
Reverts getsentry/sentry#11763