### PR TITLE
feat(app-platform): Issue Ignored Webhooks

### DIFF
--- a/src/sentry/receivers/sentry_apps.py
+++ b/src/sentry/receivers/sentry_apps.py
@@ -5,6 +5,7 @@ from django.dispatch import receiver
 
 from sentry.models import Group, Organization
 from sentry.signals import (
+    issue_ignored,
     issue_resolved,
     issue_resolved_in_release,
     resolved_with_commit,
@@ -37,7 +38,7 @@ def issue_resolved_in_release(project, group, user, resolution_type, **kwargs):
         group,
         user,
         'issue.resolved',
-        'resolved_in_release',
+        {'resolution_type': 'resolved_in_release'},
     )
 
 
@@ -48,8 +49,19 @@ def issue_resolved(project, group, user, **kwargs):
         group,
         user,
         'issue.resolved',
-        'resolved',
+        {'resolution_type': 'resolved'},
     )
+
+
+@issue_ignored.connect(weak=False)
+def issue_ignored(project, user, group_list, **kwargs):
+    for issue in group_list:
+        send_workflow_webhooks(
+            project.organization,
+            issue,
+            user,
+            'issue.ignored',
+        )
 
 
 @resolved_with_commit.connect(weak=False)
@@ -60,18 +72,20 @@ def resolved_with_commit(organization_id, group, user, **kwargs):
         group,
         user,
         'issue.resolved',
-        'resolved_in_commit',
+        {'resolution_type': 'resolved_in_commit'},
     )
 
 
-def send_workflow_webhooks(organization, issue, user, event, resolution_type):
+def send_workflow_webhooks(organization, issue, user, event, data=None):
+    data = data or {}
+
     for install in installations_to_notify(organization, event):
         workflow_notification.delay(
             installation_id=install.id,
             issue_id=issue.id,
-            type='resolved',
+            type=event.split('.')[-1],
             user_id=(user.id if user else None),
-            data={'resolution_type': resolution_type},
+            data=data,
         )
 
 


### PR DESCRIPTION
The code that handles ignoring issues already emits this `issue_ignored` signal. This change adds a receiver for that signal which processes any Sentry App webhook subscriptions.