### PR TITLE
tests(acceptance): Remove waiting for assistant cue

### DIFF
--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -40,7 +40,7 @@ class IssueDetailsTest(AcceptanceTestCase):
         )
 
         self.browser.get(
-            u'/{}/{}/issues/{}/#assistant'.format(self.org.slug, self.project.slug, event.group.id)
+            u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
         self.wait_until_loaded()
         self.browser.snapshot('issue details python')
@@ -51,7 +51,7 @@ class IssueDetailsTest(AcceptanceTestCase):
         )
 
         self.browser.get(
-            u'/{}/{}/issues/{}/#assistant'.format(self.org.slug, self.project.slug, event.group.id)
+            u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
         self.wait_until_loaded()
         self.browser.snapshot('issue details cocoa')
@@ -63,7 +63,7 @@ class IssueDetailsTest(AcceptanceTestCase):
         )
 
         self.browser.get(
-            u'/{}/{}/issues/{}/#assistant'.format(self.org.slug, self.project.slug, event.group.id)
+            u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
         self.wait_until_loaded()
         self.browser.snapshot('issue details unity')
@@ -75,7 +75,7 @@ class IssueDetailsTest(AcceptanceTestCase):
         )
 
         self.browser.get(
-            u'/{}/{}/issues/{}/#assistant'.format(self.org.slug, self.project.slug, event.group.id)
+            u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
         self.wait_until_loaded()
         self.browser.snapshot('issue details aspnetcore')
@@ -86,8 +86,8 @@ class IssueDetailsTest(AcceptanceTestCase):
         )
 
         self.browser.get(
-            u'/{}/{}/issues/{}/events/{}/#assistant'.format(self.org.slug,
-                                                            self.project.slug, event.group.id, event.id)
+            u'/{}/{}/issues/{}/events/{}/'.format(self.org.slug,
+                                                  self.project.slug, event.group.id, event.id)
         )
         self.wait_until_loaded()
         self.browser.snapshot('issue details javascript - event details')
@@ -103,7 +103,7 @@ class IssueDetailsTest(AcceptanceTestCase):
         )
 
         self.browser.get(
-            u'/{}/{}/issues/{}/#assistant'.format(self.org.slug, self.project.slug, event.group.id)
+            u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
         self.wait_until_loaded()
         self.browser.snapshot('issue details rust')
@@ -114,7 +114,7 @@ class IssueDetailsTest(AcceptanceTestCase):
         )
 
         self.browser.get(
-            u'/{}/{}/issues/{}/#assistant'.format(self.org.slug, self.project.slug, event.group.id)
+            u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
         self.wait_until_loaded()
         self.browser.snapshot('issue details cordova')
@@ -125,7 +125,7 @@ class IssueDetailsTest(AcceptanceTestCase):
         )
 
         self.browser.get(
-            u'/{}/{}/issues/{}/#assistant'.format(self.org.slug, self.project.slug, event.group.id)
+            u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
         self.wait_until_loaded()
         self.browser.snapshot('issue details pii stripped')
@@ -171,7 +171,7 @@ class IssueDetailsTest(AcceptanceTestCase):
         )
 
         self.browser.get(
-            u'/{}/{}/issues/{}/activity/#assistant'.format(
+            u'/{}/{}/issues/{}/activity/'.format(
                 self.org.slug, self.project.slug, event.group.id)
         )
         self.browser.wait_until('.activity-item')

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -138,7 +138,7 @@ class IssueDetailsTest(AcceptanceTestCase):
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
-        self.wait_until_loaded(skip_assistant=True)
+        self.wait_until_loaded()
         self.browser.snapshot('issue details empty exception')
 
     def test_empty_stacktrace(self):
@@ -149,7 +149,7 @@ class IssueDetailsTest(AcceptanceTestCase):
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
-        self.wait_until_loaded(skip_assistant=True)
+        self.wait_until_loaded()
         self.browser.snapshot('issue details empty stacktrace')
 
     def test_invalid_interfaces(self):
@@ -160,7 +160,7 @@ class IssueDetailsTest(AcceptanceTestCase):
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
-        self.wait_until_loaded(skip_assistant=True)
+        self.wait_until_loaded()
         self.browser.click('.errors-toggle')
         self.browser.wait_until('.entries > .errors ul')
         self.browser.snapshot('issue details invalid interfaces')
@@ -177,10 +177,8 @@ class IssueDetailsTest(AcceptanceTestCase):
         self.browser.wait_until('.activity-item')
         self.browser.snapshot('issue activity python')
 
-    def wait_until_loaded(self, skip_assistant=None):
+    def wait_until_loaded(self):
         self.browser.wait_until_not('.loading-indicator')
         self.browser.wait_until('.entries')
         self.browser.wait_until('[data-test-id="linked-issues"]')
         self.browser.wait_until('[data-test-id="loaded-device-name"]')
-        if skip_assistant is None:
-            self.browser.wait_until('[data-test-id="assistant-cue"]')

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -40,7 +40,7 @@ class IssueDetailsTest(AcceptanceTestCase):
         )
 
         self.browser.get(
-            u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
+            u'/{}/{}/issues/{}/#assistant'.format(self.org.slug, self.project.slug, event.group.id)
         )
         self.wait_until_loaded()
         self.browser.snapshot('issue details python')
@@ -51,7 +51,7 @@ class IssueDetailsTest(AcceptanceTestCase):
         )
 
         self.browser.get(
-            u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
+            u'/{}/{}/issues/{}/#assistant'.format(self.org.slug, self.project.slug, event.group.id)
         )
         self.wait_until_loaded()
         self.browser.snapshot('issue details cocoa')
@@ -63,7 +63,7 @@ class IssueDetailsTest(AcceptanceTestCase):
         )
 
         self.browser.get(
-            u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
+            u'/{}/{}/issues/{}/#assistant'.format(self.org.slug, self.project.slug, event.group.id)
         )
         self.wait_until_loaded()
         self.browser.snapshot('issue details unity')
@@ -75,7 +75,7 @@ class IssueDetailsTest(AcceptanceTestCase):
         )
 
         self.browser.get(
-            u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
+            u'/{}/{}/issues/{}/#assistant'.format(self.org.slug, self.project.slug, event.group.id)
         )
         self.wait_until_loaded()
         self.browser.snapshot('issue details aspnetcore')
@@ -86,8 +86,8 @@ class IssueDetailsTest(AcceptanceTestCase):
         )
 
         self.browser.get(
-            u'/{}/{}/issues/{}/events/{}/'.format(self.org.slug,
-                                                  self.project.slug, event.group.id, event.id)
+            u'/{}/{}/issues/{}/events/{}/#assistant'.format(self.org.slug,
+                                                            self.project.slug, event.group.id, event.id)
         )
         self.wait_until_loaded()
         self.browser.snapshot('issue details javascript - event details')
@@ -103,7 +103,7 @@ class IssueDetailsTest(AcceptanceTestCase):
         )
 
         self.browser.get(
-            u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
+            u'/{}/{}/issues/{}/#assistant'.format(self.org.slug, self.project.slug, event.group.id)
         )
         self.wait_until_loaded()
         self.browser.snapshot('issue details rust')
@@ -114,7 +114,7 @@ class IssueDetailsTest(AcceptanceTestCase):
         )
 
         self.browser.get(
-            u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
+            u'/{}/{}/issues/{}/#assistant'.format(self.org.slug, self.project.slug, event.group.id)
         )
         self.wait_until_loaded()
         self.browser.snapshot('issue details cordova')
@@ -125,7 +125,7 @@ class IssueDetailsTest(AcceptanceTestCase):
         )
 
         self.browser.get(
-            u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
+            u'/{}/{}/issues/{}/#assistant'.format(self.org.slug, self.project.slug, event.group.id)
         )
         self.wait_until_loaded()
         self.browser.snapshot('issue details pii stripped')
@@ -171,15 +171,16 @@ class IssueDetailsTest(AcceptanceTestCase):
         )
 
         self.browser.get(
-            u'/{}/{}/issues/{}/activity'.format(self.org.slug, self.project.slug, event.group.id)
+            u'/{}/{}/issues/{}/activity/#assistant'.format(
+                self.org.slug, self.project.slug, event.group.id)
         )
         self.browser.wait_until('.activity-item')
         self.browser.snapshot('issue activity python')
 
     def wait_until_loaded(self, skip_assistant=None):
-        self.browser.wait_until('.entries')
         self.browser.wait_until_not('.loading-indicator')
+        self.browser.wait_until('.entries')
         self.browser.wait_until('[data-test-id="linked-issues"]')
         self.browser.wait_until('[data-test-id="loaded-device-name"]')
         if skip_assistant is None:
-            self.browser.wait_until('[data-test-id="assistant-cue"]', timeout=6)
+            self.browser.wait_until('[data-test-id="assistant-cue"]')


### PR DESCRIPTION
This has been causing travis failures, it's better to deal with percy than waiting 20 minutes to re-run a test.