### PR TITLE
tests: Attempt to make discover saved query test more stable

### DIFF
--- a/tests/acceptance/test_organization_discover.py
+++ b/tests/acceptance/test_organization_discover.py
@@ -65,6 +65,6 @@ class OrganizationDiscoverTest(AcceptanceTestCase):
             self.browser.wait_until_not('.loading')
             self.browser.find_element_by_xpath("//button//span[contains(text(), 'Save')]").click()
             self.browser.get(self.path + '?view=saved')
-            self.browser.wait_until_not('.loading')
             self.browser.wait_until('[data-test-id="result"]')
+            self.browser.wait_until_not('.loading')
             self.browser.snapshot('discover - saved query list')

--- a/tests/acceptance/test_organization_discover.py
+++ b/tests/acceptance/test_organization_discover.py
@@ -55,7 +55,8 @@ class OrganizationDiscoverTest(AcceptanceTestCase):
             self.browser.get(self.path)
             self.browser.wait_until_not('.loading')
             self.browser.find_element_by_xpath("//button//span[contains(text(), 'Save')]").click()
-            self.browser.get(self.path + 'saved/1/?edit=true')
+            self.browser.get(self.path + 'saved/1/?editing=true')
+            self.browser.wait_until('[data-test-id="result"]')
             self.browser.wait_until_not('.loading')
             self.browser.snapshot('discover - saved query')
 


### PR DESCRIPTION
This test has been changing state quite a bit in percy lately. Trying to reverse the wait conditions so that we don't end up with a loading spinner on top of the results table.