### PR TITLE
ref: Fixed a broken test and refactored more of grouping

### DIFF
--- a/src/sentry/interfaces/base.py
+++ b/src/sentry/interfaces/base.py
@@ -198,14 +198,8 @@ class Interface(object):
     def to_json(self):
         return prune_empty_keys(self._data)
 
-    def get_hash(self, platform=None):
-        return []
-
     def compute_hashes(self, platform=None):
-        result = self.get_hash(platform)
-        if not result:
-            return []
-        return [result]
+        return []
 
     def get_title(self):
         return _(type(self).__name__)

--- a/src/sentry/interfaces/message.py
+++ b/src/sentry/interfaces/message.py
@@ -89,8 +89,8 @@ class Message(Interface):
             'params': self.params or None
         })
 
-    def get_hash(self, platform=None):
-        return [self.message or self.formatted]
+    def compute_hashes(self, platform=None):
+        return [[self.message or self.formatted]]
 
     def to_string(self, event, is_public=False, **kwargs):
         return self.formatted or self.message

--- a/src/sentry/interfaces/security.py
+++ b/src/sentry/interfaces/security.py
@@ -171,8 +171,8 @@ class Hpkp(SecurityReport):
     def get_culprit(self):
         return None
 
-    def get_hash(self, platform=None, is_processed_data=True):
-        return ['hpkp', self.hostname]
+    def compute_hashes(self, platform=None, is_processed_data=True):
+        return [['hpkp', self.hostname]]
 
     def get_message(self):
         return u"Public key pinning validation failed for '{self.hostname}'".format(self=self)
@@ -235,8 +235,8 @@ class ExpectStaple(SecurityReport):
     def get_culprit(self):
         return self.hostname
 
-    def get_hash(self, platform=None, is_processed_data=True):
-        return ['expect-staple', self.hostname]
+    def compute_hashes(self, platform=None, is_processed_data=True):
+        return [['expect-staple', self.hostname]]
 
     def get_message(self):
         return u"Expect-Staple failed for '{self.hostname}'".format(self=self)
@@ -297,8 +297,8 @@ class ExpectCT(SecurityReport):
     def get_culprit(self):
         return self.hostname
 
-    def get_hash(self, platform=None, is_processed_data=True):
-        return ['expect-ct', self.hostname]
+    def compute_hashes(self, platform=None, is_processed_data=True):
+        return [['expect-ct', self.hostname]]
 
     def get_message(self):
         return u"Expect-CT failed for '{self.hostname}'".format(self=self)
@@ -353,13 +353,13 @@ class Csp(SecurityReport):
 
         return cls.to_python(kwargs)
 
-    def get_hash(self, platform=None, is_processed_data=True):
+    def compute_hashes(self, platform=None, is_processed_data=True):
         if self._local_script_violation_type:
             uri = "'%s'" % self._local_script_violation_type
         else:
             uri = self._normalized_blocked_uri
 
-        return [self.effective_directive, uri]
+        return [[self.effective_directive, uri]]
 
     def get_message(self):
         templates = {

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -640,6 +640,18 @@ class Frame(Interface):
         return '%s in %s' % (fileloc, self.function or '?', )
 
 
+def compute_hashes_from_inner_stacks(self, platform):
+    system_hash = self.compute_stack_hash(platform, system_frames=True)
+    if not system_hash:
+        return []
+
+    app_hash = self.compute_stack_hash(platform, system_frames=False)
+    if system_hash == app_hash or not app_hash:
+        return [system_hash]
+
+    return [system_hash, app_hash]
+
+
 class Stacktrace(Interface):
     """
     A stacktrace contains a list of frames, each with various bits (most optional)
@@ -834,17 +846,9 @@ class Stacktrace(Interface):
         })
 
     def compute_hashes(self, platform=None):
-        system_hash = self.get_hash(platform, system_frames=True)
-        if not system_hash:
-            return []
+        return compute_hashes_from_inner_stacks(self, platform)
 
-        app_hash = self.get_hash(platform, system_frames=False)
-        if system_hash == app_hash or not app_hash:
-            return [system_hash]
-
-        return [system_hash, app_hash]
-
-    def get_hash(self, platform=None, system_frames=True):
+    def compute_stack_hash(self, platform=None, system_frames=True):
         frames = self.frames
 
         # TODO(dcramer): this should apply only to platform=javascript

--- a/src/sentry/interfaces/template.py
+++ b/src/sentry/interfaces/template.py
@@ -58,8 +58,8 @@ class Template(Interface):
         }
         return cls(**kwargs)
 
-    def get_hash(self, platform=None):
-        return [self.filename, self.context_line]
+    def compute_hashes(self, platform=None):
+        return [[self.filename, self.context_line]]
 
     def to_string(self, event, is_public=False, **kwargs):
         context = get_context(

--- a/src/sentry/interfaces/threads.py
+++ b/src/sentry/interfaces/threads.py
@@ -86,17 +86,10 @@ class Threads(Interface):
         else:
             return meta
 
-    def get_hash(self, platform=None):
+    def compute_hashes(self, platform=None):
         if len(self.values) != 1:
             return []
         stacktrace = self.values[0].get('stacktrace')
         if not stacktrace:
             return []
-        system_hash = stacktrace.get_hash(system_frames=True)
-        if not system_hash:
-            return []
-        app_hash = stacktrace.get_hash(system_frames=False)
-        if system_hash == app_hash or not app_hash:
-            return [system_hash]
-
-        return [system_hash, app_hash]
+        return stacktrace.compute_hashes(platform)

--- a/tests/sentry/interfaces/test_exception.py
+++ b/tests/sentry/interfaces/test_exception.py
@@ -114,8 +114,6 @@ ValueError: hello world
         inst = self.interface
 
         all_values = [sum(chain.from_iterable(v.compute_hashes() for v in inst.values), [])]
-        print('want', all_values)
-        print('got', inst.compute_hashes())
         assert inst.compute_hashes() == all_values
 
     def test_compute_hashes_no_stacks(self):

--- a/tests/sentry/interfaces/test_exception.py
+++ b/tests/sentry/interfaces/test_exception.py
@@ -114,6 +114,8 @@ ValueError: hello world
         inst = self.interface
 
         all_values = [sum(chain.from_iterable(v.compute_hashes() for v in inst.values), [])]
+        print('want', all_values)
+        print('got', inst.compute_hashes())
         assert inst.compute_hashes() == all_values
 
     def test_context_with_mixed_frames(self):

--- a/tests/sentry/interfaces/test_exception.py
+++ b/tests/sentry/interfaces/test_exception.py
@@ -118,6 +118,51 @@ ValueError: hello world
         print('got', inst.compute_hashes())
         assert inst.compute_hashes() == all_values
 
+    def test_compute_hashes_no_stacks(self):
+        interface = Exception.to_python(
+            dict(
+                values=[
+                    {
+                        'type': 'ValueError',
+                        'value': 'hello world',
+                        'module': 'foo.bar',
+                    }, {
+                        'type': 'NameError',
+                        'value': 'yo',
+                        'module': 'foo.bar',
+                    }
+                ]
+            )
+        )
+
+        assert interface.compute_hashes() == [['ValueError', 'hello world', 'NameError', 'yo']]
+
+    def test_compute_hashes_half_stacks(self):
+        interface = Exception.to_python(
+            dict(
+                values=[
+                    {
+                        'type': 'ValueError',
+                        'value': 'hello world',
+                        'module': 'foo.bar',
+                        'stacktrace': {
+                            'frames': [{
+                                'filename': 'foo/baz.py',
+                                'lineno': 1,
+                                'in_app': True,
+                            }]
+                        },
+                    }, {
+                        'type': 'NameError',
+                        'value': 'yo',
+                        'module': 'foo.bar',
+                    }
+                ]
+            )
+        )
+
+        assert interface.compute_hashes() == [['foo/baz.py', 1, 'ValueError']]
+
     def test_context_with_mixed_frames(self):
         inst = Exception.to_python(
             dict(

--- a/tests/sentry/interfaces/test_threads.py
+++ b/tests/sentry/interfaces/test_threads.py
@@ -78,7 +78,7 @@ class ThreadsTest(TestCase):
 
     def test_compute_hashes(self):
         result = self.interface.compute_hashes()
-        self.assertEquals(result, [[['foo/baz.c', 'main']]])
+        self.assertEquals(result, [['foo/baz.c', 'main']])
 
     def test_no_hash(self):
         interface = Threads.to_python(


### PR DESCRIPTION
This pull request is the followup to #11958.

It removes a few more calls to `get_hash` across interfaces but it can't fully replace the call from exception to stacktrace. This also fixes what I assume is a bug: threads returned one level too much of hash information.