### PR TITLE
fix(app-platform): Include `code` in redirect

### DIFF
--- a/src/sentry/api/serializers/models/sentry_app_installation.py
+++ b/src/sentry/api/serializers/models/sentry_app_installation.py
@@ -19,7 +19,7 @@ class SentryAppInstallationSerializer(Serializer):
             'uuid': install.uuid,
         }
 
-        if 'code' in attrs:
-            data['code'] = attrs['code']
+        if install.api_grant:
+            data['code'] = install.api_grant.code
 
         return data

--- a/src/sentry/mediators/sentry_app_installations/installation_notifier.py
+++ b/src/sentry/mediators/sentry_app_installations/installation_notifier.py
@@ -36,7 +36,7 @@ class InstallationNotifier(Mediator):
     def request(self):
         attrs = {}
 
-        if self.install.is_new and self.api_grant:
+        if self.action == 'created' and self.api_grant:
             attrs['code'] = self.api_grant.code
 
         data = SentryAppInstallationSerializer().serialize(

--- a/src/sentry/mediators/token_exchange/grant_exchanger.py
+++ b/src/sentry/mediators/token_exchange/grant_exchanger.py
@@ -25,6 +25,10 @@ class GrantExchanger(Mediator):
     def call(self):
         self._validate()
 
+        # Once it's exchanged it's no longer valid and should not be
+        # exchangable, so we delete it.
+        self._delete_grant()
+
         return ApiToken.objects.create(
             user=self.user,
             application=self.application,
@@ -56,6 +60,9 @@ class GrantExchanger(Mediator):
 
     def _grant_is_active(self):
         return self.grant.expires_at > datetime.now(pytz.UTC)
+
+    def _delete_grant(self):
+        self.grant.delete()
 
     @memoize
     def grant(self):

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -58,6 +58,7 @@ class GetSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
                 'slug': self.org.slug,
             },
             'uuid': self.installation2.uuid,
+            'code': self.installation2.api_grant.code,
         }
 
     @with_feature('organizations:sentry-apps')

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -59,6 +59,7 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
                 'slug': self.org.slug,
             },
             'uuid': self.installation2.uuid,
+            'code': self.installation2.api_grant.code,
         }]
 
         url = reverse(
@@ -78,6 +79,7 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
                 'slug': self.super_org.slug,
             },
             'uuid': self.installation.uuid,
+            'code': self.installation.api_grant.code,
         }]
 
     @with_feature('organizations:sentry-apps')
@@ -95,6 +97,7 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
                 'slug': self.org.slug,
             },
             'uuid': self.installation2.uuid,
+            'code': self.installation2.api_grant.code,
         }]
 
         # Org the User is not a part of

--- a/tests/sentry/mediators/token_exchange/test_grant_exchanger.py
+++ b/tests/sentry/mediators/token_exchange/test_grant_exchanger.py
@@ -4,7 +4,7 @@ from mock import patch
 from datetime import datetime, timedelta
 
 from sentry.coreapi import APIUnauthorized
-from sentry.models import ApiApplication, SentryApp
+from sentry.models import ApiApplication, SentryApp, ApiGrant
 from sentry.mediators.token_exchange import GrantExchanger
 from sentry.testutils import TestCase
 
@@ -70,3 +70,8 @@ class TestGrantExchanger(TestCase):
     def test_sentry_app_must_exist(self, _):
         with self.assertRaises(APIUnauthorized):
             self.grant_exchanger.call()
+
+    def test_deletes_grant_on_successful_exchange(self):
+        grant_id = self.install.api_grant_id
+        self.grant_exchanger.call()
+        assert not ApiGrant.objects.filter(id=grant_id)


### PR DESCRIPTION
Previous changes removed `code` (the ApiGrant code) from ever being
included in the Redirect and the Installation Webhook. This change fixes
that in two parts:

First, when a Grant Code is exchanged for an Access Token, we delete the
ApiGrant.

Second, we use the fact that a SentryAppInstallation has NO ApiGrant
associated with it to mean it was already exchanged and therefor no
longer an attribute we need to serialize.

The outcome is that `code` will be included in all requests (webhook and
redirect), but only when it's valid.