### PR TITLE
fix(ui): Redirect some old project settings urls

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -665,6 +665,17 @@ function routes() {
               {projectSettingsRoutes}
             </Route>
           </Route>
+
+          <Redirect from=":projectId/" to="projects/:projectId/" />
+          <Redirect from=":projectId/alerts/" to="projects/:projectId/alerts/" />
+          <Redirect
+            from=":projectId/alerts/rules/"
+            to="projects/:projectId/alerts/rules/"
+          />
+          <Redirect
+            from=":projectId/alerts/rules/:ruleId/"
+            to="projects/:projectId/alerts/rules/:ruleId/"
+          />
         </Route>
       </Route>
 


### PR DESCRIPTION
e.g. `/settings/org/project/`, `/settings/org/project/alerts/`, alert rules, and a specific rule as well