### PR TITLE
feat(discover): Ignore double quotes in Discover condition values

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/conditions/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/conditions/utils.jsx
@@ -83,6 +83,11 @@ export function getExternal(internal, columns) {
       external[2] = internal.replace(strStart, '');
     }
 
+    // Ignore double quotes if they have been entered
+    if (external[2] !== null && external[2].match(/^".*"$/)) {
+      external[2] = external[2].slice(1, -1);
+    }
+
     const type = columns.find(({name}) => name === colValue).type;
 
     if (type === 'number') {

--- a/tests/js/spec/views/organizationDiscover/conditions/utils.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/conditions/utils.spec.jsx
@@ -53,8 +53,12 @@ describe('Conditions', function() {
     });
 
     // datetime fields are expanded
-    const expected = ['timestamp', '=', '2018-05-05T00:00:00'];
-    expect(getExternal('timestamp = 2018-05-05', COLUMNS)).toEqual(expected);
+    const expectedTimestamp = ['timestamp', '=', '2018-05-05T00:00:00'];
+    expect(getExternal('timestamp = 2018-05-05', COLUMNS)).toEqual(expectedTimestamp);
+
+    // strips double quotes
+    const expectedValue = ['message', '=', 'test'];
+    expect(getExternal('message = "test"', COLUMNS)).toEqual(expectedValue);
   });
 
   it('getInternal()', function() {


### PR DESCRIPTION
Since these are frequently entered by users, just ignore double quotes
by default. Users will need to enter 2 sets of double quotes if they
want to query for an actual value with double quotes.