### PR TITLE
ref: Remove some more usage of createReactClass / mixins

### DIFF
--- a/src/sentry/static/sentry/app/components/activity/feed.jsx
+++ b/src/sentry/static/sentry/app/components/activity/feed.jsx
@@ -1,49 +1,44 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 
 import {logException} from 'app/utils/logging';
 import {t} from 'app/locale';
 import ActivityItem from 'app/components/activity/item';
-import ApiMixin from 'app/mixins/apiMixin';
 import ErrorBoundary from 'app/components/errorBoundary';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import Pagination from 'app/components/pagination';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
+import withApi from 'app/utils/withApi';
 
-const ActivityFeed = createReactClass({
-  displayName: 'ActivityFeed',
-
-  propTypes: {
+class ActivityFeed extends React.Component {
+  static propTypes = {
+    api: PropTypes.object,
     organization: SentryTypes.Organization,
     endpoint: PropTypes.string,
     query: PropTypes.object,
     pagination: PropTypes.bool,
-  },
+  };
 
-  mixins: [ApiMixin],
+  static defaultProps = {
+    pagination: true,
+    query: {},
+  };
 
-  getDefaultProps() {
-    return {
-      pagination: true,
-      query: {},
-    };
-  },
-
-  getInitialState() {
-    return {
+  constructor(props) {
+    super(props);
+    this.state = {
       itemList: [],
       loading: true,
       error: false,
       pageLinks: null,
     };
-  },
+  }
 
   componentWillMount() {
     this.fetchData();
-  },
+  }
 
   componentWillReceiveProps(nextProps) {
     const location = this.props.location;
@@ -54,16 +49,12 @@ const ActivityFeed = createReactClass({
     ) {
       this.remountComponent();
     }
-  },
-
-  remountComponent() {
-    this.setState(this.getInitialState(), this.fetchData);
-  },
+  }
 
   fetchData() {
     const location = this.props.location;
-    this.api.clear();
-    this.api.request(this.props.endpoint, {
+    this.props.api.clear();
+    this.props.api.request(this.props.endpoint, {
       method: 'GET',
       query: {
         cursor: location.query.cursor || '',
@@ -84,7 +75,7 @@ const ActivityFeed = createReactClass({
         });
       },
     });
-  },
+  }
 
   renderResults() {
     let body;
@@ -119,7 +110,7 @@ const ActivityFeed = createReactClass({
     } else body = this.renderEmpty();
 
     return body;
-  },
+  }
 
   renderLoading() {
     return (
@@ -127,11 +118,11 @@ const ActivityFeed = createReactClass({
         <LoadingIndicator />
       </div>
     );
-  },
+  }
 
   renderEmpty() {
     return <div className="box empty">{t('Nothing to show here, move along.')}</div>;
-  },
+  }
 
   render() {
     return (
@@ -143,7 +134,7 @@ const ActivityFeed = createReactClass({
           )}
       </div>
     );
-  },
-});
+  }
+}
 
-export default ActivityFeed;
+export default withApi(ActivityFeed);

--- a/src/sentry/static/sentry/app/components/avatarChooser.jsx
+++ b/src/sentry/static/sentry/app/components/avatarChooser.jsx
@@ -1,25 +1,23 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
 
+import RadioGroup from 'app/views/settings/components/forms/controls/radioGroup';
+import {t} from 'app/locale';
+import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
+import withApi from 'app/utils/withApi';
 import Well from 'app/components/well';
 import {Panel, PanelBody, PanelHeader} from './panels';
-import {addErrorMessage, addSuccessMessage} from '../actionCreators/indicator';
-import {t} from '../locale';
-import ApiMixin from '../mixins/apiMixin';
 import Avatar from './avatar';
 import AvatarCropper from './avatarCropper';
 import Button from './button';
 import ExternalLink from './externalLink';
 import LoadingError from './loadingError';
 import LoadingIndicator from './loadingIndicator';
-import RadioGroup from '../views/settings/components/forms/controls/radioGroup';
 
-const AvatarChooser = createReactClass({
-  displayName: 'AvatarChooser',
-
-  propTypes: {
+class AvatarChooser extends React.Component {
+  static propTypes = {
+    api: PropTypes.object,
     endpoint: PropTypes.string.isRequired,
     allowGravatar: PropTypes.bool,
     allowLetter: PropTypes.bool,
@@ -35,56 +33,53 @@ const AvatarChooser = createReactClass({
     savedDataUrl: PropTypes.string,
     onSave: PropTypes.func,
     disabled: PropTypes.bool,
-  },
+  };
 
-  mixins: [ApiMixin],
+  static defaultProps = {
+    allowGravatar: true,
+    allowLetter: true,
+    allowUpload: true,
+    onSave: () => {},
+  };
 
-  getDefaultProps() {
-    return {
-      allowGravatar: true,
-      allowLetter: true,
-      allowUpload: true,
-      onSave: () => {},
-    };
-  },
-
-  getInitialState() {
-    return {
+  constructor(props) {
+    super(props);
+    this.state = {
       model: this.props.model,
       savedDataUrl: null,
       dataUrl: null,
       hasError: false,
     };
-  },
+  }
 
   componentWillReceiveProps(nextProps) {
     // Update local state if defined in props
     if (typeof nextProps.model !== 'undefined') {
       this.setState({model: nextProps.model});
     }
-  },
+  }
 
   updateState(model) {
     this.setState({model});
-  },
+  }
 
   updateDataUrlState(dataUrlState) {
     this.setState(dataUrlState);
-  },
+  }
 
   handleError(msg) {
     addErrorMessage(msg);
-  },
+  }
 
   handleSuccess(model) {
     const {onSave} = this.props;
     this.setState({model});
     onSave(model);
     addSuccessMessage(t('Successfully saved avatar preferences'));
-  },
+  }
 
   handleSaveSettings(ev) {
-    const {endpoint} = this.props;
+    const {endpoint, api} = this.props;
     const {model, dataUrl} = this.state;
     ev.preventDefault();
     let data = {};
@@ -96,7 +91,7 @@ const AvatarChooser = createReactClass({
       avatar_type: avatarType,
     };
 
-    this.api.request(endpoint, {
+    api.request(endpoint, {
       method: 'PUT',
       data,
       success: resp => {
@@ -105,13 +100,13 @@ const AvatarChooser = createReactClass({
       },
       error: this.handleError.bind(this, 'There was an error saving your preferences.'),
     });
-  },
+  }
 
   handleChange(id) {
     const model = {...this.state.model};
     model.avatar.avatarType = id;
     this.updateState(model);
-  },
+  }
 
   render() {
     const {
@@ -209,8 +204,8 @@ const AvatarChooser = createReactClass({
         </PanelBody>
       </Panel>
     );
-  },
-});
+  }
+}
 
 const AvatarGroup = styled.div`
   display: flex;
@@ -232,4 +227,4 @@ const AvatarUploadSection = styled('div')`
   margin-top: 1em;
 `;
 
-export default AvatarChooser;
+export default withApi(AvatarChooser);

--- a/src/sentry/static/sentry/app/components/commitAuthorStats.jsx
+++ b/src/sentry/static/sentry/app/components/commitAuthorStats.jsx
@@ -1,14 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Flex} from 'grid-emotion';
-import createReactClass from 'create-react-class';
 
 import LoadingIndicator from 'app/components/loadingIndicator';
 import LoadingError from 'app/components/loadingError';
 import Avatar from 'app/components/avatar';
 import Tooltip from 'app/components/tooltip';
 
-import ApiMixin from 'app/mixins/apiMixin';
+import withApi from 'app/utils/withApi';
 
 import {t} from 'app/locale';
 import {Panel, PanelItem, PanelBody} from 'app/components/panels';
@@ -27,27 +26,25 @@ class CommitBar extends React.Component {
   }
 }
 
-const CommitAuthorStats = createReactClass({
-  displayName: 'CommitAuthorStats',
-
-  propTypes: {
+class CommitAuthorStats extends React.Component {
+  static propTypes = {
+    api: PropTypes.object,
     orgId: PropTypes.string.isRequired,
     // Provided in project release views, not in org release views
     projectId: PropTypes.string,
     version: PropTypes.string.isRequired,
-  },
+  };
 
-  mixins: [ApiMixin],
-
-  getInitialState() {
-    return {
+  constructor(props) {
+    super(props);
+    this.state = {
       loading: true,
       error: false,
     };
-  },
+  }
 
   componentDidMount() {
-    this.api.request(this.getPath(), {
+    this.props.api.request(this.getPath(), {
       method: 'GET',
       success: (data, _, jqXHR) => {
         this.setState({
@@ -64,7 +61,7 @@ const CommitAuthorStats = createReactClass({
         });
       },
     });
-  },
+  }
 
   getPath() {
     const {orgId, projectId, version} = this.props;
@@ -73,11 +70,11 @@ const CommitAuthorStats = createReactClass({
     return this.props.projectId
       ? `/projects/${orgId}/${projectId}/releases/${encodedVersion}/commits/`
       : `/organizations/${orgId}/releases/${encodedVersion}/commits/`;
-  },
+  }
 
   renderEmpty() {
     return <div className="box empty">{t('No authors in this release')}</div>;
-  },
+  }
 
   render() {
     if (this.state.loading) return <LoadingIndicator />;
@@ -136,7 +133,7 @@ const CommitAuthorStats = createReactClass({
         </Panel>
       </div>
     );
-  },
-});
+  }
+}
 
-export default CommitAuthorStats;
+export default withApi(CommitAuthorStats);

--- a/src/sentry/static/sentry/app/components/createSampleEvent.jsx
+++ b/src/sentry/static/sentry/app/components/createSampleEvent.jsx
@@ -1,30 +1,26 @@
 import {browserHistory} from 'react-router';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import styled from 'react-emotion';
 import * as Sentry from '@sentry/browser';
 
 import {analytics} from 'app/utils/analytics';
-import ApiMixin from 'app/mixins/apiMixin';
+import withApi from 'app/utils/withApi';
 import Button from 'app/components/button';
 import IndicatorStore from 'app/stores/indicatorStore';
 import SentryTypes from 'app/sentryTypes';
 import {t} from 'app/locale';
 
-const CreateSampleEvent = createReactClass({
-  displayName: 'createSampleEvent',
-
-  propTypes: {
+class CreateSampleEvent extends React.Component {
+  static propTypes = {
+    api: PropTypes.object,
     params: PropTypes.object.isRequired,
     source: PropTypes.string.isRequired,
-  },
+  };
 
-  contextTypes: {
+  static contextTypes = {
     organization: SentryTypes.Organization.isRequired,
-  },
-
-  mixins: [ApiMixin],
+  };
 
   componentDidMount() {
     const {projectId} = this.props.params;
@@ -39,11 +35,11 @@ const CreateSampleEvent = createReactClass({
       project_id: parseInt(project.id, 10),
     };
     analytics('sample_event.button_viewed', data);
-  },
+  }
 
   createSampleEvent() {
     // TODO(DENA): swap out for action creator
-    const {orgId, projectId} = this.props.params;
+    const {api, params: {orgId, projectId}} = this.props;
     const {organization} = this.context;
     const url = `/projects/${orgId}/${projectId}/create-sample/`;
     const project = organization.projects.find(proj => proj.slug === projectId);
@@ -55,7 +51,7 @@ const CreateSampleEvent = createReactClass({
       source: 'installation',
     });
 
-    this.api.request(url, {
+    api.request(url, {
       method: 'POST',
       success: data => {
         const issueUrl = hasSentry10
@@ -74,7 +70,7 @@ const CreateSampleEvent = createReactClass({
         IndicatorStore.addError('Unable to create a sample event');
       },
     });
-  },
+  }
 
   render() {
     return (
@@ -84,8 +80,8 @@ const CreateSampleEvent = createReactClass({
         </StyledButton>
       </div>
     );
-  },
-});
+  }
+}
 
 const StyledButton = styled(Button)`
   div {
@@ -93,4 +89,4 @@ const StyledButton = styled(Button)`
   }
 `;
 
-export default CreateSampleEvent;
+export default withApi(CreateSampleEvent);

--- a/src/sentry/static/sentry/app/components/events/interfaces/rawExceptionContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/rawExceptionContent.jsx
@@ -1,53 +1,48 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import rawStacktraceContent from 'app/components/events/interfaces/rawStacktraceContent';
-import ApiMixin from 'app/mixins/apiMixin';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import LoadingError from 'app/components/loadingError';
 import ClippedBox from 'app/components/clippedBox';
 
-const RawExceptionContent = createReactClass({
-  displayName: 'RawExceptionContent',
-
-  propTypes: {
+class RawExceptionContent extends React.Component {
+  static propTypes = {
     type: PropTypes.oneOf(['original', 'minified']),
     platform: PropTypes.string,
     eventId: PropTypes.string,
     values: PropTypes.array.isRequired,
-  },
+  };
 
-  mixins: [ApiMixin],
-
-  getInitialState() {
-    return {
+  constructor(props) {
+    super(props);
+    this.state = {
       loading: false,
       error: false,
       crashReport: '',
     };
-  },
+  }
 
   componentDidMount() {
     if (this.isNative()) {
       this.fetchAppleCrashReport();
     }
-  },
+  }
 
   componentDidUpdate(prevProps) {
     if (this.isNative() && this.props.type !== prevProps.type) {
       this.fetchAppleCrashReport();
     }
-  },
+  }
 
   isNative() {
     const {platform} = this.props;
     return platform === 'cocoa' || platform === 'native';
-  },
+  }
 
   getAppleCrashReportEndpoint() {
     const minified = this.props.type == 'minified';
     return `/events/${this.props.eventId}/apple-crash-report?minified=${minified}`;
-  },
+  }
 
   fetchAppleCrashReport() {
     this.setState({
@@ -71,7 +66,7 @@ const RawExceptionContent = createReactClass({
         });
       },
     });
-  },
+  }
 
   render() {
     const {type} = this.props;
@@ -109,7 +104,7 @@ const RawExceptionContent = createReactClass({
     });
 
     return <div>{children}</div>;
-  },
-});
+  }
+}
 
 export default RawExceptionContent;

--- a/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
@@ -13,7 +13,7 @@ exports[`Configure should render correctly render() should redirect to if no mat
       }
     >
       Configure your application
-      <createSampleEvent
+      <withApi(CreateSampleEvent)
         params={
           Object {
             "orgId": "testOrg",
@@ -82,7 +82,7 @@ exports[`Configure should render correctly render() should render platform docs 
         }
       >
         Configure your application
-        <createSampleEvent
+        <withApi(CreateSampleEvent)
           params={
             Object {
               "orgId": "testOrg",
@@ -92,36 +92,39 @@ exports[`Configure should render correctly render() should render platform docs 
           }
           source="header"
         >
-          <div
-            className="pull-right"
+          <CreateSampleEvent
+            api={Client {}}
+            params={
+              Object {
+                "orgId": "testOrg",
+                "platform": "node",
+                "projectId": "project-slug",
+              }
+            }
+            source="header"
           >
-            <StyledButton
-              onClick={[Function]}
-              priority="primary"
+            <div
+              className="pull-right"
             >
-              <Button
-                className="css-1lewl16-StyledButton eadl9o50"
-                disabled={false}
+              <StyledButton
                 onClick={[Function]}
                 priority="primary"
               >
-                <StyledButton
-                  aria-label="Or See Sample Event"
+                <Button
                   className="css-1lewl16-StyledButton eadl9o50"
                   disabled={false}
                   onClick={[Function]}
                   priority="primary"
-                  role="button"
                 >
-                  <Component
+                  <StyledButton
                     aria-label="Or See Sample Event"
-                    className="eadl9o50 css-w2sk1s-StyledButton-getColors-StyledButton eqrebog0"
+                    className="css-1lewl16-StyledButton eadl9o50"
                     disabled={false}
                     onClick={[Function]}
                     priority="primary"
                     role="button"
                   >
-                    <button
+                    <Component
                       aria-label="Or See Sample Event"
                       className="eadl9o50 css-w2sk1s-StyledButton-getColors-StyledButton eqrebog0"
                       disabled={false}
@@ -129,27 +132,36 @@ exports[`Configure should render correctly render() should render platform docs 
                       priority="primary"
                       role="button"
                     >
-                      <ButtonLabel
+                      <button
+                        aria-label="Or See Sample Event"
+                        className="eadl9o50 css-w2sk1s-StyledButton-getColors-StyledButton eqrebog0"
+                        disabled={false}
+                        onClick={[Function]}
                         priority="primary"
+                        role="button"
                       >
-                        <Component
-                          className="css-ga4b18-ButtonLabel eqrebog1"
+                        <ButtonLabel
                           priority="primary"
                         >
-                          <span
+                          <Component
                             className="css-ga4b18-ButtonLabel eqrebog1"
+                            priority="primary"
                           >
-                            Or See Sample Event
-                          </span>
-                        </Component>
-                      </ButtonLabel>
-                    </button>
-                  </Component>
-                </StyledButton>
-              </Button>
-            </StyledButton>
-          </div>
-        </createSampleEvent>
+                            <span
+                              className="css-ga4b18-ButtonLabel eqrebog1"
+                            >
+                              Or See Sample Event
+                            </span>
+                          </Component>
+                        </ButtonLabel>
+                      </button>
+                    </Component>
+                  </StyledButton>
+                </Button>
+              </StyledButton>
+            </div>
+          </CreateSampleEvent>
+        </withApi(CreateSampleEvent)>
       </h2>
       <withProjects(withRouter(ProjectContext))
         orgId="testOrg"
@@ -727,7 +739,7 @@ exports[`Configure should render correctly render() shouldn't redirect for a fou
       }
     >
       Configure your application
-      <createSampleEvent
+      <withApi(CreateSampleEvent)
         params={
           Object {
             "orgId": "testOrg",


### PR DESCRIPTION
Refactor a number of components that use the ApiMixin to use withApi and
`extends React.Component` syntax instead of createReactClas