### PR TITLE
feat(ui): Remove "Project Name" input from settings

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
@@ -43,21 +43,6 @@ const ORG_DISABLED_REASON = t(
 const hasOrgOverride = ({organization, name}) => organization[name];
 
 export const fields = {
-  name: {
-    name: 'name',
-    type: 'string',
-    required: true,
-
-    label: t('Legacy Name'),
-    placeholder: t('My Service Name'),
-    help: tct(
-      '[Deprecated] In the future, only [Name] will be used to identify your project',
-      {
-        Deprecated: <strong>DEPRECATED</strong>,
-        Name: <strong>Name</strong>,
-      }
-    ),
-  },
   slug: {
     name: 'slug',
     type: 'string',

--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
@@ -258,7 +258,7 @@ class ProjectGeneralSettings extends AsyncView {
           <JsonForm
             {...jsonFormProps}
             title={t('Project Details')}
-            fields={[fields.slug, fields.name, fields.platform]}
+            fields={[fields.slug, fields.platform]}
           />
 
           <JsonForm

--- a/tests/js/spec/views/projectGeneralSettings.spec.jsx
+++ b/tests/js/spec/views/projectGeneralSettings.spec.jsx
@@ -57,7 +57,6 @@ describe('projectGeneralSettings', function() {
       TestStubs.routerContext()
     );
 
-    expect(wrapper.find('Input[name="name"]').prop('value')).toBe('Project Name');
     expect(wrapper.find('Input[name="slug"]').prop('value')).toBe('project-slug');
     expect(wrapper.find('Input[name="subjectPrefix"]').prop('value')).toBe('[my-org]');
     expect(wrapper.find('RangeSlider[name="resolveAge"]').prop('value')).toBe(48);


### PR DESCRIPTION
This has been deprecated for over a year, removing the input field (models are still the same)