### PR TITLE
fix: Workaround for invalid filenames in frames

### DIFF
--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -198,6 +198,8 @@ def get_event_file_committers(project, event, frame_limit=25):
     # file paths.
     if event.platform == 'java':
         for frame in frames:
+            if frame.get('filename') is None:
+                continue
             if '/' not in frame.get('filename') and frame.get('module'):
                 frame['filename'] = frame['module'].replace('.', '/') + '/' + frame['filename']
 


### PR DESCRIPTION
This fixes SENTRY-9JJ