### PR TITLE
feat: Improved event titles for native crashes

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -55,7 +55,7 @@ redis>=2.10.3,<2.10.6
 requests-oauthlib==0.3.3
 requests[security]>=2.20.0,<2.21.0
 selenium==3.11.0
-semaphore>=0.4.15,<0.5.0
+semaphore>=0.4.16,<0.5.0
 sentry-sdk>=0.7.0
 setproctitle>=1.1.7,<1.2.0
 simplejson>=3.2.0,<3.9.0

--- a/src/sentry/culprit.py
+++ b/src/sentry/culprit.py
@@ -17,8 +17,6 @@ def generate_culprit(data):
     platform = data.get('platform')
     exceptions = get_path(data, 'exception', 'values')
     if exceptions:
-        import pprint
-        pprint.pprint(exceptions)
         # Synthetic events no longer get a culprit
         last_exception = get_path(exceptions, -1)
         if last_exception and (last_exception.get('mechanism') or {}).get('synthetic'):
@@ -46,6 +44,8 @@ def generate_culprit(data):
 def get_stacktrace_culprit(stacktrace, platform):
     default = None
     for frame in reversed(stacktrace['frames']):
+        if not frame:
+            continue
         if frame.get('in_app'):
             culprit = get_frame_culprit(frame, platform=platform)
             if culprit:

--- a/src/sentry/culprit.py
+++ b/src/sentry/culprit.py
@@ -1,0 +1,72 @@
+"""
+This file implements the legacy culprit system.  The culprit at this point is
+just used as a fallback if no transaction is set.  When a transaction is set
+the culprit is overriden by the transaction value.
+
+Over time we want to fully phase out the culprit.  Until then this is the
+code that generates it.
+"""
+
+from __future__ import absolute_import
+from sentry.constants import MAX_CULPRIT_LENGTH
+from sentry.utils.safe import get_path
+from sentry.utils.strings import truncatechars
+
+
+def generate_culprit(data):
+    platform = data.get('platform')
+    exceptions = get_path(data, 'exception', 'values')
+    if exceptions:
+        import pprint
+        pprint.pprint(exceptions)
+        # Synthetic events no longer get a culprit
+        last_exception = get_path(exceptions, -1)
+        if last_exception and (last_exception.get('mechanism') or {}).get('synthetic'):
+            return ''
+
+        stacktraces = [e['stacktrace'] for e in exceptions if get_path(e, 'stacktrace', 'frames')]
+    else:
+        stacktrace = data.get('stacktrace')
+        if stacktrace and stacktrace.get('frames'):
+            stacktraces = [stacktrace]
+        else:
+            stacktraces = None
+
+    culprit = None
+
+    if not culprit and stacktraces:
+        culprit = get_stacktrace_culprit(get_path(stacktraces, -1), platform=platform)
+
+    if not culprit and data.get('request'):
+        culprit = get_path(data, 'request', 'url')
+
+    return truncatechars(culprit or '', MAX_CULPRIT_LENGTH)
+
+
+def get_stacktrace_culprit(stacktrace, platform):
+    default = None
+    for frame in reversed(stacktrace['frames']):
+        if frame.get('in_app'):
+            culprit = get_frame_culprit(frame, platform=platform)
+            if culprit:
+                return culprit
+        elif default is None:
+            default = get_frame_culprit(frame, platform=platform)
+    return default
+
+
+def get_frame_culprit(frame, platform):
+    # If this frame has a platform, we use it instead of the one that
+    # was passed in (as that one comes from the exception which might
+    # not necessarily be the same platform).
+    platform = frame.get('platform') or platform
+    if platform in ('objc', 'cocoa', 'native'):
+        return frame.get('function') or '?'
+    fileloc = frame.get('module') or frame.get('filename')
+    if not fileloc:
+        return ''
+    elif platform in ('javascript', 'node'):
+        # function and fileloc might be unicode here, so let it coerce
+        # to a unicode string if needed.
+        return '%s(%s)' % (frame.get('function') or '?', fileloc)
+    return '%s in %s' % (fileloc, frame.get('function') or '?')

--- a/src/sentry/culprit.py
+++ b/src/sentry/culprit.py
@@ -15,7 +15,7 @@ from sentry.utils.strings import truncatechars
 
 def generate_culprit(data):
     platform = data.get('platform')
-    exceptions = get_path(data, 'exception', 'values')
+    exceptions = get_path(data, 'exception', 'values', filter=True)
     if exceptions:
         # Synthetic events no longer get a culprit
         last_exception = get_path(exceptions, -1)

--- a/src/sentry/culprit.py
+++ b/src/sentry/culprit.py
@@ -19,7 +19,7 @@ def generate_culprit(data):
     if exceptions:
         # Synthetic events no longer get a culprit
         last_exception = get_path(exceptions, -1)
-        if last_exception and (last_exception.get('mechanism') or {}).get('synthetic'):
+        if get_path(last_exception, 'mechanism', 'synthetic'):
             return ''
 
         stacktraces = [e['stacktrace'] for e in exceptions if get_path(e, 'stacktrace', 'frames')]

--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -39,9 +39,9 @@ class ErrorEvent(BaseEvent):
         loc = get_crash_location(exception, data.get('platform'))
         rv = {}
 
-        # If the exception mechanism indicates a synthesized exception we do not
+        # If the exception mechanism indicates a synthetic exception we do not
         # want to record the type and value into the metadata.
-        if not get_path(exception, 'mechanism', 'synthesized'):
+        if not get_path(exception, 'mechanism', 'synthetic'):
             rv.update({
                 'type': trim(get_path(exception, 'type', default='Error'), 128),
                 'value': trim(get_path(exception, 'value', default=''), 1024),

--- a/src/sentry/interfaces/exception.py
+++ b/src/sentry/interfaces/exception.py
@@ -710,6 +710,7 @@ class Mechanism(Interface):
     >>>         "relevant_address": "0x1"
     >>>     },
     >>>     "handled": false,
+    >>>     "synthesized": false,
     >>>     "help_link": "https://developer.apple.com/library/content/qa/qa1367/_index.html",
     >>>     "meta": {
     >>>         "mach_exception": {
@@ -762,6 +763,7 @@ class Mechanism(Interface):
 
         kwargs = {
             'type': trim(data['type'], 128),
+            'synthesized': data.get('synthesized') or False,
             'description': trim(data.get('description'), 1024),
             'help_link': trim(data.get('help_link'), 1024),
             'handled': data.get('handled'),
@@ -778,6 +780,7 @@ class Mechanism(Interface):
     def to_json(self):
         return prune_empty_keys({
             'type': self.type,
+            'synthesized': self.synthesized,
             'description': self.description,
             'help_link': self.help_link,
             'handled': self.handled,

--- a/src/sentry/interfaces/exception.py
+++ b/src/sentry/interfaces/exception.py
@@ -710,7 +710,7 @@ class Mechanism(Interface):
     >>>         "relevant_address": "0x1"
     >>>     },
     >>>     "handled": false,
-    >>>     "synthesized": false,
+    >>>     "synthetic": false,
     >>>     "help_link": "https://developer.apple.com/library/content/qa/qa1367/_index.html",
     >>>     "meta": {
     >>>         "mach_exception": {
@@ -763,7 +763,7 @@ class Mechanism(Interface):
 
         kwargs = {
             'type': trim(data['type'], 128),
-            'synthesized': data.get('synthesized') or False,
+            'synthetic': data.get('synthetic'),
             'description': trim(data.get('description'), 1024),
             'help_link': trim(data.get('help_link'), 1024),
             'handled': data.get('handled'),
@@ -780,7 +780,7 @@ class Mechanism(Interface):
     def to_json(self):
         return prune_empty_keys({
             'type': self.type,
-            'synthesized': self.synthesized,
+            'synthetic': self.synthetic,
             'description': self.description,
             'help_link': self.help_link,
             'handled': self.handled,

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -105,6 +105,10 @@ def trim_function_name(func, platform):
     # TODO(mitsuhiko): we actually want to use the language information here
     # but we don't have that yet.
     if platform in ('objc', 'cocoa', 'native'):
+        # objc function
+        if func.startswith(('[', '+[', '-[')):
+            return func
+        # c/c++ function hopefully
         match = _native_function_trim_re.match(func.strip())
         if match is not None:
             return match.group(1).strip()

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -640,23 +640,6 @@ class Frame(Interface):
             }
         ).strip('\n')
 
-    def get_culprit_string(self, platform=None):
-        # If this frame has a platform, we use it instead of the one that
-        # was passed in (as that one comes from the exception which might
-        # not necessarily be the same platform).
-        if self.platform is not None:
-            platform = self.platform
-        fileloc = self.module or self.filename
-        # File location is necessary and for native platforms we no longer
-        # produce a culprit at all.
-        if not fileloc or platform in ('objc', 'cocoa', 'native'):
-            return ''
-        elif platform in ('javascript', 'node'):
-            # function and fileloc might be unicode here, so let it coerce
-            # to a unicode string if needed.
-            return '%s(%s)' % (self.function or '?', fileloc)
-        return '%s in %s' % (fileloc, self.function or '?', )
-
 
 class Stacktrace(Interface):
     """
@@ -962,14 +945,3 @@ class Stacktrace(Interface):
             )
 
         return '\n'.join(result)
-
-    def get_culprit_string(self, platform=None):
-        default = None
-        for frame in reversed(self.frames):
-            if frame.in_app:
-                culprit = frame.get_culprit_string(platform=platform)
-                if culprit:
-                    return culprit
-            elif default is None:
-                default = frame.get_culprit_string(platform=platform)
-        return default

--- a/src/sentry/lang/native/minidump.py
+++ b/src/sentry/lang/native/minidump.py
@@ -78,7 +78,7 @@ def merge_process_state_event(data, state, cfi=None):
         'mechanism': {
             'type': 'minidump',
             'handled': False,
-            'synthesized': True,
+            'synthetic': True,
             # We cannot extract exception codes or signals with the breakpad
             # extractor just yet. Once these capabilities are added to symbolic,
             # these values should go in the mechanism here.

--- a/src/sentry/lang/native/minidump.py
+++ b/src/sentry/lang/native/minidump.py
@@ -78,6 +78,7 @@ def merge_process_state_event(data, state, cfi=None):
         'mechanism': {
             'type': 'minidump',
             'handled': False,
+            'synthesized': True,
             # We cannot extract exception codes or signals with the breakpad
             # extractor just yet. Once these capabilities are added to symbolic,
             # these values should go in the mechanism here.

--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
@@ -63,8 +63,11 @@ class EventOrGroupHeader extends React.Component {
 
   getLocation() {
     const {data} = this.props;
-    const {metadata} = data || {};
-    return metadata.filename || null;
+    if (data.type === 'error') {
+      const {metadata} = data || {};
+      return metadata.filename || null;
+    }
+    return null;
   }
 
   getTitle() {

--- a/src/sentry/static/sentry/app/components/eventOrGroupTitle.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupTitle.jsx
@@ -26,8 +26,12 @@ class EventOrGroupTitle extends React.Component {
     let subtitle = null;
 
     if (type == 'error') {
-      title = metadata.type;
       subtitle = culprit;
+      if (metadata.type) {
+        title = metadata.type;
+      } else {
+        title = metadata.function || '<unknown>';
+      }
     } else if (type == 'csp') {
       title = metadata.directive;
       subtitle = metadata.uri;

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -75,11 +75,19 @@ def merge_mappings(values):
     return result
 
 
+def _generate_culprit(event):
+    # XXX(mitsuhiko): workaround: some old events do not have this data yet.
+    # This should be save delete by end of 2019 even considering slow on-prem
+    # releases.  Platform was added back to data in december 2018.
+    data = event.data
+    if data.get('platform') is None:
+        data = dict(data.items())
+        data['platform'] = event.platform
+    return generate_culprit(data)
+
+
 initial_fields = {
-    'culprit': lambda event: generate_culprit(
-        event.data,
-        event.platform,
-    ),
+    'culprit': lambda event: _generate_culprit(event),
     'data': lambda event: {
         'last_received': event.data.get('received') or float(event.datetime.strftime('%s')),
         'type': event.data['type'],

--- a/tests/sentry/interfaces/test_stacktrace.py
+++ b/tests/sentry/interfaces/test_stacktrace.py
@@ -748,7 +748,7 @@ class StacktraceTest(TestCase):
                 ]
             )
         )
-        assert stacktrace.get_culprit_string(platform='cocoa') == ''
+        assert stacktrace.get_culprit_string(platform='cocoa') is None
 
     def test_emoji_culprit(self):
         stacktrace = Stacktrace.to_python(

--- a/tests/sentry/interfaces/test_stacktrace.py
+++ b/tests/sentry/interfaces/test_stacktrace.py
@@ -734,64 +734,6 @@ class StacktraceTest(TestCase):
         result = interface.compute_hashes()
         self.assertEquals(result, [])
 
-    def test_cocoa_culprit(self):
-        stacktrace = Stacktrace.to_python(
-            dict(
-                frames=[
-                    {
-                        'filename': 'foo/baz.c',
-                        'package': '/foo/bar/baz.dylib',
-                        'lineno': 1,
-                        'in_app': True,
-                        'function': '-[CRLCrashAsyncSafeThread crash]',
-                    }
-                ]
-            )
-        )
-        assert stacktrace.get_culprit_string(platform='cocoa') is None
-
-    def test_emoji_culprit(self):
-        stacktrace = Stacktrace.to_python(
-            dict(
-                frames=[
-                    {
-                        'filename': 'foo/baz.c',
-                        'package': '/foo/bar/baz.dylib',
-                        'module': u'\U0001f62d',
-                        'lineno': 1,
-                        'in_app': True,
-                        'function': u'\U0001f60d',
-                    }
-                ]
-            )
-        )
-        assert stacktrace.get_culprit_string(platform='javascript') == u'\U0001f60d(\U0001f62d)'
-
-    def test_cocoa_strict_stacktrace(self):
-        stacktrace = Stacktrace.to_python(
-            dict(
-                frames=[
-                    {
-                        'filename': 'foo/baz.c',
-                        'package': '/foo/bar/libswiftCore.dylib',
-                        'lineno': 1,
-                        'in_app': False,
-                        'function': 'fooBar',
-                    }, {
-                        'package': '/foo/bar/MyApp',
-                        'in_app': True,
-                        'function': 'fooBar2',
-                    }, {
-                        'filename': 'Mycontroller.swift',
-                        'package': '/foo/bar/MyApp',
-                        'in_app': True,
-                        'function': '-[CRLCrashAsyncSafeThread crash]',
-                    }
-                ]
-            )
-        )
-        assert stacktrace.get_culprit_string(platform='cocoa') == ''
-
     def test_compute_hashes_does_not_group_different_js_errors(self):
         interface = Stacktrace.to_python(
             {

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -569,7 +569,7 @@ class GenerateModulesTest(TestCase):
         }
         generate_modules(data)
         fix_culprit(data)
-        assert data['culprit'] == 'bar in oops'
+        assert data['culprit'] == 'oops(bar)'
 
     def test_ensure_module_names(self):
         from sentry.lang.javascript.plugin import generate_modules

--- a/tests/sentry/lang/native/test_minidump.py
+++ b/tests/sentry/lang/native/test_minidump.py
@@ -148,7 +148,8 @@ def test_minidump_linux():
         'exception': {
             'mechanism': {
                 'type': 'minidump',
-                'handled': False
+                'handled': False,
+                'synthetic': True,
             },
             'stacktrace': {
                 'frames': [
@@ -625,7 +626,8 @@ def test_minidump_macos():
         'exception': {
             'mechanism': {
                 'type': 'minidump',
-                'handled': False
+                'handled': False,
+                'synthetic': True,
             },
             'stacktrace': {
                 'frames': [
@@ -836,7 +838,8 @@ def test_minidump_windows():
         'exception': {
             'mechanism': {
                 'type': 'minidump',
-                'handled': False
+                'handled': False,
+                'synthetic': True,
             },
             'stacktrace': {
                 'frames': [

--- a/tests/sentry/test_culprit.py
+++ b/tests/sentry/test_culprit.py
@@ -1,0 +1,131 @@
+from __future__ import absolute_import
+
+from sentry.event_manager import EventManager
+
+
+def get_culprit(data):
+    mgr = EventManager(data)
+    mgr.normalize()
+    return mgr.get_culprit()
+
+
+def test_cocoa_culprit():
+    culprit = get_culprit({
+        'platform': 'cocoa',
+        'exception': {
+            'type': 'Crash',
+            'stacktrace': {
+                'frames': [
+                    {
+                        'filename': 'foo/baz.c',
+                        'package': '/foo/bar/baz.dylib',
+                        'lineno': 1,
+                        'in_app': True,
+                        'function': '-[CRLCrashAsyncSafeThread crash]',
+                    }
+                ]
+            }
+        }
+    })
+    assert culprit == '-[CRLCrashAsyncSafeThread crash]'
+
+
+def test_emoji_culprit():
+    culprit = get_culprit({
+        'platform': 'native',
+        'exception': {
+            'type': 'Crash',
+            'stacktrace': {
+                'frames': [
+                    {
+                        'filename': 'foo/baz.c',
+                        'package': '/foo/bar/baz.dylib',
+                        'module': u'\U0001f62d',
+                        'lineno': 1,
+                        'in_app': True,
+                        'function': u'\U0001f60d',
+                    }
+                ]
+            }
+        }
+    })
+    assert culprit == u'\U0001f60d'
+
+
+def test_cocoa_strict_stacktrace():
+    culprit = get_culprit({
+        'platform': 'native',
+        'exception': {
+            'type': 'Crash',
+            'stacktrace': {
+                'frames': [
+                    {
+                        'filename': 'foo/baz.c',
+                        'package': '/foo/bar/libswiftCore.dylib',
+                        'lineno': 1,
+                        'in_app': False,
+                        'function': 'fooBar',
+                    }, {
+                        'package': '/foo/bar/MyApp',
+                        'in_app': True,
+                        'function': 'fooBar2',
+                    }, {
+                        'filename': 'Mycontroller.swift',
+                        'package': '/foo/bar/MyApp',
+                        'in_app': True,
+                        'function': '-[CRLCrashAsyncSafeThread crash]',
+                    }
+                ]
+            }
+        }
+    })
+    assert culprit == '-[CRLCrashAsyncSafeThread crash]'
+
+
+def test_culprit_for_synthetic_event():
+    # Synthetic events do not generate a culprit
+    culprit = get_culprit({
+        'platform': 'javascript',
+        'exception': {
+            'type': 'Error',
+            'value': 'I threw up stringly',
+            'mechanism': {
+                'type': 'string-error',
+                'synthetic': True,
+            },
+            'stacktrace': {
+                'frames': [
+                    {
+                        'filename': 'foo/baz.js',
+                        'package': 'node_modules/blah/foo/bar.js',
+                        'lineno': 42,
+                        'in_app': True,
+                        'function': 'fooBar',
+                    }
+                ]
+            }
+        }
+    })
+    assert culprit == ''
+
+
+def test_culprit_for_javascript_event():
+    culprit = get_culprit({
+        'platform': 'javascript',
+        'exception': {
+            'type': 'Error',
+            'value': 'I fail hard',
+            'stacktrace': {
+                'frames': [
+                    {
+                        'filename': 'foo/baz.js',
+                        'package': 'node_modules/blah/foo/bar.js',
+                        'lineno': 42,
+                        'in_app': True,
+                        'function': 'fooBar',
+                    }
+                ]
+            }
+        }
+    })
+    assert culprit == 'fooBar(foo/baz.js)'

--- a/tests/sentry/test_culprit.py
+++ b/tests/sentry/test_culprit.py
@@ -129,3 +129,26 @@ def test_culprit_for_javascript_event():
         }
     })
     assert culprit == 'fooBar(foo/baz.js)'
+
+
+def test_culprit_for_python_event():
+    culprit = get_culprit({
+        'platform': 'python',
+        'exception': {
+            'type': 'ZeroDivisionError',
+            'value': 'integer division or modulo by zero',
+            'stacktrace': {
+                'frames': [
+                    {
+                        'filename': 'foo/baz.py',
+                        'module': 'foo.baz',
+                        'package': 'foo/baz.py',
+                        'lineno': 23,
+                        'in_app': True,
+                        'function': 'it_failed',
+                    }
+                ]
+            }
+        }
+    })
+    assert culprit == 'foo.baz in it_failed'


### PR DESCRIPTION
This is a work in progress change to make the native event rendering show the
offending function rather than the exception type of the error is not very
useful.  This requires https://github.com/getsentry/semaphore/pull/177