### PR TITLE
fix(integrations) Normalize jira logging parameters

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -406,10 +406,10 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             )
         except ApiError as exc:
             logger.info(
-                'error-fetching-issue-config',
+                'jira.error-fetching-issue-config',
                 extra={
                     'integration_id': self.model.id,
-                    'organization': group.organization.id,
+                    'organization_id': group.organization.id,
                     'error': exc.message,
                 }
             )


### PR DESCRIPTION
Use the indexed `organization_id` instead of an unindexed field. I came across this looking into a customer issue.