### PR TITLE
fix(tagstore): Return TagKey instance from delete_tag_key

### DIFF
--- a/src/sentry/api/endpoints/project_tagkey_details.py
+++ b/src/sentry/api/endpoints/project_tagkey_details.py
@@ -59,7 +59,7 @@ class ProjectTagKeyDetailsEndpoint(ProjectEndpoint, EnvironmentMixin):
             self.create_audit_entry(
                 request=request,
                 organization=project.organization,
-                target_object=tagkey.id,
+                target_object=getattr(tagkey, 'id', None),
                 event=AuditLogEntryEvent.TAGKEY_REMOVE,
                 data=tagkey.get_audit_log_data(),
             )

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -749,8 +749,17 @@ class SnubaCompatibilityTagStorage(SnubaTagStorage):
 
     def delete_tag_key(self, project_id, key):
         # Called by ``ProjectTagKeyDetailsEndpoint.delete``. The return value
-        # is not used.
-        pass
+        # is used for audit logging.
+        try:
+            return [
+                self.get_tag_key(
+                    project_id=project_id,
+                    key=key,
+                    environment_id=None,
+                ),
+            ]
+        except TagKeyNotFound:
+            return []
 
     def incr_tag_value_times_seen(self, project_id, environment_id,
                                   key, value, extra=None, count=1):

--- a/src/sentry/tagstore/types.py
+++ b/src/sentry/tagstore/types.py
@@ -37,6 +37,11 @@ class TagKey(TagType):
         self.count = count
         self.top_values = top_values
 
+    def get_audit_log_data(self):
+        return {
+            'key': self.key,
+        }
+
 
 class TagValue(TagType):
     __slots__ = ['key', 'value', 'times_seen', 'first_seen', 'last_seen']


### PR DESCRIPTION
This enables the deletions to be written to the audit log.
    
This wasn't working earlier since GH-8270 only changed the return types
of the read interface (tag deletions for legacy and v2 were still
returning model instances.) The result value of this method was later
mistakenly diagnosed as unused in GH-11903.
    
Fixes SENTRY-9GS.