### PR TITLE
fix(api): Fix has:user queries in search

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -100,6 +100,7 @@ SENTRY_SNUBA_MAP = {
     'contexts.value': 'contexts.value',
     # misc
     'release': 'tags[sentry:release]',
+    'user': 'sentry:user',
 }
 
 


### PR DESCRIPTION
This used to map to `sentry:user`, so adding it back in. We also used to support user:(email|id|ip)
etc, which we should probably also add support back in for. Will do so separately.