### PR TITLE
feat(api): Start passing search filters to search backend, and use them for some filtering

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -116,7 +116,11 @@ class InvalidSearchQuery(Exception):
 
 
 class SearchFilter(namedtuple('SearchFilter', 'key operator value')):
-    pass
+
+    def __str__(self):
+        return ''.join(
+            map(six.text_type, (self.key.name, self.operator, self.value.raw_value)),
+        )
 
 
 class SearchKey(namedtuple('SearchKey', 'name')):
@@ -224,6 +228,7 @@ class SearchVisitor(NodeVisitor):
         except InvalidQuery as exc:
             raise InvalidSearchQuery(exc.message)
 
+        # TODO: Handle negations
         if from_val is not None:
             operator = '>='
             search_value = from_val[0]
@@ -248,6 +253,10 @@ class SearchVisitor(NodeVisitor):
         except InvalidQuery as exc:
             raise InvalidSearchQuery(exc.message)
 
+        # TODO: Handle negations here. This is tricky because these will be
+        # separate filters, and to negate this range we need (< val or >= val).
+        # We currently AND all filters together, so we'll need extra logic to
+        # handle. Maybe not necessary to allow negations for this.
         return [
             SearchFilter(
                 search_key,

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -29,6 +29,10 @@ from sentry.models import (
 )
 from sentry.models.group import looks_like_short_id
 from sentry.search.utils import InvalidQuery, parse_query
+from sentry.api.issue_search import (
+    convert_query_values,
+    parse_search_query,
+)
 from sentry.signals import (
     issue_deleted, issue_ignored, issue_resolved, issue_resolved_in_release,
     resolved_with_commit
@@ -67,6 +71,7 @@ def build_query_params_from_request(request, projects):
         query_kwargs['cursor'] = Cursor.from_string(cursor)
 
     query = request.GET.get('query', 'is:unresolved').strip()
+    use_new_filters = request.GET.get('use_new_filters', '0') == '1'
     if query:
         try:
             query_kwargs.update(parse_query(projects, query, request.user))
@@ -75,7 +80,23 @@ def build_query_params_from_request(request, projects):
                 u'Your search query could not be parsed: {}'.format(
                     e.message)
             )
+        try:
+            search_filters = convert_query_values(
+                parse_search_query(query),
+                projects,
+                request.user,
+            )
+        except Exception:
+            # TODO: Catch less broad exceptions when we're confident in these
+            # new filters
+            logging.exception('Error occurred while parsing new style search query')
+            search_filters = []
+            # If something goes wrong here we just want to use the working
+            # filters
+            use_new_filters = False
+        query_kwargs['search_filters'] = search_filters
 
+    query_kwargs['use_new_filters'] = use_new_filters
     return query_kwargs
 
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -437,8 +437,17 @@ class APITestCase(BaseTestCase, BaseAPITestCase):
     def get_response(self, *args, **params):
         if self.endpoint is None:
             raise Exception('Implement self.endpoint to use this method.')
+
         url = reverse(self.endpoint, args=args)
-        return getattr(self.client, self.method)(
+        # In some cases we want to pass querystring params to put/post, handle
+        # this here.
+        if 'qs_params' in params:
+            query_string = urlencode(params.pop('qs_params'), doseq=True)
+            url = u'{}?{}'.format(url, query_string)
+
+        method = params.pop('method', self.method)
+
+        return getattr(self.client, method)(
             url,
             format='json',
             data=params,


### PR DESCRIPTION
This diff adds in support for our new search filters to the search backend. At the moment it's only
used for a subset of parameters, and only used if `use_new_filters=1` is passed as a query param.

Refactored the `QuerySetBuilder` to be able to work with Q objects, which allows us to handle
negations more easily. Also change it to operate off of a list of params rather than a dictionary.
Add versions that support either the old style params or new style search filters.

Plan is to start using this for additional filters, but wanted to keep this diff reasonably small.
I'll leave `DjangoSearchBackend._query` as is for a while, since we're only using Snuba in
production and I want to get this finished. Once the feature is working though I'll go back and
clean up the `DjangoSearchBackend` so that we can remove the old QuerysetBuilders.

Unfortunately, the test changes are huge, but the refactors I did there are reasonably simple, and
allow us to run all tests with both new and old style parameters, so we can be reasonably sure that
the results are equivalent. Some of the test changes are for tests filters that aren't actually
using the new style search filters yet. I expect these to break as I use them for more filters,
will be helpful as I continue converting things across.