### PR TITLE
feat: Add feature list to organization serializer

### DIFF
--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -14,4 +14,15 @@ class OrganizationSerializerTest(TestCase):
         organization = self.create_organization(owner=user)
 
         result = serialize(organization, user)
+
         assert result['id'] == six.text_type(organization.id)
+        assert result['features'] == set([
+            'new-teams',
+            'shared-issues',
+            'repos',
+            'open-membership',
+            'invite-members',
+            'sso-saml2',
+            'sso-basic',
+            'suggested-commits'
+        ])


### PR DESCRIPTION
This change returns the features list for the organization index endpoint.
Since the home route for each organization now depends on which features
are active, we need to return the list of features in order to make the
organization switcher work.