### PR TITLE
fix(ui): Fixes document titles for Activity and Stats pages

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationActivity.jsx
+++ b/src/sentry/static/sentry/app/views/organizationActivity.jsx
@@ -18,7 +18,7 @@ export default class OrganizationActivity extends AsyncView {
   }
 
   getTitle() {
-    return 'Activity';
+    return `Activity - ${this.props.params.orgId}`;
   }
 
   renderActivityFeed() {
@@ -37,7 +37,7 @@ export default class OrganizationActivity extends AsyncView {
     );
   }
 
-  render() {
+  renderBody() {
     const hasSentry10 = new Set(this.context.organization.features).has('sentry10');
 
     return hasSentry10 ? (

--- a/src/sentry/static/sentry/app/views/organizationStats/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/index.jsx
@@ -2,6 +2,8 @@ import $ from 'jquery';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
+import DocumentTitle from 'react-document-title';
+
 import ApiMixin from 'app/mixins/apiMixin';
 import OrganizationState from 'app/mixins/organizationState';
 
@@ -250,14 +252,16 @@ const OrganizationStatsContainer = createReactClass({
     let organization = this.getOrganization();
 
     return (
-      <LazyLoad
-        component={() =>
-          import(/* webpackChunkName: "organizationStats" */ './organizationStatsDetails').then(
-            mod => mod.default
-          )}
-        organization={organization}
-        {...this.state}
-      />
+      <DocumentTitle title={`Stats - ${organization.slug} - Sentry`}>
+        <LazyLoad
+          component={() =>
+            import(/* webpackChunkName: "organizationStats" */ './organizationStatsDetails').then(
+              mod => mod.default
+            )}
+          organization={organization}
+          {...this.state}
+        />
+      </DocumentTitle>
     );
   },
 });


### PR DESCRIPTION
Updates the activity and stats pages document titles in line with all
organization level pages. These are now:
- Activity - orgId - Sentry
- Stats - orgId - Sentry