### PR TITLE
ref(rest-framework): Fixing Bugs in ListField.

### DIFF
--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -34,7 +34,11 @@ class CommitPatchSetSerializer(serializers.Serializer):
 
 
 class CommitSerializerWithPatchSet(CommitSerializer):
-    patch_set = ListField(child=CommitPatchSetSerializer(), required=False, allow_null=False)
+    patch_set = ListField(
+        child=CommitPatchSetSerializer(
+            required=False),
+        required=False,
+        allow_null=True)
 
 
 class ReleaseSerializer(serializers.Serializer):
@@ -43,7 +47,11 @@ class ReleaseSerializer(serializers.Serializer):
     url = serializers.URLField(required=False)
     owner = UserField(required=False)
     dateReleased = serializers.DateTimeField(required=False)
-    commits = ListField(child=CommitSerializerWithPatchSet(), required=False, allow_null=False)
+    commits = ListField(
+        child=CommitSerializerWithPatchSet(
+            required=False),
+        required=False,
+        allow_null=True)
 
     def validate_version(self, attrs, source):
         value = attrs[source]

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -688,5 +688,5 @@ class ProjectReleaseCreateCommitPatch(ReleaseCommitPatchTest):
         )
 
         assert response.status_code == 400
-        # TODO(lb): What happened to my ValidationError??? this is not as helpful
-        assert response.content == '{"commits": ["patch_set: Incorrect type. Expected value, but got null"]}'
+        assert response.data == {
+            'commits': [u'patch_set: type: Commit patch_set type Z is not supported.']}

--- a/tests/sentry/api/serializers/rest_framework/test_list.py
+++ b/tests/sentry/api/serializers/rest_framework/test_list.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
-from sentry.api.serializers.rest_framework import ListField
+from sentry.api.serializers.rest_framework import ListField, ValidationError
 
 from rest_framework import serializers
 
-from sentry.testutils import TestCase
+from sentry.testutils import TestCase, APITestCase
 
 
 class ListFieldTest(TestCase):
@@ -98,3 +98,64 @@ class ListFieldTest(TestCase):
             list_field = ListField(child=serializers.IntegerField(), required=False)
         serializer = DummySerializer(data={'list_field': [1, 2, 3]})
         self.assert_success(serializer, {'list_field': [1, 2, 3]})
+
+
+class ListFieldAPITest(APITestCase):
+    def setUp(self):
+        super(ListFieldAPITest, self).setUp()
+
+        class DummyChildSerializer(serializers.Serializer):
+            age = serializers.IntegerField()
+
+            def validate_age(self, attrs, source):
+                age = attrs[source]
+                if age > 5:
+                    raise ValidationError('age %d is not allowed', age)
+                return attrs
+
+        class DummySerializer(serializers.Serializer):
+            list_field = ListField(
+                required=False,
+                child=DummyChildSerializer(required=False),
+                allow_null=True,
+            )
+            name = serializers.CharField()
+
+        self.serializer_class = DummySerializer
+
+    def test_simple(self):
+        serializer = self.serializer_class(data={
+            'name': 'John',
+            'list_field': [{'age': 200}]
+        })
+        assert not serializer.is_valid()
+
+    def test_incorrect_value_before_correct_value(self):
+        serializer = self.serializer_class(data={
+            'name': 'John',
+            'list_field': [
+                {'age': 200}, {'age': 3}
+            ]
+        })
+        assert not serializer.is_valid()
+
+    def test_correct_value_before_incorrect_value(self):
+        serializer = self.serializer_class(data={
+            'name': 'John',
+            'list_field': [
+                {'age': 3}, {'age': 200}
+            ]
+        })
+        assert not serializer.is_valid()
+
+    def test_clears_child_errors_between_use(self):
+        serializer = self.serializer_class(data={
+            'name': 'John',
+            'list_field': [{'age': 200}]
+        })
+        assert not serializer.is_valid()
+        serializer = self.serializer_class(data={
+            'name': 'John',
+            'list_field': []
+        })
+        assert serializer.is_valid()


### PR DESCRIPTION
Fixing a couple issues with the `ListField` serializer class. 

**1. The `ListField` class did not propagate all errors it encountered while validating children.** 
Given the following serializer:
```py
class DummyChildSerializer(serializers.Serializer):
    age = serializers.IntegerField()

     def validate_age(self, attrs, source):
           age = attrs[source]
            if age > 5:
                raise ValidationError('age %d is not allowed' % age)
             return attrs

class DummySerializer(serializers.Serializer):
   list_field = ListField(
        required=False,
        child=DummyChildSerializer(required=False),
        allow_null=True,
    )
    name = serializers.CharField()
```

Depending on the order in which an invalid value is given, will determine whether the serializer is valid or not. For Example:

```py
serializer = DummySerializer(data={
   'name': 'John',
   'list_field': [
        {'age': 200}, {'age': 3}
    ]
})
```
In the above case `serializer.is_valid()` returns `True`.
```py
serializer = DummySerializer(data={
   'name': 'John',
   'list_field': [
        {'age': 3}, {'age': 200}
    ]
})
```
However, in this case, `serializer.is_valid()` returns `False`. The last child was the sole determining factor if the serializer was valid or invalid despite the other children.

**2. The `ListField`'s child errors persist between instantiating serializers.**
Given `DummySerializer` and `DummyChildSerializer` from above the following happens:

```py
serializer = DummySerializer(data={
   'name': 'John',
   'list_field': [{'age': 200}]
})
serializer = DummySerializer(data={
    'name': 'John',
    'list_field': []
})
```
The first instantiated serializer is not valid with an error of `'age: age 200 is not allowed'` as expected. But if the serializer is instantiated again (in this order), it is also invalid. If the error message is checked, it contains the exact same message as before: `'age: age 200 is not allowed'` despite not having any such value. 

This PR addresses these concerns.
