### PR TITLE
fix(ui): Use project slug in locked multiple project selector [APP-1108]

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -136,9 +136,9 @@ export default class MultipleProjectSelector extends React.PureComponent {
       <StyledHeaderItem
         icon={<StyledInlineSvg src="icon-project" />}
         locked={true}
-        lockedMessage={t(`This issue is unique to the ${forceProject.name} project`)}
+        lockedMessage={t(`This issue is unique to the ${forceProject.slug} project`)}
       >
-        {forceProject.name}
+        {forceProject.slug}
       </StyledHeaderItem>
     ) : (
       <StyledProjectSelector


### PR DESCRIPTION
`project.name` has been deprecated for over a year now, use slug instead