### PR TITLE
fix(events): Fix events request ignoring project changing

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEvents/utils/eventsRequest.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/utils/eventsRequest.jsx
@@ -9,7 +9,7 @@ import SentryTypes from 'app/sentryTypes';
 
 import LoadingPanel from '../loadingPanel';
 
-const propNamesToIgnore = ['api', 'children', 'organizations', 'project', 'loading'];
+const propNamesToIgnore = ['api', 'children', 'organization', 'loading'];
 const omitIgnoredProps = props =>
   omitBy(props, (value, key) => propNamesToIgnore.includes(key));
 

--- a/tests/js/spec/views/organizationEvents/events.spec.jsx
+++ b/tests/js/spec/views/organizationEvents/events.spec.jsx
@@ -368,6 +368,34 @@ describe('OrganizationEventsContainer', function() {
       })
     );
   });
+
+  it('updates when changing projects', async function() {
+    expect(wrapper.find('MultipleProjectSelector').prop('value')).toEqual([]);
+
+    wrapper.find('MultipleProjectSelector HeaderItem').simulate('click');
+
+    wrapper
+      .find('MultipleProjectSelector AutoCompleteItem')
+      .at(0)
+      .simulate('click');
+
+    await tick();
+    wrapper.update();
+
+    expect(eventsStatsMock).toHaveBeenLastCalledWith(
+      '/organizations/org-slug/events-stats/',
+      expect.objectContaining({
+        query: expect.objectContaining({project: [2], statsPeriod: '28d'}),
+      })
+    );
+
+    expect(eventsMock).toHaveBeenLastCalledWith(
+      '/organizations/org-slug/events/',
+      expect.objectContaining({
+        query: {project: [2], statsPeriod: '14d'},
+      })
+    );
+  });
 });
 
 describe('parseRowFromLinks', function() {


### PR DESCRIPTION
This affected the Events chart not re-rendering when changing projects