### PR TITLE
fix: Fix global selection persistence

### DIFF
--- a/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
+++ b/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
@@ -143,7 +143,7 @@ const GlobalSelectionStore = Reflux.createStore({
     // Do nothing if no org is loaded or user is not an org member. Only
     // organizations that a user has membership in will be available via the
     // organizations store
-    if (!this.organization || OrganizationsStore.get(this.organization.slug)) {
+    if (!this.organization || !OrganizationsStore.get(this.organization.slug)) {
       return;
     }
 


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/getsentry/sentry/pull/12160
where the organization member check was flipped around the wrong way.