### PR TITLE
fix(sidebar): Fix org navigation with query string

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -163,7 +163,7 @@ class Sidebar extends React.Component {
       'events',
       'releases',
       'user-feedback',
-    ].map(route => `/organizations/${this.props.params.orgId}/${route}/`);
+    ].map(route => `/organizations/${this.props.organization.slug}/${route}/`);
 
     // Only keep the querystring if the current route matches one of the above
     if (globalSelectionRoutes.includes(this.props.location.pathname)) {


### PR DESCRIPTION
Get slug from the active org instead of url params. Since the sidebar is
used outside of org routes (e.g. settings) this.props.params.orgId isn't
always present.

Fixes JAVASCRIPT-57R