### PR TITLE
fix(source maps): Ignore fragment if present in URL

### DIFF
--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -73,10 +73,12 @@ class ReleaseFile(Model):
         """
         # Always ignore the fragment
         scheme, netloc, path, query, _ = urlsplit(url)
+
+        uri_without_fragment = (scheme, netloc, path, query, None)
         uri_relative = (None, None, path, query, None)
         uri_without_query = (scheme, netloc, path, None, None)
         uri_relative_without_query = (None, None, path, None, None)
-        urls = [url]
+        urls = [urlunsplit(uri_without_fragment)]
         if query:
             urls.append(urlunsplit(uri_without_query))
         urls.append('~' + urlunsplit(uri_relative))

--- a/tests/sentry/models/test_releasefile.py
+++ b/tests/sentry/models/test_releasefile.py
@@ -27,6 +27,13 @@ class ReleaseFileTestCase(TestCase):
             '~/foo.js',
         ]
 
+        assert n('http://example.com/foo.js?bar#baz') == [
+            'http://example.com/foo.js?bar',
+            'http://example.com/foo.js',
+            '~/foo.js?bar',
+            '~/foo.js',
+        ]
+
         # This is the current behavior, but seems weird to me.
         # unclear if we actually experience this case in the real
         # world, but worth documenting the behavior


### PR DESCRIPTION
Right now, if we have an `abs_path` like `'http://www.example.com/script.js#random-fragment'`, and an artifact uploaded as `'http://www.example.com/script.js'`, we won't find it.