### PR TITLE
ref: Move culprit generating code into eventtypes

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -18,8 +18,7 @@ from django.utils.encoding import force_text
 
 from sentry import buffer, eventtypes, eventstream, features, tagstore, tsdb, filters
 from sentry.constants import (
-    LOG_LEVELS, LOG_LEVELS_MAP, MAX_CULPRIT_LENGTH, VALID_PLATFORMS,
-    MAX_TAG_VALUE_LENGTH,
+    LOG_LEVELS, LOG_LEVELS_MAP, VALID_PLATFORMS, MAX_TAG_VALUE_LENGTH,
 )
 from sentry.coreapi import (
     APIError,
@@ -52,7 +51,6 @@ from sentry.utils.data_filters import (
 from sentry.utils.dates import to_timestamp
 from sentry.utils.db import is_postgres, is_mysql
 from sentry.utils.safe import safe_execute, trim, get_path, setdefault_path
-from sentry.utils.strings import truncatechars
 from sentry.utils.geo import rust_geoip
 from sentry.utils.validators import is_float
 from sentry.utils.contexts_normalization import normalize_user_agent
@@ -133,31 +131,6 @@ else:
             return False
 
         return True
-
-
-def generate_culprit(data, platform=None):
-    exceptions = get_path(data, 'exception', 'values')
-    if exceptions:
-        stacktraces = [e['stacktrace'] for e in exceptions if get_path(e, 'stacktrace', 'frames')]
-    else:
-        stacktrace = data.get('stacktrace')
-        if stacktrace and stacktrace.get('frames'):
-            stacktraces = [stacktrace]
-        else:
-            stacktraces = None
-
-    culprit = None
-
-    if not culprit and stacktraces:
-        from sentry.interfaces.stacktrace import Stacktrace
-        culprit = Stacktrace.to_python(stacktraces[-1]).get_culprit_string(
-            platform=platform,
-        )
-
-    if not culprit and data.get('request'):
-        culprit = get_path(data, 'request', 'url')
-
-    return truncatechars(culprit or '', MAX_CULPRIT_LENGTH)
 
 
 def plugin_is_regression(group, event):
@@ -542,12 +515,9 @@ class EventManager(object):
 
     def get_culprit(self):
         """Helper to calculate the default culprit"""
-        return force_text(
-            self._data.get('culprit') or
-            self._data.get('transaction') or
-            generate_culprit(self._data, platform=self._data['platform']) or
-            ''
-        )
+        # Callers should not use this function any more.  The culprit is now
+        # part of the materialized metadata.
+        return self.materialize_metadata()['culprit']
 
     def get_event_type(self):
         """Returns the event type."""
@@ -564,6 +534,7 @@ class EventManager(object):
         return {
             'type': event_type.key,
             'metadata': event_metadata,
+            'culprit': event_type.get_culprit(event_metadata),
             'title': event_type.get_title(event_metadata),
             'location': event_type.get_location(event_metadata),
         }

--- a/src/sentry/eventtypes/base.py
+++ b/src/sentry/eventtypes/base.py
@@ -4,6 +4,7 @@ from warnings import warn
 
 from sentry.utils.strings import truncatechars, strip
 from sentry.utils.safe import get_path
+from sentry.constants import MAX_CULPRIT_LENGTH
 
 
 class BaseEvent(object):
@@ -13,7 +14,39 @@ class BaseEvent(object):
         raise NotImplementedError
 
     def get_metadata(self, data):
-        raise NotImplementedError
+        return {
+            'culprit': self.generate_culprit_for_data(data),
+        }
+
+    def generate_culprit_for_data(self, data):
+        # If a value has been forced by the client we use that one.
+        forced = data.get('culprit') or data.get('transaction')
+        if forced:
+            return forced
+
+        exceptions = get_path(data, 'exception', 'values')
+        if exceptions:
+            stacktraces = [e['stacktrace']
+                           for e in exceptions if get_path(e, 'stacktrace', 'frames')]
+        else:
+            stacktrace = data.get('stacktrace')
+            if stacktrace and stacktrace.get('frames'):
+                stacktraces = [stacktrace]
+            else:
+                stacktraces = None
+
+        culprit = None
+
+        if not culprit and stacktraces:
+            from sentry.interfaces.stacktrace import Stacktrace
+            culprit = Stacktrace.to_python(stacktraces[-1]).get_culprit_string(
+                platform=data.get('platform'),
+            )
+
+        if not culprit and data.get('request'):
+            culprit = get_path(data, 'request', 'url')
+
+        return truncatechars(culprit or '', MAX_CULPRIT_LENGTH)
 
     def get_title(self, metadata):
         raise NotImplementedError
@@ -26,6 +59,9 @@ class BaseEvent(object):
                                 stacklevel=2))
         return self.get_title()
 
+    def get_culprit(self, metadata):
+        return metadata.get('culprit')
+
 
 class DefaultEvent(BaseEvent):
     key = 'default'
@@ -35,6 +71,7 @@ class DefaultEvent(BaseEvent):
         return True
 
     def get_metadata(self, data):
+        rv = BaseEvent.get_metadata(self, data)
         message = strip(get_path(data, 'logentry', 'formatted') or
                         get_path(data, 'logentry', 'message'))
 
@@ -42,10 +79,8 @@ class DefaultEvent(BaseEvent):
             title = truncatechars(message.splitlines()[0], 100)
         else:
             title = '<unlabeled event>'
-
-        return {
-            'title': title,
-        }
+        rv['title'] = title
+        return rv
 
     def get_title(self, metadata):
         return metadata['title']

--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -28,13 +28,12 @@ class ErrorEvent(BaseEvent):
         return exception and any(v is not None for v in six.itervalues(exception))
 
     def get_metadata(self, data):
+        rv = BaseEvent.get_metadata(self)
         exception = get_path(data, 'exception', 'values', -1)
 
         # in some situations clients are submitting non-string data for these
-        rv = {
-            'type': trim(get_path(exception, 'type', default='Error'), 128),
-            'value': trim(get_path(exception, 'value', default=''), 1024),
-        }
+        rv['type'] = trim(get_path(exception, 'type', default='Error'), 128)
+        rv['value'] = trim(get_path(exception, 'value', default=''), 1024)
 
         # Attach crash location
         if exception:

--- a/src/sentry/eventtypes/security.py
+++ b/src/sentry/eventtypes/security.py
@@ -10,16 +10,20 @@ class CspEvent(BaseEvent):
         return data.get('csp') is not None
 
     def get_metadata(self, data):
+        rv = BaseEvent.get_metadata(self, data)
+
         from sentry.interfaces.security import Csp
         # TODO(dcramer): pull get message into here to avoid instantiation
         # or ensure that these get interfaces passed instead of raw data
         csp = Csp.to_python(data['csp'])
 
-        return {
+        rv.update({
             'directive': csp.effective_directive,
             'uri': csp._normalized_blocked_uri,
             'message': csp.get_message(),
-        }
+        })
+
+        return rv
 
     def get_title(self, metadata):
         return metadata['message']
@@ -35,12 +39,14 @@ class HpkpEvent(BaseEvent):
         return data.get('hpkp') is not None
 
     def get_metadata(self, data):
+        rv = BaseEvent.get_metadata(self, data)
         from sentry.interfaces.security import Hpkp
         hpkp = Hpkp.to_python(data['hpkp'])
-        return {
+        rv.update({
             'origin': hpkp.get_origin(),
             'message': hpkp.get_message(),
-        }
+        })
+        return rv
 
     def get_title(self, metadata):
         return metadata['message']
@@ -56,12 +62,14 @@ class ExpectCTEvent(BaseEvent):
         return data.get('expectct') is not None
 
     def get_metadata(self, data):
+        rv = BaseEvent.get_metadata(self, data)
         from sentry.interfaces.security import ExpectCT
         expectct = ExpectCT.to_python(data['expectct'])
-        return {
+        rv.update({
             'origin': expectct.get_origin(),
             'message': expectct.get_message(),
-        }
+        })
+        return rv
 
     def get_title(self, metadata):
         return metadata['message']
@@ -77,12 +85,14 @@ class ExpectStapleEvent(BaseEvent):
         return data.get('expectstaple') is not None
 
     def get_metadata(self, data):
+        rv = BaseEvent.get_metadata(self, data)
         from sentry.interfaces.security import ExpectStaple
         expectstaple = ExpectStaple.to_python(data['expectstaple'])
-        return {
+        rv.update({
             'origin': expectstaple.get_origin(),
             'message': expectstaple.get_message(),
-        }
+        })
+        return rv
 
     def get_title(self, metadata):
         return metadata['message']


### PR DESCRIPTION
This is the initial support for moving culprit closer together with the rest
of the event metadata deriving to make it customizable on a per platform basis.