### PR TITLE
fix(slack): Handle native event types in slack integration better

### DIFF
--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -64,12 +64,18 @@ def get_assignee(group):
 
 
 def build_attachment_title(group, event=None):
+    # XXX(mitsuhiko): This is all super event specific and ideally could just use a
+    # combination of `group.title` and `group.title + group.culprit`.
     ev_metadata = group.get_event_metadata()
     ev_type = group.get_event_type()
     if ev_type == 'error':
+        if 'type' in ev_metadata:
+            if group.culprit:
+                return u'{} - {}'.format(ev_metadata['type'][:40], group.culprit)
+            return ev_metadata['type']
         if group.culprit:
-            return u'{} - {}'.format(ev_metadata['type'][:40], group.culprit)
-        return ev_metadata['type']
+            return u'{} - {}'.format(group.title, group.culprit)
+        return group.title
     elif ev_type == 'csp':
         return u'{} - {}'.format(ev_metadata['directive'], ev_metadata['uri'])
     else:


### PR DESCRIPTION
I think longer term we should do something else for such things. Special casing this in all plugins is hard to maintain going forward.

Fixes SENTRY-9ND