### PR TITLE
fix(forms): Fix invalid query selectors

### DIFF
--- a/src/sentry/static/sentry/app/utils/sanitizeQuerySelector.jsx
+++ b/src/sentry/static/sentry/app/utils/sanitizeQuerySelector.jsx
@@ -1,0 +1,12 @@
+/**
+ * Sanitizes a string so that it can be used as a query selector
+ *
+ * e.g. `feedback:branding` --> `feedback-branding` or
+ * 'Data Privacy' --> 'Data-Privacy'
+ *
+ * @param {String} str The string to sanitize
+ * @return {String} Returns a sanitized string (replace
+ */
+export function sanitizeQuerySelector(str) {
+  return typeof str === 'string' ? str.replace(/[ :]+/g, '-') : '';
+}

--- a/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
@@ -14,6 +14,7 @@ import InlineSvg from 'app/components/inlineSvg';
 import PanelAlert from 'app/components/panels/panelAlert';
 import Spinner from 'app/views/settings/components/forms/spinner';
 import returnButton from 'app/views/settings/components/forms/returnButton';
+import {sanitizeQuerySelector} from 'app/utils/sanitizeQuerySelector';
 import space from 'app/styles/space';
 
 const FormFieldErrorReason = styled.div`
@@ -254,7 +255,7 @@ class FormField extends React.Component {
   }
 
   getId() {
-    return this.props.name;
+    return sanitizeQuerySelector(this.props.name);
   }
 
   getModel() {

--- a/src/sentry/static/sentry/app/views/settings/components/forms/jsonForm.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/jsonForm.jsx
@@ -1,11 +1,13 @@
 import {Box} from 'grid-emotion';
 import PropTypes from 'prop-types';
 import React from 'react';
+import * as Sentry from '@sentry/browser';
 import scrollToElement from 'scroll-to-element';
 
+import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {defined} from 'app/utils';
 import FieldFromConfig from 'app/views/settings/components/forms/fieldFromConfig';
-import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
+import {sanitizeQuerySelector} from 'app/utils/sanitizeQuerySelector';
 
 class JsonForm extends React.Component {
   static propTypes = {
@@ -84,7 +86,14 @@ class JsonForm extends React.Component {
     // Push onto callback queue so it runs after the DOM is updated,
     // this is required when navigating from a different page so that
     // the element is rendered on the page before trying to getElementById.
-    scrollToElement(hash, {align: 'middle', offset: -100});
+    try {
+      scrollToElement(sanitizeQuerySelector(decodeURIComponent(hash)), {
+        align: 'middle',
+        offset: -100,
+      });
+    } catch (err) {
+      Sentry.captureException(err);
+    }
   }
 
   render() {
@@ -188,7 +197,7 @@ class FormPanel extends React.Component {
     const shouldRenderHeader = typeof renderHeader === 'function';
 
     return (
-      <Panel key={title} id={title}>
+      <Panel key={title} id={sanitizeQuerySelector(title)}>
         <PanelHeader>{title}</PanelHeader>
         <PanelBody>
           {shouldRenderHeader && renderHeader({title, fields})}

--- a/tests/js/spec/utils/sanitizeQuerySelector.spec.jsx
+++ b/tests/js/spec/utils/sanitizeQuerySelector.spec.jsx
@@ -1,0 +1,15 @@
+import {sanitizeQuerySelector} from 'app/utils/sanitizeQuerySelector';
+
+describe('sanitizeQuerySelector', function() {
+  it('replaces all spaces with a hyphen', function() {
+    expect(sanitizeQuerySelector('foo bar baz bar foo')).toBe('foo-bar-baz-bar-foo');
+  });
+
+  it('replaces colons with a hyphen', function() {
+    expect(sanitizeQuerySelector('foo:bar:baz bar foo')).toBe('foo-bar-baz-bar-foo');
+  });
+
+  it('returns an empty string if passed undefined', function() {
+    expect(sanitizeQuerySelector()).toBe('');
+  });
+});

--- a/tests/js/spec/views/projectFilters.spec.jsx
+++ b/tests/js/spec/views/projectFilters.spec.jsx
@@ -197,7 +197,7 @@ describe('ProjectFilters', function() {
     });
 
     wrapper
-      .find('TextArea[id="filters:blacklisted_ips"]')
+      .find('TextArea[name="filters:blacklisted_ips"]')
       .simulate('change', {target: {value: 'test\ntest2'}})
       .simulate('blur');
     expect(mock.mock.calls[0][0]).toBe(PROJECT_URL);
@@ -207,10 +207,10 @@ describe('ProjectFilters', function() {
   });
 
   it('filter by release/error message are not enabled', function() {
-    expect(wrapper.find('TextArea[id="filters:releases"][disabled]')).toHaveLength(1);
-    expect(wrapper.find('TextArea[id="filters:error_messages"][disabled]')).toHaveLength(
-      1
-    );
+    expect(wrapper.find('TextArea[name="filters:releases"][disabled]')).toHaveLength(1);
+    expect(
+      wrapper.find('TextArea[name="filters:error_messages"][disabled]')
+    ).toHaveLength(1);
   });
 
   it('has custom inbound filters with flag + can change', function() {
@@ -233,8 +233,8 @@ describe('ProjectFilters', function() {
       );
     });
 
-    expect(wrapper.find('TextArea[id="filters:releases"]')).toHaveLength(1);
-    expect(wrapper.find('TextArea[id="filters:error_messages"]')).toHaveLength(1);
+    expect(wrapper.find('TextArea[name="filters:releases"]')).toHaveLength(1);
+    expect(wrapper.find('TextArea[name="filters:error_messages"]')).toHaveLength(1);
 
     const mock = MockApiClient.addMockResponse({
       url: PROJECT_URL,
@@ -242,7 +242,7 @@ describe('ProjectFilters', function() {
     });
 
     wrapper
-      .find('TextArea[id="filters:releases"]')
+      .find('TextArea[name="filters:releases"]')
       .simulate('change', {target: {value: 'release\nrelease2'}})
       .simulate('blur');
     expect(mock.mock.calls[0][0]).toBe(PROJECT_URL);
@@ -251,7 +251,7 @@ describe('ProjectFilters', function() {
     );
 
     wrapper
-      .find('TextArea[id="filters:error_messages"]')
+      .find('TextArea[name="filters:error_messages"]')
       .simulate('change', {target: {value: 'error\nerror2'}})
       .simulate('blur');
     expect(mock.mock.calls[1][1].data.options['filters:error_messages']).toBe(

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/sentryApplicationDetails.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/sentryApplicationDetails.spec.jsx.snap
@@ -645,16 +645,16 @@ exports[`Sentry Application Details edit existing application renders() it shows
                         title="Application Details"
                       >
                         <Panel
-                          id="Application Details"
+                          id="Application-Details"
                           key="Application Details"
                         >
                           <Component
                             className="css-yahxlu-Panel e1laxa7d0"
-                            id="Application Details"
+                            id="Application-Details"
                           >
                             <div
                               className="css-yahxlu-Panel e1laxa7d0"
-                              id="Application Details"
+                              id="Application-Details"
                             >
                               <PanelHeader>
                                 <Component
@@ -7631,12 +7631,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             >
                                                                                               <span
                                                                                                 className="Select-multi-value-wrapper"
-                                                                                                id="react-select-14--value"
+                                                                                                id="react-select-8--value"
                                                                                               >
                                                                                                 <Value
                                                                                                   disabled={false}
-                                                                                                  id="react-select-14--value-item"
-                                                                                                  instancePrefix="react-select-14-"
+                                                                                                  id="react-select-8--value-item"
+                                                                                                  instancePrefix="react-select-8-"
                                                                                                   onClick={null}
                                                                                                   placeholder="--"
                                                                                                   value={
@@ -7652,7 +7652,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     <span
                                                                                                       aria-selected="true"
                                                                                                       className="Select-value-label"
-                                                                                                      id="react-select-14--value-item"
+                                                                                                      id="react-select-8--value-item"
                                                                                                       role="option"
                                                                                                     >
                                                                                                       Read
@@ -7660,7 +7660,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                   </div>
                                                                                                 </Value>
                                                                                                 <AutosizeInput
-                                                                                                  aria-activedescendant="react-select-14--value"
+                                                                                                  aria-activedescendant="react-select-8--value"
                                                                                                   aria-expanded="false"
                                                                                                   aria-haspopup="false"
                                                                                                   aria-owns=""
@@ -7684,7 +7684,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     }
                                                                                                   >
                                                                                                     <input
-                                                                                                      aria-activedescendant="react-select-14--value"
+                                                                                                      aria-activedescendant="react-select-8--value"
                                                                                                       aria-expanded="false"
                                                                                                       aria-haspopup="false"
                                                                                                       aria-owns=""
@@ -9309,12 +9309,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             >
                                                                                               <span
                                                                                                 className="Select-multi-value-wrapper"
-                                                                                                id="react-select-15--value"
+                                                                                                id="react-select-9--value"
                                                                                               >
                                                                                                 <Value
                                                                                                   disabled={false}
-                                                                                                  id="react-select-15--value-item"
-                                                                                                  instancePrefix="react-select-15-"
+                                                                                                  id="react-select-9--value-item"
+                                                                                                  instancePrefix="react-select-9-"
                                                                                                   onClick={null}
                                                                                                   placeholder="--"
                                                                                                   value={
@@ -9330,7 +9330,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     <span
                                                                                                       aria-selected="true"
                                                                                                       className="Select-value-label"
-                                                                                                      id="react-select-15--value-item"
+                                                                                                      id="react-select-9--value-item"
                                                                                                       role="option"
                                                                                                     >
                                                                                                       No Access
@@ -9338,7 +9338,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                   </div>
                                                                                                 </Value>
                                                                                                 <AutosizeInput
-                                                                                                  aria-activedescendant="react-select-15--value"
+                                                                                                  aria-activedescendant="react-select-9--value"
                                                                                                   aria-expanded="false"
                                                                                                   aria-haspopup="false"
                                                                                                   aria-owns=""
@@ -9362,7 +9362,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     }
                                                                                                   >
                                                                                                     <input
-                                                                                                      aria-activedescendant="react-select-15--value"
+                                                                                                      aria-activedescendant="react-select-9--value"
                                                                                                       aria-expanded="false"
                                                                                                       aria-haspopup="false"
                                                                                                       aria-owns=""
@@ -10907,12 +10907,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             >
                                                                                               <span
                                                                                                 className="Select-multi-value-wrapper"
-                                                                                                id="react-select-16--value"
+                                                                                                id="react-select-10--value"
                                                                                               >
                                                                                                 <Value
                                                                                                   disabled={false}
-                                                                                                  id="react-select-16--value-item"
-                                                                                                  instancePrefix="react-select-16-"
+                                                                                                  id="react-select-10--value-item"
+                                                                                                  instancePrefix="react-select-10-"
                                                                                                   onClick={null}
                                                                                                   placeholder="--"
                                                                                                   value={
@@ -10928,7 +10928,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     <span
                                                                                                       aria-selected="true"
                                                                                                       className="Select-value-label"
-                                                                                                      id="react-select-16--value-item"
+                                                                                                      id="react-select-10--value-item"
                                                                                                       role="option"
                                                                                                     >
                                                                                                       No Access
@@ -10936,7 +10936,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                   </div>
                                                                                                 </Value>
                                                                                                 <AutosizeInput
-                                                                                                  aria-activedescendant="react-select-16--value"
+                                                                                                  aria-activedescendant="react-select-10--value"
                                                                                                   aria-expanded="false"
                                                                                                   aria-haspopup="false"
                                                                                                   aria-owns=""
@@ -10960,7 +10960,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     }
                                                                                                   >
                                                                                                     <input
-                                                                                                      aria-activedescendant="react-select-16--value"
+                                                                                                      aria-activedescendant="react-select-10--value"
                                                                                                       aria-expanded="false"
                                                                                                       aria-haspopup="false"
                                                                                                       aria-owns=""
@@ -12585,12 +12585,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             >
                                                                                               <span
                                                                                                 className="Select-multi-value-wrapper"
-                                                                                                id="react-select-17--value"
+                                                                                                id="react-select-11--value"
                                                                                               >
                                                                                                 <Value
                                                                                                   disabled={false}
-                                                                                                  id="react-select-17--value-item"
-                                                                                                  instancePrefix="react-select-17-"
+                                                                                                  id="react-select-11--value-item"
+                                                                                                  instancePrefix="react-select-11-"
                                                                                                   onClick={null}
                                                                                                   placeholder="--"
                                                                                                   value={
@@ -12606,7 +12606,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     <span
                                                                                                       aria-selected="true"
                                                                                                       className="Select-value-label"
-                                                                                                      id="react-select-17--value-item"
+                                                                                                      id="react-select-11--value-item"
                                                                                                       role="option"
                                                                                                     >
                                                                                                       No Access
@@ -12614,7 +12614,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                   </div>
                                                                                                 </Value>
                                                                                                 <AutosizeInput
-                                                                                                  aria-activedescendant="react-select-17--value"
+                                                                                                  aria-activedescendant="react-select-11--value"
                                                                                                   aria-expanded="false"
                                                                                                   aria-haspopup="false"
                                                                                                   aria-owns=""
@@ -12638,7 +12638,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     }
                                                                                                   >
                                                                                                     <input
-                                                                                                      aria-activedescendant="react-select-17--value"
+                                                                                                      aria-activedescendant="react-select-11--value"
                                                                                                       aria-expanded="false"
                                                                                                       aria-haspopup="false"
                                                                                                       aria-owns=""
@@ -14263,12 +14263,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             >
                                                                                               <span
                                                                                                 className="Select-multi-value-wrapper"
-                                                                                                id="react-select-18--value"
+                                                                                                id="react-select-12--value"
                                                                                               >
                                                                                                 <Value
                                                                                                   disabled={false}
-                                                                                                  id="react-select-18--value-item"
-                                                                                                  instancePrefix="react-select-18-"
+                                                                                                  id="react-select-12--value-item"
+                                                                                                  instancePrefix="react-select-12-"
                                                                                                   onClick={null}
                                                                                                   placeholder="--"
                                                                                                   value={
@@ -14284,7 +14284,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     <span
                                                                                                       aria-selected="true"
                                                                                                       className="Select-value-label"
-                                                                                                      id="react-select-18--value-item"
+                                                                                                      id="react-select-12--value-item"
                                                                                                       role="option"
                                                                                                     >
                                                                                                       No Access
@@ -14292,7 +14292,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                   </div>
                                                                                                 </Value>
                                                                                                 <AutosizeInput
-                                                                                                  aria-activedescendant="react-select-18--value"
+                                                                                                  aria-activedescendant="react-select-12--value"
                                                                                                   aria-expanded="false"
                                                                                                   aria-haspopup="false"
                                                                                                   aria-owns=""
@@ -14316,7 +14316,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     }
                                                                                                   >
                                                                                                     <input
-                                                                                                      aria-activedescendant="react-select-18--value"
+                                                                                                      aria-activedescendant="react-select-12--value"
                                                                                                       aria-expanded="false"
                                                                                                       aria-haspopup="false"
                                                                                                       aria-owns=""
@@ -15941,12 +15941,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             >
                                                                                               <span
                                                                                                 className="Select-multi-value-wrapper"
-                                                                                                id="react-select-19--value"
+                                                                                                id="react-select-13--value"
                                                                                               >
                                                                                                 <Value
                                                                                                   disabled={false}
-                                                                                                  id="react-select-19--value-item"
-                                                                                                  instancePrefix="react-select-19-"
+                                                                                                  id="react-select-13--value-item"
+                                                                                                  instancePrefix="react-select-13-"
                                                                                                   onClick={null}
                                                                                                   placeholder="--"
                                                                                                   value={
@@ -15962,7 +15962,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     <span
                                                                                                       aria-selected="true"
                                                                                                       className="Select-value-label"
-                                                                                                      id="react-select-19--value-item"
+                                                                                                      id="react-select-13--value-item"
                                                                                                       role="option"
                                                                                                     >
                                                                                                       No Access
@@ -15970,7 +15970,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                   </div>
                                                                                                 </Value>
                                                                                                 <AutosizeInput
-                                                                                                  aria-activedescendant="react-select-19--value"
+                                                                                                  aria-activedescendant="react-select-13--value"
                                                                                                   aria-expanded="false"
                                                                                                   aria-haspopup="false"
                                                                                                   aria-owns=""
@@ -15994,7 +15994,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     }
                                                                                                   >
                                                                                                     <input
-                                                                                                      aria-activedescendant="react-select-19--value"
+                                                                                                      aria-activedescendant="react-select-13--value"
                                                                                                       aria-expanded="false"
                                                                                                       aria-haspopup="false"
                                                                                                       aria-owns=""
@@ -19473,16 +19473,16 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                         title="Application Details"
                       >
                         <Panel
-                          id="Application Details"
+                          id="Application-Details"
                           key="Application Details"
                         >
                           <Component
                             className="css-yahxlu-Panel e1laxa7d0"
-                            id="Application Details"
+                            id="Application-Details"
                           >
                             <div
                               className="css-yahxlu-Panel e1laxa7d0"
-                              id="Application Details"
+                              id="Application-Details"
                             >
                               <PanelHeader>
                                 <Component

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/sentryApplicationDetails.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/sentryApplicationDetails.spec.jsx.snap
@@ -7631,12 +7631,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             >
                                                                                               <span
                                                                                                 className="Select-multi-value-wrapper"
-                                                                                                id="react-select-8--value"
+                                                                                                id="react-select-14--value"
                                                                                               >
                                                                                                 <Value
                                                                                                   disabled={false}
-                                                                                                  id="react-select-8--value-item"
-                                                                                                  instancePrefix="react-select-8-"
+                                                                                                  id="react-select-14--value-item"
+                                                                                                  instancePrefix="react-select-14-"
                                                                                                   onClick={null}
                                                                                                   placeholder="--"
                                                                                                   value={
@@ -7652,7 +7652,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     <span
                                                                                                       aria-selected="true"
                                                                                                       className="Select-value-label"
-                                                                                                      id="react-select-8--value-item"
+                                                                                                      id="react-select-14--value-item"
                                                                                                       role="option"
                                                                                                     >
                                                                                                       Read
@@ -7660,7 +7660,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                   </div>
                                                                                                 </Value>
                                                                                                 <AutosizeInput
-                                                                                                  aria-activedescendant="react-select-8--value"
+                                                                                                  aria-activedescendant="react-select-14--value"
                                                                                                   aria-expanded="false"
                                                                                                   aria-haspopup="false"
                                                                                                   aria-owns=""
@@ -7684,7 +7684,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     }
                                                                                                   >
                                                                                                     <input
-                                                                                                      aria-activedescendant="react-select-8--value"
+                                                                                                      aria-activedescendant="react-select-14--value"
                                                                                                       aria-expanded="false"
                                                                                                       aria-haspopup="false"
                                                                                                       aria-owns=""
@@ -9309,12 +9309,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             >
                                                                                               <span
                                                                                                 className="Select-multi-value-wrapper"
-                                                                                                id="react-select-9--value"
+                                                                                                id="react-select-15--value"
                                                                                               >
                                                                                                 <Value
                                                                                                   disabled={false}
-                                                                                                  id="react-select-9--value-item"
-                                                                                                  instancePrefix="react-select-9-"
+                                                                                                  id="react-select-15--value-item"
+                                                                                                  instancePrefix="react-select-15-"
                                                                                                   onClick={null}
                                                                                                   placeholder="--"
                                                                                                   value={
@@ -9330,7 +9330,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     <span
                                                                                                       aria-selected="true"
                                                                                                       className="Select-value-label"
-                                                                                                      id="react-select-9--value-item"
+                                                                                                      id="react-select-15--value-item"
                                                                                                       role="option"
                                                                                                     >
                                                                                                       No Access
@@ -9338,7 +9338,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                   </div>
                                                                                                 </Value>
                                                                                                 <AutosizeInput
-                                                                                                  aria-activedescendant="react-select-9--value"
+                                                                                                  aria-activedescendant="react-select-15--value"
                                                                                                   aria-expanded="false"
                                                                                                   aria-haspopup="false"
                                                                                                   aria-owns=""
@@ -9362,7 +9362,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     }
                                                                                                   >
                                                                                                     <input
-                                                                                                      aria-activedescendant="react-select-9--value"
+                                                                                                      aria-activedescendant="react-select-15--value"
                                                                                                       aria-expanded="false"
                                                                                                       aria-haspopup="false"
                                                                                                       aria-owns=""
@@ -10907,12 +10907,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             >
                                                                                               <span
                                                                                                 className="Select-multi-value-wrapper"
-                                                                                                id="react-select-10--value"
+                                                                                                id="react-select-16--value"
                                                                                               >
                                                                                                 <Value
                                                                                                   disabled={false}
-                                                                                                  id="react-select-10--value-item"
-                                                                                                  instancePrefix="react-select-10-"
+                                                                                                  id="react-select-16--value-item"
+                                                                                                  instancePrefix="react-select-16-"
                                                                                                   onClick={null}
                                                                                                   placeholder="--"
                                                                                                   value={
@@ -10928,7 +10928,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     <span
                                                                                                       aria-selected="true"
                                                                                                       className="Select-value-label"
-                                                                                                      id="react-select-10--value-item"
+                                                                                                      id="react-select-16--value-item"
                                                                                                       role="option"
                                                                                                     >
                                                                                                       No Access
@@ -10936,7 +10936,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                   </div>
                                                                                                 </Value>
                                                                                                 <AutosizeInput
-                                                                                                  aria-activedescendant="react-select-10--value"
+                                                                                                  aria-activedescendant="react-select-16--value"
                                                                                                   aria-expanded="false"
                                                                                                   aria-haspopup="false"
                                                                                                   aria-owns=""
@@ -10960,7 +10960,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     }
                                                                                                   >
                                                                                                     <input
-                                                                                                      aria-activedescendant="react-select-10--value"
+                                                                                                      aria-activedescendant="react-select-16--value"
                                                                                                       aria-expanded="false"
                                                                                                       aria-haspopup="false"
                                                                                                       aria-owns=""
@@ -12585,12 +12585,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             >
                                                                                               <span
                                                                                                 className="Select-multi-value-wrapper"
-                                                                                                id="react-select-11--value"
+                                                                                                id="react-select-17--value"
                                                                                               >
                                                                                                 <Value
                                                                                                   disabled={false}
-                                                                                                  id="react-select-11--value-item"
-                                                                                                  instancePrefix="react-select-11-"
+                                                                                                  id="react-select-17--value-item"
+                                                                                                  instancePrefix="react-select-17-"
                                                                                                   onClick={null}
                                                                                                   placeholder="--"
                                                                                                   value={
@@ -12606,7 +12606,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     <span
                                                                                                       aria-selected="true"
                                                                                                       className="Select-value-label"
-                                                                                                      id="react-select-11--value-item"
+                                                                                                      id="react-select-17--value-item"
                                                                                                       role="option"
                                                                                                     >
                                                                                                       No Access
@@ -12614,7 +12614,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                   </div>
                                                                                                 </Value>
                                                                                                 <AutosizeInput
-                                                                                                  aria-activedescendant="react-select-11--value"
+                                                                                                  aria-activedescendant="react-select-17--value"
                                                                                                   aria-expanded="false"
                                                                                                   aria-haspopup="false"
                                                                                                   aria-owns=""
@@ -12638,7 +12638,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     }
                                                                                                   >
                                                                                                     <input
-                                                                                                      aria-activedescendant="react-select-11--value"
+                                                                                                      aria-activedescendant="react-select-17--value"
                                                                                                       aria-expanded="false"
                                                                                                       aria-haspopup="false"
                                                                                                       aria-owns=""
@@ -14263,12 +14263,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             >
                                                                                               <span
                                                                                                 className="Select-multi-value-wrapper"
-                                                                                                id="react-select-12--value"
+                                                                                                id="react-select-18--value"
                                                                                               >
                                                                                                 <Value
                                                                                                   disabled={false}
-                                                                                                  id="react-select-12--value-item"
-                                                                                                  instancePrefix="react-select-12-"
+                                                                                                  id="react-select-18--value-item"
+                                                                                                  instancePrefix="react-select-18-"
                                                                                                   onClick={null}
                                                                                                   placeholder="--"
                                                                                                   value={
@@ -14284,7 +14284,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     <span
                                                                                                       aria-selected="true"
                                                                                                       className="Select-value-label"
-                                                                                                      id="react-select-12--value-item"
+                                                                                                      id="react-select-18--value-item"
                                                                                                       role="option"
                                                                                                     >
                                                                                                       No Access
@@ -14292,7 +14292,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                   </div>
                                                                                                 </Value>
                                                                                                 <AutosizeInput
-                                                                                                  aria-activedescendant="react-select-12--value"
+                                                                                                  aria-activedescendant="react-select-18--value"
                                                                                                   aria-expanded="false"
                                                                                                   aria-haspopup="false"
                                                                                                   aria-owns=""
@@ -14316,7 +14316,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     }
                                                                                                   >
                                                                                                     <input
-                                                                                                      aria-activedescendant="react-select-12--value"
+                                                                                                      aria-activedescendant="react-select-18--value"
                                                                                                       aria-expanded="false"
                                                                                                       aria-haspopup="false"
                                                                                                       aria-owns=""
@@ -15941,12 +15941,12 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             >
                                                                                               <span
                                                                                                 className="Select-multi-value-wrapper"
-                                                                                                id="react-select-13--value"
+                                                                                                id="react-select-19--value"
                                                                                               >
                                                                                                 <Value
                                                                                                   disabled={false}
-                                                                                                  id="react-select-13--value-item"
-                                                                                                  instancePrefix="react-select-13-"
+                                                                                                  id="react-select-19--value-item"
+                                                                                                  instancePrefix="react-select-19-"
                                                                                                   onClick={null}
                                                                                                   placeholder="--"
                                                                                                   value={
@@ -15962,7 +15962,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     <span
                                                                                                       aria-selected="true"
                                                                                                       className="Select-value-label"
-                                                                                                      id="react-select-13--value-item"
+                                                                                                      id="react-select-19--value-item"
                                                                                                       role="option"
                                                                                                     >
                                                                                                       No Access
@@ -15970,7 +15970,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                   </div>
                                                                                                 </Value>
                                                                                                 <AutosizeInput
-                                                                                                  aria-activedescendant="react-select-13--value"
+                                                                                                  aria-activedescendant="react-select-19--value"
                                                                                                   aria-expanded="false"
                                                                                                   aria-haspopup="false"
                                                                                                   aria-owns=""
@@ -15994,7 +15994,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                     }
                                                                                                   >
                                                                                                     <input
-                                                                                                      aria-activedescendant="react-select-13--value"
+                                                                                                      aria-activedescendant="react-select-19--value"
                                                                                                       aria-expanded="false"
                                                                                                       aria-haspopup="false"
                                                                                                       aria-owns=""


### PR DESCRIPTION
Fix invalid query selectors in settings. Some fields/titles have invalid characters (e.g. spaces, `:`, etc)
for an `id` attribute. Use `slugify()` function on these fields.

Also adds a try/catch to `scrollToElement` call in case there are other special characters not captured in our slugify function.

Fixes JAVASCRIPT-45J