### PR TITLE
feat(serializers): Added environment names to ProjectSummarySerializer.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,7 +46,7 @@
   "python.formatting.provider": "autopep8",
   "python.formatting.autopep8Args": ["--global-config", "${workspaceRoot}/setup.cfg"],
   // https://github.com/DonJayamanne/pythonVSCode/issues/992
-  "python.pythonPath": "${env.WORKON_HOME}/sentry/bin/python",
+  "python.pythonPath": "/usr/local/opt/python@2/bin/python2.7",
   // test discovery is sluggish and the UI around running
   // tests is often in your way and misclicked
   "python.unitTest.pyTestEnabled": false,
@@ -54,5 +54,7 @@
   "python.unitTest.nosetestsEnabled": false,
   "prettier-eslint.prettierPath":
     "${env.WORKON_HOME}/node_modules/prettier/bin/prettier.js",
-  "editor.tabSize": 4
+  "editor.tabSize": 4,
+  "restructuredtext.confPath": "",
+  "python.linting.enabled": true
 }

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -320,7 +320,7 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
         for item in item_list:
             attrs[item]['latest_release'] = latest_releases.get(item.id)
             attrs[item]['deploys'] = deploys_by_project.get(item.id)
-            attrs[item]['environments'] = environments_by_project.get(item.id)
+            attrs[item]['environments'] = environments_by_project.get(item.id, [])
 
         return attrs
 

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -17,7 +17,7 @@ from sentry.auth.superuser import is_active_superuser
 from sentry.constants import StatsPeriod
 from sentry.digests import backend as digests
 from sentry.models import (
-    Project, ProjectAvatar, ProjectBookmark, ProjectOption, ProjectPlatform,
+    EnvironmentProject, Project, ProjectAvatar, ProjectBookmark, ProjectOption, ProjectPlatform,
     ProjectStatus, ProjectTeam, Release, ReleaseProjectEnvironment, Deploy, UserOption, DEFAULT_SUBJECT_TEMPLATE
 )
 from sentry.utils.data_filters import FilterTypes
@@ -269,6 +269,14 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
         attrs = super(ProjectSummarySerializer,
                       self).get_attrs(item_list, user)
 
+        project_envs = EnvironmentProject.objects.filter(
+            project_id__in=[i.id for i in item_list],
+        ).values('project_id', 'environment__name')
+        environments_by_project = defaultdict(list)
+        for project_env in project_envs:
+            environments_by_project[project_env['project_id']].append(
+                project_env['environment__name'])
+
         release_project_envs = list(ReleaseProjectEnvironment.objects.filter(
             project__in=item_list,
             last_deploy_id__isnull=False
@@ -306,6 +314,7 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
         for item in item_list:
             attrs[item]['latest_release'] = latest_releases.get(item.id)
             attrs[item]['deploys'] = deploys_by_project.get(item.id)
+            attrs[item]['environments'] = environments_by_project.get(item.id)
 
         return attrs
 
@@ -321,6 +330,7 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
             'isMember': attrs['is_member'],
             'hasAccess': attrs['has_access'],
             'dateCreated': obj.date_added,
+            'environments': attrs['environments'],
             'features': feature_list,
             'firstEvent': obj.first_event,
             'platform': obj.platform,

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -271,7 +271,13 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
 
         project_envs = EnvironmentProject.objects.filter(
             project_id__in=[i.id for i in item_list],
+        ).exclude(
+            is_hidden=True
+        ).exclude(
+            # HACK(lb): avoiding the no environment value
+            environment__name=''
         ).values('project_id', 'environment__name')
+
         environments_by_project = defaultdict(list)
         for project_env in project_envs:
             environments_by_project[project_env['project_id']].append(

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -55,7 +55,7 @@ class OrganizationDetailsTest(APITestCase):
         )
         # TODO(dcramer): we need to pare this down -- lots of duplicate queries
         # for membership data
-        with self.assertNumQueries(34, using='default'):
+        with self.assertNumQueries(35, using='default'):
             from django.db import connections
             response = self.client.get(url, format='json')
             pprint(connections['default'].queries)

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -224,7 +224,7 @@ class ProjectSummarySerializerTest(TestCase):
 
         assert result['latestDeploys'] is None
         assert result['latestRelease'] is None
-        assert result['environments'] is None
+        assert result['environments'] == []
 
     def test_avoid_hidden_and_no_env(self):
         hidden_env = Environment.objects.create(


### PR DESCRIPTION
The `ProjectSummarySerializer` will now contain a list of environments the project is related to or `None` if no environments are associated with the project. This is used by `DetailedOrganizationSerializer`, `OrganizationProjectsEndpoint`, and `TeamProjectsEndpoint`. 

Note: Will need to update the api documentation so that it exposes this change.