### PR TITLE
feat(service-hooks): Use ServiceHookProject for hook lookup

### DIFF
--- a/src/sentry/models/servicehook.py
+++ b/src/sentry/models/servicehook.py
@@ -18,7 +18,7 @@ from sentry.db.models import (
     FlexibleForeignKey,
     sane_repr,
 )
-from sentry.models import SentryApp
+from sentry.models import SentryApp, Project
 
 SERVICE_HOOK_EVENTS = [
     'event.alert',
@@ -112,3 +112,14 @@ class ServiceHook(Model):
             project_id=project.id,
             service_hook_id=self.id,
         )
+
+    def get_projects(self):
+        """
+        Get all projects associated with a service hook.
+
+        """
+        ids = ServiceHookProject.objects.filter(
+            service_hook_id=self.id,
+        ).values_list('project_id', flat=True)
+
+        return Project.objects.filter(id__in=ids)

--- a/src/sentry/models/servicehook.py
+++ b/src/sentry/models/servicehook.py
@@ -18,7 +18,7 @@ from sentry.db.models import (
     FlexibleForeignKey,
     sane_repr,
 )
-from sentry.models import SentryApp, Project
+from sentry.models import SentryApp
 
 SERVICE_HOOK_EVENTS = [
     'event.alert',
@@ -112,14 +112,3 @@ class ServiceHook(Model):
             project_id=project.id,
             service_hook_id=self.id,
         )
-
-    def get_projects(self):
-        """
-        Get all projects associated with a service hook.
-
-        """
-        ids = ServiceHookProject.objects.filter(
-            service_hook_id=self.id,
-        ).values_list('project_id', flat=True)
-
-        return Project.objects.filter(id__in=ids)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -28,12 +28,16 @@ logger = logging.getLogger('sentry')
 
 
 def _get_service_hooks(project_id):
-    from sentry.models import ServiceHook
+    from sentry.models import ServiceHook, ServiceHookProject
     cache_key = u'servicehooks:1:{}'.format(project_id)
     result = cache.get(cache_key)
     if result is None:
+        hook_ids = ServiceHookProject.object.filter(
+            project_id=project_id,
+        ).values_list('service_hook_id', flat=True)
+
         result = [(h.id, h.events) for h in
-                  ServiceHook.objects.filter(project_id=project_id)]
+                  ServiceHook.objects.filter(service_hook_id__in=hook_ids)]
         cache.set(cache_key, result, 60)
     return result
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -28,16 +28,15 @@ logger = logging.getLogger('sentry')
 
 
 def _get_service_hooks(project_id):
-    from sentry.models import ServiceHook, ServiceHookProject
+    from sentry.models import ServiceHook
     cache_key = u'servicehooks:1:{}'.format(project_id)
     result = cache.get(cache_key)
     if result is None:
-        hook_ids = ServiceHookProject.objects.filter(
-            project_id=project_id,
-        ).values_list('service_hook_id', flat=True)
 
-        result = [(h.id, h.events) for h in
-                  ServiceHook.objects.filter(id__in=hook_ids)]
+        result = ServiceHook.objects.filter(
+            servicehookproject__project_id=project_id,
+        ).values_list('id', 'events')
+
         cache.set(cache_key, result, 60)
     return result
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -32,12 +32,12 @@ def _get_service_hooks(project_id):
     cache_key = u'servicehooks:1:{}'.format(project_id)
     result = cache.get(cache_key)
     if result is None:
-        hook_ids = ServiceHookProject.object.filter(
+        hook_ids = ServiceHookProject.objects.filter(
             project_id=project_id,
         ).values_list('service_hook_id', flat=True)
 
         result = [(h.id, h.events) for h in
-                  ServiceHook.objects.filter(service_hook_id__in=hook_ids)]
+                  ServiceHook.objects.filter(id__in=hook_ids)]
         cache.set(cache_key, result, 60)
     return result
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -31,12 +31,12 @@ def _get_service_hooks(project_id):
     from sentry.models import ServiceHook
     cache_key = u'servicehooks:1:{}'.format(project_id)
     result = cache.get(cache_key)
+
     if result is None:
-
-        result = ServiceHook.objects.filter(
+        hooks = ServiceHook.objects.filter(
             servicehookproject__project_id=project_id,
-        ).values_list('id', 'events')
-
+        )
+        result = [(h.id, h.events) for h in hooks]
         cache.set(cache_key, result, 60)
     return result
 

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -12,7 +12,7 @@ from sentry.tasks.base import instrumented_task, retry
 from sentry.utils.http import absolute_uri
 from sentry.api.serializers import serialize, AppPlatformEvent
 from sentry.models import (
-    SentryAppInstallation, Group, User, ServiceHook, Project, SentryApp,
+    SentryAppInstallation, Group, User, ServiceHook, SentryApp,
 )
 from sentry.models.sentryapp import VALID_EVENTS
 
@@ -246,21 +246,22 @@ def notify_sentry_app(event, futures):
 
 
 def send_webhooks(installation, event, **kwargs):
-    project_ids = Project.objects.filter(
-        organization_id=installation.organization_id,
-    ).values_list('id', flat=True)
+    try:
+        servicehook = ServiceHook.objects.get(
+            organization_id=installation.organization_id,
+            actor_id=installation.id,
+        )
+    except ServiceHook.DoesNotExist:
+        return
 
-    servicehooks = ServiceHook.objects.filter(
-        project_id__in=project_ids,
-    )
+    if event not in servicehook.events:
+        return
 
-    for servicehook in filter(lambda s: event in s.events, servicehooks):
-        if not servicehook.created_by_sentry_app:
-            continue
-
-        if servicehook.sentry_app != installation.sentry_app:
-            continue
-
+    # The service hook applies to all projects if there are no
+    # ServiceHookProject records. Otherwise want to check if we
+    # should send the webhook or not.
+    projects = servicehook.get_projects()
+    if not projects:
         resource, action = event.split('.')
 
         kwargs['resource'] = resource

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -258,13 +258,13 @@ def send_webhooks(installation, event, **kwargs):
         return
 
     # The service hook applies to all projects if there are no
-    # ServiceHookProject records. Otherwise we want to check if we
-    # should send the webhook or not.
-    project_ids = ServiceHookProject.objects.filter(
+    # ServiceHookProject records. Otherwise we want check if
+    # the event is within the allowed projects.
+    project_limited = ServiceHookProject.objects.filter(
         service_hook_id=servicehook.id,
-    ).values_list('project_id', flat=True)
+    ).exists()
 
-    if not project_ids:
+    if not project_limited:
         resource, action = event.split('.')
 
         kwargs['resource'] = resource

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -782,7 +782,7 @@ class Fixtures(object):
             org = self.create_organization(owner=actor)
         if not project:
             project = self.create_project(organization=org)
-        if not events:
+        if events is None:
             events = ('event.created',)
         if not url:
             url = 'https://example.com/sentry/webhook'

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from mock import Mock, patch
 
 from sentry import tagstore
-from sentry.models import Group, GroupSnooze, GroupStatus, ServiceHook
+from sentry.models import Group, GroupSnooze, GroupStatus
 from sentry.testutils import TestCase
 from sentry.tasks.merge import merge_groups
 from sentry.tasks.post_process import index_event_tags, post_process_group
@@ -124,10 +124,10 @@ class PostProcessGroupTest(TestCase):
         group = self.create_group(project=self.project)
         event = self.create_event(group=group)
 
-        hook = ServiceHook.objects.create(
-            project_id=self.project.id,
-            organization_id=self.project.organization_id,
-            actor_id=self.user.id,
+        hook = self.create_service_hook(
+            project=self.project,
+            organization=self.project.organization,
+            actor=self.user,
             events=['event.created'],
         )
 
@@ -158,10 +158,10 @@ class PostProcessGroupTest(TestCase):
             (mock_callback, mock_futures),
         ]
 
-        hook = ServiceHook.objects.create(
-            project_id=self.project.id,
-            organization_id=self.project.organization_id,
-            actor_id=self.user.id,
+        hook = self.create_service_hook(
+            project=self.project,
+            organization=self.project.organization,
+            actor=self.user,
             events=['event.alert'],
         )
 
@@ -188,10 +188,10 @@ class PostProcessGroupTest(TestCase):
 
         mock_processor.return_value.apply.return_value = []
 
-        ServiceHook.objects.create(
-            project_id=self.project.id,
-            organization_id=self.project.organization_id,
-            actor_id=self.user.id,
+        self.create_service_hook(
+            project=self.project,
+            organization=self.project.organization,
+            actor=self.user,
             events=['event.alert'],
         )
 
@@ -211,10 +211,10 @@ class PostProcessGroupTest(TestCase):
         group = self.create_group(project=self.project)
         event = self.create_event(group=group)
 
-        ServiceHook.objects.create(
-            project_id=self.project.id,
-            organization_id=self.project.organization_id,
-            actor_id=self.user.id,
+        self.create_service_hook(
+            project=self.project,
+            organization=self.project.organization,
+            actor=self.user,
             events=[],
         )
 

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -171,14 +171,6 @@ class TestProcessResourceChange(TestCase):
             slug=self.sentry_app.slug,
         )
 
-        self.hook = self.create_service_hook(
-            actor=self.install,
-            org=self.project.organization,
-            application=self.install.sentry_app.application,
-            project=self.project,
-            events=('issue.created', ),
-        )
-
     def test_group_created_sends_webhook(self, safe_urlopen):
         with self.tasks():
             issue = self.create_group(project=self.project)

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -278,3 +278,29 @@ class TestWorkflowNotification(TestCase):
         assert faux(safe_urlopen).kwarg_equals('data.actor.type', 'application', format='json')
         assert faux(safe_urlopen).kwarg_equals('data.actor.id', 'sentry', format='json')
         assert faux(safe_urlopen).kwarg_equals('data.actor.name', 'Sentry', format='json')
+
+    def test_does_not_send_if_no_service_hook_exists(self, safe_urlopen):
+        sentry_app = self.create_sentry_app(
+            name='Another App',
+            organization=self.project.organization,
+            events=[],
+        )
+        install = self.create_sentry_app_installation(
+            organization=self.project.organization,
+            slug=sentry_app.slug,
+        )
+        workflow_notification(install.id, self.issue.id, 'assigned', self.user.id)
+        assert not safe_urlopen.called
+
+    def test_does_not_send_if_event_not_in_app_events(self, safe_urlopen):
+        sentry_app = self.create_sentry_app(
+            name='Another App',
+            organization=self.project.organization,
+            events=['issue.resolved', 'issue.ignored'],
+        )
+        install = self.create_sentry_app_installation(
+            organization=self.project.organization,
+            slug=sentry_app.slug,
+        )
+        workflow_notification(install.id, self.issue.id, 'assigned', self.user.id)
+        assert not safe_urlopen.called


### PR DESCRIPTION
Another piece to #11725

Relies on https://github.com/getsentry/sentry/pull/12001.

**Note:** Choosing not to use `values_list` when looking up the service hooks as it seems there is something wrong with both mySql and sqlite3 wrt the `ArrayField`. 
(for sqlite3) - when `events` is an empty array it gets store as `None`  and when not empty, getting the value back doesn't seem to use the `json.loads(value)` in `to_python` 
example result from query: `[(1, u'["event.created"]')]`