### PR TITLE
feat: Refactor eventtypes to take data by argument

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -88,7 +88,7 @@ def get_tag(data, key):
             return v
 
 
-def get_event_metadata_compat(data, fallback_message):
+def get_event_metadata_compat(data):
     """This is a fallback path to getting the event metadata.  This is used
     by some code paths that could potentially deal with old sentry events that
     do not have metadata yet.  This does not happen in practice any more but
@@ -96,7 +96,7 @@ def get_event_metadata_compat(data, fallback_message):
     """
     etype = data.get('type') or 'default'
     if 'metadata' not in data:
-        return eventtypes.get(etype)(data).get_metadata()
+        return eventtypes.get(etype)().get_metadata(data)
     return data['metadata']
 
 
@@ -563,7 +563,7 @@ class EventManager(object):
 
     def get_event_type(self):
         """Returns the event type."""
-        return eventtypes.get(self._data.get('type', 'default'))(self._data)
+        return eventtypes.get(self._data.get('type', 'default'))()
 
     def get_search_message(self, event_metadata=None, culprit=None):
         """This generates the internal event.message attribute which is used
@@ -571,7 +571,7 @@ class EventManager(object):
         the culprit.
         """
         if event_metadata is None:
-            event_metadata = self.get_event_type().get_metadata()
+            event_metadata = self.get_event_type().get_metadata(self._data)
         if culprit is None:
             culprit = self.get_culprit()
 
@@ -730,7 +730,7 @@ class EventManager(object):
         hashes = event.get_hashes()
 
         event_type = self.get_event_type()
-        event_metadata = event_type.get_metadata()
+        event_metadata = event_type.get_metadata(self._data)
 
         data['hashes'] = hashes
 

--- a/src/sentry/eventtypes/base.py
+++ b/src/sentry/eventtypes/base.py
@@ -9,13 +9,10 @@ from sentry.utils.safe import get_path
 class BaseEvent(object):
     id = None
 
-    def __init__(self, data):
-        self.data = data
-
-    def has_metadata(self):
+    def has_metadata(self, data):
         raise NotImplementedError
 
-    def get_metadata(self):
+    def get_metadata(self, data):
         raise NotImplementedError
 
     def get_title(self, metadata):
@@ -33,13 +30,13 @@ class BaseEvent(object):
 class DefaultEvent(BaseEvent):
     key = 'default'
 
-    def has_metadata(self):
+    def has_metadata(self, data):
         # the default event can always work
         return True
 
-    def get_metadata(self):
-        message = strip(get_path(self.data, 'logentry', 'formatted') or
-                        get_path(self.data, 'logentry', 'message'))
+    def get_metadata(self, data):
+        message = strip(get_path(data, 'logentry', 'formatted') or
+                        get_path(data, 'logentry', 'message'))
 
         if message:
             title = truncatechars(message.splitlines()[0], 100)

--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -23,12 +23,12 @@ def get_crash_file(stacktrace):
 class ErrorEvent(BaseEvent):
     key = 'error'
 
-    def has_metadata(self):
-        exception = get_path(self.data, 'exception', 'values', -1)
+    def has_metadata(self, data):
+        exception = get_path(data, 'exception', 'values', -1)
         return exception and any(v is not None for v in six.itervalues(exception))
 
-    def get_metadata(self):
-        exception = get_path(self.data, 'exception', 'values', -1)
+    def get_metadata(self, data):
+        exception = get_path(data, 'exception', 'values', -1)
 
         # in some situations clients are submitting non-string data for these
         rv = {

--- a/src/sentry/eventtypes/security.py
+++ b/src/sentry/eventtypes/security.py
@@ -6,14 +6,14 @@ from .base import BaseEvent
 class CspEvent(BaseEvent):
     key = 'csp'
 
-    def has_metadata(self):
-        return self.data.get('csp') is not None
+    def has_metadata(self, data):
+        return data.get('csp') is not None
 
-    def get_metadata(self):
+    def get_metadata(self, data):
         from sentry.interfaces.security import Csp
         # TODO(dcramer): pull get message into here to avoid instantiation
         # or ensure that these get interfaces passed instead of raw data
-        csp = Csp.to_python(self.data['csp'])
+        csp = Csp.to_python(data['csp'])
 
         return {
             'directive': csp.effective_directive,
@@ -31,12 +31,12 @@ class CspEvent(BaseEvent):
 class HpkpEvent(BaseEvent):
     key = 'hpkp'
 
-    def has_metadata(self):
-        return self.data.get('hpkp') is not None
+    def has_metadata(self, data):
+        return data.get('hpkp') is not None
 
-    def get_metadata(self):
+    def get_metadata(self, data):
         from sentry.interfaces.security import Hpkp
-        hpkp = Hpkp.to_python(self.data['hpkp'])
+        hpkp = Hpkp.to_python(data['hpkp'])
         return {
             'origin': hpkp.get_origin(),
             'message': hpkp.get_message(),
@@ -52,12 +52,12 @@ class HpkpEvent(BaseEvent):
 class ExpectCTEvent(BaseEvent):
     key = 'expectct'
 
-    def has_metadata(self):
-        return self.data.get('expectct') is not None
+    def has_metadata(self, data):
+        return data.get('expectct') is not None
 
-    def get_metadata(self):
+    def get_metadata(self, data):
         from sentry.interfaces.security import ExpectCT
-        expectct = ExpectCT.to_python(self.data['expectct'])
+        expectct = ExpectCT.to_python(data['expectct'])
         return {
             'origin': expectct.get_origin(),
             'message': expectct.get_message(),
@@ -73,12 +73,12 @@ class ExpectCTEvent(BaseEvent):
 class ExpectStapleEvent(BaseEvent):
     key = 'expectstaple'
 
-    def has_metadata(self):
-        return self.data.get('expectstaple') is not None
+    def has_metadata(self, data):
+        return data.get('expectstaple') is not None
 
-    def get_metadata(self):
+    def get_metadata(self, data):
         from sentry.interfaces.security import ExpectStaple
-        expectstaple = ExpectStaple.to_python(self.data['expectstaple'])
+        expectstaple = ExpectStaple.to_python(data['expectstaple'])
         return {
             'origin': expectstaple.get_origin(),
             'message': expectstaple.get_message(),

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -140,7 +140,7 @@ class Event(Model):
         See ``sentry.eventtypes``.
         """
         from sentry.event_manager import get_event_metadata_compat
-        return get_event_metadata_compat(self.data, self.message)
+        return get_event_metadata_compat(self.data)
 
     def get_hashes(self):
         """
@@ -161,7 +161,7 @@ class Event(Model):
     @property
     def title(self):
         # also see event_manager.py which inserts this for snuba
-        et = eventtypes.get(self.get_event_type())(self.data)
+        et = eventtypes.get(self.get_event_type())()
         return et.get_title(self.get_event_metadata())
 
     @property
@@ -172,7 +172,7 @@ class Event(Model):
     @property
     def location(self):
         # also see event_manager.py which inserts this for snuba
-        et = eventtypes.get(self.get_event_type())(self.data)
+        et = eventtypes.get(self.get_event_type())()
         return et.get_location(self.get_event_metadata())
 
     @property
@@ -218,9 +218,8 @@ class Event(Model):
 
     def get_tags(self):
         try:
-            rv = [(t, v) for t, v in get_path(
-                self.data, 'tags', filter=True) or () if t is not None and v is not None]
-            rv.sort()
+            rv = sorted([(t, v) for t, v in get_path(
+                self.data, 'tags', filter=True) or () if t is not None and v is not None])
             return rv
         except ValueError:
             # at one point Sentry allowed invalid tag sets such as (foo, bar)

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -417,15 +417,15 @@ class Group(Model):
         See ``sentry.eventtypes``.
         """
         from sentry.event_manager import get_event_metadata_compat
-        return get_event_metadata_compat(self.data, self.message)
+        return get_event_metadata_compat(self.data)
 
     @property
     def title(self):
-        et = eventtypes.get(self.get_event_type())(self.data)
+        et = eventtypes.get(self.get_event_type())()
         return et.get_title(self.get_event_metadata())
 
     def location(self):
-        et = eventtypes.get(self.get_event_type())(self.data)
+        et = eventtypes.get(self.get_event_type())()
         return et.get_location(self.get_event_metadata())
 
     def error(self):

--- a/src/sentry/models/grouptombstone.py
+++ b/src/sentry/models/grouptombstone.py
@@ -48,4 +48,4 @@ class GroupTombstone(Model):
         See ``sentry.eventtypes``.
         """
         from sentry.event_manager import get_event_metadata_compat
-        return get_event_metadata_compat(self.data, self.message)
+        return get_event_metadata_compat(self.data)

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -203,12 +203,13 @@ class ActivityMailDebugView(View):
 
         event_manager = EventManager(data)
         event_manager.normalize()
+        data = event_manager.get_data()
         event_type = event_manager.get_event_type()
 
-        group.mesage = event_manager.get_search_message()
+        group.message = event_manager.get_search_message()
         group.data = {
             'type': event_type.key,
-            'metadata': event_type.get_metadata(),
+            'metadata': event_type.get_metadata(data),
         }
 
         event = Event(
@@ -266,6 +267,7 @@ def alert(request):
 
     event_manager = EventManager(data)
     event_manager.normalize()
+    data = event_manager.get_data()
     event = event_manager.save(project.id)
     # Prevent Percy screenshot from constantly changing
     event.datetime = datetime(2017, 9, 6, 0, 0)
@@ -275,7 +277,7 @@ def alert(request):
     group.message = event_manager.get_search_message()
     group.data = {
         'type': event_type.key,
-        'metadata': event_type.get_metadata(),
+        'metadata': event_type.get_metadata(data),
     }
 
     rule = Rule(label="An example rule")

--- a/tests/sentry/eventtypes/test_default.py
+++ b/tests/sentry/eventtypes/test_default.py
@@ -6,35 +6,38 @@ from sentry.testutils import TestCase
 
 class DefaultEventTest(TestCase):
     def test_get_metadata(self):
-        inst = DefaultEvent({})
-        assert inst.get_metadata() == {
+        inst = DefaultEvent()
+        assert inst.get_metadata({}) == {
             'title': '<unlabeled event>'
         }
 
-        inst = DefaultEvent({
+        inst = DefaultEvent()
+        data = {
             'logentry': {
                 'formatted': '  ',
             }
-        })
-        assert inst.get_metadata() == {
+        }
+        assert inst.get_metadata(data) == {
             'title': '<unlabeled event>'
         }
 
-        inst = DefaultEvent({
+        inst = DefaultEvent()
+        data = {
             'logentry': {
                 'formatted': 'foo',
                 'message': 'bar',
             }
-        })
-        assert inst.get_metadata() == {
+        }
+        assert inst.get_metadata(data) == {
             'title': 'foo'
         }
 
-        inst = DefaultEvent({
+        inst = DefaultEvent()
+        data = {
             'logentry': {
                 'message': 'foo',
             }
-        })
-        assert inst.get_metadata() == {
+        }
+        assert inst.get_metadata(data) == {
             'title': 'foo'
         }

--- a/tests/sentry/eventtypes/test_error.py
+++ b/tests/sentry/eventtypes/test_error.py
@@ -6,71 +6,80 @@ from sentry.testutils import TestCase
 
 class ErrorEventTest(TestCase):
     def test_has_metadata_none(self):
-        inst = ErrorEvent({})
-        assert not inst.has_metadata()
+        inst = ErrorEvent()
+        assert not inst.has_metadata({})
 
-        inst = ErrorEvent({'exception': None})
-        assert not inst.has_metadata()
+        inst = ErrorEvent()
+        data = {'exception': None}
+        assert not inst.has_metadata(data)
 
-        inst = ErrorEvent({'exception': {'values': None}})
-        assert not inst.has_metadata()
+        inst = ErrorEvent()
+        data = {'exception': {'values': None}}
+        assert not inst.has_metadata(data)
 
-        inst = ErrorEvent({'exception': {'values': [None]}})
-        assert not inst.has_metadata()
+        inst = ErrorEvent()
+        data = {'exception': {'values': [None]}}
+        assert not inst.has_metadata(data)
 
-        inst = ErrorEvent({'exception': {'values': [{}]}})
-        assert not inst.has_metadata()
+        inst = ErrorEvent()
+        data = {'exception': {'values': [{}]}}
+        assert not inst.has_metadata(data)
 
-        inst = ErrorEvent({'exception': {'values': [{
+        inst = ErrorEvent()
+        data = {'exception': {'values': [{
             'type': None,
             'value': None,
-        }]}})
-        assert not inst.has_metadata()
+        }]}}
+        assert not inst.has_metadata(data)
 
     def test_has_metadata(self):
-        inst = ErrorEvent({'exception': {'values': [{
+        inst = ErrorEvent()
+        data = {'exception': {'values': [{
             'type': 'Exception',
             'value': 'Foo',
-        }]}})
-        assert inst.has_metadata()
+        }]}}
+        assert inst.has_metadata(data)
 
-        inst = ErrorEvent({'exception': {'values': [{
+        inst = ErrorEvent()
+        data = {'exception': {'values': [{
             'stacktrace': {},
-        }]}})
-        assert inst.has_metadata()
+        }]}}
+        assert inst.has_metadata(data)
 
     def test_get_metadata(self):
-        inst = ErrorEvent({'exception': {'values': [{
+        inst = ErrorEvent()
+        data = {'exception': {'values': [{
             'type': 'Exception',
             'value': 'Foo',
-        }]}})
-        assert inst.get_metadata() == {
+        }]}}
+        assert inst.get_metadata(data) == {
             'type': 'Exception',
             'value': 'Foo',
         }
 
     def test_get_metadata_none(self):
-        inst = ErrorEvent({'exception': {'values': [{
+        inst = ErrorEvent()
+        data = {'exception': {'values': [{
             'type': None,
             'value': None,
             'stacktrace': {},
-        }]}})
-        assert inst.get_metadata() == {
+        }]}}
+        assert inst.get_metadata(data) == {
             'type': 'Error',
             'value': '',
         }
 
     def test_get_title_none_value(self):
-        inst = ErrorEvent({})
+        inst = ErrorEvent()
         result = inst.get_title({'type': 'Error', 'value': None})
         assert result == 'Error'
 
     def test_get_title_eliminates_values_with_newline(self):
-        inst = ErrorEvent({})
+        inst = ErrorEvent()
         result = inst.get_title({'type': 'Error', 'value': 'foo\nbar'})
         assert result == 'Error: foo'
 
     def test_get_title_handles_empty_value(self):
-        inst = ErrorEvent({})
+        inst = ErrorEvent()
         result = inst.get_title({'type': 'Error', 'value': ''})
         assert result == 'Error'

--- a/tests/sentry/plugins/mail/tests.py
+++ b/tests/sentry/plugins/mail/tests.py
@@ -135,7 +135,7 @@ class MailPluginTest(TestCase):
             short_id=2,
             data={
                 'type': event_type.key,
-                'metadata': event_type.get_metadata(),
+                'metadata': event_type.get_metadata(event_data),
             }
         )
 
@@ -178,7 +178,7 @@ class MailPluginTest(TestCase):
             short_id=2,
             data={
                 'type': event_type.key,
-                'metadata': event_type.get_metadata(),
+                'metadata': event_type.get_metadata(event_data),
             }
         )
 


### PR DESCRIPTION
The current event type constructor needs a data dictionary even if we
only want to deal with metadata.  This is no longer useful and we
already pass an incorrect data dictionary in some cases when we only
want to read the metadata.

This moves the data so that its passed to the event type method
directly.