### PR TITLE
feat: Add beta tags on remaining Sentry 10 pages

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/list/organizationReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/organizationReleases/index.jsx
@@ -16,6 +16,7 @@ import withOrganization from 'app/utils/withOrganization';
 
 import {PageContent, PageHeader} from 'app/styles/organization';
 import PageHeading from 'app/components/pageHeading';
+import BetaTag from 'app/components/betaTag';
 
 import ReleaseList from '../shared/releaseList';
 import ReleaseListHeader from '../shared/releaseListHeader';
@@ -133,7 +134,10 @@ class OrganizationReleases extends AsyncView {
     return (
       <PageContent>
         <PageHeader>
-          <PageHeading>{t('Releases')}</PageHeading>
+          <PageHeading>
+            {t('Releases')}
+            <BetaTag />
+          </PageHeading>
           <div>
             <SearchBar
               defaultQuery=""

--- a/src/sentry/static/sentry/app/views/userFeedback/container.jsx
+++ b/src/sentry/static/sentry/app/views/userFeedback/container.jsx
@@ -6,16 +6,28 @@ import {t} from 'app/locale';
 import Pagination from 'app/components/pagination';
 import {Panel, PanelBody} from 'app/components/panels';
 import PageHeading from 'app/components/pageHeading';
+import BetaTag from 'app/components/betaTag';
 
 export default class UserFeedbackContainer extends React.Component {
   static propTypes = {
     location: PropTypes.object.isRequired,
     pageLinks: PropTypes.string,
     status: PropTypes.string.isRequired,
+    showBeta: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    showBeta: false,
   };
 
   render() {
-    const {location: {pathname, query}, pageLinks, children, status} = this.props;
+    const {
+      location: {pathname, query},
+      pageLinks,
+      children,
+      status,
+      showBeta,
+    } = this.props;
 
     const unresolvedQuery = omit(query, 'status');
     const allIssuesQuery = {...query, status: ''};
@@ -24,7 +36,10 @@ export default class UserFeedbackContainer extends React.Component {
       <div>
         <div className="row">
           <div className="col-sm-9" style={{marginBottom: '5px'}}>
-            <PageHeading withMargins>{t('User Feedback')}</PageHeading>
+            <PageHeading withMargins>
+              {t('User Feedback')}
+              {showBeta && <BetaTag />}
+            </PageHeading>
           </div>
           <div className="col-sm-3" style={{textAlign: 'right', marginTop: '4px'}}>
             <div className="btn-group">

--- a/src/sentry/static/sentry/app/views/userFeedback/organizationUserFeedback.jsx
+++ b/src/sentry/static/sentry/app/views/userFeedback/organizationUserFeedback.jsx
@@ -114,6 +114,7 @@ class OrganizationUserFeedback extends AsyncView {
             pageLinks={reportListPageLinks}
             status={status}
             location={location}
+            showBeta={true}
           >
             {this.renderStreamBody()}
           </UserFeedbackContainer>

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -1622,6 +1622,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                   }
                 }
                 pageLinks="<https://sentry.io/api/0/organizations/sentry/user-feedback/?statsPeriod=14d&cursor=0:0:1>; rel=\\"previous\\"; results=\\"false\\"; cursor=\\"0:0:1\\", <https://sentry.io/api/0/organizations/sentry/user-feedback/?statsPeriod=14d&cursor=0:100:0>; rel=\\"next\\"; results=\\"true\\"; cursor=\\"0:100:0\\""
+                showBeta={true}
                 status="unresolved"
               >
                 <div>
@@ -1646,6 +1647,59 @@ exports[`OrganizationUserFeedback renders 1`] = `
                             className="css-13ev48w-Wrapper e1f8hk460"
                           >
                             User Feedback
+                            <BetaTag>
+                              <Tooltip
+                                title="This feature is in beta and may change in the future."
+                                tooltipOptions={
+                                  Object {
+                                    "placement": "right",
+                                  }
+                                }
+                              >
+                                <span
+                                  className="tip"
+                                  title="This feature is in beta and may change in the future."
+                                >
+                                  <StyledTag
+                                    priority="beta"
+                                    size="small"
+                                  >
+                                    <Tag
+                                      className="css-f9iwbc-StyledTag e1xs0x250"
+                                      priority="beta"
+                                      size="small"
+                                    >
+                                      <TagTextStyled
+                                        className="css-f9iwbc-StyledTag e1xs0x250"
+                                        priority="beta"
+                                        size="small"
+                                      >
+                                        <Component
+                                          className="e1xs0x250 css-4og6iv-TagTextStyled-StyledTag e6q9yfr0"
+                                          priority="beta"
+                                          size="small"
+                                        >
+                                          <Box
+                                            className="e1xs0x250 css-4og6iv-TagTextStyled-StyledTag e6q9yfr0"
+                                          >
+                                            <Base
+                                              className="e1xs0x250 e6q9yfr0 css-1r8ewb4-TagTextStyled-StyledTag"
+                                            >
+                                              <div
+                                                className="e1xs0x250 e6q9yfr0 css-1r8ewb4-TagTextStyled-StyledTag"
+                                                is={null}
+                                              >
+                                                beta
+                                              </div>
+                                            </Base>
+                                          </Box>
+                                        </Component>
+                                      </TagTextStyled>
+                                    </Tag>
+                                  </StyledTag>
+                                </span>
+                              </Tooltip>
+                            </BetaTag>
                           </h1>
                         </Wrapper>
                       </PageHeading>

--- a/tests/js/spec/views/userFeedback/__snapshots__/projectUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/projectUserFeedback.spec.jsx.snap
@@ -8,6 +8,7 @@ exports[`projectUserFeedback renders 1`] = `
     }
   }
   pageLinks="<https://sentry.io/api/0/organizations/sentry/user-feedback/?statsPeriod=14d&cursor=0:0:1>; rel=\\"previous\\"; results=\\"false\\"; cursor=\\"0:0:1\\", <https://sentry.io/api/0/organizations/sentry/user-feedback/?statsPeriod=14d&cursor=0:100:0>; rel=\\"next\\"; results=\\"true\\"; cursor=\\"0:100:0\\""
+  showBeta={false}
   status="unresolved"
 >
   <WithOrganizationMockWrapper


### PR DESCRIPTION
Add beta tag on the remaining Sentry 10 root level pages - User feedback
and Release list views.