### PR TITLE
feat(api): Use search filters in various other miscellaneous places in the snuba search backend

### DIFF
--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -31,7 +31,6 @@ class IssueSearchVisitor(SearchVisitor):
         # on date_from and date_to explicitly
         'date': ['event.timestamp'],
         'times_seen': ['timesSeen'],
-        'timestamp': ['event.timestamp'],
         'sentry:dist': ['dist'],
     }
     numeric_keys = SearchVisitor.numeric_keys.union(['times_seen'])


### PR DESCRIPTION
While working on cleanup I noticed that I missed a couple of places, this handles the to/from dates
and exiting the query process early if there are no terms