### PR TITLE
feat(superuser): Do not track last active org

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -238,6 +238,8 @@ class OrganizationEndpoint(Endpoint):
 
         # Track the 'active' organization when the request came from
         # a cookie based agent (react app)
+        # Never track any org (regardless of whether the user does or doesn't have
+        # membership in that org) when the user is in active superuser mode
         if request.auth is None and request.user and not is_active_superuser(request):
             request.session['activeorg'] = organization.slug
 

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -238,7 +238,7 @@ class OrganizationEndpoint(Endpoint):
 
         # Track the 'active' organization when the request came from
         # a cookie based agent (react app)
-        if request.auth is None and request.user:
+        if request.auth is None and request.user and not is_active_superuser(request):
             request.session['activeorg'] = organization.slug
 
         kwargs['organization'] = organization


### PR DESCRIPTION
Do not track last active org when accessing as an active superuser. We
don't want to remember a latest selection in this case.

Fixes APP-1155