### PR TITLE
feat(api): Add `IssueSearchVisitor` for parsing issue searches, and converters

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -82,7 +82,7 @@ numeric_filter  = search_key sep operator ~r"[0-9]+"
 
 # has filter for not null type checks
 has_filter      = negation? "has" sep (search_key / search_value)
-is_filter       = negation? "is" sep (search_key / search_value)
+is_filter       = negation? "is" sep search_value
 
 search_key      = key / quoted_key
 search_value    = quoted_value / value

--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -1,0 +1,104 @@
+from __future__ import absolute_import
+
+from django.utils.functional import cached_property
+
+from sentry.api.event_search import (
+    event_search_grammar,
+    InvalidSearchQuery,
+    SearchFilter,
+    SearchKey,
+    SearchValue,
+    SearchVisitor,
+)
+from sentry.constants import STATUS_CHOICES
+from sentry.search.utils import (
+    parse_actor_value,
+    parse_user_value,
+)
+
+
+class IssueSearchVisitor(SearchVisitor):
+    key_mappings = {
+        'assigned_to': ['assigned'],
+        'bookmarked_by': ['bookmarks'],
+        'subscribed_by': ['subscribed'],
+        'first_release': ['first-release', 'firstRelease'],
+        'age': ['firstSeen'],
+        'last_seen': ['lastSeen'],
+        'active_at': ['activeSince'],
+        # TODO: Special case this in the backends, since they currently rely
+        # on date_from and date_to explicitly
+        'date': ['event.timestamp'],
+        'times_seen': ['timesSeen'],
+    }
+
+    @cached_property
+    def is_filter_translators(self):
+        is_filter_translators = {
+            'assigned': (SearchKey('unassigned'), SearchValue(False)),
+            'unassigned': (SearchKey('unassigned'), SearchValue(True)),
+        }
+        for status_key, status_value in STATUS_CHOICES.items():
+            is_filter_translators[status_key] = (SearchKey('status'), SearchValue(status_value))
+        return is_filter_translators
+
+    def visit_is_filter(self, node, children):
+        # the key is "is" here, which we don't need
+        negation, _, _, search_value = children
+
+        if search_value.raw_value not in self.is_filter_translators:
+            raise InvalidSearchQuery(
+                'Invalid value for "is" search, valid values are {}'.format(
+                    sorted(self.is_filter_translators.keys()),
+                ),
+            )
+
+        search_key, search_value = self.is_filter_translators[search_value.raw_value]
+
+        operator = '!=' if self.is_negated(negation) else '='
+
+        return SearchFilter(
+            search_key,
+            operator,
+            search_value,
+        )
+
+
+def parse_search_query(query):
+    tree = event_search_grammar.parse(query)
+    return IssueSearchVisitor().visit(tree)
+
+
+def convert_actor_value(value, projects, user):
+    return parse_actor_value(projects, value, user)
+
+
+def convert_user_value(value, projects, user):
+    return parse_user_value(value, user)
+
+
+value_converters = {
+    'assigned_to': convert_actor_value,
+    'bookmarked_by': convert_user_value,
+    'subscribed_by': convert_user_value,
+}
+
+
+def convert_query_values(search_filters, projects, user):
+    """
+    Accepts a collection of SearchFilter objects and converts their values into
+    a specific format, based on converters specified in `value_converters`.
+    :param search_filters: Collection of `SearchFilter` objects.
+    :param projects: List of projects being searched across
+    :param user: The user making the search
+    :return: New collection of `SearchFilters`, which may have converted values.
+    """
+
+    def convert_search_filter(search_filter):
+        if search_filter.key.name in value_converters:
+            converter = value_converters[search_filter.key.name]
+            new_value = converter(search_filter.value.raw_value, projects, user)
+            search_filter = search_filter._replace(value=SearchValue(new_value))
+        return search_filter
+
+    return map(convert_search_filter, search_filters)

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -1,0 +1,158 @@
+from __future__ import absolute_import
+
+from sentry.api.event_search import (
+    InvalidSearchQuery,
+    SearchFilter,
+    SearchKey,
+    SearchValue,
+)
+from sentry.api.issue_search import (
+    convert_actor_value,
+    convert_query_values,
+    convert_user_value,
+    parse_search_query,
+    value_converters,
+)
+from sentry.constants import STATUS_CHOICES
+from sentry.testutils import TestCase
+
+
+class ParseSearchQueryTest(TestCase):
+    def test_key_mappings(self):
+        # Test a couple of keys to ensure things are working as expected
+        assert parse_search_query('bookmarks:123') == [
+            SearchFilter(
+                key=SearchKey(name='bookmarked_by'),
+                operator='=',
+                value=SearchValue('123'),
+            )
+        ]
+        assert parse_search_query('first-release:123') == [
+            SearchFilter(
+                key=SearchKey(name='first_release'),
+                operator='=',
+                value=SearchValue('123'),
+            )
+        ]
+        assert parse_search_query('first-release:123 non_mapped:456') == [
+            SearchFilter(
+                key=SearchKey(name='first_release'),
+                operator='=',
+                value=SearchValue('123'),
+            ),
+            SearchFilter(
+                key=SearchKey(name='non_mapped'),
+                operator='=',
+                value=SearchValue('456'),
+            ),
+        ]
+
+    def test_is_query_unassigned(self):
+        assert parse_search_query('is:unassigned') == [
+            SearchFilter(
+                key=SearchKey(name='unassigned'),
+                operator='=',
+                value=SearchValue(True),
+            ),
+        ]
+        assert parse_search_query('is:assigned') == [
+            SearchFilter(
+                key=SearchKey(name='unassigned'),
+                operator='=',
+                value=SearchValue(False),
+            ),
+        ]
+
+        assert parse_search_query('!is:unassigned') == [
+            SearchFilter(
+                key=SearchKey(name='unassigned'),
+                operator='!=',
+                value=SearchValue(True),
+            ),
+        ]
+        assert parse_search_query('!is:assigned') == [
+            SearchFilter(
+                key=SearchKey(name='unassigned'),
+                operator='!=',
+                value=SearchValue(False),
+            ),
+        ]
+
+    def test_is_query_status(self):
+        for status_string, status_val in STATUS_CHOICES.items():
+            assert parse_search_query('is:%s' % status_string) == [
+                SearchFilter(
+                    key=SearchKey(name='status'),
+                    operator='=',
+                    value=SearchValue(status_val),
+                ),
+            ]
+            assert parse_search_query('!is:%s' % status_string) == [
+                SearchFilter(
+                    key=SearchKey(name='status'),
+                    operator='!=',
+                    value=SearchValue(status_val),
+                ),
+            ]
+
+    def test_is_query_invalid(self):
+        with self.assertRaises(InvalidSearchQuery) as cm:
+            parse_search_query('is:wrong')
+
+        assert cm.exception.message.startswith(
+            'Invalid value for "is" search, valid values are',
+        )
+
+
+class ConvertQueryValuesTest(TestCase):
+
+    def test_valid_converter(self):
+        filters = [SearchFilter(SearchKey('assigned_to'), '=', SearchValue('me'))]
+        expected = value_converters['assigned_to'](
+            filters[0].value.raw_value,
+            [self.project],
+            self.user,
+        )
+        filters = convert_query_values(filters, [self.project], self.user)
+        assert filters[0].value.raw_value == expected
+
+    def test_no_converter(self):
+        search_val = SearchValue('me')
+        filters = [SearchFilter(SearchKey('something'), '=', search_val)]
+        filters = convert_query_values(filters, [self.project], self.user)
+        assert filters[0].value.raw_value == search_val.raw_value
+
+
+class ConvertActorValueTest(TestCase):
+    def test_user(self):
+        assert convert_actor_value(
+            'me',
+            [self.project],
+            self.user,
+        ) == convert_user_value('me', [self.project], self.user)
+
+    def test_team(self):
+        assert convert_actor_value(
+            '#%s' % self.team.slug,
+            [self.project],
+            self.user,
+        ) == self.team
+
+    def test_invalid_team(self):
+        assert convert_actor_value(
+            '#never_upgrade',
+            [self.project],
+            self.user,
+        ).id == 0
+
+
+class ConvertUserValueTest(TestCase):
+    def test_me(self):
+        assert convert_user_value('me', [self.project], self.user) == self.user
+
+    def test_specified_user(self):
+        user = self.create_user()
+        assert convert_user_value(user.username, [self.project], self.user) == user
+
+    def test_invalid_user(self):
+        assert convert_user_value('fake-user', [], None).id == 0


### PR DESCRIPTION
`IssueSearchVisitor` adds some extra logic for handling `is` queries, and includes key mappings
for existing searches handled by the current `parse_query` method.

Also add in the concept of value converters, which convert the value corresponding to a specific key
into another value. This seemed to make sense outside of the parser since it's not directly related
to the parsing logic, but could include it in the core class if people think it's useful there.