### PR TITLE
fix(environments): Fix value displayed in environment selector

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
@@ -144,9 +144,8 @@ class MultipleEnvironmentSelector extends React.PureComponent {
     return (
       <FetchOrganizationEnvironments organization={organization}>
         {({environments}) => {
-          const envNames = new Set(environments || [].map(env => env.name));
+          const envNames = new Set((environments || []).map(env => env.name));
           const validatedValue = value.filter(env => envNames.has(env));
-
           const summary = validatedValue.length
             ? `${validatedValue.join(', ')}`
             : t('All Environments');


### PR DESCRIPTION
Fixes a bug where selected environments were never correctly matched to
their fetched values, causing "All Environments" to always be displayed