### PR TITLE
ref: Fixed a broken test and refactored more of grouping

### DIFF
--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -29,7 +29,12 @@ def basic_protocol_handler(unsupported_operations):
         ).replace(tzinfo=pytz.utc)
 
         def _get_attr(name):
-            return event_data[name]
+            try:
+                return event_data[name]
+            except LookupError:
+                if name != 'search_message':
+                    raise
+                return event_data['message']
 
         kwargs = {
             'event': Event(**{


### PR DESCRIPTION
Relay workers come up in the wrong order, so SENTRY-9FM is caused during deploy. If it does not resolve this is for working around the issue.