### PR TITLE
fix(issues): Reduce calls to group details endpoint

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/shared/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/groupDetails.jsx
@@ -5,6 +5,7 @@ import Reflux from 'reflux';
 import {browserHistory} from 'react-router';
 import DocumentTitle from 'react-document-title';
 import * as Sentry from '@sentry/browser';
+import {isEqual} from 'lodash';
 
 import ApiMixin from 'app/mixins/apiMixin';
 import GroupStore from 'app/stores/groupStore';
@@ -63,7 +64,7 @@ const GroupDetails = createReactClass({
   componentDidUpdate(prevProps) {
     if (
       prevProps.params.groupId !== this.props.params.groupId ||
-      prevProps.environments !== this.props.environments
+      !isEqual(prevProps.environments, this.props.environments)
     ) {
       this.fetchData();
     }


### PR DESCRIPTION
Fixes a bug causing a large number of API requests to the group details
endpoint for non Sentry 10 users. We now check deep equality of the
environment list before re-fetching since the environment array is not
guaranteed to be the same object.