### PR TITLE
fix(releases): Fix releases links

### DIFF
--- a/src/sentry/static/sentry/app/components/version.jsx
+++ b/src/sentry/static/sentry/app/components/version.jsx
@@ -1,12 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import SentryTypes from 'app/sentryTypes';
 import ProjectLink from 'app/components/projectLink';
 import Link from 'app/components/link';
 import {getShortVersion} from 'app/utils';
+import withOrganization from 'app/utils/withOrganization';
 
 class Version extends React.Component {
   static propTypes = {
+    organization: SentryTypes.Organization.isRequired,
     anchor: PropTypes.bool,
     version: PropTypes.string.isRequired,
     orgId: PropTypes.string,
@@ -20,11 +23,20 @@ class Version extends React.Component {
   };
 
   render() {
-    const {orgId, projectId, showShortVersion, version, anchor} = this.props;
+    const {
+      organization,
+      orgId,
+      projectId,
+      showShortVersion,
+      version,
+      anchor,
+    } = this.props;
     const versionTitle = showShortVersion ? getShortVersion(version) : version;
 
+    const hasSentry10 = new Set(organization.features).has('sentry10');
+
     if (anchor) {
-      if (projectId) {
+      if (projectId && !hasSentry10) {
         return (
           // NOTE: version is encoded because it can contain slashes "/",
           //       which can interfere with URL construction
@@ -35,14 +47,17 @@ class Version extends React.Component {
           </ProjectLink>
         );
       }
-      return (
-        <Link to={`/organizations/${orgId}/releases/${encodeURIComponent(version)}`}>
-          <span title={version}>{versionTitle}</span>
-        </Link>
-      );
+
+      if (orgId) {
+        return (
+          <Link to={`/organizations/${orgId}/releases/${encodeURIComponent(version)}`}>
+            <span title={version}>{versionTitle}</span>
+          </Link>
+        );
+      }
     }
     return <span title={version}>{versionTitle}</span>;
   }
 }
 
-export default Version;
+export default withOrganization(Version);

--- a/tests/js/spec/components/__snapshots__/resolutionBox.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/resolutionBox.spec.jsx.snap
@@ -233,12 +233,10 @@ exports[`ResolutionBox render() handles inRelease 1`] = `
       >
         This issue has been marked as resolved in version 
       </span>
-      <Version
-        anchor={true}
+      <WithOrganizationMockWrapper
         key="1"
         orgId="org"
         projectId="project"
-        showShortVersion={true}
         version="1.0"
       />
       <span
@@ -314,12 +312,10 @@ exports[`ResolutionBox render() handles inRelease with actor 1`] = `
       >
          marked this issue as resolved in version 
       </span>
-      <Version
-        anchor={true}
+      <WithOrganizationMockWrapper
         key="2"
         orgId="org"
         projectId="project"
-        showShortVersion={true}
         version="1.0"
       />
       <span


### PR DESCRIPTION
We need to check the Sentry 10 flag to determine which variant to
display. We should only display the static (non-link) variant if both
orgId and projectId are not passed. This caused an invalid link to be
generated in some cases.