### PR TITLE
fix(app-platform): Handle deleted ApiGrant

### DIFF
--- a/src/sentry/api/serializers/models/sentry_app_installation.py
+++ b/src/sentry/api/serializers/models/sentry_app_installation.py
@@ -19,7 +19,7 @@ class SentryAppInstallationSerializer(Serializer):
             'uuid': install.uuid,
         }
 
-        if install.is_new:
-            data['code'] = install.api_grant.code
+        if 'code' in attrs:
+            data['code'] = attrs['code']
 
         return data

--- a/src/sentry/mediators/mediator.py
+++ b/src/sentry/mediators/mediator.py
@@ -193,7 +193,7 @@ class Mediator(object):
         if param and param.has_default:
             return param.default(self)
 
-        if not param.is_required and not param.has_default:
+        if param and not param.is_required and not param.has_default:
             return None
 
         try:

--- a/src/sentry/mediators/sentry_app_installations/destroyer.py
+++ b/src/sentry/mediators/sentry_app_installations/destroyer.py
@@ -18,10 +18,12 @@ class Destroyer(Mediator):
         return self.install
 
     def _destroy_authorization(self):
-        self.install.authorization.delete()
+        if self.install.authorization:
+            self.install.authorization.delete()
 
     def _destroy_grant(self):
-        self.install.api_grant.delete()
+        if self.install.api_grant_id:
+            self.install.api_grant.delete()
 
     def _destroy_service_hooks(self):
         hooks = ServiceHook.objects.filter(

--- a/src/sentry/mediators/sentry_app_installations/installation_notifier.py
+++ b/src/sentry/mediators/sentry_app_installations/installation_notifier.py
@@ -34,9 +34,14 @@ class InstallationNotifier(Mediator):
 
     @property
     def request(self):
+        attrs = {}
+
+        if self.install.is_new and self.api_grant:
+            attrs['code'] = self.api_grant.code
+
         data = SentryAppInstallationSerializer().serialize(
             self.install,
-            attrs={'code': self.api_grant.code},
+            attrs=attrs,
             user=self.user,
         )
 
@@ -54,4 +59,4 @@ class InstallationNotifier(Mediator):
 
     @memoize
     def api_grant(self):
-        return self.install.api_grant
+        return self.install.api_grant_id and self.install.api_grant

--- a/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
@@ -55,6 +55,14 @@ class TestDestroyer(TestCase):
         assert not ApiGrant.objects.filter(pk=grant.id).exists()
 
     @responses.activate
+    def test_deletes_without_grant(self):
+        self.install.api_grant.delete()
+        self.install.update(api_grant=None)
+
+        responses.add(responses.POST, 'https://example.com/webhook')
+        assert self.destroyer.call()
+
+    @responses.activate
     def test_deletes_service_hooks(self):
         hook = self.create_service_hook(
             application=self.sentry_app.application,


### PR DESCRIPTION
ApiGrants expire. When they do, they get deleted. When they are deleted,
the reference to them in SentryAppInstallation (`api_grant_id`) is set
to None.

This updates everywhere we expect an `api_grant_id` to be set, to handle
when it is not set, in this expired scenario.

Also makes a small fix to only check whether a Param is required when
the request attribute is actually a Param.