### PR TITLE
ref: Change top tags to not include unique values seen.

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -175,15 +175,12 @@ class SnubaTagStorage(TagStorage):
         if keys is not None:
             filters['tags_key'] = keys
         aggregations = [
-            ['uniq', 'tags_value', 'values_seen'],
             ['count()', '', 'count']
         ]
         conditions = [['tags_key', 'NOT IN', self.EXCLUDE_TAG_KEYS]]
 
-        # TODO should this be sorted by count() descending, rather than the
-        # number of unique values
         result = snuba.query(start, end, ['tags_key'], conditions, filters,
-                             aggregations, limit=limit, orderby='-values_seen',
+                             aggregations, limit=limit, orderby='-count',
                              referrer='tagstore.__get_tag_keys')
 
         if group_id is None:
@@ -194,9 +191,8 @@ class SnubaTagStorage(TagStorage):
         return set([
             ctor(
                 key=key,
-                values_seen=data['values_seen'],
-                count=data['count'],
-            ) for key, data in six.iteritems(result) if data['values_seen']
+                count=count,
+            ) for key, count in six.iteritems(result)
         ])
 
     def __get_tag_value(self, project_id, group_id, environment_id, key, value):

--- a/src/sentry/tagstore/types.py
+++ b/src/sentry/tagstore/types.py
@@ -1,3 +1,4 @@
+from sentry.api.serializers import Serializer, register, serialize
 from __future__ import absolute_import
 
 import six
@@ -30,7 +31,8 @@ class TagType(object):
 class TagKey(TagType):
     __slots__ = ['key', 'values_seen', 'status']
 
-    def __init__(self, key, values_seen, status=TagKeyStatus.VISIBLE, count=None, top_values=None):
+    def __init__(self, key, values_seen=None, status=TagKeyStatus.VISIBLE,
+                 count=None, top_values=None):
         self.key = key
         self.values_seen = values_seen
         self.status = status
@@ -57,7 +59,7 @@ class TagValue(TagType):
 class GroupTagKey(TagType):
     __slots__ = ['group_id', 'key', 'values_seen']
 
-    def __init__(self, group_id, key, values_seen, count=None, top_values=None):
+    def __init__(self, group_id, key, values_seen=None, count=None, top_values=None):
         self.group_id = group_id
         self.key = key
         self.values_seen = values_seen
@@ -77,9 +79,6 @@ class GroupTagValue(TagType):
         self.last_seen = last_seen
 
 
-from sentry.api.serializers import Serializer, register, serialize
-
-
 @register(GroupTagKey)
 @register(TagKey)
 class TagKeySerializer(Serializer):
@@ -88,9 +87,10 @@ class TagKeySerializer(Serializer):
 
         output = {
             'key': tagstore.get_standardized_key(obj.key),
-            'name': tagstore.get_tag_key_label(obj.key),
-            'uniqueValues': obj.values_seen,
+            'name': tagstore.get_tag_key_label(obj.key)
         }
+        if obj.values_seen is not None:
+            output['uniqueValues'] = obj.values_seen
         if obj.count is not None:
             output['totalValues'] = obj.count
         if obj.top_values is not None:

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -115,11 +115,9 @@ class TagStorageTest(SnubaTestCase):
         result.sort(key=lambda r: r.key)
         assert result[0].key == 'baz'
         assert result[0].top_values[0].value == 'quux'
-        assert result[0].values_seen == 1
         assert result[0].count == 2
 
         assert result[3].key == 'sentry:release'
-        assert result[3].values_seen == 2
         assert result[3].count == 2
         top_release_values = result[3].top_values
         assert len(top_release_values) == 2
@@ -192,11 +190,6 @@ class TagStorageTest(SnubaTestCase):
             )
         }
         assert set(keys) == set(['baz', 'environment', 'foo', 'sentry:release', 'sentry:user'])
-        for k in keys.values():
-            if k.key not in set(['sentry:release', 'sentry:user']):
-                assert k.values_seen == 1, u'expected {!r} to have 1 unique value'.format(k.key)
-            else:
-                assert k.values_seen == 2
 
     def test_get_group_tag_value(self):
         with pytest.raises(GroupTagValueNotFound):


### PR DESCRIPTION
This is just a proof of concept for a tags endpoint that doesn't include
the values seen. Omitting this key means that snuba doesn't have to look
at the tag.values column, which will probably speed up the top tags
query by about 2x. This could be useful when we don't really even need
that data but just want a list of all tag keys to populate a dropdown.

I haven't really checked everywhere to see if there are other consumers
of this tagstore function that do require the unique values. If so, we
probably have to fork the top tags endpoint into one that returns them
and one that doesn't.