### PR TITLE
fix(issues) Allow basic resolution with selections from multiple projects

### DIFF
--- a/src/sentry/static/sentry/app/components/actions/resolve.jsx
+++ b/src/sentry/static/sentry/app/components/actions/resolve.jsx
@@ -20,6 +20,7 @@ export default class ResolveActions extends React.Component {
     shouldConfirm: PropTypes.bool,
     confirmMessage: PropTypes.node,
     disabled: PropTypes.bool,
+    disableDropdown: PropTypes.bool,
     isResolved: PropTypes.bool,
     isAutoResolved: PropTypes.bool,
     confirmLabel: PropTypes.string,
@@ -95,6 +96,7 @@ export default class ResolveActions extends React.Component {
       shouldConfirm,
       disabled,
       confirmLabel,
+      disableDropdown,
     } = this.props;
 
     const buttonClass = this.getButtonClass();
@@ -141,7 +143,7 @@ export default class ResolveActions extends React.Component {
             className={buttonClass}
             title=""
             alwaysRenderMenu
-            disabled={disabled}
+            disabled={disableDropdown || disabled}
           >
             <MenuItem header={true}>{t('Resolved In')}</MenuItem>
             <MenuItem noAnchor={true}>

--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -321,7 +321,8 @@ const StreamActions = createReactClass({
 
     // resolve and merge require a single project to be active
     // in an org context projectId is null when 0 or >1 projects are selected.
-    const resolveDisabled = !(anySelected && projectId);
+    const resolveDisabled = !anySelected;
+    const resolveDropdownDisabled = !(anySelected && projectId);
     const mergeDisabled = !(multiSelected && projectId);
 
     return (
@@ -341,6 +342,7 @@ const StreamActions = createReactClass({
               confirmMessage={confirm('resolve', true)}
               confirmLabel={label('resolve')}
               disabled={resolveDisabled}
+              disableDropdown={resolveDropdownDisabled}
             />
             <IgnoreActions
               onUpdate={this.onUpdate}

--- a/tests/js/spec/components/actions/resolve.spec.jsx
+++ b/tests/js/spec/components/actions/resolve.spec.jsx
@@ -32,6 +32,40 @@ describe('ResolveActions', function() {
     });
   });
 
+  describe('disableDropdown', function() {
+    let component, button;
+    const spy = sinon.stub();
+
+    beforeEach(function() {
+      component = mount(
+        <ResolveActions
+          onUpdate={spy}
+          disableDropdown={true}
+          hasRelease={false}
+          orgId={'org-1'}
+          projectId={'proj-1'}
+        />,
+        TestStubs.routerContext()
+      );
+    });
+
+    it('main button is enabled', function() {
+      button = component.find('ActionLink[title="Resolve"]');
+      expect(button.prop('disabled')).toBeFalsy();
+    });
+
+    it('main button calls onUpdate when clicked', function() {
+      button = component.find('ActionLink[title="Resolve"]');
+      button.simulate('click');
+      expect(spy.called).toBe(true);
+    });
+
+    it('dropdown menu is disabled', function() {
+      button = component.find('DropdownLink');
+      expect(button.prop('disabled')).toBe(true);
+    });
+  });
+
   describe('resolved', function() {
     let component;
     const spy = sinon.stub();

--- a/tests/js/spec/views/stream/actions.spec.jsx
+++ b/tests/js/spec/views/stream/actions.spec.jsx
@@ -197,12 +197,13 @@ describe('StreamActions', function() {
 
     it('should disable resolve picker', function() {
       const resolve = wrapper.find('ResolveActions').first();
-      expect(resolve.props().disabled).toBeTruthy();
+      expect(resolve.props().disabled).toBe(true);
+      expect(resolve.props().disableDropdown).toBe(true);
     });
 
     it('should disable merge button', function() {
       const merge = wrapper.find('ActionLink[className~="action-merge"]').first();
-      expect(merge.props().disabled).toBeTruthy();
+      expect(merge.props().disabled).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Doing basic resolution should be allowed from the issue list across projects as there is no project specific release/commit data being used.

Fixes APP-1084