### PR TITLE
feat(api): Add multi env support to group tags endpint

### DIFF
--- a/src/sentry/api/endpoints/group_tags.py
+++ b/src/sentry/api/endpoints/group_tags.py
@@ -3,13 +3,12 @@ from __future__ import absolute_import
 from rest_framework.response import Response
 
 from sentry import tagstore
-from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.helpers.environments import get_environments
 from sentry.api.serializers import serialize
 
 
-class GroupTagsEndpoint(GroupEndpoint, EnvironmentMixin):
+class GroupTagsEndpoint(GroupEndpoint):
     def get(self, request, group):
 
         # optional queryparam `key` can be used to get results

--- a/tests/snuba/api/endpoints/test_group_tags.py
+++ b/tests/snuba/api/endpoints/test_group_tags.py
@@ -30,9 +30,9 @@ class GroupTagsTest(APITestCase, SnubaTestCase):
             format='json'
         )
         assert response.status_code == 200
-        assert [
+        assert sorted([
             (tag['key'], tag['uniqueValues']) for tag in response.data
-        ] == [
-            ('environment', 2), ('biz', 1), ('foo', 1)
+        ], key=lambda x: x[0]) == [
+            ('biz', 1), ('environment', 2), ('foo', 1)
         ]
         assert len(response.data) == 3

--- a/tests/snuba/api/endpoints/test_group_tags.py
+++ b/tests/snuba/api/endpoints/test_group_tags.py
@@ -10,8 +10,6 @@ class GroupTagsTest(APITestCase, SnubaTestCase):
         now = timezone.now()
         min_ago = now - timedelta(minutes=1)
         group = self.create_group(first_seen=min_ago, last_seen=now)
-        # group.data['tags'] = (['foo', 'bar'], ['biz', 'baz'])
-        # group.save()
         env = self.create_environment(project=group.project, name='prod')
         env2 = self.create_environment(project=group.project, name='staging')
         self.create_event(

--- a/tests/snuba/api/endpoints/test_group_tags.py
+++ b/tests/snuba/api/endpoints/test_group_tags.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import
+
+from datetime import timedelta
+from django.utils import timezone
+from sentry.testutils import APITestCase, SnubaTestCase
+
+
+class GroupTagsTest(APITestCase, SnubaTestCase):
+    def test_multi_env(self):
+        now = timezone.now()
+        min_ago = now - timedelta(minutes=1)
+        group = self.create_group(first_seen=min_ago, last_seen=now)
+        # group.data['tags'] = (['foo', 'bar'], ['biz', 'baz'])
+        # group.save()
+        env = self.create_environment(project=group.project, name='prod')
+        env2 = self.create_environment(project=group.project, name='staging')
+        self.create_event(
+            group=group,
+            tags=[['foo', 'bar'], ['environment', env.name]],
+            datetime=min_ago,
+        )
+        self.create_event(
+            group=group,
+            tags=[['biz', 'baz'], ['environment', env2.name]],
+            datetime=min_ago,
+        )
+
+        self.login_as(user=self.user)
+        url = u'/api/0/issues/{}/tags/?enable_snuba=1'.format(group.id)
+        response = self.client.get(
+            '%s&environment=%s&environment=%s' % (url, env.name, env2.name),
+            format='json'
+        )
+        assert response.status_code == 200
+        assert [
+            (tag['key'], tag['uniqueValues']) for tag in response.data
+        ] == [
+            ('environment', 2), ('biz', 1), ('foo', 1)
+        ]
+        assert len(response.data) == 3


### PR DESCRIPTION
- relies on https://github.com/getsentry/sentry/pull/11804
- changes behavior to 404 on invalid environment
- otherwise, defaults to old behavior unless `enable_snuba` is passed