### PR TITLE
ref(settings): Clarify help text for per-project rate limit

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationRateLimits/organizationRateLimits.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationRateLimits/organizationRateLimits.jsx
@@ -113,7 +113,7 @@ export default class OrganizationRateLimit extends React.Component {
                 name="projectRateLimit"
                 label={t('Per-Project Limit')}
                 help={t(
-                  'The maximum percentage of your account limit an individual project can consume.'
+                  'The maximum percentage of the account limit above which an individual project can consume.'
                 )}
                 step={5}
                 min={50}

--- a/src/sentry/static/sentry/app/views/settings/organizationRateLimits/organizationRateLimits.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationRateLimits/organizationRateLimits.jsx
@@ -113,7 +113,7 @@ export default class OrganizationRateLimit extends React.Component {
                 name="projectRateLimit"
                 label={t('Per-Project Limit')}
                 help={t(
-                  'The maximum percentage of the account limit above that an individual project can consume.'
+                  'The maximum percentage of the account limit (set above) that an individual project can consume.'
                 )}
                 step={5}
                 min={50}

--- a/src/sentry/static/sentry/app/views/settings/organizationRateLimits/organizationRateLimits.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationRateLimits/organizationRateLimits.jsx
@@ -113,7 +113,7 @@ export default class OrganizationRateLimit extends React.Component {
                 name="projectRateLimit"
                 label={t('Per-Project Limit')}
                 help={t(
-                  'The maximum percentage of the account limit above which an individual project can consume.'
+                  'The maximum percentage of the account limit above that an individual project can consume.'
                 )}
                 step={5}
                 min={50}


### PR DESCRIPTION
A customer was confused and thought the "account limit" was their quota, not the account limit set above, and was upset when they ran out of events. Hopefully this makes it crystal clear what we mean.