### PR TITLE
ref(eventstream): Remove unneeded transitional option

### DIFF
--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 from confluent_kafka import OFFSET_INVALID, Producer, TopicPartition
 from django.utils.functional import cached_property
 
-from sentry import options, quotas
+from sentry import quotas
 from sentry.models import Organization
 from sentry.eventstream.base import EventStream
 from sentry.eventstream.kafka.consumer import SynchronizedConsumer
@@ -117,13 +117,6 @@ class KafkaEventStream(EventStream):
 
     def insert(self, group, event, is_new, is_sample, is_regression,
                is_new_group_environment, primary_hash, skip_consume=False):
-        if options.get('eventstream.kafka.send-post_process-task'):
-            super(KafkaEventStream, self).insert(
-                group, event, is_new, is_sample,
-                is_regression, is_new_group_environment,
-                primary_hash, skip_consume
-            )
-
         project = event.project
         retention_days = quotas.get_event_retention(
             organization=Organization(project.organization_id)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -152,9 +152,6 @@ register('snuba.events-queries.enabled', type=Bool, default=False)
 register('kafka-publisher.raw-event-sample-rate', default=0.0)
 register('kafka-publisher.max-event-size', default=100000)
 
-# Event Stream
-register('eventstream.kafka.send-post_process-task', type=Bool, default=True)
-
 # Ingest refactor
 register('store.projects-normalize-in-rust-opt-in', type=Sequence, default=[])
 register('store.projects-normalize-in-rust-opt-out', type=Sequence, default=[])


### PR DESCRIPTION
This was only required when we were cold starting the worker relay.