### PR TITLE
feat(acls): Project-based access scopes

### DIFF
--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -10,7 +10,7 @@ from django.utils.functional import cached_property
 from sentry import roles
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import (
-    AuthIdentity, AuthProvider, OrganizationMember, SentryApp, UserPermission
+    AuthIdentity, AuthProvider, OrganizationMember, Project, SentryApp, UserPermission
 )
 
 
@@ -61,19 +61,33 @@ class BaseAccess(object):
     is_active = False
     sso_is_valid = False
     requires_sso = False
-    # teams with valid access
+    organization_id = None
+    # teams with membership
     teams = ()
-    # teams with valid membership
-    memberships = ()
+    # projects with membership
+    projects = ()
+    # if open access policy is specified, then any project
+    # matching organization_id is valid
+    open_access_policy = False
     scopes = frozenset()
     permissions = frozenset()
 
     def has_permission(self, permission):
+        """
+        Return bool representing if the user has the given permission.
+
+        >>> access.has_permission('broadcasts.admin')
+        """
         if not self.is_active:
             return False
         return permission in self.permissions
 
     def has_scope(self, scope):
+        """
+        Return bool representing if the user has the given scope.
+
+        >>> access.has_project('org:read')
+        """
         if not self.is_active:
             return False
         return scope in self.scopes
@@ -83,17 +97,56 @@ class BaseAccess(object):
         return self.has_team_access(team)
 
     def has_team_access(self, team):
+        """
+        Return bool representing if a user should have access to information for the given team.
+
+        >>> access.has_team_access(team)
+        """
         if not self.is_active:
             return False
+        if self.open_access_policy and self.organization_id == team.organization_id:
+            return True
         return team in self.teams
 
-    def has_team_membership(self, team):
+    def has_team_scope(self, team, scope):
+        """
+        Return bool representing if a user should have access with the given scope to information
+        for the given team.
+
+        >>> access.has_team_scope(team, 'team:read')
+        """
+        return self.has_team_access(team) and self.has_scope(scope)
+
+    def has_project_access(self, project):
+        """
+        Return bool representing if a user should have access to information for the given project.
+
+        >>> access.has_project_access(project)
+        """
         if not self.is_active:
             return False
-        return team in self.memberships
+        if self.open_access_policy and self.organization_id == project.organization_id:
+            return True
+        return project in self.projects
 
-    def has_team_scope(self, team, scope):
-        return self.has_team_access(team) and self.has_scope(scope)
+    def has_project_membership(self, project):
+        """
+        Return bool representing if a user has explicit membership for the given project.
+
+        >>> access.has_project_membership(project)
+        """
+        if not self.is_active:
+            return False
+        return project in self.projects
+
+    def has_project_scope(self, project, scope):
+        """
+        Return bool representing if a user should have access with the given scope to information
+        for the given project.
+
+        >>> access.has_project_scope(project, 'project:read')
+        """
+        return self.has_project_access(project) and self.has_scope(scope)
 
     def to_django_context(self):
         return {s.replace(':', '_'): self.has_scope(s) for s in settings.SENTRY_SCOPES}
@@ -103,10 +156,12 @@ class Access(BaseAccess):
     # TODO(dcramer): this is still a little gross, and ideally backend access
     # would be based on the same scopes as API access so theres clarity in
     # what things mean
-    def __init__(self, scopes, is_active, teams, memberships,
+    def __init__(self, scopes, is_active, organization_id, teams, projects, open_access_policy,
                  sso_is_valid, requires_sso, permissions=None):
+        self.organization_id = organization_id
         self.teams = teams
-        self.memberships = memberships
+        self.projects = projects
+        self.open_access_policy = open_access_policy
         self.scopes = scopes
         if permissions is not None:
             self.permissions = permissions
@@ -120,31 +175,25 @@ class OrganizationGlobalAccess(BaseAccess):
     requires_sso = False
     sso_is_valid = True
     is_active = True
-    memberships = ()
+    open_access_policy = True
+    teams = ()
+    projects = ()
     permissions = frozenset()
 
     def __init__(self, organization, scopes=None):
         if scopes:
             self.scopes = scopes
-        self.organization = organization
+        self.organization_id = organization.id
 
     @cached_property
     def scopes(self):
         return settings.SENTRY_SCOPES
 
-    @cached_property
-    def teams(self):
-        from sentry.models import Team
-        return list(Team.objects.filter(organization=self.organization))
-
     def has_team_access(self, team):
-        return team.organization_id == self.organization.id
+        return team.organization_id == self.organization_id
 
-    def has_team_membership(self, team):
-        return team.organization_id == self.organization.id
-
-    def has_team_scope(self, team, scope):
-        return team.organization_id == self.organization.id
+    def has_project_access(self, project):
+        return project.organization_id == self.organization_id
 
     def has_scope(self, scope):
         return True
@@ -162,7 +211,10 @@ class NoAccess(BaseAccess):
     requires_sso = False
     sso_is_valid = True
     is_active = False
+    organization_id = None
+    open_access_policy = False
     teams = ()
+    projects = ()
     memberships = ()
     scopes = frozenset()
     permissions = frozenset()
@@ -190,14 +242,18 @@ def from_request(request, organization=None, scopes=None):
         else:
             requires_sso, sso_is_valid = _sso_params(member)
 
-        team_list = list(organization.team_set.all())
+        team_list = ()
+
+        project_list = ()
         return Access(
             scopes=scopes if scopes is not None else settings.SENTRY_SCOPES,
             is_active=True,
+            organization_id=organization.id if organization else None,
             teams=team_list,
-            memberships=team_list,
+            projects=project_list,
             sso_is_valid=sso_is_valid,
             requires_sso=requires_sso,
+            open_access_policy=True,
             permissions=UserPermission.for_user(request.user.id),
         )
 
@@ -216,12 +272,19 @@ def from_sentry_app(user, organization=None):
     if not sentry_app.is_installed_on(organization):
         return NoAccess()
 
+    team_list = list(sentry_app.teams.all())
+    project_list = list(Project.objects.filter(
+        teams__in=team_list,
+    ))
+
     return Access(
         scopes=sentry_app.scope_list,
         is_active=True,
-        teams=list(sentry_app.teams.all()),
-        memberships=(),
+        organization_id=organization.id if organization else None,
+        teams=team_list,
+        projects=project_list,
         permissions=(),
+        open_access_policy=False,
         sso_is_valid=True,
         requires_sso=False,
     )
@@ -257,13 +320,8 @@ def from_member(member, scopes=None):
     # network hops and needed in a lot of places
     requires_sso, sso_is_valid = _sso_params(member)
 
-    team_memberships = member.get_teams()
-    if member.organization.flags.allow_joinleave:
-        # an org having open membership means anyone could in theory join any
-        # team, so for permission purposes, pretend they've joined them all
-        team_access = list(member.organization.team_set.all())
-    else:
-        team_access = team_memberships
+    team_list = member.get_teams()
+    project_list = list(Project.objects.filter(teams__in=team_list))
 
     if scopes is not None:
         scopes = set(scopes) & member.get_scopes()
@@ -275,8 +333,10 @@ def from_member(member, scopes=None):
         requires_sso=requires_sso,
         sso_is_valid=sso_is_valid,
         scopes=scopes,
-        memberships=team_memberships,
-        teams=team_access,
+        organization_id=member.organization_id,
+        teams=team_list,
+        projects=project_list,
+        open_access_policy=bool(member.organization.flags.allow_joinleave),
         permissions=UserPermission.for_user(member.user_id),
     )
 

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -12,6 +12,7 @@ class FromUserTest(TestCase):
     def test_no_access(self):
         organization = self.create_organization()
         team = self.create_team(organization=organization)
+        project = self.create_project(organization=organization, teams=[team])
         user = self.create_user()
 
         result = access.from_user(user, organization)
@@ -19,7 +20,10 @@ class FromUserTest(TestCase):
         assert not result.requires_sso
         assert not result.scopes
         assert not result.has_team_access(team)
-        assert not result.has_team_membership(team)
+        assert not result.has_team_scope(team, 'project:read')
+        assert not result.has_project_access(project)
+        assert not result.has_project_scope(project, 'project:read')
+        assert not result.has_project_membership(project)
 
     def test_owner_all_teams(self):
         user = self.create_user()
@@ -30,13 +34,17 @@ class FromUserTest(TestCase):
             role='owner',
         )
         team = self.create_team(organization=organization)
+        project = self.create_project(organization=organization, teams=[team])
 
         result = access.from_user(user, organization)
         assert result.sso_is_valid
         assert not result.requires_sso
         assert result.scopes == member.get_scopes()
         assert result.has_team_access(team)
-        assert result.has_team_membership(team)
+        assert result.has_team_scope(team, 'project:read')
+        assert result.has_project_access(project)
+        assert result.has_project_scope(project, 'project:read')
+        assert result.has_project_membership(project)
 
     def test_member_no_teams_closed_membership(self):
         user = self.create_user()
@@ -50,13 +58,17 @@ class FromUserTest(TestCase):
             role='member',
         )
         team = self.create_team(organization=organization)
+        project = self.create_project(organization=organization, teams=[team])
 
         result = access.from_user(user, organization)
         assert result.sso_is_valid
         assert not result.requires_sso
         assert result.scopes == member.get_scopes()
         assert not result.has_team_access(team)
-        assert not result.has_team_membership(team)
+        assert not result.has_team_scope(team, 'project:read')
+        assert not result.has_project_access(project)
+        assert not result.has_project_scope(project, 'project:read')
+        assert not result.has_project_membership(project)
 
     def test_member_no_teams_open_membership(self):
         user = self.create_user()
@@ -71,18 +83,23 @@ class FromUserTest(TestCase):
             teams=(),
         )
         team = self.create_team(organization=organization)
+        project = self.create_project(organization=organization, teams=[team])
 
         result = access.from_user(user, organization)
         assert result.sso_is_valid
         assert not result.requires_sso
         assert result.scopes == member.get_scopes()
         assert result.has_team_access(team)
-        assert not result.has_team_membership(team)
+        assert result.has_team_scope(team, 'project:read')
+        assert result.has_project_access(project)
+        assert result.has_project_scope(project, 'project:read')
+        assert not result.has_project_membership(project)
 
     def test_team_restricted_org_member_access(self):
         user = self.create_user()
         organization = self.create_organization()
         team = self.create_team(organization=organization)
+        project = self.create_project(organization=organization, teams=[team])
         member = self.create_member(
             organization=organization,
             user=user,
@@ -94,7 +111,10 @@ class FromUserTest(TestCase):
         assert not result.requires_sso
         assert result.scopes == member.get_scopes()
         assert result.has_team_access(team)
-        assert result.has_team_membership(team)
+        assert result.has_team_scope(team, 'project:read')
+        assert result.has_project_access(project)
+        assert result.has_project_scope(project, 'project:read')
+        assert result.has_project_membership(project)
 
     def test_unlinked_sso(self):
         user = self.create_user()
@@ -199,4 +219,7 @@ class DefaultAccessTest(TestCase):
         assert result.sso_is_valid
         assert not result.scopes
         assert not result.has_team_access(Mock())
-        assert not result.has_team_membership(Mock())
+        assert not result.has_team_scope(Mock(), 'project:read')
+        assert not result.has_project_access(Mock())
+        assert not result.has_project_scope(Mock(), 'project:read')
+        assert not result.has_project_membership(Mock())


### PR DESCRIPTION
This refactors the Access-based permission management to better work under project-scoped memberships.

- Remove "team memberships" as a concept - its not relevant vs access
- Add "open access policy" as a core component to understand membership vs access
- Add has_project_X helpers, including has_project_membership

This specifically adds the open policy flag so we can avoid querying every project just to always return a True boolean.