### PR TITLE
fix(jira) Default to the first project when no preference exist

### DIFF
--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -140,17 +140,15 @@ class JiraApiClient(ApiClient):
                 return project['key'].encode('utf-8')
         return ''
 
-    def get_create_meta(self, project=None):
-        params = {'expand': 'projects.issuetypes.fields'}
-        if project is not None:
-            params['projectIds'] = project
-        return self.get_cached(
+    def get_create_meta_for_project(self, project):
+        params = {
+            'expand': 'projects.issuetypes.fields',
+            'projectIds': project
+        }
+        metas = self.get_cached(
             self.META_URL,
             params=params,
         )
-
-    def get_create_meta_for_project(self, project):
-        metas = self.get_create_meta(project)
         # We saw an empty JSON response come back from the API :(
         if not metas:
             return None

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -351,14 +351,11 @@ SAMPLE_TRANSITION_RESPONSE = """
 
 
 class MockJiraApiClient(object):
-    def get_create_meta(self, project=None):
+    def get_create_meta_for_project(self, project):
         resp = json.loads(SAMPLE_CREATE_META_RESPONSE)
         if project == '10001':
             resp['projects'][0]['id'] = '10001'
-        return resp
-
-    def get_create_meta_for_project(self, project):
-        return self.get_create_meta()['projects'][0]
+        return resp['projects'][0]
 
     def get_projects_list(self):
         return json.loads(SAMPLE_PROJECT_LIST_RESPONSE)


### PR DESCRIPTION
When first using the Jira integrations we don't have a default project selected, this results in us getting the issue create configuration for *all* jira projects. While this isn't generally a problem, some users have jira instances with 300+ projects and our requests timeout/fail with duplicate screen errors.

I've merged the two get_create_meta methods as now we only really need one as we should never be fetching config for all projects, as those requests are expensive, slow and often fail.

Fixes APP-1100