### PR TITLE
fix(releases): Disable project stats row link for Sentry 10

### DIFF
--- a/src/sentry/static/sentry/app/components/releaseProjectStatSparkline.jsx
+++ b/src/sentry/static/sentry/app/components/releaseProjectStatSparkline.jsx
@@ -3,17 +3,18 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import {Link} from 'react-router';
 
+import SentryTypes from 'app/sentryTypes';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import LoadingError from 'app/components/loadingError';
-
 import ApiMixin from 'app/mixins/apiMixin';
-
 import {t, tn} from 'app/locale';
+import withOrganization from 'app/utils/withOrganization';
 
 const ReleaseProjectStatSparkline = createReactClass({
   displayName: 'ReleaseProjectStatSparkline',
 
   propTypes: {
+    organization: SentryTypes.Organization,
     orgId: PropTypes.string,
     project: PropTypes.object,
     version: PropTypes.string,
@@ -95,14 +96,34 @@ const ReleaseProjectStatSparkline = createReactClass({
     });
   },
 
+  renderProjectSummary() {
+    const {project} = this.props;
+    let {newIssueCount} = this.state;
+
+    return (
+      <React.Fragment>
+        <h6 className="m-b-0">{project.slug}</h6>
+        <p className="m-b-0 text-muted">
+          <small>
+            {newIssueCount > 0
+              ? tn('%s new issue', '%s new issues', newIssueCount)
+              : t('No new issues')}
+          </small>
+        </p>
+      </React.Fragment>
+    );
+  },
+
   render() {
-    let {orgId, project, version} = this.props;
+    let {organization, orgId, project, version} = this.props;
 
     if (this.state.loading) return <LoadingIndicator />;
     if (this.state.error) return <LoadingError />;
 
-    let {Sparklines, SparklinesLine, newIssueCount, stats} = this.state;
+    let {Sparklines, SparklinesLine, stats} = this.state;
     let values = stats.map(tuple => tuple[1]);
+
+    let hasSentry10 = new Set(organization.features).has('sentry10');
 
     return (
       <li>
@@ -111,19 +132,16 @@ const ReleaseProjectStatSparkline = createReactClass({
             <SparklinesLine style={{stroke: '#8f85d4', fill: 'none', strokeWidth: 3}} />
           </Sparklines>
         </div>
-        <Link to={`/${orgId}/${project.slug}/releases/${encodeURIComponent(version)}/`}>
-          <h6 className="m-b-0">{project.slug}</h6>
-          <p className="m-b-0 text-muted">
-            <small>
-              {newIssueCount > 0
-                ? tn('%s new issue', '%s new issues', newIssueCount)
-                : t('No new issues')}
-            </small>
-          </p>
-        </Link>
+        {hasSentry10 ? (
+          <div>{this.renderProjectSummary()}</div>
+        ) : (
+          <Link to={`/${orgId}/${project.slug}/releases/${encodeURIComponent(version)}/`}>
+            {this.renderProjectSummary()}
+          </Link>
+        )}
       </li>
     );
   },
 });
 
-export default ReleaseProjectStatSparkline;
+export default withOrganization(ReleaseProjectStatSparkline);

--- a/src/sentry/static/sentry/app/components/releaseProjectStatSparkline.jsx
+++ b/src/sentry/static/sentry/app/components/releaseProjectStatSparkline.jsx
@@ -98,7 +98,7 @@ const ReleaseProjectStatSparkline = createReactClass({
 
   renderProjectSummary() {
     const {project} = this.props;
-    let {newIssueCount} = this.state;
+    const {newIssueCount} = this.state;
 
     return (
       <React.Fragment>


### PR DESCRIPTION
Disable this link in Sentry 10 since we don't have a project specific
release page.