### PR TITLE
fix(api): Change PermissionDenied to ResourceDoesNotExist in releases endpoints

### DIFF
--- a/src/sentry/api/endpoints/filechange.py
+++ b/src/sentry/api/endpoints/filechange.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from rest_framework.exceptions import PermissionDenied
-
 from sentry.api.base import DocSection
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -34,7 +32,7 @@ class CommitFileChangeEndpoint(OrganizationReleasesBaseEndpoint):
             raise ResourceDoesNotExist
 
         if not self.has_release_permission(request, organization, release):
-            raise PermissionDenied
+            raise ResourceDoesNotExist
 
         queryset = list(
             CommitFileChange.objects.filter(

--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 from rest_framework import serializers
-from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
 from sentry.api.base import DocSection
@@ -82,7 +81,7 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint):
             raise ResourceDoesNotExist
 
         if not self.has_release_permission(request, organization, release):
-            raise PermissionDenied
+            raise ResourceDoesNotExist
 
         return Response(serialize(release, request.user))
 
@@ -128,7 +127,7 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint):
             raise ResourceDoesNotExist
 
         if not self.has_release_permission(request, organization, release):
-            raise PermissionDenied
+            raise ResourceDoesNotExist
 
         serializer = ReleaseSerializer(data=request.DATA)
 
@@ -210,7 +209,7 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint):
             raise ResourceDoesNotExist
 
         if not self.has_release_permission(request, organization, release):
-            raise PermissionDenied
+            raise ResourceDoesNotExist
 
         # we don't want to remove the first_release metadata on the Group, and
         # while people might want to kill a release (maybe to remove files),

--- a/src/sentry/api/endpoints/organization_release_file_details.py
+++ b/src/sentry/api/endpoints/organization_release_file_details.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 import posixpath
 
 from rest_framework import serializers
-from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
 from sentry.api.base import DocSection
@@ -60,7 +59,7 @@ class OrganizationReleaseFileDetailsEndpoint(OrganizationReleasesBaseEndpoint):
             raise ResourceDoesNotExist
 
         if not self.has_release_permission(request, organization, release):
-            raise PermissionDenied
+            raise ResourceDoesNotExist
 
         try:
             releasefile = ReleaseFile.objects.get(
@@ -102,7 +101,7 @@ class OrganizationReleaseFileDetailsEndpoint(OrganizationReleasesBaseEndpoint):
             raise ResourceDoesNotExist
 
         if not self.has_release_permission(request, organization, release):
-            raise PermissionDenied
+            raise ResourceDoesNotExist
 
         try:
             releasefile = ReleaseFile.objects.get(
@@ -149,7 +148,7 @@ class OrganizationReleaseFileDetailsEndpoint(OrganizationReleasesBaseEndpoint):
             raise ResourceDoesNotExist
 
         if not self.has_release_permission(request, organization, release):
-            raise PermissionDenied
+            raise ResourceDoesNotExist
 
         try:
             releasefile = ReleaseFile.objects.get(

--- a/src/sentry/api/endpoints/organization_release_files.py
+++ b/src/sentry/api/endpoints/organization_release_files.py
@@ -4,7 +4,6 @@ import re
 import logging
 from django.db import IntegrityError, transaction
 from rest_framework.response import Response
-from rest_framework.exceptions import PermissionDenied
 
 from sentry.api.base import DocSection
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
@@ -43,7 +42,7 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint):
             raise ResourceDoesNotExist
 
         if not self.has_release_permission(request, organization, release):
-            raise PermissionDenied
+            raise ResourceDoesNotExist
 
         file_list = ReleaseFile.objects.filter(
             release=release,
@@ -96,7 +95,7 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint):
         logger.info('organizationreleasefile.start')
 
         if not self.has_release_permission(request, organization, release):
-            raise PermissionDenied
+            raise ResourceDoesNotExist
 
         if 'file' not in request.FILES:
             return Response({'detail': 'Missing uploaded file'}, status=400)

--- a/src/sentry/api/endpoints/release_deploys.py
+++ b/src/sentry/api/endpoints/release_deploys.py
@@ -4,7 +4,6 @@ from django.db.models import F
 from django.utils import timezone
 
 from rest_framework import serializers
-from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
 from sentry.api.base import DocSection
@@ -52,7 +51,7 @@ class ReleaseDeploysEndpoint(OrganizationReleasesBaseEndpoint):
             raise ResourceDoesNotExist
 
         if not self.has_release_permission(request, organization, release):
-            raise PermissionDenied
+            raise ResourceDoesNotExist
 
         queryset = Deploy.objects.filter(
             organization_id=organization.id,
@@ -94,7 +93,7 @@ class ReleaseDeploysEndpoint(OrganizationReleasesBaseEndpoint):
             raise ResourceDoesNotExist
 
         if not self.has_release_permission(request, organization, release):
-            raise PermissionDenied
+            raise ResourceDoesNotExist
 
         serializer = DeploySerializer(data=request.DATA)
 

--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -75,7 +75,7 @@ class ReleaseDetailsTest(APITestCase):
             }
         )
         response = self.client.get(url)
-        assert response.status_code == 403
+        assert response.status_code == 404
 
     def test_multiple_projects(self):
         user = self.create_user(is_staff=False, is_superuser=False)
@@ -241,7 +241,7 @@ class UpdateReleaseDetailsTest(APITestCase):
             }
         )
         response = self.client.put(url, {'ref': 'master'})
-        assert response.status_code == 403
+        assert response.status_code == 404
 
     @patch('sentry.tasks.commits.fetch_commits')
     def test_deprecated_head_commits(self, mock_fetch_commits):
@@ -374,7 +374,7 @@ class UpdateReleaseDetailsTest(APITestCase):
             }
         )
         response = self.client.put(url, {'ref': 'master'})
-        assert response.status_code == 403
+        assert response.status_code == 404
 
     def test_commits(self):
         user = self.create_user(is_staff=False, is_superuser=False)


### PR DESCRIPTION
for some additional context: in sentry 10, the has_release_permission check
could mean that the user doesn't have access to the release OR that
the release isn't found in the project(s) provided. it seems less confusing
to change this to a 404 because of that. (but @wedamija lmk if you disagree and i could also try to figure out which it is -- permissions or the release not being in the projects)


cc @billyvg 