### PR TITLE
fix(api): Only apply int/date conversion to whitelisted columns in search

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -176,6 +176,8 @@ class SearchVisitor(NodeVisitor):
     # A list of mappers that map source keys to a target name. Format is
     # <target_name>: [<list of source names>],
     key_mappings = {}
+    numeric_keys = set()
+    date_keys = set(['start', 'end', 'first_seen', 'last_seen', 'timestamp'])
 
     unwrapped_exceptions = (InvalidSearchQuery,)
 
@@ -218,16 +220,16 @@ class SearchVisitor(NodeVisitor):
 
     def visit_numeric_filter(self, node, children):
         search_key, _, operator, search_value = children
-        # Tags are always strings
-        if not search_key.is_tag:
+        operator = operator[0] if not isinstance(operator, Node) else '='
+
+        if search_key.name in self.numeric_keys:
             try:
                 search_value = int(search_value.text)
             except ValueError:
                 raise InvalidSearchQuery('Invalid numeric query: %s' % (search_key,))
         else:
-            search_value = search_value.text
-
-        operator = operator[0] if not isinstance(operator, Node) else '='
+            search_value = operator + search_value.text if operator != '=' else search_value.text
+            operator = '='
 
         return SearchFilter(
             search_key,
@@ -237,10 +239,14 @@ class SearchVisitor(NodeVisitor):
 
     def visit_time_filter(self, node, children):
         search_key, _, operator, search_value = children
-        try:
-            search_value = parse_datetime_string(search_value)
-        except InvalidQuery as exc:
-            raise InvalidSearchQuery(exc.message)
+        if search_key.name in self.date_keys:
+            try:
+                search_value = parse_datetime_string(search_value)
+            except InvalidQuery as exc:
+                raise InvalidSearchQuery(exc.message)
+        else:
+            search_value = operator + search_value if operator != '=' else search_value
+            operator = '='
 
         try:
             return SearchFilter(
@@ -253,18 +259,22 @@ class SearchVisitor(NodeVisitor):
 
     def visit_rel_time_filter(self, node, children):
         search_key, _, value = children
-        try:
-            from_val, to_val = parse_datetime_range(value.text)
-        except InvalidQuery as exc:
-            raise InvalidSearchQuery(exc.message)
+        if search_key.name in self.date_keys:
+            try:
+                from_val, to_val = parse_datetime_range(value.text)
+            except InvalidQuery as exc:
+                raise InvalidSearchQuery(exc.message)
 
-        # TODO: Handle negations
-        if from_val is not None:
-            operator = '>='
-            search_value = from_val[0]
+            # TODO: Handle negations
+            if from_val is not None:
+                operator = '>='
+                search_value = from_val[0]
+            else:
+                operator = '<='
+                search_value = to_val[0]
         else:
-            operator = '<='
-            search_value = to_val[0]
+            operator = '='
+            search_value = value.text
 
         return SearchFilter(
             search_key,
@@ -278,6 +288,13 @@ class SearchVisitor(NodeVisitor):
         # day, and if we specify a specific datetime then it means a few minutes
         # interval on either side of that datetime
         search_key, _, date_value = children
+        if search_key.name not in self.date_keys:
+            return SearchFilter(
+                search_key,
+                '=',
+                SearchValue(date_value),
+            )
+
         try:
             from_val, to_val = parse_datetime_value(date_value)
         except InvalidQuery as exc:

--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -34,6 +34,8 @@ class IssueSearchVisitor(SearchVisitor):
         'timestamp': ['event.timestamp'],
         'sentry:dist': ['dist'],
     }
+    numeric_keys = SearchVisitor.numeric_keys.union(['times_seen'])
+    date_keys = SearchVisitor.date_keys.union(['active_at', 'date'])
 
     @cached_property
     def is_filter_translators(self):

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -101,9 +101,9 @@ class ParseSearchQueryTest(TestCase):
 
     def test_other_dates(self):
         # test date format with other name
-        assert parse_search_query('some_date>2015-05-18') == [
+        assert parse_search_query('first_seen>2015-05-18') == [
             SearchFilter(
-                key=SearchKey(name='some_date'),
+                key=SearchKey(name='first_seen'),
                 operator=">",
                 value=SearchValue(
                     raw_value=datetime.datetime(
@@ -119,9 +119,9 @@ class ParseSearchQueryTest(TestCase):
         ]
 
         # test colon format
-        assert parse_search_query('some_date:>2015-05-18') == [
+        assert parse_search_query('first_seen:>2015-05-18') == [
             SearchFilter(
-                key=SearchKey(name='some_date'),
+                key=SearchKey(name='first_seen'),
                 operator=">",
                 value=SearchValue(
                     raw_value=datetime.datetime(
@@ -136,39 +136,54 @@ class ParseSearchQueryTest(TestCase):
             ),
         ]
 
+        assert parse_search_query('random:>2015-05-18') == [
+            SearchFilter(
+                key=SearchKey(name='random'),
+                operator="=",
+                value=SearchValue('>2015-05-18'),
+            ),
+        ]
+
     def test_rel_time_filter(self):
         now = timezone.now()
         with freeze_time(now):
-            assert parse_search_query('some_rel_date:+7d') == [
+            assert parse_search_query('first_seen:+7d') == [
                 SearchFilter(
-                    key=SearchKey(name='some_rel_date'),
+                    key=SearchKey(name='first_seen'),
                     operator="<=",
                     value=SearchValue(
                         raw_value=now - timedelta(days=7),
                     ),
                 ),
             ]
-            assert parse_search_query('some_rel_date:-2w') == [
+            assert parse_search_query('first_seen:-2w') == [
                 SearchFilter(
-                    key=SearchKey(name='some_rel_date'),
+                    key=SearchKey(name='first_seen'),
                     operator=">=",
                     value=SearchValue(
                         raw_value=now - timedelta(days=14),
                     ),
                 ),
             ]
+            assert parse_search_query('random:-2w') == [
+                SearchFilter(
+                    key=SearchKey(name='random'),
+                    operator="=",
+                    value=SearchValue('-2w'),
+                ),
+            ]
 
     def test_specific_time_filter(self):
-        assert parse_search_query('some_rel_date:2018-01-01') == [
+        assert parse_search_query('first_seen:2018-01-01') == [
             SearchFilter(
-                key=SearchKey(name='some_rel_date'),
+                key=SearchKey(name='first_seen'),
                 operator=">=",
                 value=SearchValue(
                     raw_value=datetime.datetime(2018, 1, 1, tzinfo=timezone.utc),
                 ),
             ),
             SearchFilter(
-                key=SearchKey(name='some_rel_date'),
+                key=SearchKey(name='first_seen'),
                 operator="<",
                 value=SearchValue(
                     raw_value=datetime.datetime(2018, 1, 2, tzinfo=timezone.utc),
@@ -176,20 +191,28 @@ class ParseSearchQueryTest(TestCase):
             ),
         ]
 
-        assert parse_search_query('some_rel_date:2018-01-01T05:06:07') == [
+        assert parse_search_query('first_seen:2018-01-01T05:06:07') == [
             SearchFilter(
-                key=SearchKey(name='some_rel_date'),
+                key=SearchKey(name='first_seen'),
                 operator=">=",
                 value=SearchValue(
                     raw_value=datetime.datetime(2018, 1, 1, 5, 1, 7, tzinfo=timezone.utc),
                 ),
             ),
             SearchFilter(
-                key=SearchKey(name='some_rel_date'),
+                key=SearchKey(name='first_seen'),
                 operator="<",
                 value=SearchValue(
                     raw_value=datetime.datetime(2018, 1, 1, 5, 12, 7, tzinfo=timezone.utc),
                 ),
+            ),
+        ]
+
+        assert parse_search_query('random:2018-01-01T05:06:07') == [
+            SearchFilter(
+                key=SearchKey(name='random'),
+                operator="=",
+                value=SearchValue(raw_value='2018-01-01T05:06:07'),
             ),
         ]
 
@@ -409,41 +432,12 @@ class ParseSearchQueryTest(TestCase):
         ]
 
     def test_numeric_filter(self):
-        # test numeric format
-        assert parse_search_query('times_seen:500') == [
+        # Numeric format should still return a string if field isn't whitelisted
+        assert parse_search_query('random_field:>500') == [
             SearchFilter(
-                key=SearchKey(name='times_seen'),
+                key=SearchKey(name='random_field'),
                 operator="=",
-                value=SearchValue(raw_value=500),
-            ),
-        ]
-        assert parse_search_query('times_seen:>500') == [
-            SearchFilter(
-                key=SearchKey(name='times_seen'),
-                operator=">",
-                value=SearchValue(raw_value=500),
-            ),
-        ]
-        assert parse_search_query('times_seen:<500') == [
-            SearchFilter(
-                key=SearchKey(name='times_seen'),
-                operator="<",
-                value=SearchValue(raw_value=500),
-            ),
-        ]
-        # Non numeric shouldn't match
-        assert parse_search_query('times_seen:<hello') == [
-            SearchFilter(
-                key=SearchKey(name='times_seen'),
-                operator="=",
-                value=SearchValue(raw_value="<hello"),
-            ),
-        ]
-        assert parse_search_query('times_seen:<512.1.0') == [
-            SearchFilter(
-                key=SearchKey(name='times_seen'),
-                operator="=",
-                value=SearchValue(raw_value="<512.1.0"),
+                value=SearchValue(raw_value='>500'),
             ),
         ]
 

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -104,6 +104,45 @@ class ParseSearchQueryTest(TestCase):
             'Invalid value for "is" search, valid values are',
         )
 
+    def test_numeric_filter(self):
+        # test numeric format
+        assert parse_search_query('times_seen:500') == [
+            SearchFilter(
+                key=SearchKey(name='times_seen'),
+                operator="=",
+                value=SearchValue(raw_value=500),
+            ),
+        ]
+        assert parse_search_query('times_seen:>500') == [
+            SearchFilter(
+                key=SearchKey(name='times_seen'),
+                operator=">",
+                value=SearchValue(raw_value=500),
+            ),
+        ]
+        assert parse_search_query('times_seen:<500') == [
+            SearchFilter(
+                key=SearchKey(name='times_seen'),
+                operator="<",
+                value=SearchValue(raw_value=500),
+            ),
+        ]
+        # Non numeric shouldn't match
+        assert parse_search_query('times_seen:<hello') == [
+            SearchFilter(
+                key=SearchKey(name='times_seen'),
+                operator="=",
+                value=SearchValue(raw_value="<hello"),
+            ),
+        ]
+        assert parse_search_query('times_seen:<512.1.0') == [
+            SearchFilter(
+                key=SearchKey(name='times_seen'),
+                operator="=",
+                value=SearchValue(raw_value="<512.1.0"),
+            ),
+        ]
+
 
 class ConvertQueryValuesTest(TestCase):
 


### PR DESCRIPTION
This is kind of a hacky way to go about this, but should get us in decent shape for release. Ideally
I think we should actually handle these whitelisted columns in the grammar so that we automatically
fall through to the basic filter if we have a key that looks like a date/int but isn't being applied
to a valid key.