### PR TITLE
fix(issues) Handle partial query string data in global selection

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
@@ -17,6 +17,7 @@ import {
   updateParamsWithoutHistory,
   updateProjects,
 } from 'app/actionCreators/globalSelection';
+import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import Header from 'app/components/organizations/header';
 import HeaderItemPosition from 'app/components/organizations/headerItemPosition';
 import HeaderSeparator from 'app/components/organizations/headerSeparator';
@@ -94,6 +95,9 @@ class GlobalSelectionHeader extends React.Component {
     // We should update store if there are any relevant URL parameters when component
     // is mounted
     if (Object.values(stateFromRouter).some(i => !!i)) {
+      if (!stateFromRouter.start && !stateFromRouter.end && !stateFromRouter.period) {
+        stateFromRouter.period = DEFAULT_STATS_PERIOD;
+      }
       const {project, environment, start, end, period, utc} = stateFromRouter;
 
       // This will update store with values from URL parameters

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -141,6 +141,38 @@ describe('GlobalSelectionHeader', function() {
     });
   });
 
+  it('updates GlobalSelection store with default period', async function() {
+    mount(
+      <GlobalSelectionHeader organization={organization} />,
+      changeQuery(routerContext, {
+        environment: 'prod',
+      })
+    );
+
+    expect(router.push).not.toHaveBeenCalled();
+    expect(globalActions.updateDateTime).toHaveBeenCalledWith({
+      period: '14d',
+      utc: null,
+      start: null,
+      end: null,
+    });
+    expect(globalActions.updateProjects).toHaveBeenCalledWith([]);
+    expect(globalActions.updateEnvironments).toHaveBeenCalledWith(['prod']);
+
+    await tick();
+
+    expect(GlobalSelectionStore.get()).toEqual({
+      datetime: {
+        period: '14d',
+        utc: null,
+        start: null,
+        end: null,
+      },
+      environments: ['prod'],
+      projects: [],
+    });
+  });
+
   it('does not update store if url params have not changed', async function() {
     const wrapper = mount(
       <GlobalSelectionHeader organization={organization} />,


### PR DESCRIPTION
When we get a partial global search filter set, we were initializing all of the datetime values to null/undefined. This resulted in invalid date showing up in the picker. By defaulting the period to 14d we can have a sane default.

Fixes APP-1088