### PR TITLE
[WIP] fix(integrations): Update all relevant info when repo name changes

### DIFF
--- a/src/sentry/integrations/bitbucket/repository.py
+++ b/src/sentry/integrations/bitbucket/repository.py
@@ -51,6 +51,10 @@ class BitbucketRepositoryProvider(providers.IntegrationRepositoryProvider):
             repo.name = new_name
             updated = True
 
+        # building the URL manually here since it's not returned from the API
+        # see https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html#EventPayloads-entity_repository
+        # and click on 'Repository property' underneath the table for example data
+        # sadly, neither 'links' nor 'website' give us what we need
         new_url = u'https://bitbucket.org/{}'.format(data['name'])
         if repo.url != new_url:
             repo.url = new_url

--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -75,7 +75,7 @@ class PushEventWebhook(Webhook):
         if repo.config.get('name') != repo_full_name:
             repo.config['name'] = repo_full_name
             repo.name = repo_full_name
-            repo.url = event['repository']['website']  # TODO is this the right data???
+            repo.url = u'https://bitbucket.org/{}'.format(repo_full_name)
             repo.save()
 
         for change in event['push']['changes']:

--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -75,6 +75,10 @@ class PushEventWebhook(Webhook):
         if repo.config.get('name') != repo_full_name:
             repo.config['name'] = repo_full_name
             repo.name = repo_full_name
+            # building the URL manually here since it's not returned from the API
+            # see https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html#EventPayloads-entity_repository
+            # and click on 'Repository property' underneath the table for example data
+            # sadly, neither 'links' nor 'website' give us what we need
             repo.url = u'https://bitbucket.org/{}'.format(repo_full_name)
             repo.save()
 

--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -75,7 +75,7 @@ class PushEventWebhook(Webhook):
         if repo.config.get('name') != repo_full_name:
             repo.config['name'] = repo_full_name
             repo.name = repo_full_name
-            repo.url = u'https://bitbucket.org/{}'.format(repo_full_name)
+            repo.url = event['repository']['website']  # TODO is this the right data???
             repo.save()
 
         for change in event['push']['changes']:

--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -70,8 +70,12 @@ class PushEventWebhook(Webhook):
         except Repository.DoesNotExist:
             raise Http404()
 
-        if repo.config.get('name') != event['repository']['full_name']:
-            repo.config['name'] = event['repository']['full_name']
+        # update our data if repo name has changed
+        repo_full_name = event['repository']['full_name']
+        if repo.config.get('name') != repo_full_name:
+            repo.config['name'] = repo_full_name
+            repo.name = repo_full_name
+            repo.url = u'https://bitbucket.org/{}'.format(repo_full_name)
             repo.save()
 
         for change in event['push']['changes']:

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -73,10 +73,15 @@ class Webhook(object):
                 external_id=six.text_type(event['repository']['id']),
             )
             for repo in repos:
-                # We need to track GitHub's "full_name" which is the repository slug.
+                # We need to track GitHub's "full_name" which is the repository
+                # slug (in the form 'github_org_name/repo_name').
                 # This is needed to access the API since `external_id` isn't sufficient.
-                if repo.config.get('name') != event['repository']['full_name']:
-                    repo.config['name'] = event['repository']['full_name']
+                repo_full_name = event['repository']['full_name']
+                # update our data if repo name has changed
+                if repo.config.get('name') != repo_full_name:
+                    repo.config['name'] = repo_full_name
+                    repo.name = repo_full_name
+                    repo.url = u'https://github.com/{}'.format(repo_full_name)
                     repo.save()
 
                 self._handle(integration, event, orgs[repo.organization_id], repo)

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -81,7 +81,7 @@ class Webhook(object):
                 if repo.config.get('name') != repo_full_name:
                     repo.config['name'] = repo_full_name
                     repo.name = repo_full_name
-                    repo.url = u'https://github.com/{}'.format(repo_full_name)
+                    repo.url = event['repository']['html_url']
                     repo.save()
 
                 self._handle(integration, event, orgs[repo.organization_id], repo)

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -36,11 +36,11 @@ class IntegrationRepositoryProvider(object):
         else:
             # check to see if we already have this repository, and update any
             # data if applicable
-            repo = Repository.objects.get(
+            repo = Repository.objects.filter(
                 organization_id=organization.id,
                 provider=self.id,
                 external_id=config.get('external_id')
-            )
+            ).first()
             if repo is not None:
                 updated = self.update_repository_data(repo, config)
                 if updated:
@@ -151,7 +151,7 @@ class IntegrationRepositoryProvider(object):
         """
         return config
 
-    def update_repository_data(self, repo, new_data):
+    def update_repository_data(self, repo, data):
         """
         Update repo in database if necessary. Return True if update happened,
         False otherwise.

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -43,15 +43,15 @@ class IntegrationRepositoryProvider(object):
             ).first()
             if repo is not None:
                 updated = self.update_repository_data(repo, config)
-                if updated:
-                    return Response(serialize(repo, request.user), status=200)
-                return Response({
-                    'errors': {
-                        '__all__': 'A repository with that name already exists'
-                    }
-                },
-                    status=400,
-                )
+                if not updated:
+                    return Response({
+                        'errors': {
+                            '__all__': 'That repository already exists'
+                        }
+                    },
+                        status=400,
+                    )
+                return Response(serialize(repo, request.user), status=200)
 
         # at this point we know it's a new repo
         try:

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -40,7 +40,7 @@ class IntegrationRepositoryProvider(object):
                 organization_id=organization.id,
                 provider=self.id,
                 external_id=config.get('external_id')
-            ).first()
+            )[0]
             if repo is not None:
                 updated = self.update_repository_data(repo, config)
                 if not updated:


### PR DESCRIPTION
Right now, we update part of the `Repository` record when the repo name changes, but not all of it.

Still to do/figure out:

- how to handle GitHub vs GitHub enterprise vis-à-vis the URL - I did this based on how we do it in `build_repository_config`, but of course GitHub and GitHub enterprise have different versions of those methods. Should I make an `update_repo_data` function which could live on the GitHub `Webhook` class and get overridden by the GitHub enterprise hooks? There's no centralized place to put it for enterprise, though... Not sure the best way to handle this.

- deal with GitLab and/or Azure, if applicable