### PR TITLE
fix(app-platform): Don't raise on every retry

### DIFF
--- a/src/sentry/receivers/sentry_apps.py
+++ b/src/sentry/receivers/sentry_apps.py
@@ -10,7 +10,7 @@ from sentry.signals import (
     resolved_with_commit,
 )
 from sentry.tasks.sentry_apps import (
-    process_resource_change,
+    process_resource_change_bound,
     workflow_notification,
 )
 
@@ -23,7 +23,7 @@ def issue_saved(sender, instance, created, **kwargs):
     if not created:
         return
 
-    process_resource_change.delay(
+    process_resource_change_bound.delay(
         action='created',
         sender=sender.__name__,
         instance_id=issue.id,

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -103,15 +103,17 @@ def send_alert_event(event, rule, sentry_app_id):
     )
 
 
-@instrumented_task('sentry.tasks.process_resource_change', **TASK_OPTIONS)
-@retry()
-def process_resource_change(action, sender, instance_id, *args, **kwargs):
+def _process_resource_change(action, sender, instance_id, retryer=None, *args, **kwargs):
     # The class is serialized as a string when enqueueing the class.
     model = TYPES[sender]
 
     # Some resources are named differently than their model. eg. Group vs
     # Issue. Looks up the human name for the model. Defaults to the model name.
     name = RESOURCE_RENAMES.get(model.__name__, model.__name__.lower())
+
+    # By default, use Celery's `current` but allow a value to be passed for the
+    # bound Task.
+    retryer = retryer or current
 
     # We may run into a race condition where this task executes before the
     # transaction that creates the Group has committed.
@@ -120,7 +122,7 @@ def process_resource_change(action, sender, instance_id, *args, **kwargs):
     except model.DoesNotExist as e:
         # Explicitly requeue the task, so we don't report this to Sentry until
         # we hit the max number of retries.
-        return current.retry(exc=e)
+        return retryer.retry(exc=e)
 
     event = '{}.{}'.format(name, action)
 
@@ -139,6 +141,18 @@ def process_resource_change(action, sender, instance_id, *args, **kwargs):
 
     for installation in installations:
         send_webhooks(installation, event, data=serialize(instance))
+
+
+@instrumented_task('sentry.tasks.process_resource_change', **TASK_OPTIONS)
+@retry()
+def process_resource_change(action, sender, instance_id, *args, **kwargs):
+    _process_resource_change(action, sender, instance_id, *args, **kwargs)
+
+
+@instrumented_task('sentry.tasks.process_resource_change_bound', bind=True, **TASK_OPTIONS)
+@retry()
+def process_resource_change_bound(self, action, sender, instance_id, *args, **kwargs):
+    _process_resource_change(action, sender, instance_id, retryer=self, *args, **kwargs)
 
 
 @instrumented_task(name='sentry.tasks.sentry_apps.installation_webhook', **TASK_OPTIONS)

--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -7,7 +7,7 @@ from sentry.testutils import APITestCase, TestCase
 from sentry.testutils.helpers.faux import faux
 
 
-@patch('sentry.tasks.sentry_apps.process_resource_change.delay')
+@patch('sentry.tasks.sentry_apps.process_resource_change_bound.delay')
 class TestIssueSaved(TestCase):
     def test_processes_created_issues(self, delay):
         issue = self.create_group()


### PR DESCRIPTION
Celery by default uses exceptions to control retry logic, which logs an event to Sentry on every retry.

This changes to not throw an exception during retry. Hopefully this decreases the number of unnecessary errors we see.

## Multi-Part Change

This change is ultimately binding this Task, so that it receive the instance of itself as an argument (`self`). That way we can use `Task#retry`, which takes a `throw` argument telling Celery to not use exceptions to retry itself.

So that I don't mess up currently enqueued Tasks when the list of arguments change – not sure if it actually would, but I'd rather be safe – I'm breaking this change up into a few steps:

### 1. New Task
I'm introducing a new Task with the correct arguments, to be used moving forward. The existing Task, and it's method signature, will still exist for all currently queued tasks.

### 2. Change Old Task to New Arguments
After all currently queued Tasks are processed, I'll change the old Task to take the new set of arguments. Nothing will be enqueueing these at this point, so it'll be safe to change.

### 3. Bind Old Task
Then, I'll change the old Task to also use `bind=True` and change all invocations back to it.

This is an annoying multi-step process to ultimately not change the Task name, but introduce a new set of arguments 😒 