### PR TITLE
fix(search): Strip enclosing quotation marks on raw query term

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -224,10 +224,10 @@ class SearchVisitor(NodeVisitor):
     def visit_raw_search(self, node, children):
         value = node.text
 
-        if value.startswith('"') and value.endswith('"') and value != '"':
-            value = value.strip('"')
+        while value.startswith('"') and value.endswith('"') and value != '"':
+            value = value[1:-1]
 
-        if len(value) == 0:
+        if not value:
             return None
 
         return SearchFilter(

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -222,10 +222,18 @@ class SearchVisitor(NodeVisitor):
         return search_term[0]
 
     def visit_raw_search(self, node, children):
+        value = node.text
+
+        if value.startswith('"') and value.endswith('"') and value != '"':
+            value = value.strip('"')
+
+        if len(value) == 0:
+            return None
+
         return SearchFilter(
             SearchKey('message'),
             "=",
-            SearchValue(node.text),
+            SearchValue(value),
         )
 
     def visit_numeric_filter(self, node, children):

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -504,6 +504,24 @@ class ParseSearchQueryTest(TestCase):
             ),
         ]
 
+        # Strip in a balanced manner
+        assert parse_search_query('""woof"') == [
+            SearchFilter(
+                key=SearchKey(name='message'),
+                operator='=',
+                value=SearchValue(raw_value='"woof'),
+            ),
+        ]
+
+        # Don't try this at home kids
+        assert parse_search_query('"""""""""') == [
+            SearchFilter(
+                key=SearchKey(name='message'),
+                operator='=',
+                value=SearchValue(raw_value='"'),
+            ),
+        ]
+
 
 class GetSnubaQueryArgsTest(TestCase):
     def test_simple(self):

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -441,6 +441,69 @@ class ParseSearchQueryTest(TestCase):
             ),
         ]
 
+    def test_quotes_filtered_on_raw(self):
+        # Enclose the full raw query? Strip it.
+        assert parse_search_query('thinger:unknown "what is this?"') == [
+            SearchFilter(
+                key=SearchKey(name='thinger'),
+                operator='=',
+                value=SearchValue(raw_value='unknown'),
+            ),
+            SearchFilter(
+                key=SearchKey(name='message'),
+                operator='=',
+                value=SearchValue(raw_value='what is this?'),
+            ),
+        ]
+
+        # Enclose the full query? Strip it and the whole query is raw.
+        assert parse_search_query('"thinger:unknown what is this?"') == [
+            SearchFilter(
+                key=SearchKey(name='message'),
+                operator='=',
+                value=SearchValue(raw_value='thinger:unknown what is this?'),
+            ),
+        ]
+
+        # Allow a single quotation at end
+        assert parse_search_query('end"') == [
+            SearchFilter(
+                key=SearchKey(name='message'),
+                operator='=',
+                value=SearchValue(raw_value='end"'),
+            ),
+        ]
+
+        # Allow a single quotation at beginning
+        assert parse_search_query('"beginning') == [
+            SearchFilter(
+                key=SearchKey(name='message'),
+                operator='=',
+                value=SearchValue(raw_value='"beginning'),
+            ),
+        ]
+
+        # Allow a single quotation
+        assert parse_search_query('"') == [
+            SearchFilter(
+                key=SearchKey(name='message'),
+                operator='=',
+                value=SearchValue(raw_value='"'),
+            ),
+        ]
+
+        # Empty quotations become a dropped term
+        assert parse_search_query('""') == []
+
+        # Allow a search for space
+        assert parse_search_query('" "') == [
+            SearchFilter(
+                key=SearchKey(name='message'),
+                operator='=',
+                value=SearchValue(raw_value=' '),
+            ),
+        ]
+
 
 class GetSnubaQueryArgsTest(TestCase):
     def test_simple(self):

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1252,3 +1252,10 @@ class SnubaSearchTest(SnubaTestCase):
             search_filter_query='first_release:%s' % release.version,
         )
         assert set(results) == set([self.group1])
+
+    def test_query_enclosed_in_quotes(self):
+        results = self.make_query(search_filter_query='"foo"', query='"foo"')
+        assert set(results) == set([self.group1])
+
+        results = self.make_query(search_filter_query='"bar"', query='"bar"')
+        assert set(results) == set([self.group2])


### PR DESCRIPTION
Users have sent in searches surrounded by quotation marks which
becomes a literal search in Snuba. This will make a best effort
attempt at stripping enclosing quotation marks.

Fixes APP-1152