### PR TITLE
fix(issues) Add project labels to saved searches

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -552,9 +552,20 @@ const OrganizationStream = createReactClass({
 
   fetchSavedSearches() {
     let {orgId, searchId} = this.props.params;
+    let {organization} = this.props;
+    let projectMap = organization.projects.reduce((acc, project) => {
+      acc[project.id] = project.slug;
+      return acc;
+    }, {});
 
     fetchSavedSearches(this.api, orgId).then(
       savedSearchList => {
+        // Add in project slugs so that we can display them in the picker bars.
+        savedSearchList = savedSearchList.map(search => {
+          search.projectSlug = projectMap[search.projectId];
+          return search;
+        });
+
         let newState = {
           savedSearchList,
           savedSearchLoading: false,

--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -559,9 +559,9 @@ const OrganizationStream = createReactClass({
     }, {});
 
     fetchSavedSearches(this.api, orgId).then(
-      savedSearchList => {
+      data => {
         // Add in project slugs so that we can display them in the picker bars.
-        savedSearchList = savedSearchList.map(search => {
+        let savedSearchList = data.map(search => {
           search.projectSlug = projectMap[search.projectId];
           return search;
         });

--- a/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
@@ -10,6 +10,7 @@ import DropdownLink from 'app/components/dropdownLink';
 import QueryCount from 'app/components/queryCount';
 import MenuItem from 'app/components/menuItem';
 import Tooltip from 'app/components/tooltip';
+import Tag from 'app/views/settings/components/tag';
 import {BooleanField, FormState, TextField} from 'app/components/forms';
 import withApi from 'app/utils/withApi';
 import space from 'app/styles/space';
@@ -235,11 +236,12 @@ const SavedSearchSelector = withApi(
       let hasProject = !!projectId;
 
       let children = this.props.savedSearchList.map(search => {
-        // let url = this.createUrl(search, hasProject);
-
         return (
           <StyledMenuItem onSelect={() => onSavedSearchSelect(search)} key={search.id}>
-            <strong>{search.name}</strong>
+            <span>
+              <strong>{search.name}</strong>
+              {search.projectSlug && <StyledTag>{search.projectSlug}</StyledTag>}
+            </span>
             <code>{search.query}</code>
           </StyledMenuItem>
         );
@@ -298,11 +300,17 @@ const EmptyItem = styled.li`
   font-style: italic;
 `;
 
+const StyledTag = styled(Tag)`
+  display: inline-block;
+  margin-left: ${space(0.25)};
+`;
+
 const StyledMenuItem = styled(MenuItem)`
   & a {
-    padding: ${space(0.5)} ${space(1)};
+    /* override shared-components.less */
+    padding: ${space(0.25)} ${space(1)} !important;
   }
-  & strong,
+  & span,
   & code {
     display: block;
     max-width: 100%;


### PR DESCRIPTION
Display a project label on saved searches at the organization level. This makes it easier for users to understand which saved searches they may want to use.

I decided to curry the project slugs in on the client side as we already have all that data available and I didn't see a reason to add more database queries.

![screen shot 2019-01-29 at 4 06 22 pm](https://user-images.githubusercontent.com/24086/51942798-f49e2a80-23e5-11e9-975e-209aef12c0a0.png)


Refs APP-1060