### PR TITLE
meta: Set correct paths for python tools in vscode config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,7 +46,7 @@
   "python.formatting.provider": "autopep8",
   "python.formatting.autopep8Args": ["--global-config", "${workspaceRoot}/setup.cfg"],
   // https://github.com/DonJayamanne/pythonVSCode/issues/992
-  "python.pythonPath": ".venv/bin/python",
+  "python.pythonPath": "${workspaceFolder}/.venv/bin/python",
   // test discovery is sluggish and the UI around running
   // tests is often in your way and misclicked
   "python.unitTest.pyTestEnabled": false,
@@ -56,5 +56,8 @@
     "${env.WORKON_HOME}/node_modules/prettier/bin/prettier.js",
   "editor.tabSize": 4,
   "restructuredtext.confPath": "",
-  "python.linting.enabled": true
+  "python.linting.enabled": true,
+  "python.linting.flake8Path": "${workspaceFolder}/.venv/bin/flake8",
+  "python.linting.pep8Path": "${workspaceFolder}/.venv/bin/pep8",
+  "python.unitTest.pyTestPath": "${workspaceFolder}/.venv/bin/pytest"
 }


### PR DESCRIPTION
This tells vscode to pick up the tools from the venv.