### PR TITLE
fix(api): Return disableNewVisibilityFeatures in organization serializer

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -97,6 +97,7 @@ class OrganizationSerializer(Serializer):
             'name': obj.name or obj.slug,
             'dateCreated': obj.date_added,
             'isEarlyAdopter': bool(obj.flags.early_adopter),
+            'disableNewVisibilityFeatures': bool(obj.flags.disable_new_visibility_features),
             'require2FA': bool(obj.flags.require_2fa),
             'avatar': avatar,
             'features': feature_list

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -12,6 +12,8 @@ class OrganizationSerializerTest(TestCase):
     def test_simple(self):
         user = self.create_user()
         organization = self.create_organization(owner=user)
+        organization.flags.disable_new_visibility_features = True
+        organization.save()
 
         result = serialize(organization, user)
 
@@ -26,3 +28,4 @@ class OrganizationSerializerTest(TestCase):
             'sso-basic',
             'suggested-commits'
         ])
+        assert result['disableNewVisibilityFeatures']


### PR DESCRIPTION
Missed including this in the serializer when adding this bitflag