### PR TITLE
feat(email): Map tags aliases to Snuba names in error email

### DIFF
--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -211,14 +211,8 @@ class Event(Model):
         return self.get_interfaces()
 
     def get_tags(self):
-        aliases = {
-            'sentry:release': 'release',
-            'sentry:dist': 'dist',
-            'sentry:user': 'user',
-        }
-
         try:
-            rv = [(aliases.get(t, t), v) for t, v in get_path(
+            rv = [(t, v) for t, v in get_path(
                 self.data, 'tags', filter=True) or () if t is not None and v is not None]
             rv.sort()
             return rv

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -211,8 +211,14 @@ class Event(Model):
         return self.get_interfaces()
 
     def get_tags(self):
+        aliases = {
+            'sentry:release': 'release',
+            'sentry:dist': 'dist',
+            'sentry:user': 'user',
+        }
+
         try:
-            rv = [(t, v) for t, v in get_path(
+            rv = [(aliases.get(t, t), v) for t, v in get_path(
                 self.data, 'tags', filter=True) or () if t is not None and v is not None]
             rv.sort()
             return rv

--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -126,10 +126,10 @@
         <ul class="tag-list">
         {% for tag_key, tag_value in tags %}
           <li>
-              <strong>{{ tag_key }}</strong>
+              <strong>{{ tag_key|as_tag_alias }}</strong>
               <em>=</em>
               <span>
-              {% with query=tag_key|add:":\""|add:tag_value|add:"\""|urlencode %}
+              {% with query=tag_key|as_tag_alias|add:":\""|add:tag_value|add:"\""|urlencode %}
               {% feature organizations:sentry10 group.project.organization %}
                   <a href="{% absolute_uri '/organizations/{}/issues/' group.project.organization.slug %}?project={{ group.project.id }}&query={{ query }}">{{ tag_value|truncatechars:50 }}</a> {% if tag_value|is_url %}<a href="{{ tag_value }}" class="icon-share"></a>{% endif %}
               {% else %}

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -190,6 +190,15 @@ def small_count(v, precision=1):
     return v
 
 
+@register.filter
+def as_tag_alias(v):
+    return {
+        'sentry:release': 'release',
+        'sentry:dist': 'dist',
+        'sentry:user': 'user',
+    }.get(v, v)
+
+
 @register.simple_tag(takes_context=True)
 def serialize(context, value):
     value = serialize_func(value, context['request'].user)


### PR DESCRIPTION
Correctly map the sentry:release, sentry:dist and sentry:user
properties.

Fixes APP-1094