### PR TITLE
fix(dev) Add uwsgi options to improve ngrok experience

### DIFF
--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -97,6 +97,9 @@ def devserver(reload, watchers, workers, browser_reload, styleguide, prefix, env
         'limit-post': 1 << 30,
         # do something with chunked
         'http-chunked-input': True,
+        'thunder-lock': False,
+        'timeout': 600,
+        'harakiri': 600,
     }
 
     if reload:


### PR DESCRIPTION
I frequently have to run sentry behind ngrok when working on integrations. Without these additional settings I frequently see uwsgi_timeout errors, which makes getting work done even harder.