### PR TITLE
fix(issues): Fix EventTag links to include project [APP-1159]

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventTags.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags.jsx
@@ -29,7 +29,7 @@ class EventTags extends React.Component {
 
     const {event, group, organization, orgId, projectId} = this.props;
 
-    const hasSentry10 = false && new Set(organization.features).has('sentry10');
+    const hasSentry10 = new Set(organization.features).has('sentry10');
 
     const streamPath = hasSentry10
       ? `/organizations/${orgId}/issues/`

--- a/src/sentry/static/sentry/app/components/events/eventTags.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags.jsx
@@ -27,9 +27,9 @@ class EventTags extends React.Component {
     const tags = this.props.event.tags;
     if (_.isEmpty(tags)) return null;
 
-    const {organization, orgId, projectId} = this.props;
+    const {event, group, organization, orgId, projectId} = this.props;
 
-    const hasSentry10 = new Set(organization.features).has('sentry10');
+    const hasSentry10 = false && new Set(organization.features).has('sentry10');
 
     const streamPath = hasSentry10
       ? `/organizations/${orgId}/issues/`
@@ -41,8 +41,8 @@ class EventTags extends React.Component {
 
     return (
       <EventDataSection
-        group={this.props.group}
-        event={this.props.event}
+        group={group}
+        event={event}
         title={t('Tags')}
         type="tags"
         className="p-b-1"
@@ -54,7 +54,10 @@ class EventTags extends React.Component {
                 <Link
                   to={{
                     pathname: streamPath,
-                    query: {query: `${tag.key}:"${tag.value}"`},
+                    query: {
+                      query: `${tag.key}:"${tag.value}"`,
+                      ...(hasSentry10 && {project: group.project.id}),
+                    },
                   }}
                 >
                   <DeviceName>{tag.value}</DeviceName>
@@ -71,7 +74,14 @@ class EventTags extends React.Component {
                     orgId={orgId}
                     projectId={projectId}
                   >
-                    <Link to={`${releasesPath}${tag.value}/`}>
+                    <Link
+                      to={{
+                        pathname: `${releasesPath}${tag.value}/`,
+                        query: {
+                          ...(hasSentry10 && {project: group.project.id}),
+                        },
+                      }}
+                    >
                       <InlineSvg src="icon-circle-info" size="14px" />
                     </Link>
                   </VersionHoverCard>


### PR DESCRIPTION
... if user has sentry10 feature, otherwise you can be in a state where the issues search will load the last used project instead of this issue's project.

![image](https://user-images.githubusercontent.com/79684/53217609-7d873b00-360d-11e9-91ef-a62bfe09fa96.png)


Fixes APP-1159