### PR TITLE
ref(eventstream): Split out `SnubaProtocolEventStream` from HTTP and Kafka transports

### DIFF
--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -1,15 +1,251 @@
 from __future__ import absolute_import
 
+import logging
+from datetime import datetime
+from uuid import uuid4
+
+import pytz
 import urllib3
 
-from sentry.eventstream.kafka import KafkaEventStream
-from sentry.eventstream.kafka.backend import EVENT_PROTOCOL_VERSION
+from sentry import quotas
+from sentry.eventstream.base import EventStream
 from sentry.utils import snuba, json
+from sentry.utils.safe import get_path
 
 
-class SnubaEventStream(KafkaEventStream):
+logger = logging.getLogger(__name__)
+
+
+# Version 1 format: (1, TYPE, [...REST...])
+#   Insert: (1, 'insert', {
+#       ...event json...
+#   }, {
+#       ...state for post-processing...
+#   })
+#
+#   Mutations that *should be ignored*: (1, ('delete_groups'|'unmerge'|'merge'), {...})
+#
+#   In short, for protocol version 1 only messages starting with (1, 'insert', ...)
+#   should be processed.
+
+# Version 2 format: (2, TYPE, [...REST...])
+#   Insert: (2, 'insert', {
+#       ...event json...
+#   }, {
+#       ...state for post-processing...
+#   })
+#   Delete Groups: (2, '(start_delete_groups|end_delete_groups)', {
+#       'transaction_id': uuid,
+#       'project_id': id,
+#       'group_ids': [id2, id2, id3],
+#       'datetime': timestamp,
+#   })
+#   Merge: (2, '(start_merge|end_merge)', {
+#       'transaction_id': uuid,
+#       'project_id': id,
+#       'previous_group_ids': [id2, id2],
+#       'new_group_id': id,
+#       'datetime': timestamp,
+#   })
+#   Unmerge: (2, '(start_unmerge|end_unmerge)', {
+#       'transaction_id': uuid,
+#       'project_id': id,
+#       'previous_group_id': id,
+#       'new_group_id': id,
+#       'hashes': [hash2, hash2]
+#       'datetime': timestamp,
+#   })
+#   Delete Tag: (2, '(start_delete_tag|end_delete_tag)', {
+#       'transaction_id': uuid,
+#       'project_id': id,
+#       'tag': 'foo',
+#       'datetime': timestamp,
+#   })
+
+
+class SnubaProtocolEventStream(EventStream):
+
+    # Beware! Changing this protocol (introducing a new version, or the message
+    # format/fields themselves) requires consideration of all downstream
+    # consumers. This includes the post-processing forwarder code!
+    EVENT_PROTOCOL_VERSION = 2
+
+    # These keys correspond to tags that are typically prefixed with `sentry:`
+    # and will wreak havok in the UI if both the `sentry:`-prefixed and
+    # non-prefixed variations occur in a response.
+    UNEXPECTED_TAG_KEYS = frozenset([
+        'dist',
+        'release',
+        'user',
+    ])
+
+    def insert(self, group, event, is_new, is_sample, is_regression,
+               is_new_group_environment, primary_hash, skip_consume=False):
+        project = event.project
+        retention_days = quotas.get_event_retention(
+            organization=project.organization,
+        )
+
+        event_data = event.get_raw_data()
+
+        unexpected_tags = set([
+            k for (k, v) in (get_path(event_data, 'tags', filter=True) or [])
+            if k in self.UNEXPECTED_TAG_KEYS
+        ])
+        if unexpected_tags:
+            logger.error('%r received unexpected tags: %r', self, unexpected_tags)
+
+        self._send(project.id, 'insert', extra_data=({
+            'group_id': event.group_id,
+            'event_id': event.event_id,
+            'organization_id': project.organization_id,
+            'project_id': event.project_id,
+            # TODO(mitsuhiko): We do not want to send this incorrect
+            # message but this is what snuba needs at the moment.
+            'message': event.message,
+            'platform': event.platform,
+            'datetime': event.datetime,
+            'data': event_data,
+            'primary_hash': primary_hash,
+            'retention_days': retention_days,
+        }, {
+            'is_new': is_new,
+            'is_sample': is_sample,
+            'is_regression': is_regression,
+            'is_new_group_environment': is_new_group_environment,
+            'skip_consume': skip_consume,
+        },))
+
+    def start_delete_groups(self, project_id, group_ids):
+        if not group_ids:
+            return
+
+        state = {
+            'transaction_id': uuid4().hex,
+            'project_id': project_id,
+            'group_ids': list(group_ids),
+            'datetime': datetime.now(tz=pytz.utc),
+        }
+
+        self._send(
+            project_id,
+            'start_delete_groups',
+            extra_data=(state,),
+            asynchronous=False
+        )
+
+        return state
+
+    def end_delete_groups(self, state):
+        state = state.copy()
+        state['datetime'] = datetime.now(tz=pytz.utc)
+        self._send(
+            state['project_id'],
+            'end_delete_groups',
+            extra_data=(state,),
+            asynchronous=False
+        )
+
+    def start_merge(self, project_id, previous_group_ids, new_group_id):
+        if not previous_group_ids:
+            return
+
+        state = {
+            'transaction_id': uuid4().hex,
+            'project_id': project_id,
+            'previous_group_ids': list(previous_group_ids),
+            'new_group_id': new_group_id,
+            'datetime': datetime.now(tz=pytz.utc),
+        }
+
+        self._send(
+            project_id,
+            'start_merge',
+            extra_data=(state,),
+            asynchronous=False
+        )
+
+        return state
+
+    def end_merge(self, state):
+        state = state.copy()
+        state['datetime'] = datetime.now(tz=pytz.utc)
+        self._send(
+            state['project_id'],
+            'end_merge',
+            extra_data=(state,),
+            asynchronous=False
+        )
+
+    def start_unmerge(self, project_id, hashes, previous_group_id, new_group_id):
+        if not hashes:
+            return
+
+        state = {
+            'transaction_id': uuid4().hex,
+            'project_id': project_id,
+            'previous_group_id': previous_group_id,
+            'new_group_id': new_group_id,
+            'hashes': list(hashes),
+            'datetime': datetime.now(tz=pytz.utc),
+        }
+
+        self._send(
+            project_id,
+            'start_unmerge',
+            extra_data=(state,),
+            asynchronous=False
+        )
+
+        return state
+
+    def end_unmerge(self, state):
+        state = state.copy()
+        state['datetime'] = datetime.now(tz=pytz.utc)
+        self._send(
+            state['project_id'],
+            'end_unmerge',
+            extra_data=(state,),
+            asynchronous=False
+        )
+
+    def start_delete_tag(self, project_id, tag):
+        if not tag:
+            return
+
+        state = {
+            'transaction_id': uuid4().hex,
+            'project_id': project_id,
+            'tag': tag,
+            'datetime': datetime.now(tz=pytz.utc),
+        }
+
+        self._send(
+            project_id,
+            'start_delete_tag',
+            extra_data=(state,),
+            asynchronous=False
+        )
+
+        return state
+
+    def end_delete_tag(self, state):
+        state = state.copy()
+        state['datetime'] = datetime.now(tz=pytz.utc)
+        self._send(
+            state['project_id'],
+            'end_delete_tag',
+            extra_data=(state,),
+            asynchronous=False
+        )
+
     def _send(self, project_id, _type, extra_data=(), asynchronous=True):
-        data = (EVENT_PROTOCOL_VERSION, _type) + extra_data
+        raise NotImplementedError
+
+
+class SnubaEventStream(SnubaProtocolEventStream):
+    def _send(self, project_id, _type, extra_data=(), asynchronous=True):
+        data = (self.EVENT_PROTOCOL_VERSION, _type) + extra_data
 
         try:
             resp = snuba._snuba_pool.urlopen(


### PR DESCRIPTION
This prevents using the HTTP-backed Snuba transport in local development from requiring all of the Kafka dependencies (such as a working `confluent-kafka` installation, which has been an occasional struggle.)