### PR TITLE
fix(redis): Reset Redis Cluster state on KeyError

### DIFF
--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -88,7 +88,11 @@ class RetryingStrictRedisCluster(StrictRedisCluster):
     def execute_command(self, *args, **kwargs):
         try:
             return super(self.__class__, self).execute_command(*args, **kwargs)
-        except (ConnectionError, BusyLoadingError):
+        except (
+            ConnectionError,
+            BusyLoadingError,
+            KeyError,  # see: https://github.com/Grokzen/redis-py-cluster/issues/287
+        ):
             self.connection_pool.nodes.reset()
             return super(self.__class__, self).execute_command(*args, **kwargs)
 


### PR DESCRIPTION
This seems to happen every once in a while when the cluster gets into a
broken state and starts to death spiral. Catching `KeyError` here isn't
ideal, but it's the only real signal we have when this happens.

Fixes SENTRY-5YG.