### PR TITLE
fix(api): Return optional 'query' key for tags when they're related to a user (APP-1158)

### DIFF
--- a/src/sentry/api/serializers/models/tagvalue.py
+++ b/src/sentry/api/serializers/models/tagvalue.py
@@ -4,6 +4,7 @@ import six
 
 from sentry.api.serializers import Serializer, serialize
 from sentry.models import EventUser
+from sentry.search.utils import convert_user_tag_to_query
 
 
 class EnvironmentTagValueSerializer(Serializer):
@@ -38,6 +39,11 @@ class UserTagValueSerializer(Serializer):
             }
         else:
             result = serialize(attrs['user'], user)
+
+        query = convert_user_tag_to_query('user', obj.value)
+        if query:
+            result['query'] = query
+
         result.update(
             {
                 'value': obj.value,

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -8,7 +8,7 @@ from django.db import DataError
 from django.utils import timezone
 
 from sentry.constants import STATUS_CHOICES
-from sentry.models import EventUser, Release, Team, User
+from sentry.models import EventUser, KEYWORD_MAP, Release, Team, User
 from sentry.search.base import ANY
 from sentry.utils.auth import find_users
 
@@ -444,3 +444,14 @@ def parse_query(projects, query, user, environments):
     results['query'] = ' '.join(results['query'])
 
     return results
+
+
+def convert_user_tag_to_query(key, value):
+    """
+    Converts a user tag to a query string that can be used to search for that
+    user. Returns None if not a user tag.
+    """
+    if key == 'user' and ':' in value:
+        sub_key, value = value.split(':', 1)
+        if KEYWORD_MAP.get_key(sub_key, None):
+            return 'user.%s:%s' % (sub_key, value)

--- a/src/sentry/tagstore/types.py
+++ b/src/sentry/tagstore/types.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import six
 
+from sentry.search.utils import convert_user_tag_to_query
 from sentry.tagstore.base import TagKeyStatus
 
 
@@ -103,12 +104,18 @@ class TagKeySerializer(Serializer):
 class TagValueSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         from sentry import tagstore
-
-        return {
-            'key': tagstore.get_standardized_key(obj.key),
+        key = tagstore.get_standardized_key(obj.key)
+        serialized = {
+            'key': key,
             'name': tagstore.get_tag_value_label(obj.key, obj.value),
             'value': obj.value,
             'count': obj.times_seen,
             'lastSeen': obj.last_seen,
             'firstSeen': obj.first_seen,
         }
+
+        query = convert_user_tag_to_query(key, obj.value)
+        if query:
+            serialized['query'] = query
+
+        return serialized

--- a/tests/sentry/api/serializers/test_tagvalue.py
+++ b/tests/sentry/api/serializers/test_tagvalue.py
@@ -4,7 +4,10 @@ from __future__ import absolute_import
 
 from datetime import datetime
 
-from sentry.api.serializers import serialize
+from sentry.api.serializers import (
+    serialize,
+    UserTagValueSerializer,
+)
 from sentry.tagstore.types import TagValue
 from sentry.testutils import TestCase
 
@@ -24,6 +27,7 @@ class TagValueSerializerTest(TestCase):
         assert result['key'] == 'user'
         assert result['value'] == 'username:ted'
         assert result['name'] == 'ted'
+        assert result['query'] == 'user.username:ted'
 
     def test_release(self):
         user = self.create_user()
@@ -39,3 +43,20 @@ class TagValueSerializerTest(TestCase):
         assert result['key'] == 'release'
         assert result['value'] == 'df84bccbb23ca15f2868be1f2a5f7c7a6464fadd'
         assert result['name'] == 'df84bcc'
+        assert 'query' not in result
+
+
+class UseTagValueSerializerTest(TestCase):
+    def test_query(self):
+        user = self.create_user()
+        tagvalue = TagValue(
+            key='sentry:user',
+            value='username:ted',
+            times_seen=1,
+            first_seen=datetime(2018, 1, 1),
+            last_seen=datetime(2018, 1, 1),
+        )
+
+        result = serialize(tagvalue, user, serializer=UserTagValueSerializer(project_id=1))
+        assert result['value'] == 'username:ted'
+        assert result['query'] == 'user.username:ted'


### PR DESCRIPTION
The query tag will contain a query that can be plugged into a search to search by that value. At the
moment it only returns a value for users. Will be a value like `user.email:test@test.com`.

We want to use this rather than values like `user:"email:test@test.com"`, since that syntax is deprecated.