### PR TITLE
fix(eventstream): Remove unexpected values before checking for other unexpected values

### DIFF
--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -141,7 +141,7 @@ class KafkaEventStream(EventStream):
         event_data = event.get_raw_data()
 
         unexpected_tags = set([
-            k for (k, v) in (get_path(event_data, 'tags') or [])
+            k for (k, v) in (get_path(event_data, 'tags', filter=True) or [])
             if k in self.UNEXPECTED_TAG_KEYS
         ])
         if unexpected_tags:


### PR DESCRIPTION
See GH-12085 for related change.

In addition to the expected `(key, value)` pairs in the `tags` list, there are sometimes `None` values. This removes them.

Fixes SENTRY-9JY.