### PR TITLE
fix(ui): Fix App being re-rendered twice when routes change

### DIFF
--- a/src/sentry/static/sentry/app/views/app.jsx
+++ b/src/sentry/static/sentry/app/views/app.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 import keydown from 'react-keydown';
-import {withRouter} from 'react-router';
 
 import {openCommandPalette} from 'app/actionCreators/modal';
 import {t} from 'app/locale';
@@ -228,4 +227,4 @@ const App = createReactClass({
   },
 });
 
-export default withRouter(App);
+export default App;


### PR DESCRIPTION
Route changing caused App to be re-rendered twice because of 1) react-router route tree and 2) `withRouter` -- we can just use `routes` from props because its a defined as a Route in our router