### PR TITLE
fix(dateselector): Fix selector for non-default periods

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import moment from 'moment';
 import styled from 'react-emotion';
 
-import {DEFAULT_RELATIVE_PERIODS, DEFAULT_STATS_PERIOD} from 'app/constants';
+import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import {analytics} from 'app/utils/analytics';
 import {
   getLocalToSystem,
@@ -12,8 +12,8 @@ import {
   getUserTimezone,
   getUtcToSystem,
 } from 'app/utils/dates';
+import {getRelativeSummary} from 'app/components/organizations/timeRangeSelector/utils';
 import {parsePeriodToHours} from 'app/utils';
-import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
 import {t} from 'app/locale';
 import DateRange from 'app/components/organizations/timeRangeSelector/dateRange';
 import DateSummary from 'app/components/organizations/timeRangeSelector/dateSummary';
@@ -24,6 +24,7 @@ import RelativeSelector from 'app/components/organizations/timeRangeSelector/dat
 import SelectorItem from 'app/components/organizations/timeRangeSelector/dateRange/selectorItem';
 import SentryTypes from 'app/sentryTypes';
 import getDynamicText from 'app/utils/getDynamicText';
+import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
 
 // Strips timezone from local date, creates a new moment date object with timezone
 // Then returns as a Date object
@@ -279,7 +280,7 @@ class TimeRangeSelector extends React.PureComponent {
     const isAbsoluteSelected = !!start && !!end;
 
     const summary = relative ? (
-      `${DEFAULT_RELATIVE_PERIODS[relative]}`
+      getRelativeSummary(relative)
     ) : (
       <DateSummary utc={this.state.utc} start={start} end={end} />
     );

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/utils.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/utils.jsx
@@ -11,7 +11,7 @@ const DATE_TIME_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
  * time that is the current time less the statsPeriod.
  *
  * @param {String} statsPeriod Relative stats period
- * @returns {Object} Object containing start and end date as YYYY-MM-DDTHH:mm:ss
+ * @return {Object} Object containing start and end date as YYYY-MM-DDTHH:mm:ss
  *
  */
 export function parseStatsPeriod(statsPeriod) {
@@ -45,6 +45,7 @@ export function parseStatsPeriod(statsPeriod) {
  * followed by a single character s|m|h|d) display "Other" or "Invalid period" if invalid
  *
  * @param {String} relative Relative stats period
+ * @return {String} Returns either one of the default "Last x days" string, "Other" if period is valid on the backend, or "Invalid period" otherwise
  */
 export function getRelativeSummary(relative) {
   const defaultRelativePeriodString = DEFAULT_RELATIVE_PERIODS[relative];

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/utils.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/utils.jsx
@@ -1,5 +1,8 @@
 import moment from 'moment';
 
+import {DEFAULT_RELATIVE_PERIODS} from 'app/constants';
+import {t} from 'app/locale';
+
 const DATE_TIME_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
 
 /**
@@ -7,7 +10,7 @@ const DATE_TIME_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
  * and end date, with the end date as the current time and the start date as the
  * time that is the current time less the statsPeriod.
  *
- * @param {String} val Relative stats period
+ * @param {String} statsPeriod Relative stats period
  * @returns {Object} Object containing start and end date as YYYY-MM-DDTHH:mm:ss
  *
  */
@@ -34,4 +37,26 @@ export function parseStatsPeriod(statsPeriod) {
       .format(DATE_TIME_FORMAT),
     end: moment().format(DATE_TIME_FORMAT),
   };
+}
+
+/**
+ * Given a relative stats period, e.g. `1h`, return a pretty string if it
+ * is a default stats period. Otherwise if it's a valid period (can be any number
+ * followed by a single character s|m|h|d) display "Other" or "Invalid period" if invalid
+ *
+ * @param {String} relative Relative stats period
+ */
+export function getRelativeSummary(relative) {
+  const defaultRelativePeriodString = DEFAULT_RELATIVE_PERIODS[relative];
+
+  if (!defaultRelativePeriodString) {
+    try {
+      parseStatsPeriod(relative);
+      return t('Other');
+    } catch (err) {
+      return 'Invalid period';
+    }
+  }
+
+  return defaultRelativePeriodString;
 }

--- a/tests/js/spec/components/organizations/timeRangeSelector/index.spec.jsx
+++ b/tests/js/spec/components/organizations/timeRangeSelector/index.spec.jsx
@@ -28,6 +28,22 @@ describe('TimeRangeSelector', function() {
     onChange.mockReset();
   });
 
+  it('renders when given relative period not in dropdown', function() {
+    wrapper = mount(
+      <TimeRangeSelector showAbsolute={false} showRelative={false} relative="9d" />,
+      routerContext
+    );
+    expect(wrapper.find('HeaderItem').text()).toEqual('Other');
+  });
+
+  it('renders when given an invalid relative period', function() {
+    wrapper = mount(
+      <TimeRangeSelector showAbsolute={false} showRelative={false} relative="1w" />,
+      routerContext
+    );
+    expect(wrapper.find('HeaderItem').text()).toEqual('Invalid period');
+  });
+
   it('hides relative and absolute selectors', async function() {
     wrapper = mount(
       <TimeRangeSelector showAbsolute={false} showRelative={false} />,


### PR DESCRIPTION
If users change the statsPeriod in the URL, it can cause the time range selector to be in an odd state if it is not a period in the dropdown. Show "Other" or "Invalid period" depending on validity of the supplied statsPeriod

![image](https://user-images.githubusercontent.com/79684/53061012-4b40d680-3471-11e9-89dd-63bb77f94907.png)
