### PR TITLE
ref(filters): Remove public registration API for inbound filters

### DIFF
--- a/src/sentry/filters/__init__.py
+++ b/src/sentry/filters/__init__.py
@@ -13,14 +13,13 @@ from .browser_extensions import BrowserExtensionsFilter
 from .legacy_browsers import LegacyBrowsersFilter
 from .web_crawlers import WebCrawlersFilter
 
-default_manager = FilterManager()
-default_manager.register(LocalhostFilter)
-default_manager.register(BrowserExtensionsFilter)
-default_manager.register(LegacyBrowsersFilter)
-default_manager.register(WebCrawlersFilter)
+default_manager = FilterManager([
+    LocalhostFilter,
+    BrowserExtensionsFilter,
+    LegacyBrowsersFilter,
+    WebCrawlersFilter,
+])
 
 all = default_manager.all
 exists = default_manager.exists
 get = default_manager.get
-register = default_manager.register
-unregister = default_manager.unregister

--- a/src/sentry/filters/manager.py
+++ b/src/sentry/filters/manager.py
@@ -12,8 +12,8 @@ class FilterNotRegistered(Exception):
 # TODO(dcramer): a lot of these managers are very similar and should abstracted
 # into some kind of base class
 class FilterManager(object):
-    def __init__(self):
-        self.__values = {}
+    def __init__(self, values):
+        self.__values = {cls.id: cls for cls in values}
 
     def __iter__(self):
         return six.itervalues(self.__values)
@@ -30,16 +30,3 @@ class FilterManager(object):
 
     def exists(self, id):
         return id in self.__values
-
-    def register(self, cls):
-        self.__values[cls.id] = cls
-
-    def unregister(self, cls):
-        try:
-            if self.__values[cls.id] != cls:
-                # dont allow unregistering of arbitrary provider
-                raise FilterNotRegistered(cls.id)
-        except KeyError:
-            # we gracefully handle a missing provider
-            return
-        del self.__values[cls.id]


### PR DESCRIPTION
The responsibility for inbound filters will be moving to Relay in the future and we won't be able to support this plugin-style registration as implemented today. Removing it earlier rather than later should hopefully prevent pain in the future, or at least let us know now if it is something that there is an overwhelming need to support moving forward (albeit the implementation will need to be different.)

I couldn't find any use of `filters.{register,unregister}` outside of this module (including in getsentry/getsentry and getsentry/sentry-plugins.)