### PR TITLE
fix(issues) Display custom search title when query string matches

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
@@ -214,6 +214,7 @@ const SavedSearchSelector = withApi(
       projectId: PropTypes.string,
       searchId: PropTypes.string,
       access: PropTypes.object.isRequired,
+      query: PropTypes.string,
       savedSearchList: PropTypes.array.isRequired,
       queryCount: PropTypes.number,
       queryMaxCount: PropTypes.number,
@@ -222,12 +223,16 @@ const SavedSearchSelector = withApi(
     };
 
     getTitle() {
-      let searchId = this.props.searchId || null;
-      if (!searchId) return t('Custom Search');
-      let results = this.props.savedSearchList.filter(search => {
-        return searchId === search.id;
-      });
-      return results.length ? results[0].name : t('Custom Search');
+      let {searchId, query, savedSearchList} = this.props;
+      let result;
+
+      if (searchId) {
+        result = savedSearchList.find(search => searchId === search.id);
+      } else {
+        result = savedSearchList.find(search => query === search.query);
+      }
+
+      return result ? result.name : t('Custom Search');
     }
 
     render() {

--- a/tests/js/spec/views/stream/savedSearchSelector.spec.jsx
+++ b/tests/js/spec/views/stream/savedSearchSelector.spec.jsx
@@ -4,7 +4,6 @@ import {mount} from 'enzyme';
 import SavedSearchSelector from 'app/views/stream/savedSearchSelector';
 
 describe('SavedSearchSelector', function() {
-  let sandbox;
   let wrapper;
   let props;
 
@@ -15,8 +14,6 @@ describe('SavedSearchSelector', function() {
   let onSelect = jest.fn();
 
   beforeEach(function() {
-    sandbox = sinon.sandbox.create();
-
     projectId = 'test-project';
     orgId = 'test-org';
     savedSearchList = [
@@ -45,11 +42,6 @@ describe('SavedSearchSelector', function() {
       onSavedSearchSelect: onSelect,
       query: '',
     };
-  });
-
-  afterEach(function() {
-    sandbox.restore();
-    MockApiClient.clearMockResponses();
   });
 
   describe('getTitle', function() {

--- a/tests/js/spec/views/stream/savedSearchSelector.spec.jsx
+++ b/tests/js/spec/views/stream/savedSearchSelector.spec.jsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import SavedSearchSelector from 'app/views/stream/savedSearchSelector';
+
+describe('SavedSearchSelector', function() {
+  let sandbox;
+  let wrapper;
+  let props;
+
+  let orgId;
+  let projectId;
+  let savedSearchList;
+  let onCreate = jest.fn();
+  let onSelect = jest.fn();
+
+  beforeEach(function() {
+    sandbox = sinon.sandbox.create();
+
+    projectId = 'test-project';
+    orgId = 'test-org';
+    savedSearchList = [
+      {
+        id: '789',
+        query: 'is:unresolved',
+        name: 'Unresolved',
+        projectId,
+      },
+      {
+        id: '122',
+        query: 'is:unresolved assigned:me',
+        name: 'Assigned to me',
+        projectId,
+      },
+    ];
+
+    let access = new Set(['project:write']);
+
+    props = {
+      projectId,
+      orgId,
+      savedSearchList,
+      access,
+      onSavedSearchCreate: onCreate,
+      onSavedSearchSelect: onSelect,
+      query: '',
+    };
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+    MockApiClient.clearMockResponses();
+  });
+
+  describe('getTitle', function() {
+    beforeEach(function() {
+      wrapper = mount(<SavedSearchSelector {...props} />, TestStubs.routerContext());
+    });
+
+    it('defaults to custom search', function() {
+      let instance = wrapper.find('SavedSearchSelector').instance();
+
+      expect(instance.getTitle()).toEqual('Custom Search');
+    });
+
+    it('uses searchId to match', function() {
+      wrapper.setProps({searchId: '789'});
+      let instance = wrapper.find('SavedSearchSelector').instance();
+
+      expect(instance.getTitle()).toEqual('Unresolved');
+    });
+
+    it('uses query to match', function() {
+      wrapper.setProps({query: 'is:unresolved assigned:me'});
+      let instance = wrapper.find('SavedSearchSelector').instance();
+
+      expect(instance.getTitle()).toEqual('Assigned to me');
+    });
+  });
+
+  describe('selecting an option', function() {
+    beforeEach(function() {
+      wrapper = mount(<SavedSearchSelector {...props} />, TestStubs.routerContext());
+    });
+
+    it('calls onSelect when clicked', async function() {
+      wrapper.find('DropdownLink').simulate('click');
+      await wrapper.update();
+
+      let item = wrapper.find('StyledMenuItem a').first();
+      expect(item).toHaveLength(1);
+
+      item.simulate('click');
+      expect(onSelect).toHaveBeenCalled();
+    });
+  });
+
+  describe('render with a projectId', function() {
+    beforeEach(function() {
+      wrapper = mount(<SavedSearchSelector {...props} />, TestStubs.routerContext());
+    });
+
+    it('renders enabled manage and create buttons', function() {
+      wrapper.find('DropdownLink').simulate('click');
+
+      let buttons = wrapper.find('Button');
+      expect(buttons).toHaveLength(2);
+
+      let createButton = buttons.first();
+      expect(createButton.text()).toEqual('Save Current Search');
+      expect(createButton.props().disabled).toBeFalsy();
+
+      let manageButton = buttons.last();
+      expect(manageButton.text()).toEqual('Manage');
+      expect(manageButton.props().disabled).toBeFalsy();
+    });
+  });
+
+  describe('render without a projectId', function() {
+    beforeEach(function() {
+      props.projectId = null;
+      wrapper = mount(<SavedSearchSelector {...props} />, TestStubs.routerContext());
+    });
+
+    it('renders disabled manage and create buttons', function() {
+      wrapper.find('DropdownLink').simulate('click');
+
+      let buttons = wrapper.find('Button');
+      expect(buttons).toHaveLength(2);
+
+      let createButton = buttons.first();
+      expect(createButton.props().disabled).toBeTruthy();
+
+      let manageButton = buttons.last();
+      expect(manageButton.props().disabled).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
In addition to matching saved searches by id, we should match by querystring so that if a user replicates a savedsearch they get a nice title.

Notably this fixes the 'Custom Search' title when users first load up the organization issue list which doesn't support default saved searches just yet.

Fixes APP-1052