### PR TITLE
feat(api): Add bitflag and api changes to allow orgs to opt out of sentry10/visibility

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -93,6 +93,7 @@ class OrganizationSerializer(serializers.Serializer):
     scrapeJavaScript = serializers.BooleanField(required=False)
     isEarlyAdopter = serializers.BooleanField(required=False)
     require2FA = serializers.BooleanField(required=False)
+    disableNewVisibilityFeatures = serializers.BooleanField(required=False)
     trustedRelays = ListField(child=serializers.CharField(), required=False)
 
     @memoize
@@ -230,6 +231,8 @@ class OrganizationSerializer(serializers.Serializer):
             org.flags.enhanced_privacy = self.init_data['enhancedPrivacy']
         if 'isEarlyAdopter' in self.init_data:
             org.flags.early_adopter = self.init_data['isEarlyAdopter']
+        if 'disableNewVisibilityFeatures' in self.init_data:
+            org.flags.disable_new_visibility_features = self.init_data['disableNewVisibilityFeatures']
         if 'require2FA' in self.init_data:
             org.flags.require_2fa = self.init_data['require2FA']
         if 'name' in self.init_data:

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -138,6 +138,9 @@ class Organization(Model):
             ), (
                 'require_2fa',
                 'Require and enforce two-factor authentication for all members.'
+            ), (
+                'disable_new_visibility_features',
+                'Temporarily opt out of new visibility features and ui',
             ),
         ),
         default=1

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -252,6 +252,36 @@ class OrganizationUpdateTest(APITestCase):
         assert u'to {}'.format(data['scrubIPAddresses']) in log.data['scrubIPAddresses']
         assert u'to {}'.format(data['scrapeJavaScript']) in log.data['scrapeJavaScript']
 
+    def test_disable_new_visibility_features(self):
+        org = self.create_organization(owner=self.user)
+        assert not org.flags.disable_new_visibility_features
+        self.login_as(user=self.user)
+        url = reverse(
+            'sentry-api-0-organization-details', kwargs={
+                'organization_slug': org.slug,
+            }
+        )
+
+        response = self.client.put(
+            url,
+            data={
+                'disableNewVisibilityFeatures': True,
+            }
+        )
+        assert response.status_code == 200, response.content
+        org = Organization.objects.get(id=org.id)
+        assert org.flags.disable_new_visibility_features
+
+        response = self.client.put(
+            url,
+            data={
+                'disableNewVisibilityFeatures': False,
+            }
+        )
+        assert response.status_code == 200, response.content
+        org = Organization.objects.get(id=org.id)
+        assert not org.flags.disable_new_visibility_features
+
     def test_setting_trusted_relays_forbidden(self):
         org = self.create_organization(owner=self.user)
         self.login_as(user=self.user)


### PR DESCRIPTION
We want this as a safety option in case any users are particularly mad about the sentry 10 changes.
This gives us a flag that we can check in getsentry to just disable sentry10 for any orgs that have
opted out.