### PR TITLE
ref(app-platform): Add issue open in link schema option

### DIFF
--- a/src/sentry/api/validators/sentry_apps/schema.py
+++ b/src/sentry/api/validators/sentry_apps/schema.py
@@ -255,14 +255,6 @@ SCHEMA = {
                 'uri': {
                     '$ref': '#/definitions/uri',
                 },
-                'params': {
-                    'type': 'array',
-                    'minItems': 1,
-                    'items': {
-                        'type': 'string',
-                        'enum': ['filename', 'lineno']
-                    },
-                },
             },
             'required': ['type', 'uri']
         },

--- a/src/sentry/api/validators/sentry_apps/schema.py
+++ b/src/sentry/api/validators/sentry_apps/schema.py
@@ -244,6 +244,27 @@ SCHEMA = {
             },
             'required': ['type', 'title', 'elements'],
         },
+
+        'issue-open-in-link': {
+            'type': 'object',
+            'properties': {
+                'type': {
+                    'type': 'string',
+                    'enum': ['issue-open-in-link'],
+                },
+                'uri': {
+                    '$ref': '#/definitions/uri',
+                },
+                'params': {
+                    'type': 'array',
+                    'items': {
+                        'type': 'string',
+                        'enum': ['project', 'filename', 'lineno']
+                    },
+                },
+            },
+            'required': ['type', 'uri']
+        },
     },
 
     'properties': {
@@ -255,6 +276,7 @@ SCHEMA = {
                     {'$ref': '#/definitions/issue-link'},
                     {'$ref': '#/definitions/alert-rule-action'},
                     {'$ref': '#/definitions/issue-media'},
+                    {'$ref': '#/definitions/issue-open-in-link'},
                 ],
             },
         },

--- a/src/sentry/api/validators/sentry_apps/schema.py
+++ b/src/sentry/api/validators/sentry_apps/schema.py
@@ -245,21 +245,22 @@ SCHEMA = {
             'required': ['type', 'title', 'elements'],
         },
 
-        'issue-open-in-link': {
+        'stacktrace-link': {
             'type': 'object',
             'properties': {
                 'type': {
                     'type': 'string',
-                    'enum': ['issue-open-in-link'],
+                    'enum': ['stacktrace-link'],
                 },
                 'uri': {
                     '$ref': '#/definitions/uri',
                 },
                 'params': {
                     'type': 'array',
+                    'minItems': 1,
                     'items': {
                         'type': 'string',
-                        'enum': ['project', 'filename', 'lineno']
+                        'enum': ['filename', 'lineno']
                     },
                 },
             },
@@ -276,7 +277,7 @@ SCHEMA = {
                     {'$ref': '#/definitions/issue-link'},
                     {'$ref': '#/definitions/alert-rule-action'},
                     {'$ref': '#/definitions/issue-media'},
-                    {'$ref': '#/definitions/issue-open-in-link'},
+                    {'$ref': '#/definitions/stacktrace-link'},
                 ],
             },
         },

--- a/tests/sentry/api/validators/sentry_apps/test_issue_open_in_link.py
+++ b/tests/sentry/api/validators/sentry_apps/test_issue_open_in_link.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import
+
+from sentry.testutils import TestCase
+
+from .util import invalid_schema, validate_component
+
+
+class TestOpenInSchemaValidation(TestCase):
+    def setUp(self):
+        self.schema = {
+            'type': 'issue-open-in-link',
+            'uri': '/sentry/issue',
+            'params': ['project', 'filename'],
+        }
+
+    def test_valid_schema(self):
+        validate_component(self.schema)
+
+    def test_no_params(self):
+        del self.schema['params']
+        validate_component(self.schema)
+
+    def test_empty_params(self):
+        self.schema['params'] = []
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_missing_uri(self):
+        del self.schema['uri']
+        validate_component(self.schema)
+
+    @invalid_schema
+    def test_invalid_params_option(self):
+        self.schema['params'] = ['project', 'tag']
+        validate_component(self.schema)

--- a/tests/sentry/api/validators/sentry_apps/test_schema.py
+++ b/tests/sentry/api/validators/sentry_apps/test_schema.py
@@ -88,6 +88,11 @@ class TestSchemaValidation(TestCase):
                         },
                     ]
                 },
+                {
+                    'type': 'issue-open-in-link',
+                    'uri': '/sentry/issue',
+                    'params': ['project', 'filename'],
+                },
             ],
         }
 

--- a/tests/sentry/api/validators/sentry_apps/test_schema.py
+++ b/tests/sentry/api/validators/sentry_apps/test_schema.py
@@ -89,9 +89,9 @@ class TestSchemaValidation(TestCase):
                     ]
                 },
                 {
-                    'type': 'issue-open-in-link',
+                    'type': 'stacktrace-link',
                     'uri': '/sentry/issue',
-                    'params': ['project', 'filename'],
+                    'params': ['filename', 'lineno'],
                 },
             ],
         }

--- a/tests/sentry/api/validators/sentry_apps/test_schema.py
+++ b/tests/sentry/api/validators/sentry_apps/test_schema.py
@@ -91,7 +91,6 @@ class TestSchemaValidation(TestCase):
                 {
                     'type': 'stacktrace-link',
                     'uri': '/sentry/issue',
-                    'params': ['filename', 'lineno'],
                 },
             ],
         }

--- a/tests/sentry/api/validators/sentry_apps/test_stacktrace_link.py
+++ b/tests/sentry/api/validators/sentry_apps/test_stacktrace_link.py
@@ -10,27 +10,12 @@ class TestOpenInSchemaValidation(TestCase):
         self.schema = {
             'type': 'stacktrace-link',
             'uri': '/sentry/issue',
-            'params': ['filename', 'lineno'],
         }
 
     def test_valid_schema(self):
         validate_component(self.schema)
 
-    def test_no_params(self):
-        del self.schema['params']
-        validate_component(self.schema)
-
-    @invalid_schema
-    def test_empty_params(self):
-        self.schema['params'] = []
-        validate_component(self.schema)
-
     @invalid_schema
     def test_missing_uri(self):
         del self.schema['uri']
-        validate_component(self.schema)
-
-    @invalid_schema
-    def test_invalid_params_option(self):
-        self.schema['params'] = ['project', 'tag']
         validate_component(self.schema)

--- a/tests/sentry/api/validators/sentry_apps/test_stacktrace_link.py
+++ b/tests/sentry/api/validators/sentry_apps/test_stacktrace_link.py
@@ -8,9 +8,9 @@ from .util import invalid_schema, validate_component
 class TestOpenInSchemaValidation(TestCase):
     def setUp(self):
         self.schema = {
-            'type': 'issue-open-in-link',
+            'type': 'stacktrace-link',
             'uri': '/sentry/issue',
-            'params': ['project', 'filename'],
+            'params': ['filename', 'lineno'],
         }
 
     def test_valid_schema(self):
@@ -20,6 +20,7 @@ class TestOpenInSchemaValidation(TestCase):
         del self.schema['params']
         validate_component(self.schema)
 
+    @invalid_schema
     def test_empty_params(self):
         self.schema['params'] = []
         validate_component(self.schema)


### PR DESCRIPTION
This adds another UI augmentation schema with `type: stacktrace-link`. The idea would be that one could click a button (or from a dropdown) where they'd want to open the event data

**attributes**

| attribute | required  | description  |
|---|---|---|
| `uri`  | yes  | where we post the data to in the other service where you are 'opening' the issue in.  |
| `params`  | no  |  the kinds of data that will be in the request*  |

*By default the `installation_id` and `project` (slug) is sent in the params, and for now the only options we'll send in addition to that will be `filename`, and `lineno`.

**example**
```javascript
    {
	type: "stacktrace-link".
	uri: "/something",
	params: ["filename", "lineno"] 
    }
```