### PR TITLE
fix(dashboard): Fix aggregation aliases when exporting to discover

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDashboard/exploreWidget.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/exploreWidget.jsx
@@ -1,10 +1,8 @@
-import {pickBy} from 'lodash';
-import PropTypes from 'prop-types';
 import React from 'react';
 import styled, {css} from 'react-emotion';
 
+import {getDiscoverUrlPathFromDiscoverQuery} from 'app/views/organizationDashboard/utils/getDiscoverUrlPathFromDiscoverQuery';
 import {getEventsUrlPathFromDiscoverQuery} from 'app/views/organizationDashboard/utils/getEventsUrlPathFromDiscoverQuery';
-import {getQueryStringFromQuery} from 'app/views/organizationDiscover/utils';
 import {t} from 'app/locale';
 import Button from 'app/components/button';
 import DropdownLink from 'app/components/dropdownLink';
@@ -22,49 +20,17 @@ const exploreMenuCss = css`
 class ExploreWidget extends React.Component {
   static propTypes = {
     widget: SentryTypes.Widget,
-    queries: PropTypes.arrayOf(SentryTypes.DiscoverQuery),
     organization: SentryTypes.Organization,
     selection: SentryTypes.GlobalSelection,
-    router: PropTypes.object,
   };
 
   getExportToDiscover = query => {
-    const {organization} = this.props;
-    const {
-      datetime,
-      environments, // eslint-disable-line no-unused-vars
-      ...selection
-    } = this.props.selection;
-
-    // Discover does not support importing these
-    const {
-      groupby, // eslint-disable-line no-unused-vars
-      rollup, // eslint-disable-line no-unused-vars
-      orderby,
-      ...restQuery
-    } = query;
-
-    const orderbyTimeIndex = orderby.indexOf('time');
-    let visual = 'table';
-
-    if (orderbyTimeIndex !== -1) {
-      restQuery.orderby = `${orderbyTimeIndex === 0 ? '' : '-'}${restQuery
-        .aggregations[0][2]}`;
-      visual = 'line-by-day';
-    } else {
-      restQuery.orderby = orderby;
-    }
-
-    return `/organizations/${organization.slug}/discover/${getQueryStringFromQuery(
-      pickBy({
-        ...restQuery,
-        ...selection,
-        start: datetime.start,
-        end: datetime.end,
-        range: datetime.period,
-        limit: 1000,
-      })
-    )}&visual=${visual}`;
+    const {selection, organization} = this.props;
+    return getDiscoverUrlPathFromDiscoverQuery({
+      organization,
+      selection,
+      query,
+    });
   };
 
   getExportToEvents = query => {

--- a/src/sentry/static/sentry/app/views/organizationDashboard/utils/getDiscoverUrlPathFromDiscoverQuery.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/utils/getDiscoverUrlPathFromDiscoverQuery.jsx
@@ -1,0 +1,43 @@
+import {
+  getExternal,
+  getInternal,
+} from 'app/views/organizationDiscover/aggregations/utils';
+import {getQueryStringFromQuery} from 'app/views/organizationDiscover/utils';
+
+export function getDiscoverUrlPathFromDiscoverQuery({organization, selection, query}) {
+  const {
+    datetime,
+    environments, // eslint-disable-line no-unused-vars
+    ...restSelection
+  } = selection;
+
+  // Discover does not support importing these
+  const {
+    groupby, // eslint-disable-line no-unused-vars
+    rollup, // eslint-disable-line no-unused-vars
+    name, // eslint-disable-line no-unused-vars
+    orderby,
+    ...restQuery
+  } = query;
+
+  const orderbyTimeIndex = orderby.indexOf('time');
+  const visual = orderbyTimeIndex === -1 ? 'table' : 'line-by-day';
+
+  const aggregations = query.aggregations.map(aggregation =>
+    getExternal(getInternal(aggregation))
+  );
+  const [, , aggregationAlias] = (aggregations.length && aggregations[0]) || [];
+
+  // Discover expects the aggregation aliases to be in a specific format
+  restQuery.orderby = `${orderbyTimeIndex === 0 ? '' : '-'}${aggregationAlias || ''}`;
+  restQuery.aggregations = aggregations;
+
+  return `/organizations/${organization.slug}/discover/${getQueryStringFromQuery({
+    ...restQuery,
+    ...restSelection,
+    start: datetime.start,
+    end: datetime.end,
+    range: datetime.period,
+    limit: 1000,
+  })}&visualization=${visual}`;
+}

--- a/src/sentry/static/sentry/app/views/organizationDiscover/aggregations/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/aggregations/utils.jsx
@@ -5,11 +5,10 @@
  * @param {Object} cols List of column objects
  * @param {String} cols.name Column name
  * @param {String} cols.type Type of column
- * @returns {Boolean} True if valid aggregatoin, false if not
+ * @returns {Boolean} True if valid aggregation, false if not
  */
 export function isValidAggregation(aggregation, cols) {
   const columns = new Set(cols.map(({name}) => name));
-
   const [func, col] = aggregation;
 
   if (!func) {

--- a/tests/js/spec/views/organizationDashboard/utils/getDiscoverUrlPathFromDiscoverQuery.spec.jsx
+++ b/tests/js/spec/views/organizationDashboard/utils/getDiscoverUrlPathFromDiscoverQuery.spec.jsx
@@ -1,0 +1,60 @@
+import {getDiscoverUrlPathFromDiscoverQuery} from 'app/views/organizationDashboard/utils/getDiscoverUrlPathFromDiscoverQuery';
+
+describe('getDiscoverUrlPathFromDiscoverQuery', function() {
+  const organization = TestStubs.Organization();
+
+  it('gets url when grouped by time', function() {
+    const query = {
+      name: 'Known Users',
+      fields: [],
+      conditions: [['user.email', 'IS NOT NULL', null]],
+      aggregations: [['uniq', 'user.email', 'Known Users']],
+      limit: 1000,
+
+      orderby: '-time',
+      groupby: ['time'],
+      rollup: 86400,
+    };
+    expect(
+      getDiscoverUrlPathFromDiscoverQuery({
+        organization,
+        selection: {
+          datetime: {
+            start: null,
+            end: null,
+            period: '14d',
+          },
+        },
+        query,
+      })
+    ).toBe(
+      '/organizations/org-slug/discover/?aggregations=%5B%5B%22uniq%22%2C%22user.email%22%2C%22uniq_user_email%22%5D%5D&conditions=%5B%5B%22user.email%22%2C%22IS%20NOT%20NULL%22%2Cnull%5D%5D&end=null&fields=%5B%5D&limit=1000&orderby=%22-uniq_user_email%22&range=%2214d%22&start=null&visualization=line-by-day'
+    );
+  });
+
+  it('gets url when not grouped by time', function() {
+    const query = {
+      name: 'Known Users',
+      fields: [],
+      conditions: [['user.email', 'IS NOT NULL', null]],
+      aggregations: [['uniq', 'user.email', 'Users']],
+      limit: 1000,
+      orderby: '-Users',
+    };
+    expect(
+      getDiscoverUrlPathFromDiscoverQuery({
+        organization,
+        selection: {
+          datetime: {
+            start: null,
+            end: null,
+            period: '14d',
+          },
+        },
+        query,
+      })
+    ).toBe(
+      '/organizations/org-slug/discover/?aggregations=%5B%5B%22uniq%22%2C%22user.email%22%2C%22uniq_user_email%22%5D%5D&conditions=%5B%5B%22user.email%22%2C%22IS%20NOT%20NULL%22%2Cnull%5D%5D&end=null&fields=%5B%5D&limit=1000&orderby=%22-uniq_user_email%22&range=%2214d%22&start=null&visualization=table'
+    );
+  });
+});


### PR DESCRIPTION
Discover expects aliases in a certain format.

Fixes SENTRY-8Y1