### PR TITLE
feat(business): Add power feature icons 

### DIFF
--- a/src/sentry/static/sentry/app/components/hovercard.jsx
+++ b/src/sentry/static/sentry/app/components/hovercard.jsx
@@ -82,7 +82,7 @@ class Hovercard extends React.Component {
   }
 
   render() {
-    const {containerClassName, className, header, body, bodyClassName} = this.props;
+    const {bodyClassName, containerClassName, className, header, body} = this.props;
     const {rendered, visible, position} = this.state;
 
     // Maintain the hovercard class name for BC with less styles

--- a/src/sentry/static/sentry/app/components/hovercard.jsx
+++ b/src/sentry/static/sentry/app/components/hovercard.jsx
@@ -15,6 +15,7 @@ class Hovercard extends React.Component {
     containerClassName: PropTypes.string,
     header: PropTypes.node,
     body: PropTypes.node,
+    bodyClassName: PropTypes.string,
   };
 
   static defaultProps = {
@@ -81,7 +82,7 @@ class Hovercard extends React.Component {
   }
 
   render() {
-    const {containerClassName, className, header, body} = this.props;
+    const {containerClassName, className, header, body, bodyClassName} = this.props;
     const {rendered, visible, position} = this.state;
 
     // Maintain the hovercard class name for BC with less styles
@@ -104,7 +105,7 @@ class Hovercard extends React.Component {
             innerRef={this.cardElement}
           >
             {header && <Header>{header}</Header>}
-            {body && <Body>{body}</Body>}
+            {body && <Body className={bodyClassName}>{body}</Body>}
           </StyledHovercard>
         )}
       </Container>

--- a/src/sentry/static/sentry/app/components/sidebar/broadcasts.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/broadcasts.jsx
@@ -150,6 +150,7 @@ const Broadcasts = createReactClass({
           icon={<InlineSvg src="icon-broadcast" size="22px" />}
           label={t("What's new")}
           onClick={this.handleShowPanel}
+          id="broadcasts"
         />
 
         {showPanel &&

--- a/src/sentry/static/sentry/app/components/sidebar/help.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/help.jsx
@@ -44,6 +44,7 @@ class SidebarHelp extends React.Component {
                   hasPanel={false}
                   icon={<InlineSvg src="icon-circle-question" />}
                   label={t('Help')}
+                  id="help"
                 />
               </HelpActor>
 

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -15,6 +15,7 @@ import {load as loadIncidents} from 'app/actionCreators/incidents';
 import {t} from 'app/locale';
 import ConfigStore from 'app/stores/configStore';
 import Feature from 'app/components/acl/feature';
+import Hook from 'app/components/hook';
 import InlineSvg from 'app/components/inlineSvg';
 import PreferencesStore from 'app/stores/preferencesStore';
 import SentryTypes from 'app/sentryTypes';
@@ -411,6 +412,13 @@ class Sidebar extends React.Component {
         {hasOrganization && (
           <SidebarSectionGroup>
             <SidebarSection>
+              <Hook
+                name="sidebar:power"
+                {...sidebarItemProps}
+                onClick={this.hidePanel}
+                organization={organization}
+              />
+
               <SidebarHelp
                 orientation={orientation}
                 collapsed={collapsed}

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -262,6 +262,7 @@ class Sidebar extends React.Component {
                     icon={<InlineSvg src="icon-issues" />}
                     label={t('Issues')}
                     to={`/organizations/${organization.slug}/issues/`}
+                    id="issues"
                   />
                 </Feature>
 
@@ -292,6 +293,7 @@ class Sidebar extends React.Component {
                       icon={<InlineSvg src="icon-releases" />}
                       label={t('Releases')}
                       to={`/organizations/${organization.slug}/releases/`}
+                      id="releases"
                     />
                     <SidebarItem
                       {...sidebarItemProps}
@@ -303,6 +305,7 @@ class Sidebar extends React.Component {
                       icon={<InlineSvg src="icon-support" />}
                       label={t('User Feedback')}
                       to={`/organizations/${organization.slug}/user-feedback/`}
+                      id="user-feedback"
                     />
                   </React.Fragment>
                 )}
@@ -354,6 +357,7 @@ class Sidebar extends React.Component {
                   icon={<InlineSvg src="icon-labs" />}
                   label={t('Monitors')}
                   to={`/organizations/${organization.slug}/monitors/`}
+                  id="monitors"
                 />
               </Feature>
 
@@ -365,6 +369,7 @@ class Sidebar extends React.Component {
                     icon={<InlineSvg src="icon-user" />}
                     label={t('Assigned to me')}
                     to={`/organizations/${organization.slug}/issues/assigned/`}
+                    id="assigned"
                   />
                   <SidebarItem
                     {...sidebarItemProps}
@@ -372,6 +377,7 @@ class Sidebar extends React.Component {
                     icon={<InlineSvg src="icon-star" />}
                     label={t('Bookmarked issues')}
                     to={`/organizations/${organization.slug}/issues/bookmarks/`}
+                    id="bookmarks"
                   />
                   <SidebarItem
                     {...sidebarItemProps}
@@ -379,6 +385,7 @@ class Sidebar extends React.Component {
                     icon={<InlineSvg src="icon-history" />}
                     label={t('Recently viewed')}
                     to={`/organizations/${organization.slug}/issues/history/`}
+                    id="history"
                   />
                 </SidebarSection>
               )}
@@ -390,6 +397,7 @@ class Sidebar extends React.Component {
                   icon={<InlineSvg src="icon-activity" />}
                   label={t('Activity')}
                   to={`/organizations/${organization.slug}/activity/`}
+                  id="activity"
                 />
                 <SidebarItem
                   {...sidebarItemProps}
@@ -397,6 +405,7 @@ class Sidebar extends React.Component {
                   icon={<InlineSvg src="icon-stats" />}
                   label={t('Stats')}
                   to={`/organizations/${organization.slug}/stats/`}
+                  id="stats"
                 />
               </SidebarSection>
 
@@ -407,6 +416,7 @@ class Sidebar extends React.Component {
                   icon={<InlineSvg src="icon-settings" />}
                   label={t('Settings')}
                   to={`/settings/${organization.slug}/`}
+                  id="settings"
                 />
               </SidebarSection>
             </React.Fragment>

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -279,8 +279,8 @@ class Sidebar extends React.Component {
                       to={`/organizations/${organization.slug}/events/`}
                     />
 
-                    {HookStore.get('sidebar:power-icon').length &&
-                      HookStore.get('sidebar:power-icon')[0]({
+                    {HookStore.get('sidebar:secondary-icon').length &&
+                      HookStore.get('sidebar:secondary-icon')[0]({
                         collapsed,
                         organization,
                         source: 'events',
@@ -326,8 +326,8 @@ class Sidebar extends React.Component {
                         to={`/organizations/${organization.slug}/discover/`}
                       />
 
-                      {HookStore.get('sidebar:power-icon').length &&
-                        HookStore.get('sidebar:power-icon')[0]({
+                      {HookStore.get('sidebar:secondary-icon').length &&
+                        HookStore.get('sidebar:secondary-icon')[0]({
                           collapsed,
                           organization,
                           source: 'discover',
@@ -355,8 +355,8 @@ class Sidebar extends React.Component {
                       label={t('Discover')}
                       to={`/organizations/${organization.slug}/discover/`}
                     />
-                    {HookStore.get('sidebar:power-icon').length &&
-                      HookStore.get('sidebar:power-icon')[0]({
+                    {HookStore.get('sidebar:secondary-icon').length &&
+                      HookStore.get('sidebar:secondary-icon')[0]({
                         collapsed,
                         organization,
                         source: 'discover',

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -15,7 +15,7 @@ import {load as loadIncidents} from 'app/actionCreators/incidents';
 import {t} from 'app/locale';
 import ConfigStore from 'app/stores/configStore';
 import Feature from 'app/components/acl/feature';
-import Hook from 'app/components/hook';
+import HookStore from 'app/stores/hookStore';
 import InlineSvg from 'app/components/inlineSvg';
 import PreferencesStore from 'app/stores/preferencesStore';
 import SentryTypes from 'app/sentryTypes';
@@ -278,12 +278,13 @@ class Sidebar extends React.Component {
                       label={t('Events')}
                       to={`/organizations/${organization.slug}/events/`}
                     />
-                    <Hook
-                      name="sidebar:power-icon"
-                      organization={organization}
-                      source="events"
-                      key={`events-power-icon`}
-                    />
+
+                    {HookStore.get('sidebar:power-icon').length &&
+                      HookStore.get('sidebar:power-icon')[0]({
+                        organization,
+                        source: 'events',
+                        collapsed,
+                      })}
                   </StyledItem>
                 </Feature>
 
@@ -324,12 +325,13 @@ class Sidebar extends React.Component {
                         label={t('Discover')}
                         to={`/organizations/${organization.slug}/discover/`}
                       />
-                      <Hook
-                        name="sidebar:power-icon"
-                        organization={organization}
-                        source="discover"
-                        key={`discover-power-icon`}
-                      />
+
+                      {HookStore.get('sidebar:power-icon').length &&
+                        HookStore.get('sidebar:power-icon')[0]({
+                          organization,
+                          source: 'discover',
+                          collapsed,
+                        })}
                     </StyledItem>
                   </Feature>
                 )}
@@ -353,12 +355,12 @@ class Sidebar extends React.Component {
                       label={t('Discover')}
                       to={`/organizations/${organization.slug}/discover/`}
                     />
-                    <Hook
-                      name="sidebar:power-icon"
-                      organization={organization}
-                      source="discover"
-                      key={`discover-power-icon`}
-                    />
+                    {HookStore.get('sidebar:power-icon').length &&
+                      HookStore.get('sidebar:power-icon')[0]({
+                        organization,
+                        source: 'discover',
+                        ...sidebarItemProps,
+                      })}
                   </StyledItem>
                 </SidebarSection>
               </Feature>
@@ -436,13 +438,12 @@ class Sidebar extends React.Component {
         {hasOrganization && (
           <SidebarSectionGroup>
             <SidebarSection>
-              <Hook
-                name="sidebar:power"
-                {...sidebarItemProps}
-                onClick={this.hidePanel}
-                organization={organization}
-              />
-
+              {HookStore.get('sidebar:power').length &&
+                HookStore.get('sidebar:power')[0]({
+                  organization,
+                  onClick: this.hidePanel,
+                  ...sidebarItemProps,
+                })}
               <SidebarHelp
                 orientation={orientation}
                 collapsed={collapsed}

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -426,7 +426,7 @@ class Sidebar extends React.Component {
         {hasOrganization && (
           <SidebarSectionGroup>
             <SidebarSection>
-              {HookStore.get('sidebar:bottom-items').length &&
+              {HookStore.get('sidebar:bottom-items').length > 0 &&
                 HookStore.get('sidebar:bottom-items')[0]({
                   organization,
                   ...sidebarItemProps,

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -266,26 +266,18 @@ class Sidebar extends React.Component {
                 </Feature>
 
                 <Feature features={['events']} organization={organization}>
-                  <StyledItem>
-                    <SidebarItem
-                      {...sidebarItemProps}
-                      onClick={(_id, evt) =>
-                        this.navigateWithGlobalSelection(
-                          `/organizations/${organization.slug}/events/`,
-                          evt
-                        )}
-                      icon={<InlineSvg src="icon-stack" />}
-                      label={t('Events')}
-                      to={`/organizations/${organization.slug}/events/`}
-                    />
-
-                    {HookStore.get('sidebar:secondary-icon').length &&
-                      HookStore.get('sidebar:secondary-icon')[0]({
-                        collapsed,
-                        organization,
-                        source: 'events',
-                      })}
-                  </StyledItem>
+                  <SidebarItem
+                    {...sidebarItemProps}
+                    onClick={(_id, evt) =>
+                      this.navigateWithGlobalSelection(
+                        `/organizations/${organization.slug}/events/`,
+                        evt
+                      )}
+                    icon={<InlineSvg src="icon-stack" />}
+                    label={t('Events')}
+                    to={`/organizations/${organization.slug}/events/`}
+                    id="events"
+                  />
                 </Feature>
 
                 {hasSentry10 && (
@@ -317,22 +309,14 @@ class Sidebar extends React.Component {
 
                 {!hasSentry10 && (
                   <Feature features={['discover']} organization={organization}>
-                    <StyledItem>
-                      <SidebarItem
-                        {...sidebarItemProps}
-                        onClick={this.hidePanel}
-                        icon={<InlineSvg src="icon-discover" />}
-                        label={t('Discover')}
-                        to={`/organizations/${organization.slug}/discover/`}
-                      />
-
-                      {HookStore.get('sidebar:secondary-icon').length &&
-                        HookStore.get('sidebar:secondary-icon')[0]({
-                          collapsed,
-                          organization,
-                          source: 'discover',
-                        })}
-                    </StyledItem>
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      onClick={this.hidePanel}
+                      icon={<InlineSvg src="icon-discover" />}
+                      label={t('Discover')}
+                      to={`/organizations/${organization.slug}/discover/`}
+                      id="discover"
+                    />
                   </Feature>
                 )}
               </SidebarSection>
@@ -346,22 +330,16 @@ class Sidebar extends React.Component {
                     icon={<InlineSvg src="icon-health" />}
                     label={t('Dashboards')}
                     to={`/organizations/${organization.slug}/dashboards/`}
+                    id="customizable-dashboards"
                   />
-                  <StyledItem>
-                    <SidebarItem
-                      {...sidebarItemProps}
-                      onClick={this.hidePanel}
-                      icon={<InlineSvg src="icon-discover" />}
-                      label={t('Discover')}
-                      to={`/organizations/${organization.slug}/discover/`}
-                    />
-                    {HookStore.get('sidebar:secondary-icon').length &&
-                      HookStore.get('sidebar:secondary-icon')[0]({
-                        collapsed,
-                        organization,
-                        source: 'discover',
-                      })}
-                  </StyledItem>
+                  <SidebarItem
+                    {...sidebarItemProps}
+                    onClick={this.hidePanel}
+                    icon={<InlineSvg src="icon-discover" />}
+                    label={t('Discover')}
+                    to={`/organizations/${organization.slug}/discover/`}
+                    id="discover"
+                  />
                 </SidebarSection>
               </Feature>
 
@@ -596,9 +574,4 @@ const SidebarCollapseItem = styled(SidebarItem)`
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     display: none;
   }
-`;
-const StyledItem = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
 `;

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -266,17 +266,25 @@ class Sidebar extends React.Component {
                 </Feature>
 
                 <Feature features={['events']} organization={organization}>
-                  <SidebarItem
-                    {...sidebarItemProps}
-                    onClick={(_id, evt) =>
-                      this.navigateWithGlobalSelection(
-                        `/organizations/${organization.slug}/events/`,
-                        evt
-                      )}
-                    icon={<InlineSvg src="icon-stack" />}
-                    label={t('Events')}
-                    to={`/organizations/${organization.slug}/events/`}
-                  />
+                  <StyledItem>
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      onClick={(_id, evt) =>
+                        this.navigateWithGlobalSelection(
+                          `/organizations/${organization.slug}/events/`,
+                          evt
+                        )}
+                      icon={<InlineSvg src="icon-stack" />}
+                      label={t('Events')}
+                      to={`/organizations/${organization.slug}/events/`}
+                    />
+                    <Hook
+                      name="sidebar:power-icon"
+                      organization={organization}
+                      source="events"
+                      key={`events-power-icon`}
+                    />
+                  </StyledItem>
                 </Feature>
 
                 {hasSentry10 && (
@@ -308,13 +316,21 @@ class Sidebar extends React.Component {
 
                 {!hasSentry10 && (
                   <Feature features={['discover']} organization={organization}>
-                    <SidebarItem
-                      {...sidebarItemProps}
-                      onClick={this.hidePanel}
-                      icon={<InlineSvg src="icon-discover" />}
-                      label={t('Discover')}
-                      to={`/organizations/${organization.slug}/discover/`}
-                    />
+                    <StyledItem>
+                      <SidebarItem
+                        {...sidebarItemProps}
+                        onClick={this.hidePanel}
+                        icon={<InlineSvg src="icon-discover" />}
+                        label={t('Discover')}
+                        to={`/organizations/${organization.slug}/discover/`}
+                      />
+                      <Hook
+                        name="sidebar:power-icon"
+                        organization={organization}
+                        source="discover"
+                        key={`discover-power-icon`}
+                      />
+                    </StyledItem>
                   </Feature>
                 )}
               </SidebarSection>
@@ -329,13 +345,21 @@ class Sidebar extends React.Component {
                     label={t('Dashboards')}
                     to={`/organizations/${organization.slug}/dashboards/`}
                   />
-                  <SidebarItem
-                    {...sidebarItemProps}
-                    onClick={this.hidePanel}
-                    icon={<InlineSvg src="icon-discover" />}
-                    label={t('Discover')}
-                    to={`/organizations/${organization.slug}/discover/`}
-                  />
+                  <StyledItem>
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      onClick={this.hidePanel}
+                      icon={<InlineSvg src="icon-discover" />}
+                      label={t('Discover')}
+                      to={`/organizations/${organization.slug}/discover/`}
+                    />
+                    <Hook
+                      name="sidebar:power-icon"
+                      organization={organization}
+                      source="discover"
+                      key={`discover-power-icon`}
+                    />
+                  </StyledItem>
                 </SidebarSection>
               </Feature>
 
@@ -572,4 +596,9 @@ const SidebarCollapseItem = styled(SidebarItem)`
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     display: none;
   }
+`;
+const StyledItem = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 `;

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -281,9 +281,9 @@ class Sidebar extends React.Component {
 
                     {HookStore.get('sidebar:power-icon').length &&
                       HookStore.get('sidebar:power-icon')[0]({
+                        collapsed,
                         organization,
                         source: 'events',
-                        collapsed,
                       })}
                   </StyledItem>
                 </Feature>
@@ -328,9 +328,9 @@ class Sidebar extends React.Component {
 
                       {HookStore.get('sidebar:power-icon').length &&
                         HookStore.get('sidebar:power-icon')[0]({
+                          collapsed,
                           organization,
                           source: 'discover',
-                          collapsed,
                         })}
                     </StyledItem>
                   </Feature>
@@ -357,9 +357,9 @@ class Sidebar extends React.Component {
                     />
                     {HookStore.get('sidebar:power-icon').length &&
                       HookStore.get('sidebar:power-icon')[0]({
+                        collapsed,
                         organization,
                         source: 'discover',
-                        ...sidebarItemProps,
                       })}
                   </StyledItem>
                 </SidebarSection>
@@ -438,10 +438,9 @@ class Sidebar extends React.Component {
         {hasOrganization && (
           <SidebarSectionGroup>
             <SidebarSection>
-              {HookStore.get('sidebar:power').length &&
-                HookStore.get('sidebar:power')[0]({
+              {HookStore.get('sidebar:bottom-items').length &&
+                HookStore.get('sidebar:bottom-items')[0]({
                   organization,
-                  onClick: this.hidePanel,
                   ...sidebarItemProps,
                 })}
               <SidebarHelp

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
@@ -2,6 +2,7 @@ import {withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled, {css} from 'react-emotion';
+import HookOrDefault from 'app/components/hookOrDefault';
 
 import Link from '../link';
 import TextOverflow from '../textOverflow';
@@ -69,6 +70,10 @@ class SidebarItem extends React.Component {
 
     const isTop = orientation === 'top';
     const placement = isTop ? 'bottom' : 'right';
+    const TextOverflowHook = HookOrDefault({
+      hookName: 'sidebar:item-label',
+      defaultComponent: TextOverflow,
+    });
 
     return (
       <Tooltip
@@ -89,7 +94,7 @@ class SidebarItem extends React.Component {
             {!collapsed &&
               !isTop && (
                 <SidebarItemLabel>
-                  <TextOverflow>{label}</TextOverflow>
+                  {<TextOverflowHook id={this.props.id}>{label}</TextOverflowHook>}
                 </SidebarItemLabel>
               )}
             {badge > 0 && (
@@ -192,6 +197,9 @@ const SidebarItemLabel = styled('span')`
   white-space: nowrap;
   opacity: 1;
   flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 `;
 
 const getCollapsedBadgeStyle = ({collapsed, theme}) => {

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
@@ -2,6 +2,7 @@ import {withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled, {css} from 'react-emotion';
+
 import HookOrDefault from 'app/components/hookOrDefault';
 
 import Link from '../link';

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
@@ -73,7 +73,9 @@ class SidebarItem extends React.Component {
     const placement = isTop ? 'bottom' : 'right';
     const LabelHook = HookOrDefault({
       hookName: 'sidebar:item-label',
-      defaultComponent: ({children}) => <React.Fragment {...children} />,
+      defaultComponent: ({children}) => {
+        return <React.Fragment>{children}</React.Fragment>;
+      },
     });
 
     return (

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
@@ -71,9 +71,9 @@ class SidebarItem extends React.Component {
 
     const isTop = orientation === 'top';
     const placement = isTop ? 'bottom' : 'right';
-    const TextOverflowHook = HookOrDefault({
+    const LabelHook = HookOrDefault({
       hookName: 'sidebar:item-label',
-      defaultComponent: TextOverflow,
+      defaultComponent: React.Fragment,
     });
 
     return (
@@ -95,7 +95,11 @@ class SidebarItem extends React.Component {
             {!collapsed &&
               !isTop && (
                 <SidebarItemLabel>
-                  {<TextOverflowHook id={this.props.id}>{label}</TextOverflowHook>}
+                  {
+                    <LabelHook id={this.props.id}>
+                      <TextOverflow>{label}</TextOverflow>
+                    </LabelHook>
+                  }
                 </SidebarItemLabel>
               )}
             {badge > 0 && (

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
@@ -73,7 +73,7 @@ class SidebarItem extends React.Component {
     const placement = isTop ? 'bottom' : 'right';
     const LabelHook = HookOrDefault({
       hookName: 'sidebar:item-label',
-      defaultComponent: React.Fragment,
+      defaultComponent: ({children}) => <React.Fragment {...children} />,
     });
 
     return (

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
@@ -95,11 +95,9 @@ class SidebarItem extends React.Component {
             {!collapsed &&
               !isTop && (
                 <SidebarItemLabel>
-                  {
-                    <LabelHook id={this.props.id}>
-                      <TextOverflow>{label}</TextOverflow>
-                    </LabelHook>
-                  }
+                  <LabelHook id={this.props.id}>
+                    <TextOverflow>{label}</TextOverflow>
+                  </LabelHook>
                 </SidebarItemLabel>
               )}
             {badge > 0 && (

--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -23,8 +23,6 @@ const validHookNames = new Set([
   'utils:onboarding-survey-url',
   'component:org-auth-view',
   'component:org-members-view',
-  'sidebar:bottom-items',
-  'sidebar:item-label',
 
   // Additional settings
   'settings:organization-navigation',
@@ -35,6 +33,8 @@ const validHookNames = new Set([
   'organization:header',
   'sidebar:help-menu',
   'sidebar:organization-dropdown-menu',
+  'sidebar:bottom-items',
+  'sidebar:item-label',
 
   // Used to provide a component for integration features.
   'integrations:feature-gates',

--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -23,6 +23,7 @@ const validHookNames = new Set([
   'utils:onboarding-survey-url',
   'component:org-auth-view',
   'component:org-members-view',
+  'sidebar:power',
 
   // Additional settings
   'settings:organization-navigation',

--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -24,7 +24,7 @@ const validHookNames = new Set([
   'component:org-auth-view',
   'component:org-members-view',
   'sidebar:bottom-items',
-  'sidebar:secondary-icon',
+  'sidebar:item-label',
 
   // Additional settings
   'settings:organization-navigation',

--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -24,6 +24,7 @@ const validHookNames = new Set([
   'component:org-auth-view',
   'component:org-members-view',
   'sidebar:power',
+  'sidebar:power-icon',
 
   // Additional settings
   'settings:organization-navigation',

--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -23,7 +23,7 @@ const validHookNames = new Set([
   'utils:onboarding-survey-url',
   'component:org-auth-view',
   'component:org-members-view',
-  'sidebar:power',
+  'sidebar:bottom-items',
   'sidebar:power-icon',
 
   // Additional settings

--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -24,7 +24,7 @@ const validHookNames = new Set([
   'component:org-auth-view',
   'component:org-members-view',
   'sidebar:bottom-items',
-  'sidebar:power-icon',
+  'sidebar:secondary-icon',
 
   // Additional settings
   'settings:organization-navigation',

--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavItem.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavItem.jsx
@@ -4,19 +4,27 @@ import React from 'react';
 import styled from 'react-emotion';
 
 import Badge from 'app/components/badge';
+import HookOrDefault from 'app/components/hookOrDefault';
 import Tag from 'app/views/settings/components/tag';
+import TextOverflow from 'app/components/textOverflow';
 
 class SettingsNavItem extends React.Component {
   static propTypes = {
     label: PropTypes.node.isRequired,
     badge: PropTypes.node,
     index: PropTypes.bool,
+    id: PropTypes.string,
   };
 
   render() {
-    const {badge, label, index, ...props} = this.props;
+    const {badge, label, index, id, ...props} = this.props;
 
     let renderedBadge = '';
+
+    const LabelHook = HookOrDefault({
+      hookName: 'sidebar:item-label',
+      defaultComponent: TextOverflow,
+    });
 
     if (badge === 'new') {
       renderedBadge = (
@@ -30,7 +38,9 @@ class SettingsNavItem extends React.Component {
 
     return (
       <StyledNavItem onlyActiveOnIndex={index} activeClassName="active" {...props}>
-        {label} {badge ? renderedBadge : null}
+        <LabelHook id={id}>{label}</LabelHook>
+
+        {badge ? renderedBadge : null}
       </StyledNavItem>
     );
   }
@@ -46,6 +56,7 @@ const StyledNavItem = styled(Link)`
   font-size: 14px;
   line-height: 30px;
   position: relative;
+  width: 100%;
 
   &.active {
     color: ${p => p.theme.gray5};

--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavItem.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavItem.jsx
@@ -18,12 +18,14 @@ class SettingsNavItem extends React.Component {
   render() {
     const {badge, label, index, id, ...props} = this.props;
 
-    let renderedBadge = '';
-
     const LabelHook = HookOrDefault({
       hookName: 'sidebar:item-label',
-      defaultComponent: ({children}) => <React.Fragment {...children} />,
+      defaultComponent: ({children}) => {
+        return <React.Fragment>{children}</React.Fragment>;
+      },
     });
+
+    let renderedBadge = '';
 
     if (badge === 'new') {
       renderedBadge = (

--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavItem.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavItem.jsx
@@ -22,7 +22,7 @@ class SettingsNavItem extends React.Component {
 
     const LabelHook = HookOrDefault({
       hookName: 'sidebar:item-label',
-      defaultComponent: React.Fragment,
+      defaultComponent: ({children}) => <React.Fragment {...children} />,
     });
 
     if (badge === 'new') {

--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavItem.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavItem.jsx
@@ -6,7 +6,6 @@ import styled from 'react-emotion';
 import Badge from 'app/components/badge';
 import HookOrDefault from 'app/components/hookOrDefault';
 import Tag from 'app/views/settings/components/tag';
-import TextOverflow from 'app/components/textOverflow';
 
 class SettingsNavItem extends React.Component {
   static propTypes = {
@@ -23,7 +22,7 @@ class SettingsNavItem extends React.Component {
 
     const LabelHook = HookOrDefault({
       hookName: 'sidebar:item-label',
-      defaultComponent: TextOverflow,
+      defaultComponent: React.Fragment,
     });
 
     if (badge === 'new') {

--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavItem.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavItem.jsx
@@ -55,7 +55,6 @@ const StyledNavItem = styled(Link)`
   font-size: 14px;
   line-height: 30px;
   position: relative;
-  width: 100%;
 
   &.active {
     color: ${p => p.theme.gray5};

--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavigationGroup.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavigationGroup.jsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
-import Hook from 'app/components/hook';
 import SentryTypes from 'app/sentryTypes';
 import SettingsNavItem from 'app/views/settings/components/settingsNavItem';
 import replaceRouterParams from 'app/utils/replaceRouterParams';
@@ -19,12 +18,6 @@ const SettingsHeading = styled.div`
   margin-bottom: 20px;
 `;
 
-const StyledItem = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-`;
-
 export default class NavigationGroup extends React.Component {
   static propTypes = {
     ...SentryTypes.NavigationGroup,
@@ -32,6 +25,7 @@ export default class NavigationGroup extends React.Component {
     project: SentryTypes.Project,
     access: PropTypes.object,
     features: PropTypes.object,
+    id: PropTypes.string,
   };
 
   static contextTypes = {
@@ -45,7 +39,7 @@ export default class NavigationGroup extends React.Component {
     return (
       <NavSection data-test-id={name}>
         <SettingsHeading>{name}</SettingsHeading>
-        {items.map(({path, title, index, show, badge}) => {
+        {items.map(({path, title, index, show, badge, id}) => {
           if (typeof show === 'function' && !show(this.props)) return null;
           if (typeof show !== 'undefined' && !show) return null;
           const badgeResult = typeof badge === 'function' ? badge(this.props) : null;
@@ -55,21 +49,14 @@ export default class NavigationGroup extends React.Component {
           });
 
           return (
-            <StyledItem key={title}>
-              <SettingsNavItem
-                key={title}
-                to={to}
-                label={title}
-                index={index}
-                badge={badgeResult}
-              />
-              <Hook
-                name="sidebar:secondary-icon"
-                organization={organization}
-                source={title.toLowerCase()}
-                key={`${title}`}
-              />
-            </StyledItem>
+            <SettingsNavItem
+              key={title}
+              to={to}
+              label={title}
+              index={index}
+              badge={badgeResult}
+              id={id}
+            />
           );
         })}
       </NavSection>

--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavigationGroup.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavigationGroup.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
+import Hook from 'app/components/hook';
 import SentryTypes from 'app/sentryTypes';
 import SettingsNavItem from 'app/views/settings/components/settingsNavItem';
 import replaceRouterParams from 'app/utils/replaceRouterParams';
@@ -16,6 +17,11 @@ const SettingsHeading = styled.div`
   font-weight: 600;
   text-transform: uppercase;
   margin-bottom: 20px;
+`;
+
+const StyledItem = styled.div`
+  display: flex;
+  justify-content: space-between;
 `;
 
 export default class NavigationGroup extends React.Component {
@@ -48,13 +54,21 @@ export default class NavigationGroup extends React.Component {
           });
 
           return (
-            <SettingsNavItem
-              key={title}
-              to={to}
-              label={title}
-              index={index}
-              badge={badgeResult}
-            />
+            <StyledItem key={title}>
+              <SettingsNavItem
+                key={title}
+                to={to}
+                label={title}
+                index={index}
+                badge={badgeResult}
+              />
+              <Hook
+                name="sidebar:power-icon"
+                organization={organization}
+                source={title}
+                key={`${title}-power-icon`}
+              />
+            </StyledItem>
           );
         })}
       </NavSection>

--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavigationGroup.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavigationGroup.jsx
@@ -64,10 +64,10 @@ export default class NavigationGroup extends React.Component {
                 badge={badgeResult}
               />
               <Hook
-                name="sidebar:power-icon"
+                name="sidebar:secondary-icon"
                 organization={organization}
                 source={title.toLowerCase()}
-                key={`${title}-power-icon`}
+                key={`${title}`}
               />
             </StyledItem>
           );

--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavigationGroup.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavigationGroup.jsx
@@ -22,6 +22,7 @@ const SettingsHeading = styled.div`
 const StyledItem = styled.div`
   display: flex;
   justify-content: space-between;
+  align-items: center;
 `;
 
 export default class NavigationGroup extends React.Component {
@@ -65,7 +66,7 @@ export default class NavigationGroup extends React.Component {
               <Hook
                 name="sidebar:power-icon"
                 organization={organization}
-                source={title}
+                source={title.toLowerCase()}
                 key={`${title}-power-icon`}
               />
             </StyledItem>

--- a/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.jsx
@@ -11,16 +11,19 @@ const organizationNavigation = [
         title: t('General Settings'),
         index: true,
         description: t('Configure general settings for an organization'),
+        id: 'general',
       },
       {
         path: `${pathPrefix}/projects/`,
         title: t('Projects'),
         description: t("View and manage an organization's projects"),
+        id: 'projects',
       },
       {
         path: `${pathPrefix}/teams/`,
         title: t('Teams'),
         description: t("Manage an organization's teams"),
+        id: 'teams',
       },
       {
         path: `${pathPrefix}/members/`,
@@ -34,22 +37,26 @@ const organizationNavigation = [
         },
         show: ({access}) => access.has('member:read'),
         description: t('Manage user membership for an organization'),
+        id: 'members',
       },
       {
         path: `${pathPrefix}/auth/`,
         title: t('Auth'),
         description: t('Configure single sign-on'),
+        id: 'sso-saml2',
       },
       {
         path: `${pathPrefix}/api-keys/`,
         title: t('API Keys'),
         show: ({access, features}) => features.has('api-keys') && access.has('org:admin'),
+        id: 'api-keys',
       },
       {
         path: `${pathPrefix}/audit-log/`,
         title: t('Audit Log'),
         show: ({access}) => access.has('org:write'),
         description: t('View the audit log for an organization'),
+        id: 'audit-log',
       },
       {
         path: `${pathPrefix}/rate-limits/`,
@@ -57,11 +64,13 @@ const organizationNavigation = [
         show: ({access, features}) =>
           features.has('legacy-rate-limits') && access.has('org:write'),
         description: t('Configure rate limits for all projects in the organization'),
+        id: 'rate-limits',
       },
       {
         path: `${pathPrefix}/repos/`,
         title: t('Repositories'),
         description: t('Manage repositories connected to the organization'),
+        id: 'repos',
       },
       {
         path: `${pathPrefix}/integrations/`,
@@ -69,12 +78,14 @@ const organizationNavigation = [
         description: t(
           'Manage organization-level integrations, including: Slack, Github, Bitbucket, Jira, and Azure DevOps'
         ),
+        id: 'integrations',
       },
       {
         path: `${pathPrefix}/developer-settings/`,
         title: t('Developer Settings'),
         show: ({access, features}) => features.has('sentry-apps'),
         description: t('Manage developer applications'),
+        id: 'developer-settings',
       },
     ],
   },

--- a/src/sentry/static/sentry/app/views/settings/organizationAuth/providerItem.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuth/providerItem.jsx
@@ -125,7 +125,7 @@ const LockedFeature = ({provider, features, className, ...props}) => (
       />
     }
   >
-    <Tag icon="icon-power-features">disabled</Tag>
+    <Tag icon="icon-lock">disabled</Tag>
   </DisabledHovercard>
 );
 

--- a/src/sentry/static/sentry/app/views/settings/organizationAuth/providerItem.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuth/providerItem.jsx
@@ -125,7 +125,7 @@ const LockedFeature = ({provider, features, className, ...props}) => (
       />
     }
   >
-    <Tag icon="icon-lock">disabled</Tag>
+    <Tag icon="icon-power-features">disabled</Tag>
   </DisabledHovercard>
 );
 


### PR DESCRIPTION
This will make room for entry points in the main sidebar and settings sidebar as well as at feature gate points that currently have the lock icon.

Related to https://github.com/getsentry/getsentry/pull/2624