### PR TITLE
fix(releases): Fix release detail title

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/detail/organization/releaseOverview.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/organization/releaseOverview.jsx
@@ -6,14 +6,14 @@ import LastCommit from 'app/components/lastCommit';
 import CommitAuthorStats from 'app/components/commitAuthorStats';
 import ReleaseProjectStatSparkline from 'app/components/releaseProjectStatSparkline';
 import RepositoryFileSummary from 'app/components/repositoryFileSummary';
-import AsyncView from 'app/views/asyncView';
+import AsyncComponent from 'app/components/asyncComponent';
 import {t} from 'app/locale';
 import {getFilesByRepository} from '../shared/utils';
 import ReleaseDeploys from '../shared/releaseDeploys';
 import ReleaseEmptyState from '../shared/releaseEmptyState';
 import ReleaseIssues from '../shared/releaseIssues';
 
-export default class OrganizationReleaseOverview extends AsyncView {
+export default class OrganizationReleaseOverview extends AsyncComponent {
   static contextTypes = {
     release: SentryTypes.Release,
   };


### PR DESCRIPTION
Overview component uses AsyncComponent instead of AsyncView so the
document title set by the parent view does not get clobbered.