### PR TITLE
fix(require-2fa): update security settings alert

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/twoFactorRequired.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/twoFactorRequired.jsx
@@ -1,54 +1,43 @@
 import React from 'react';
 import styled from 'react-emotion';
 
-import PropTypes from 'prop-types';
-import {capitalize} from 'lodash';
-import {t} from 'app/locale';
+import {tct} from 'app/locale';
 import Alert from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
+import Cookies from 'js-cookie';
+import ExternalLink from 'app/components/externalLink';
 import space from 'app/styles/space';
 
-const StyledAlert = styled(Alert)`
-  margin: ${space(3)} 0;
-`;
+const PENDING_INVITE = 'pending-invite';
 
 class TwoFactorRequired extends AsyncComponent {
-  static propTypes = {
-    orgsRequire2fa: PropTypes.arrayOf(PropTypes.object).isRequired,
-  };
-
   getEndpoints() {
     return [];
   }
 
   renderBody() {
-    const {orgsRequire2fa} = this.props;
-    if (!orgsRequire2fa.length) {
+    const pendingInvite = Cookies.get(PENDING_INVITE);
+
+    if (!pendingInvite) {
       return null;
     }
 
-    // singular vs plural message
-    const plural = orgsRequire2fa.length > 1;
-    const require = plural ? t('organizations require') : t('organization requires');
-    const organizations = plural ? t('these organizations') : t('this organization');
-
-    const names = orgsRequire2fa.map(({name}) => capitalize(name));
-    const organizationNames = [names.slice(0, -1).join(', '), names.slice(-1)[0]].join(
-      plural ? ' and ' : ''
-    );
-
     return (
-      <StyledAlert className="require-2fa" type="error" icon="icon-circle-exclamation">
-        {t(
-          'The %s %s all members to enable two-factor authentication.' +
-            ' You need to enable two-factor authentication to access projects under %s.',
-          organizationNames,
-          require,
-          organizations
+      <StyledAlert data-test-id="require-2fa" type="error" icon="icon-circle-exclamation">
+        {tct(
+          'You have been invited to an organization that requires [link:two-factor authentication].' +
+            ' Setup two-factor authentication below to join your organization.',
+          {
+            link: <ExternalLink href="https://docs.sentry.io/accounts/require-2fa/" />,
+          }
         )}
       </StyledAlert>
     );
   }
 }
+
+const StyledAlert = styled(Alert)`
+  margin: ${space(3)} 0;
+`;
 
 export default TwoFactorRequired;

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/index.jsx
@@ -23,10 +23,6 @@ import RemoveConfirm from 'app/views/settings/account/accountSecurity/components
 import PasswordForm from 'app/views/settings/account/passwordForm';
 import recreateRoute from 'app/utils/recreateRoute';
 
-const AuthenticatorName = styled.span`
-  font-size: 1.2em;
-`;
-
 class AccountSecurity extends AsyncView {
   static PropTypes = {
     authenticators: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -54,14 +50,17 @@ class AccountSecurity extends AsyncView {
     });
   };
 
+  formatOrgSlugs = () => {
+    const {orgsRequire2fa} = this.props;
+    const slugs = orgsRequire2fa.map(({slug}) => slug);
+
+    return [slugs.slice(0, -1).join(', '), slugs.slice(-1)[0]].join(
+      slugs.length > 1 ? ' and ' : ''
+    );
+  };
+
   renderBody() {
-    const {
-      authenticators,
-      orgsRequire2fa,
-      countEnrolled,
-      deleteDisabled,
-      onDisable,
-    } = this.props;
+    const {authenticators, countEnrolled, deleteDisabled, onDisable} = this.props;
     const isEmpty = !authenticators.length;
 
     return (
@@ -80,8 +79,7 @@ class AccountSecurity extends AsyncView {
           }
         />
 
-        {!isEmpty &&
-          countEnrolled == 0 && <TwoFactorRequired orgsRequire2fa={orgsRequire2fa} />}
+        {!isEmpty && countEnrolled == 0 && <TwoFactorRequired />}
 
         <PasswordForm />
 
@@ -159,7 +157,7 @@ class AccountSecurity extends AsyncView {
                         isEnrolled && (
                           <Tooltip
                             title={t(
-                              "Two-factor authentication is required for at least one organization you're a member of."
+                              `Two-factor authentication is required for organization(s): ${this.formatOrgSlugs()}.`
                             )}
                             disabled={!deleteDisabled}
                           >
@@ -191,5 +189,9 @@ class AccountSecurity extends AsyncView {
     );
   }
 }
+
+const AuthenticatorName = styled.span`
+  font-size: 1.2em;
+`;
 
 export default AccountSecurity;

--- a/tests/js/spec/views/accountSecurity.spec.jsx
+++ b/tests/js/spec/views/accountSecurity.spec.jsx
@@ -145,6 +145,19 @@ describe('AccountSecurity', function() {
         .prop('enabled')
     ).toBe(true);
 
+    expect(
+      wrapper
+        .find('RemoveConfirm')
+        .first()
+        .prop('disabled')
+    ).toBe(false);
+    expect(
+      wrapper
+        .find('Tooltip')
+        .first()
+        .prop('disabled')
+    ).toBe(true);
+
     // This will open confirm modal
     wrapper
       .find('Button .icon-trash')
@@ -187,6 +200,10 @@ describe('AccountSecurity', function() {
       TestStubs.routerContext()
     );
     expect(wrapper.find('CircleIndicator').prop('enabled')).toBe(true);
+
+    expect(wrapper.find('RemoveConfirm').prop('disabled')).toBe(true);
+    expect(wrapper.find('Tooltip').prop('disabled')).toBe(false);
+    expect(wrapper.find('Tooltip').prop('title')).toContain('test 1 and test 2');
 
     // This will open confirm modal
     wrapper.find('Button .icon-trash').simulate('click');


### PR DESCRIPTION
- Updates require 2fa alert in security settings. Previously the alert showed when a member was in an organization that required 2fa but had 2fa disabled. Now users are removed from organizations when they don't have 2fa, so the alert wasn't visible.
- Includes the org slugs that require 2fa in a tooltip explaining why the last 2fa method can't be deleted.

<img width="655" alt="screen shot 2019-02-12 at 10 36 42 am" src="https://user-images.githubusercontent.com/16394317/52679091-c7bf3c80-2ee8-11e9-9ec7-c721cdd95fd0.png">

Ref APP-1112