### PR TITLE
feat(api): Have GroupSerializerSnuba use GroupEnvironment.first_seen

### DIFF
--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -500,3 +500,13 @@ class TagStorageTest(SnubaTestCase):
                 last_seen=self.now - timedelta(seconds=2)
             )
         ]
+
+    def test_get_group_seen_values_for_environments(self):
+        assert self.ts.get_group_seen_values_for_environments(
+            [self.proj1.id], [self.proj1group1.id], [self.proj1env1.id]
+        ) == {self.proj1group1.id: {
+            'first_seen': self.now - timedelta(seconds=2),
+            'last_seen': self.now - timedelta(seconds=1),
+            'times_seen': 2,
+        }
+        }


### PR DESCRIPTION
cc @mattrobenolt so he knows his work rerunning that backfill script 3 times was not in vain 