### PR TITLE
refs(api): Remove use_new_filters param from issue search code (SEN-181)

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -2,9 +2,8 @@ from __future__ import absolute_import
 
 from hashlib import md5
 import logging
-import pytz
 import time
-from datetime import timedelta, datetime
+from datetime import timedelta
 
 from django.db.models import Q
 from django.utils import timezone
@@ -16,26 +15,12 @@ from sentry.event_manager import ALLOWED_FUTURE_DELTA
 from sentry.models import Group
 from sentry.search.django import backend as ds
 from sentry.utils import snuba, metrics
-from sentry.utils.dates import to_timestamp
 
 
 logger = logging.getLogger('sentry.search.snuba')
 datetime_format = '%Y-%m-%dT%H:%M:%S+00:00'
 
 EMPTY_RESULT = Paginator(Group.objects.none()).get_result()
-
-
-# TODO: Would be nice if this was handled in the Snuba abstraction, but that
-# would require knowledge of which fields are datetimes
-def snuba_str_to_datetime(d):
-    if not isinstance(d, datetime):
-        d = datetime.strptime(d, datetime_format)
-
-    if not d.tzinfo:
-        d = d.replace(tzinfo=pytz.utc)
-
-    return d
-
 
 # mapping from query parameter sort name to underlying scoring aggregation name
 sort_strategies = {
@@ -64,74 +49,6 @@ issue_only_fields = set([
 ])
 
 
-class SnubaConditionBuilder(object):
-    """\
-    Constructions a Snuba conditions list from a ``parameters`` mapping.
-
-    ``Condition`` objects are registered by their parameter name and used to
-    construct the Snuba condition list if they are present in the ``parameters``
-    mapping.
-    """
-
-    def __init__(self, conditions):
-        self.conditions = conditions
-
-    def build(self, parameters):
-        result = []
-        for name, condition in self.conditions.items():
-            if name in parameters:
-                result.append(condition.apply(name, parameters))
-        return result
-
-
-class Condition(object):
-    """\
-    Adds a single condition to a Snuba conditions list. Used with
-    ``SnubaConditionBuilder``.
-    """
-
-    def apply(self, name, parameters):
-        raise NotImplementedError
-
-
-class CallbackCondition(Condition):
-    def __init__(self, callback):
-        self.callback = callback
-
-    def apply(self, name, parameters):
-        return self.callback(parameters[name])
-
-
-class ScalarCondition(Condition):
-    """\
-    Adds a scalar filter (less than or greater than are supported) to a Snuba
-    condition list. Whether or not the filter is inclusive is defined by the
-    '{parameter_name}_inclusive' parameter.
-    """
-
-    def __init__(self, field, operator, default_inclusivity=True):
-        assert operator in ['<', '>']
-        self.field = field
-        self.operator = operator
-        self.default_inclusivity = default_inclusivity
-
-    def apply(self, name, parameters):
-        inclusive = parameters.get(
-            u'{}_inclusive'.format(name),
-            self.default_inclusivity,
-        )
-
-        arg = parameters[name]
-        if isinstance(arg, datetime):
-            arg = int(to_timestamp(arg)) * 1000
-
-        return (
-            self.field,
-            self.operator + ('=' if inclusive else ''),
-            arg
-        )
-
-
 def get_search_filter(search_filters, name, operator):
     """
     Finds the value of a search filter with the passed name and operator. If
@@ -156,19 +73,12 @@ def get_search_filter(search_filters, name, operator):
 class SnubaSearchBackend(ds.DjangoSearchBackend):
     def _query(self, projects, retention_window_start, group_queryset, tags, environments,
                sort_by, limit, cursor, count_hits, paginator_options, search_filters,
-               use_new_filters, **parameters):
+               **parameters):
 
         # TODO: Product decision: we currently search Group.message to handle
         # the `query` parameter, because that's what we've always done. We could
         # do that search against every event in Snuba instead, but results may
         # differ.
-
-        if use_new_filters:
-            query_set_builder_class = ds.SearchFilterQuerySetBuilder
-            query_set_builder_params = search_filters
-        else:
-            query_set_builder_class = ds.NewQuerySetBuilder
-            query_set_builder_params = parameters
 
         # TODO: It's possible `first_release` could be handled by Snuba.
         if environments is not None:
@@ -177,42 +87,32 @@ class SnubaSearchBackend(ds.DjangoSearchBackend):
                     environment.id for environment in environments
                 ],
             )
-            group_queryset = query_set_builder_class({
+            group_queryset = ds.SearchFilterQuerySetBuilder({
                 'first_release': ds.QCallbackCondition(
                     lambda version: Q(
                         groupenvironment__first_release__organization_id=projects[0].organization_id,
                         groupenvironment__first_release__version=version,
                     )
                 ),
-            }).build(
-                group_queryset,
-                query_set_builder_params,
-            )
+            }).build(group_queryset, search_filters)
         else:
-            group_queryset = query_set_builder_class({
+            group_queryset = ds.SearchFilterQuerySetBuilder({
                 'first_release': ds.QCallbackCondition(
                     lambda version: Q(
                         first_release__organization_id=projects[0].organization_id,
                         first_release__version=version,
                     ),
                 ),
-            }).build(
-                group_queryset,
-                query_set_builder_params,
-            )
+            }).build(group_queryset, search_filters)
 
         now = timezone.now()
-        date_to = parameters.get('date_to')
         end = None
-        if use_new_filters:
-            end_params = filter(
-                None,
-                [date_to, get_search_filter(search_filters, 'date', '<')],
-            )
-            if end_params:
-                end = min(end_params)
-        else:
-            end = date_to
+        end_params = filter(
+            None,
+            [parameters.get('date_to'), get_search_filter(search_filters, 'date', '<')],
+        )
+        if end_params:
+            end = min(end_params)
 
         if not end:
             end = now + ALLOWED_FUTURE_DELTA
@@ -225,24 +125,11 @@ class SnubaSearchBackend(ds.DjangoSearchBackend):
                 cursor is None
                 and sort_by == 'date'
                 and not environments
-                and (
-                    use_new_filters
-                    or (
-                        not any(param in parameters for param in [
-                            'age_from', 'age_to', 'last_seen_from', 'last_seen_to',
-                            'times_seen', 'times_seen_lower', 'times_seen_upper',
-                        ])
-                        and not tags
-                    )
-                )
                 # This handles tags and date parameters for search filters.
-                and (
-                    not use_new_filters
-                    or not [
-                        sf for sf in search_filters
-                        if sf.key.name not in issue_only_fields.union(['date', 'message'])
-                    ]
-                )
+                and not [
+                    sf for sf in search_filters
+                    if sf.key.name not in issue_only_fields.union(['date', 'message'])
+                ]
             ):
                 group_queryset = group_queryset.order_by('-last_seen')
                 paginator = DateTimePaginator(group_queryset, '-last_seen', **paginator_options)
@@ -260,13 +147,14 @@ class SnubaSearchBackend(ds.DjangoSearchBackend):
             ])
         )
 
-        start_params = [parameters.get('date_from'), retention_date]
-
         # TODO: We should try and consolidate all this logic together a little
         # better, maybe outside the backend. Should be easier once we're on
         # just the new search filters
-        if use_new_filters:
-            start_params.append(get_search_filter(search_filters, 'date', '>'))
+        start_params = [
+            parameters.get('date_from'),
+            retention_date,
+            get_search_filter(search_filters, 'date', '>'),
+        ]
         start = max(filter(None, start_params))
 
         end = max([
@@ -354,14 +242,11 @@ class SnubaSearchBackend(ds.DjangoSearchBackend):
                 end=end,
                 project_ids=[p.id for p in projects],
                 environment_ids=environments and [environment.id for environment in environments],
-                tags=tags,
                 sort_field=sort_field,
                 limit=sample_size,
                 offset=0,
                 get_sample=True,
                 search_filters=search_filters,
-                use_new_filters=use_new_filters,
-                **parameters
             )
             snuba_count = len(snuba_groups)
             if snuba_count == 0:
@@ -395,15 +280,12 @@ class SnubaSearchBackend(ds.DjangoSearchBackend):
                 end=end,
                 project_ids=[p.id for p in projects],
                 environment_ids=environments and [environment.id for environment in environments],
-                tags=tags,
                 sort_field=sort_field,
                 cursor=cursor,
                 candidate_ids=candidate_ids,
                 limit=chunk_limit,
                 offset=offset,
                 search_filters=search_filters,
-                use_new_filters=use_new_filters,
-                **parameters
             )
             metrics.timing('snuba.search.num_snuba_results', len(snuba_groups))
             count = len(snuba_groups)
@@ -499,10 +381,9 @@ class SnubaSearchBackend(ds.DjangoSearchBackend):
         return paginator_results
 
 
-def snuba_search(start, end, project_ids, environment_ids, tags,
-                 sort_field, cursor=None, candidate_ids=None, limit=None,
-                 offset=0, get_sample=False, search_filters=None,
-                 use_new_filters=False, **parameters):
+def snuba_search(start, end, project_ids, environment_ids, sort_field,
+                 cursor=None, candidate_ids=None, limit=None, offset=0,
+                 get_sample=False, search_filters=None):
     """
     This function doesn't strictly benefit from or require being pulled out of the main
     query method above, but the query method is already large and this function at least
@@ -512,9 +393,6 @@ def snuba_search(start, end, project_ids, environment_ids, tags,
      * a sorted list of (group_id, group_score) tuples sorted descending by score,
      * the count of total results (rows) available for this query.
     """
-
-    from sentry.search.base import ANY
-
     filters = {
         'project_id': project_ids,
     }
@@ -526,40 +404,20 @@ def snuba_search(start, end, project_ids, environment_ids, tags,
         filters['issue'] = candidate_ids
 
     conditions = []
-    if use_new_filters:
-        having = []
-        for search_filter in search_filters:
-            if (
-                # Don't filter on issue fields here, they're not available
-                search_filter.key.name in issue_only_fields
-                # We special case date
-                or search_filter.key.name == 'date'
-            ):
-                continue
-            converted_filter = convert_search_filter_to_snuba_query(search_filter)
-            if search_filter.key.name in aggregation_defs:
-                having.append(converted_filter)
-            else:
-                conditions.append(converted_filter)
-    else:
-        having = SnubaConditionBuilder({
-            'age_from': ScalarCondition('first_seen', '>'),
-            'age_to': ScalarCondition('first_seen', '<'),
-            'last_seen_from': ScalarCondition('last_seen', '>'),
-            'last_seen_to': ScalarCondition('last_seen', '<'),
-            'times_seen': CallbackCondition(
-                lambda times_seen: ('times_seen', '=', times_seen),
-            ),
-            'times_seen_lower': ScalarCondition('times_seen', '>'),
-            'times_seen_upper': ScalarCondition('times_seen', '<'),
-        }).build(parameters)
-
-        for tag, val in sorted(tags.items()):
-            col = u'tags[{}]'.format(tag)
-            if val == ANY:
-                conditions.append((col, '!=', ''))
-            else:
-                conditions.append((col, '=', val))
+    having = []
+    for search_filter in search_filters:
+        if (
+            # Don't filter on issue fields here, they're not available
+            search_filter.key.name in issue_only_fields
+            # We special case date
+            or search_filter.key.name == 'date'
+        ):
+            continue
+        converted_filter = convert_search_filter_to_snuba_query(search_filter)
+        if search_filter.key.name in aggregation_defs:
+            having.append(converted_filter)
+        else:
+            conditions.append(converted_filter)
 
     extra_aggregations = dependency_aggregations.get(sort_field, [])
     required_aggregations = set([sort_field, 'total'] + extra_aggregations)

--- a/tests/sentry/search/django/tests.py
+++ b/tests/sentry/search/django/tests.py
@@ -27,7 +27,6 @@ def date_to_query_format(date):
 
 
 class DjangoSearchBackendTest(TestCase):
-    use_new_filters = False
 
     def create_backend(self):
         return DjangoSearchBackend()
@@ -188,7 +187,6 @@ class DjangoSearchBackendTest(TestCase):
             search_filters = self.build_search_filter(search_filter_query, projects, environments)
         return self.backend.query(
             projects if projects is not None else [self.project],
-            use_new_filters=self.use_new_filters,
             search_filters=search_filters,
             environments=environments,
             **kwargs
@@ -848,7 +846,3 @@ class DjangoSearchBackendTest(TestCase):
             search_filter_query='subscribed:%s' % self.user.username
         )
         assert set(results) == set([])
-
-
-class DjangoSearchBackendWithSearchFiltersTest(DjangoSearchBackendTest):
-    use_new_filters = True

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -7,7 +7,6 @@ from uuid import uuid4
 
 from django.core.urlresolvers import reverse
 from django.utils import timezone
-from exam import fixture
 from mock import patch, Mock
 
 from sentry.models import (
@@ -22,7 +21,6 @@ from sentry.testutils.helpers import parse_link_header
 
 class GroupListTest(APITestCase, SnubaTestCase):
     endpoint = 'sentry-api-0-organization-group-index'
-    use_new_filters = False
 
     def setUp(self):
         super(GroupListTest, self).setUp()
@@ -41,8 +39,6 @@ class GroupListTest(APITestCase, SnubaTestCase):
             org = self.project.organization.slug
         else:
             org = args[0]
-
-        kwargs['use_new_filters'] = '1' if self.use_new_filters else '0'
         return super(GroupListTest, self).get_response(org, **kwargs)
 
     def test_sort_by_date_with_tag(self):
@@ -387,10 +383,6 @@ class GroupListTest(APITestCase, SnubaTestCase):
             response = self.get_valid_response(statsPeriod='1h')
             assert len(response.data) == 0
 
-
-class GroupListTestWithSearchFilters(GroupListTest):
-    use_new_filters = True
-
     def test_advanced_search_errors(self):
         self.login_as(user=self.user)
         with self.feature({'organizations:advanced-search': False}):
@@ -408,7 +400,6 @@ class GroupListTestWithSearchFilters(GroupListTest):
 class GroupUpdateTest(APITestCase, SnubaTestCase):
     endpoint = 'sentry-api-0-organization-group-index'
     method = 'put'
-    use_new_filters = False
 
     def setUp(self):
         super(GroupUpdateTest, self).setUp()
@@ -419,9 +410,6 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             org = self.project.organization.slug
         else:
             org = args[0]
-
-        qs_params = kwargs.get('qs_params', {})
-        qs_params['use_new_filters'] = '1' if self.use_new_filters else '0'
         return super(GroupUpdateTest, self).get_response(org, **kwargs)
 
     def assertNoResolution(self, group):
@@ -1566,29 +1554,15 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert tombstone.data == group1.data
 
 
-class GroupUpdateTestWithSelectFilters(GroupUpdateTest):
-    use_new_filters = True
-
-
 class GroupDeleteTest(APITestCase, SnubaTestCase):
     endpoint = 'sentry-api-0-organization-group-index'
     method = 'delete'
-    use_new_filters = False
-
-    @fixture
-    def path(self):
-        return u'/api/0/organizations/{}/issues/'.format(
-            self.project.organization.slug,
-        )
 
     def get_response(self, *args, **kwargs):
         if not args:
             org = self.project.organization.slug
         else:
             org = args[0]
-
-        qs_params = kwargs.get('qs_params', {})
-        qs_params['use_new_filters'] = '1' if self.use_new_filters else '0'
         return super(GroupDeleteTest, self).get_response(org, **kwargs)
 
     @patch('sentry.api.helpers.group_index.eventstream')
@@ -1703,7 +1677,3 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
         for group in groups:
             assert not Group.objects.filter(id=group.id).exists()
             assert not GroupHash.objects.filter(group_id=group.id).exists()
-
-
-class GroupDeleteTestWithSelectFilters(GroupDeleteTest):
-    use_new_filters = True

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -27,8 +27,6 @@ def date_to_query_format(date):
 
 
 class SnubaSearchTest(SnubaTestCase):
-    use_new_filters = False
-
     def setUp(self):
         super(SnubaSearchTest, self).setUp()
         self.backend = SnubaSearchBackend()
@@ -182,7 +180,6 @@ class SnubaSearchTest(SnubaTestCase):
             )
         return self.backend.query(
             projects,
-            use_new_filters=self.use_new_filters,
             search_filters=search_filters,
             environments=environments,
             **kwargs
@@ -1006,7 +1003,7 @@ class SnubaSearchTest(SnubaTestCase):
             },
             'referrer': 'search',
             'groupby': ['issue'],
-            'conditions': [],
+            'conditions': [[['positionCaseInsensitive', ['message', "'foo'"]], '!=', 0]],
             'selected_columns': [],
             'limit': limit,
             'offset': 0,
@@ -1019,7 +1016,7 @@ class SnubaSearchTest(SnubaTestCase):
         assert not query_mock.called
 
         self.make_query(
-            search_filter_query='last_seen:>%s foo' % date_to_query_format(timezone.now()),
+            search_filter_query='last_seen:>=%s foo' % date_to_query_format(timezone.now()),
             query='foo',
             last_seen_from=timezone.now(),
             sort_by='date',
@@ -1030,7 +1027,7 @@ class SnubaSearchTest(SnubaTestCase):
                 ['uniq', 'issue', 'total'],
                 ['toUInt64(max(timestamp)) * 1000', '', 'last_seen']
             ],
-            having=[('last_seen', '>=', Any(int))],
+            having=[['last_seen', '>=', Any(int)]],
             **common_args
         )
 
@@ -1063,12 +1060,12 @@ class SnubaSearchTest(SnubaTestCase):
                 ['count()', '', 'times_seen'],
                 ['uniq', 'issue', 'total'],
             ],
-            having=[('times_seen', '=', 5)],
+            having=[['times_seen', '=', 5]],
             **common_args
         )
 
         self.make_query(
-            search_filter_query='age:>%s foo' % date_to_query_format(timezone.now()),
+            search_filter_query='age:>=%s foo' % date_to_query_format(timezone.now()),
             query='foo',
             age_from=timezone.now(),
             sort_by='new',
@@ -1079,7 +1076,7 @@ class SnubaSearchTest(SnubaTestCase):
                 ['toUInt64(min(timestamp)) * 1000', '', 'first_seen'],
                 ['uniq', 'issue', 'total'],
             ],
-            having=[('first_seen', '>=', Any(int))],
+            having=[['first_seen', '>=', Any(int)]],
             **common_args
         )
 
@@ -1255,111 +1252,3 @@ class SnubaSearchTest(SnubaTestCase):
             search_filter_query='first_release:%s' % release.version,
         )
         assert set(results) == set([self.group1])
-
-
-class SnubaSearchBackendWithSearchFiltersTest(SnubaSearchTest):
-    use_new_filters = True
-
-    @mock.patch('sentry.utils.snuba.raw_query')
-    def test_optimized_aggregates(self, query_mock):
-        # TODO this test is annoyingly fragile and breaks in hard-to-see ways
-        # any time anything about the snuba query changes
-        # XXX: Copy/pasting this because the query changes differently depending
-        # on whether we're using the new search filters or not.
-        query_mock.return_value = {'data': [], 'totals': {'total': 0}}
-
-        def Any(cls):
-            class Any(object):
-                def __eq__(self, other):
-                    return isinstance(other, cls)
-            return Any()
-
-        DEFAULT_LIMIT = 100
-        chunk_growth = options.get('snuba.search.chunk-growth-rate')
-        limit = int(DEFAULT_LIMIT * chunk_growth)
-
-        common_args = {
-            'start': Any(datetime),
-            'end': Any(datetime),
-            'filter_keys': {
-                'project_id': [self.project.id],
-                'issue': [self.group1.id]
-            },
-            'referrer': 'search',
-            'groupby': ['issue'],
-            'conditions': [[['positionCaseInsensitive', ['message', "'foo'"]], '!=', 0]],
-            'selected_columns': [],
-            'limit': limit,
-            'offset': 0,
-            'totals': True,
-            'turbo': False,
-            'sample': 1,
-        }
-
-        self.make_query(query='foo', search_filter_query='foo')
-        assert not query_mock.called
-
-        self.make_query(
-            search_filter_query='last_seen:>=%s foo' % date_to_query_format(timezone.now()),
-            query='foo',
-            last_seen_from=timezone.now(),
-            sort_by='date',
-        )
-        assert query_mock.call_args == mock.call(
-            orderby=['-last_seen', 'issue'],
-            aggregations=[
-                ['uniq', 'issue', 'total'],
-                ['toUInt64(max(timestamp)) * 1000', '', 'last_seen']
-            ],
-            having=[['last_seen', '>=', Any(int)]],
-            **common_args
-        )
-
-        self.make_query(
-            search_filter_query='foo',
-            query='foo',
-            sort_by='priority',
-        )
-        assert query_mock.call_args == mock.call(
-            orderby=['-priority', 'issue'],
-            aggregations=[
-                ['(toUInt64(log(times_seen) * 600)) + last_seen', '', 'priority'],
-                ['count()', '', 'times_seen'],
-                ['uniq', 'issue', 'total'],
-                ['toUInt64(max(timestamp)) * 1000', '', 'last_seen']
-            ],
-            having=[],
-            **common_args
-        )
-
-        self.make_query(
-            search_filter_query='times_seen:5 foo',
-            query='foo',
-            times_seen=5,
-            sort_by='freq',
-        )
-        assert query_mock.call_args == mock.call(
-            orderby=['-times_seen', 'issue'],
-            aggregations=[
-                ['count()', '', 'times_seen'],
-                ['uniq', 'issue', 'total'],
-            ],
-            having=[['times_seen', '=', 5]],
-            **common_args
-        )
-
-        self.make_query(
-            search_filter_query='age:>=%s foo' % date_to_query_format(timezone.now()),
-            query='foo',
-            age_from=timezone.now(),
-            sort_by='new',
-        )
-        assert query_mock.call_args == mock.call(
-            orderby=['-first_seen', 'issue'],
-            aggregations=[
-                ['toUInt64(min(timestamp)) * 1000', '', 'first_seen'],
-                ['uniq', 'issue', 'total'],
-            ],
-            having=[['first_seen', '>=', Any(int)]],
-            **common_args
-        )


### PR DESCRIPTION
This removes `use_new_filters` and all related code. We can't remove the parsing code yet because
the Django backend still relies on it. I'll remove that and consolidate the backends in a later
diff, since it requires people to have snuba running locally, and we need to provide instructions on
how to do so.

To be merged after we've enabled the new parser for everyone and are happy that there are no issues.