### PR TITLE
feat(app-platform): Add schema serializer 

### DIFF
--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -42,7 +42,7 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
 
             return Response(serialize(sentry_app), status=201)
 
-        return Response({'errors': serializer.errors}, status=422)
+        return Response(serializer.errors, status=422)
 
     def _get_user_org(self, request):
         return next(

--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import
 
+from jsonschema.exceptions import ValidationError as SchemaValidationError
+
 from rest_framework import serializers
 from rest_framework.serializers import Serializer, ValidationError
 
+from sentry.api.validators.sentry_apps.schema import validate
 from sentry.models import ApiScopes
 from sentry.models.sentryapp import VALID_EVENT_RESOURCES, REQUIRED_EVENT_PERMISSIONS
 
@@ -26,10 +29,19 @@ class EventListField(serializers.WritableField):
             ))
 
 
+class SchemaField(serializers.WritableField):
+    def validate(self, data):
+        try:
+            validate(data)
+        except SchemaValidationError as e:
+            raise ValidationError(u'{}'.format(e.message))
+
+
 class SentryAppSerializer(Serializer):
     name = serializers.CharField()
     scopes = ApiScopesField()
     events = EventListField(required=False)
+    schema = SchemaField(required=False)
     webhookUrl = serializers.URLField()
     redirectUrl = serializers.URLField(required=False)
     isAlertable = serializers.BooleanField(required=False)

--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -5,7 +5,7 @@ from jsonschema.exceptions import ValidationError as SchemaValidationError
 from rest_framework import serializers
 from rest_framework.serializers import Serializer, ValidationError
 
-from sentry.api.validators.sentry_apps.schema import validate
+from sentry.api.validators.sentry_apps.schema import validate as validate_schema
 from sentry.models import ApiScopes
 from sentry.models.sentryapp import VALID_EVENT_RESOURCES, REQUIRED_EVENT_PERMISSIONS
 
@@ -32,9 +32,9 @@ class EventListField(serializers.WritableField):
 class SchemaField(serializers.WritableField):
     def validate(self, data):
         try:
-            validate(data)
+            validate_schema(data)
         except SchemaValidationError as e:
-            raise ValidationError(u'{}'.format(e.message))
+            raise ValidationError(e.message)
 
 
 class SentryAppSerializer(Serializer):

--- a/src/sentry/api/validators/sentry_apps/schema.py
+++ b/src/sentry/api/validators/sentry_apps/schema.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
-from jsonschema import validate as json_schema_validate
+from jsonschema import Draft4Validator
+from jsonschema.exceptions import best_match
 
 SCHEMA = {
     'type': 'object',
@@ -17,6 +18,7 @@ SCHEMA = {
 
         'options': {
             'type': 'array',
+            'minItems': 1,
             'items': {
                 'type': 'array',
                 'minItems': 2,
@@ -214,7 +216,7 @@ SCHEMA = {
                     '$ref': '#/definitions/fieldset',
                 },
             },
-            'required': ['required_fields'],
+            'required': ['type', 'required_fields'],
         },
 
         'issue-media': {
@@ -261,5 +263,8 @@ SCHEMA = {
 }
 
 
-def validate(instance, schema=SCHEMA):
-    json_schema_validate(instance=instance, schema=schema)
+def validate(value, schema=SCHEMA):
+    v = Draft4Validator(schema)
+
+    if not v.is_valid(value):
+        raise best_match(v.iter_errors(value))

--- a/src/sentry/api/validators/sentry_apps/schema.py
+++ b/src/sentry/api/validators/sentry_apps/schema.py
@@ -263,8 +263,8 @@ SCHEMA = {
 }
 
 
-def validate(value, schema=SCHEMA):
+def validate(instance, schema=SCHEMA):
     v = Draft4Validator(schema)
 
-    if not v.is_valid(value):
-        raise best_match(v.iter_errors(value))
+    if not v.is_valid(instance):
+        raise best_match(v.iter_errors(instance))

--- a/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
+++ b/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
@@ -49,6 +49,15 @@ const forms = [
         autosize: true,
         help: 'Description of your application and its functionality.',
       },
+      {
+        name: 'schema',
+        type: 'textarea',
+        label: 'Schema',
+        autosize: true,
+        help: 'Schema for your UI components',
+        getValue: val => JSON.parse(val),
+        setValue: val => JSON.stringify(val),
+      },
     ],
   },
 ];

--- a/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
+++ b/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
@@ -49,15 +49,6 @@ const forms = [
         autosize: true,
         help: 'Description of your application and its functionality.',
       },
-      {
-        name: 'schema',
-        type: 'textarea',
-        label: 'Schema',
-        autosize: true,
-        help: 'Schema for your UI components',
-        getValue: val => JSON.parse(val),
-        setValue: val => JSON.stringify(val),
-      },
     ],
   },
 ];

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
@@ -105,7 +105,6 @@ export default class SentryApplicationDetails extends AsyncView {
           initialData={{organization: orgId, isAlertable: false, ...app}}
           model={this.form}
           onSubmitSuccess={this.onSubmitSuccess}
-          onSubmitError={err => addErrorMessage(t('Unable to save change'))}
         >
           <JsonForm location={this.props.location} forms={sentryApplicationForm} />
 

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {browserHistory} from 'react-router';
 
-import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
+import {addSuccessMessage} from 'app/actionCreators/indicator';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -135,7 +135,7 @@ class PostSentryAppsTest(SentryAppsTest):
         response = self._post(**kwargs)
 
         assert response.status_code == 422
-        assert response.data['errors'] == \
+        assert response.data == \
             {'events': ['issue webhooks require the event:read permission.']}
 
     @with_feature('organizations:internal-catchall')
@@ -144,7 +144,7 @@ class PostSentryAppsTest(SentryAppsTest):
         response = self._post(name=None)
 
         assert response.status_code == 422, response.content
-        assert 'name' in response.data['errors']
+        assert 'name' in response.data
 
     @with_feature('organizations:internal-catchall')
     def test_missing_scopes(self):
@@ -152,7 +152,7 @@ class PostSentryAppsTest(SentryAppsTest):
         response = self._post(scopes=None)
 
         assert response.status_code == 422, response.content
-        assert 'scopes' in response.data['errors']
+        assert 'scopes' in response.data
 
     @with_feature('organizations:internal-catchall')
     def test_invalid_events(self):
@@ -160,7 +160,7 @@ class PostSentryAppsTest(SentryAppsTest):
         response = self._post(events=['project'])
 
         assert response.status_code == 422, response.content
-        assert 'events' in response.data['errors']
+        assert 'events' in response.data
 
     @with_feature('organizations:internal-catchall')
     def test_invalid_scope(self):
@@ -168,7 +168,7 @@ class PostSentryAppsTest(SentryAppsTest):
         response = self._post(scopes=('not:ascope', ))
 
         assert response.status_code == 422, response.content
-        assert 'scopes' in response.data['errors']
+        assert 'scopes' in response.data
 
     @with_feature('organizations:internal-catchall')
     def test_missing_webhook_url(self):
@@ -176,7 +176,7 @@ class PostSentryAppsTest(SentryAppsTest):
         response = self._post(webhookUrl=None)
 
         assert response.status_code == 422, response.content
-        assert 'webhookUrl' in response.data['errors']
+        assert 'webhookUrl' in response.data
 
     def _post(self, **kwargs):
         body = {

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -139,6 +139,31 @@ class PostSentryAppsTest(SentryAppsTest):
             {'events': ['issue webhooks require the event:read permission.']}
 
     @with_feature('organizations:internal-catchall')
+    def test_wrong_schema_format(self):
+        self.login_as(user=self.user)
+        kwargs = {'schema': {
+            'elements': [
+                {
+                    'type': 'alert-rule-action',
+                    'required_fields': [
+                        {
+                            'type': 'select',
+                            'label': 'Channel',
+                            'name': 'channel',
+                            'options': [
+                                ['#general'],
+                            ]
+                        },
+                    ],
+                }
+            ],
+        }}
+        response = self._post(**kwargs)
+        assert response.status_code == 422
+        assert response.data == \
+            {'schema': ["['#general'] is too short"]}
+
+    @with_feature('organizations:internal-catchall')
     def test_missing_name(self):
         self.login_as(self.user)
         response = self._post(name=None)

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -151,6 +151,8 @@ class PostSentryAppsTest(SentryAppsTest):
                             'label': 'Channel',
                             'name': 'channel',
                             'options': [
+                                # option items should have 2 elements
+                                # i.e. ['channel_id', '#general']
                                 ['#general'],
                             ]
                         },


### PR DESCRIPTION
* Adds the `SchemaField` validator to the `SentryAppSerializer`
* Changes the `validate` method for the schema
    * This isn't perfect, but it uses [`best_match`](https://python-jsonschema.readthedocs.io/en/latest/errors/#jsonschema.exceptions.best_match) from `jsonschema.exceptions`. For now I think this is the best thing to do because it gives back one error to show (making it easy to render in the UI) and uses logic to show the most relevant error*. We can also link to docs outlining the schema.


*_still some problems with this but it tries_