### PR TITLE
test(discover): Mark saved query name as dynamic text

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/queryFields.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/queryFields.jsx
@@ -8,6 +8,7 @@ import TextField from 'app/components/forms/textField';
 import NumberField from 'app/components/forms/numberField';
 import SelectControl from 'app/components/forms/selectControl';
 import Badge from 'app/components/badge';
+import getDynamicText from 'app/utils/getDynamicText';
 
 import Aggregations from '../aggregations';
 import Conditions from '../conditions';
@@ -92,7 +93,7 @@ export default class QueryFields extends React.Component {
               </SidebarLabel>
               <TextField
                 name="name"
-                value={savedQueryName}
+                value={getDynamicText({value: savedQueryName, fixed: 'query name'})}
                 placeholder={t('Saved search name')}
                 onChange={val => onUpdateName(val)}
               />


### PR DESCRIPTION
Since this field is generated based on the current time, we need
this to prevent undesired Percy diffs.