### PR TITLE
test(interfaces): Refactor tests to no longer call get_hash directly

### DIFF
--- a/src/sentry/interfaces/base.py
+++ b/src/sentry/interfaces/base.py
@@ -198,11 +198,11 @@ class Interface(object):
     def to_json(self):
         return prune_empty_keys(self._data)
 
-    def get_hash(self):
+    def get_hash(self, platform=None):
         return []
 
-    def compute_hashes(self, platform):
-        result = self.get_hash()
+    def compute_hashes(self, platform=None):
+        result = self.get_hash(platform)
         if not result:
             return []
         return [result]

--- a/src/sentry/interfaces/exception.py
+++ b/src/sentry/interfaces/exception.py
@@ -1031,7 +1031,7 @@ class Exception(Interface):
             'exc_omitted': self.exc_omitted,
         })
 
-    def compute_hashes(self, platform):
+    def compute_hashes(self, platform=None):
         system_hash = self.get_hash(platform, system_frames=True)
         if not system_hash:
             return []

--- a/src/sentry/interfaces/message.py
+++ b/src/sentry/interfaces/message.py
@@ -89,7 +89,7 @@ class Message(Interface):
             'params': self.params or None
         })
 
-    def get_hash(self):
+    def get_hash(self, platform=None):
         return [self.message or self.formatted]
 
     def to_string(self, event, is_public=False, **kwargs):

--- a/src/sentry/interfaces/security.py
+++ b/src/sentry/interfaces/security.py
@@ -171,7 +171,7 @@ class Hpkp(SecurityReport):
     def get_culprit(self):
         return None
 
-    def get_hash(self, is_processed_data=True):
+    def get_hash(self, platform=None, is_processed_data=True):
         return ['hpkp', self.hostname]
 
     def get_message(self):
@@ -235,7 +235,7 @@ class ExpectStaple(SecurityReport):
     def get_culprit(self):
         return self.hostname
 
-    def get_hash(self, is_processed_data=True):
+    def get_hash(self, platform=None, is_processed_data=True):
         return ['expect-staple', self.hostname]
 
     def get_message(self):
@@ -297,7 +297,7 @@ class ExpectCT(SecurityReport):
     def get_culprit(self):
         return self.hostname
 
-    def get_hash(self, is_processed_data=True):
+    def get_hash(self, platform=None, is_processed_data=True):
         return ['expect-ct', self.hostname]
 
     def get_message(self):
@@ -353,7 +353,7 @@ class Csp(SecurityReport):
 
         return cls.to_python(kwargs)
 
-    def get_hash(self, is_processed_data=True):
+    def get_hash(self, platform=None, is_processed_data=True):
         if self._local_script_violation_type:
             uri = "'%s'" % self._local_script_violation_type
         else:

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -833,7 +833,7 @@ class Stacktrace(Interface):
             'registers': self.registers,
         })
 
-    def compute_hashes(self, platform):
+    def compute_hashes(self, platform=None):
         system_hash = self.get_hash(platform, system_frames=True)
         if not system_hash:
             return []

--- a/src/sentry/interfaces/template.py
+++ b/src/sentry/interfaces/template.py
@@ -58,7 +58,7 @@ class Template(Interface):
         }
         return cls(**kwargs)
 
-    def get_hash(self):
+    def get_hash(self, platform=None):
         return [self.filename, self.context_line]
 
     def to_string(self, event, is_public=False, **kwargs):

--- a/src/sentry/interfaces/threads.py
+++ b/src/sentry/interfaces/threads.py
@@ -86,7 +86,7 @@ class Threads(Interface):
         else:
             return meta
 
-    def get_hash(self):
+    def get_hash(self, platform=None):
         if len(self.values) != 1:
             return []
         stacktrace = self.values[0].get('stacktrace')

--- a/src/sentry/interfaces/user.py
+++ b/src/sentry/interfaces/user.py
@@ -125,9 +125,6 @@ class User(Interface):
             'data': meta.get('data'),
         }
 
-    def get_hash(self):
-        return []
-
     def get_display_name(self):
         return self.email or self.username
 

--- a/tests/sentry/interfaces/test_message.py
+++ b/tests/sentry/interfaces/test_message.py
@@ -26,16 +26,16 @@ class MessageTest(TestCase):
             'formatted': 'Hello there world!'
         }
 
-    def test_get_hash_prefers_message(self):
-        assert self.interface.get_hash() == [self.interface.message]
+    def test_compute_hashes_prefers_message(self):
+        assert self.interface.compute_hashes() == [[self.interface.message]]
 
-    def test_get_hash_uses_formatted(self):
+    def test_compute_hashes_uses_formatted(self):
         interface = Message.to_python(dict(
             message=None,
             params=(),
             formatted='Hello there world!'
         ))
-        assert interface.get_hash() == [interface.formatted]
+        assert interface.compute_hashes() == [[interface.formatted]]
 
     def test_format_kwargs(self):
         interface = Message.to_python(dict(

--- a/tests/sentry/interfaces/test_security.py
+++ b/tests/sentry/interfaces/test_security.py
@@ -97,7 +97,7 @@ class CspTest(TestCase):
         )
         assert result.get_culprit() == "style-src http://example2.com 'self'"
 
-    def test_get_hash(self):
+    def test_compute_hashes(self):
         result = Csp.to_python(
             dict(
                 document_uri='http://example.com/foo',
@@ -105,7 +105,7 @@ class CspTest(TestCase):
                 blocked_uri='',
             )
         )
-        assert result.get_hash() == ['script-src', "'self'"]
+        assert result.compute_hashes() == [['script-src', "'self'"]]
 
         result = Csp.to_python(
             dict(
@@ -114,7 +114,7 @@ class CspTest(TestCase):
                 blocked_uri='self',
             )
         )
-        assert result.get_hash() == ['script-src', "'self'"]
+        assert result.compute_hashes() == [['script-src', "'self'"]]
 
         result = Csp.to_python(
             dict(
@@ -123,7 +123,7 @@ class CspTest(TestCase):
                 blocked_uri='http://example.com/lol.js',
             )
         )
-        assert result.get_hash() == ['script-src', 'example.com']
+        assert result.compute_hashes() == [['script-src', 'example.com']]
 
         result = Csp.to_python(
             dict(
@@ -132,7 +132,7 @@ class CspTest(TestCase):
                 blocked_uri='data:foo',
             )
         )
-        assert result.get_hash() == ['img-src', 'data:']
+        assert result.compute_hashes() == [['img-src', 'data:']]
 
         result = Csp.to_python(
             dict(
@@ -141,7 +141,7 @@ class CspTest(TestCase):
                 blocked_uri='ftp://example.com/foo',
             )
         )
-        assert result.get_hash() == ['img-src', 'ftp://example.com']
+        assert result.compute_hashes() == [['img-src', 'ftp://example.com']]
 
     def test_get_tags(self):
         assert self.interface.get_tags() == [

--- a/tests/sentry/interfaces/test_template.py
+++ b/tests/sentry/interfaces/test_template.py
@@ -41,9 +41,9 @@ class TemplateTest(TestCase):
         with pytest.raises(InterfaceValidationError):
             Template.to_python({"lineno": 1, "context_line": 42})
 
-    def test_get_hash(self):
-        result = self.interface.get_hash()
-        self.assertEquals(result, ['foo.html', 'hello world'])
+    def test_compute_hashes(self):
+        result = self.interface.compute_hashes()
+        self.assertEquals(result, [['foo.html', 'hello world']])
 
     @mock.patch('sentry.interfaces.template.get_context')
     @mock.patch('sentry.interfaces.template.Template.get_traceback')

--- a/tests/sentry/interfaces/test_threads.py
+++ b/tests/sentry/interfaces/test_threads.py
@@ -76,9 +76,9 @@ class ThreadsTest(TestCase):
         assert Threads.to_python({"values": [{"name": None}]}).to_json() == sink
         assert Threads.to_python({"values": [{"stacktrace": None}]}).to_json() == sink
 
-    def test_get_hash(self):
-        result = self.interface.get_hash()
-        self.assertEquals(result, [['foo/baz.c', 'main']])
+    def test_compute_hashes(self):
+        result = self.interface.compute_hashes()
+        self.assertEquals(result, [[['foo/baz.c', 'main']]])
 
     def test_no_hash(self):
         interface = Threads.to_python(
@@ -138,5 +138,4 @@ class ThreadsTest(TestCase):
                 ]
             )
         )
-        result = interface.get_hash()
-        assert not result
+        assert interface.compute_hashes() == []


### PR DESCRIPTION
My plan is to move out grouping from the interfaces and to facilitate this I
refactored the tests to use compute_hashes instead of get_hash now.  I will
further refactor this going forward to no longer use the interfaces directly.