### PR TITLE
fix(models): Don't auto-update timestamps

### DIFF
--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -16,7 +16,6 @@ from bitfield.types import BitHandler
 from django.db import models
 from django.db.models import signals
 from django.db.models.query_utils import DeferredAttribute
-from django.utils import timezone
 
 from .fields.bounded import BoundedBigAutoField
 from .manager import BaseManager
@@ -105,10 +104,6 @@ class BaseModel(models.Model):
         else:
             self.__data = UNSAVED
 
-    def _update_timestamps(self):
-        if hasattr(self, 'date_updated'):
-            self.date_updated = timezone.now()
-
     def has_changed(self, field_name):
         "Returns ``True`` if ``field`` has changed since initialization."
         if self.__data is UNSAVED:
@@ -144,12 +139,6 @@ def __model_post_save(instance, **kwargs):
     instance._update_tracked_data()
 
 
-def __model_pre_save(instance, **kwargs):
-    if not isinstance(instance, BaseModel):
-        return
-    instance._update_timestamps()
-
-
 def __model_class_prepared(sender, **kwargs):
     if not issubclass(sender, BaseModel):
         return
@@ -158,6 +147,5 @@ def __model_class_prepared(sender, **kwargs):
         raise ValueError(u'{!r} model has not defined __core__'.format(sender))
 
 
-signals.pre_save.connect(__model_pre_save)
 signals.post_save.connect(__model_post_save)
 signals.class_prepared.connect(__model_class_prepared)

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -145,6 +145,7 @@ class SentryApp(ParanoidModel, HasApiScopes):
 
     def save(self, *args, **kwargs):
         self._set_slug()
+        self.date_updated = timezone.now()
         return super(SentryApp, self).save(*args, **kwargs)
 
     def is_installed_on(self, organization):

--- a/src/sentry/models/sentryappinstallation.py
+++ b/src/sentry/models/sentryappinstallation.py
@@ -53,3 +53,7 @@ class SentryAppInstallation(ParanoidModel):
     # Used when first creating an Installation to tell the serializer that the
     # grant code should be included in the serialization.
     is_new = False
+
+    def save(self, *args, **kwargs):
+        self.date_updated = timezone.now()
+        return super(SentryAppInstallation, self).save(*args, **kwargs)


### PR DESCRIPTION
Not all models want `date_updated` to be updated automatically when the record is saved.

Removes the auto-update and just puts it in the models that want that.