### PR TITLE
fix: Update group.get_absolute_url() for Sentry 10

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -280,7 +280,11 @@ class Group(Model):
         super(Group, self).save(*args, **kwargs)
 
     def get_absolute_url(self, params=None):
-        url = reverse('sentry-group', args=[self.organization.slug, self.project.slug, self.id])
+        from sentry import features
+        if features.has('organizations:sentry10', self.organization):
+            url = reverse('sentry-organization-issue', args=[self.organization.slug, self.id])
+        else:
+            url = reverse('sentry-group', args=[self.organization.slug, self.project.slug, self.id])
         if params:
             url = url + '?' + urlencode(params)
         return absolute_uri(url)

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -410,6 +410,11 @@ urlpatterns += patterns(
         name='sentry-organization-issue-list'
     ),
     url(
+        r'^organizations/(?P<organization_slug>[\w_-]+)/issues/(?P<group_id>\d+)/$',
+        react_page_view,
+        name='sentry-organization-issue'
+    ),
+    url(
         r'^organizations/(?P<organization_slug>[\w_-]+)/issues/(?P<issue_id>\d+)/$',
         react_page_view,
         name='sentry-organization-issue-detail'


### PR DESCRIPTION
Returns the new group URL for Sentry 10 users. Fixes links in emails,
intergrations and most likely a bunch of other places.