### PR TITLE
fix(integrations) Use shorter ids for gitlab

### DIFF
--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -279,7 +279,7 @@ class GitlabIntegrationProvider(IntegrationProvider):
             # This value is embedded then in the webook token that we
             # give to gitlab to allow us to find the integration a hook came
             # from.
-            'external_id': u'{}:{}'.format(hostname, group['full_path']),
+            'external_id': u'{}:{}'.format(hostname, group['id']),
             'metadata': {
                 'icon': group['avatar_url'],
                 'instance': hostname,

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -33,10 +33,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
         super(GitlabIntegrationTest, self).setUp()
         self.init_path_without_guide = '%s%s' % (self.init_path, '?completed_installation_guide')
 
-    def assert_setup_flow(self, user_id='user_id_1', group_id=None):
-        if group_id is None:
-            group_id = self.default_group_id
-
+    def assert_setup_flow(self, user_id='user_id_1'):
         resp = self.client.get(self.init_path)
         assert resp.status_code == 200
         self.assertContains(resp, 'you will need to create a Sentry app in your GitLab instance')
@@ -74,7 +71,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
             responses.GET,
             'https://gitlab.example.com/api/v4/groups/cool-group',
             json={
-                'id': group_id,
+                'id': self.default_group_id,
                 'full_name': 'Cool',
                 'full_path': 'cool-group',
                 'web_url': 'https://gitlab.example.com/groups/cool-group',
@@ -121,7 +118,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
 
         integration = Integration.objects.get(provider=self.provider.key)
 
-        assert integration.external_id == 'gitlab.example.com:cool-group'
+        assert integration.external_id == 'gitlab.example.com:4'
         assert integration.name == 'Cool'
         assert integration.metadata == {
             'instance': 'gitlab.example.com',


### PR DESCRIPTION
The group path + domain can exceed our column limits, but using the group.id should not overflow nearly as often if ever.

I tested locally that webhooks work for both new and existing integrations. The webhook handler treats the `external_id` part of the hook secret as an opaque value thankfully.

Fixes APP-1093