### PR TITLE
feat: Hide no project message for superusers

### DIFF
--- a/src/sentry/static/sentry/app/components/noProjectMessage.jsx
+++ b/src/sentry/static/sentry/app/components/noProjectMessage.jsx
@@ -9,6 +9,7 @@ import PageHeading from 'app/components/pageHeading';
 import Tooltip from 'app/components/tooltip';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
+import ConfigStore from 'app/stores/configStore';
 /* TODO: replace with I/O when finished */
 import img from '../../images/dashboard/hair-on-fire.svg';
 
@@ -26,7 +27,12 @@ export default class NoProjectMessage extends React.Component {
     const orgId = organization.slug;
     const canCreateProject = organization.access.includes('project:write');
     const canJoinTeam = organization.access.includes('team:read');
-    const hasProjects = organization.projects.some(p => p.isMember && p.hasAccess);
+
+    const {isSuperuser} = ConfigStore.get('user');
+
+    const hasProjects = isSuperuser
+      ? organization.projects.some(p => p.hasAccess)
+      : organization.projects.some(p => p.isMember && p.hasAccess);
 
     return hasProjects ? (
       children


### PR DESCRIPTION
The previous check prevented superusers from viewing page content if
there were projects they were not a member of. Note that this doesn't
change anything for non-superusers in open access orgs.