### PR TITLE
ref(ui) Use EmptyState properties better

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationMonitors/monitorStats.jsx
+++ b/src/sentry/static/sentry/app/views/organizationMonitors/monitorStats.jsx
@@ -79,7 +79,6 @@ export default class MonitorStats extends AsyncComponent {
             />
           ) : (
             <EmptyMessage
-              css={{flexDirection: 'column', alignItems: 'center'}}
               title={t('Nothing recorded in the last 30 days.')}
               description={t('All check-ins for this monitor.')}
             />

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.jsx
@@ -199,14 +199,12 @@ const ProjectFiltersChart = createReactClass({
             )}
           {hasLoaded &&
             this.state.blankStats && (
-              <EmptyMessage css={{flexDirection: 'column', alignItems: 'center'}}>
-                <h3 css={noMarginBottom}>{t('Nothing filtered in the last 30 days.')}</h3>
-                <TextBlock css={{fontSize: '0.9em', ...noMarginBottom}}>
-                  {t(
-                    'Issues filtered as a result of your settings below will be shown here.'
-                  )}
-                </TextBlock>
-              </EmptyMessage>
+              <EmptyMessage
+                title={t('Nothing filtered in the last 30 days.')}
+                description={t(
+                  'Issues filtered as a result of your settings below will be shown here.'
+                )}
+              />
             )}
         </PanelBody>
       </Panel>

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.jsx
@@ -13,9 +13,6 @@ import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import StackedBarChart from 'app/components/stackedBarChart';
-import TextBlock from 'app/views/settings/components/text/textBlock';
-
-const noMarginBottom = {marginBottom: 0};
 
 const ProjectFiltersChart = createReactClass({
   displayName: 'ProjectFiltersChart',

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/index.jsx
@@ -238,10 +238,10 @@ export default class ProjectKeys extends AsyncView {
   renderEmpty() {
     return (
       <Panel>
-        <EmptyMessage>
-          <span className="icon icon-exclamation" />
-          <p>{t('There are no keys active for this project.')}</p>
-        </EmptyMessage>
+        <EmptyMessage
+          icon="icon-circle-exclamation"
+          description={t('There are no keys active for this project.')}
+        />
       </Panel>
     );
   }

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
@@ -37,7 +37,6 @@ import SelectField from 'app/views/settings/components/forms/selectField';
 import SentryTypes from 'app/sentryTypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import StackedBarChart from 'app/components/stackedBarChart';
-import TextBlock from 'app/views/settings/components/text/textBlock';
 import TextCopyInput from 'app/views/settings/components/forms/textCopyInput';
 import TextField from 'app/views/settings/components/forms/textField';
 import getDynamicText from 'app/utils/getDynamicText';
@@ -153,12 +152,10 @@ const KeyStats = createReactClass({
               tooltip={this.renderTooltip}
             />
           ) : (
-            <EmptyMessage css={{flexDirection: 'column', alignItems: 'center'}}>
-              <EmptyHeader>{t('Nothing recorded in the last 30 days.')}</EmptyHeader>
-              <TextBlock css={{marginBottom: 0}}>
-                {t('Total events captured using these credentials.')}
-              </TextBlock>
-            </EmptyMessage>
+            <EmptyMessage
+              title={t('Nothing recorded in the last 30 days.')}
+              description={t('Total events captured using these credentials.')}
+            />
           )}
         </PanelBody>
       </Panel>
@@ -506,7 +503,3 @@ export default class ProjectKeyDetails extends AsyncView {
     );
   }
 }
-
-const EmptyHeader = styled.div`
-  font-size: 1.3em;
-`;

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
@@ -3,7 +3,6 @@ import {browserHistory} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import styled from 'react-emotion';
 
 import {Panel, PanelAlert, PanelBody, PanelHeader} from 'app/components/panels';
 import {

--- a/src/sentry/static/sentry/app/views/settings/project/projectServiceHookDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectServiceHookDetails.jsx
@@ -14,7 +14,6 @@ import getDynamicText from 'app/utils/getDynamicText';
 import IndicatorStore from 'app/stores/indicatorStore';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import StackedBarChart from 'app/components/stackedBarChart';
-import TextBlock from 'app/views/settings/components/text/textBlock';
 import TextCopyInput from 'app/views/settings/components/forms/textCopyInput';
 
 import ServiceHookSettingsForm from 'app/views/settings/project/serviceHookSettingsForm';
@@ -83,12 +82,10 @@ class HookStats extends AsyncComponent {
               tooltip={this.renderTooltip}
             />
           ) : (
-            <EmptyMessage css={{flexDirection: 'column', alignItems: 'center'}}>
-              <EmptyHeader>{t('Nothing recorded in the last 30 days.')}</EmptyHeader>
-              <TextBlock css={{marginBottom: 0}}>
-                {t('Total webhooks fired for this configuration.')}
-              </TextBlock>
-            </EmptyMessage>
+            <EmptyMessage
+              title={t('Nothing recorded in the last 30 days.')}
+              description={t('Total webhooks fired for this configuration.')}
+            />
           )}
         </PanelBody>
       </Panel>

--- a/src/sentry/static/sentry/app/views/settings/project/projectServiceHookDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectServiceHookDetails.jsx
@@ -1,6 +1,5 @@
 import {browserHistory} from 'react-router';
 import React from 'react';
-import styled from 'react-emotion';
 
 import {t} from 'app/locale';
 import AsyncComponent from 'app/components/asyncComponent';
@@ -17,11 +16,6 @@ import StackedBarChart from 'app/components/stackedBarChart';
 import TextCopyInput from 'app/views/settings/components/forms/textCopyInput';
 
 import ServiceHookSettingsForm from 'app/views/settings/project/serviceHookSettingsForm';
-
-// TODO(dcramer): this is duplicated in ProjectKeyDetails
-const EmptyHeader = styled.div`
-  font-size: 1.3em;
-`;
 
 class HookStats extends AsyncComponent {
   getEndpoints() {


### PR DESCRIPTION
Use the properties EmptyState exposes instead of defining more inline CSS and styled components.