### PR TITLE
test(acceptance): Fix issue details timeouts with assistant

### DIFF
--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -178,8 +178,8 @@ class IssueDetailsTest(AcceptanceTestCase):
 
     def wait_until_loaded(self, skip_assistant=None):
         self.browser.wait_until('.entries')
+        self.browser.wait_until_not('.loading-indicator')
         self.browser.wait_until('[data-test-id="linked-issues"]')
         self.browser.wait_until('[data-test-id="loaded-device-name"]')
         if skip_assistant is None:
-            self.browser.wait_until('[data-test-id="assistant-cue"]')
-        self.browser.wait_until_not('.loading-indicator')
+            self.browser.wait_until('[data-test-id="assistant-cue"]', timeout=6)


### PR DESCRIPTION
I suspect this condition was timing out because it was ordered incorrectly. We should wait for loading indicator to disappear, then wait for the other elements to be present.