### PR TITLE
feat(api): Restrict advanced search usage to organizations with `advanced_search` feature. (APP-1127)

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -27,7 +27,9 @@ search = SnubaSearchBackend(**settings.SENTRY_SEARCH_OPTIONS)
 class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
 
     def _search(self, request, organization, projects, environments, extra_query_kwargs=None):
-        query_kwargs = build_query_params_from_request(request, projects, environments)
+        query_kwargs = build_query_params_from_request(
+            request, organization, projects, environments,
+        )
         if extra_query_kwargs is not None:
             assert 'environment' not in extra_query_kwargs
             query_kwargs.update(extra_query_kwargs)

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -77,7 +77,9 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
             query_kwargs = {}
         else:
             environments = [environment] if environment is not None else environment
-            query_kwargs = build_query_params_from_request(request, [project], environments)
+            query_kwargs = build_query_params_from_request(
+                request, project.organization, [project], environments,
+            )
             if extra_query_kwargs is not None:
                 assert 'environment' not in extra_query_kwargs
                 query_kwargs.update(extra_query_kwargs)

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -142,6 +142,16 @@ class SearchFilter(namedtuple('SearchFilter', 'key operator value')):
             map(six.text_type, (self.key.name, self.operator, self.value.raw_value)),
         )
 
+    @cached_property
+    def is_negation(self):
+        # Negations are mostly just using != operators. But we also have
+        # negations on has: filters, which translate to = '', so handle that
+        # case as well.
+        return (
+            self.operator == '!=' and self.value.raw_value != ''
+            or self.operator == '=' and self.value.raw_value == ''
+        )
+
 
 class SearchKey(namedtuple('SearchKey', 'name')):
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -791,6 +791,8 @@ SENTRY_FEATURES = {
     # Enables user registration.
     'auth:register': True,
 
+    # Enable advanced search features, like negation and wildcard matching.
+    'organizations:advanced_search': True,
     # Enable obtaining and using API keys.
     'organizations:api-keys': False,
     # Enable creating organizations within sentry (if SENTRY_SINGLE_ORGANIZATION

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -50,10 +50,12 @@ default_manager.add('auth:register')
 default_manager.add('organizations:create')
 
 # Organization scoped features
+default_manager.add('organizations:advanced_search', OrganizationFeature)  # NOQA
 default_manager.add('organizations:api-keys', OrganizationFeature)  # NOQA
 default_manager.add('organizations:discover', OrganizationFeature)  # NOQA
 default_manager.add('organizations:events', OrganizationFeature)  # NOQA
 default_manager.add('organizations:event-attachments', OrganizationFeature)  # NOQA
+default_manager.add('organizations:gitlab-integration', OrganizationFeature)  # NOQA
 default_manager.add('organizations:global-views', OrganizationFeature)  # NOQA
 default_manager.add('organizations:integrations-issue-basic', OrganizationFeature)  # NOQA
 default_manager.add('organizations:integrations-issue-sync', OrganizationFeature)  # NOQA
@@ -61,6 +63,8 @@ default_manager.add('organizations:internal-catchall', OrganizationFeature)  # N
 default_manager.add('organizations:sentry-apps', OrganizationFeature)  # NOQA
 default_manager.add('organizations:invite-members', OrganizationFeature)  # NOQA
 default_manager.add('organizations:js-loader', OrganizationFeature)  # NOQA
+default_manager.add('organizations:large-debug-files', OrganizationFeature)  # NOQA
+default_manager.add('organizations:legacy-event-id', OrganizationFeature)  # NOQA
 default_manager.add('organizations:monitors', OrganizationFeature)  # NOQA
 default_manager.add('organizations:new-teams', OrganizationFeature)  # NOQA
 default_manager.add('organizations:onboarding', OrganizationFeature)  # NOQA
@@ -74,20 +78,17 @@ default_manager.add('organizations:sso-rippling', OrganizationFeature)  # NOQA
 default_manager.add('organizations:sso-saml2', OrganizationFeature)  # NOQA
 default_manager.add('organizations:suggested-commits', OrganizationFeature)  # NOQA
 default_manager.add('organizations:unreleased-changes', OrganizationFeature)  # NOQA
-default_manager.add('organizations:gitlab-integration', OrganizationFeature)  # NOQA
-default_manager.add('organizations:large-debug-files', OrganizationFeature)  # NOQA
-default_manager.add('organizations:legacy-event-id', OrganizationFeature)  # NOQA
 
 # Project scoped features
-default_manager.add('projects:similarity-view', ProjectFeature)  # NOQA
+default_manager.add('projects:custom-inbound-filters', ProjectFeature)  # NOQA
 default_manager.add('projects:data-forwarding', ProjectFeature)  # NOQA
+default_manager.add('projects:discard-groups', ProjectFeature)  # NOQA
+default_manager.add('projects:minidump', ProjectFeature)  # NOQA
 default_manager.add('projects:rate-limits', ProjectFeature)  # NOQA
 default_manager.add('projects:sample-events', ProjectFeature)  # NOQA
 default_manager.add('projects:servicehooks', ProjectFeature)  # NOQA
+default_manager.add('projects:similarity-view', ProjectFeature)  # NOQA
 default_manager.add('projects:similarity-indexing', ProjectFeature)  # NOQA
-default_manager.add('projects:discard-groups', ProjectFeature)  # NOQA
-default_manager.add('projects:custom-inbound-filters', ProjectFeature)  # NOQA
-default_manager.add('projects:minidump', ProjectFeature)  # NOQA
 
 # Project plugin features
 default_manager.add('projects:plugins', ProjectPluginFeature)  # NOQA

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -1,0 +1,48 @@
+from __future__ import absolute_import
+
+from sentry.api.helpers.group_index import (
+    validate_search_filter_permissions,
+    ValidationError,
+)
+from sentry.api.issue_search import parse_search_query
+from sentry.testutils import TestCase
+
+
+class ValidateSearchFilterPermissionsTest(TestCase):
+
+    def run_test(self, query):
+        validate_search_filter_permissions(self.organization, parse_search_query(query))
+
+    def test_negative(self):
+        query = '!has:user'
+        with self.feature(
+                {'organizations:advanced_search': False},
+        ), self.assertRaisesRegexp(ValidationError, '.*negative search.*'):
+            self.run_test(query)
+
+        self.run_test(query)
+
+        query = '!something:123'
+        with self.feature(
+                {'organizations:advanced_search': False},
+        ), self.assertRaisesRegexp(ValidationError, '.*negative search.*'):
+            self.run_test(query)
+
+        self.run_test(query)
+
+    def test_wildcard(self):
+        query = 'abc:hello*'
+        with self.feature(
+                {'organizations:advanced_search': False},
+        ), self.assertRaisesRegexp(ValidationError, '.*wildcard search.*'):
+            self.run_test(query)
+
+        self.run_test(query)
+
+        query = 'raw * search'
+        with self.feature(
+                {'organizations:advanced_search': False},
+        ), self.assertRaisesRegexp(ValidationError, '.*wildcard search.*'):
+            self.run_test(query)
+
+        self.run_test(query)

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -17,6 +17,7 @@ class OrganizationSerializerTest(TestCase):
 
         assert result['id'] == six.text_type(organization.id)
         assert result['features'] == set([
+            'advanced_search',
             'new-teams',
             'shared-issues',
             'repos',

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -391,6 +391,19 @@ class GroupListTest(APITestCase, SnubaTestCase):
 class GroupListTestWithSearchFilters(GroupListTest):
     use_new_filters = True
 
+    def test_advanced_search_errors(self):
+        self.login_as(user=self.user)
+        with self.feature({'organizations:advanced_search': False}):
+            response = self.get_response(sort_by='date', query='!has:user')
+            assert response.status_code == 400, response.data
+            assert (
+                'You need access to the advanced search feature to use negative '
+                'search' == response.data['detail']
+            )
+
+        response = self.get_response(sort_by='date', query='!has:user')
+        assert response.status_code == 200, response.data
+
 
 class GroupUpdateTest(APITestCase, SnubaTestCase):
     endpoint = 'sentry-api-0-organization-group-index'


### PR DESCRIPTION
Advanced search is currently considered to be negative and wildcard searches. We'll probably expand
this to include new search features over time.

When a user attempts an advanced search without having the feature, we return a 400 with an error message like "You need access to the advanced search feature to use negative search"