### PR TITLE
feat(stream): Add user attributes to stream autocomplete

### DIFF
--- a/src/sentry/static/sentry/app/stores/tagStore.jsx
+++ b/src/sentry/static/sentry/app/stores/tagStore.jsx
@@ -89,6 +89,18 @@ const TagStore = Reflux.createStore({
         values: [],
         predefined: true,
       },
+      'user.id': {
+        key: 'user.id',
+      },
+      'user.username': {
+        key: 'user.username',
+      },
+      'user.email': {
+        key: 'user.email',
+      },
+      'user.ip': {
+        key: 'user.ip',
+      },
     };
     this.trigger(this.tags);
   },

--- a/tests/js/spec/views/stream/__snapshots__/stream.spec.jsx.snap
+++ b/tests/js/spec/views/stream/__snapshots__/stream.spec.jsx.snap
@@ -239,6 +239,18 @@ exports[`Stream render() displays the group list 1`] = `
           "predefined": true,
           "values": Array [],
         },
+        "user.email": Object {
+          "key": "user.email",
+        },
+        "user.id": Object {
+          "key": "user.id",
+        },
+        "user.ip": Object {
+          "key": "user.ip",
+        },
+        "user.username": Object {
+          "key": "user.username",
+        },
       }
     }
   />
@@ -483,6 +495,18 @@ exports[`Stream toggles environment select all environments 1`] = `
           "name": "Times Seen",
           "predefined": true,
           "values": Array [],
+        },
+        "user.email": Object {
+          "key": "user.email",
+        },
+        "user.id": Object {
+          "key": "user.id",
+        },
+        "user.ip": Object {
+          "key": "user.ip",
+        },
+        "user.username": Object {
+          "key": "user.username",
         },
       }
     }


### PR DESCRIPTION
Adds user.id, user.username, user.email and user.ip to stream autocomplete. These attributes are already supported and listed in the documentation.