### PR TITLE
feat(global-selection-header): lock project dropdown and show back button when viewing an issue

### DIFF
--- a/src/sentry/static/sentry/app/components/inlineSvg.jsx
+++ b/src/sentry/static/sentry/app/components/inlineSvg.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
-const InlineSvg = ({src, size, width, height, ...props}) => {
+const InlineSvg = ({src, size, width, height, alt, ...props}) => {
   const {id, viewBox} = require(`../icons/${src}.svg`).default;
 
   return (

--- a/src/sentry/static/sentry/app/components/inlineSvg.jsx
+++ b/src/sentry/static/sentry/app/components/inlineSvg.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
-const InlineSvg = ({src, size, width, height, alt, ...props}) => {
+const InlineSvg = ({src, size, width, height, ...props}) => {
   const {id, viewBox} = require(`../icons/${src}.svg`).default;
 
   return (

--- a/src/sentry/static/sentry/app/components/organizations/backToIssues.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/backToIssues.jsx
@@ -1,0 +1,27 @@
+import styled from 'react-emotion';
+import {Link} from 'react-router';
+import space from 'app/styles/space';
+
+const BackToIssues = styled(Link)`
+  color: ${p => p.theme.gray4};
+  background: ${p => p.theme.offWhite2};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${space(1)};
+  width: ${space(1.5)};
+  height: ${space(1.5)};
+  border-radius: 50%;
+  box-sizing: content-box;
+  margin: 0 -${space(2)} 0 ${space(2)};
+  position: relative;
+  z-index: 1;
+  transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+
+  &:hover {
+    background: ${p => p.theme.offwhite};
+    transform: scale(1.125);
+  }
+`;
+
+export default BackToIssues;

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
@@ -38,6 +38,10 @@ class GlobalSelectionHeader extends React.Component {
      * List of projects to display in project selector
      */
     projects: PropTypes.arrayOf(SentryTypes.Project),
+    /**
+     * If a forced project is passed, selection is disabled
+     */
+    forcedProject: SentryTypes.Project,
 
     /**
      * Currently selected values(s)
@@ -288,24 +292,33 @@ class GlobalSelectionHeader extends React.Component {
   render() {
     const {
       className,
+      forcedProject,
       organization,
       showAbsolute,
       showRelative,
       showEnvironmentSelector,
     } = this.props;
     const {period, start, end, utc} = this.props.selection.datetime || {};
-
     return (
       <Header className={className}>
         <HeaderItemPosition>
-          <MultipleProjectSelector
-            organization={organization}
-            projects={this.getProjects()}
-            value={this.state.projects || this.props.selection.projects}
-            onChange={this.handleChangeProjects}
-            onUpdate={this.handleUpdateProjects}
-            multi={this.hasMultipleProjectSelection()}
-          />
+          {forcedProject ? (
+            <MultipleProjectSelector
+              organization={organization}
+              projects={[forcedProject]}
+              value={[parseInt(forcedProject.id)]}
+              multi={true}
+            />
+          ) : (
+            <MultipleProjectSelector
+              organization={organization}
+              projects={this.getProjects()}
+              value={this.state.projects || this.props.selection.projects}
+              onChange={this.handleChangeProjects}
+              onUpdate={this.handleUpdateProjects}
+              multi={this.hasMultipleProjectSelection()}
+            />
+          )}
         </HeaderItemPosition>
 
         {showEnvironmentSelector && (

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
@@ -2,6 +2,7 @@ import {pick, isEqual} from 'lodash';
 import {withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'react-emotion';
 
 import {
   DATE_TIME_KEYS,
@@ -321,7 +322,7 @@ class GlobalSelectionHeader extends React.Component {
         <HeaderItemPosition>
           {forceProject && this.getBackButton()}
 
-          <MultipleProjectSelector
+          <StyledMultipleProjectSelector
             organization={organization}
             forceProject={forceProject}
             projects={this.getProjects()}
@@ -366,3 +367,9 @@ class GlobalSelectionHeader extends React.Component {
 }
 
 export default withRouter(withGlobalSelection(GlobalSelectionHeader));
+
+// We need this because HeaderItemPosition has `align-items` center for the back button
+// Otherwise the dropdown menu of project selector will not be at the base of the header
+const StyledMultipleProjectSelector = styled(MultipleProjectSelector)`
+  height: 100%;
+`;

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
@@ -28,6 +28,7 @@ import MultipleProjectSelector from 'app/components/organizations/multipleProjec
 import SentryTypes from 'app/sentryTypes';
 import TimeRangeSelector from 'app/components/organizations/timeRangeSelector';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
+import {t} from 'app/locale';
 
 import {getStateFromQuery} from './utils';
 
@@ -43,7 +44,7 @@ class GlobalSelectionHeader extends React.Component {
     /**
      * If a forced project is passed, selection is disabled
      */
-    forcedProject: SentryTypes.Project,
+    forceProject: SentryTypes.Project,
 
     /**
      * Currently selected values(s)
@@ -296,7 +297,7 @@ class GlobalSelectionHeader extends React.Component {
       <BackToIssues
         to={`/organizations/${this.props.organization.slug}/issues/${window.location
           .search}`}
-        title="back to issues list"
+        title={t('back to issues list')}
       >
         <InlineSvg src="icon-arrow-left" />
       </BackToIssues>
@@ -306,7 +307,7 @@ class GlobalSelectionHeader extends React.Component {
   render() {
     const {
       className,
-      forcedProject,
+      forceProject,
       organization,
       showAbsolute,
       showRelative,
@@ -316,11 +317,11 @@ class GlobalSelectionHeader extends React.Component {
     return (
       <Header className={className}>
         <HeaderItemPosition>
-          {forcedProject && this.getBackButton()}
+          {forceProject && this.getBackButton()}
 
           <MultipleProjectSelector
             organization={organization}
-            forcedProject={forcedProject}
+            forceProject={forceProject}
             projects={this.getProjects()}
             value={this.state.projects || this.props.selection.projects}
             onChange={this.handleChangeProjects}

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
@@ -10,6 +10,7 @@ import {
 import {callIfFunction} from 'app/utils/callIfFunction';
 import {defined} from 'app/utils';
 import {isEqualWithDates} from 'app/utils/isEqualWithDates';
+import {t} from 'app/locale';
 import {
   updateDateTime,
   updateEnvironments,
@@ -18,17 +19,17 @@ import {
   updateProjects,
 } from 'app/actionCreators/globalSelection';
 import {DEFAULT_STATS_PERIOD} from 'app/constants';
-import Header from 'app/components/organizations/header';
-import InlineSvg from 'app/components/inlineSvg';
-import HeaderItemPosition from 'app/components/organizations/headerItemPosition';
 import BackToIssues from 'app/components/organizations/backToIssues';
+import Header from 'app/components/organizations/header';
+import HeaderItemPosition from 'app/components/organizations/headerItemPosition';
 import HeaderSeparator from 'app/components/organizations/headerSeparator';
+import InlineSvg from 'app/components/inlineSvg';
 import MultipleEnvironmentSelector from 'app/components/organizations/multipleEnvironmentSelector';
 import MultipleProjectSelector from 'app/components/organizations/multipleProjectSelector';
 import SentryTypes from 'app/sentryTypes';
 import TimeRangeSelector from 'app/components/organizations/timeRangeSelector';
+import Tooltip from 'app/components/tooltip';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
-import {t} from 'app/locale';
 
 import {getStateFromQuery} from './utils';
 
@@ -294,13 +295,14 @@ class GlobalSelectionHeader extends React.Component {
 
   getBackButton = () => {
     return (
-      <BackToIssues
-        to={`/organizations/${this.props.organization.slug}/issues/${window.location
-          .search}`}
-        title={t('Back to Issues Stream')}
-      >
-        <InlineSvg src="icon-arrow-left" />
-      </BackToIssues>
+      <Tooltip title={t('Back to Issues Stream')} tooltipOptions={{placement: 'bottom'}}>
+        <BackToIssues
+          to={`/organizations/${this.props.organization.slug}/issues/${window.location
+            .search}`}
+        >
+          <InlineSvg src="icon-arrow-left" />
+        </BackToIssues>
+      </Tooltip>
     );
   };
 

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
@@ -302,24 +302,15 @@ class GlobalSelectionHeader extends React.Component {
     return (
       <Header className={className}>
         <HeaderItemPosition>
-          {forcedProject ? (
-            <MultipleProjectSelector
-              organization={organization}
-              projects={[forcedProject]}
-              value={[parseInt(forcedProject.id)]}
-              multi={true}
-              locked={true}
-            />
-          ) : (
-            <MultipleProjectSelector
-              organization={organization}
-              projects={this.getProjects()}
-              value={this.state.projects || this.props.selection.projects}
-              onChange={this.handleChangeProjects}
-              onUpdate={this.handleUpdateProjects}
-              multi={this.hasMultipleProjectSelection()}
-            />
-          )}
+          <MultipleProjectSelector
+            organization={organization}
+            forcedProject={forcedProject}
+            projects={this.getProjects()}
+            value={this.state.projects || this.props.selection.projects}
+            onChange={this.handleChangeProjects}
+            onUpdate={this.handleUpdateProjects}
+            multi={this.hasMultipleProjectSelection()}
+          />
         </HeaderItemPosition>
 
         {showEnvironmentSelector && (

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
@@ -308,6 +308,7 @@ class GlobalSelectionHeader extends React.Component {
               projects={[forcedProject]}
               value={[parseInt(forcedProject.id)]}
               multi={true}
+              locked={true}
             />
           ) : (
             <MultipleProjectSelector

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
@@ -1,5 +1,5 @@
 import {pick, isEqual} from 'lodash';
-import {Link, withRouter} from 'react-router';
+import {withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -19,7 +19,9 @@ import {
 } from 'app/actionCreators/globalSelection';
 import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import Header from 'app/components/organizations/header';
+import InlineSvg from 'app/components/inlineSvg';
 import HeaderItemPosition from 'app/components/organizations/headerItemPosition';
+import BackToIssues from 'app/components/organizations/backToIssues';
 import HeaderSeparator from 'app/components/organizations/headerSeparator';
 import MultipleEnvironmentSelector from 'app/components/organizations/multipleEnvironmentSelector';
 import MultipleProjectSelector from 'app/components/organizations/multipleProjectSelector';
@@ -291,12 +293,13 @@ class GlobalSelectionHeader extends React.Component {
 
   getBackButton = () => {
     return (
-      <Link
+      <BackToIssues
         to={`/organizations/${this.props.organization.slug}/issues/${window.location
           .search}`}
+        title="back to issues list"
       >
-        Back
-      </Link>
+        <InlineSvg src="icon-arrow-left" />
+      </BackToIssues>
     );
   };
 
@@ -312,9 +315,9 @@ class GlobalSelectionHeader extends React.Component {
     const {period, start, end, utc} = this.props.selection.datetime || {};
     return (
       <Header className={className}>
-        {forcedProject && this.getBackButton()}
-
         <HeaderItemPosition>
+          {forcedProject && this.getBackButton()}
+
           <MultipleProjectSelector
             organization={organization}
             forcedProject={forcedProject}
@@ -358,4 +361,5 @@ class GlobalSelectionHeader extends React.Component {
     );
   }
 }
+
 export default withRouter(withGlobalSelection(GlobalSelectionHeader));

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
@@ -297,7 +297,7 @@ class GlobalSelectionHeader extends React.Component {
       <BackToIssues
         to={`/organizations/${this.props.organization.slug}/issues/${window.location
           .search}`}
-        title={t('back to issues list')}
+        title={t('Back to Issues Stream')}
       >
         <InlineSvg src="icon-arrow-left" />
       </BackToIssues>

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
@@ -1,5 +1,5 @@
 import {pick, isEqual} from 'lodash';
-import {withRouter} from 'react-router';
+import {Link, withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -289,6 +289,18 @@ class GlobalSelectionHeader extends React.Component {
       .slice(0, 1);
   };
 
+  getBackButton = () => {
+    console.log(window.location.search);
+    return (
+      <Link
+        to={`/organizations/${this.props.organization.slug}/issues/${window.location
+          .search}`}
+      >
+        Back
+      </Link>
+    );
+  };
+
   render() {
     const {
       className,
@@ -301,6 +313,8 @@ class GlobalSelectionHeader extends React.Component {
     const {period, start, end, utc} = this.props.selection.datetime || {};
     return (
       <Header className={className}>
+        {forcedProject && this.getBackButton()}
+
         <HeaderItemPosition>
           <MultipleProjectSelector
             organization={organization}

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
@@ -290,7 +290,6 @@ class GlobalSelectionHeader extends React.Component {
   };
 
   getBackButton = () => {
-    console.log(window.location.search);
     return (
       <Link
         to={`/organizations/${this.props.organization.slug}/issues/${window.location

--- a/src/sentry/static/sentry/app/components/organizations/headerItem.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/headerItem.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'react-emotion';
 import InlineSvg from 'app/components/inlineSvg';
+import Tooltip from 'app/components/tooltip';
 import space from 'app/styles/space';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 
@@ -14,6 +15,7 @@ class HeaderItem extends React.Component {
     hasChanges: PropTypes.bool,
     hasSelected: PropTypes.bool,
     isOpen: PropTypes.bool,
+    locked: PropTypes.bool
   };
 
   static defaultProps = {
@@ -43,6 +45,7 @@ class HeaderItem extends React.Component {
       hasChanges,
       allowClear,
       icon,
+      locked,
       onClear, // eslint-disable-line no-unused-vars
       onSubmit, // eslint-disable-line no-unused-vars
       ...props
@@ -53,30 +56,44 @@ class HeaderItem extends React.Component {
         className={className}
         isOpen={isOpen}
         hasSelected={hasSelected}
+        locked={locked}
         {...props}
       >
-        <IconContainer hasSelected={hasSelected}>{icon}</IconContainer>
+        <IconContainer hasSelected={hasSelected} locked={locked}>{icon}</IconContainer>
         <Content>{children}</Content>
-        {hasSelected &&
-          allowClear && <StyledClose src="icon-close" onClick={this.handleClear} />}
-        <StyledChevron
+        {hasSelected && !locked &&
+          allowClear && <StyledClose src="icon-close" locked={locked} hasSelected={hasSelected} onClick={this.handleClear} />}
+        {!locked && <StyledChevron
           isOpen={isOpen}
           hasChanges={hasChanges}
           onClick={this.handleChevronClick}
         >
           <InlineSvg src="icon-chevron-down" />
-        </StyledChevron>
+        </StyledChevron>}
+        {locked && <Tooltip
+          title="issues may only be under a single project"
+          tooltipOptions={{
+            placement: 'bottom',
+          }}
+        >
+          <StyledLock src="icon-lock"/>
+        </Tooltip>}
       </StyledHeaderItem>
     );
   }
+}
+
+const getColor = p => {
+  if (p.locked) return p.theme.gray4;
+  return (p.isOpen || p.hasSelected ? p.theme.gray4 : p.theme.gray2);
 }
 
 const StyledHeaderItem = styled('div')`
   display: flex;
   padding: 0 ${space(4)};
   align-items: center;
-  cursor: pointer;
-  color: ${p => (p.isOpen || p.hasSelected ? p.theme.gray4 : p.theme.gray2)};
+  cursor: ${p => p.locked ? "text" : "pointer"};
+  color: ${getColor};
   transition: 0.1s color;
   user-select: none;
 `;
@@ -88,14 +105,14 @@ const Content = styled('div')`
 `;
 
 const IconContainer = styled('span')`
-  color: ${p => (p.hasSelected ? p.theme.blue : null)};
+  color: ${getColor};
   margin-right: ${space(1.5)};
 `;
 
 const StyledClose = styled(InlineSvg)`
-  color: ${p => p.theme.gray2};
-  height: 10px;
-  width: 10px;
+  color: ${getColor};
+  height: ${space(1.5)};
+  width: ${space(1.5)};
   stroke-width: 1.5;
   padding: ${space(1)};
   box-sizing: content-box;
@@ -105,8 +122,8 @@ const StyledClose = styled(InlineSvg)`
 const StyledChevron = styled('div')`
   transform: rotate(${p => (p.isOpen ? '180deg' : '0deg')});
   transition: 0.1s all;
-  width: 16px;
-  height: 16px;
+  width: ${space(2)};
+  height: ${space(2)};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -121,6 +138,13 @@ const StyledChevron = styled('div')`
     transform: rotate(270deg);
   `
       : ''};
+`;
+
+const StyledLock = styled(InlineSvg)`
+  color: ${p => p.theme.gray2};
+  width: ${space(2)};
+  height: ${space(2)};
+  stroke-width: 1.5;
 `;
 
 export default React.forwardRef((props, ref) => <HeaderItem {...props} innerRef={ref} />);

--- a/src/sentry/static/sentry/app/components/organizations/headerItem.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/headerItem.jsx
@@ -15,7 +15,7 @@ class HeaderItem extends React.Component {
     hasChanges: PropTypes.bool,
     hasSelected: PropTypes.bool,
     isOpen: PropTypes.bool,
-    locked: PropTypes.bool
+    locked: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -59,40 +59,54 @@ class HeaderItem extends React.Component {
         locked={locked}
         {...props}
       >
-        <IconContainer hasSelected={hasSelected} locked={locked}>{icon}</IconContainer>
+        <IconContainer hasSelected={hasSelected} locked={locked}>
+          {icon}
+        </IconContainer>
         <Content>{children}</Content>
-        {hasSelected && !locked &&
-          allowClear && <StyledClose src="icon-close" locked={locked} hasSelected={hasSelected} onClick={this.handleClear} />}
-        {!locked && <StyledChevron
-          isOpen={isOpen}
-          hasChanges={hasChanges}
-          onClick={this.handleChevronClick}
-        >
-          <InlineSvg src="icon-chevron-down" />
-        </StyledChevron>}
-        {locked && <Tooltip
-          title="issues may only be under a single project"
-          tooltipOptions={{
-            placement: 'bottom',
-          }}
-        >
-          <StyledLock src="icon-lock"/>
-        </Tooltip>}
+        {hasSelected &&
+          !locked &&
+          allowClear && (
+            <StyledClose
+              src="icon-close"
+              locked={locked}
+              hasSelected={hasSelected}
+              onClick={this.handleClear}
+            />
+          )}
+        {!locked && (
+          <StyledChevron
+            isOpen={isOpen}
+            hasChanges={hasChanges}
+            onClick={this.handleChevronClick}
+          >
+            <InlineSvg src="icon-chevron-down" />
+          </StyledChevron>
+        )}
+        {locked && (
+          <Tooltip
+            title="issues may only be under a single project"
+            tooltipOptions={{
+              placement: 'bottom',
+            }}
+          >
+            <StyledLock src="icon-lock" />
+          </Tooltip>
+        )}
       </StyledHeaderItem>
     );
   }
 }
 
 const getColor = p => {
-  if (p.locked) return p.theme.gray4;
-  return (p.isOpen || p.hasSelected ? p.theme.gray4 : p.theme.gray2);
-}
+  if (p.locked) return p.theme.gray2;
+  return p.isOpen || p.hasSelected ? p.theme.gray4 : p.theme.gray2;
+};
 
 const StyledHeaderItem = styled('div')`
   display: flex;
   padding: 0 ${space(4)};
   align-items: center;
-  cursor: ${p => p.locked ? "text" : "pointer"};
+  cursor: ${p => (p.locked ? 'text' : 'pointer')};
   color: ${getColor};
   transition: 0.1s color;
   user-select: none;

--- a/src/sentry/static/sentry/app/components/organizations/headerItem.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/headerItem.jsx
@@ -16,6 +16,7 @@ class HeaderItem extends React.Component {
     hasSelected: PropTypes.bool,
     isOpen: PropTypes.bool,
     locked: PropTypes.bool,
+    lockedMessage: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -46,6 +47,7 @@ class HeaderItem extends React.Component {
       allowClear,
       icon,
       locked,
+      lockedMessage,
       onClear, // eslint-disable-line no-unused-vars
       onSubmit, // eslint-disable-line no-unused-vars
       ...props
@@ -84,7 +86,7 @@ class HeaderItem extends React.Component {
         )}
         {locked && (
           <Tooltip
-            title="issues may only be under a single project"
+            title={lockedMessage || 'this selection is locked'}
             tooltipOptions={{
               placement: 'bottom',
             }}

--- a/src/sentry/static/sentry/app/components/organizations/headerItem.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/headerItem.jsx
@@ -16,7 +16,7 @@ class HeaderItem extends React.Component {
     hasSelected: PropTypes.bool,
     isOpen: PropTypes.bool,
     locked: PropTypes.bool,
-    lockedMessage: PropTypes.bool,
+    lockedMessage: PropTypes.string,
   };
 
   static defaultProps = {
@@ -86,7 +86,7 @@ class HeaderItem extends React.Component {
         )}
         {locked && (
           <Tooltip
-            title={lockedMessage || 'this selection is locked'}
+            title={lockedMessage || 'This selection is locked'}
             tooltipOptions={{
               placement: 'bottom',
             }}

--- a/src/sentry/static/sentry/app/components/organizations/headerItemPosition.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/headerItemPosition.jsx
@@ -4,6 +4,7 @@ import {TimeRangeRoot} from 'app/components/organizations/timeRangeSelector/inde
 
 const HeaderItemPosition = styled.div`
   display: flex;
+  align-items: center;
   flex: 1;
   max-width: 450px;
   height: 100%;

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -21,7 +21,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
     onChange: PropTypes.func,
     onUpdate: PropTypes.func,
     multi: PropTypes.bool,
-    locked: PropTypes.bool,
+    forcedProject: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -94,14 +94,18 @@ export default class MultipleProjectSelector extends React.PureComponent {
   };
 
   render() {
-    const {value, projects, multi, locked} = this.props;
+    const {value, projects, multi, forcedProject} = this.props;
     const selectedProjectIds = new Set(value);
 
     const selected = projects.filter(project =>
       selectedProjectIds.has(parseInt(project.id, 10))
     );
 
-    return (
+    return forcedProject ? (
+      <StyledHeaderItem icon={<StyledInlineSvg src="icon-project" />} locked={true}>
+        {forcedProject.name}
+      </StyledHeaderItem>
+    ) : (
       <StyledProjectSelector
         {...this.props}
         multi={multi}
@@ -135,7 +139,6 @@ export default class MultipleProjectSelector extends React.PureComponent {
               onSubmit={() => this.handleUpdate(actions)}
               onClear={this.handleClear}
               allowClear={multi}
-              locked={locked}
               {...getActorProps()}
             >
               {title}
@@ -155,6 +158,7 @@ const StyledProjectSelector = styled(ProjectSelector)`
 
 const StyledHeaderItem = styled(HeaderItem)`
   height: 100%;
+  width: 100%;
 `;
 
 const StyledInlineSvg = styled(InlineSvg)`

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -21,6 +21,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
     onChange: PropTypes.func,
     onUpdate: PropTypes.func,
     multi: PropTypes.bool,
+    locked: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -93,7 +94,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
   };
 
   render() {
-    const {value, projects, multi} = this.props;
+    const {value, projects, multi, locked} = this.props;
     const selectedProjectIds = new Set(value);
 
     const selected = projects.filter(project =>
@@ -134,6 +135,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
               onSubmit={() => this.handleUpdate(actions)}
               onClear={this.handleClear}
               allowClear={multi}
+              locked={locked}
               {...getActorProps()}
             >
               {title}

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -21,7 +21,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
     onChange: PropTypes.func,
     onUpdate: PropTypes.func,
     multi: PropTypes.bool,
-    forceProject: PropTypes.bool,
+    forceProject: SentryTypes.Project,
   };
 
   static defaultProps = {

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -21,7 +21,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
     onChange: PropTypes.func,
     onUpdate: PropTypes.func,
     multi: PropTypes.bool,
-    forcedProject: PropTypes.bool,
+    forceProject: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -94,20 +94,20 @@ export default class MultipleProjectSelector extends React.PureComponent {
   };
 
   render() {
-    const {value, projects, multi, forcedProject} = this.props;
+    const {value, projects, multi, forceProject} = this.props;
     const selectedProjectIds = new Set(value);
 
     const selected = projects.filter(project =>
       selectedProjectIds.has(parseInt(project.id, 10))
     );
 
-    return forcedProject ? (
+    return forceProject ? (
       <StyledHeaderItem
         icon={<StyledInlineSvg src="icon-project" />}
         locked={true}
-        lockedMessage={`This issue is unique to the ${forcedProject.name} project`}
+        lockedMessage={t(`This issue is unique to the ${forceProject.name} project`)}
       >
-        {forcedProject.name}
+        {forceProject.name}
       </StyledHeaderItem>
     ) : (
       <StyledProjectSelector

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -102,7 +102,11 @@ export default class MultipleProjectSelector extends React.PureComponent {
     );
 
     return forcedProject ? (
-      <StyledHeaderItem icon={<StyledInlineSvg src="icon-project" />} locked={true}>
+      <StyledHeaderItem
+        icon={<StyledInlineSvg src="icon-project" />}
+        locked={true}
+        lockedMessage={`This issue is unique to the ${forcedProject.name} project`}
+      >
         {forcedProject.name}
       </StyledHeaderItem>
     ) : (

--- a/src/sentry/static/sentry/app/views/groupDetails/organization/index.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/organization/index.jsx
@@ -21,6 +21,7 @@ class OrganizationGroupDetails extends React.Component {
         <GroupDetails
           environments={selection.environments}
           enableSnuba={true}
+          showGlobalHeader={true}
           {...props}
         />
       </Feature>

--- a/src/sentry/static/sentry/app/views/groupDetails/organization/index.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/organization/index.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 
-import withOrganization from 'app/utils/withOrganization';
-import withGlobalSelection from 'app/utils/withGlobalSelection';
 import Feature from 'app/components/acl/feature';
+import SentryTypes from 'app/sentryTypes';
+import withGlobalSelection from 'app/utils/withGlobalSelection';
+import withOrganization from 'app/utils/withOrganization';
 
 import GroupDetails from '../shared/groupDetails';
 
 class OrganizationGroupDetails extends React.Component {
   static propTypes = {
-    organization: SentryTypes.Organization.isRequired,
     selection: SentryTypes.GlobalSelection.isRequired,
   };
 

--- a/src/sentry/static/sentry/app/views/groupDetails/organization/index.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/organization/index.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
-import SentryTypes from 'app/sentryTypes';
 
 import withOrganization from 'app/utils/withOrganization';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
-import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
-import {PageContent} from 'app/styles/organization';
 import Feature from 'app/components/acl/feature';
 
 import GroupDetails from '../shared/groupDetails';
@@ -21,14 +18,11 @@ class OrganizationGroupDetails extends React.Component {
 
     return (
       <Feature features={['sentry10']} renderDisabled>
-        <GlobalSelectionHeader organization={this.props.organization} />
-        <PageContent>
-          <GroupDetails
-            environments={selection.environments}
-            enableSnuba={true}
-            {...props}
-          />
-        </PageContent>
+        <GroupDetails
+          environments={selection.environments}
+          enableSnuba={true}
+          {...props}
+        />
       </Feature>
     );
   }

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/groupDetails.jsx
@@ -14,6 +14,8 @@ import LoadingIndicator from 'app/components/loadingIndicator';
 import SentryTypes from 'app/sentryTypes';
 import {t} from 'app/locale';
 import ProjectsStore from 'app/stores/projectsStore';
+import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
+import {PageContent} from 'app/styles/organization';
 
 import GroupHeader from '../shared/header';
 import {ERROR_TYPES} from '../shared/constants';
@@ -210,15 +212,23 @@ const GroupDetails = createReactClass({
     } else if (this.state.loading || !group) return <LoadingIndicator />;
 
     return (
-      <DocumentTitle title={this.getTitle()}>
-        <div className={this.props.className}>
-          <GroupHeader params={params} project={project} group={group} />
-          {React.cloneElement(this.props.children, {
-            group,
-            project,
-          })}
-        </div>
-      </DocumentTitle>
+      <React.Fragment>
+        <GlobalSelectionHeader
+          organization={this.props.organization}
+          forcedProject={project}
+        />
+        <PageContent>
+          <DocumentTitle title={this.getTitle()}>
+            <div className={this.props.className}>
+              <GroupHeader params={params} project={project} group={group} />
+              {React.cloneElement(this.props.children, {
+                group,
+                project,
+              })}
+            </div>
+          </DocumentTitle>
+        </PageContent>
+      </React.Fragment>
     );
   },
 });

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/groupDetails.jsx
@@ -244,7 +244,7 @@ const GroupDetails = createReactClass({
               )}
             {hasFeature &&
               showGlobalHeader && <PageContent>{this.renderContent()}</PageContent>}
-            {!hasFeature || (!showGlobalHeader && this.renderContent())}
+            {!hasFeature && this.renderContent()}
           </React.Fragment>
         )}
       </Feature>

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/groupDetails.jsx
@@ -32,6 +32,7 @@ const GroupDetails = createReactClass({
     // environment: SentryTypes.Environment,
     environments: PropTypes.arrayOf(PropTypes.string),
     enableSnuba: PropTypes.bool,
+    showGlobalHeader: PropTypes.bool,
   },
 
   childContextTypes: {
@@ -214,7 +215,7 @@ const GroupDetails = createReactClass({
   },
 
   render() {
-    const {organization} = this.props;
+    const {organization, showGlobalHeader} = this.props;
     const {group, project} = this.state;
 
     if (this.state.error) {
@@ -234,11 +235,16 @@ const GroupDetails = createReactClass({
       <Feature features={['sentry10']}>
         {({hasFeature}) => (
           <React.Fragment>
-            {hasFeature && (
-              <GlobalSelectionHeader organization={organization} forceProject={project} />
-            )}
-            {hasFeature && <PageContent>{this.renderContent()}</PageContent>}
-            {!hasFeature && this.renderContent()}
+            {hasFeature &&
+              showGlobalHeader && (
+                <GlobalSelectionHeader
+                  organization={organization}
+                  forceProject={project}
+                />
+              )}
+            {hasFeature &&
+              showGlobalHeader && <PageContent>{this.renderContent()}</PageContent>}
+            {!hasFeature || (!showGlobalHeader && this.renderContent())}
           </React.Fragment>
         )}
       </Feature>

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/groupDetails.jsx
@@ -215,7 +215,7 @@ const GroupDetails = createReactClass({
       <React.Fragment>
         <GlobalSelectionHeader
           organization={this.props.organization}
-          forcedProject={project}
+          forceProject={project}
         />
         <PageContent>
           <DocumentTitle title={this.getTitle()}>

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -966,7 +966,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                     <ForwardRef
                                                       active={false}
                                                       allowClear={false}
-                                                      className="css-22y332-StyledHeaderItem ewlipse1"
+                                                      className="css-16gvadh-StyledHeaderItem ewlipse1"
                                                       hasChanges={false}
                                                       hasSelected={false}
                                                       icon={
@@ -991,7 +991,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                       <HeaderItem
                                                         active={false}
                                                         allowClear={false}
-                                                        className="css-22y332-StyledHeaderItem ewlipse1"
+                                                        className="css-16gvadh-StyledHeaderItem ewlipse1"
                                                         hasChanges={false}
                                                         hasSelected={false}
                                                         icon={
@@ -1016,7 +1016,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                       >
                                                         <StyledHeaderItem
                                                           active={false}
-                                                          className="css-22y332-StyledHeaderItem ewlipse1"
+                                                          className="css-16gvadh-StyledHeaderItem ewlipse1"
                                                           hasSelected={false}
                                                           innerRef={null}
                                                           isOpen={false}
@@ -1032,7 +1032,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                           tabIndex={-1}
                                                         >
                                                           <div
-                                                            className="ewlipse1 css-1v6igws-StyledHeaderItem-StyledHeaderItem enk2k7v0"
+                                                            className="ewlipse1 css-1y3fkpa-StyledHeaderItem-StyledHeaderItem enk2k7v0"
                                                             onClick={[Function]}
                                                             onKeyDown={[Function]}
                                                             onMouseEnter={[Function]}
@@ -1048,7 +1048,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                               hasSelected={false}
                                                             >
                                                               <span
-                                                                className="css-1af7peg-IconContainer enk2k7v2"
+                                                                className="css-1g4tz50-IconContainer enk2k7v2"
                                                               >
                                                                 <StyledInlineSvg
                                                                   src="icon-project"
@@ -1579,7 +1579,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                                   hasSelected={false}
                                                                 >
                                                                   <span
-                                                                    className="css-1af7peg-IconContainer enk2k7v2"
+                                                                    className="css-1g4tz50-IconContainer enk2k7v2"
                                                                   >
                                                                     <StyledInlineSvg
                                                                       src="icon-window"
@@ -1812,7 +1812,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                               hasSelected={false}
                                             >
                                               <span
-                                                className="css-1af7peg-IconContainer enk2k7v2"
+                                                className="css-1g4tz50-IconContainer enk2k7v2"
                                               >
                                                 <StyledInlineSvg
                                                   src="icon-calendar"

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -528,7 +528,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                         <div
                           className="css-1n6pjju-HeaderItemPosition e165b9e40"
                         >
-                          <MultipleProjectSelector
+                          <StyledMultipleProjectSelector
                             multi={false}
                             onChange={[Function]}
                             onUpdate={[Function]}
@@ -586,12 +586,10 @@ exports[`OrganizationUserFeedback renders 1`] = `
                             }
                             value={Array []}
                           >
-                            <StyledProjectSelector
+                            <MultipleProjectSelector
+                              className="css-ios481-StyledMultipleProjectSelector ebbiq050"
                               multi={false}
                               onChange={[Function]}
-                              onClose={[Function]}
-                              onMultiSelect={[Function]}
-                              onSelect={[Function]}
                               onUpdate={[Function]}
                               organization={
                                 Object {
@@ -645,12 +643,10 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                   },
                                 ]
                               }
-                              rootClassName="css-h5t9nh-rootContainerStyles"
-                              selectedProjects={Array []}
                               value={Array []}
                             >
-                              <ProjectSelector
-                                className="css-iw79rr-StyledProjectSelector ewlipse0"
+                              <StyledProjectSelector
+                                className="css-ios481-StyledMultipleProjectSelector ebbiq050"
                                 multi={false}
                                 onChange={[Function]}
                                 onClose={[Function]}
@@ -696,7 +692,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                     "teams": Array [],
                                   }
                                 }
-                                projectId={null}
                                 projects={
                                   Array [
                                     Object {
@@ -714,27 +709,35 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                 selectedProjects={Array []}
                                 value={Array []}
                               >
-                                <DropdownAutoComplete
-                                  alignMenu="left"
-                                  blendCorner={false}
-                                  className="ewlipse0 css-11ijjr3-StyledProjectSelector"
-                                  closeOnSelect={true}
-                                  emptyHidesInput={true}
-                                  emptyMessage="You have no projects"
-                                  inputProps={
+                                <ProjectSelector
+                                  className="ebbiq050 css-85v2fe-StyledProjectSelector-StyledMultipleProjectSelector ewlipse0"
+                                  multi={false}
+                                  onChange={[Function]}
+                                  onClose={[Function]}
+                                  onMultiSelect={[Function]}
+                                  onSelect={[Function]}
+                                  onUpdate={[Function]}
+                                  organization={
                                     Object {
-                                      "style": Object {
-                                        "padding": 8,
-                                        "paddingLeft": 14,
-                                      },
-                                    }
-                                  }
-                                  items={
-                                    Array [
-                                      Object {
-                                        "label": [Function],
-                                        "searchKey": "project-slug",
-                                        "value": Object {
+                                      "access": Array [
+                                        "org:read",
+                                        "org:write",
+                                        "org:admin",
+                                        "project:read",
+                                        "project:write",
+                                        "project:admin",
+                                        "team:read",
+                                        "team:write",
+                                        "team:admin",
+                                      ],
+                                      "features": Array [
+                                        "sentry10",
+                                      ],
+                                      "id": "3",
+                                      "name": "Organization Name",
+                                      "onboardingTasks": Array [],
+                                      "projects": Array [
+                                        Object {
                                           "hasAccess": true,
                                           "id": "2",
                                           "isBookmarked": false,
@@ -743,65 +746,38 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                           "slug": "project-slug",
                                           "teams": Array [],
                                         },
+                                      ],
+                                      "scrapeJavaScript": true,
+                                      "slug": "org-slug",
+                                      "status": Object {
+                                        "id": "active",
+                                        "name": "active",
+                                      },
+                                      "teams": Array [],
+                                    }
+                                  }
+                                  projectId={null}
+                                  projects={
+                                    Array [
+                                      Object {
+                                        "hasAccess": true,
+                                        "id": "2",
+                                        "isBookmarked": false,
+                                        "isMember": true,
+                                        "name": "Project Name",
+                                        "slug": "project-slug",
+                                        "teams": Array [],
                                       },
                                     ]
                                   }
-                                  maxHeight={500}
-                                  menuFooter={[Function]}
-                                  menuProps={
-                                    Object {
-                                      "organization": Object {
-                                        "access": Array [
-                                          "org:read",
-                                          "org:write",
-                                          "org:admin",
-                                          "project:read",
-                                          "project:write",
-                                          "project:admin",
-                                          "team:read",
-                                          "team:write",
-                                          "team:admin",
-                                        ],
-                                        "features": Array [
-                                          "sentry10",
-                                        ],
-                                        "id": "3",
-                                        "name": "Organization Name",
-                                        "onboardingTasks": Array [],
-                                        "projects": Array [
-                                          Object {
-                                            "hasAccess": true,
-                                            "id": "2",
-                                            "isBookmarked": false,
-                                            "isMember": true,
-                                            "name": "Project Name",
-                                            "slug": "project-slug",
-                                            "teams": Array [],
-                                          },
-                                        ],
-                                        "scrapeJavaScript": true,
-                                        "slug": "org-slug",
-                                        "status": Object {
-                                          "id": "active",
-                                          "name": "active",
-                                        },
-                                        "teams": Array [],
-                                      },
-                                      "showSettingsLink": true,
-                                    }
-                                  }
-                                  noResultsMessage="No projects found"
-                                  onClose={[Function]}
-                                  onSelect={[Function]}
                                   rootClassName="css-h5t9nh-rootContainerStyles"
-                                  searchPlaceholder="Filter projects"
-                                  virtualizedHeight={40}
-                                  zIndex={1001}
+                                  selectedProjects={Array []}
+                                  value={Array []}
                                 >
-                                  <DropdownAutoCompleteMenu
+                                  <DropdownAutoComplete
                                     alignMenu="left"
                                     blendCorner={false}
-                                    className="ewlipse0 css-11ijjr3-StyledProjectSelector"
+                                    className="ebbiq050 ewlipse0 css-o5ymgs-StyledProjectSelector-StyledMultipleProjectSelector"
                                     closeOnSelect={true}
                                     emptyHidesInput={true}
                                     emptyMessage="You have no projects"
@@ -882,51 +858,121 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                     virtualizedHeight={40}
                                     zIndex={1001}
                                   >
-                                    <AutoComplete
+                                    <DropdownAutoCompleteMenu
+                                      alignMenu="left"
+                                      blendCorner={false}
+                                      className="ebbiq050 ewlipse0 css-o5ymgs-StyledProjectSelector-StyledMultipleProjectSelector"
                                       closeOnSelect={true}
-                                      disabled={false}
-                                      inputIsActor={false}
-                                      itemToString={[Function]}
+                                      emptyHidesInput={true}
+                                      emptyMessage="You have no projects"
+                                      inputProps={
+                                        Object {
+                                          "style": Object {
+                                            "padding": 8,
+                                            "paddingLeft": 14,
+                                          },
+                                        }
+                                      }
+                                      items={
+                                        Array [
+                                          Object {
+                                            "label": [Function],
+                                            "searchKey": "project-slug",
+                                            "value": Object {
+                                              "hasAccess": true,
+                                              "id": "2",
+                                              "isBookmarked": false,
+                                              "isMember": true,
+                                              "name": "Project Name",
+                                              "slug": "project-slug",
+                                              "teams": Array [],
+                                            },
+                                          },
+                                        ]
+                                      }
+                                      maxHeight={500}
+                                      menuFooter={[Function]}
+                                      menuProps={
+                                        Object {
+                                          "organization": Object {
+                                            "access": Array [
+                                              "org:read",
+                                              "org:write",
+                                              "org:admin",
+                                              "project:read",
+                                              "project:write",
+                                              "project:admin",
+                                              "team:read",
+                                              "team:write",
+                                              "team:admin",
+                                            ],
+                                            "features": Array [
+                                              "sentry10",
+                                            ],
+                                            "id": "3",
+                                            "name": "Organization Name",
+                                            "onboardingTasks": Array [],
+                                            "projects": Array [
+                                              Object {
+                                                "hasAccess": true,
+                                                "id": "2",
+                                                "isBookmarked": false,
+                                                "isMember": true,
+                                                "name": "Project Name",
+                                                "slug": "project-slug",
+                                                "teams": Array [],
+                                              },
+                                            ],
+                                            "scrapeJavaScript": true,
+                                            "slug": "org-slug",
+                                            "status": Object {
+                                              "id": "active",
+                                              "name": "active",
+                                            },
+                                            "teams": Array [],
+                                          },
+                                          "showSettingsLink": true,
+                                        }
+                                      }
+                                      noResultsMessage="No projects found"
                                       onClose={[Function]}
                                       onSelect={[Function]}
-                                      resetInputOnClose={true}
-                                      shouldSelectWithEnter={true}
-                                      shouldSelectWithTab={false}
+                                      rootClassName="css-h5t9nh-rootContainerStyles"
+                                      searchPlaceholder="Filter projects"
                                       virtualizedHeight={40}
                                       zIndex={1001}
                                     >
-                                      <DropdownMenu
-                                        closeOnEscape={true}
-                                        isOpen={false}
-                                        keepMenuOpen={false}
-                                        onClickOutside={[Function]}
+                                      <AutoComplete
+                                        closeOnSelect={true}
+                                        disabled={false}
+                                        inputIsActor={false}
+                                        itemToString={[Function]}
+                                        onClose={[Function]}
+                                        onSelect={[Function]}
+                                        resetInputOnClose={true}
+                                        shouldSelectWithEnter={true}
+                                        shouldSelectWithTab={false}
+                                        virtualizedHeight={40}
+                                        zIndex={1001}
                                       >
-                                        <AutoCompleteRoot
-                                          className="css-h5t9nh-rootContainerStyles"
+                                        <DropdownMenu
+                                          closeOnEscape={true}
+                                          isOpen={false}
+                                          keepMenuOpen={false}
+                                          onClickOutside={[Function]}
                                         >
-                                          <Component
-                                            className="css-1ppsre-AutoCompleteRoot-rootContainerStyles ejumqxq0"
+                                          <AutoCompleteRoot
+                                            className="css-h5t9nh-rootContainerStyles"
                                           >
-                                            <div
+                                            <Component
                                               className="css-1ppsre-AutoCompleteRoot-rootContainerStyles ejumqxq0"
                                             >
-                                              <Actor
-                                                innerRef={[Function]}
-                                                isOpen={false}
-                                                onClick={[Function]}
-                                                onKeyDown={[Function]}
-                                                onMouseEnter={[Function]}
-                                                onMouseLeave={[Function]}
-                                                role="button"
-                                                style={
-                                                  Object {
-                                                    "outline": "none",
-                                                  }
-                                                }
-                                                tabIndex={-1}
+                                              <div
+                                                className="css-1ppsre-AutoCompleteRoot-rootContainerStyles ejumqxq0"
                                               >
-                                                <div
-                                                  className="css-17fe80j-Actor e53us8t0"
+                                                <Actor
+                                                  innerRef={[Function]}
+                                                  isOpen={false}
                                                   onClick={[Function]}
                                                   onKeyDown={[Function]}
                                                   onMouseEnter={[Function]}
@@ -939,23 +985,13 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                   }
                                                   tabIndex={-1}
                                                 >
-                                                  <StyledHeaderItem
-                                                    active={false}
-                                                    allowClear={false}
-                                                    hasChanges={false}
-                                                    hasSelected={false}
-                                                    icon={
-                                                      <StyledInlineSvg
-                                                        src="icon-project"
-                                                      />
-                                                    }
-                                                    isOpen={false}
-                                                    onClear={[Function]}
+                                                  <div
+                                                    className="css-17fe80j-Actor e53us8t0"
                                                     onClick={[Function]}
                                                     onKeyDown={[Function]}
                                                     onMouseEnter={[Function]}
                                                     onMouseLeave={[Function]}
-                                                    onSubmit={[Function]}
+                                                    role="button"
                                                     style={
                                                       Object {
                                                         "outline": "none",
@@ -963,10 +999,9 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                     }
                                                     tabIndex={-1}
                                                   >
-                                                    <ForwardRef
+                                                    <StyledHeaderItem
                                                       active={false}
                                                       allowClear={false}
-                                                      className="css-16gvadh-StyledHeaderItem ewlipse1"
                                                       hasChanges={false}
                                                       hasSelected={false}
                                                       icon={
@@ -988,7 +1023,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                       }
                                                       tabIndex={-1}
                                                     >
-                                                      <HeaderItem
+                                                      <ForwardRef
                                                         active={false}
                                                         allowClear={false}
                                                         className="css-16gvadh-StyledHeaderItem ewlipse1"
@@ -999,7 +1034,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                             src="icon-project"
                                                           />
                                                         }
-                                                        innerRef={null}
                                                         isOpen={false}
                                                         onClear={[Function]}
                                                         onClick={[Function]}
@@ -1014,16 +1048,25 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                         }
                                                         tabIndex={-1}
                                                       >
-                                                        <StyledHeaderItem
+                                                        <HeaderItem
                                                           active={false}
+                                                          allowClear={false}
                                                           className="css-16gvadh-StyledHeaderItem ewlipse1"
+                                                          hasChanges={false}
                                                           hasSelected={false}
+                                                          icon={
+                                                            <StyledInlineSvg
+                                                              src="icon-project"
+                                                            />
+                                                          }
                                                           innerRef={null}
                                                           isOpen={false}
+                                                          onClear={[Function]}
                                                           onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onMouseEnter={[Function]}
                                                           onMouseLeave={[Function]}
+                                                          onSubmit={[Function]}
                                                           style={
                                                             Object {
                                                               "outline": "none",
@@ -1031,8 +1074,12 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                           }
                                                           tabIndex={-1}
                                                         >
-                                                          <div
-                                                            className="ewlipse1 css-1y3fkpa-StyledHeaderItem-StyledHeaderItem enk2k7v0"
+                                                          <StyledHeaderItem
+                                                            active={false}
+                                                            className="css-16gvadh-StyledHeaderItem ewlipse1"
+                                                            hasSelected={false}
+                                                            innerRef={null}
+                                                            isOpen={false}
                                                             onClick={[Function]}
                                                             onKeyDown={[Function]}
                                                             onMouseEnter={[Function]}
@@ -1044,27 +1091,80 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                             }
                                                             tabIndex={-1}
                                                           >
-                                                            <IconContainer
-                                                              hasSelected={false}
+                                                            <div
+                                                              className="ewlipse1 css-1y3fkpa-StyledHeaderItem-StyledHeaderItem enk2k7v0"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              onMouseEnter={[Function]}
+                                                              onMouseLeave={[Function]}
+                                                              style={
+                                                                Object {
+                                                                  "outline": "none",
+                                                                }
+                                                              }
+                                                              tabIndex={-1}
                                                             >
-                                                              <span
-                                                                className="css-1g4tz50-IconContainer enk2k7v2"
+                                                              <IconContainer
+                                                                hasSelected={false}
                                                               >
-                                                                <StyledInlineSvg
-                                                                  src="icon-project"
+                                                                <span
+                                                                  className="css-1g4tz50-IconContainer enk2k7v2"
                                                                 >
-                                                                  <InlineSvg
-                                                                    className="css-1ibtmti-StyledInlineSvg ewlipse2"
+                                                                  <StyledInlineSvg
                                                                     src="icon-project"
                                                                   >
-                                                                    <StyledSvg
+                                                                    <InlineSvg
                                                                       className="css-1ibtmti-StyledInlineSvg ewlipse2"
+                                                                      src="icon-project"
+                                                                    >
+                                                                      <StyledSvg
+                                                                        className="css-1ibtmti-StyledInlineSvg ewlipse2"
+                                                                        height="1em"
+                                                                        viewBox={Object {}}
+                                                                        width="1em"
+                                                                      >
+                                                                        <svg
+                                                                          className="ewlipse2 css-1ux8cow-StyledSvg-StyledInlineSvg e2idor0"
+                                                                          height="1em"
+                                                                          viewBox={Object {}}
+                                                                          width="1em"
+                                                                        >
+                                                                          <use
+                                                                            href="#test"
+                                                                            xlinkHref="#test"
+                                                                          />
+                                                                        </svg>
+                                                                      </StyledSvg>
+                                                                    </InlineSvg>
+                                                                  </StyledInlineSvg>
+                                                                </span>
+                                                              </IconContainer>
+                                                              <Content>
+                                                                <div
+                                                                  className="css-1yquznf-Content enk2k7v1"
+                                                                >
+                                                                  All Projects
+                                                                </div>
+                                                              </Content>
+                                                              <StyledChevron
+                                                                hasChanges={false}
+                                                                isOpen={false}
+                                                                onClick={[Function]}
+                                                              >
+                                                                <div
+                                                                  className="css-ft4nwy-StyledChevron enk2k7v4"
+                                                                  onClick={[Function]}
+                                                                >
+                                                                  <InlineSvg
+                                                                    src="icon-chevron-down"
+                                                                  >
+                                                                    <StyledSvg
                                                                       height="1em"
                                                                       viewBox={Object {}}
                                                                       width="1em"
                                                                     >
                                                                       <svg
-                                                                        className="ewlipse2 css-1ux8cow-StyledSvg-StyledInlineSvg e2idor0"
+                                                                        className="css-ryh69w-StyledSvg e2idor0"
                                                                         height="1em"
                                                                         viewBox={Object {}}
                                                                         width="1em"
@@ -1076,65 +1176,26 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                                       </svg>
                                                                     </StyledSvg>
                                                                   </InlineSvg>
-                                                                </StyledInlineSvg>
-                                                              </span>
-                                                            </IconContainer>
-                                                            <Content>
-                                                              <div
-                                                                className="css-1yquznf-Content enk2k7v1"
-                                                              >
-                                                                All Projects
-                                                              </div>
-                                                            </Content>
-                                                            <StyledChevron
-                                                              hasChanges={false}
-                                                              isOpen={false}
-                                                              onClick={[Function]}
-                                                            >
-                                                              <div
-                                                                className="css-ft4nwy-StyledChevron enk2k7v4"
-                                                                onClick={[Function]}
-                                                              >
-                                                                <InlineSvg
-                                                                  src="icon-chevron-down"
-                                                                >
-                                                                  <StyledSvg
-                                                                    height="1em"
-                                                                    viewBox={Object {}}
-                                                                    width="1em"
-                                                                  >
-                                                                    <svg
-                                                                      className="css-ryh69w-StyledSvg e2idor0"
-                                                                      height="1em"
-                                                                      viewBox={Object {}}
-                                                                      width="1em"
-                                                                    >
-                                                                      <use
-                                                                        href="#test"
-                                                                        xlinkHref="#test"
-                                                                      />
-                                                                    </svg>
-                                                                  </StyledSvg>
-                                                                </InlineSvg>
-                                                              </div>
-                                                            </StyledChevron>
-                                                          </div>
-                                                        </StyledHeaderItem>
-                                                      </HeaderItem>
-                                                    </ForwardRef>
-                                                  </StyledHeaderItem>
-                                                </div>
-                                              </Actor>
-                                            </div>
-                                          </Component>
-                                        </AutoCompleteRoot>
-                                      </DropdownMenu>
-                                    </AutoComplete>
-                                  </DropdownAutoCompleteMenu>
-                                </DropdownAutoComplete>
-                              </ProjectSelector>
-                            </StyledProjectSelector>
-                          </MultipleProjectSelector>
+                                                                </div>
+                                                              </StyledChevron>
+                                                            </div>
+                                                          </StyledHeaderItem>
+                                                        </HeaderItem>
+                                                      </ForwardRef>
+                                                    </StyledHeaderItem>
+                                                  </div>
+                                                </Actor>
+                                              </div>
+                                            </Component>
+                                          </AutoCompleteRoot>
+                                        </DropdownMenu>
+                                      </AutoComplete>
+                                    </DropdownAutoCompleteMenu>
+                                  </DropdownAutoComplete>
+                                </ProjectSelector>
+                              </StyledProjectSelector>
+                            </MultipleProjectSelector>
+                          </StyledMultipleProjectSelector>
                         </div>
                       </HeaderItemPosition>
                       <HeaderSeparator>

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -526,7 +526,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                     >
                       <HeaderItemPosition>
                         <div
-                          className="css-5udiwc-HeaderItemPosition e165b9e40"
+                          className="css-1n6pjju-HeaderItemPosition e165b9e40"
                         >
                           <MultipleProjectSelector
                             multi={false}
@@ -1149,7 +1149,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                       </HeaderSeparator>
                       <HeaderItemPosition>
                         <div
-                          className="css-5udiwc-HeaderItemPosition e165b9e40"
+                          className="css-1n6pjju-HeaderItemPosition e165b9e40"
                         >
                           <withApi(MultipleEnvironmentSelector)
                             onChange={[Function]}
@@ -1682,7 +1682,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                       </HeaderSeparator>
                       <HeaderItemPosition>
                         <div
-                          className="css-5udiwc-HeaderItemPosition e165b9e40"
+                          className="css-1n6pjju-HeaderItemPosition e165b9e40"
                         >
                           <TimeRangeSelector
                             end={null}


### PR DESCRIPTION
![back-to-issues](https://user-images.githubusercontent.com/435981/52375506-ab1c9380-2a14-11e9-911d-07bd297916b3.gif)

I had to reorganize the templates a bit here, since previously the header was outside of the scope of the project request. 