### PR TITLE
fix(similarity): Use interface attribute that exists

### DIFF
--- a/src/sentry/similarity/__init__.py
+++ b/src/sentry/similarity/__init__.py
@@ -121,7 +121,7 @@ features = FeatureSet(
         'message:message:character-shingles': MessageFeature(
             lambda message: text_shingle(
                 5,
-                message.message,
+                message.formatted,
             ),
         ),
     },


### PR DESCRIPTION
This was probably broken with GH-11078 but it's hard to tell for sure
because the logger is disabled that reports feature extraction failure.
This only really presents itself as a failure in development when
bootstrapping an environment with `bin/load-mocks`.