### PR TITLE
fix(charts): Fix default axis label formatting

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
@@ -8,7 +8,7 @@ function defaultFormatAxisLabel(value, isTimestamp, utc) {
     return value;
   }
 
-  return getFormattedDate(value, 'MMM D, YYYY', utc);
+  return getFormattedDate(value, 'MMM D, YYYY', {local: !utc});
 }
 
 function valueFormatter(value) {


### PR DESCRIPTION
Passed in utc option in the wrong format

Fixes JAVASCRIPT-5C6