### PR TITLE
fix(api): First `first_seen` being null in `GroupSerializerSnuba` when all environments selected

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -560,7 +560,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
         first_seen = {}
         last_seen = {}
         times_seen = {}
-        if self.environment_ids is None:
+        if not self.environment_ids:
             # use issue fields
             for item in item_list:
                 first_seen[item.id] = item.first_seen

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -299,7 +299,7 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         group = self.create_group(first_seen=self.week_ago, times_seen=5)
 
         # should use group columns when no environments arg passed
-        result = serialize(group, serializer=GroupSerializerSnuba())
+        result = serialize(group, serializer=GroupSerializerSnuba(environment_ids=[]))
         assert result['count'] == '5'
         assert result['lastSeen'] == group.last_seen
         assert result['firstSeen'] == group.first_seen


### PR DESCRIPTION
Whenever we select all environments, we have an empty list of envs rather than `None`. This means
we query the tagstore to get `last_seen` and `times_seen`, but we query `GroupEnvironment` for
`first_seen`, which returns nothing since the list of envs is empty.