### PR TITLE
feat(app-platform): Issue Assigned Webhook

### DIFF
--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -25,7 +25,12 @@ from sentry.db.models import (
 # listening to a list of specific events. This is a mapping of what those
 # specific events are for each resource.
 EVENT_EXPANSION = {
-    'issue': ['issue.created', 'issue.resolved'],
+    'issue': [
+        'issue.created',
+        'issue.resolved',
+        'issue.ignored',
+        'issue.assigned',
+    ],
 }
 
 # We present Webhook Subscriptions per-resource (Issue, Project, etc.), not

--- a/tests/sentry/mediators/service_hooks/test_creator.py
+++ b/tests/sentry/mediators/service_hooks/test_creator.py
@@ -34,10 +34,21 @@ class TestCreator(TestCase):
     def test_expands_resource_events_to_specific_events(self):
         self.creator.events = ['issue']
         service_hook = self.creator.call()
-        assert set(service_hook.events) == set(['issue.created', 'issue.resolved'])
+
+        assert set(service_hook.events) == set([
+            'issue.created',
+            'issue.resolved',
+            'issue.ignored',
+            'issue.assigned',
+        ])
 
     def test_expand_events(self):
-        assert expand_events(['issue']) == set(['issue.created', 'issue.resolved'])
+        assert expand_events(['issue']) == set([
+            'issue.created',
+            'issue.resolved',
+            'issue.ignored',
+            'issue.assigned',
+        ])
 
     def test_consolidate_events(self):
         assert consolidate_events(['issue.created']) == set(['issue'])

--- a/tests/sentry/receivers/test_featureadoption.py
+++ b/tests/sentry/receivers/test_featureadoption.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import json
 from django.utils import timezone
 
-from sentry.models import FeatureAdoption, GroupTombstone, Rule
+from sentry.models import FeatureAdoption, GroupAssignee, GroupTombstone, Rule
 from sentry.plugins import IssueTrackingPlugin2, NotificationPlugin
 from sentry.signals import (
     alert_rule_created,
@@ -634,6 +634,12 @@ class FeatureAdoptionTest(TestCase):
         assert feature_complete
 
     def test_assignment(self):
+        GroupAssignee.objects.create(
+            group_id=self.group.id,
+            user_id=self.user.id,
+            project_id=self.project.id,
+        )
+
         issue_assigned.send(
             project=self.project,
             group=self.group,


### PR DESCRIPTION
Sentry Apps have the option to be notified when Issues are assigned. This change hooks into the existing `issue_assigned` signal to deliver those webhooks.

## Default Behavior
By default this webhook includes the Assignee's `name` and `email`, if it is a user. If it's a Team, it just sends `name`.

## Enhanced Privacy
When an Org has `enhanced_privacy` enabled, we only send `name` (which may be blank).

## Request Body Additions
```
{
  assignee: {
    type: 'user|team',
    name: '<name>',
    email: '<email-only-for-a-user>', 
  }
}
```