### PR TITLE
build(jest): Fix precommit hook with jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
   "proxyURL": "http://localhost:8000",
   "scripts": {
     "test": "node scripts/test.js",
-    "test-precommit": "yarn test --findRelatedTests --bail",
+    "test-precommit": "yarn test --bail --findRelatedTests",
     "test-ci": "JEST_JUNIT_OUTPUT=.artifacts/jest.junit.xml yarn test --runInBand --ci --coverage --testResultsProcessor=jest-junit",
     "test-debug": "node --inspect-brk scripts/test.js --runInBand",
     "test-staged": "yarn test --findRelatedTests $(git diff --name-only --cached)",


### PR DESCRIPTION
I guess something changed where argument order matters with `--findRelatedTests`