### PR TITLE
fix: workaround for search_message in relay

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -73,6 +73,10 @@ class Buffer(Service):
                 last_seen=update_kwargs['last_seen'],
             )
 
+        # HACK: temporary workaround
+        if model is Group and 'search_message' in update_kwargs:
+            update_kwargs['message'] = update_kwargs.pop('search_message')
+
         _, created = model.objects.create_or_update(values=update_kwargs, **filters)
 
         buffer_incr_complete.send_robust(

--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -28,6 +28,10 @@ def basic_protocol_handler(unsupported_operations):
             "%Y-%m-%dT%H:%M:%S.%fZ",
         ).replace(tzinfo=pytz.utc)
 
+        # workaround for temporarily bad events
+        if 'search_message' in event_data and not event_data.get('message'):
+            event_data['message'] = event_data['search_message']
+
         kwargs = {
             'event': Event(**{
                 name: event_data[name] for name in [


### PR DESCRIPTION
we have some events with search_message in there so we need to rename
this to message if missing.