### PR TITLE
feat(app-platform): UI Integrations Schema

### DIFF
--- a/src/sentry/api/validators/sentry_apps/__init__.py
+++ b/src/sentry/api/validators/sentry_apps/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/src/sentry/api/validators/sentry_apps/schema.py
+++ b/src/sentry/api/validators/sentry_apps/schema.py
@@ -1,0 +1,265 @@
+from __future__ import absolute_import
+
+from jsonschema import validate as json_schema_validate
+
+SCHEMA = {
+    'type': 'object',
+
+    'definitions': {
+
+        # Property Types
+
+        'uri': {
+            'type': 'string',
+            'format': 'uri',
+            'pattern': '^\/',
+        },
+
+        'options': {
+            'type': 'array',
+            'items': {
+                'type': 'array',
+                'minItems': 2,
+                'maxItems': 2,
+                'items': [
+                    {'type': 'string'},
+                    {'anyOf': [
+                        {'type': 'string'},
+                        {'type': 'number'},
+                    ]}
+                ]
+            }
+        },
+
+        'fieldset': {
+            'type': 'array',
+            'minItems': 1,
+            'items': [
+                {
+                    'anyOf': [
+                        {'$ref': '#/definitions/select'},
+                        {'$ref': '#/definitions/text'},
+                    ],
+                },
+            ],
+        },
+
+        # Form Components
+
+        'select': {
+            'type': 'object',
+            'properties': {
+                'type': {
+                    'type': 'string',
+                    'enum': ['select'],
+                },
+                'label': {
+                    'type': 'string',
+                },
+                'name': {
+                    'type': 'string',
+                },
+                'uri': {
+                    '$ref': '#/definitions/uri',
+                },
+                'options': {
+                    '$ref': '#/definitions/options',
+                },
+            },
+            'required': ['type', 'name', 'label'],
+            'oneOf': [
+                {'required': ['uri']},
+                {'required': ['options']},
+            ],
+        },
+
+        'text': {
+            'type': 'object',
+            'properties': {
+                'type': {
+                    'type': 'string',
+                    'enum': ['text'],
+                },
+                'label': {
+                    'type': 'string',
+                },
+                'name': {
+                    'type': 'string',
+                },
+            },
+            'required': ['type', 'label', 'name'],
+        },
+
+        # Composable Components
+
+        'header': {
+            'type': 'object',
+            'properties': {
+                'type': {
+                    'type': 'string',
+                    'enum': ['header'],
+                },
+                'text': {
+                    'type': 'string',
+                },
+            },
+            'required': ['type', 'text'],
+        },
+
+        'image': {
+            'type': 'object',
+            'properties': {
+                'type': {
+                    'type': 'string',
+                    'enum': ['image'],
+                },
+                'url': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'pattern': '^(?:https?|\/)',
+                },
+                'alt': {
+                    'type': 'string',
+                },
+            },
+            'required': ['type', 'url'],
+        },
+
+        'video': {
+            'type': 'object',
+            'properties': {
+                'type': {
+                    'type': 'string',
+                    'enum': ['video'],
+                },
+                'url': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'pattern': '^(?:https?|\/)',
+                },
+            },
+            'required': ['type', 'url'],
+        },
+
+        'markdown': {
+            'type': 'object',
+            'properties': {
+                'type': {
+                    'type': 'string',
+                    'enum': ['markdown'],
+                },
+                'text': {
+                    'type': 'string',
+                },
+            },
+            'required': ['type', 'text'],
+        },
+
+        # Feature Components
+
+        'issue-link': {
+            'type': 'object',
+            'properties': {
+                'type': {
+                    'type': 'string',
+                    'enum': ['issue-link'],
+                },
+
+                'link': {
+                    'type': 'object',
+                    'properties': {
+                        'uri': {
+                            '$ref': '#/definitions/uri',
+                        },
+                        'required_fields': {
+                            '$ref': '#/definitions/fieldset',
+                        },
+                        'optional_fields': {
+                            '$ref': '#/definitions/fieldset',
+                        },
+                    },
+                    'required': ['uri', 'required_fields'],
+                },
+
+                'create': {
+                    'type': 'object',
+                    'properties': {
+                        'uri': {
+                            '$ref': '#/definitions/uri',
+                        },
+                        'required_fields': {
+                            '$ref': '#/definitions/fieldset',
+                        },
+                        'optional_fields': {
+                            '$ref': '#/definitions/fieldset',
+                        },
+                    },
+                    'required': ['uri', 'required_fields'],
+                },
+            },
+            'required': ['type', 'link', 'create'],
+        },
+
+        'alert-rule-action': {
+            'type': 'object',
+            'properties': {
+                'type': {
+                    'type': 'string',
+                    'enum': ['alert-rule-action'],
+                },
+                'required_fields': {
+                    '$ref': '#/definitions/fieldset',
+                },
+                'optional_fields': {
+                    '$ref': '#/definitions/fieldset',
+                },
+            },
+            'required': ['required_fields'],
+        },
+
+        'issue-media': {
+            'type': 'object',
+            'properties': {
+                'type': {
+                    'type': 'string',
+                    'enum': ['issue-media'],
+                },
+                'title': {
+                    'type': 'string',
+                },
+                'elements': {
+                    'type': 'array',
+                    'minItems': 1,
+                    'items': {
+                        'anyOf': [
+                            {'$ref': '#/definitions/header'},
+                            {'$ref': '#/definitions/markdown'},
+                            {'$ref': '#/definitions/image'},
+                            {'$ref': '#/definitions/video'},
+                        ],
+                    },
+                },
+            },
+            'required': ['type', 'title', 'elements'],
+        },
+    },
+
+    'properties': {
+        'elements': {
+            'type': 'array',
+            'minItems': 1,
+            'items': {
+                'anyOf': [
+                    {'$ref': '#/definitions/issue-link'},
+                    {'$ref': '#/definitions/alert-rule-action'},
+                    {'$ref': '#/definitions/issue-media'},
+                ],
+            },
+        },
+    },
+    'required': ['elements'],
+}
+
+
+def validate(instance, schema=SCHEMA):
+    json_schema_validate(instance=instance, schema=schema)

--- a/tests/sentry/api/validators/__init__.py
+++ b/tests/sentry/api/validators/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/api/validators/sentry_apps/__init__.py
+++ b/tests/sentry/api/validators/sentry_apps/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/api/validators/sentry_apps/test_alert_rule_action.py
+++ b/tests/sentry/api/validators/sentry_apps/test_alert_rule_action.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import
+
+from sentry.testutils import TestCase
+
+from .util import invalid_schema, validate_component
+
+
+class TestAlertRuleActionSchemaValidation(TestCase):
+    def setUp(self):
+        self.schema = {
+            'type': 'alert-rule-action',
+            'required_fields': [
+                {
+                    'type': 'text',
+                    'name': 'channel',
+                    'label': 'Channel',
+                },
+            ],
+            'optional_fields': [
+                {
+                    'type': 'text',
+                    'name': 'prefix',
+                    'label': 'Prefix',
+                },
+            ]
+        }
+
+    def test_valid_schema(self):
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_missing_required_fields_fails(self):
+        del self.schema['required_fields']
+        validate_component(self.schema)

--- a/tests/sentry/api/validators/sentry_apps/test_header.py
+++ b/tests/sentry/api/validators/sentry_apps/test_header.py
@@ -1,0 +1,26 @@
+from __future__ import absolute_import
+
+from sentry.testutils import TestCase
+
+from .util import invalid_schema, validate_component
+
+
+class TestHeaderSchemaValidation(TestCase):
+    def setUp(self):
+        self.schema = {
+            'type': 'header',
+            'text': 'Beep',
+        }
+
+    def test_valid_schema(self):
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_missing_text(self):
+        del self.schema['text']
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_invalid_text_type(self):
+        self.schema['text'] = 1
+        validate_component(self.schema)

--- a/tests/sentry/api/validators/sentry_apps/test_image.py
+++ b/tests/sentry/api/validators/sentry_apps/test_image.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import
+
+from sentry.testutils import TestCase
+
+from .util import invalid_schema, validate_component
+
+
+class TestImageSchemaValidation(TestCase):
+    def setUp(self):
+        self.schema = {
+            'type': 'image',
+            'url': 'https://example.com/image.gif',
+            'alt': 'example video',
+        }
+
+    def test_valid_schema(self):
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_missing_url(self):
+        del self.schema['url']
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_invalid_url(self):
+        self.schema['url'] = 'not-a-url'
+        validate_component(self.schema)
+
+    def test_missing_alt(self):
+        del self.schema['alt']
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_invalid_alt_type(self):
+        self.schema['alt'] = 1
+        validate_component(self.schema)

--- a/tests/sentry/api/validators/sentry_apps/test_issue_link.py
+++ b/tests/sentry/api/validators/sentry_apps/test_issue_link.py
@@ -1,0 +1,113 @@
+from __future__ import absolute_import
+
+from sentry.testutils import TestCase
+
+from .util import invalid_schema, validate_component
+
+
+class TestIssueLinkSchemaValidation(TestCase):
+    def setUp(self):
+        self.schema = {
+            'type': 'issue-link',
+            'link': {
+                'uri': '/sentry/tasks/link',
+                'required_fields': [
+                    {
+                        'type': 'select',
+                        'name': 'task_id',
+                        'label': 'Task ID',
+                        'uri': '/sentry/tasks',
+                    },
+                ],
+                'optional_fields': [
+                    {
+                        'type': 'text',
+                        'name': 'owner',
+                        'label': 'Owner',
+                    },
+                ]
+            },
+            'create': {
+                'uri': '/sentry/tasks/create',
+                'required_fields': [
+                    {
+                        'type': 'text',
+                        'name': 'title',
+                        'label': 'Title',
+                    },
+                    {
+                        'type': 'text',
+                        'name': 'description',
+                        'label': 'Description',
+                    },
+                ],
+
+                'optional_fields': [
+                    {
+                        'type': 'text',
+                        'name': 'owner',
+                        'label': 'Owner',
+                    },
+                ]
+            },
+        }
+
+    def test_valid_schema(self):
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_missing_create_fails(self):
+        del self.schema['create']
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_missing_create_uri(self):
+        del self.schema['create']['uri']
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_missing_create_required_fields(self):
+        del self.schema['create']['required_fields']
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_create_required_fields_no_elements(self):
+        self.schema['create']['required_fields'] = []
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_create_required_fields_invalid_element(self):
+        self.schema['create']['required_fields'] = [
+            {'type': 'markdown'}
+        ]
+        validate_component(self.schema)
+
+    def test_missing_create_optional_fields(self):
+        del self.schema['create']['optional_fields']
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_create_optional_fields_invalid_element(self):
+        self.schema['create']['optional_fields'] = [
+            {'type': 'markdown'}
+        ]
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_missing_link(self):
+        del self.schema['link']
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_missing_link_uri(self):
+        del self.schema['link']['uri']
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_missing_link_required_fields(self):
+        del self.schema['link']['required_fields']
+        validate_component(self.schema)
+
+    def test_missing_link_optional_fields(self):
+        del self.schema['link']['optional_fields']
+        validate_component(self.schema)

--- a/tests/sentry/api/validators/sentry_apps/test_issue_media.py
+++ b/tests/sentry/api/validators/sentry_apps/test_issue_media.py
@@ -1,0 +1,52 @@
+from __future__ import absolute_import
+
+from sentry.testutils import TestCase
+
+from .util import invalid_schema, validate_component
+
+
+class TestIssueMediaSchemaValidation(TestCase):
+    def setUp(self):
+        self.schema = {
+            'type': 'issue-media',
+            'title': 'Video Playback',
+            'elements': [
+                {
+                    'type': 'video',
+                    'url': 'https://example.com/video.mov',
+                },
+            ]
+        }
+
+    def test_valid_schema(self):
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_missing_title(self):
+        del self.schema['title']
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_invalid_title_type(self):
+        self.schema['title'] = 1
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_missing_elements(self):
+        del self.schema['elements']
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_no_elements(self):
+        self.schema['elements'] = []
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_invalid_element(self):
+        self.schema['elements'].append({
+            'type': 'select',
+            'name': 'thing',
+            'label': 'Thing',
+            'options': [['a', 'a']],
+        })
+        validate_component(self.schema)

--- a/tests/sentry/api/validators/sentry_apps/test_markdown.py
+++ b/tests/sentry/api/validators/sentry_apps/test_markdown.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import
+
+from sentry.testutils import TestCase
+
+from .util import invalid_schema, validate_component
+
+
+class TestMarkdownSchemaValidation(TestCase):
+    def setUp(self):
+        self.schema = {
+            'type': 'markdown',
+            'text': """
+# This Is a Title
+- this
+- is
+- a
+- list
+            """
+        }
+
+    def test_valid_schema(self):
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_missing_text(self):
+        del self.schema['text']
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_invalid_text_type(self):
+        self.schema['text'] = 1
+        validate_component(self.schema)

--- a/tests/sentry/api/validators/sentry_apps/test_schema.py
+++ b/tests/sentry/api/validators/sentry_apps/test_schema.py
@@ -1,0 +1,95 @@
+from __future__ import absolute_import
+
+from sentry.testutils import TestCase
+from sentry.api.validators.sentry_apps.schema import validate
+
+
+class TestSchemaValidation(TestCase):
+    def setUp(self):
+        self.schema = {
+            'elements': [
+                {
+                    'type': 'issue-link',
+                    'link': {
+                        'uri': '/sentry/issues/link',
+                        'required_fields': [
+                            {
+                                'type': 'select',
+                                'name': 'assignee',
+                                'label': 'Assignee',
+                                'uri': '/sentry/members',
+                            },
+                        ],
+                    },
+
+                    'create': {
+                        'uri': '/sentry/issues/create',
+                        'required_fields': [
+                            {
+                                'type': 'text',
+                                'name': 'title',
+                                'label': 'Title',
+                            },
+                            {
+                                'type': 'text',
+                                'name': 'summary',
+                                'label': 'Summary',
+                            },
+                        ],
+
+                        'optional_fields': [
+                            {
+                                'type': 'select',
+                                'name': 'points',
+                                'label': 'Points',
+                                'options': [
+                                    ['1', '1'],
+                                    ['2', '2'],
+                                    ['3', '3'],
+                                    ['5', '5'],
+                                    ['8', '8'],
+                                ],
+                            },
+                            {
+                                'type': 'select',
+                                'name': 'assignee',
+                                'label': 'Assignee',
+                                'uri': '/sentry/members',
+                            },
+                        ],
+                    },
+                },
+                {
+                    'type': 'alert-rule-action',
+                    'required_fields': [
+                        {
+                            'type': 'text',
+                            'name': 'channel',
+                            'label': 'Channel',
+                        },
+                        {
+                            'type': 'select',
+                            'name': 'send_email',
+                            'label': 'Send Email?',
+                            'options': [
+                                ['Yes', 'yes'],
+                                ['No', 'no'],
+                            ],
+                        },
+                    ],
+                },
+                {
+                    'type': 'issue-media',
+                    'title': 'Feature Demo',
+                    'elements': [
+                        {
+                            'type': 'video',
+                            'url': '/sentry/issues/video',
+                        },
+                    ]
+                },
+            ],
+        }
+
+    def test_valid_schema_with_options(self):
+        validate(self.schema)

--- a/tests/sentry/api/validators/sentry_apps/test_select.py
+++ b/tests/sentry/api/validators/sentry_apps/test_select.py
@@ -1,0 +1,45 @@
+from __future__ import absolute_import
+
+from sentry.testutils import TestCase
+
+from .util import invalid_schema, validate_component
+
+
+class TestSelectSchemaValidation(TestCase):
+    def setUp(self):
+        self.schema = {
+            'type': 'select',
+            'name': 'title',
+            'label': 'Title',
+            'options': [
+                ['Stuff', 'stuff'],
+                ['Things', 'things'],
+            ]
+        }
+
+    def test_valid_schema_with_options(self):
+        validate_component(self.schema)
+
+    def test_valid_schema_options_with_numeric_value(self):
+        self.schema['options'][0][1] = 1
+        self.schema['options'][1][1] = 2
+
+        validate_component(self.schema)
+
+    def test_valid_schema_with_uri(self):
+        del self.schema['options']
+        self.schema['uri'] = '/foo'
+
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_invalid_schema_missing_uri_and_options(self):
+        del self.schema['options']
+
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_invalid_schema_missing_name(self):
+        del self.schema['name']
+
+        validate_component(self.schema)

--- a/tests/sentry/api/validators/sentry_apps/test_text.py
+++ b/tests/sentry/api/validators/sentry_apps/test_text.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import
+
+from sentry.testutils import TestCase
+
+from .util import invalid_schema, validate_component
+
+
+class TestTextSchemaValidation(TestCase):
+    def setUp(self):
+        self.schema = {
+            'type': 'text',
+            'name': 'title',
+            'label': 'Title',
+        }
+
+    def test_valid_schema(self):
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_missing_name(self):
+        del self.schema['name']
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_missing_label(self):
+        del self.schema['label']
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_invalid_label_type(self):
+        self.schema['label'] = 1
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_invalid_name_type(self):
+        self.schema['name'] = 1
+        validate_component(self.schema)

--- a/tests/sentry/api/validators/sentry_apps/test_video.py
+++ b/tests/sentry/api/validators/sentry_apps/test_video.py
@@ -1,0 +1,26 @@
+from __future__ import absolute_import
+
+from sentry.testutils import TestCase
+
+from .util import invalid_schema, validate_component
+
+
+class TestVideoSchemaValidation(TestCase):
+    def setUp(self):
+        self.schema = {
+            'type': 'video',
+            'url': 'https://example.com/video.mov',
+        }
+
+    def test_valid_schema(self):
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_missing_url(self):
+        del self.schema['url']
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_invalid_url(self):
+        self.schema['url'] = 'not-a-url'
+        validate_component(self.schema)

--- a/tests/sentry/api/validators/sentry_apps/util.py
+++ b/tests/sentry/api/validators/sentry_apps/util.py
@@ -1,0 +1,23 @@
+from __future__ import absolute_import
+
+from jsonschema import ValidationError
+from sentry.api.validators.sentry_apps.schema import validate, SCHEMA
+
+
+def invalid_schema(func):
+    def inner(self, *args, **kwargs):
+        with self.assertRaises(ValidationError):
+            func(self)
+    return inner
+
+
+def validate_component(schema):
+    """
+    In order to test individual components, that aren't normally allowed at the
+    top-level of a schema, we just plop all `definitions` into `properties`.
+    This makes the validator think they're all valid top-level elements.
+    """
+    component_schema = SCHEMA.copy()
+    component_schema['properties'] = component_schema['definitions']
+    del component_schema['required']
+    validate(instance={schema['type']: schema}, schema=component_schema)


### PR DESCRIPTION
Introduces the specification for UI Integration components. It's written in and uses JSON Schema to validate. When developers submit their UI Integration schema, this will be used to validate everything.

There are three categories of components that are usable:

## Form Field Components
Used as children of certain **Feature Components** that allow you to specify form inputs for Users to fill out.

## Composable Components
Used as children `elements` to create content in components like **Issue Media**.

## Feature Components
The top-level components you specify that enable specific UI features for Users.

This PR is just the schema definition and tests for each individual component. The work to use this specification to validate received schema will come later.