### PR TITLE
feat(deletions): Created a mixin to handle renaming pending deletions.

### DIFF
--- a/src/sentry/api/serializers/models/repository.py
+++ b/src/sentry/api/serializers/models/repository.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import six
 
 from sentry.api.serializers import Serializer, register
-from sentry.models import ObjectStatus, Repository
+from sentry.models import Repository
 
 
 @register(Repository)
@@ -26,14 +26,9 @@ class RepositorySerializer(Serializer):
                 'name': 'Unknown Provider',
             }
 
-        if obj.status == ObjectStatus.PENDING_DELETION:
-            repo_name = obj.config.get('pending_deletion_name', obj.name)
-        else:
-            repo_name = obj.name
-
         return {
             'id': six.text_type(obj.id),
-            'name': repo_name,
+            'name': obj.config.get('pending_deletion_name', obj.name),
             'url': obj.url,
             'provider': provider,
             'status': obj.get_status_display(),

--- a/src/sentry/api/serializers/models/repository.py
+++ b/src/sentry/api/serializers/models/repository.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import six
 
 from sentry.api.serializers import Serializer, register
-from sentry.models import Repository
+from sentry.models import ObjectStatus, Repository
 
 
 @register(Repository)
@@ -25,13 +25,19 @@ class RepositorySerializer(Serializer):
                 'id': 'unknown',
                 'name': 'Unknown Provider',
             }
+
+        if obj.status == ObjectStatus.PENDING_DELETION:
+            repo_name = obj.config.get('pending_deletion_name', obj.name)
+        else:
+            repo_name = obj.name
+
         return {
             'id': six.text_type(obj.id),
-            'name': obj.name,
+            'name': repo_name,
             'url': obj.url,
             'provider': provider,
             'status': obj.get_status_display(),
             'dateCreated': obj.date_added,
             'integrationId': integration_id,
-            'externalSlug': external_slug
+            'externalSlug': external_slug,
         }

--- a/src/sentry/db/mixin.py
+++ b/src/sentry/db/mixin.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import logging
 import six
 
-from time import time
+from uuid import uuid4
 
 from sentry.models import OrganizationOption
 
@@ -27,7 +27,7 @@ class PendingDeletionMixin(object):
 
         for field in fields:
             original_data[field] = getattr(self, field)
-            setattr(self, field, '%s %d' % (original_data[field], time()))
+            setattr(self, field, uuid4().hex)
 
         self.save()
         original_data['id'] = self.id
@@ -54,8 +54,8 @@ class PendingDeletionMixin(object):
 
     def reset_pending_deletion_field_names(self):
         try:
-            original_data = self.get_pending_deletion_option().value
-        except self.__class__.DoesNotExist:
+            option = self.get_pending_deletion_option()
+        except OrganizationOption.DoesNotExist:
             logger.info(
                 'reset-on-pending-deletion.does-not-exist',
                 extra={
@@ -66,7 +66,7 @@ class PendingDeletionMixin(object):
             )
             return False
 
-        for field_name, field_value in six.iteritems(original_data):
+        for field_name, field_value in six.iteritems(option.value):
             if field_name in ('id', 'model'):
                 continue
             setattr(self, field_name, field_value)

--- a/src/sentry/db/mixin.py
+++ b/src/sentry/db/mixin.py
@@ -2,23 +2,22 @@ from __future__ import absolute_import
 
 import six
 
-
 from uuid import uuid4
 
+from sentry.api.base import logger
 from sentry.models import OrganizationOption
 
 
 def delete_pending_deletion_option(instance, **kwargs):
-    if not issubclass(instance.__class__, PendingDeletionMixin):
-        return
-    instance.delete_pending_deletion_option()
+    if hasattr(instance, 'delete_pending_deletion_option'):
+        instance.delete_pending_deletion_option()
 
 
 class PendingDeletionMixin(object):
     _rename_fields_on_pending_delete = []
 
     def build_pending_deletion_key(self):
-        return 'pending-delete:%s:%s' % (self.__class__, self.id)
+        return 'pending-delete:%s:%s' % (self.__class__.__name__, self.id)
 
     def rename_on_pending_deletion(self, fields=None):
         fields = fields or self._rename_fields_on_pending_delete
@@ -30,11 +29,19 @@ class PendingDeletionMixin(object):
 
         self.save()
         original_data['id'] = self.id
-        original_data['model'] = self.__class__
+        original_data['model'] = self.__class__.__name__
         OrganizationOption.objects.create(
             organization_id=self.organization_id,
             key=self.build_pending_deletion_key(),
             value=original_data,
+        )
+        logger.info(
+            'rename-on-pending-deletion',
+            extra={
+                'organization_id': self.organization_id,
+                'model': original_data['model'],
+                'id': original_data['id'],
+            }
         )
 
     def get_pending_deletion_option(self):
@@ -44,13 +51,53 @@ class PendingDeletionMixin(object):
         )
 
     def reset_pending_deletion_field_names(self):
-        original_data = self.get_pending_deletion_option().value
+        try:
+            original_data = self.get_pending_deletion_option().value
+        except self.__class__.DoesNotExist:
+            logger.info(
+                'reset-on-pending-deletion:does-not-exist',
+                extra={
+                    'organization_id': self.organization_id,
+                    'model': self.__class__.__name__,
+                    'id': self.id,
+                }
+            )
+            return False
+
         for field_name, field_value in six.iteritems(original_data):
             if field_name in ('id', 'model'):
                 continue
             setattr(self, field_name, field_value)
         self.save()
+        logger.info(
+            'reset-on-pending-deletion:success',
+            extra={
+                'organization_id': self.organization_id,
+                'model': self.__class__.__name__,
+                'id': self.id,
+            }
+        )
+        return True
 
     def delete_pending_deletion_option(self):
-        option = self.get_pending_deletion_option()
+        try:
+            option = self.get_pending_deletion_option()
+        except self.__class__.DoesNotExist:
+            logger.info(
+                'delete-pending-deletion-option:does-not-exist',
+                extra={
+                    'organization_id': self.organization_id,
+                    'model': self.__class__.__name__,
+                    'id': self.id,
+                }
+            )
+            return
         option.delete()
+        logger.info(
+            'delete-pending-deletion-option:success',
+            extra={
+                'organization_id': self.organization_id,
+                'model': self.__class__.__name__,
+                'id': self.id,
+            }
+        )

--- a/src/sentry/db/mixin.py
+++ b/src/sentry/db/mixin.py
@@ -1,0 +1,56 @@
+from __future__ import absolute_import
+
+import six
+
+
+from uuid import uuid4
+
+from sentry.models import OrganizationOption
+
+
+def delete_pending_deletion_option(instance, **kwargs):
+    if not issubclass(instance.__class__, PendingDeletionMixin):
+        return
+    instance.delete_pending_deletion_option()
+
+
+class PendingDeletionMixin(object):
+    _rename_fields_on_pending_delete = []
+
+    def build_pending_deletion_key(self):
+        return 'pending-delete:%s:%s' % (self.__class__, self.id)
+
+    def rename_on_pending_deletion(self, fields=None):
+        fields = fields or self._rename_fields_on_pending_delete
+        original_data = {}
+
+        for field in fields:
+            original_data[field] = getattr(self, field)
+            setattr(self, field, uuid4().hex)
+
+        self.save()
+        original_data['id'] = self.id
+        original_data['model'] = self.__class__
+        OrganizationOption.objects.create(
+            organization_id=self.organization_id,
+            key=self.build_pending_deletion_key(),
+            value=original_data,
+        )
+
+    def get_pending_deletion_option(self):
+        return OrganizationOption.objects.get(
+            organization_id=self.organization_id,
+            key=self.build_pending_deletion_key(),
+        )
+
+    def reset_pending_deletion_field_names(self):
+        original_data = self.get_pending_deletion_option().value
+        for field_name, field_value in six.iteritems(original_data):
+            if field_name in ('id', 'model'):
+                continue
+            setattr(self, field_name, field_value)
+        self.save()
+
+    def delete_pending_deletion_option(self):
+        option = self.get_pending_deletion_option()
+        option.delete()

--- a/src/sentry/db/mixin.py
+++ b/src/sentry/db/mixin.py
@@ -84,15 +84,7 @@ class PendingDeletionMixin(object):
     def delete_pending_deletion_option(self):
         try:
             option = self.get_pending_deletion_option()
-        except self.__class__.DoesNotExist:
-            logger.info(
-                'delete-pending-deletion-option.does-not-exist',
-                extra={
-                    'organization_id': self.organization_id,
-                    'model': self.__class__.__name__,
-                    'id': self.id,
-                }
-            )
+        except OrganizationOption.DoesNotExist:
             return
         option.delete()
         logger.info(

--- a/src/sentry/db/mixin.py
+++ b/src/sentry/db/mixin.py
@@ -29,7 +29,7 @@ class PendingDeletionMixin(object):
             original_data[field] = getattr(self, field)
             setattr(self, field, uuid4().hex)
 
-        self.save()
+        self.save(update_fields=fields)
         original_data['id'] = self.id
         original_data['model'] = self.__class__.__name__
         OrganizationOption.objects.create(
@@ -70,7 +70,7 @@ class PendingDeletionMixin(object):
             if field_name in ('id', 'model'):
                 continue
             setattr(self, field_name, field_value)
-        self.save()
+        self.save(update_fields=[k for k in six.iterkeys(option.value) if k not in ('id', 'model')])
         logger.info(
             'reset-on-pending-deletion.success',
             extra={

--- a/src/sentry/db/mixin.py
+++ b/src/sentry/db/mixin.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import logging
 import six
 
-from uuid import uuid4
+from time import time
 
 from sentry.models import OrganizationOption
 
@@ -27,7 +27,7 @@ class PendingDeletionMixin(object):
 
         for field in fields:
             original_data[field] = getattr(self, field)
-            setattr(self, field, uuid4().hex)
+            setattr(self, field, '%s %d' % (original_data[field], time()))
 
         self.save()
         original_data['id'] = self.id

--- a/src/sentry/db/mixin.py
+++ b/src/sentry/db/mixin.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import
 
+import logging
 import six
 
 from uuid import uuid4
 
-from sentry.api.base import logger
 from sentry.models import OrganizationOption
+
+logger = logging.getLogger('sentry.deletions')
 
 
 def delete_pending_deletion_option(instance, **kwargs):
@@ -55,7 +57,7 @@ class PendingDeletionMixin(object):
             original_data = self.get_pending_deletion_option().value
         except self.__class__.DoesNotExist:
             logger.info(
-                'reset-on-pending-deletion:does-not-exist',
+                'reset-on-pending-deletion.does-not-exist',
                 extra={
                     'organization_id': self.organization_id,
                     'model': self.__class__.__name__,
@@ -70,7 +72,7 @@ class PendingDeletionMixin(object):
             setattr(self, field_name, field_value)
         self.save()
         logger.info(
-            'reset-on-pending-deletion:success',
+            'reset-on-pending-deletion.success',
             extra={
                 'organization_id': self.organization_id,
                 'model': self.__class__.__name__,
@@ -84,7 +86,7 @@ class PendingDeletionMixin(object):
             option = self.get_pending_deletion_option()
         except self.__class__.DoesNotExist:
             logger.info(
-                'delete-pending-deletion-option:does-not-exist',
+                'delete-pending-deletion-option.does-not-exist',
                 extra={
                     'organization_id': self.organization_id,
                     'model': self.__class__.__name__,
@@ -94,7 +96,7 @@ class PendingDeletionMixin(object):
             return
         option.delete()
         logger.info(
-            'delete-pending-deletion-option:success',
+            'delete-pending-deletion-option.success',
             extra={
                 'organization_id': self.organization_id,
                 'model': self.__class__.__name__,

--- a/src/sentry/db/mixin.py
+++ b/src/sentry/db/mixin.py
@@ -16,7 +16,7 @@ def delete_pending_deletion_option(instance, **kwargs):
 
 
 class PendingDeletionMixin(object):
-    _rename_fields_on_pending_delete = []
+    _rename_fields_on_pending_delete = frozenset()
 
     def build_pending_deletion_key(self):
         return 'pending-delete:%s:%s' % (self.__class__.__name__, self.id)

--- a/src/sentry/db/mixin.py
+++ b/src/sentry/db/mixin.py
@@ -29,7 +29,7 @@ class PendingDeletionMixin(object):
             original_data[field] = getattr(self, field)
             setattr(self, field, uuid4().hex)
 
-        self.save(update_fields=fields)
+        self.save()
         original_data['id'] = self.id
         original_data['model'] = self.__class__.__name__
         OrganizationOption.objects.create(
@@ -70,7 +70,7 @@ class PendingDeletionMixin(object):
             if field_name in ('id', 'model'):
                 continue
             setattr(self, field_name, field_value)
-        self.save(update_fields=[k for k in six.iterkeys(option.value) if k not in ('id', 'model')])
+        self.save()
         logger.info(
             'reset-on-pending-deletion.success',
             extra={

--- a/src/sentry/models/repository.py
+++ b/src/sentry/models/repository.py
@@ -67,6 +67,17 @@ class Repository(Model, PendingDeletionMixin):
             html_template='sentry/emails/unable-to-delete-repo.html',
         )
 
+    def rename_on_pending_deletion(self, fields=None):
+        # Due to the fact that Repository is shown to the user
+        # as it is pending deletion, this is added to display the fields
+        # correctly to the user.
+        self.config['pending_deletion_name'] = self.name
+        super(Repository, self).rename_on_pending_deletion(fields)
+
+    def reset_pending_deletion_field_names(self):
+        del self.config['pending_deletion_name']
+        super(Repository, self).reset_pending_deletion_field_names()
+
 
 def on_delete(instance, actor=None, **kwargs):
     # If there is no provider, we don't have any webhooks, etc to delete

--- a/src/sentry/models/repository.py
+++ b/src/sentry/models/repository.py
@@ -37,7 +37,7 @@ class Repository(Model, PendingDeletionMixin):
 
     __repr__ = sane_repr('organization_id', 'name', 'provider')
 
-    _rename_fields_on_pending_delete = ['name', 'external_id']
+    _rename_fields_on_pending_delete = frozenset(['name', 'external_id'])
 
     def has_integration_provider(self):
         return self.provider and self.provider.startswith('integrations:')

--- a/tests/sentry/api/endpoints/test_organization_repository_details.py
+++ b/tests/sentry/api/endpoints/test_organization_repository_details.py
@@ -103,15 +103,16 @@ class OrganizationRepositoryDeleteTest(APITestCase):
                 repo.id,
             ]
         )
-        response = self.client.delete(url)
+        with patch('sentry.db.mixin.time', new_callable=lambda: lambda: 1234567):
+            response = self.client.delete(url)
         assert response.status_code == 202, (response.status_code, response.content)
 
         repo = Repository.objects.get(id=repo.id)
         assert repo.status == ObjectStatus.PENDING_DELETION
 
         # renamed on pending delete
-        assert repo.name != 'example'
-        assert repo.external_id != '12345'
+        assert repo.name == 'example 1234567'
+        assert repo.external_id == '12345 1234567'
 
         mock_delete_repository.apply_async.assert_called_with(
             kwargs={

--- a/tests/sentry/db/test_mixin.py
+++ b/tests/sentry/db/test_mixin.py
@@ -21,12 +21,25 @@ class RenamePendingDeleteTest(TestCase):
 
         self.mock_uuid4 = MockUuid4
 
+    def assert_organization_option(self, repo):
+        option = OrganizationOption.objects.get(
+            organization_id=repo.organization_id,
+            key=repo.build_pending_deletion_key(),
+        )
+        assert option.value == {
+            'id': repo.id,
+            'model': Repository.__name__,
+            'name': 'example/name',
+            'external_id': 'external_id',
+        }
+
     def test_rename_on_pending_deletion(self):
         with patch('sentry.db.mixin.uuid4', new=self.mock_uuid4):
             self.repository.rename_on_pending_deletion()
         repo = Repository.objects.get(id=self.repository.id)
         assert repo.name == '1234567'
         assert repo.external_id == '1234567'
+        self.assert_organization_option(repo)
 
     def test_reset_pending_deletion_field_names(self):
         self.repository.rename_on_pending_deletion()
@@ -34,10 +47,12 @@ class RenamePendingDeleteTest(TestCase):
         repo = Repository.objects.get(id=self.repository.id)
         assert repo.name == 'example/name'
         assert repo.external_id == 'external_id'
+        self.assert_organization_option(repo)
 
     def test_delete_pending_deletion_option(self):
         self.repository.rename_on_pending_deletion()
         self.repository.delete()
         assert not OrganizationOption.objects.filter(
             organization_id=self.organization.id,
+            key=self.repository.build_pending_deletion_key(),
         ).exists()

--- a/tests/sentry/db/test_mixin.py
+++ b/tests/sentry/db/test_mixin.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import
+
+from sentry.models import OrganizationOption, Repository
+from sentry.testutils import TestCase
+
+
+class RenamePendingDeleteTest(TestCase):
+    def setUp(self):
+        super(RenamePendingDeleteTest, self).setUp()
+        self.repository = Repository.objects.create(
+            organization_id=self.organization.id,
+            name='name',
+            provider='provider',
+            external_id='external_id',
+        )
+
+    def test_rename_on_pending_deletion(self):
+        self.repository.rename_on_pending_deletion()
+        repo = Repository.objects.get(id=self.repository.id)
+        assert repo.name != 'name'
+        assert repo.external_id != 'external_id'
+
+    def test_reset_pending_deletion_field_names(self):
+        self.repository.rename_on_pending_deletion()
+        self.repository.reset_pending_deletion_field_names()
+        repo = Repository.objects.get(id=self.repository.id)
+        assert repo.name == 'name'
+        assert repo.external_id == 'external_id'
+
+    def test_delete_pending_deletion_option(self):
+        self.repository.rename_on_pending_deletion()
+        self.repository.delete()
+        assert not OrganizationOption.objects.filter(
+            organization_id=self.organization.id,
+        ).exists()

--- a/tests/sentry/db/test_mixin.py
+++ b/tests/sentry/db/test_mixin.py
@@ -16,12 +16,17 @@ class RenamePendingDeleteTest(TestCase):
             external_id='external_id',
         )
 
+        class MockUuid4:
+            hex = '1234567'
+
+        self.mock_uuid4 = MockUuid4
+
     def test_rename_on_pending_deletion(self):
-        with patch('sentry.db.mixin.time', new_callable=lambda: lambda: 1234567):
+        with patch('sentry.db.mixin.uuid4', new=self.mock_uuid4):
             self.repository.rename_on_pending_deletion()
         repo = Repository.objects.get(id=self.repository.id)
-        assert repo.name == 'example/name 1234567'
-        assert repo.external_id == 'external_id 1234567'
+        assert repo.name == '1234567'
+        assert repo.external_id == '1234567'
 
     def test_reset_pending_deletion_field_names(self):
         self.repository.rename_on_pending_deletion()


### PR DESCRIPTION
When complex models like `Repository` are deleted in Sentry, their status is marked as `PENDING_DELETION`. The model is then eventually deleted by an asynchronous task that handles deletion (which can take a long time depending on the data). In the meantime, if a user wishes to delete their `Repository` (or similar model), and then immediately recreate it with the same attributes, they will hit an error, because any unique keys would still be owned by the model pending deletion.

For example, if the user has a `Repository` with the following attributes:
```
Repository(organization_id=1, name='repo')
```
where `Repository` has a unqiue constraint on `(organization_id, name)`.

If the user deletes the repository, that repository's status is set to `PENDING_DELETION`. It then waits for the deletions task to delete it. But if, the user attempts to immediately recreate a repository with the same `name` and `organization_id`, they will be unable to for as long as the repository that is `PENDING_DELETION` still exists. This behavior is confusing to the user as there is no clear feedback or indication that this is what's happening.

This change will rename fields in the model that are pending deletion that must be unique. The original values are then saved in `OrganizationOptions`, so that, if necessary, the model's original values can be reclaimed.