### PR TITLE
feat: Add `get_url_viewname` to `Organization`

### DIFF
--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -439,10 +439,12 @@ class Organization(Model):
             ip_address=ip_address
         )
 
-    def get_url(self):
+    def get_url_viewname(self):
         from sentry import features
         if features.has('organizations:sentry10', self):
-            url = reverse('sentry-organization-issue-list', args=[self.slug])
+            return 'sentry-organization-issue-list'
         else:
-            url = reverse('sentry-organization-home', args=[self.slug])
-        return url
+            return 'sentry-organization-home'
+
+    def get_url(self):
+        return reverse(self.get_url_viewname(), args=[self.slug])


### PR DESCRIPTION
We need this in `getsentry` so that we can redirect to the correct url. getsentry uses django-hosts
and a different reverse, so we can't rely on the reverse method here.

Related to https://github.com/getsentry/getsentry/pull/2580.