### PR TITLE
feat: Tag name autocomplete for negation operators

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar.jsx
@@ -301,7 +301,8 @@ class SmartSearchBar extends React.Component {
 
     if (index === -1) {
       // No colon present; must still be deciding key
-      matchValue = last;
+      matchValue = last.replace(new RegExp(`^${NEGATION_OPERATOR}`), '');
+
       autoCompleteItems = this.getTagKeys(matchValue);
 
       this.setState({searchTerm: matchValue});

--- a/tests/js/spec/components/smartSearchBar.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar.spec.jsx
@@ -314,6 +314,20 @@ describe('SmartSearchBar', function() {
       expect(searchBar.state.activeSearchItem).toEqual(0);
     });
 
+    it('sets state when incomplete tag has negation operator', function() {
+      const props = {
+        orgId: '123',
+        projectId: '456',
+        query: '!fu',
+        supportedTags,
+      };
+      const searchBar = mount(<SmartSearchBar {...props} />, options).instance();
+      searchBar.updateAutoCompleteItems();
+      expect(searchBar.state.searchTerm).toEqual('fu');
+      expect(searchBar.state.searchItems).toEqual([]);
+      expect(searchBar.state.activeSearchItem).toEqual(0);
+    });
+
     it('sets state when incomplete tag as second input', function() {
       const props = {
         orgId: '123',


### PR DESCRIPTION
Allow tag names to be autocompleted when the negation operator is used.
This applies to the issue and event streams.