### PR TITLE
feat(monitors): Add a timeout to checkins

### DIFF
--- a/src/sentry/models/monitorcheckin.py
+++ b/src/sentry/models/monitorcheckin.py
@@ -33,7 +33,7 @@ class CheckInStatus(object):
 
 
 class MonitorCheckIn(Model):
-    __core__ = True
+    __core__ = False
 
     guid = UUIDField(unique=True, auto_add=True)
     project_id = BoundedPositiveIntegerField(db_index=True)
@@ -54,3 +54,15 @@ class MonitorCheckIn(Model):
         db_table = 'sentry_monitorcheckin'
 
     __repr__ = sane_repr('guid', 'project_id', 'status')
+
+    def save(self, *args, **kwargs):
+        if not self.date_added:
+            self.date_added = timezone.now()
+        if not self.date_updated:
+            self.date_updated = self.date_added
+        return super(MonitorCheckIn, self).save(*args, **kwargs)
+
+    # XXX(dcramer): BaseModel is trying to automatically set date_updated which is not
+    # what we want to happen, so kill it here
+    def _update_timestamps(self):
+        pass

--- a/src/sentry/tasks/check_monitors.py
+++ b/src/sentry/tasks/check_monitors.py
@@ -2,25 +2,59 @@ from __future__ import absolute_import, print_function
 
 import logging
 
+from datetime import timedelta
 from django.utils import timezone
 
-from sentry.models import Monitor, MonitorStatus, MonitorType
+from sentry.models import CheckInStatus, Monitor, MonitorCheckIn, MonitorStatus, MonitorType
 from sentry.tasks.base import instrumented_task
 
 
 logger = logging.getLogger('sentry')
 
+TIMEOUT = timedelta(hours=12)
+
 
 @instrumented_task(name='sentry.tasks.check_monitors', time_limit=15, soft_time_limit=10)
-def check_monitors():
+def check_monitors(current_datetime=None):
+    if current_datetime is None:
+        current_datetime = timezone.now()
+
     qs = Monitor.objects.filter(
         type__in=[MonitorType.HEARTBEAT, MonitorType.CRON_JOB],
-        next_checkin__lt=timezone.now(),
+        next_checkin__lt=current_datetime,
     ).exclude(
         status=MonitorStatus.DISABLED,
-    )
+    )[:10000]
     for monitor in qs:
         logger.info('monitor.missed-checkin', extra={
             'monitor_id': monitor.id,
         })
         monitor.mark_failed()
+
+    # timeout any monitors still marked as in progress after X time
+    qs = MonitorCheckIn.objects.filter(
+        status=CheckInStatus.IN_PROGRESS,
+        date_updated__lt=current_datetime - TIMEOUT,
+    ).select_related('monitor')[:10000]
+    for checkin in qs:
+        monitor = checkin.monitor
+        logger.info('monitor.checkin-timeout', extra={
+            'monitor_id': monitor.id,
+            'checkin_id': checkin.id,
+        })
+        affected = MonitorCheckIn.objects.filter(
+            id=checkin.id,
+            status=CheckInStatus.IN_PROGRESS,
+        ).update(status=CheckInStatus.ERROR)
+        if not affected:
+            continue
+
+        # we only mark the monitor as failed if a newer checkin wasn't responsible for the state
+        # change
+        has_newer_result = MonitorCheckIn.objects.filter(
+            monitor=monitor.id,
+            date_added__gt=checkin.date_added,
+            status__in=[CheckInStatus.OK, CheckInStatus.ERROR]
+        ).exists()
+        if not has_newer_result:
+            monitor.mark_failed()

--- a/tests/sentry/tasks/test_check_monitors.py
+++ b/tests/sentry/tasks/test_check_monitors.py
@@ -53,3 +53,103 @@ class CheckMonitorsTest(TestCase):
             id=monitor.id,
             status=MonitorStatus.OK,
         ).exists()
+
+    def test_timeout_with_no_future_complete_checkin(self):
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+
+        current_datetime = timezone.now() - timedelta(hours=24)
+
+        monitor = Monitor.objects.create(
+            organization_id=org.id,
+            project_id=project.id,
+            next_checkin=current_datetime + timedelta(hours=12, minutes=1),
+            last_checkin=current_datetime + timedelta(hours=12),
+            type=MonitorType.CRON_JOB,
+            config={'schedule': '0 0 * * *'},
+            status=MonitorStatus.OK,
+            date_added=current_datetime,
+        )
+        checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            project_id=project.id,
+            status=CheckInStatus.IN_PROGRESS,
+            date_added=current_datetime,
+            date_updated=current_datetime,
+        )
+        checkin2 = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            project_id=project.id,
+            status=CheckInStatus.IN_PROGRESS,
+            date_added=monitor.last_checkin,
+            date_updated=monitor.last_checkin,
+        )
+
+        assert checkin.date_added == checkin.date_updated == current_datetime
+
+        check_monitors(current_datetime=current_datetime + timedelta(hours=12, minutes=1))
+
+        assert MonitorCheckIn.objects.filter(
+            id=checkin.id,
+            status=CheckInStatus.ERROR,
+        ).exists()
+
+        assert MonitorCheckIn.objects.filter(
+            id=checkin2.id,
+            status=CheckInStatus.IN_PROGRESS,
+        ).exists()
+
+        assert Monitor.objects.filter(
+            id=monitor.id,
+            status=MonitorStatus.ERROR,
+        ).exists()
+
+    def test_timeout_with_future_complete_checkin(self):
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+
+        current_datetime = timezone.now() - timedelta(hours=24)
+
+        monitor = Monitor.objects.create(
+            organization_id=org.id,
+            project_id=project.id,
+            next_checkin=current_datetime + timedelta(hours=12, minutes=1),
+            last_checkin=current_datetime + timedelta(hours=12),
+            type=MonitorType.CRON_JOB,
+            config={'schedule': '0 0 * * *'},
+            status=MonitorStatus.OK,
+            date_added=current_datetime,
+        )
+        checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            project_id=project.id,
+            status=CheckInStatus.IN_PROGRESS,
+            date_added=current_datetime,
+            date_updated=current_datetime,
+        )
+        checkin2 = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            project_id=project.id,
+            status=CheckInStatus.OK,
+            date_added=monitor.last_checkin,
+            date_updated=monitor.last_checkin,
+        )
+
+        assert checkin.date_added == checkin.date_updated == current_datetime
+
+        check_monitors(current_datetime=current_datetime + timedelta(hours=12, minutes=1))
+
+        assert MonitorCheckIn.objects.filter(
+            id=checkin.id,
+            status=CheckInStatus.ERROR,
+        ).exists()
+
+        assert MonitorCheckIn.objects.filter(
+            id=checkin2.id,
+            status=CheckInStatus.OK,
+        ).exists()
+
+        assert Monitor.objects.filter(
+            id=monitor.id,
+            status=MonitorStatus.OK,
+        ).exists()


### PR DESCRIPTION
Our intention would be to decrease this timeout once we support active checkins (continuous updates on progress).