### PR TITLE
meta: Configure toolchains for notion users

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,5 +144,9 @@
     "storybook-build": "build-storybook -c .storybook -o .storybook-out && sed -i -e 's/\\/sb_dll/sb_dll/g' .storybook-out/index.html",
     "snapshot": "build-storybook && PERCY_TOKEN=$STORYBOOK_PERCY_TOKEN PERCY_PROJECT=$STORYBOOK_PERCY_PROJECT percy-storybook --widths=1280",
     "webpack-profile": "yarn -s webpack --profile --json > stats.json"
+  },
+  "toolchain": {
+    "node": "8.10.0",
+    "yarn": "1.3.2"
   }
 }


### PR DESCRIPTION
This adds our toolchain versions to the package.json which means that
notion users will automatically find the toolchain configured in the
right format out of the box.