### PR TITLE
fix(sidebar): Renders all sidebar items in settings view

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -247,7 +247,11 @@ class Sidebar extends React.Component {
           {hasOrganization && (
             <React.Fragment>
               <SidebarSection>
-                <Feature features={['sentry10']} renderDisabled={projectsSidebarItem}>
+                <Feature
+                  features={['sentry10']}
+                  renderDisabled={projectsSidebarItem}
+                  organization={organization}
+                >
                   <SidebarItem
                     {...sidebarItemProps}
                     index
@@ -283,7 +287,7 @@ class Sidebar extends React.Component {
                   />
                 </Feature>
 
-                <Feature features={['sentry10']}>
+                <Feature features={['sentry10']} organization={organization}>
                   <SidebarItem
                     {...sidebarItemProps}
                     onClick={(_id, evt) =>

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -293,7 +293,7 @@ describe('Sidebar', function() {
       wrapper.setProps({organization: sentry10Org});
       wrapper.update();
       const labels = wrapper.find('SidebarItemLabel').map(node => node.text());
-      expect(labels).toHaveLength(7);
+      expect(labels).toHaveLength(10);
       expect(labels).not.toContain('Assigned to me');
       expect(labels).not.toContain('Bookmarked issues');
       expect(labels).not.toContain('Recently viewed');


### PR DESCRIPTION
Always pass the sidebar organization when doing the feature check for
sentry 10.  This is required since we won't always have an orgnaiation
in context - e.g. in account settings.