### PR TITLE
fix(jira) Handle invalid URLs better

### DIFF
--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -7,6 +7,7 @@ from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from cryptography.hazmat.backends import default_backend
 from django import forms
 from django.core.urlresolvers import reverse
+from django.core.validators import URLValidator
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_exempt
 from six.moves.urllib.parse import urlparse
@@ -89,6 +90,7 @@ class InstallationForm(forms.Form):
         widget=forms.TextInput(
             attrs={'placeholder': 'https://jira.example.com'}
         ),
+        validators=[URLValidator()]
     )
     verify_ssl = forms.BooleanField(
         label=_('Verify SSL'),

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -29,6 +29,22 @@ class JiraServerIntegrationTest(IntegrationTestCase):
         self.assertContains(resp, 'Submit</button>')
 
     @responses.activate
+    def test_validate_url(self):
+        # Start pipeline and go to setup page.
+        self.client.get(self.setup_path)
+
+        # Submit credentials
+        data = {
+            'url': 'jira.example.com/',
+            'verify_ssl': False,
+            'consumer_key': 'sentry-bot',
+            'private_key': 'hot-garbage'
+        }
+        resp = self.client.post(self.setup_path, data=data)
+        assert resp.status_code == 200
+        self.assertContains(resp, 'Enter a valid URL')
+
+    @responses.activate
     def test_validate_private_key(self):
         responses.add(
             responses.POST,


### PR DESCRIPTION
Some users were giving only the host name (with no protocol) this was resulting in an error when it could just be a validation warning.

Fixes SENTRY-98C