### PR TITLE
perf(logging): Bump threshold for sentry.files to WARN for a little less noise.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -689,6 +689,9 @@ LOGGING = {
         'sentry': {
             'level': 'INFO',
         },
+        'sentry.files': {
+            'level': 'WARNING',
+        },
         'sentry.minidumps': {
             'handlers': ['internal'],
             'propagate': False,


### PR DESCRIPTION
We discussed this a while ago, just finally got around to it.