### PR TITLE
fix(discover): Fix crashes in discover

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/dateRange.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/dateRange.jsx
@@ -181,7 +181,7 @@ class DateRange extends React.Component {
               {t('Use UTC')}
               <Checkbox
                 onChange={onChangeUtc}
-                checked={utc}
+                checked={utc || false}
                 style={{
                   margin: '0 0 0 0.5em',
                 }}

--- a/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
+++ b/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
@@ -23,7 +23,7 @@ const getDefaultSelection = () => {
       [DATE_TIME.START]: null,
       [DATE_TIME.END]: null,
       [DATE_TIME.PERIOD]: DEFAULT_STATS_PERIOD,
-      [DATE_TIME.UTC]: user?.options?.timezone === 'UTC' ? true : undefined,
+      [DATE_TIME.UTC]: user?.options?.timezone === 'UTC' ? true : null,
     },
   };
 };
@@ -74,7 +74,7 @@ const GlobalSelectionStore = Reflux.createStore({
           [DATE_TIME.START]: parsed.start || null,
           [DATE_TIME.END]: parsed.end || null,
           [DATE_TIME.PERIOD]: parsed.period || null,
-          [DATE_TIME.UTC]: parsed.utc || undefined,
+          [DATE_TIME.UTC]: parsed.utc || null,
         },
       };
     } else {

--- a/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/index.jsx
@@ -175,7 +175,7 @@ class OrganizationDiscoverContainer extends React.Component {
   render() {
     const {isLoading, savedQuery, view} = this.state;
 
-    const {location, params} = this.props;
+    const {location, params, selection} = this.props;
 
     const {organization} = this.context;
 
@@ -188,6 +188,7 @@ class OrganizationDiscoverContainer extends React.Component {
         >
           <DiscoverWrapper>
             <Discover
+              utc={selection.datetime.utc}
               isLoading={isLoading}
               organization={organization}
               queryBuilder={this.queryBuilder}

--- a/src/sentry/static/sentry/app/views/organizationDiscover/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/utils.jsx
@@ -18,7 +18,7 @@ const VALID_QUERY_KEYS = [
 ];
 
 export function getQueryFromQueryString(queryString) {
-  const queryKeys = new Set([...VALID_QUERY_KEYS, 'utc']);
+  const queryKeys = new Set(VALID_QUERY_KEYS);
   const result = {};
   let parsedQuery = queryString;
   parsedQuery = parsedQuery.replace(/^\?|\/$/g, '').split('&');

--- a/src/sentry/static/sentry/app/views/organizationDiscover/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/utils.jsx
@@ -18,7 +18,7 @@ const VALID_QUERY_KEYS = [
 ];
 
 export function getQueryFromQueryString(queryString) {
-  const queryKeys = new Set(VALID_QUERY_KEYS);
+  const queryKeys = new Set([...VALID_QUERY_KEYS, 'utc']);
   const result = {};
   let parsedQuery = queryString;
   parsedQuery = parsedQuery.replace(/^\?|\/$/g, '').split('&');

--- a/tests/js/spec/views/organizationDiscover/discover.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/discover.spec.jsx
@@ -651,8 +651,9 @@ describe('Discover', function() {
         expect.anything(),
         expect.objectContaining({
           data: expect.objectContaining({
-            start: '2017-10-02T22:41:20',
-            end: '2017-10-16T22:41:20',
+            start: '2017-10-03T02:41:20',
+            end: '2017-10-17T02:41:20',
+            utc: null,
           }),
         })
       );
@@ -680,8 +681,9 @@ describe('Discover', function() {
         expect.anything(),
         expect.objectContaining({
           data: expect.objectContaining({
-            start: '2017-10-01T00:00:00',
-            end: '2017-10-01T23:59:59',
+            start: '2017-10-01T04:00:00',
+            end: '2017-10-02T03:59:59',
+            utc: null,
           }),
         })
       );
@@ -697,8 +699,27 @@ describe('Discover', function() {
         expect.anything(),
         expect.objectContaining({
           data: expect.objectContaining({
+            start: '2017-10-01T00:00:00',
+            end: '2017-10-01T23:59:59',
+            utc: true,
+          }),
+        })
+      );
+
+      wrapper.find('TimeRangeSelector HeaderItem').simulate('click');
+
+      // Switch from UTC
+      wrapper.find('UtcPicker Checkbox').simulate('change');
+      // Hide dropdown
+      wrapper.find('TimeRangeSelector HeaderItem').simulate('click');
+
+      expect(query).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
             start: '2017-10-01T04:00:00',
             end: '2017-10-02T03:59:59',
+            utc: false,
           }),
         })
       );


### PR DESCRIPTION
This fixes issues with bad utc values in url param (generally for
superusers?)

https://github.com/getsentry/sentry/pull/12078 would break toggling UTC in
date picker because we would lose utc state.