### PR TITLE
feat: Added better virtualenv config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,7 +46,7 @@
   "python.formatting.provider": "autopep8",
   "python.formatting.autopep8Args": ["--global-config", "${workspaceRoot}/setup.cfg"],
   // https://github.com/DonJayamanne/pythonVSCode/issues/992
-  "python.pythonPath": "/usr/local/opt/python@2/bin/python2.7",
+  "python.pythonPath": ".venv/bin/python",
   // test discovery is sluggish and the UI around running
   // tests is often in your way and misclicked
   "python.unitTest.pyTestEnabled": false,

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,12 @@ PIP = LDFLAGS="$(LDFLAGS)" pip
 WEBPACK = NODE_ENV=production ./node_modules/.bin/webpack
 YARN_VERSION = 1.13.0
 
-develop: setup-git develop-only
+develop: setup-git ensure-venv develop-only
 develop-only: update-submodules install-system-pkgs install-yarn-pkgs install-sentry-dev
 test: develop lint test-js test-python test-cli
+
+ensure-venv:
+	@./scripts/ensure-venv.sh
 
 build: locale
 

--- a/scripts/ensure-venv.sh
+++ b/scripts/ensure-venv.sh
@@ -2,7 +2,7 @@
 set -xe
 
 # if we already have a venv, we can leave
-if [ -f .venv/bin/python ]; then
+if .venv/bin/python --version &> /dev/null; then
   exit 0
 fi
 

--- a/scripts/ensure-venv.sh
+++ b/scripts/ensure-venv.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# if we already have a venv, we can leave
+if [ -f .venv/bin/python ]; then
+  exit 0
+fi
+
+# do we have a WORKON_HOME? Prime from there
+if [ "x$WORKON_HOME" != x ]; then
+  ln -s "${WORKON_HOME}/sentry" .venv
+  exit 0
+fi
+
+# otherwise make a new virtualenv from scratch
+virtualenv -ppython2.7 .venv

--- a/scripts/ensure-venv.sh
+++ b/scripts/ensure-venv.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -xe
 
 # if we already have a venv, we can leave
 if [ -f .venv/bin/python ]; then


### PR DESCRIPTION
Someone accidentally broke the virtualenv config three days ago and I think that
few people noticed says that our vscode config is probably already not working for
a lot of people.  I know that I had to git assume the file for a long time because
of how I have this set up.

The new behavior is that we use a .venv in our codebase and that is either assumed
to be a symlink to wherever you want, we also try to use WORKON_HOME/sentry for
the initial run or make a new virtualenv on the spot.