### PR TITLE
feat(email): Update project links for Sentry 10

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -147,7 +147,12 @@ class Project(Model):
         self.update_rev_for_option()
 
     def get_absolute_url(self):
-        return absolute_uri(u'/{}/{}/'.format(self.organization.slug, self.slug))
+        from sentry import features
+        if features.has('organizations:sentry10', self.organization):
+            return absolute_uri(
+                u'/organizations/{}/issues/?project={}'.format(self.organization.slug, self.id))
+        else:
+            return absolute_uri(u'/{}/{}/'.format(self.organization.slug, self.slug))
 
     def is_internal_project(self):
         for value in (settings.SENTRY_FRONTEND_PROJECT, settings.SENTRY_PROJECT):

--- a/src/sentry/templates/sentry/emails/group_header.html
+++ b/src/sentry/templates/sentry/emails/group_header.html
@@ -1,6 +1,10 @@
 {% load sentry_helpers %}
+{% load sentry_features %}
 
-{% url 'sentry-stream' group.organization.slug group.project.slug as project_link %}
+{% url 'sentry-stream' group.organization.slug group.project.slug as old_project_link %}
+{% url 'sentry-organization-issue-list' group.organization.slug as new_stream_link %}
+
+
 <div class="group-header">
   <table class="group-stats">
     <thead>
@@ -20,7 +24,12 @@
           <small>
             <span class="count">Seen <strong>{{ group.times_seen }}</strong> time{{ group.times_seen|pluralize }}.</span>
             <span class="last-seen pretty-date"> Last seen: {{ group.last_seen }} UTC</span>
-            in <a href="{% absolute_uri project_link %}"><strong>{{ group.project.organization.slug }} / {{ group.project.slug }}</strong></a>
+            in
+            {% feature organizations:sentry10 group.organization %}
+            <a href="{% absolute_uri new_stream_link %}?project={{group.project.id}}"><strong>{{ group.project.organization.slug }} / {{ group.project.slug }}</strong></a>
+            {% else %}
+            <a href="{% absolute_uri old_project_link %}"><strong>{{ group.project.organization.slug }} / {{ group.project.slug }}</strong></a>
+            {% endfeature %}
           </small>
         </p>
       </td>


### PR DESCRIPTION
Project links in emails go to the stream with the relevant project
selected in Sentry 10.