### PR TITLE
fix(stream): Fix empty search in stream

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -168,7 +168,8 @@ const OrganizationStream = createReactClass({
     if (this.state.savedSearch) {
       return this.state.savedSearch.query;
     }
-    return this.props.location.query.query || DEFAULT_QUERY;
+    const {query} = this.props.location.query;
+    return typeof query === 'undefined' ? DEFAULT_QUERY : query;
   },
 
   getSort() {


### PR DESCRIPTION
Fixes a bug preventing the user from making an empty search in the
issue stream view since a query value of "" would not get short
circuited and always apply the default value of is:unresolved