### PR TITLE
feat: Fall back to empty metadata

### DIFF
--- a/src/sentry/eventtypes/base.py
+++ b/src/sentry/eventtypes/base.py
@@ -48,4 +48,4 @@ class DefaultEvent(BaseEvent):
         }
 
     def get_title(self, metadata):
-        return metadata['title']
+        return metadata.get('title') or '<untitled>'

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -139,7 +139,10 @@ class Event(Model):
 
         See ``sentry.eventtypes``.
         """
-        return self.data['metadata']
+        # For some inexplicable reason we have some cases where the data
+        # is completely empty.  In that case we want to hobble along
+        # further.
+        return self.data.get('metadata') or {}
 
     def get_hashes(self):
         """


### PR DESCRIPTION
Really no idea why it happens but this fixes the system if bad data was
ingested.

Fixes SENTRY-9KM