### PR TITLE
Revert "ref(store): Remove unused signals (#11921)"

### DIFF
--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -54,9 +54,11 @@ class BetterSignal(Signal):
 
 
 buffer_incr_complete = BetterSignal(providing_args=["model", "columns", "extra", "result"])
+event_accepted = BetterSignal(providing_args=["ip", "data", "project"])
 event_discarded = BetterSignal(providing_args=["project"])
 event_dropped = BetterSignal(providing_args=["ip", "data", "project", "reason_code"])
 event_filtered = BetterSignal(providing_args=["ip", "data", "project"])
+event_received = BetterSignal(providing_args=["ip", "project"])
 pending_delete = BetterSignal(providing_args=['instance', 'actor'])
 event_processed = BetterSignal(providing_args=['project', 'group', 'event'])
 event_saved = BetterSignal(providing_args=["project"])

--- a/tests/sentry/web/api/tests.py
+++ b/tests/sentry/web/api/tests.py
@@ -10,7 +10,7 @@ from mock import Mock
 
 from sentry.coreapi import APIRateLimited
 from sentry.models import ProjectKey
-from sentry.signals import event_dropped, event_filtered
+from sentry.signals import event_accepted, event_dropped, event_filtered
 from sentry.testutils import (assert_mock_called_once_with_partial, TestCase)
 from sentry.utils import json
 from sentry.utils.data_filters import FilterTypes
@@ -668,6 +668,23 @@ class StoreViewTest(TestCase):
             'name': '_postWithHeader',
             'version': '0.0.0',
         }
+
+    @mock.patch('sentry.coreapi.ClientApiHelper.insert_data_to_database', Mock())
+    def test_accepted_signal(self):
+        mock_event_accepted = Mock()
+
+        event_accepted.connect(mock_event_accepted)
+
+        resp = self._postWithHeader({'logentry': {'message': u'hello'}})
+
+        assert resp.status_code == 200, resp.content
+
+        assert_mock_called_once_with_partial(
+            mock_event_accepted,
+            ip='127.0.0.1',
+            project=self.project,
+            signal=event_accepted,
+        )
 
     @mock.patch('sentry.coreapi.ClientApiHelper.insert_data_to_database', Mock())
     @mock.patch('sentry.app.quotas.is_rate_limited')


### PR DESCRIPTION
This reverts commit c8916fee9e1c9a4ec853a27490c478e60b65fb41.

`event_accepted` is used by Orbital (getsentry/sentry-orbital) which is
apparently required as part of the getsentry/getsentry build.