### PR TITLE
ref(tagstore): Move `index_event_tags.delay` into `TagStorage` backend

### DIFF
--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -89,6 +89,8 @@ class TagStorage(Service):
         'incr_group_tag_value_times_seen',
         'update_group_tag_key_values_seen',
         'update_group_for_events',
+
+        'delay_index_event_tags',
     ])
 
     __all__ = frozenset([
@@ -440,3 +442,7 @@ class TagStorage(Service):
                     project_id, group_id, environment_id, tk.key)
 
         return tag_keys
+
+    def delay_index_event_tags(self, organization_id, project_id, group_id,
+                               environment_id, event_id, tags, date_added):
+        raise NotImplementedError

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -26,6 +26,7 @@ from sentry.utils import db
 
 from . import models
 from sentry.tagstore.types import TagKey, TagValue, GroupTagKey, GroupTagValue
+from sentry.tasks.post_process import index_event_tags
 
 
 transformers = {
@@ -759,3 +760,15 @@ class LegacyTagStorage(TagStorage):
             project_id=project_id,
             event_id__in=event_ids,
         ).update(group_id=destination_id)
+
+    def delay_index_event_tags(self, organization_id, project_id, group_id,
+                               environment_id, event_id, tags, date_added):
+        index_event_tags.delay(
+            organization_id=organization_id,
+            project_id=project_id,
+            group_id=group_id,
+            environment_id=environment_id,
+            event_id=event_id,
+            tags=tags,
+            date_added=date_added,
+        )

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -707,6 +707,7 @@ class SnubaCompatibilityTagStorage(SnubaTagStorage):
     in the future, this subclass can be removed (along with the entire
     ``TagStorage`` write interface from the base implementation.)
     """
+
     def get_or_create_group_tag_key(self, project_id, group_id, environment_id, key, **kwargs):
         # Called by ``unmerge.repair_tag_data``. The return value is not used.
         pass
@@ -753,3 +754,9 @@ class SnubaCompatibilityTagStorage(SnubaTagStorage):
     def update_group_tag_key_values_seen(self, project_id, group_ids):
         # Called by ``unmerge``. The return value is not used.
         pass
+
+    def delay_index_event_tags(self, organization_id, project_id, group_id,
+                               environment_id, event_id, tags, date_added):
+        # Called by ``EventManager.save``. The return value is not
+        # used.
+        raise NotImplementedError

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -759,4 +759,4 @@ class SnubaCompatibilityTagStorage(SnubaTagStorage):
                                environment_id, event_id, tags, date_added):
         # Called by ``EventManager.save``. The return value is not
         # used.
-        raise NotImplementedError
+        pass

--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -27,6 +27,7 @@ from sentry.utils import db
 
 from . import models
 from sentry.tagstore.types import TagKey, TagValue, GroupTagKey, GroupTagValue
+from sentry.tasks.post_process import index_event_tags
 
 
 logger = logging.getLogger('sentry.tagstore.v2')
@@ -1121,3 +1122,15 @@ class V2TagStorage(TagStorage):
             return queryset.filter(_key__environment_id=environment_id)
         else:
             raise ValueError("queryset of unsupported model '%s' provided" % queryset.model)
+
+    def delay_index_event_tags(self, organization_id, project_id, group_id,
+                               environment_id, event_id, tags, date_added):
+        index_event_tags.delay(
+            organization_id=organization_id,
+            project_id=project_id,
+            group_id=group_id,
+            environment_id=environment_id,
+            event_id=event_id,
+            tags=tags,
+            date_added=date_added,
+        )

--- a/tests/snuba/eventstream/test_eventstream.py
+++ b/tests/snuba/eventstream/test_eventstream.py
@@ -20,7 +20,8 @@ class SnubaEventStreamTest(SnubaTestCase):
         self.kafka_eventstream.producer = Mock()
 
     @patch('sentry.eventstream.insert')
-    def test(self, mock_eventstream_insert):
+    @patch('sentry.tagstore.delay_index_event_tags')
+    def test(self, mock_delay_index_event_tags, mock_eventstream_insert):
         now = datetime.utcnow()
 
         def _get_event_count():
@@ -59,6 +60,8 @@ class SnubaEventStreamTest(SnubaTestCase):
             'primary_hash': 'acbd18db4cc2f85cedef654fccc4a4d8',
             'skip_consume': False
         }
+
+        assert mock_delay_index_event_tags.call_count == 1
 
         # pass arguments on to Kafka EventManager
         self.kafka_eventstream.insert(*insert_args, **insert_kwargs)


### PR DESCRIPTION
This is used by Postgres-based backends but skipped for the Snuba
compatibility backend. This prevents tasks from being unnecessarily
dispatched for backends that don't support the write API.