### PR TITLE
ref(api): Use has_project_X methods in org endpoint base

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -149,8 +149,10 @@ class OrganizationEventsEndpointTest(OrganizationEventsTestBase):
         assert response.data['detail'] == "Parse error: 'search' (column 1)"
 
     def test_project_filtering(self):
-        user = self.create_user()
+        user = self.create_user(is_staff=False, is_superuser=False)
         org = self.create_organization()
+        org.flags.allow_joinleave = False
+        org.save()
         team = self.create_team(organization=org)
         self.create_member(organization=org, user=user, teams=[team])
 


### PR DESCRIPTION
Also has the added side effect that org owners and admins should be shown data from a project they have access (but not membership) to if it is explicitly passed as a param