### PR TITLE
feat: Superuser dashboard view

### DIFF
--- a/src/sentry/static/sentry/app/utils/getProjectsByTeams.jsx
+++ b/src/sentry/static/sentry/app/utils/getProjectsByTeams.jsx
@@ -1,7 +1,11 @@
-export default function getProjectsByTeams(teams, projects) {
+export default function getProjectsByTeams(teams, projects, isSuperuser = false) {
   const projectsByTeam = {};
   const teamlessProjects = [];
-  const usersTeams = new Set(teams.filter(team => team.isMember).map(team => team.slug));
+  let usersTeams = new Set(teams.filter(team => team.isMember).map(team => team.slug));
+
+  if (usersTeams.size === 0 && isSuperuser) {
+    usersTeams = new Set(teams.map(team => team.slug));
+  }
 
   projects.forEach(project => {
     if (!project.teams.length && project.isMember) {

--- a/src/sentry/static/sentry/app/views/organizationProjectsDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationProjectsDashboard/index.jsx
@@ -11,6 +11,7 @@ import IdBadge from 'app/components/idBadge';
 import NoProjectMessage from 'app/components/noProjectMessage';
 import OrganizationState from 'app/mixins/organizationState';
 import ProjectsStatsStore from 'app/stores/projectsStatsStore';
+import ConfigStore from 'app/stores/configStore';
 import getProjectsByTeams from 'app/utils/getProjectsByTeams';
 import {sortProjects} from 'app/utils';
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
@@ -49,7 +50,10 @@ class Dashboard extends React.Component {
   render() {
     const {teams, projects, params, organization} = this.props;
     const sortedProjects = sortProjects(projects);
-    const {projectsByTeam} = getProjectsByTeams(teams, sortedProjects);
+
+    const {isSuperuser} = ConfigStore.get('user');
+
+    const {projectsByTeam} = getProjectsByTeams(teams, sortedProjects, isSuperuser);
     const teamSlugs = Object.keys(projectsByTeam).sort();
     const favorites = projects.filter(project => project.isBookmarked);
     const access = new Set(organization.access);


### PR DESCRIPTION
Render all the teams/projects for superusers for superusers.
Superusers who aren't in any teams won't see anything in this view so
let's make it useful for them. If a superuser isn't in any teams, just
show every team/project for that organization.