### PR TITLE
feat(ui): Add actor toggling to DropdownAutocomplete

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownAutoComplete.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoComplete.jsx
@@ -9,7 +9,7 @@ class DropdownAutoComplete extends React.Component {
     ...DropdownAutoCompleteMenu.propTypes,
 
     // Should clicking the actor toggle visibility?
-    shouldToggle: PropTypes.bool,
+    allowActorToggle: PropTypes.bool,
 
     children: PropTypes.func,
   };
@@ -19,7 +19,7 @@ class DropdownAutoComplete extends React.Component {
   };
 
   render() {
-    const {children, shouldToggle, ...props} = this.props;
+    const {children, allowActorToggle, ...props} = this.props;
 
     return (
       <DropdownAutoCompleteMenu {...props}>
@@ -36,7 +36,7 @@ class DropdownAutoComplete extends React.Component {
               isOpen={renderProps.isOpen}
               role="button"
               onClick={
-                renderProps.isOpen && shouldToggle
+                renderProps.isOpen && allowActorToggle
                   ? renderProps.actions.close
                   : renderProps.actions.open
               }

--- a/src/sentry/static/sentry/app/components/dropdownAutoComplete.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoComplete.jsx
@@ -7,6 +7,10 @@ import DropdownAutoCompleteMenu from 'app/components/dropdownAutoCompleteMenu';
 class DropdownAutoComplete extends React.Component {
   static propTypes = {
     ...DropdownAutoCompleteMenu.propTypes,
+
+    // Should clicking the actor toggle visibility?
+    shouldToggle: PropTypes.bool,
+
     children: PropTypes.func,
   };
 
@@ -15,7 +19,7 @@ class DropdownAutoComplete extends React.Component {
   };
 
   render() {
-    const {children, ...props} = this.props;
+    const {children, shouldToggle, ...props} = this.props;
 
     return (
       <DropdownAutoCompleteMenu {...props}>
@@ -31,7 +35,11 @@ class DropdownAutoComplete extends React.Component {
             <Actor
               isOpen={renderProps.isOpen}
               role="button"
-              onClick={renderProps.actions.open}
+              onClick={
+                renderProps.isOpen && shouldToggle
+                  ? renderProps.actions.close
+                  : renderProps.actions.open
+              }
               {...actorProps}
             >
               {children(renderProps)}

--- a/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
@@ -182,7 +182,7 @@ class MultipleEnvironmentSelector extends React.PureComponent {
           return (
             <StyledDropdownAutoComplete
               alignMenu="left"
-              shouldToggle={true}
+              allowActorToggle={true}
               closeOnSelect={true}
               blendCorner={false}
               searchPlaceholder={t('Filter environments')}

--- a/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
@@ -182,6 +182,7 @@ class MultipleEnvironmentSelector extends React.PureComponent {
           return (
             <StyledDropdownAutoComplete
               alignMenu="left"
+              shouldToggle={true}
               closeOnSelect={true}
               blendCorner={false}
               searchPlaceholder={t('Filter environments')}

--- a/src/sentry/static/sentry/app/components/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectSelector.jsx
@@ -171,6 +171,7 @@ class ProjectSelector extends React.Component {
     return (
       <DropdownAutoComplete
         alignMenu="left"
+        shouldToggle={true}
         closeOnSelect={true}
         blendCorner={false}
         searchPlaceholder={t('Filter projects')}

--- a/src/sentry/static/sentry/app/components/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectSelector.jsx
@@ -171,7 +171,7 @@ class ProjectSelector extends React.Component {
     return (
       <DropdownAutoComplete
         alignMenu="left"
-        shouldToggle={true}
+        allowActorToggle={true}
         closeOnSelect={true}
         blendCorner={false}
         searchPlaceholder={t('Filter projects')}

--- a/tests/js/spec/components/dropdownAutoComplete.spec.jsx
+++ b/tests/js/spec/components/dropdownAutoComplete.spec.jsx
@@ -43,7 +43,7 @@ describe('DropdownAutoComplete', function() {
 
   it('toggles dropdown menu when actor is clicked', function() {
     const wrapper = mount(
-      <DropdownAutoComplete shouldToggle items={items}>
+      <DropdownAutoComplete allowActorToggle items={items}>
         {() => 'Click Me!'}
       </DropdownAutoComplete>,
       routerContext

--- a/tests/js/spec/components/dropdownAutoComplete.spec.jsx
+++ b/tests/js/spec/components/dropdownAutoComplete.spec.jsx
@@ -5,27 +5,24 @@ import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
 
 describe('DropdownAutoComplete', function() {
   const routerContext = TestStubs.routerContext();
+  const items = [
+    {
+      value: 'apple',
+      label: <div>Apple</div>,
+    },
+    {
+      value: 'bacon',
+      label: <div>Bacon</div>,
+    },
+    {
+      value: 'corn',
+      label: <div>Corn</div>,
+    },
+  ];
 
   it('has actor wrapper', function() {
     const wrapper = mount(
-      <DropdownAutoComplete
-        items={[
-          {
-            value: 'apple',
-            label: <div>Apple</div>,
-          },
-          {
-            value: 'bacon',
-            label: <div>Bacon</div>,
-          },
-          {
-            value: 'corn',
-            label: <div>Corn</div>,
-          },
-        ]}
-      >
-        {() => 'Click Me!'}
-      </DropdownAutoComplete>,
+      <DropdownAutoComplete items={items}>{() => 'Click Me!'}</DropdownAutoComplete>,
       routerContext
     );
     expect(wrapper.find('div[role="button"]')).toHaveLength(1);
@@ -34,27 +31,26 @@ describe('DropdownAutoComplete', function() {
 
   it('opens dropdown menu when actor is clicked', function() {
     const wrapper = mount(
-      <DropdownAutoComplete
-        items={[
-          {
-            value: 'apple',
-            label: <div>Apple</div>,
-          },
-          {
-            value: 'bacon',
-            label: <div>Bacon</div>,
-          },
-          {
-            value: 'corn',
-            label: <div>Corn</div>,
-          },
-        ]}
-      >
+      <DropdownAutoComplete items={items}>{() => 'Click Me!'}</DropdownAutoComplete>,
+      routerContext
+    );
+    wrapper.find('Actor[role="button"]').simulate('click');
+    expect(wrapper.find('StyledMenu')).toHaveLength(1);
+
+    wrapper.find('Actor[role="button"]').simulate('click');
+    expect(wrapper.find('StyledMenu')).toHaveLength(1);
+  });
+
+  it('toggles dropdown menu when actor is clicked', function() {
+    const wrapper = mount(
+      <DropdownAutoComplete shouldToggle items={items}>
         {() => 'Click Me!'}
       </DropdownAutoComplete>,
       routerContext
     );
     wrapper.find('Actor[role="button"]').simulate('click');
     expect(wrapper.find('StyledMenu')).toHaveLength(1);
+    wrapper.find('Actor[role="button"]').simulate('click');
+    expect(wrapper.find('StyledMenu')).toHaveLength(0);
   });
 });

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -879,6 +879,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                     onSelect={[Function]}
                                     rootClassName="css-h5t9nh-rootContainerStyles"
                                     searchPlaceholder="Filter projects"
+                                    shouldToggle={true}
                                     virtualizedHeight={40}
                                     zIndex={1001}
                                   >
@@ -1351,6 +1352,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                     onSelect={[Function]}
                                     rootClassName="css-1utm1zz-rootClassName"
                                     searchPlaceholder="Filter environments"
+                                    shouldToggle={true}
                                     virtualizedHeight={40}
                                     zIndex={1001}
                                   >
@@ -1383,6 +1385,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                       onSelect={[Function]}
                                       rootClassName="css-1utm1zz-rootClassName"
                                       searchPlaceholder="Filter environments"
+                                      shouldToggle={true}
                                       virtualizedHeight={40}
                                       zIndex={1001}
                                     >

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -800,6 +800,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                 >
                                   <DropdownAutoCompleteMenu
                                     alignMenu="left"
+                                    allowActorToggle={true}
                                     blendCorner={false}
                                     className="ewlipse0 css-11ijjr3-StyledProjectSelector"
                                     closeOnSelect={true}
@@ -879,7 +880,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                     onSelect={[Function]}
                                     rootClassName="css-h5t9nh-rootContainerStyles"
                                     searchPlaceholder="Filter projects"
-                                    shouldToggle={true}
                                     virtualizedHeight={40}
                                     zIndex={1001}
                                   >
@@ -1326,6 +1326,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                 >
                                   <StyledDropdownAutoComplete
                                     alignMenu="left"
+                                    allowActorToggle={true}
                                     blendCorner={false}
                                     closeOnSelect={true}
                                     emptyHidesInput={true}
@@ -1352,12 +1353,12 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                     onSelect={[Function]}
                                     rootClassName="css-1utm1zz-rootClassName"
                                     searchPlaceholder="Filter environments"
-                                    shouldToggle={true}
                                     virtualizedHeight={40}
                                     zIndex={1001}
                                   >
                                     <DropdownAutoComplete
                                       alignMenu="left"
+                                      allowActorToggle={true}
                                       blendCorner={false}
                                       className="css-qn89t6-StyledDropdownAutoComplete e1gsuvme2"
                                       closeOnSelect={true}
@@ -1385,7 +1386,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                       onSelect={[Function]}
                                       rootClassName="css-1utm1zz-rootClassName"
                                       searchPlaceholder="Filter environments"
-                                      shouldToggle={true}
                                       virtualizedHeight={40}
                                       zIndex={1001}
                                     >

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -716,6 +716,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                               >
                                 <DropdownAutoComplete
                                   alignMenu="left"
+                                  allowActorToggle={true}
                                   blendCorner={false}
                                   className="ewlipse0 css-11ijjr3-StyledProjectSelector"
                                   closeOnSelect={true}
@@ -800,7 +801,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                 >
                                   <DropdownAutoCompleteMenu
                                     alignMenu="left"
-                                    allowActorToggle={true}
                                     blendCorner={false}
                                     className="ewlipse0 css-11ijjr3-StyledProjectSelector"
                                     closeOnSelect={true}


### PR DESCRIPTION
I opted to make this a prop as to not break existing behavior (even though this seems like a reasonable default)

Fixes issue with closing multiple environment selector when there are no environments