### PR TITLE
fix(jira) Normalize jira server logger names.

### DIFF
--- a/src/sentry/integrations/jira_server/webhooks.py
+++ b/src/sentry/integrations/jira_server/webhooks.py
@@ -13,7 +13,7 @@ from sentry.integrations.jira.webhooks import (
 from sentry.models import Integration
 
 
-logger = logging.getLogger('sentry.integrations.jiraserver.webhooks')
+logger = logging.getLogger('sentry.integrations.jira_server.webhooks')
 
 
 def get_integration_from_token(token):


### PR DESCRIPTION
Make logger names match the module paths.