### PR TITLE
fix(async-component): Cancel in flight requests before refetching

### DIFF
--- a/src/sentry/static/sentry/app/components/asyncComponent.jsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.jsx
@@ -157,7 +157,9 @@ export default class AsyncComponent extends React.Component {
       return;
     }
 
-    // TODO(dcramer): this should cancel any existing API requests
+    // Cancel any in flight requests
+    this.api.clear();
+
     this.setState({
       loading: true,
       error: false,


### PR DESCRIPTION
Make sure in flight requests are cancelled before refetching. Not doing
this can cause major problems in Sentry 10 due to the way redirecting to
saved global values works. If the first request returns after the
second, data will not be correct.

Fixes APP-1140