### PR TITLE
fix(ui): Fix global selection header adding an extra history entry

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/globalSelection.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/globalSelection.jsx
@@ -111,6 +111,34 @@ export function updateParams(obj, router, options) {
 }
 
 /**
+ * Like updateParams but just replaces the current URL and does not create a
+ * new browser history entry
+ *
+ * @param {Object} obj New query params
+ * @param {Object} [router] React router object
+ * @param {Object} [options] Options object
+ * @param {String[]} [options.resetParams] List of parameters to remove when changing URL params
+ */
+export function updateParamsWithoutHistory(obj, router, options) {
+  // Allow another component to handle routing
+  if (!router) {
+    return;
+  }
+
+  const newQuery = getNewQueryParams(obj, router.location.query, options);
+
+  // Only push new location if query params has changed because this will cause a heavy re-render
+  if (isEqualWithEmptyArrays(newQuery, router.location.query)) {
+    return;
+  }
+
+  router.replace({
+    pathname: router.location.pathname,
+    query: newQuery,
+  });
+}
+
+/**
  * Creates a new query parameter object given new params and old params
  * Preserves the old query params, except for `cursor`
  *

--- a/src/sentry/static/sentry/app/actionCreators/globalSelection.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/globalSelection.jsx
@@ -127,7 +127,7 @@ export function updateParamsWithoutHistory(obj, router, options) {
 
   const newQuery = getNewQueryParams(obj, router.location.query, options);
 
-  // Only push new location if query params has changed because this will cause a heavy re-render
+  // Only push new location if query params have changed because this will cause a heavy re-render
   if (isEqualWithEmptyArrays(newQuery, router.location.query)) {
     return;
   }

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
@@ -14,6 +14,7 @@ import {
   updateDateTime,
   updateEnvironments,
   updateParams,
+  updateParamsWithoutHistory,
   updateProjects,
 } from 'app/actionCreators/globalSelection';
 import Header from 'app/components/organizations/header';
@@ -121,7 +122,7 @@ class GlobalSelectionHeader extends React.Component {
       const {datetime, environments, projects} = this.props.selection;
 
       if (hasMultipleProjectFeature || projects.length === 1) {
-        updateParams(
+        updateParamsWithoutHistory(
           {project: projects, environment: environments, ...datetime},
           this.getRouter()
         );

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -45,6 +45,7 @@ describe('GlobalSelectionHeader', function() {
       globalActions.updateProjects,
       globalActions.updateEnvironments,
       router.push,
+      router.replace,
     ].forEach(mock => mock.mockClear());
   });
 
@@ -56,10 +57,10 @@ describe('GlobalSelectionHeader', function() {
     expect(router.push).not.toHaveBeenCalled();
   });
 
-  it('updates URL with values from store when mounted with no query params', function() {
+  it('replaces URL with values from store when mounted with no query params', function() {
     mount(<GlobalSelectionHeader organization={organization} />, routerContext);
 
-    expect(router.push).toHaveBeenCalledWith(
+    expect(router.replace).toHaveBeenCalledWith(
       expect.objectContaining({
         query: {
           environment: [],


### PR DESCRIPTION
The global selection header was adding an additional browser history
entry on mount when URLs might be updated in line with their stored
values if they are out of sync. This PR updates this step to use a
function that uses browserHistory.replace instead of .push.