### PR TITLE
fix: Fix bug in suggested owner hovercard commit message

### DIFF
--- a/src/sentry/static/sentry/app/components/group/suggestedOwnerHovercard.jsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwnerHovercard.jsx
@@ -125,7 +125,7 @@ const CommitIcon = styled(p => <InlineSvg src="icon-commit" size="16px" {...p} /
   flex-shrink: 0;
 `;
 
-const CommitMessage = styled(({message, date, ...props}) => (
+const CommitMessage = styled(({message = '', date, ...props}) => (
   <div {...props}>
     {message.split('\n')[0]}
     <CommitDate date={date} />


### PR DESCRIPTION
Message is optional in a commit so we can't guarantee it's provided

Fixes JAVASCRIPT-51G