### PR TITLE
fix: Chunked mass-deletion of raw events

### DIFF
--- a/src/sentry/tasks/reprocessing.py
+++ b/src/sentry/tasks/reprocessing.py
@@ -52,13 +52,31 @@ def create_reprocessing_report(project_id, event_id):
 def clear_expired_raw_events():
     from sentry.models import RawEvent, ProcessingIssue, ReprocessingReport
 
+    def batched_delete(model_cls, **filter):
+        # Django 1.6's `Queryset.delete` runs in this order:
+        #
+        # 1. Fetch all models
+        # 2. Call all `on_delete`s
+        # 3. Delete from DB (batched `DELETE WHERE id in (...)`)
+        #
+        # Since we attempt to unpickle `NodeField`s in Step 2, we might time
+        # out at that point and never do the delete.
+        #
+        # Better to delete a few rows than none.
+        while True:
+            result = model_cls.objects.filter(**filter)[:200]
+            if not result.exists():
+                break
+
+            result.delete()
+
     cutoff = timezone.now() - \
         timedelta(days=settings.SENTRY_RAW_EVENT_MAX_AGE_DAYS)
 
     # Clear old raw events and reprocessing reports
-    RawEvent.objects.filter(datetime__lt=cutoff).delete()
-    ReprocessingReport.objects.filter(datetime__lt=cutoff).delete()
+    batched_delete(RawEvent, datetime__lt=cutoff)
+    batched_delete(ReprocessingReport, datetime__lt=cutoff)
 
     # Processing issues get a bit of extra time before we delete them
     cutoff = timezone.now() - timedelta(days=int(settings.SENTRY_RAW_EVENT_MAX_AGE_DAYS * 1.3))
-    ProcessingIssue.objects.filter(datetime__lt=cutoff).delete()
+    batched_delete(ProcessingIssue, datetime__lt=cutoff)


### PR DESCRIPTION
At `Tue Feb  5 21:18:17 CET 2019` we would have had 4 Mio events to
delete. Those events keep accumulating.

This should be enough to work off the backlog *eventually*. Right now we
have 81 `RawEvents` created in the last 15 mins (=interval in which this
job runs), so if the task deletes 200 events and then times out we're already golden.

Probably still smarter to do a manual cleanup without timeout.