### PR TITLE
feat(monitors): Add intervals and various UI

### DIFF
--- a/src/sentry/api/endpoints/monitor_details.py
+++ b/src/sentry/api/endpoints/monitor_details.py
@@ -1,7 +1,17 @@
 from __future__ import absolute_import
 
+import logging
+
+from django.db import transaction
+from uuid import uuid4
+
 from sentry.api.bases.monitor import MonitorEndpoint
 from sentry.api.serializers import serialize
+from sentry.api.validators import MonitorValidator
+from sentry.tasks.deletion import generic_delete
+from sentry.models import AuditLogEntryEvent, Monitor, MonitorStatus
+
+delete_logger = logging.getLogger('sentry.deletions.api')
 
 
 class MonitorDetailsEndpoint(MonitorEndpoint):
@@ -14,3 +24,106 @@ class MonitorDetailsEndpoint(MonitorEndpoint):
         :auth: required
         """
         return self.respond(serialize(monitor, request.user))
+
+    def put(self, request, project, monitor):
+        """
+        Update a monitor
+        ````````````````
+
+        :pparam string monitor_id: the id of the monitor.
+        :auth: required
+        """
+        validator = MonitorValidator(
+            data=request.DATA,
+            partial=True,
+            instance={
+                'name': monitor.name,
+                'status': monitor.status,
+                'type': monitor.type,
+                'config': monitor.config,
+                'project': project,
+            },
+            context={
+                'organization': project.organization,
+                'access': request.access,
+            },
+        )
+        if not validator.is_valid():
+            return self.respond(validator.errors, status=400)
+
+        result = validator.data
+
+        params = {}
+        if 'name' in result:
+            params['name'] = result['name']
+        if 'status' in result:
+            if result['status'] == MonitorStatus.ACTIVE:
+                if monitor.status not in (MonitorStatus.OK, MonitorStatus.ERROR):
+                    params['status'] = MonitorStatus.ACTIVE
+            else:
+                params['status'] = result['status']
+        if 'config' in result:
+            params['config'] = result['config']
+        if 'project' in result and result['project'].id != monitor.project_id:
+            params['project_id'] = result['project'].id
+
+        if params:
+            monitor.update(**params)
+            self.create_audit_entry(
+                request=request,
+                organization=project.organization,
+                target_object=monitor.id,
+                event=AuditLogEntryEvent.MONITOR_EDIT,
+                data=monitor.get_audit_log_data(),
+            )
+
+        return self.respond(serialize(monitor, request.user))
+
+    def delete(self, request, project, monitor):
+        """
+        Delete a monitor
+        ````````````````
+
+        :pparam string monitor_id: the id of the monitor.
+        :auth: required
+        """
+        # TODO(dcramer0:)
+        with transaction.atomic():
+            affected = Monitor.objects.filter(
+                id=monitor.id,
+            ).exclude(
+                status__in=[MonitorStatus.PENDING_DELETION, MonitorStatus.DELETION_IN_PROGRESS],
+            ).update(
+                status=MonitorStatus.PENDING_DELETION
+            )
+            if not affected:
+                return self.respond(status=404)
+
+            transaction_id = uuid4().hex
+
+            self.create_audit_entry(
+                request=request,
+                organization=project.organization,
+                target_object=monitor.id,
+                event=AuditLogEntryEvent.MONITOR_REMOVE,
+                data=monitor.get_audit_log_data(),
+                transaction_id=transaction_id,
+            )
+
+        generic_delete.apply_async(
+            kwargs={
+                'object_id': monitor.id,
+                'transaction_id': transaction_id,
+                'actor_id': request.user.id,
+            },
+        )
+
+        delete_logger.info(
+            'object.delete.queued',
+            extra={
+                'object_id': monitor.id,
+                'transaction_id': transaction_id,
+                'model': Monitor.__name__,
+            }
+        )
+        return self.respond(status=202)

--- a/src/sentry/api/serializers/models/monitor.py
+++ b/src/sentry/api/serializers/models/monitor.py
@@ -2,19 +2,44 @@ from __future__ import absolute_import
 
 import six
 
-from sentry.api.serializers import Serializer, register
-from sentry.models import Monitor
+from sentry.api.serializers import Serializer, register, serialize
+from sentry.models import Monitor, Project, ScheduleType
+
+
+SCHEDULE_TYPES = dict(ScheduleType.as_choices())
 
 
 @register(Monitor)
 class MonitorSerializer(Serializer):
+    def get_attrs(self, item_list, user):
+        # TODO(dcramer): assert on relations
+        projects = {
+            d['id']: d for d in serialize(
+                list(
+                    Project.objects.filter(
+                        id__in=[
+                            i.project_id for i in item_list])),
+                user)}
+
+        return {
+            item: {
+                'project': projects[six.text_type(item.project_id)] if item.project_id else None,
+            }
+            for item in item_list
+        }
+
     def serialize(self, obj, attrs, user):
+        config = obj.config.copy()
+        if 'schedule_type' in config:
+            config['schedule_type'] = SCHEDULE_TYPES.get(config['schedule_type'], 'unknown')
         return {
             'id': six.text_type(obj.guid),
             'status': obj.get_status_display(),
             'type': obj.get_type_display(),
             'name': obj.name,
+            'config': config,
             'lastCheckIn': obj.last_checkin,
             'nextCheckIn': obj.next_checkin,
             'dateCreated': obj.date_added,
+            'project': attrs['project'],
         }

--- a/src/sentry/api/serializers/rest_framework/project.py
+++ b/src/sentry/api/serializers/rest_framework/project.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import
+
+from rest_framework import serializers
+
+from sentry.models import Project
+
+ValidationError = serializers.ValidationError
+
+
+class ProjectField(serializers.WritableField):
+    def to_native(self, obj):
+        return obj
+
+    def from_native(self, data):
+        try:
+            project = Project.objects.get(
+                organization=self.context['organization'],
+                slug=data,
+            )
+        except Project.DoesNotExist:
+            raise ValidationError(
+                'Invalid project'
+            )
+        if not self.context['access'].has_project_scope(project, 'project:write'):
+            raise ValidationError(
+                'Insufficient access to project'
+            )
+        return project

--- a/src/sentry/api/validators/monitor.py
+++ b/src/sentry/api/validators/monitor.py
@@ -1,0 +1,118 @@
+from __future__ import absolute_import
+
+import six
+
+from collections import OrderedDict
+from croniter import croniter
+from django.core.exceptions import ValidationError
+from rest_framework import serializers
+
+from sentry.models import MonitorStatus, MonitorType, ScheduleType
+from sentry.api.serializers.rest_framework.project import ProjectField
+
+
+SCHEDULE_TYPES = OrderedDict([
+    ('crontab', ScheduleType.CRONTAB),
+    ('interval', ScheduleType.INTERVAL),
+])
+
+MONITOR_TYPES = OrderedDict([
+    ('cron_job', MonitorType.CRON_JOB),
+])
+
+MONITOR_STATUSES = OrderedDict([
+    ('active', MonitorStatus.ACTIVE),
+    ('disabled', MonitorStatus.DISABLED),
+])
+
+INTERVAL_NAMES = ('year', 'month', 'week', 'day', 'hour', 'minute')
+
+# XXX(dcramer): @reboot is not supported (as it cannot be)
+NONSTANDARD_CRONTAB_SCHEDULES = {
+    '@yearly': '0 0 1 1 *',
+    '@annually': '0 0 1 1 *',
+    '@monthly': '0 0 1 * *',
+    '@weekly': '0 0 * * 0',
+    '@daily': '0 0 * * *',
+    '@hourly': '0 * * * *',
+}
+
+
+class CronJobValidator(serializers.Serializer):
+    schedule_type = serializers.ChoiceField(
+        choices=zip(SCHEDULE_TYPES.keys(), SCHEDULE_TYPES.keys()),
+    )
+    schedule = serializers.WritableField()
+
+    def validate_schedule_type(self, attrs, source):
+        value = attrs[source]
+        if value:
+            attrs[source] = SCHEDULE_TYPES[value]
+        return attrs
+
+    def validate_schedule(self, attrs, source):
+        if 'schedule_type' in attrs:
+            schedule_type = attrs['schedule_type']
+        else:
+            schedule_type = self.object['schedule_type']
+
+        value = attrs[source]
+        if not value:
+            return attrs
+
+        if schedule_type == ScheduleType.INTERVAL:
+            if not isinstance(value, list):
+                raise ValidationError('Invalid value for schedule_type')
+            if not isinstance(value[0], int):
+                raise ValidationError('Invalid value for schedule frequency')
+            if value[1] not in INTERVAL_NAMES:
+                raise ValidationError('Invalid value for schedlue interval')
+        elif schedule_type == ScheduleType.CRONTAB:
+            if not isinstance(value, six.string_types):
+                raise ValidationError('Invalid value for schedule_type')
+            value = value.strip()
+            if value.startswith('@'):
+                try:
+                    value = NONSTANDARD_CRONTAB_SCHEDULES[value]
+                except KeyError:
+                    raise ValidationError('Schedule was not parseable')
+            if not croniter.is_valid(value):
+                raise ValidationError('Schedule was not parseable')
+            attrs[source] = value
+        return attrs
+
+
+class MonitorValidator(serializers.Serializer):
+    project = ProjectField()
+    name = serializers.CharField()
+    status = serializers.ChoiceField(
+        choices=zip(MONITOR_STATUSES.keys(), MONITOR_STATUSES.keys()),
+        default='active',
+    )
+    type = serializers.ChoiceField(
+        choices=zip(MONITOR_TYPES.keys(), MONITOR_TYPES.keys())
+    )
+
+    def get_default_fields(self):
+        type = self.init_data.get('type', self.object.get('type') if self.object else None)
+        if type in MONITOR_TYPES:
+            type = MONITOR_TYPES[type]
+        if type == MonitorType.CRON_JOB:
+            config = CronJobValidator()
+        elif not type:
+            return {}
+        else:
+            raise NotImplementedError
+        return {'config': config}
+
+    def validate_status(self, attrs, source):
+        value = attrs[source]
+        if value:
+            attrs[source] = MONITOR_STATUSES[value]
+        return attrs
+
+    def validate_type(self, attrs, source):
+        value = attrs[source]
+        if value:
+            attrs[source] = MONITOR_TYPES[value]
+        return attrs

--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -79,6 +79,10 @@ class AuditLogEntryEvent(object):
     INTEGRATION_EDIT = 111
     INTEGRATION_REMOVE = 112
 
+    MONITOR_ADD = 120
+    MONITOR_EDIT = 121
+    MONITOR_REMOVE = 122
+
 
 class AuditLogEntry(Model):
     __core__ = False

--- a/src/sentry/static/sentry/app/components/issueList.jsx
+++ b/src/sentry/static/sentry/app/components/issueList.jsx
@@ -25,6 +25,7 @@ const IssueList = createReactClass({
     statsPeriod: PropTypes.string,
     showActions: PropTypes.bool,
     noBorder: PropTypes.bool,
+    noMargin: PropTypes.bool,
   },
 
   mixins: [ApiMixin],
@@ -34,6 +35,7 @@ const IssueList = createReactClass({
       pagination: true,
       query: {},
       noBorder: false,
+      noMargin: false,
     };
   },
 
@@ -96,12 +98,13 @@ const IssueList = createReactClass({
 
   renderResults() {
     let body;
-    const {noBorder} = this.props;
+    const {noBorder, noMargin} = this.props;
 
     if (this.state.loading) body = this.renderLoading();
     else if (this.state.error) body = this.renderError();
     else if (this.state.issueIds.length > 0) {
       const panelStyle = noBorder ? {border: 0, borderRadius: 0} : {};
+      if (noMargin) panelStyle.marginBottom = 0;
 
       body = (
         <Panel style={panelStyle}>
@@ -143,9 +146,12 @@ const IssueList = createReactClass({
 
   renderEmpty() {
     const {emptyText} = this.props;
+    const {noBorder, noMargin} = this.props;
+    const panelStyle = noBorder ? {border: 0, borderRadius: 0} : {};
+    if (noMargin) panelStyle.marginBottom = 0;
 
     return (
-      <Panel>
+      <Panel style={panelStyle}>
         <EmptyMessage icon="icon-circle-exclamation">
           {emptyText ? emptyText : t('Nothing to show here, move along.')}
         </EmptyMessage>

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -818,6 +818,12 @@ function routes() {
               component={errorHandler(LazyLoad)}
             />
             <Route
+              path="/organizations/:orgId/monitors/create/"
+              componentPromise={() =>
+                import(/* webpackChunkName: "OrganizationMonitorCreate" */ './views/organizationMonitors/create')}
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
               path="/organizations/:orgId/monitors/:monitorId/"
               componentPromise={() =>
                 import(/* webpackChunkName: "OrganizationMonitorDetails" */ './views/organizationMonitors/details')}

--- a/src/sentry/static/sentry/app/sentryTypes.jsx
+++ b/src/sentry/static/sentry/app/sentryTypes.jsx
@@ -221,6 +221,12 @@ export const Team = PropTypes.shape({
   slug: PropTypes.string.isRequired,
 });
 
+export const Monitor = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  dateCreated: PropTypes.string,
+});
+
 export const Project = PropTypes.shape({
   // snuba returns id as number
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
@@ -905,6 +911,7 @@ const SentryTypes = {
   GlobalSelection,
   Group,
   Tag,
+  Monitor,
   PageLinks,
   Project,
   Series,

--- a/src/sentry/static/sentry/app/views/organizationMonitors/create.jsx
+++ b/src/sentry/static/sentry/app/views/organizationMonitors/create.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {browserHistory} from 'react-router';
+
+import AsyncView from 'app/views/asyncView';
+
+import MonitorForm from './monitorForm';
+
+export default class CreateMonitor extends AsyncView {
+  getTitle() {
+    return `Monitors - ${this.props.params.orgId}`;
+  }
+
+  onSubmitSuccess = data => {
+    browserHistory.push(`/organizations/${this.props.params.orgId}/monitors/${data.id}/`);
+  };
+
+  renderBody() {
+    return (
+      <React.Fragment>
+        <h1>New Monitor</h1>
+        <MonitorForm
+          apiMethod="POST"
+          apiEndpoint={`/organizations/${this.props.params.orgId}/monitors/`}
+          onSubmitSuccess={this.onSubmitSuccess}
+        />
+      </React.Fragment>
+    );
+  }
+}

--- a/src/sentry/static/sentry/app/views/organizationMonitors/details.jsx
+++ b/src/sentry/static/sentry/app/views/organizationMonitors/details.jsx
@@ -29,15 +29,28 @@ class OrganizationMonitorDetails extends AsyncView {
     return `Monitors - ${this.props.params.orgId}`;
   }
 
+  onUpdate = data => {
+    this.setState({
+      monitor: {
+        ...this.state.monitor,
+        ...data,
+      },
+    });
+  };
+
   renderBody() {
     const {monitor} = this.state;
     return (
       <React.Fragment>
-        <MonitorHeader monitor={monitor} />
+        <MonitorHeader
+          monitor={monitor}
+          orgId={this.props.params.orgId}
+          onUpdate={this.onUpdate}
+        />
 
         <MonitorStats monitor={monitor} />
 
-        <Panel>
+        <Panel style={{paddingBottom: 0}}>
           <PanelHeader>{t('Related Issues')}</PanelHeader>
 
           <MonitorIssues monitor={monitor} orgId={this.props.params.orgId} />

--- a/src/sentry/static/sentry/app/views/organizationMonitors/edit.jsx
+++ b/src/sentry/static/sentry/app/views/organizationMonitors/edit.jsx
@@ -1,42 +1,28 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import {browserHistory} from 'react-router';
 
-import Access from 'app/components/acl/access';
 import AsyncView from 'app/views/asyncView';
-import DateTime from 'app/components/dateTime';
-import Field from 'app/views/settings/components/forms/field';
-import Form from 'app/views/settings/components/forms/form';
-import TextCopyInput from 'app/views/settings/components/forms/textCopyInput';
-import TextField from 'app/views/settings/components/forms/textField';
-import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
-import withOrganization from 'app/utils/withOrganization';
-import SentryTypes from 'app/sentryTypes';
-import {t} from 'app/locale';
 
-import MonitorHeader from './monitorHeader';
+import MonitorForm from './monitorForm';
 
-class EditMonitor extends AsyncView {
-  static contextTypes = {
-    organization: SentryTypes.Organization,
-  };
-
-  static propTypes = {
-    location: PropTypes.object.isRequired,
-    ...AsyncView.propTypes,
-  };
-
+export default class EditMonitor extends AsyncView {
   getEndpoints() {
-    const {params, location} = this.props;
-    return [
-      [
-        'monitor',
-        `/monitors/${params.monitorId}/`,
-        {
-          query: location.query,
-        },
-      ],
-    ];
+    const {params} = this.props;
+    return [['monitor', `/monitors/${params.monitorId}/`]];
   }
+
+  onUpdate = data => {
+    this.setState({
+      monitor: {
+        ...this.state.monitor,
+        ...data,
+      },
+    });
+  };
+
+  onSubmitSuccess = data => {
+    browserHistory.push(`/organizations/${this.props.params.orgId}/monitors/${data.id}/`);
+  };
 
   getTitle() {
     if (this.state.monitor)
@@ -48,59 +34,15 @@ class EditMonitor extends AsyncView {
     const {monitor} = this.state;
     return (
       <React.Fragment>
-        <MonitorHeader monitor={monitor} />
+        <h1>Edit Monitor</h1>
 
-        <Access access={['project:write']}>
-          {({hasAccess}) => (
-            <React.Fragment>
-              <Form
-                saveOnBlur
-                allowUndo
-                apiEndpoint={`/monitors/${monitor.id}/`}
-                apiMethod="PUT"
-                initialData={{
-                  name: monitor.name,
-                }}
-              >
-                <Panel>
-                  <PanelHeader>{t('Details')}</PanelHeader>
-
-                  <PanelBody>
-                    <Field label={t('ID')}>
-                      <div className="controls">
-                        <TextCopyInput>{monitor.id}</TextCopyInput>
-                      </div>
-                    </Field>
-                    <TextField
-                      name="name"
-                      label={t('Name')}
-                      disabled={!hasAccess}
-                      required={false}
-                    />
-                    <Field label={t('Last Check-in')}>
-                      <div className="controls">
-                        <DateTime date={monitor.lastCheckIn} />
-                      </div>
-                    </Field>
-                    <Field label={t('Next Check-in (expected)')}>
-                      <div className="controls">
-                        <DateTime date={monitor.nextCheckIn} />
-                      </div>
-                    </Field>
-                    <Field label={t('Created')}>
-                      <div className="controls">
-                        <DateTime date={monitor.dateCreated} />
-                      </div>
-                    </Field>
-                  </PanelBody>
-                </Panel>
-              </Form>
-            </React.Fragment>
-          )}
-        </Access>
+        <MonitorForm
+          monitor={monitor}
+          apiMethod="PUT"
+          apiEndpoint={`/monitors/${monitor.id}/`}
+          onSubmitSuccess={this.onSubmitSuccess}
+        />
       </React.Fragment>
     );
   }
 }
-
-export default withOrganization(EditMonitor);

--- a/src/sentry/static/sentry/app/views/organizationMonitors/monitorForm.jsx
+++ b/src/sentry/static/sentry/app/views/organizationMonitors/monitorForm.jsx
@@ -1,0 +1,162 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import {Observer} from 'mobx-react';
+
+import Access from 'app/components/acl/access';
+import Field from 'app/views/settings/components/forms/field';
+import Form from 'app/views/settings/components/forms/form';
+import SelectField from 'app/views/settings/components/forms/selectField';
+import TextCopyInput from 'app/views/settings/components/forms/textCopyInput';
+import TextField from 'app/views/settings/components/forms/textField';
+import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
+import SentryTypes from 'app/sentryTypes';
+import {t, tct} from 'app/locale';
+import withGlobalSelection from 'app/utils/withGlobalSelection';
+import withOrganization from 'app/utils/withOrganization';
+
+import MonitorModel from './monitorModel';
+
+class MonitorForm extends Component {
+  static propTypes = {
+    monitor: SentryTypes.Monitor,
+    organization: SentryTypes.Organization.isRequired,
+    selection: SentryTypes.GlobalSelection,
+    apiEndpoint: PropTypes.string.isRequired,
+    apiMethod: PropTypes.string.isRequired,
+    onSubmitSuccess: PropTypes.func.isRequired,
+  };
+
+  constructor(...args) {
+    super(...args);
+    this.form = new MonitorModel();
+  }
+
+  formDataFromConfig(type, config) {
+    switch (type) {
+      case 'cron_job':
+        return {
+          'config.schedule_type': config.schedule_type,
+          'config.schedule': config.schedule,
+        };
+      default:
+        return {};
+    }
+  }
+
+  render() {
+    const {monitor} = this.props;
+    const selectedProjectId = this.props.selection.projects[0];
+    const selectedProject = selectedProjectId
+      ? this.props.organization.projects.find(p => p.id === selectedProjectId + '')
+      : null;
+    return (
+      <Access access={['project:write']}>
+        {({hasAccess}) => (
+          <Form
+            allowUndo
+            requireChanges
+            apiEndpoint={this.props.apiEndpoint}
+            apiMethod={this.props.apiMethod}
+            model={this.form}
+            initialData={
+              monitor
+                ? {
+                    name: monitor.name,
+                    type: monitor.type,
+                    project: monitor.project.slug,
+                    ...this.formDataFromConfig(monitor.type, monitor.config),
+                  }
+                : {
+                    project: selectedProject.slug,
+                  }
+            }
+            onSubmitSuccess={this.props.onSubmitSuccess}
+          >
+            <Panel>
+              <PanelHeader>{t('Details')}</PanelHeader>
+
+              <PanelBody>
+                {monitor && (
+                  <Field label={t('ID')}>
+                    <div className="controls">
+                      <TextCopyInput>{monitor.id}</TextCopyInput>
+                    </div>
+                  </Field>
+                )}
+                <SelectField
+                  name="project"
+                  label={t('Project')}
+                  disabled={!hasAccess}
+                  choices={this.props.organization.projects
+                    .filter(p => p.isMember)
+                    .map(p => {
+                      return [p.slug, p.slug];
+                    })}
+                  required
+                />
+                <TextField
+                  name="name"
+                  placeholder={t('My Cron Job')}
+                  label={t('Name')}
+                  disabled={!hasAccess}
+                  required
+                />
+              </PanelBody>
+            </Panel>
+            <Panel>
+              <PanelHeader>{t('Config')}</PanelHeader>
+
+              <PanelBody>
+                <SelectField
+                  name="type"
+                  label={t('Type')}
+                  disabled={!hasAccess}
+                  choices={[['cron_job', 'Cron Job']]}
+                  required
+                />
+                <Observer>
+                  {() => {
+                    return (
+                      this.form.getValue('type') === 'cron_job' && (
+                        <SelectField
+                          name="config.schedule_type"
+                          label={t('Schedule Type')}
+                          disabled={!hasAccess}
+                          choices={[['crontab', 'Crontab']]}
+                          required
+                        />
+                      )
+                    );
+                  }}
+                </Observer>
+                <Observer>
+                  {() => {
+                    return (
+                      this.form.getValue('config.schedule_type') === 'crontab' && (
+                        <TextField
+                          name="config.schedule"
+                          label={t('Schedule')}
+                          disabled={!hasAccess}
+                          placeholder="*/5 * * *"
+                          required
+                          help={tct(
+                            'Changes to the schedule will apply on the next check-in. See [link:Wikipedia] for crontab syntax.',
+                            {
+                              link: <a href="https://en.wikipedia.org/wiki/Cron" />,
+                            }
+                          )}
+                        />
+                      )
+                    );
+                  }}
+                </Observer>
+              </PanelBody>
+            </Panel>
+          </Form>
+        )}
+      </Access>
+    );
+  }
+}
+
+export default withGlobalSelection(withOrganization(MonitorForm));

--- a/src/sentry/static/sentry/app/views/organizationMonitors/monitorHeader.jsx
+++ b/src/sentry/static/sentry/app/views/organizationMonitors/monitorHeader.jsx
@@ -3,12 +3,16 @@ import React from 'react';
 
 import TimeSince from 'app/components/timeSince';
 import {t} from 'app/locale';
+import SentryTypes from 'app/sentryTypes';
 
+import MonitorHeaderActions from './monitorHeaderActions';
 import MonitorIcon from './monitorIcon';
 
 export default class MonitorHeader extends React.Component {
   static propTypes = {
-    monitor: PropTypes.object.isRequired,
+    orgId: PropTypes.string.isRequired,
+    monitor: SentryTypes.Monitor.isRequired,
+    onUpdate: PropTypes.func,
   };
 
   render() {
@@ -34,6 +38,11 @@ export default class MonitorHeader extends React.Component {
             <MonitorIcon status={monitor.status} size={16} />
           </div>
         </div>
+        <MonitorHeaderActions
+          orgId={this.props.orgId}
+          monitor={monitor}
+          onUpdate={this.props.onUpdate}
+        />
       </div>
     );
   }

--- a/src/sentry/static/sentry/app/views/organizationMonitors/monitorHeaderActions.jsx
+++ b/src/sentry/static/sentry/app/views/organizationMonitors/monitorHeaderActions.jsx
@@ -1,0 +1,103 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {browserHistory} from 'react-router';
+
+import {t} from 'app/locale';
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  removeIndicator,
+} from 'app/actionCreators/indicator';
+import {logException} from 'app/utils/logging';
+import SentryTypes from 'app/sentryTypes';
+import Button from 'app/components/button';
+import Confirm from 'app/components/confirm';
+import withApi from 'app/utils/withApi';
+
+class MonitorHeaderActions extends React.Component {
+  static propTypes = {
+    monitor: SentryTypes.Monitor.isRequired,
+    orgId: PropTypes.string.isRequired,
+    onUpdate: PropTypes.func,
+  };
+
+  handleDelete = () => {
+    const {orgId, monitor} = this.props;
+    const redirectPath = `/organizations/${orgId}/monitors/`;
+    addLoadingMessage(t('Deleting Monitor...'));
+
+    this.api
+      .requestPromise(`/monitors/${monitor.id}/`, {
+        method: 'DELETE',
+      })
+      .then(() => {
+        browserHistory.push(redirectPath);
+      })
+      .catch(() => {
+        removeIndicator();
+        addErrorMessage(t('Unable to remove monitor.'));
+      });
+  };
+
+  updateMonitor = data => {
+    const {monitor} = this.props;
+    addLoadingMessage();
+    this.api
+      .requestPromise(`/monitors/${monitor.id}/`, {
+        method: 'PUT',
+        data,
+      })
+      .then(resp => {
+        removeIndicator();
+        this.props.onUpdate && this.props.onUpdate(resp);
+      })
+      .catch(err => {
+        logException(err);
+        removeIndicator();
+        addErrorMessage(t('Unable to update monitor.'));
+      });
+  };
+
+  toggleStatus = () => {
+    const {monitor} = this.props;
+    this.updateMonitor({
+      status: monitor.status === 'disabled' ? 'active' : 'disabled',
+    });
+  };
+
+  render() {
+    const {monitor, orgId} = this.props;
+    return (
+      <div className="m-b-1">
+        <div className="btn-group">
+          <Button
+            size="small"
+            icon="icon-edit"
+            to={`/organizations/${orgId}/monitors/${monitor.id}/edit/`}
+          >
+            {t('Edit')}
+          </Button>
+        </div>
+        <div className="btn-group" style={{marginLeft: 10}}>
+          <Button size="small" icon="icon-edit" onClick={this.toggleStatus}>
+            {monitor.status !== 'disabled' ? t('Pause') : t('Enable')}
+          </Button>
+        </div>
+        <div className="btn-group" style={{marginLeft: 10}}>
+          <Confirm
+            onConfirm={this.handleDelete}
+            message={t(
+              'Deleting this monitor is permanent. Are you sure you wish to continue?'
+            )}
+          >
+            <Button size="small" icon="icon-trash">
+              {t('Delete')}
+            </Button>
+          </Confirm>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default withApi(MonitorHeaderActions);

--- a/src/sentry/static/sentry/app/views/organizationMonitors/monitorIssues.jsx
+++ b/src/sentry/static/sentry/app/views/organizationMonitors/monitorIssues.jsx
@@ -2,7 +2,6 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
 import IssueList from 'app/components/issueList';
-import {Panel, PanelBody, PanelItem} from 'app/components/panels';
 import {t} from 'app/locale';
 
 export default class MonitorIssues extends Component {
@@ -28,14 +27,10 @@ export default class MonitorIssues extends Component {
         }}
         statsPeriod="0"
         pagination={false}
-        renderEmpty={() => (
-          <Panel>
-            <PanelBody>
-              <PanelItem justify="center">{t('No issues found')}</PanelItem>
-            </PanelBody>
-          </Panel>
-        )}
+        emptyText={t('No issues found')}
         showActions={false}
+        noBorder={true}
+        noMargin={true}
         params={{orgId}}
       />
     );

--- a/src/sentry/static/sentry/app/views/organizationMonitors/monitorModel.jsx
+++ b/src/sentry/static/sentry/app/views/organizationMonitors/monitorModel.jsx
@@ -1,0 +1,20 @@
+import FormModel from 'app/views/settings/components/forms/model';
+
+export default class MonitorModel extends FormModel {
+  getTransformedData() {
+    return Object.entries(this.fields.toJSON()).reduce((data, [k, v]) => {
+      if (k.indexOf('config.') === 0) {
+        if (!data.config) data.config = {};
+        data.config[k.substr(7)] = v;
+      } else {
+        data[k] = v;
+      }
+      return data;
+    }, {});
+  }
+
+  getTransformedValue(id) {
+    if (id.indexOf('config') === 0) return this.getValue(id);
+    return super.getTransformedValue(id);
+  }
+}

--- a/src/sentry/static/sentry/app/views/organizationMonitors/monitors.jsx
+++ b/src/sentry/static/sentry/app/views/organizationMonitors/monitors.jsx
@@ -6,6 +6,7 @@ import {Box} from 'grid-emotion';
 
 import AsyncView from 'app/views/asyncView';
 import BetaTag from 'app/components/betaTag';
+import Button from 'app/components/button';
 import {getParams} from 'app/views/organizationEvents/utils/getParams';
 import {Panel, PanelBody, PanelItem} from 'app/components/panels';
 import {PageHeader} from 'app/styles/organization';
@@ -14,6 +15,7 @@ import TimeSince from 'app/components/timeSince';
 import Pagination from 'app/components/pagination';
 import SentryTypes from 'app/sentryTypes';
 import SearchBar from 'app/components/searchBar';
+import space from 'app/styles/space';
 import withOrganization from 'app/utils/withOrganization';
 import {t} from 'app/locale';
 
@@ -74,6 +76,14 @@ class OrganizationMonitors extends AsyncView {
         <PageHeader>
           <HeaderTitle>
             {t('Monitors')} <BetaTag />
+            <Button
+              to={`/organizations/${organization.slug}/monitors/create/`}
+              priority="primary"
+              size="xsmall"
+              style={{marginLeft: space(0.5)}}
+            >
+              New Monitor
+            </Button>
           </HeaderTitle>
           <StyledSearchBar
             organization={organization}

--- a/tests/sentry/api/endpoints/test_monitor_details.py
+++ b/tests/sentry/api/endpoints/test_monitor_details.py
@@ -5,7 +5,7 @@ import six
 from datetime import timedelta
 from django.utils import timezone
 
-from sentry.models import Monitor, MonitorType
+from sentry.models import Monitor, MonitorStatus, MonitorType, ScheduleType
 from sentry.testutils import APITestCase
 
 
@@ -30,3 +30,207 @@ class MonitorDetailsTest(APITestCase):
 
         assert resp.status_code == 200, resp.content
         assert resp.data['id'] == six.text_type(monitor.guid)
+
+
+class UpdateMonitorTest(APITestCase):
+    def setUp(self):
+        self.user = self.create_user()
+        self.org = self.create_organization(owner=self.user)
+        self.team = self.create_team(organization=self.org, members=[self.user])
+        self.project = self.create_project(teams=[self.team])
+
+        self.monitor = Monitor.objects.create(
+            organization_id=self.org.id,
+            project_id=self.project.id,
+            next_checkin=timezone.now() - timedelta(minutes=1),
+            type=MonitorType.CRON_JOB,
+            config={'schedule': '* * * * *', 'schedule_type': ScheduleType.CRONTAB},
+        )
+
+        self.path = '/api/0/monitors/{}/'.format(self.monitor.guid)
+
+        self.login_as(user=self.user)
+
+    def test_name(self):
+        with self.feature({'organizations:monitors': True}):
+            resp = self.client.put(self.path, data={
+                'name': 'Monitor Name',
+            })
+
+        assert resp.status_code == 200, resp.content
+        assert resp.data['id'] == six.text_type(self.monitor.guid)
+
+        monitor = Monitor.objects.get(id=self.monitor.id)
+        assert monitor.name == 'Monitor Name'
+
+    def test_can_disable(self):
+        with self.feature({'organizations:monitors': True}):
+            resp = self.client.put(self.path, data={
+                'status': 'disabled',
+            })
+
+        assert resp.status_code == 200, resp.content
+        assert resp.data['id'] == six.text_type(self.monitor.guid)
+
+        monitor = Monitor.objects.get(id=self.monitor.id)
+        assert monitor.status == MonitorStatus.DISABLED
+
+    def test_can_enable(self):
+        self.monitor.update(status=MonitorStatus.DISABLED)
+        with self.feature({'organizations:monitors': True}):
+            resp = self.client.put(self.path, data={
+                'status': 'active',
+            })
+
+        assert resp.status_code == 200, resp.content
+        assert resp.data['id'] == six.text_type(self.monitor.guid)
+
+        monitor = Monitor.objects.get(id=self.monitor.id)
+        assert monitor.status == MonitorStatus.ACTIVE
+
+    def test_cannot_enable_if_enabled(self):
+        self.monitor.update(status=MonitorStatus.OK)
+        with self.feature({'organizations:monitors': True}):
+            resp = self.client.put(self.path, data={
+                'status': 'active',
+            })
+
+        assert resp.status_code == 200, resp.content
+        assert resp.data['id'] == six.text_type(self.monitor.guid)
+
+        monitor = Monitor.objects.get(id=self.monitor.id)
+        assert monitor.status == MonitorStatus.OK
+
+    def test_cronjob_crontab(self):
+        with self.feature({'organizations:monitors': True}):
+            resp = self.client.put(self.path, data={
+                'config': {
+                    'schedule': '*/5 * * * *',
+                }
+            })
+
+        assert resp.status_code == 200, resp.content
+        assert resp.data['id'] == six.text_type(self.monitor.guid)
+
+        monitor = Monitor.objects.get(id=self.monitor.id)
+        assert monitor.config == {
+            'schedule_type': ScheduleType.CRONTAB,
+            'schedule': '*/5 * * * *',
+        }
+
+    # TODO(dcramer): would be lovely to run the full spectrum, but it requires
+    # this test to not be class-based
+    # @pytest.mark.parametrize('input,expected', (
+    #     ['@yearly', '0 0 1 1 *'],
+    #     ['@annually', '0 0 1 1 *'],
+    #     ['@monthly', '0 0 1 * *'],
+    #     ['@weekly', '0 0 * * 0'],
+    #     ['@daily', '0 0 * * *'],
+    #     ['@hourly', '0 * * * *'],
+    # ))
+    def test_cronjob_nonstandard(self):
+        with self.feature({'organizations:monitors': True}):
+            resp = self.client.put(self.path, data={
+                'config': {
+                    'schedule': '@monthly',
+                }
+            })
+
+        assert resp.status_code == 200, resp.content
+        assert resp.data['id'] == six.text_type(self.monitor.guid)
+
+        monitor = Monitor.objects.get(id=self.monitor.id)
+        assert monitor.config == {
+            'schedule_type': ScheduleType.CRONTAB,
+            'schedule': '0 0 1 * *',
+        }
+
+    def test_cronjob_crontab_invalid(self):
+        with self.feature({'organizations:monitors': True}):
+            resp = self.client.put(self.path, data={
+                'config': {
+                    'schedule': '*/0.5 * * * *',
+                }
+            })
+
+            assert resp.status_code == 400, resp.content
+
+            resp = self.client.put(self.path, data={
+                'config': {
+                    'schedule': '* * * *',
+                }
+            })
+
+            assert resp.status_code == 400, resp.content
+
+    def test_cronjob_interval(self):
+        with self.feature({'organizations:monitors': True}):
+            resp = self.client.put(self.path, data={
+                'config': {
+                    'schedule_type': 'interval',
+                    'schedule': [1, 'month'],
+                }
+            })
+
+        assert resp.status_code == 200, resp.content
+        assert resp.data['id'] == six.text_type(self.monitor.guid)
+
+        monitor = Monitor.objects.get(id=self.monitor.id)
+        assert monitor.config == {
+            'schedule_type': ScheduleType.INTERVAL,
+            'schedule': [1, 'month'],
+        }
+
+    def test_cronjob_interval_invalid_inteval(self):
+        with self.feature({'organizations:monitors': True}):
+            resp = self.client.put(self.path, data={
+                'config': {
+                    'schedule_type': 'interval',
+                    'schedule': [1, 'decade'],
+                }
+            })
+
+            assert resp.status_code == 400, resp.content
+
+            resp = self.client.put(self.path, data={
+                'config': {
+                    'schedule_type': 'interval',
+                    'schedule': ['foo', 'month'],
+                }
+            })
+
+            assert resp.status_code == 400, resp.content
+
+            resp = self.client.put(self.path, data={
+                'config': {
+                    'schedule_type': 'interval',
+                    'schedule': 'bar',
+                }
+            })
+
+            assert resp.status_code == 400, resp.content
+
+
+class DeleteMonitorTest(APITestCase):
+    def test_simple(self):
+        user = self.create_user()
+        org = self.create_organization(owner=user)
+        team = self.create_team(organization=org, members=[user])
+        project = self.create_project(teams=[team])
+
+        monitor = Monitor.objects.create(
+            organization_id=org.id,
+            project_id=project.id,
+            next_checkin=timezone.now() - timedelta(minutes=1),
+            type=MonitorType.CRON_JOB,
+            config={'schedule': '* * * * *'},
+        )
+
+        self.login_as(user=user)
+        with self.feature({'organizations:monitors': True}):
+            resp = self.client.delete('/api/0/monitors/{}/'.format(monitor.guid))
+
+        assert resp.status_code == 202, resp.content
+
+        monitor = Monitor.objects.get(id=monitor.id)
+        assert monitor.status == MonitorStatus.PENDING_DELETION

--- a/tests/sentry/api/endpoints/test_organization_monitors.py
+++ b/tests/sentry/api/endpoints/test_organization_monitors.py
@@ -4,11 +4,11 @@ import six
 
 from exam import fixture
 
-from sentry.models import Monitor
+from sentry.models import Monitor, MonitorStatus, MonitorType, ScheduleType
 from sentry.testutils import APITestCase
 
 
-class OrganizationProjectsTest(APITestCase):
+class ListOrganizationMonitorsTest(APITestCase):
     @fixture
     def org(self):
         return self.create_organization(owner=self.user, name='baz')
@@ -41,3 +41,49 @@ class OrganizationProjectsTest(APITestCase):
         with self.feature({'organizations:monitors': True}):
             response = self.client.get(self.path)
         self.check_valid_response(response, [monitor])
+
+
+class CreateOrganizationMonitorTest(APITestCase):
+    @fixture
+    def org(self):
+        return self.create_organization(owner=self.user, name='baz')
+
+    @fixture
+    def team(self):
+        return self.create_team(organization=self.org, members=[self.user])
+
+    @fixture
+    def project(self):
+        return self.create_project(teams=[self.team])
+
+    @fixture
+    def path(self):
+        return u'/api/0/organizations/{}/monitors/'.format(self.org.slug)
+
+    def test_simple(self):
+        self.login_as(user=self.user)
+
+        with self.feature({'organizations:monitors': True}):
+            response = self.client.post(self.path, {
+                'project': self.project.slug,
+                'name': 'My Monitor',
+                'type': 'cron_job',
+                'config': {
+                    'schedule_type': 'crontab',
+                    'schedule': '@daily',
+                }
+            })
+
+        assert response.status_code == 201
+        assert response.data['id']
+
+        monitor = Monitor.objects.get(guid=response.data['id'])
+        assert monitor.organization_id == self.org.id
+        assert monitor.project_id == self.project.id
+        assert monitor.name == 'My Monitor'
+        assert monitor.status == MonitorStatus.ACTIVE
+        assert monitor.type == MonitorType.CRON_JOB
+        assert monitor.config == {
+            'schedule_type': ScheduleType.CRONTAB,
+            'schedule': '0 0 * * *',
+        }

--- a/tests/sentry/models/test_monitor.py
+++ b/tests/sentry/models/test_monitor.py
@@ -2,12 +2,12 @@ from __future__ import absolute_import, print_function
 
 from datetime import datetime
 from django.utils import timezone
-from sentry.models import Monitor
+from sentry.models import Monitor, ScheduleType
 from sentry.testutils import TestCase
 
 
 class MonitorTestCase(TestCase):
-    def test_next_run(self):
+    def test_next_run_crontab_implicit(self):
         monitor = Monitor(
             last_checkin=datetime(2019, 1, 1, 1, 10, 20, tzinfo=timezone.utc),
             config={
@@ -18,3 +18,26 @@ class MonitorTestCase(TestCase):
 
         monitor.config['schedule'] = '*/5 * * * *'
         assert monitor.get_next_scheduled_checkin() == datetime(2019, 1, 1, 1, 15, tzinfo=timezone.utc)
+
+    def test_next_run_crontab_explicit(self):
+        monitor = Monitor(
+            last_checkin=datetime(2019, 1, 1, 1, 10, 20, tzinfo=timezone.utc),
+            config={
+                'schedule': '* * * * *',
+                'schedule_type': ScheduleType.CRONTAB,
+            }
+        )
+        assert monitor.get_next_scheduled_checkin() == datetime(2019, 1, 1, 1, 11, tzinfo=timezone.utc)
+
+        monitor.config['schedule'] = '*/5 * * * *'
+        assert monitor.get_next_scheduled_checkin() == datetime(2019, 1, 1, 1, 15, tzinfo=timezone.utc)
+
+    def test_next_run_interval(self):
+        monitor = Monitor(
+            last_checkin=datetime(2019, 1, 1, 1, 10, 20, tzinfo=timezone.utc),
+            config={
+                'schedule': ['month', 1],
+                'schedule_type': ScheduleType.INTERVAL,
+            }
+        )
+        assert monitor.get_next_scheduled_checkin() == datetime(2019, 2, 1, 1, 10, 20, tzinfo=timezone.utc)


### PR DESCRIPTION
- Add interval schedule types
- Add monitor update endpoint
- Add monitor delete endpoint
- Add monitor create endpoint
- Add pause/enable action to monitor header (ui)
- Add delete action to monitor header (ui)
- Expose config on monitor edit (ui) - cron job only
- Add create monitor flow
- Support non-standard formats (converted on input)
