### PR TITLE
fix(settings): Remove back button in settings for sentry10 [APP-1096]

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/settingsBackButton.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBackButton.jsx
@@ -55,6 +55,10 @@ class BackButton extends React.Component {
     // otherwise use what we have in latest context (e.g. if you navigated to settings directly)
     const shouldGoBackToProject = lastRoute && lastAppContext === 'project';
 
+    if (organization && organization.features.includes('sentry10')) {
+      return null;
+    }
+
     const projectId = shouldGoBackToProject || !lastAppContext ? params.projectId : null;
     const orgId = params.orgId || (organization && organization.slug);
     const url = projectId ? '/:orgId/:projectId/' : '/:orgId/';


### PR DESCRIPTION
With cross project visibility, there is no reason to have the "Back" button in settings since you now have the sidebar to navigate back to where you want to go.

It will still remain with non-sentry10 users since we still want to be able to go back to the selected project when you're in project settings.

Fixes APP-1096