### PR TITLE
fix(superuser): Fix redirect from old stream to new issues

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationProjectsDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationProjectsDashboard/index.jsx
@@ -97,7 +97,9 @@ class Dashboard extends React.Component {
           );
         })}
         {teamSlugs.length === 0 &&
-          favorites.length === 0 && <NoProjectMessage organization={organization} />}
+          favorites.length === 0 && (
+            <NoProjectMessage organization={organization}>{null}</NoProjectMessage>
+          )}
       </React.Fragment>
     );
   }


### PR DESCRIPTION
This happens for sentry10 (and generally superusers) when accessing old dashboard URL (e.g. /sentry/), it attempts to render `<NoProjectsMessage>` which renders its child if you are a superuser and have access to a project. This will throw an error because it did not have a child and would not redirect.

Fixes JAVASCRIPT-5A7