### PR TITLE
fix(commits) Fix mistake in java suspect commits

### DIFF
--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -199,7 +199,11 @@ def get_event_file_committers(project, event, frame_limit=25):
     if event.platform == 'java':
         for frame in frames:
             if '/' not in frame.get('filename') and frame.get('module'):
-                frame['filename'] = frame['module'].replace('.', '/') + '/' + frame['filename']
+                # Replace the last module segment with the filename, as the
+                # terminal element in a module path is the class
+                module = frame['module'].split('.')
+                module[-1] = frame['filename']
+                frame['filename'] = '/'.join(module)
 
     # TODO(maxbittker) return this set instead of annotated frames
     # XXX(dcramer): frames may not define a filepath. For example, in Java its common

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -272,7 +272,7 @@ class GetEventFileCommitters(CommitTestCase):
                 'message': 'i fixed a bug',
                 'patch_set': [
                     {
-                        'path': 'sentry/example/Application/Application.java',
+                        'path': 'src/main/java/io/sentry/example/Application.java',
                         'type': 'M',
                     },
                 ]


### PR DESCRIPTION
The `module` key in java stacktraces includes the class name. I originally thought it was the containing namespace, but after looking at our demo applications, spring and log4j that isn't the case. By replacing the terminal node with the filename we can get a probable file name more reliably.

Fixes APP-1099