### PR TITLE
fix(discover): Fix timepicker bug in Discover

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/utils.jsx
@@ -18,7 +18,7 @@ const VALID_QUERY_KEYS = [
 ];
 
 export function getQueryFromQueryString(queryString) {
-  const queryKeys = new Set([...VALID_QUERY_KEYS, 'utc']);
+  const queryKeys = new Set(VALID_QUERY_KEYS);
   const result = {};
   let parsedQuery = queryString;
   parsedQuery = parsedQuery.replace(/^\?|\/$/g, '').split('&');


### PR DESCRIPTION
Prevents Discover crashing for superusers due to an undefined utc
property. This was introduced in
https://github.com/getsentry/sentry/pull/11936.

Fixes JAVASCRIPT-57X