### PR TITLE
feat(dashboard): Padding fixes for widgets

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/percentageTableChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/percentageTableChart.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
+import {PanelItem} from 'app/components/panels';
 import {t} from 'app/locale';
 import Count from 'app/components/count';
 import InlineSvg from 'app/components/inlineSvg';
@@ -49,9 +50,6 @@ class PercentageTableChart extends React.Component {
     // Height of body
     height: PropTypes.string,
 
-    // props to pass to PanelHeader
-    headerProps: PropTypes.object,
-
     // Main title (left most column) should
     title: PropTypes.node,
 
@@ -83,13 +81,11 @@ class PercentageTableChart extends React.Component {
   };
 
   render() {
-    const {height, headerProps, title, countTitle, extraTitle, data} = this.props;
+    const {height, title, countTitle, extraTitle, data} = this.props;
 
     return (
       <TableChart
-        headerProps={headerProps}
         bodyHeight={height}
-        headers={[title, countTitle, t('Percentage'), extraTitle]}
         data={data.map(({value, lastValue, name, percentage}) => [
           <Name key="name">{name}</Name>,
           <CountColumn key="count">
@@ -115,7 +111,21 @@ class PercentageTableChart extends React.Component {
             </PercentageContainer>
           </Row>
         )}
-      />
+      >
+        {({renderRow, renderBody, ...props}) => (
+          <TableChartWrapper>
+            <TableHeader>
+              {renderRow({
+                isTableHeader: true,
+                items: [title, countTitle, t('Percentage'), extraTitle],
+                rowIndex: -1,
+                ...props,
+              })}
+            </TableHeader>
+            {renderBody({renderRow, ...props})}
+          </TableChartWrapper>
+        )}
+      </TableChart>
     );
   }
 }
@@ -132,11 +142,8 @@ const Row = styled(function RowComponent({className, data, rowIndex, onClick, ch
 })`
   display: flex;
   flex: 1;
-  cursor: pointer;
-`;
-
-const StyledPercentageTableChart = styled(PercentageTableChart)`
-  width: 100%;
+  ${p => p.rowIndex > -1 && 'cursor: pointer'};
+  font-size: 0.9em;
 `;
 
 const FlexContainers = styled('div')`
@@ -191,4 +198,20 @@ const CountColumn = styled(Name)`
   margin-left: ${space(0.5)};
 `;
 
-export default StyledPercentageTableChart;
+const TableHeader = styled(PanelItem)`
+  color: ${p => p.theme.gray2};
+  padding: ${space(1)};
+`;
+
+const TableChartWrapper = styled('div')`
+  margin-bottom: 0;
+  width: 100%;
+  padding: 0 ${space(2)};
+
+  /* stylelint-disable-next-line no-duplicate-selectors */
+  ${PanelItem} {
+    padding: ${space(1)};
+  }
+`;
+
+export default PercentageTableChart;

--- a/src/sentry/static/sentry/app/components/charts/tableChart/index.jsx
+++ b/src/sentry/static/sentry/app/components/charts/tableChart/index.jsx
@@ -318,19 +318,19 @@ export const TableChart = styled(
         showColumnTotal,
         shadeRowPercentage,
         widths,
+        renderBody,
+        renderTableHeader,
         ...props,
       };
 
+      if (isRenderProp) {
+        return children(renderProps);
+      }
+
       return (
         <Panel className={className}>
-          {isRenderProp ? (
-            children(renderProps)
-          ) : (
-            <React.Fragment>
-              {renderTableHeader(renderProps)}
-              {renderBody(renderProps)}
-            </React.Fragment>
-          )}
+          {renderTableHeader(renderProps)}
+          {renderBody(renderProps)}
         </Panel>
       );
     }

--- a/src/sentry/static/sentry/app/views/organizationDashboard/dashboard.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/dashboard.jsx
@@ -34,5 +34,7 @@ const Widgets = styled('div')`
 `;
 const WidgetWrapper = styled('div')`
   width: 50%;
-  padding: ${space(1)};
+  :nth-child(odd) {
+    padding-right: ${space(2)};
+  }
 `;

--- a/src/sentry/static/sentry/app/views/organizationDashboard/utils/getData.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/utils/getData.jsx
@@ -1,10 +1,11 @@
 import {WIDGET_DISPLAY} from 'app/views/organizationDashboard/constants';
 import {getChartDataFunc} from 'app/views/organizationDashboard/utils/getChartDataFunc';
 import {isTimeSeries} from 'app/views/organizationDashboard/utils/isTimeSeries';
+import {t} from 'app/locale';
 
 // TODO(billy): Currently only supports discover queries
 export function getData(results, widget) {
-  const {type, title, queries, yAxisMapping} = widget;
+  const {type, queries, yAxisMapping} = widget;
   const isTable = type === WIDGET_DISPLAY.TABLE;
   const [chartDataFunc, chartDataFuncArgs] = getChartDataFunc(widget);
   const hasYAxes = yAxisMapping && yAxisMapping.length === 2;
@@ -17,8 +18,8 @@ export function getData(results, widget) {
     );
 
     return {
-      title,
-      countTitle: 'Events',
+      title: t('Name'),
+      countTitle: t('Events'),
       height: '200px',
       data: series.data,
     };

--- a/src/sentry/static/sentry/app/views/organizationDashboard/widget.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/widget.jsx
@@ -4,12 +4,12 @@ import React from 'react';
 import styled from 'react-emotion';
 
 import {LoadingMask} from 'app/views/organizationEvents/loadingPanel';
-import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
-import {WIDGET_DISPLAY} from 'app/views/organizationDashboard/constants';
+import {Panel, PanelBody} from 'app/components/panels';
 import {t} from 'app/locale';
 import ErrorBoundary from 'app/components/errorBoundary';
 import ExploreWidget from 'app/views/organizationDashboard/exploreWidget';
 import SentryTypes from 'app/sentryTypes';
+import space from 'app/styles/space';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 
@@ -27,8 +27,7 @@ class Widget extends React.Component {
 
   render() {
     const {organization, router, widget, releases, selection} = this.props;
-    const {type, title, includePreviousPeriod, compareToPeriod} = widget;
-    const isTable = type === WIDGET_DISPLAY.TABLE;
+    const {title, includePreviousPeriod, compareToPeriod} = widget;
 
     return (
       <ErrorBoundary customComponent={<ErrorCard>{t('Error loading widget')}</ErrorCard>}>
@@ -56,23 +55,18 @@ class Widget extends React.Component {
             };
 
             return (
-              <WidgetWrapper>
+              <WidgetWrapperForMask>
                 {reloading && <ReloadingMask />}
-                {isTable && <WidgetChart {...widgetChartProps} />}
-                {!isTable && (
-                  <Panel>
-                    <PanelHeader hasButtons>
-                      {title}
-
-                      <ExploreWidget {...{widget, queries, router, selection}} />
-                    </PanelHeader>
-
-                    <StyledPanelBody>
-                      <WidgetChart {...widgetChartProps} />
-                    </StyledPanelBody>
-                  </Panel>
-                )}
-              </WidgetWrapper>
+                <StyledPanel>
+                  <WidgetHeader>
+                    {title}
+                    <ExploreWidget {...{widget, queries, router, selection}} />
+                  </WidgetHeader>
+                  <StyledPanelBody>
+                    <WidgetChart {...widgetChartProps} />
+                  </StyledPanelBody>
+                </StyledPanel>
+              </WidgetWrapperForMask>
             );
           }}
         </DiscoverQuery>
@@ -84,6 +78,10 @@ class Widget extends React.Component {
 export default withRouter(withOrganization(withGlobalSelection(Widget)));
 export {Widget};
 
+const StyledPanel = styled(Panel)`
+  margin-bottom: ${space(2)};
+`;
+
 const StyledPanelBody = styled(PanelBody)`
   height: 200px;
 `;
@@ -93,7 +91,7 @@ const Placeholder = styled('div')`
   height: 237px;
 `;
 
-const WidgetWrapper = styled('div')`
+const WidgetWrapperForMask = styled('div')`
   position: relative;
 `;
 
@@ -110,4 +108,11 @@ const ErrorCard = styled(Placeholder)`
   border: 1px solid ${p => p.theme.alert.error.border};
   color: ${p => p.theme.alert.error.textLight};
   border-radius: ${p => p.theme.borderRadius};
+`;
+
+const WidgetHeader = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: ${space(1)} ${space(2)};
 `;

--- a/src/sentry/static/sentry/app/views/organizationDashboard/widgetChart.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/widgetChart.jsx
@@ -2,11 +2,9 @@ import {isEqual} from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {WIDGET_DISPLAY} from 'app/views/organizationDashboard/constants';
 import {getChartComponent} from 'app/views/organizationDashboard/utils/getChartComponent';
 import {getData} from 'app/views/organizationDashboard/utils/getData';
 import ChartZoom from 'app/components/charts/chartZoom';
-import ExploreWidget from 'app/views/organizationDashboard/exploreWidget';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
 import SentryTypes from 'app/sentryTypes';
 
@@ -52,21 +50,13 @@ class WidgetChart extends React.Component {
   }
 
   render() {
-    const {results, releases, router, selection, widget} = this.props;
-    const isTable = widget.type === WIDGET_DISPLAY.TABLE;
+    const {results, releases, widget} = this.props;
 
     // get visualization based on widget data
     const ChartComponent = getChartComponent(widget);
 
     // get data func based on query
     const chartData = getData(results, widget);
-
-    const extra = {
-      ...(isTable && {
-        headerProps: {hasButtons: true},
-        extraTitle: <ExploreWidget {...{widget, router, selection}} />,
-      }),
-    };
 
     // Releases can only be added to time charts
     if (widget.includeReleases) {
@@ -75,7 +65,6 @@ class WidgetChart extends React.Component {
           {({releaseSeries}) =>
             this.renderZoomableChart(ChartComponent, {
               ...chartData,
-              ...extra,
               series: [...chartData.series, ...releaseSeries],
             })}
         </ReleaseSeries>
@@ -85,11 +74,10 @@ class WidgetChart extends React.Component {
     if (chartData.isGroupedByDate) {
       return this.renderZoomableChart(ChartComponent, {
         ...chartData,
-        ...extra,
       });
     }
 
-    return <ChartComponent {...chartData} {...extra} />;
+    return <ChartComponent {...chartData} />;
   }
 }
 

--- a/tests/js/spec/components/charts/percentageTableChart.spec.jsx
+++ b/tests/js/spec/components/charts/percentageTableChart.spec.jsx
@@ -30,12 +30,12 @@ describe('PercentageTableChart', function() {
 
     it('renders headers', function() {
       expect(
-        wrapper.find('PanelHeader NameAndCountContainer').prop('children')
+        wrapper.find('TableHeader NameAndCountContainer').prop('children')
       ).toHaveLength(2);
 
-      expect(wrapper.find('PanelHeader').text()).toContain('User');
-      expect(wrapper.find('PanelHeader').text()).toContain('Count');
-      expect(wrapper.find('PanelHeader').text()).toContain('Percentage');
+      expect(wrapper.find('TableHeader').text()).toContain('User');
+      expect(wrapper.find('TableHeader').text()).toContain('Count');
+      expect(wrapper.find('TableHeader').text()).toContain('Percentage');
     });
 
     it('renders data rows', function() {

--- a/tests/js/spec/components/charts/tableChart/index.spec.jsx
+++ b/tests/js/spec/components/charts/tableChart/index.spec.jsx
@@ -4,6 +4,12 @@ import {mount} from 'enzyme';
 import TableChart from 'app/components/charts/tableChart';
 
 describe('TableChart', function() {
+  const renderer = jest.fn(() => null);
+
+  beforeEach(function() {
+    renderer.mockClear();
+  });
+
   it('calculates row and column totals and passes to renderers', function() {
     const ERROR_TYPE_DATA = [
       ['TypeError', 50, 40, 30],
@@ -11,7 +17,6 @@ describe('TableChart', function() {
       ['NameError', 15, 15, 15],
       ['ZeroDivisionError', 20, 10, 0],
     ];
-    const renderer = jest.fn();
     mount(
       <TableChart
         title="Error Type"
@@ -50,7 +55,6 @@ describe('TableChart', function() {
       ['NameError', 'Label', 15, 15, 15],
       ['ZeroDivisionError', 'Label', 20, 10, 0],
     ];
-    const renderer = jest.fn();
     mount(
       <TableChart
         title="Error Type"
@@ -101,7 +105,6 @@ describe('TableChart', function() {
   });
 
   it('renders headers', function() {
-    const renderer = jest.fn();
     const headers = ['Foo', 'Bar', 'Baz'];
     mount(
       <TableChart
@@ -122,7 +125,6 @@ describe('TableChart', function() {
   });
 
   it('renders headers with row total column', function() {
-    const renderer = jest.fn();
     mount(
       <TableChart
         title="Error Type"


### PR DESCRIPTION
* Fixes some padding
* Remove panel header bg from widgets
* Adds widget header for table charts (simplifies some code)
* Change PercentageTableChart to not use panel header (+ other style
changes)

Depends on https://github.com/getsentry/sentry/pull/11723

![image](https://user-images.githubusercontent.com/79684/51953946-3aadbb00-23f3-11e9-8349-96b8f554eb6f.png)
