### PR TITLE
fix(issues) Fix accessing undefined properties

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -388,6 +388,7 @@ const OrganizationStream = createReactClass({
     const selected = SelectedGroupStore.getSelectedIds();
     const projects = [...selected]
       .map(id => GroupStore.get(id))
+      .filter(group => group && group.project)
       .map(group => group.project.slug);
 
     const uniqProjects = uniq(projects);


### PR DESCRIPTION
Don't explode when GroupStore is missing records.

Fixes JAVASCRIPT-58Q