### PR TITLE
fix(charts): Release series are not always rendered

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEvents/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/eventsChart.jsx
@@ -32,7 +32,10 @@ class EventsLineChart extends React.Component {
       return false;
     }
 
-    if (isEqual(this.props.timeseriesData, nextProps.timeseriesData)) {
+    if (
+      isEqual(this.props.timeseriesData, nextProps.timeseriesData) &&
+      isEqual(this.props.releaseSeries, nextProps.releaseSeries)
+    ) {
       return false;
     }
 


### PR DESCRIPTION
This fixes the EventsChart not always rendering the release series because of `shouldComponentUpdate`