### PR TITLE
fix(discover): Load tags before saved queries

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
@@ -76,9 +76,11 @@ class OrganizationDiscoverContainer extends React.Component {
     const {savedQueryId} = this.props.params;
 
     if (savedQueryId) {
-      this.fetchSavedQuery(savedQueryId).then(this.loadTags);
+      this.loadTags()
+        .then(() => this.fetchSavedQuery(savedQueryId))
+        .then(this.setLoadedState);
     } else {
-      this.loadTags();
+      this.loadTags().then(this.setLoadedState);
     }
   }
 
@@ -108,9 +110,11 @@ class OrganizationDiscoverContainer extends React.Component {
   }
 
   loadTags = () => {
-    this.queryBuilder.load().then(() => {
-      this.setState({isLoading: false});
-    });
+    return this.queryBuilder.load();
+  };
+
+  setLoadedState = () => {
+    this.setState({isLoading: false});
   };
 
   fetchSavedQuery = savedQueryId => {

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
@@ -207,7 +207,7 @@ class Result extends React.Component {
     };
 
     return (
-      <ResultContainer>
+      <ResultContainer data-test-id="result">
         <div>
           <HeadingContainer>
             {savedQuery ? this.renderSavedQueryHeader() : this.renderQueryResultHeader()}

--- a/tests/acceptance/test_organization_discover.py
+++ b/tests/acceptance/test_organization_discover.py
@@ -66,4 +66,5 @@ class OrganizationDiscoverTest(AcceptanceTestCase):
             self.browser.find_element_by_xpath("//button//span[contains(text(), 'Save')]").click()
             self.browser.get(self.path + '?view=saved')
             self.browser.wait_until_not('.loading')
+            self.browser.wait_until('[data-test-id="result"]')
             self.browser.snapshot('discover - saved query list')


### PR DESCRIPTION
Load tags before saved queries instead of the other way round. Since
validations are performed on saved query conditions, this caused
conditions on dynamic tag fields that were not yet loaded to be
sometimes incorrectly determined to be invalid and dropped.