### PR TITLE
ref(api): Add multi environment support to group details endpoint

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -5,6 +5,7 @@ import functools
 import logging
 from uuid import uuid4
 
+from django.conf import settings
 from django.utils import timezone
 from rest_framework.response import Response
 
@@ -12,12 +13,12 @@ from sentry import eventstream, tsdb, tagstore
 from sentry.api import client
 from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases import GroupEndpoint
-from sentry.api.serializers import serialize, GroupSerializer
+from sentry.api.helpers.environments import get_environments
+from sentry.api.serializers import serialize, GroupSerializer, GroupSerializerSnuba
 from sentry.api.serializers.models.plugin import PluginSerializer
 from sentry.api.serializers.models.grouprelease import GroupReleaseWithStatsSerializer
 from sentry.models import (
     Activity,
-    Environment,
     Group,
     GroupHash,
     GroupRelease,
@@ -179,14 +180,6 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         :auth: required
         """
         # TODO(dcramer): handle unauthenticated/public response
-        data = serialize(
-            group,
-            request.user,
-            GroupSerializer(
-                environment_func=self._get_environment_func(
-                    request, group.project.organization_id)
-            )
-        )
 
         # TODO: these probably should be another endpoint
         activity = self._get_activity(request, group, num=100)
@@ -206,24 +199,44 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         if last_release:
             last_release = self._get_release_info(request, group, last_release)
 
-        try:
-            environment_id = self._get_environment_id_from_request(
-                request, group.project.organization_id)
-        except Environment.DoesNotExist:
-            get_range = lambda model, keys, start, end, **kwargs: \
-                {k: tsdb.make_series(0, start, end) for k in keys}
-            tags = []
-            user_reports = UserReport.objects.none()
+        # TODO(jess): This can be removed when tagstore v2 is deprecated
+        use_snuba = (
+            settings.SENTRY_TAGSTORE == 'sentry.tagstore.snuba.SnubaTagStorage' or
+            request.GET.get('enable_snuba') == '1'
+        )
+        environments = get_environments(request, group.project.organization)
+        environment_ids = [e.id for e in environments]
 
+        if use_snuba:
+            data = serialize(
+                group,
+                request.user,
+                GroupSerializerSnuba(
+                    environment_ids=environment_ids,
+                )
+            )
         else:
-            get_range = functools.partial(tsdb.get_range,
-                                          environment_ids=environment_id and [environment_id])
-            tags = tagstore.get_group_tag_keys(
-                group.project_id, group.id, environment_id and [environment_id], limit=100)
-            if environment_id is None:
-                user_reports = UserReport.objects.filter(group=group)
-            else:
-                user_reports = UserReport.objects.filter(group=group, environment_id=environment_id)
+            data = serialize(
+                group,
+                request.user,
+                GroupSerializer(
+                    environment_func=self._get_environment_func(
+                        request, group.project.organization_id)
+                )
+            )
+
+        get_range = functools.partial(tsdb.get_range,
+                                      environment_ids=environment_ids)
+
+        # TODO(jess): dependent on another pr for multi env support
+        tags = tagstore.get_group_tag_keys(
+            group.project_id, group.id, environment_ids and environment_ids[0], limit=100)
+        if not environment_ids:
+            user_reports = UserReport.objects.filter(group=group)
+        else:
+            user_reports = UserReport.objects.filter(
+                group=group, environment_id__in=environment_ids
+            )
 
         now = timezone.now()
         hourly_stats = tsdb.rollup(
@@ -271,25 +284,16 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
 
         # the current release is the 'latest seen' release within the
         # environment even if it hasnt affected this issue
-
-        try:
-            environment = self._get_environment_from_request(
-                request,
-                group.project.organization_id,
-            )
-        except Environment.DoesNotExist:
-            environment = None
-
-        if environment is not None:
+        if environments:
             try:
                 current_release = GroupRelease.objects.filter(
                     group_id=group.id,
-                    environment=environment.name,
+                    environment__in=[env.name for env in environments],
                     release_id=ReleaseEnvironment.objects.filter(
                         release_id__in=ReleaseProject.objects.filter(project_id=group.project_id
                                                                      ).values_list('release_id', flat=True),
                         organization_id=group.project.organization_id,
-                        environment_id=environment.id,
+                        environment_id__in=environment_ids,
                     ).order_by('-first_seen').values_list('release_id', flat=True)[:1],
                 )[0]
             except IndexError:

--- a/src/sentry/tsdb/inmemory.py
+++ b/src/sentry/tsdb/inmemory.py
@@ -83,7 +83,7 @@ class InMemoryTSDB(BaseTSDB):
             norm_epoch = self.normalize_to_rollup(timestamp, rollup)
 
             for key in keys:
-                if environment_ids is None:
+                if not environment_ids:
                     value = self.data[model][(key, None)][norm_epoch]
                 else:
                     value = sum(int(self.data[model][(key, environment_id)][norm_epoch])

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -99,12 +99,8 @@ class GroupDetailsTest(APITestCase):
             for args, kwargs in get_range.call_args_list:
                 assert kwargs['environment_ids'] == [environment.id]
 
-        with mock.patch(
-                'sentry.api.endpoints.group_details.tsdb.make_series',
-                side_effect=tsdb.make_series) as make_series:
-            response = self.client.get(url, {'environment': 'invalid'}, format='json')
-            assert response.status_code == 200
-            assert make_series.call_count == 2
+        response = self.client.get(url, {'environment': 'invalid'}, format='json')
+        assert response.status_code == 404
 
 
 class GroupUpdateTest(APITestCase):

--- a/tests/snuba/api/endpoints/test_group_details.py
+++ b/tests/snuba/api/endpoints/test_group_details.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import, print_function
+
+import mock
+
+from sentry.models import Environment
+from sentry.testutils import APITestCase, SnubaTestCase
+
+
+class GroupDetailsTest(APITestCase, SnubaTestCase):
+    def test_multiple_environments(self):
+        group = self.create_group()
+        self.login_as(user=self.user)
+
+        environment = Environment.get_or_create(group.project, 'production')
+        environment2 = Environment.get_or_create(group.project, 'staging')
+
+        url = u'/api/0/issues/{}/?enable_snuba=1'.format(group.id)
+
+        from sentry.api.endpoints.group_details import tsdb
+
+        with mock.patch(
+                'sentry.api.endpoints.group_details.tsdb.get_range',
+                side_effect=tsdb.get_range) as get_range:
+            response = self.client.get(
+                '%s&environment=production&environment=staging' % (url,),
+                format='json'
+            )
+            assert response.status_code == 200
+            assert get_range.call_count == 2
+            for args, kwargs in get_range.call_args_list:
+                assert kwargs['environment_ids'] == [environment.id, environment2.id]
+
+        response = self.client.get('%s&environment=invalid' % (url,), format='json')
+        assert response.status_code == 404


### PR DESCRIPTION
this is a start on https://getsentry.atlassian.net/browse/APP-1056

This adds multi-env support for the following:
- last 24h/30d stats 
- user count
- event count
- first seen**
- last seen

** with the caveat that this is subject to snuba retention right now. I will fix that separately. (https://github.com/getsentry/sentry/pull/11789)