### PR TITLE
fix(ui): Actually send ignoreDuration in utc (as specified by form)

### DIFF
--- a/src/sentry/static/sentry/app/components/customIgnoreDurationModal.jsx
+++ b/src/sentry/static/sentry/app/components/customIgnoreDurationModal.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import moment from 'moment';
 import Modal from 'react-bootstrap/lib/Modal';
 import {sprintf} from 'sprintf-js';
 
@@ -30,12 +31,10 @@ export default class CustomIgnoreDurationModal extends React.Component {
     const dateStr = this.snoozeDateInputRef.current.value; // YYYY-MM-DD
     const timeStr = this.snoozeTimeInputRef.current.value; // HH:MM
     if (dateStr && timeStr) {
-      const selectedDate = new Date(dateStr + 'T' + timeStr); // poor man's ISO datetime
+      const selectedDate = moment.utc(dateStr + ' ' + timeStr);
       if (!isNaN(selectedDate)) {
-        const now = new Date();
-        const millis = selectedDate.getTime() - now.getTime();
-        const minutes = parseInt(Math.ceil(millis / 1000.0 / 60.0), 10);
-        return minutes;
+        const now = moment.utc();
+        return selectedDate.diff(now, 'minutes');
       }
     }
     return 0;


### PR DESCRIPTION
fixes ISSUE-311

This isn't a perfect fix in that it can still be slightly off due to the fact that `ignoreDuration` is specified in the api as minutes rather than an absolute date. I think if we want this to be exact, we should update the api to accept a date. This fix gets it closer, but still can be a few seconds off:

<img width="607" alt="screenshot 2019-02-21 19 46 26" src="https://user-images.githubusercontent.com/5026776/53218776-5717ce80-3612-11e9-9e85-6fe2194dc8e3.png">
<img width="726" alt="screenshot 2019-02-21 19 52 35" src="https://user-images.githubusercontent.com/5026776/53218775-5717ce80-3612-11e9-8b77-a31244a5fa22.png">
