### PR TITLE
ref(api) Get partial from functools

### DIFF
--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from django.db.models import Q
 from django.utils import timezone
 from rest_framework.response import Response
-from functools32 import partial
+from functools import partial
 
 
 from sentry import options, quotas, tagstore

--- a/src/sentry/api/endpoints/organization_discover_query.py
+++ b/src/sentry/api/endpoints/organization_discover_query.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import re
 import six
-from functools32 import partial
+from functools import partial
 from copy import deepcopy
 
 from rest_framework import serializers

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from collections import namedtuple
 from datetime import timedelta
-from functools32 import partial
+from functools import partial
 
 from rest_framework.response import Response
 

--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from datetime import timedelta
 from django.utils import timezone
+from functools import partial
 
 from sentry import options
 from sentry.api.base import DocSection
@@ -52,7 +53,6 @@ class ProjectEventsEndpoint(ProjectEndpoint):
         )
 
     def _get_events_snuba(self, request, project):
-        from functools32 import partial
         from sentry.api.paginator import GenericOffsetPaginator
         from sentry.api.serializers.models.event import SnubaEvent
         from sentry.utils.snuba import raw_query


### PR DESCRIPTION
Normalize our imports for `partial` to draw from functools instead of functools32.