### PR TITLE
feat(api): Support weeks in relative dates

### DIFF
--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -123,7 +123,7 @@ def parse_stats_period(period):
     Convert a value such as 1h into a
     proper timedelta.
     """
-    m = re.match('^(\d+)([hdms]?)$', period)
+    m = re.match('^(\d+)([hdmsw]?)$', period)
     if not m:
         return None
     value, unit = m.groups()
@@ -131,5 +131,5 @@ def parse_stats_period(period):
     if not unit:
         unit = 's'
     return timedelta(**{
-        {'h': 'hours', 'd': 'days', 'm': 'minutes', 's': 'seconds'}[unit]: value,
+        {'h': 'hours', 'd': 'days', 'm': 'minutes', 's': 'seconds', 'w': 'weeks'}[unit]: value,
     })

--- a/tests/sentry/utils/test_dates.py
+++ b/tests/sentry/utils/test_dates.py
@@ -23,3 +23,4 @@ def test_parse_stats_period():
     assert parse_stats_period('20d') == datetime.timedelta(days=20)
     assert parse_stats_period('20f') is None
     assert parse_stats_period('-1s') is None
+    assert parse_stats_period('4w') == datetime.timedelta(weeks=4)


### PR DESCRIPTION
see JAVASCRIPT-50R. the old project overview page uses week time buckets, which then causes that time bucket to follow them into sentry 10 views (cc @billyvg to correct me if that's not actually what's happening)

this should prevent them from having a bad time when they go to the new views by adding support for week intervals