### PR TITLE
fix(api): For issue/event search, remap column names that conflict with tags

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -33,11 +33,15 @@ OVERRIDE_OPTIONS = {
     'consistent': os.environ.get('SENTRY_SNUBA_CONSISTENT', 'false').lower() in ('true', '1')
 }
 
+# There are several cases here where we support both a top level column name and
+# a tag with the same name. Existing search patterns expect to refer to the tag,
+# so we support <real_column_name>.name to refer to the top level column name.
 SENTRY_SNUBA_MAP = {
     # general
     'id': 'event_id',
     'project.id': 'project_id',
-    'platform': 'platform',
+    # We support platform as both tag and a real column.
+    'platform.name': 'platform',
     'message': 'message',
     'title': 'title',
     'location': 'location',
@@ -45,8 +49,10 @@ SENTRY_SNUBA_MAP = {
     'issue.id': 'issue',
     'timestamp': 'timestamp',
     'time': 'time',
-    'type': 'type',
-    'version': 'version',
+    # We support type as both tag and a real column
+    'type.name': 'type',
+    # We support version as both tag and a real column
+    'version.name': 'version',
     # user
     'user.id': 'user_id',
     'user.email': 'email',

--- a/tests/snuba/test_organization_discover_query.py
+++ b/tests/snuba/test_organization_discover_query.py
@@ -65,7 +65,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
             url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
-                'fields': ['message', 'platform'],
+                'fields': ['message', 'platform.name'],
                 'start': (datetime.now() - timedelta(seconds=10)).strftime('%Y-%m-%dT%H:%M:%S'),
                 'end': (datetime.now()).strftime('%Y-%m-%dT%H:%M:%S'),
                 'orderby': '-timestamp',
@@ -75,14 +75,14 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert len(response.data['data']) == 1
         assert response.data['data'][0]['message'] == 'message!'
-        assert response.data['data'][0]['platform'] == 'python'
+        assert response.data['data'][0]['platform.name'] == 'python'
 
     def test_relative_dates(self):
         with self.feature('organizations:discover'):
             url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
-                'fields': ['message', 'platform'],
+                'fields': ['message', 'platform.name'],
                 'range': '1d',
                 'orderby': '-timestamp',
                 'start': None,
@@ -92,7 +92,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert len(response.data['data']) == 1
         assert response.data['data'][0]['message'] == 'message!'
-        assert response.data['data'][0]['platform'] == 'python'
+        assert response.data['data'][0]['platform.name'] == 'python'
 
     def test_invalid_date_request(self):
         with self.feature('organizations:discover'):
@@ -156,7 +156,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
             url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
-                'fields': ['message', 'platform', 'stack.in_app'],
+                'fields': ['message', 'platform.name', 'stack.in_app'],
                 'conditions': [['stack.in_app', '=', True]],
                 'start': (datetime.now() - timedelta(seconds=10)).strftime('%Y-%m-%dT%H:%M:%S'),
                 'end': (datetime.now()).strftime('%Y-%m-%dT%H:%M:%S'),
@@ -167,7 +167,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert len(response.data['data']) == 1
         assert response.data['data'][0]['message'] == 'message!'
-        assert response.data['data'][0]['platform'] == 'python'
+        assert response.data['data'][0]['platform.name'] == 'python'
 
     def test_array_join(self):
         with self.feature('organizations:discover'):


### PR DESCRIPTION
We have a few cases where people have existing searches that search on `platform`, `type`,
`version`, etc. These are valid columns in snuba, but previously we treated them as tags when
searching on them. To not break existing searches, I'm remapping these columns to `<column>.name` in
our searches.

For reference, a list of these types of fields is available at
https://github.com/getsentry/snuba/blob/fcc0bc6be085afb0879904e99dd007409dea4e58/snuba/clickhouse.py#L441