### PR TITLE
fix(emails) Update urls for project & tags in alert emails

### DIFF
--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -241,6 +241,7 @@ class MailPlugin(NotificationPlugin):
                             commits[commit['id']] = commit_data
 
         context = {
+            'project_link': project.get_absolute_url(),
             'project_label': project.get_full_name(),
             'group': group,
             'event': event,

--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -2,6 +2,7 @@
 
 {% load sentry_avatars %}
 {% load sentry_helpers %}
+{% load sentry_features %}
 {% load i18n %}
 
 {% block preheader %}
@@ -15,7 +16,7 @@
 
 {% block main %}
     <h2 style="margin-bottom: 15px">
-        New alert from <a href="{% absolute_uri '/{}/{}/' group.project.organization.slug group.project.slug %}">{{ project_label }}</a>
+        New alert from <a href="{{ project_link }}">{{ project_label }}</a>
         {% if environment %} in {{ environment }}{% endif %}
     </h2>
 
@@ -125,13 +126,22 @@
         <ul class="tag-list">
         {% for tag_key, tag_value in tags %}
           <li>
-              <strong>{{ tag_key }}</strong>
-              <em>=</em>
-              <span>
-              {% with query=tag_key|add:":\""|add:tag_value|add:"\""|urlencode %}
-                <a href="{% absolute_uri '/{}/{}/' group.project.organization.slug group.project.slug %}?query={{ query }}">{{ tag_value|truncatechars:50 }}</a> {% if tag_value|is_url %}<a href="{{ tag_value }}" class="icon-share"></a>{% endif %}
-              {% endwith %}
-              </span>
+            <strong>{{ tag_key }}</strong>
+            <em>=</em>
+            <span>
+            {% with query=tag_key|add:":\""|add:tag_value|add:"\""|urlencode %}
+              {% feature organizations:sentry10 group.organization %}
+                <a href="{% absolute_uri '/organizations/{}/issues' group.project.organization.slug %}?projectid={{ group.project.id }}&query={{ query }}">
+                  {{ tag_value|truncatechars:50 }}
+                </a>
+              {% else %}
+                <a href="{% absolute_uri '/{}/{}/issues' group.project.organization.slug group.project.slug %}?query={{ query }}">
+                  {{ tag_value|truncatechars:50 }}
+                </a>
+              {% endfeature %}
+            {% endwith %}
+            {% if tag_value|is_url %}<a href="{{ tag_value }}" class="icon-share"></a>{% endif %}
+            </span>
           </li>
         {% endfor %}
         </ul>


### PR DESCRIPTION
Alert emails should point to sentry10 URLs if the organization has sentry10.