### PR TITLE
ref(app-platform): Add organizations:sentry-apps feature flag

### DIFF
--- a/src/sentry/api/endpoints/organization_sentry_apps.py
+++ b/src/sentry/api/endpoints/organization_sentry_apps.py
@@ -8,7 +8,7 @@ from sentry.models import SentryApp
 
 
 class OrganizationSentryAppsEndpoint(OrganizationEndpoint):
-    @requires_feature('organizations:internal-catchall')
+    @requires_feature('organizations:sentry-apps')
     def get(self, request, organization):
         queryset = SentryApp.objects.filter(
             owner=organization,

--- a/src/sentry/api/endpoints/sentry_app_details.py
+++ b/src/sentry/api/endpoints/sentry_app_details.py
@@ -12,7 +12,7 @@ from sentry.mediators.sentry_apps import Updater, Destroyer
 
 class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
     def get(self, request, sentry_app):
-        if not features.has('organizations:internal-catchall',
+        if not features.has('organizations:sentry-apps',
                             sentry_app.owner,
                             actor=request.user):
 
@@ -21,7 +21,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
         return Response(serialize(sentry_app, request.user))
 
     def put(self, request, sentry_app):
-        if not features.has('organizations:internal-catchall',
+        if not features.has('organizations:sentry-apps',
                             sentry_app.owner,
                             actor=request.user):
 
@@ -48,7 +48,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
         return Response(serializer.errors, status=400)
 
     def delete(self, request, sentry_app):
-        if not features.has('organizations:internal-catchall',
+        if not features.has('organizations:sentry-apps',
                             sentry_app.owner,
                             actor=request.user):
             return Response(status=404)

--- a/src/sentry/api/endpoints/sentry_app_installation_details.py
+++ b/src/sentry/api/endpoints/sentry_app_installation_details.py
@@ -10,7 +10,7 @@ from sentry.mediators.sentry_app_installations import Destroyer
 
 class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
     def get(self, request, installation):
-        if not features.has('organizations:internal-catchall',
+        if not features.has('organizations:sentry-apps',
                             installation.organization,
                             actor=request.user):
             return Response(status=404)
@@ -18,7 +18,7 @@ class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
         return Response(serialize(installation))
 
     def delete(self, request, installation):
-        if not features.has('organizations:internal-catchall',
+        if not features.has('organizations:sentry-apps',
                             installation.organization,
                             actor=request.user):
             return Response(status=404)

--- a/src/sentry/api/endpoints/sentry_app_installations.py
+++ b/src/sentry/api/endpoints/sentry_app_installations.py
@@ -31,7 +31,7 @@ class SentryAppInstallationsSerializer(serializers.Serializer):
 
 
 class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
-    @requires_feature('organizations:internal-catchall')
+    @requires_feature('organizations:sentry-apps')
     def get(self, request, organization):
         queryset = SentryAppInstallation.objects.filter(
             organization=organization,
@@ -45,7 +45,7 @@ class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
             on_results=lambda x: serialize(x, request.user),
         )
 
-    @requires_feature('organizations:internal-catchall')
+    @requires_feature('organizations:sentry-apps')
     def post(self, request, organization):
         serializer = SentryAppInstallationsSerializer(data=request.DATA)
 

--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -12,7 +12,7 @@ from sentry.models import SentryApp
 
 
 class SentryAppsEndpoint(SentryAppsBaseEndpoint):
-    @requires_feature('organizations:internal-catchall', any_org=True)
+    @requires_feature('organizations:sentry-apps', any_org=True)
     def get(self, request):
         return self.paginate(
             request=request,
@@ -22,7 +22,7 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
             on_results=lambda x: serialize(x, request.user),
         )
 
-    @requires_feature('organizations:internal-catchall', any_org=True)
+    @requires_feature('organizations:sentry-apps', any_org=True)
     def post(self, request, organization):
         serializer = SentryAppSerializer(data=request.json_body)
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -813,8 +813,11 @@ SENTRY_FEATURES = {
     # Special feature flag primarily used on the sentry.io SAAS product for
     # easily enabling features while in early development.
     'organizations:internal-catchall': False,
+    # Enable organizations to create and utilize Sentry Apps.
+    'organizations:sentry-apps': False,
     # Enable inviting members to organizations.
     'organizations:invite-members': True,
+
 
     # DEPRECATED: pending removal.
     'organizations:js-loader': False,

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -58,6 +58,7 @@ default_manager.add('organizations:global-views', OrganizationFeature)  # NOQA
 default_manager.add('organizations:integrations-issue-basic', OrganizationFeature)  # NOQA
 default_manager.add('organizations:integrations-issue-sync', OrganizationFeature)  # NOQA
 default_manager.add('organizations:internal-catchall', OrganizationFeature)  # NOQA
+default_manager.add('organizations:sentry-apps', OrganizationFeature)  # NOQA
 default_manager.add('organizations:invite-members', OrganizationFeature)  # NOQA
 default_manager.add('organizations:js-loader', OrganizationFeature)  # NOQA
 default_manager.add('organizations:monitors', OrganizationFeature)  # NOQA

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
@@ -38,7 +38,7 @@ class OrganizationIntegrations extends AsyncComponent {
       ['integrations', `/organizations/${orgId}/integrations/`],
       ['plugins', `/organizations/${orgId}/plugins/`, {query}],
     ];
-    if (!this.props.organization.features.includes('internal-catchall')) {
+    if (!this.props.organization.features.includes('sentry-apps')) {
       return endpoints;
     }
     return [

--- a/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.jsx
@@ -73,7 +73,7 @@ const organizationNavigation = [
       {
         path: `${pathPrefix}/developer-settings/`,
         title: t('Developer Settings'),
-        show: ({access, features}) => features.has('internal-catchall'),
+        show: ({access, features}) => features.has('sentry-apps'),
         description: t('Manage developer applications'),
       },
     ],

--- a/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
@@ -69,7 +69,7 @@ describe('OrganizationIntegrations', function() {
         routerContext
       );
 
-      it('renders with internal-catchall', function() {
+      it('renders with sentry-apps', function() {
         Client.addMockResponse({
           url: `/organizations/${org.slug}/integrations/`,
           body: [],
@@ -94,7 +94,7 @@ describe('OrganizationIntegrations', function() {
           url: `/organizations/${org.slug}/sentry-app-installations/`,
           body: [],
         });
-        const organization = {...org, features: ['internal-catchall']};
+        const organization = {...org, features: ['sentry-apps']};
         mount(
           <OrganizationIntegrations organization={organization} params={params} />,
           TestStubs.routerContext([{organization}])
@@ -103,7 +103,7 @@ describe('OrganizationIntegrations', function() {
         expect(installsRequest).toHaveBeenCalled();
       });
 
-      it('Does`t hit sentry apps endpoints when internal-catchall isn`t present', function() {
+      it('Does`t hit sentry apps endpoints when sentry-apps isn`t present', function() {
         expect(sentryAppsRequest).not.toHaveBeenCalled();
         expect(sentryInstallsRequest).not.toHaveBeenCalled();
       });

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -43,7 +43,7 @@ class SentryAppInstallationDetailsTest(APITestCase):
 
 
 class GetSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_access_within_installs_organization(self):
         self.login_as(user=self.user)
         response = self.client.get(self.url, format='json')
@@ -60,7 +60,7 @@ class GetSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
             'uuid': self.installation2.uuid,
         }
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_no_access_outside_install_organization(self):
         self.login_as(user=self.user)
 
@@ -80,14 +80,14 @@ class GetSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
 
 
 class DeleteSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_delete_install(self):
         self.login_as(user=self.user)
         response = self.client.delete(self.url, format='json')
 
         assert response.status_code == 204
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_member_cannot_delete_install(self):
         user = self.create_user('bar@example.com')
         self.create_member(

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -44,7 +44,7 @@ class SentryAppInstallationsTest(APITestCase):
 
 
 class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_superuser_sees_all_installs(self):
         self.login_as(user=self.superuser, superuser=True)
         response = self.client.get(self.url, format='json')
@@ -80,7 +80,7 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
             'uuid': self.installation.uuid,
         }]
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_users_only_sees_installs_on_their_org(self):
         self.login_as(user=self.user)
         response = self.client.get(self.url, format='json')
@@ -114,7 +114,7 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
 
 
 class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_install_unpublished_app(self):
         self.login_as(user=self.user)
         app = self.create_sentry_app(
@@ -139,7 +139,7 @@ class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
         assert response.status_code == 200, response.content
         assert six.viewitems(expected) <= six.viewitems(response.data)
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_install_published_app(self):
         self.login_as(user=self.user)
         app = self.create_sentry_app(
@@ -165,7 +165,7 @@ class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
         assert response.status_code == 200, response.content
         assert six.viewitems(expected) <= six.viewitems(response.data)
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_members_cannot_install_apps(self):
         user = self.create_user('bar@example.com')
         self.create_member(

--- a/tests/sentry/api/endpoints/test_organization_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_apps.py
@@ -33,7 +33,7 @@ class OrganizationSentryAppsTest(APITestCase):
 
 
 class GetOrganizationSentryAppsTest(OrganizationSentryAppsTest):
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_gets_all_apps_in_own_org(self):
         self.login_as(user=self.user)
         response = self.client.get(self.url, format='json')
@@ -55,7 +55,7 @@ class GetOrganizationSentryAppsTest(OrganizationSentryAppsTest):
             'overview': self.unpublished_app.overview,
         }])
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_cannot_see_apps_in_other_orgs(self):
         self.login_as(user=self.user)
         url = reverse('sentry-api-0-organization-sentry-apps', args=[self.super_org.slug])

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -37,7 +37,7 @@ class SentryAppDetailsTest(APITestCase):
 
 
 class GetSentryAppDetailsTest(SentryAppDetailsTest):
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_superuser_sees_all_apps(self):
         self.login_as(user=self.superuser, superuser=True)
         response = self.client.get(self.url, format='json')
@@ -55,7 +55,7 @@ class GetSentryAppDetailsTest(SentryAppDetailsTest):
         assert response.status_code == 200
         assert response.data['uuid'] == self.unpublished_app.uuid
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_users_see_published_app(self):
         self.login_as(user=self.user)
 
@@ -63,7 +63,7 @@ class GetSentryAppDetailsTest(SentryAppDetailsTest):
         assert response.status_code == 200
         assert response.data['uuid'] == self.published_app.uuid
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_users_see_unpublished_apps_owned_by_their_org(self):
         self.login_as(self.user)
 
@@ -75,7 +75,7 @@ class GetSentryAppDetailsTest(SentryAppDetailsTest):
         response = self.client.get(url, format='json')
         assert response.status_code == 200
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_users_do_not_see_unowned_unpublished_apps(self):
         self.login_as(self.user)
 
@@ -95,7 +95,7 @@ class GetSentryAppDetailsTest(SentryAppDetailsTest):
 
 
 class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_update_published_app(self):
         self.login_as(user=self.superuser, superuser=True)
         response = self.client.put(
@@ -123,7 +123,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             'overview': self.published_app.overview,
         }
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_update_unpublished_app(self):
         self.login_as(user=self.user)
         url = reverse('sentry-api-0-sentry-app-details', args=[self.unpublished_app.slug])
@@ -146,7 +146,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         assert response.data['uuid'] == self.unpublished_app.uuid
         assert response.data['webhookUrl'] == 'https://newurl.com'
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_cannot_update_events_without_permissions(self):
         self.login_as(user=self.user)
         url = reverse('sentry-api-0-sentry-app-details', args=[self.unpublished_app.slug])
@@ -166,7 +166,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         assert response.data == \
             {'events': ['issue webhooks require the event:read permission.']}
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_cannot_update_scopes_published_app(self):
         self.login_as(user=self.user)
 
@@ -181,7 +181,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         )
         assert response.status_code == 500
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_cannot_update_non_owned_apps(self):
         self.login_as(user=self.user)
         app = self.create_sentry_app(
@@ -201,7 +201,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
 
 
 class DeleteSentryAppDetailsTest(SentryAppDetailsTest):
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_delete_unpublished_app(self):
         self.login_as(user=self.superuser)
         url = reverse(
@@ -211,7 +211,7 @@ class DeleteSentryAppDetailsTest(SentryAppDetailsTest):
         response = self.client.delete(url)
         assert response.status_code == 204
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_cannot_delete_published_app(self):
         self.login_as(user=self.superuser)
         url = reverse(

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -38,7 +38,7 @@ class SentryAppsTest(APITestCase):
 
 
 class GetSentryAppsTest(SentryAppsTest):
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_superuser_sees_all_apps(self):
         self.login_as(user=self.superuser)
 
@@ -50,7 +50,7 @@ class GetSentryAppsTest(SentryAppsTest):
         assert self.unpublished_app.uuid in response_uuids
         assert self.unowned_unpublished_app.uuid in response_uuids
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_users_see_published_apps(self):
         self.login_as(user=self.user)
 
@@ -72,7 +72,7 @@ class GetSentryAppsTest(SentryAppsTest):
             'overview': self.published_app.overview,
         } in json.loads(response.content)
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_users_see_unpublished_apps_their_org_owns(self):
         self.login_as(user=self.user)
 
@@ -94,7 +94,7 @@ class GetSentryAppsTest(SentryAppsTest):
             'overview': self.unpublished_app.overview,
         } in json.loads(response.content)
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_users_dont_see_unpublished_apps_outside_their_orgs(self):
         self.login_as(user=self.user)
 
@@ -113,7 +113,7 @@ class GetSentryAppsTest(SentryAppsTest):
 
 
 class PostSentryAppsTest(SentryAppsTest):
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_creates_sentry_app(self):
         self.login_as(user=self.user)
 
@@ -128,7 +128,7 @@ class PostSentryAppsTest(SentryAppsTest):
         assert response.status_code == 201, response.content
         assert six.viewitems(expected) <= six.viewitems(json.loads(response.content))
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_cannot_create_app_without_correct_permissions(self):
         self.login_as(user=self.user)
         kwargs = {'scopes': ('project:read',)}
@@ -138,7 +138,7 @@ class PostSentryAppsTest(SentryAppsTest):
         assert response.data == \
             {'events': ['issue webhooks require the event:read permission.']}
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_wrong_schema_format(self):
         self.login_as(user=self.user)
         kwargs = {'schema': {
@@ -165,7 +165,7 @@ class PostSentryAppsTest(SentryAppsTest):
         assert response.data == \
             {'schema': ["['#general'] is too short"]}
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_missing_name(self):
         self.login_as(self.user)
         response = self._post(name=None)
@@ -173,7 +173,7 @@ class PostSentryAppsTest(SentryAppsTest):
         assert response.status_code == 422, response.content
         assert 'name' in response.data
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_missing_scopes(self):
         self.login_as(self.user)
         response = self._post(scopes=None)
@@ -181,7 +181,7 @@ class PostSentryAppsTest(SentryAppsTest):
         assert response.status_code == 422, response.content
         assert 'scopes' in response.data
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_invalid_events(self):
         self.login_as(self.user)
         response = self._post(events=['project'])
@@ -189,7 +189,7 @@ class PostSentryAppsTest(SentryAppsTest):
         assert response.status_code == 422, response.content
         assert 'events' in response.data
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_invalid_scope(self):
         self.login_as(self.user)
         response = self._post(scopes=('not:ascope', ))
@@ -197,7 +197,7 @@ class PostSentryAppsTest(SentryAppsTest):
         assert response.status_code == 422, response.content
         assert 'scopes' in response.data
 
-    @with_feature('organizations:internal-catchall')
+    @with_feature('organizations:sentry-apps')
     def test_missing_webhook_url(self):
         self.login_as(self.user)
         response = self._post(webhookUrl=None)


### PR DESCRIPTION
Replaces `organizations:internal-catchall` with `organizations:sentry-apps`.