### PR TITLE
feat: Remove deprecated event metadata compat code path

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -88,18 +88,6 @@ def get_tag(data, key):
             return v
 
 
-def get_event_metadata_compat(data):
-    """This is a fallback path to getting the event metadata.  This is used
-    by some code paths that could potentially deal with old sentry events that
-    do not have metadata yet.  This does not happen in practice any more but
-    the testsuite was never adapted so the tests hit this code path constantly.
-    """
-    etype = data.get('type') or 'default'
-    if 'metadata' not in data:
-        return eventtypes.get(etype)().get_metadata(data)
-    return data['metadata']
-
-
 def count_limit(count):
     # TODO: could we do something like num_to_store = max(math.sqrt(100*count)+59, 200) ?
     # ~ 150 * ((log(n) - 1.5) ^ 2 - 0.25)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -742,6 +742,7 @@ class EventManager(object):
         materialized_metadata = self.materialize_metadata()
         event_metadata = materialized_metadata['metadata']
         data.update(materialized_metadata)
+        data['culprit'] = culprit
 
         # index components into ``Event.message``
         # See GH-3248

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -139,8 +139,7 @@ class Event(Model):
 
         See ``sentry.eventtypes``.
         """
-        from sentry.event_manager import get_event_metadata_compat
-        return get_event_metadata_compat(self.data)
+        return self.data['metadata']
 
     def get_hashes(self):
         """

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -416,8 +416,7 @@ class Group(Model):
 
         See ``sentry.eventtypes``.
         """
-        from sentry.event_manager import get_event_metadata_compat
-        return get_event_metadata_compat(self.data)
+        return self.data['metadata']
 
     @property
     def title(self):

--- a/src/sentry/models/grouptombstone.py
+++ b/src/sentry/models/grouptombstone.py
@@ -47,5 +47,4 @@ class GroupTombstone(Model):
 
         See ``sentry.eventtypes``.
         """
-        from sentry.event_manager import get_event_metadata_compat
-        return get_event_metadata_compat(self.data)
+        return self.data['metadata']

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -507,14 +507,7 @@ class Fixtures(object):
                                    for_store=False)
             manager.normalize()
             kwargs['data'] = manager.get_data()
-
-            event_type = manager.get_event_type()
-            event_metadata = event_type.get_metadata(kwargs['data'])
-            kwargs['data']['type'] = event_type.key
-            kwargs['data']['metadata'] = event_metadata
-            kwargs['data']['title'] = event_type.get_title(event_metadata)
-            kwargs['data']['location'] = event_type.get_location(event_metadata)
-
+            kwargs['data'].update(manager.materialize_metadata())
             kwargs['message'] = manager.get_search_message()
 
         event = Event(event_id=event_id, **kwargs)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -507,6 +507,14 @@ class Fixtures(object):
                                    for_store=False)
             manager.normalize()
             kwargs['data'] = manager.get_data()
+
+            event_type = manager.get_event_type()
+            event_metadata = event_type.get_metadata(kwargs['data'])
+            kwargs['data']['type'] = event_type.key
+            kwargs['data']['metadata'] = event_metadata
+            kwargs['data']['title'] = event_type.get_title(event_metadata)
+            kwargs['data']['location'] = event_type.get_location(event_metadata)
+
             kwargs['message'] = manager.get_search_message()
 
         event = Event(event_id=event_id, **kwargs)

--- a/tests/sentry/plugins/mail/tests.py
+++ b/tests/sentry/plugins/mail/tests.py
@@ -124,6 +124,8 @@ class MailPluginTest(TestCase):
         event_manager.normalize()
         event_data = event_manager.get_data()
         event_type = event_manager.get_event_type()
+        event_data['type'] = event_type.key
+        event_data['metadata'] = event_type.get_metadata(event_data)
 
         group = Group(
             id=2,
@@ -167,6 +169,8 @@ class MailPluginTest(TestCase):
         event_manager.normalize()
         event_data = event_manager.get_data()
         event_type = event_manager.get_event_type()
+        event_data['type'] = event_type.key
+        event_data['metadata'] = event_type.get_metadata(event_data)
 
         group = Group(
             id=2,
@@ -552,7 +556,7 @@ class MailPluginOwnersTest(TestCase):
         )
 
     def make_event_data(self, filename, url='http://example.com'):
-        data = {
+        mgr = EventManager({
             'tags': [('level', 'error')],
             'stacktrace': {
                 'frames': [
@@ -565,7 +569,13 @@ class MailPluginOwnersTest(TestCase):
             'request': {
                 'url': url
             },
-        }
+        })
+        mgr.normalize()
+        data = mgr.get_data()
+        event_type = mgr.get_event_type()
+        data['type'] = event_type.key
+        data['metadata'] = event_type.get_metadata(data)
+
         return data
 
     def assert_notify(self, event, emails_sent_to):


### PR DESCRIPTION
Metadata has been written for about two years now, this code path only
existed because of some legacy tests.  Some tests are still very brittle
and I just patched them up now.  Longer term the testsuite would benefit
from using the new `store_event` function rather than using the
`create_event` method which has a hacked together emulation of what
happens during store.