### PR TITLE
fix(issues) Remove overflow on container

### DIFF
--- a/src/sentry/static/sentry/app/styles/organization.jsx
+++ b/src/sentry/static/sentry/app/styles/organization.jsx
@@ -6,7 +6,6 @@ export const PageContent = styled('div')`
   display: flex;
   flex-direction: column;
   flex: 1;
-  overflow: hidden;
   padding: ${space(2)} ${space(4)} ${space(3)};
   margin-bottom: -20px; /* <footer> has margin-top: 20px; */
 `;

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -1612,7 +1612,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
           </withRouter(withGlobalSelection(GlobalSelectionHeader))>
           <PageContent>
             <div
-              className="css-rejmra-PageContent e6lvex70"
+              className="css-16fe6ul-PageContent e6lvex70"
             >
               <UserFeedbackContainer
                 location={


### PR DESCRIPTION
The organization pages currently hide overflow which clips assignee dropdowns and any other dropdown that crosses over to the footer area.

Fixes APP-1069