### PR TITLE
fix(deploys) Fix 500 when deploying releases with long names

### DIFF
--- a/src/sentry/models/deploy.py
+++ b/src/sentry/models/deploy.py
@@ -77,7 +77,7 @@ class Deploy(Model):
                 activity = Activity.objects.create(
                     type=Activity.DEPLOY,
                     project=project,
-                    ident=release.version,
+                    ident=Activity.get_version_ident(release.version),
                     data={
                         'version': release.version,
                         'deploy_id': deploy.id,


### PR DESCRIPTION
When deploying a release with a long version number we would respond with a 500 as the `sentry_activity.ident` column would overflow. In other places where we create activity for releases we truncate the ident value with this same function.

Fixes APP-1119