### PR TITLE
feat: Added title and location to discover

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/data.jsx
@@ -41,6 +41,8 @@ export const COLUMNS = [
   {name: 'project.name', type: TYPES.STRING},
   {name: 'platform', type: TYPES.STRING},
   {name: 'message', type: TYPES.STRING},
+  {name: 'title', type: TYPES.STRING},
+  {name: 'location', type: TYPES.STRING},
   {name: 'timestamp', type: TYPES.DATETIME},
   {name: 'release', type: TYPES.STRING},
 


### PR DESCRIPTION
This adds the new title and location fields to discover which should help
visualizing events from different types of sources (particularly useful for
native events and CSP).