### PR TITLE
fix(members): Remove org after redirect

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/organizations.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/organizations.jsx
@@ -7,7 +7,7 @@ import OrganizationsStore from 'app/stores/organizationsStore';
 import ProjectsStore from 'app/stores/projectsStore';
 import TeamStore from 'app/stores/teamStore';
 
-export function redirectToRemainingOrganization({orgId}) {
+export function redirectToRemainingOrganization({orgId, removeOrg}) {
   // Remove queued, should redirect
   let allOrgs = OrganizationsStore.getAll().filter(
     org => org.status.id === 'active' && org.slug !== orgId
@@ -20,6 +20,11 @@ export function redirectToRemainingOrganization({orgId}) {
   // Let's be smart and select the best org to redirect to
   let firstRemainingOrg = allOrgs[0];
   browserHistory.push(`/${firstRemainingOrg.slug}/`);
+
+  // Remove org from SidebarDropdown
+  if (removeOrg) {
+    OrganizationsStore.remove(orgId);
+  }
 }
 
 export function remove(api, {successMessage, errorMessage, orgId} = {}) {

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/index.jsx
@@ -14,7 +14,6 @@ import Pagination from 'app/components/pagination';
 import SentryTypes from 'app/sentryTypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import recreateRoute from 'app/utils/recreateRoute';
-import OrganizationsStore from 'app/stores/organizationsStore';
 import {redirectToRemainingOrganization} from 'app/actionCreators/organizations';
 
 import OrganizationAccessRequests from './organizationAccessRequests';
@@ -163,9 +162,7 @@ class OrganizationMembersView extends AsyncView {
 
     this.removeMember(id).then(
       () => {
-        // Remove org from dropdown and redirect to remaining org
-        OrganizationsStore.remove(orgName);
-        redirectToRemainingOrganization({orgId: orgName});
+        redirectToRemainingOrganization({orgId: orgName, removeOrg: true});
 
         addSuccessMessage(
           tct('You left [orgName]', {

--- a/tests/js/spec/views/settings/organizationMembers/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/index.spec.jsx
@@ -188,7 +188,6 @@ describe('OrganizationMembers', function() {
 
     expect(browserHistory.push).toHaveBeenCalledTimes(1);
     expect(browserHistory.push).toHaveBeenCalledWith('/organizations/new/');
-    expect(OrganizationsStore.getAll()).toEqual([]);
   });
 
   it('can redirect to remaining org after leaving', async function() {


### PR DESCRIPTION
After leaving an organization, redirect to a remaining org before removing from OrganizationsStore. This is to avoid errors in OrganizationsStore listeners when the active organization is undefined.

Fixes JAVASCRIPT-54M