### PR TITLE
fix(issues) Fix searching by eventid not redirecting

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -113,7 +113,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                     response = Response(
                         serialize(
                             groups, request.user, serializer(
-                                matching_event_id=query.strip()
+                                matching_event_id=query
                             )
                         )
                     )

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -107,11 +107,18 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
             # check to see if we've got an event ID
             if len(query) == 32:
                 groups = list(
-                    Group.objects.filter_by_event_id(
-                        project_ids,
-                        query,
-                    )
+                    Group.objects.filter_by_event_id(project_ids, query)
                 )
+                if len(groups) == 1:
+                    response = Response(
+                        serialize(
+                            groups, request.user, serializer(
+                                matching_event_id=query.strip()
+                            )
+                        )
+                    )
+                    response['X-Sentry-Direct-Hit'] = '1'
+                    return response
 
                 if groups:
                     return Response(serialize(groups, request.user, serializer()))

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -602,13 +602,15 @@ class GroupSerializerSnuba(GroupSerializerBase):
 
 
 class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
-    def __init__(self, environment_ids=None, stats_period=None):
+    def __init__(self, environment_ids=None, stats_period=None,
+                 matching_event_id=None):
         super(StreamGroupSerializerSnuba, self).__init__(environment_ids)
 
         if stats_period is not None:
             assert stats_period in self.STATS_PERIOD_CHOICES
 
         self.stats_period = stats_period
+        self.matching_event_id = matching_event_id
 
     def query_tsdb(self, group_ids, query_params):
         return snuba_tsdb.get_range(
@@ -637,5 +639,8 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
             result['stats'] = {
                 self.stats_period: attrs['stats'],
             }
+
+        if self.matching_event_id:
+            result['matchingEventId'] = self.matching_event_id
 
         return result


### PR DESCRIPTION
The project issue list would automatically redirect to the matching event when searching by eventid. This adds that behavior to the organization issue list. The frontend uses the `x-sentry-direct-hit` header and `matchingEventId` attribute to generate the destination URL.

This path is only followed if the search finds a single group as events are only unique per project, not per-org.

Fixes APP-1061