### PR TITLE
ref(hooks): Update sidebar hooks

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/help.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/help.jsx
@@ -8,7 +8,7 @@ import {t} from 'app/locale';
 import DropdownMenu from 'app/components/dropdownMenu';
 import InlineSvg from 'app/components/inlineSvg';
 import SidebarItem from 'app/components/sidebar/sidebarItem';
-import HookStore from 'app/stores/hookStore';
+import Hook from 'app/components/hook';
 
 import SidebarMenuItem from './sidebarMenuItem';
 import SidebarDropdownMenu from './sidebarDropdownMenu.styled';
@@ -19,27 +19,6 @@ class SidebarHelp extends React.Component {
     collapsed: PropTypes.bool,
     hidePanel: PropTypes.func,
     organization: SentryTypes.Organization,
-  };
-
-  constructor(props) {
-    super(props);
-    this.state = {
-      supportMenuItem: null,
-    };
-  }
-
-  componentDidMount() {
-    if (!this.props.organization) return;
-
-    HookStore.get('sidebar:help-menu').map(cb =>
-      cb(this.props.organization, {SidebarMenuItem}, this.handleSupportHookUpdate)
-    );
-  }
-
-  handleSupportHookUpdate = menuItem => {
-    this.setState({
-      supportMenuItem: menuItem,
-    });
   };
 
   handleActorClick = () => {
@@ -70,7 +49,7 @@ class SidebarHelp extends React.Component {
 
               {isOpen && (
                 <HelpMenu {...getMenuProps({isStyled: true})}>
-                  {this.state.supportMenuItem}
+                  <Hook name="sidebar:help-menu" organization={this.props.organization} />
                   <SidebarMenuItem onClick={this.handleSearchClick}>
                     {t('Search Docs and FAQs')}
                   </SidebarMenuItem>

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
@@ -122,7 +122,6 @@ const SidebarDropdown = withApi(
                         <Hook
                           name="sidebar:organization-dropdown-menu"
                           organization={org}
-                          Components={{SidebarMenuItem}}
                         />
 
                         {!config.singleOrganization && (

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -444,11 +444,6 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
       </MenuItemLink>
     </SidebarMenuItem>
     <Hook
-      Components={
-        Object {
-          "SidebarMenuItem": [Function],
-        }
-      }
       name="sidebar:organization-dropdown-menu"
       organization={
         Object {
@@ -991,6 +986,36 @@ exports[`Sidebar SidebarHelp can toggle help menu 1`] = `
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
+    <Hook
+      name="sidebar:help-menu"
+      organization={
+        Object {
+          "access": Array [
+            "org:read",
+            "org:write",
+            "org:admin",
+            "project:read",
+            "project:write",
+            "project:admin",
+            "team:read",
+            "team:write",
+            "team:admin",
+          ],
+          "features": Array [],
+          "id": "3",
+          "name": "Organization Name",
+          "onboardingTasks": Array [],
+          "projects": Array [],
+          "scrapeJavaScript": true,
+          "slug": "org-slug",
+          "status": Object {
+            "id": "active",
+            "name": "active",
+          },
+          "teams": Array [],
+        }
+      }
+    />
     <SidebarMenuItem
       onClick={[Function]}
     >


### PR DESCRIPTION
- Simplifies the help menu hook and brings it more inline with the organization menu hook.

 - No need to pass `Components` in the hook, getsentry can import these.