### PR TITLE
feat(integrations) Add linking comment to GitLab

### DIFF
--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -22,6 +22,7 @@ class GitLabApiClientPath(object):
     hooks = u'/hooks'
     issue = u'/projects/{project}/issues/{issue}'
     issues = u'/projects/{project}/issues'
+    notes = u'/projects/{project}/issues/{issue_id}/notes'
     project = u'/projects/{project}'
     project_issues = u'/projects/{project}/issues'
     project_hooks = u'/projects/{project}/hooks'
@@ -180,6 +181,16 @@ class GitLabApiClient(ApiClient):
         """
         return self.post(
             GitLabApiClientPath.issues.format(project=project),
+            data=data,
+        )
+
+    def create_issue_comment(self, project_id, issue_id, data):
+        """Create an issue note/comment
+
+        See https://docs.gitlab.com/ee/api/notes.html#create-new-issue-note
+        """
+        return self.post(
+            GitLabApiClientPath.notes.format(project=project_id, issue_id=issue_id),
             data=data,
         )
 

--- a/tests/sentry/integrations/gitlab/test_issues.py
+++ b/tests/sentry/integrations/gitlab/test_issues.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import pytest
 import responses
 import six
 
@@ -380,7 +379,7 @@ class GitlabIssuesTest(GitLabTestCase):
             integration_id=self.integration.id,
             key='#',
         )
-        with pytest.raises(IntegrationError):
+        with self.assertRaises(IntegrationError):
             self.installation.after_link_issue(external_issue, data=data)
 
     @responses.activate
@@ -396,5 +395,5 @@ class GitlabIssuesTest(GitLabTestCase):
             integration_id=self.integration.id,
             key='2#321',
         )
-        with pytest.raises(IntegrationError):
+        with self.assertRaises(IntegrationError):
             self.installation.after_link_issue(external_issue, data=data)

--- a/tests/sentry/integrations/gitlab/test_issues.py
+++ b/tests/sentry/integrations/gitlab/test_issues.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import
 
+import pytest
 import responses
 import six
 
+from sentry.integrations.exceptions import IntegrationError
+from sentry.models import ExternalIssue
 from sentry.utils.http import absolute_uri
 from .testutils import GitLabTestCase
 
@@ -54,7 +57,7 @@ class GitlabIssuesTest(GitLabTestCase):
                 'name': 'project',
                 'required': True,
                 'type': 'select',
-                'label': 'Gitlab Project',
+                'label': 'GitLab Project',
                 'choices': [(1, u'getsentry / sentry'), (22, u'getsentry / hello')],
                 'defaultValue': 1,
             },
@@ -105,6 +108,20 @@ class GitlabIssuesTest(GitLabTestCase):
                 'url': autocomplete_url,
                 'required': True,
             },
+            {
+                'name': 'comment',
+                'label': 'Comment',
+                'default': u'Sentry issue: [{issue_id}]({url})'.format(
+                    url=absolute_uri(
+                        self.group.get_absolute_url(params={'referrer': 'gitlab_integration'})
+                    ),
+                    issue_id=self.group.qualified_short_id,
+                ),
+                'type': 'textarea',
+                'required': False,
+                'help': ('Leave blank if you don\'t want to '
+                         'add a comment to the GitLab issue.'),
+            }
         ]
 
     @responses.activate
@@ -215,7 +232,7 @@ class GitlabIssuesTest(GitLabTestCase):
                 ],
                 'defaultValue': project_id,
                 'type': 'select',
-                'label': 'Gitlab Project'
+                'label': 'GitLab Project'
             },
             {
                 'name': 'title',
@@ -278,7 +295,7 @@ class GitlabIssuesTest(GitLabTestCase):
                 ],
                 'defaultValue': project_id,
                 'type': 'select',
-                'label': 'Gitlab Project'
+                'label': 'GitLab Project'
             },
             {
                 'name': 'title',
@@ -322,7 +339,7 @@ class GitlabIssuesTest(GitLabTestCase):
                 'choices': [],
                 'defaultValue': '',
                 'type': 'select',
-                'label': 'Gitlab Project'
+                'label': 'GitLab Project'
             },
             {
                 'name': 'title',
@@ -340,3 +357,44 @@ class GitlabIssuesTest(GitLabTestCase):
                 'maxRows': 10,
             }
         ]
+
+    @responses.activate
+    def test_after_link_issue(self):
+        responses.add(
+            responses.POST,
+            u'https://example.gitlab.com/api/v4/projects/2/issues/321/notes',
+            json=[]
+        )
+        data = {'externalIssue': '2#321', 'comment': 'This is not good.'}
+        external_issue = ExternalIssue.objects.create(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            key='2#321',
+        )
+        self.installation.after_link_issue(external_issue, data=data)
+
+    def test_after_link_issue_required_fields(self):
+        data = {'externalIssue': '2#231', 'comment': 'This is not good.'}
+        external_issue = ExternalIssue.objects.create(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            key='#',
+        )
+        with pytest.raises(IntegrationError):
+            self.installation.after_link_issue(external_issue, data=data)
+
+    @responses.activate
+    def test_after_link_issue_failure(self):
+        responses.add(
+            responses.POST,
+            u'https://example.gitlab.com/api/v4/projects/2/issues/321/notes',
+            status=502
+        )
+        data = {'externalIssue': '2#321', 'comment': 'This is not good.'}
+        external_issue = ExternalIssue.objects.create(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            key='2#321',
+        )
+        with pytest.raises(IntegrationError):
+            self.installation.after_link_issue(external_issue, data=data)


### PR DESCRIPTION
When building out the gitlab integration we didn't add a comment field. To improve parity with the gitlab plugin customers have requested that this field be added to the new integration.

Fixes ISSUE-301