### PR TITLE
ref: Fetch events by id or event_id in a common Manager

### DIFF
--- a/src/sentry/api/endpoints/event_apple_crash_report.py
+++ b/src/sentry/api/endpoints/event_apple_crash_report.py
@@ -30,9 +30,8 @@ class EventAppleCrashReportEndpoint(Endpoint):
         and not the event ID that is reported by the client upon submission.
         This works only if the event.platform == cocoa
         """
-        try:
-            event = Event.objects.get(id=event_id)
-        except Event.DoesNotExist:
+        event = Event.get_event(event_id)
+        if event is None:
             raise ResourceDoesNotExist
 
         self.check_object_permissions(request, event.group)

--- a/src/sentry/api/endpoints/event_apple_crash_report.py
+++ b/src/sentry/api/endpoints/event_apple_crash_report.py
@@ -30,7 +30,7 @@ class EventAppleCrashReportEndpoint(Endpoint):
         and not the event ID that is reported by the client upon submission.
         This works only if the event.platform == cocoa
         """
-        event = Event.objects.from_event_id(event_id, None)
+        event = Event.objects.from_event_id(event_id, project_id=None)
         if event is None:
             raise ResourceDoesNotExist
 

--- a/src/sentry/api/endpoints/event_apple_crash_report.py
+++ b/src/sentry/api/endpoints/event_apple_crash_report.py
@@ -30,7 +30,7 @@ class EventAppleCrashReportEndpoint(Endpoint):
         and not the event ID that is reported by the client upon submission.
         This works only if the event.platform == cocoa
         """
-        event = Event.get_event(event_id)
+        event = Event.objects.from_event_id(event_id, None)
         if event is None:
             raise ResourceDoesNotExist
 

--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -40,15 +40,12 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
         :pparam string attachment_id: the id of the attachment.
         :auth: required
         """
-        if not features.has('organizations:event-attachments', project.organization, actor=request.user):
+        if not features.has('organizations:event-attachments',
+                            project.organization, actor=request.user):
             return self.respond(status=404)
 
-        try:
-            event = Event.objects.get(
-                id=event_id,
-                project_id=project.id,
-            )
-        except Event.DoesNotExist:
+        event = Event.get_event(event_id, project.id)
+        if event is None:
             return self.respond({'detail': 'Event not found'}, status=404)
 
         try:

--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -44,7 +44,7 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
                             project.organization, actor=request.user):
             return self.respond(status=404)
 
-        event = Event.get_event(event_id, project.id)
+        event = Event.objects.from_event_id(event_id, project.id)
         if event is None:
             return self.respond({'detail': 'Event not found'}, status=404)
 

--- a/src/sentry/api/endpoints/event_attachments.py
+++ b/src/sentry/api/endpoints/event_attachments.py
@@ -24,12 +24,8 @@ class EventAttachmentsEndpoint(ProjectEndpoint):
                             project.organization, actor=request.user):
             return self.respond(status=404)
 
-        try:
-            event = Event.objects.get(
-                id=event_id,
-                project_id=project.id,
-            )
-        except Event.DoesNotExist:
+        event = Event.get_event(event_id, project.id)
+        if event is None:
             return self.respond({'detail': 'Event not found'}, status=404)
 
         queryset = EventAttachment.objects.filter(

--- a/src/sentry/api/endpoints/event_attachments.py
+++ b/src/sentry/api/endpoints/event_attachments.py
@@ -24,7 +24,7 @@ class EventAttachmentsEndpoint(ProjectEndpoint):
                             project.organization, actor=request.user):
             return self.respond(status=404)
 
-        event = Event.get_event(event_id, project.id)
+        event = Event.objects.from_event_id(event_id, project.id)
         if event is None:
             return self.respond({'detail': 'Event not found'}, status=404)
 

--- a/src/sentry/api/endpoints/event_details.py
+++ b/src/sentry/api/endpoints/event_details.py
@@ -23,7 +23,7 @@ class EventDetailsEndpoint(Endpoint):
         is the event as it appears in the Sentry database and not the event
         ID that is reported by the client upon submission.
         """
-        event = Event.objects.from_event_id(event_id, None)
+        event = Event.objects.from_event_id(event_id, project_id=None)
         if event is None:
             raise ResourceDoesNotExist
 

--- a/src/sentry/api/endpoints/event_details.py
+++ b/src/sentry/api/endpoints/event_details.py
@@ -23,9 +23,8 @@ class EventDetailsEndpoint(Endpoint):
         is the event as it appears in the Sentry database and not the event
         ID that is reported by the client upon submission.
         """
-        try:
-            event = Event.objects.get(id=event_id)
-        except Event.DoesNotExist:
+        event = Event.get_event(event_id)
+        if event is None:
             raise ResourceDoesNotExist
 
         self.check_object_permissions(request, event.group)

--- a/src/sentry/api/endpoints/event_details.py
+++ b/src/sentry/api/endpoints/event_details.py
@@ -23,7 +23,7 @@ class EventDetailsEndpoint(Endpoint):
         is the event as it appears in the Sentry database and not the event
         ID that is reported by the client upon submission.
         """
-        event = Event.get_event(event_id)
+        event = Event.objects.from_event_id(event_id, None)
         if event is None:
             raise ResourceDoesNotExist
 

--- a/src/sentry/api/endpoints/event_file_committers.py
+++ b/src/sentry/api/endpoints/event_file_committers.py
@@ -21,7 +21,7 @@ class EventFileCommittersEndpoint(ProjectEndpoint):
                                  retrieve (as reported by the raven client).
         :auth: required
         """
-        event = Event.get_event(event_id, project.id)
+        event = Event.objects.from_event_id(event_id, project.id)
         if event is None:
             return Response({'detail': 'Event not found'}, status=404)
 

--- a/src/sentry/api/endpoints/event_file_committers.py
+++ b/src/sentry/api/endpoints/event_file_committers.py
@@ -21,12 +21,8 @@ class EventFileCommittersEndpoint(ProjectEndpoint):
                                  retrieve (as reported by the raven client).
         :auth: required
         """
-        try:
-            event = Event.objects.get(
-                id=event_id,
-                project_id=project.id,
-            )
-        except Event.DoesNotExist:
+        event = Event.get_event(event_id, project.id)
+        if event is None:
             return Response({'detail': 'Event not found'}, status=404)
 
         # populate event data

--- a/src/sentry/api/endpoints/event_owners.py
+++ b/src/sentry/api/endpoints/event_owners.py
@@ -21,7 +21,7 @@ class EventOwnersEndpoint(ProjectEndpoint):
         :auth: required
         """
 
-        event = Event.get_event(event_id, project.id)
+        event = Event.objects.from_event_id(event_id, project.id)
         if event is None:
             return Response({'detail': 'Event not found'}, status=404)
 

--- a/src/sentry/api/endpoints/event_owners.py
+++ b/src/sentry/api/endpoints/event_owners.py
@@ -20,12 +20,9 @@ class EventOwnersEndpoint(ProjectEndpoint):
         :pparam string event_id: the id of the event.
         :auth: required
         """
-        try:
-            event = Event.objects.get(
-                id=event_id,
-                project_id=project.id,
-            )
-        except Event.DoesNotExist:
+
+        event = Event.get_event(event_id, project.id)
+        if event is None:
             return Response({'detail': 'Event not found'}, status=404)
 
         # populate event data

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -9,7 +9,6 @@ from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import DetailedEventSerializer, serialize
 from sentry.models import Event
 from sentry.utils.apidocs import scenario, attach_scenarios
-from sentry.utils.validators import is_event_id
 
 
 @scenario('RetrieveEventForProject')
@@ -42,26 +41,7 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
         :auth: required
         """
 
-        event = None
-        # If its a numeric string, check if it's an event Primary Key first
-        if event_id.isdigit():
-            try:
-                event = Event.objects.get(
-                    id=event_id,
-                    project_id=project.id,
-                )
-            except Event.DoesNotExist:
-                pass
-        # If it was not found as a PK, and its a possible event_id, search by that instead.
-        if event is None and is_event_id(event_id):
-            try:
-                event = Event.objects.get(
-                    event_id=event_id,
-                    project_id=project.id,
-                )
-            except Event.DoesNotExist:
-                pass
-
+        event = Event.get_event(event_id, project.id)
         if event is None:
             return Response({'detail': 'Event not found'}, status=404)
 

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -41,7 +41,7 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
         :auth: required
         """
 
-        event = Event.get_event(event_id, project.id)
+        event = Event.objects.from_event_id(event_id, project.id)
         if event is None:
             return Response({'detail': 'Event not found'}, status=404)
 

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -146,7 +146,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                 except Group.DoesNotExist:
                     pass
                 else:
-                    matching_event = Event.get_event(query, project.id)
+                    matching_event = Event.objects.from_event_id(query, project.id)
                     if matching_event is not None:
                         Event.objects.bind_nodes([matching_event], 'data')
             elif matching_group is None:

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -146,12 +146,8 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                 except Group.DoesNotExist:
                     pass
                 else:
-                    try:
-                        matching_event = Event.objects.get(
-                            event_id=query, project_id=project.id)
-                    except Event.DoesNotExist:
-                        pass
-                    else:
+                    matching_event = Event.get_event(query, project.id)
+                    if matching_event is not None:
                         Event.objects.bind_nodes([matching_event], 'data')
             elif matching_group is None:
                 matching_group = get_by_short_id(

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -20,14 +20,18 @@ from hashlib import md5
 from sentry import eventtypes
 from sentry.constants import EVENT_ORDERING_KEY
 from sentry.db.models import (
-    BoundedBigIntegerField, BoundedIntegerField, Model, NodeField, sane_repr
+    BoundedBigIntegerField,
+    BoundedIntegerField,
+    Model,
+    NodeField,
+    sane_repr
 )
+from sentry.db.models.manager import EventManager
 from sentry.interfaces.base import get_interfaces
 from sentry.utils.cache import memoize
 from sentry.utils.canonical import CanonicalKeyDict, CanonicalKeyView
 from sentry.utils.safe import get_path
 from sentry.utils.strings import truncatechars
-from sentry.utils.validators import is_event_id
 
 
 class Event(Model):
@@ -50,6 +54,8 @@ class Event(Model):
         ref_version=2,
         wrapper=CanonicalKeyDict,
     )
+
+    objects = EventManager()
 
     class Meta:
         app_label = 'sentry'
@@ -342,8 +348,8 @@ class Event(Model):
             group_id=self.group_id,
         ).exclude(id=self.id).order_by('datetime')[0:5]
 
-        events = [e for e in events if e.datetime == self.datetime and e.id > self.id or
-                  e.datetime > self.datetime]
+        events = [e for e in events if e.datetime == self.datetime and e.id > self.id
+                  or e.datetime > self.datetime]
         events.sort(key=EVENT_ORDERING_KEY)
         return events[0] if events else None
 
@@ -354,52 +360,10 @@ class Event(Model):
             group_id=self.group_id,
         ).exclude(id=self.id).order_by('-datetime')[0:5]
 
-        events = [e for e in events if e.datetime == self.datetime and e.id < self.id or
-                  e.datetime < self.datetime]
+        events = [e for e in events if e.datetime == self.datetime and e.id < self.id
+                  or e.datetime < self.datetime]
         events.sort(key=EVENT_ORDERING_KEY, reverse=True)
         return events[0] if events else None
-
-    @classmethod
-    def get_event(cls, id_or_event_id, project_id=None):
-        """
-        Get an Event by either its id primary key or its hex event_id.
-
-        Will automatically try to infer the type of id, and grab the correct
-        event.  If the provided id is a hex event_id, the project_id must also
-        be provided to disambiguate it.
-
-        Returns None if the event cannot be found under either scheme.
-        """
-        # TODO (alexh) instrument this to report any times we are still trying
-        # to get events by id.
-        # TODO (alexh) deprecate lookup by id so we can move to snuba.
-
-        event = None
-        if id_or_event_id.isdigit():
-            # If its a numeric string, check if it's an event Primary Key first
-            try:
-                if project_id is None:
-                    event = cls.objects.get(
-                        id=id_or_event_id,
-                    )
-                else:
-                    event = cls.objects.get(
-                        id=id_or_event_id,
-                        project_id=project_id,
-                    )
-            except Event.DoesNotExist:
-                pass
-        # If it was not found as a PK, and its a possible event_id, search by that instead.
-        if project_id is not None and event is None and is_event_id(id_or_event_id):
-            try:
-                event = cls.objects.get(
-                    event_id=id_or_event_id,
-                    project_id=project_id,
-                )
-            except Event.DoesNotExist:
-                pass
-
-        return event
 
 
 class EventSubjectTemplate(string.Template):

--- a/src/sentry/models/rawevent.py
+++ b/src/sentry/models/rawevent.py
@@ -10,7 +10,13 @@ from __future__ import absolute_import
 from django.db import models
 from django.utils import timezone
 
-from sentry.db.models import (Model, NodeField, FlexibleForeignKey, sane_repr)
+from sentry.db.models import (
+    Model,
+    NodeField,
+    FlexibleForeignKey,
+    sane_repr
+)
+from sentry.db.models.manager import EventManager
 from sentry.utils.canonical import CanonicalKeyView
 
 
@@ -27,6 +33,8 @@ class RawEvent(Model):
         ref_version=1,
         wrapper=CanonicalKeyView,
     )
+
+    objects = EventManager()
 
     class Meta:
         app_label = 'sentry'


### PR DESCRIPTION
In preparation for using Snuba as the source of truth for events,
force Event.objects.get() type calls through a helper method that
adds the ability to use hex ids in all API endpoints, while also
allowing us to track the usage of the different id types.