### PR TITLE
fix(api): Return the latest release version in ProjectSummarySerializer, rather than the entire serialized object

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -311,14 +311,15 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
                     'dateFinished': date_finished
                 }
 
-        latest_release_list = bulk_fetch_project_latest_releases(item_list)
-        latest_releases = {
-            r.actual_project_id: d
-            for r, d in zip(latest_release_list, serialize(latest_release_list, user))
+        # We  just return the version key here so that we cut down on response
+        # size
+        latest_release_verions = {
+            release.actual_project_id: {'version': release.version}
+            for release in bulk_fetch_project_latest_releases(item_list)
         }
 
         for item in item_list:
-            attrs[item]['latest_release'] = latest_releases.get(item.id)
+            attrs[item]['latest_release'] = latest_release_verions.get(item.id)
             attrs[item]['deploys'] = deploys_by_project.get(item.id)
             attrs[item]['environments'] = environments_by_project.get(item.id, [])
 

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -204,7 +204,7 @@ class ProjectSummarySerializerTest(TestCase):
         assert result['latestDeploys'] == {
             'production': {'dateFinished': self.date, 'version': self.release.version}
         }
-        assert result['latestRelease'] == serialize(self.release)
+        assert result['latestRelease'] == {'version': self.release.version}
         assert result['environments'] == ['production', 'staging']
 
     def test_no_enviroments(self):
@@ -256,7 +256,7 @@ class ProjectSummarySerializerTest(TestCase):
         assert result['latestDeploys'] == {
             'production': {'dateFinished': self.date, 'version': self.release.version}
         }
-        assert result['latestRelease'] == serialize(self.release)
+        assert result['latestRelease'] == {'version': self.release.version}
         assert result['environments'] == ['production', 'staging']
 
 


### PR DESCRIPTION
The latest release accounts for nearly half the response, and we only use the version. Cutting this down in hopes of improving response times on initial page load.