### PR TITLE
fix(permissions) Don't mutate scope dictionaries

### DIFF
--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import copy
 import six
 
 from django.db import IntegrityError, transaction
@@ -42,6 +43,10 @@ def list_organization_teams_scenario(runner):
 # OrganizationPermission + team:write
 class OrganizationTeamsPermission(OrganizationPermission):
     def __init__(self):
+        # Deep clone so we don't mutate the dict
+        # on the parent class object.
+        self.scope_map = copy.deepcopy(self.scope_map)
+
         for m in 'POST', 'PUT', 'DELETE':
             self.scope_map[m].append('team:write')
 

--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import copy
 import six
 
 from django.db import IntegrityError, transaction
@@ -42,13 +41,12 @@ def list_organization_teams_scenario(runner):
 
 # OrganizationPermission + team:write
 class OrganizationTeamsPermission(OrganizationPermission):
-    def __init__(self):
-        # Deep clone so we don't mutate the dict
-        # on the parent class object.
-        self.scope_map = copy.deepcopy(self.scope_map)
-
-        for m in 'POST', 'PUT', 'DELETE':
-            self.scope_map[m].append('team:write')
+    scope_map = {
+        'GET': ['org:read', 'org:write', 'org:admin'],
+        'POST': ['org:write', 'org:admin', 'team:write'],
+        'PUT': ['org:write', 'org:admin', 'team:write'],
+        'DELETE': ['org:admin', 'team:write'],
+    }
 
 
 class TeamSerializer(serializers.Serializer):


### PR DESCRIPTION
Deep copy the OrganizationPermission scope_map before mutating it. This prevents mutations from happening on the class object.

Fixes APP-1106