### PR TITLE
fix(api): Use tags[sentry:user] instead of sentry:user when querying snuba (APP-1151)

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -106,7 +106,7 @@ SENTRY_SNUBA_MAP = {
     'contexts.value': 'contexts.value',
     # misc
     'release': 'tags[sentry:release]',
-    'user': 'sentry:user',
+    'user': 'tags[sentry:user]',
 }
 
 

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -3,217 +3,132 @@ from __future__ import absolute_import
 from datetime import timedelta
 from django.utils import timezone
 from django.core.urlresolvers import reverse
+from exam import fixture
 
 from sentry.testutils import APITestCase, SnubaTestCase
 
 
 class OrganizationTagKeyValuesTest(APITestCase, SnubaTestCase):
+    endpoint = 'sentry-api-0-organization-tagkey-values'
+
     def setUp(self):
         super(OrganizationTagKeyValuesTest, self).setUp()
         self.min_ago = timezone.now() - timedelta(minutes=1)
         self.day_ago = timezone.now() - timedelta(days=1)
-
-    def test_simple(self):
         user = self.create_user()
-        org = self.create_organization()
-        team = self.create_team(organization=org)
-        self.create_member(organization=org, user=user, teams=[team])
-
+        self.org = self.create_organization()
+        self.team = self.create_team(organization=self.org)
+        self.create_member(organization=self.org, user=user, teams=[self.team])
         self.login_as(user=user)
 
-        project = self.create_project(organization=org, teams=[team])
-        group = self.create_group(project=project)
+    def get_response(self, key, **kwargs):
+        return super(OrganizationTagKeyValuesTest, self).get_response(self.org.slug, key)
 
+    def run_test(self, key, expected):
+        response = self.get_valid_response(key)
+        assert [(val['value'], val['count']) for val in response.data] == expected
+
+    @fixture
+    def project(self):
+        return self.create_project(organization=self.org, teams=[self.team])
+
+    @fixture
+    def group(self):
+        return self.create_group(project=self.project)
+
+    def test_simple(self):
         self.create_event(
-            'a' * 32, group=group, datetime=self.day_ago, tags={'fruit': 'apple'}
+            'a' * 32, group=self.group, datetime=self.day_ago, tags={'fruit': 'apple'}
         )
         self.create_event(
-            'b' * 32, group=group, datetime=self.min_ago, tags={'fruit': 'orange'}
+            'b' * 32, group=self.group, datetime=self.min_ago, tags={'fruit': 'orange'}
         )
         self.create_event(
-            'c' * 32, group=group, datetime=self.min_ago, tags={'some_tag': 'some_value'}
+            'c' * 32, group=self.group, datetime=self.min_ago, tags={'some_tag': 'some_value'}
         )
         self.create_event(
-            'd' * 32, group=group, datetime=self.min_ago, tags={'fruit': 'orange'}
+            'd' * 32, group=self.group, datetime=self.min_ago, tags={'fruit': 'orange'}
         )
 
         url = reverse(
             'sentry-api-0-organization-tagkey-values',
             kwargs={
-                'organization_slug': org.slug,
+                'organization_slug': self.org.slug,
                 'key': 'fruit',
             }
         )
-
         response = self.client.get(url, format='json')
         assert response.status_code == 200, response.content
-
-        assert [(val['value'], val['count'])
-                for val in response.data] == [('orange', 2), ('apple', 1)]
+        self.run_test('fruit', expected=[('orange', 2), ('apple', 1)])
 
     def test_bad_key(self):
-        user = self.create_user()
-        org = self.create_organization()
-        team = self.create_team(organization=org)
-        self.create_member(organization=org, user=user, teams=[team])
-
-        self.login_as(user=user)
-
-        url = reverse(
-            'sentry-api-0-organization-tagkey-values',
-            kwargs={
-                'organization_slug': org.slug,
-                'key': 'fr uit',
-            }
-        )
-
-        response = self.client.get(url, format='json')
+        response = self.get_response('fr uit')
         assert response.status_code == 400, response.content
         assert response.data == {'detail': 'Invalid tag key format for "fr uit"'}
 
     def test_snuba_column(self):
-        user = self.create_user()
-        org = self.create_organization()
-        team = self.create_team(organization=org)
-        self.create_member(organization=org, user=user, teams=[team])
-
-        self.login_as(user=user)
-
-        project = self.create_project(organization=org, teams=[team])
-        group = self.create_group(project=project)
-
         self.create_event(
-            'a' * 32, group=group, datetime=self.day_ago, user={'email': 'foo@example.com'},
+            'a' * 32, group=self.group, datetime=self.day_ago, user={'email': 'foo@example.com'},
         )
         self.create_event(
-            'b' * 32, group=group, datetime=self.min_ago, user={'email': 'bar@example.com'},
+            'b' * 32, group=self.group, datetime=self.min_ago, user={'email': 'bar@example.com'},
         )
         self.create_event(
-            'c' * 32, group=group, datetime=timezone.now() - timedelta(seconds=10), user={'email': 'baz@example.com'},
+            'c' * 32, group=self.group, datetime=timezone.now() - timedelta(seconds=10), user={'email': 'baz@example.com'},
         )
         self.create_event(
-            'd' * 32, group=group, datetime=timezone.now() - timedelta(seconds=10), user={'email': 'baz@example.com'},
+            'd' * 32, group=self.group, datetime=timezone.now() - timedelta(seconds=10), user={'email': 'baz@example.com'},
         )
-
-        url = reverse(
-            'sentry-api-0-organization-tagkey-values',
-            kwargs={
-                'organization_slug': org.slug,
-                'key': 'user.email',
-            }
+        self.run_test(
+            'user.email',
+            expected=[('baz@example.com', 2), ('bar@example.com', 1), ('foo@example.com', 1)],
         )
-
-        response = self.client.get(url, format='json')
-        assert response.status_code == 200, response.content
-        assert [(val['value'], val['count'])
-                for val in response.data] == [('baz@example.com', 2), ('bar@example.com', 1), ('foo@example.com', 1)]
 
     def test_release(self):
-        user = self.create_user()
-        org = self.create_organization()
-        team = self.create_team(organization=org)
-        self.create_member(organization=org, user=user, teams=[team])
-
-        self.login_as(user=user)
-
-        project = self.create_project(organization=org, teams=[team])
-        group = self.create_group(project=project)
-
         self.create_event(
-            'a' * 32, group=group, datetime=self.day_ago, tags={'sentry:release': '3.1.2'},
+            'a' * 32, group=self.group, datetime=self.day_ago, tags={'sentry:release': '3.1.2'},
         )
         self.create_event(
-            'b' * 32, group=group, datetime=self.min_ago, tags={'sentry:release': '4.1.2'},
+            'b' * 32, group=self.group, datetime=self.min_ago, tags={'sentry:release': '4.1.2'},
         )
         self.create_event(
-            'c' * 32, group=group, datetime=self.day_ago, tags={'sentry:release': '3.1.2'},
+            'c' * 32, group=self.group, datetime=self.day_ago, tags={'sentry:release': '3.1.2'},
         )
         self.create_event(
-            'd' * 32, group=group, datetime=timezone.now() - timedelta(seconds=10), tags={'sentry:release': '5.1.2'},
+            'd' * 32, group=self.group, datetime=timezone.now() - timedelta(seconds=10), tags={'sentry:release': '5.1.2'},
         )
+        self.run_test('release', expected=[('5.1.2', 1), ('4.1.2', 1), ('3.1.2', 2)])
 
-        url = reverse(
-            'sentry-api-0-organization-tagkey-values',
-            kwargs={
-                'organization_slug': org.slug,
-                'key': 'release',
-            }
+    def test_user_tag(self):
+        self.create_event(
+            'a' * 32, group=self.group, datetime=self.day_ago, tags={'sentry:user': '1'},
         )
-
-        response = self.client.get(url, format='json')
-        assert response.status_code == 200, response.content
-        assert [(val['value'], val['count'])
-                for val in response.data] == [('5.1.2', 1), ('4.1.2', 1), ('3.1.2', 2)]
+        self.create_event(
+            'b' * 32, group=self.group, datetime=self.min_ago, tags={'sentry:user': '2'},
+        )
+        self.create_event(
+            'c' * 32, group=self.group, datetime=self.day_ago, tags={'sentry:user': '1'},
+        )
+        self.create_event(
+            'd' * 32, group=self.group, datetime=timezone.now() - timedelta(seconds=10), tags={'sentry:user': '3'},
+        )
+        self.run_test('user', expected=[('3', 1), ('2', 1), ('1', 2)])
 
     def test_project_id(self):
-        user = self.create_user()
-        org = self.create_organization()
-        team = self.create_team(organization=org)
-        self.create_member(organization=org, user=user, teams=[team])
         other_org = self.create_organization()
-
-        self.login_as(user=user)
-
-        project = self.create_project(organization=org, teams=[team])
-        group = self.create_group(project=project)
-
         other_project = self.create_project(organization=other_org)
         other_group = self.create_group(project=other_project)
 
-        self.create_event('a' * 32, group=group, datetime=self.day_ago)
-        self.create_event('b' * 32, group=group, datetime=self.min_ago)
+        self.create_event('a' * 32, group=self.group, datetime=self.day_ago)
+        self.create_event('b' * 32, group=self.group, datetime=self.min_ago)
         self.create_event('c' * 32, group=other_group, datetime=self.day_ago)
-
-        url = reverse(
-            'sentry-api-0-organization-tagkey-values',
-            kwargs={
-                'organization_slug': org.slug,
-                'key': 'project.id',
-            }
-        )
-
-        response = self.client.get(url, format='json')
-        assert response.status_code == 200, response.content
-        assert len(response.data) == 0
+        self.run_test('project.id', expected=[])
 
     def test_array_column(self):
-        user = self.create_user()
-        org = self.create_organization()
-        team = self.create_team(organization=org)
-        self.create_member(organization=org, user=user, teams=[team])
-
-        self.login_as(user=user)
-
-        project = self.create_project(organization=org, teams=[team])
-        group = self.create_group(project=project)
-
-        self.create_event('a' * 32, group=group, datetime=self.day_ago)
-        self.create_event('b' * 32, group=group, datetime=self.min_ago)
-        self.create_event('c' * 32, group=group, datetime=self.day_ago)
-
-        url = reverse(
-            'sentry-api-0-organization-tagkey-values',
-            kwargs={
-                'organization_slug': org.slug,
-                'key': 'error.type',
-            }
-        )
-
-        response = self.client.get(url, format='json')
-        assert response.status_code == 200, response.content
+        self.create_event('a' * 32, group=self.group, datetime=self.day_ago)
+        self.create_event('b' * 32, group=self.group, datetime=self.min_ago)
+        self.create_event('c' * 32, group=self.group, datetime=self.day_ago)
+        self.run_test('error.type', expected=[])
 
     def test_no_projects(self):
-        user = self.create_user()
-        org = self.create_organization(owner=user)
-        self.login_as(user=user)
-        url = reverse(
-            'sentry-api-0-organization-tagkey-values',
-            kwargs={
-                'organization_slug': org.slug,
-                'key': 'fruit',
-            }
-        )
-
-        response = self.client.get(url, format='json')
-        assert response.status_code == 200, response.content
-        assert len(response.data) == 0
+        self.run_test('fruit', expected=[])


### PR DESCRIPTION
Even when a tag is a promoted tag, we should still just query it as a normal tag.

Fixes SENTRY-9KW