### PR TITLE
fix(load-mocks): Changed 'github' Repository to 'integrations:github' repo.

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -451,7 +451,7 @@ def main(num_events=1, extra_events=False):
 
             repo = Repository.objects.get_or_create(
                 organization_id=org.id,
-                provider='github',
+                provider='integrations:github',
                 external_id='example/example',
                 defaults={
                     'name': 'Example Repo',


### PR DESCRIPTION
Without `'integrations'` prepended, this is referencing the legacy plugin rather than the github integration.