### PR TITLE
feat(releases): Redirect Sentry 10 users off project releases pages

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/detail/project/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/project/index.jsx
@@ -2,6 +2,7 @@ import DocumentTitle from 'react-document-title';
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
+import {browserHistory} from 'react-router';
 
 import ApiMixin from 'app/mixins/apiMixin';
 
@@ -20,6 +21,10 @@ const ProjectReleaseDetails = createReactClass({
   propTypes: {
     setProjectNavSection: PropTypes.func,
     environment: SentryTypes.Environment,
+  },
+
+  contextTypes: {
+    organization: SentryTypes.Organization,
   },
 
   childContextTypes: {
@@ -43,6 +48,15 @@ const ProjectReleaseDetails = createReactClass({
   },
 
   componentWillMount() {
+    // Redirect any Sentry 10 user that has followed an old link and ended up here
+    const {location, params: {orgId, version}} = this.props;
+    const hasSentry10 = new Set(this.context.organization.features).has('sentry10');
+    if (hasSentry10) {
+      browserHistory.replace(
+        `/organizations/${orgId}/releases/${version}/${location.search}`
+      );
+    }
+
     this.props.setProjectNavSection('releases');
     this.fetchData();
   },

--- a/src/sentry/static/sentry/app/views/releases/list/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/projectReleases/index.jsx
@@ -55,6 +55,13 @@ const ProjectReleases = createReactClass({
   },
 
   componentWillMount() {
+    // Redirect any Sentry 10 user that has followed an old link and ended up here
+    const {location, params: {orgId}} = this.props;
+    const hasSentry10 = new Set(this.context.organization.features).has('sentry10');
+    if (hasSentry10) {
+      browserHistory.replace(`/organizations/${orgId}/releases/${location.search}`);
+    }
+
     this.props.setProjectNavSection('releases');
     this.fetchData();
   },

--- a/tests/js/spec/views/releases/list/projectReleases.spec.jsx
+++ b/tests/js/spec/views/releases/list/projectReleases.spec.jsx
@@ -20,7 +20,7 @@ describe('ProjectReleases', function() {
       params: {orgId: '123', projectId: '456'},
       location: {query: {per_page: 0, query: 'derp'}},
     };
-    projectReleases = shallow(<ProjectReleases {...props} />);
+    projectReleases = shallow(<ProjectReleases {...props} />, TestStubs.routerContext());
   });
 
   afterEach(function() {


### PR DESCRIPTION
If Sentry 10 users land on the project releases list or detail page
they will automatically get redirected to the associated Sentry 10 routes.