### PR TITLE
build(webpack): Do not generate empty js file for style entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "u2f-api": "0.2.3",
     "webpack": "^4.28.1",
     "webpack-cli": "^3.1.2",
+    "webpack-fix-style-only-entries": "^0.2.0",
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ const ExtractTextPlugin = require('mini-css-extract-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
+const FixStyleOnlyEntriesPlugin = require('webpack-fix-style-only-entries');
 
 const {env} = process;
 
@@ -315,7 +316,7 @@ const legacyCssConfig = {
   output: {
     path: distPath,
   },
-  plugins: [new ExtractTextPlugin()],
+  plugins: [new FixStyleOnlyEntriesPlugin(), new ExtractTextPlugin()],
   resolve: {
     extensions: ['.less', '.js'],
     modules: [staticPrefix, 'node_modules'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -14206,6 +14206,11 @@ webpack-dev-server@^3.1.10:
     webpack-log "^2.0.0"
     yargs "12.0.2"
 
+webpack-fix-style-only-entries@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-fix-style-only-entries/-/webpack-fix-style-only-entries-0.2.0.tgz#87b11a0eee21c2fe6191a50d478d69eb70815957"
+  integrity sha512-3EKneRqg1NI5iQro9tFq3W0hYNu7iH2ZvTB7CbTQMUymsouZZd1elsDIYh8KUqCQj7O+/QySepHM80FcWi4O0Q==
+
 webpack-hot-middleware@^2.24.3:
   version "2.24.3"
   resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.24.3.tgz#5bb76259a8fc0d97463ab517640ba91d3382d4a6"


### PR DESCRIPTION
Stops webpack from outputting associated JS files with our style only entry points.

See: https://github.com/webpack-contrib/mini-css-extract-plugin/issues/151