### PR TITLE
perf: Bind Organization during EventManger

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -43,7 +43,7 @@ from sentry.models import (
     Activity, Environment, Event, EventError, EventMapping, EventUser, Group,
     GroupEnvironment, GroupHash, GroupLink, GroupRelease, GroupResolution, GroupStatus,
     Project, Release, ReleaseEnvironment, ReleaseProject,
-    ReleaseProjectEnvironment, UserReport
+    ReleaseProjectEnvironment, UserReport, Organization,
 )
 from sentry.plugins import plugins
 from sentry.signals import event_discarded, event_saved, first_event_received
@@ -852,6 +852,7 @@ class EventManager(object):
         data = self._data
 
         project = Project.objects.get_from_cache(id=project_id)
+        project._organization_cache = Organization.objects.get_from_cache(id=project.organization_id)
 
         # Check to make sure we're not about to do a bunch of work that's
         # already been done if we've processed an event with this ID. (This
@@ -866,6 +867,8 @@ class EventManager(object):
         except Event.DoesNotExist:
             pass
         else:
+            # Make sure we cache on the project before returning
+            event._project_cache = project
             logger.info(
                 'duplicate.found',
                 exc_info=True,

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -10,7 +10,6 @@ from confluent_kafka import OFFSET_INVALID, Producer, TopicPartition
 from django.utils.functional import cached_property
 
 from sentry import quotas
-from sentry.models import Organization
 from sentry.eventstream.base import EventStream
 from sentry.eventstream.kafka.consumer import SynchronizedConsumer
 from sentry.eventstream.kafka.protocol import get_task_kwargs_for_message
@@ -125,7 +124,7 @@ class KafkaEventStream(EventStream):
                is_new_group_environment, primary_hash, skip_consume=False):
         project = event.project
         retention_days = quotas.get_event_retention(
-            organization=Organization(project.organization_id)
+            organization=project.organization,
         )
 
         self._send(project.id, 'insert', extra_data=({


### PR DESCRIPTION
There are multiple places now that project.organization is needed,
including feature switches and options that are checked inside of
save_event, that we can't really skip binding this anymore.

It's being queried explicitly inside the the JavaScript plugin since
this happens in a different step of the process, and would need to be
rebound there, but is only used for a feature switch so choosing not to
bind it back.