### PR TITLE
feat: Stats links to project settings page in Sentry 10

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationStats/projectTable.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/projectTable.jsx
@@ -25,15 +25,21 @@ const ProjectTable = ({projectMap, projectTotals, orgTotal, organization}) => {
     return <div />;
   }
 
+  const hasSentry10 = new Set(organization.features).has('sentry10');
+
   return projectTotals.sort((a, b) => b.received - a.received).map((item, index) => {
     let project = projectMap[item.id];
 
     if (!project) return null;
 
+    const projectLink = hasSentry10
+      ? `/settings/${organization.slug}/${project.slug}/`
+      : `/${organization.slug}/${project.slug}/`;
+
     return (
       <StyledProjectTableLayout key={index}>
         <StyledProjectTitle>
-          <Link to={`/${organization.slug}/${project.slug}/`}>{project.slug}</Link>
+          <Link to={projectLink}>{project.slug}</Link>
         </StyledProjectTitle>
         <ProjectTableDataElement>
           <Count value={item.accepted} />


### PR DESCRIPTION
Since we don't have another project specific page for Sentry 10 the project
links on the stats page go to the project settings page.