### PR TITLE
fix(api): Use `is_active_superuser` method rather than `request.user.is_superuser` (SEN-172)

### DIFF
--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -6,6 +6,7 @@ from sentry.utils.sdk import configure_scope
 from sentry.api.authentication import ClientIdSecretAuthentication
 from sentry.api.base import Endpoint
 from sentry.api.permissions import SentryPermission
+from sentry.auth.superuser import is_active_superuser
 from sentry.models import SentryApp, SentryAppInstallation, Organization
 
 
@@ -44,7 +45,7 @@ class SentryAppsPermission(SentryPermission):
 
         self.determine_access(request, organization)
 
-        if request.user.is_superuser:
+        if is_active_superuser(request):
             return True
 
         # User must be a part of the Org they're trying to create the app in.
@@ -111,7 +112,7 @@ class SentryAppPermission(SentryPermission):
 
         self.determine_access(request, sentry_app.owner)
 
-        if request.user.is_superuser:
+        if is_active_superuser(request):
             return True
 
         # User must be in the Org who owns the app.
@@ -162,7 +163,7 @@ class SentryAppInstallationsPermission(SentryPermission):
 
         self.determine_access(request, organization)
 
-        if request.user.is_superuser:
+        if is_active_superuser(request):
             return True
 
         if organization not in request.user.get_orgs():
@@ -178,7 +179,7 @@ class SentryAppInstallationsBaseEndpoint(Endpoint):
     permission_classes = (SentryAppInstallationsPermission, )
 
     def convert_args(self, request, organization_slug, *args, **kwargs):
-        if request.user.is_superuser:
+        if is_active_superuser(request):
             organizations = Organization.objects.all()
         else:
             organizations = request.user.get_orgs()
@@ -206,7 +207,7 @@ class SentryAppInstallationPermission(SentryPermission):
 
         self.determine_access(request, installation.organization)
 
-        if request.user.is_superuser:
+        if is_active_superuser(request):
             return True
 
         if installation.organization not in request.user.get_orgs():

--- a/src/sentry/api/endpoints/organization_health.py
+++ b/src/sentry/api/endpoints/organization_health.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from sentry.api.bases import OrganizationEndpoint, EnvironmentMixin
 from sentry.api.utils import get_date_range_from_params, InvalidParams
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.auth.superuser import is_active_superuser
 from sentry.models import (
     Project, ProjectStatus, OrganizationMemberTeam,
     Environment,
@@ -40,7 +41,7 @@ class OrganizationHealthEndpointBase(OrganizationEndpoint, EnvironmentMixin):
         project_ids = set(map(int, request.GET.getlist('project')))
 
         before = project_ids.copy()
-        if request.user.is_superuser:
+        if is_active_superuser(request):
             # Superusers can query any projects within the organization
             qs = Project.objects.filter(
                 organization=organization,

--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -16,7 +16,7 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
     def get(self, request):
         return self.paginate(
             request=request,
-            queryset=SentryApp.visible_for_user(request.user),
+            queryset=SentryApp.visible_for_user(request),
             order_by='-date_added',
             paginator_cls=OffsetPaginator,
             on_results=lambda x: serialize(x, request.user),

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -114,10 +114,12 @@ class SentryApp(ParanoidModel, HasApiScopes):
         db_table = 'sentry_sentryapp'
 
     @classmethod
-    def visible_for_user(cls, user):
-        if user.is_superuser:
+    def visible_for_user(cls, request):
+        from sentry.auth.superuser import is_active_superuser
+        if is_active_superuser(request):
             return cls.objects.all()
 
+        user = request.user
         return cls.objects.filter(
             Q(status=SentryAppStatus.PUBLISHED) | Q(owner__in=user.get_orgs()),
         )

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -203,7 +203,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
 class DeleteSentryAppDetailsTest(SentryAppDetailsTest):
     @with_feature('organizations:sentry-apps')
     def test_delete_unpublished_app(self):
-        self.login_as(user=self.superuser)
+        self.login_as(user=self.superuser, superuser=True)
         url = reverse(
             'sentry-api-0-sentry-app-details',
             args=[self.unpublished_app.slug],
@@ -213,7 +213,7 @@ class DeleteSentryAppDetailsTest(SentryAppDetailsTest):
 
     @with_feature('organizations:sentry-apps')
     def test_cannot_delete_published_app(self):
-        self.login_as(user=self.superuser)
+        self.login_as(user=self.superuser, superuser=True)
         url = reverse(
             'sentry-api-0-sentry-app-details',
             args=[self.published_app.slug],

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -40,7 +40,7 @@ class SentryAppsTest(APITestCase):
 class GetSentryAppsTest(SentryAppsTest):
     @with_feature('organizations:sentry-apps')
     def test_superuser_sees_all_apps(self):
-        self.login_as(user=self.superuser)
+        self.login_as(user=self.superuser, superuser=True)
 
         response = self.client.get(self.url, format='json')
         response_uuids = set(o['uuid'] for o in response.data)


### PR DESCRIPTION
We need to use `is_active_superuser` so that we correctly prompt superusers to enter their password
from time to time to get elevated permissions.