### PR TITLE
ref(api): Add support to snuba group serializer for date filtering user count by date

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -544,8 +544,10 @@ class SharedGroupSerializer(GroupSerializer):
 
 
 class GroupSerializerSnuba(GroupSerializerBase):
-    def __init__(self, environment_ids=None):
+    def __init__(self, environment_ids=None, start=None, end=None):
         self.environment_ids = environment_ids
+        self.start = start
+        self.end = end
 
     def _get_seen_stats(self, item_list, user):
         tagstore = SnubaTagStorage()
@@ -555,6 +557,8 @@ class GroupSerializerSnuba(GroupSerializerBase):
             project_ids,
             group_ids,
             environment_ids=self.environment_ids,
+            start=self.start,
+            end=self.end,
         )
 
         first_seen = {}

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -353,9 +353,11 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def get_groups_user_counts(self, project_ids, group_ids, environment_ids):
+    def get_groups_user_counts(self, project_ids, group_ids, environment_ids,
+                               start=None, end=None):
         """
         >>> get_groups_user_counts([1, 2], [2, 3], [4, 5])
+        `start` and `end` are only used by the snuba backend
         """
         raise NotImplementedError
 

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -499,7 +499,7 @@ class LegacyTagStorage(TagStorage):
 
         return {'id__in': set(matches)}
 
-    def get_groups_user_counts(self, project_ids, group_ids, environment_ids):
+    def get_groups_user_counts(self, project_ids, group_ids, environment_ids, start=None, end=None):
         # only the snuba backend supports multi project
         if len(project_ids) > 1:
             raise NotImplementedError

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -523,8 +523,9 @@ class SnubaTagStorage(TagStorage):
                 )
         return values
 
-    def get_groups_user_counts(self, project_ids, group_ids, environment_ids):
-        start, end = self.get_time_range()
+    def get_groups_user_counts(self, project_ids, group_ids, environment_ids, start=None, end=None):
+        if start is None or end is None:
+            start, end = self.get_time_range()
         filters = {
             'project_id': project_ids,
             'issue': group_ids,

--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -757,7 +757,7 @@ class V2TagStorage(TagStorage):
 
         return {'id__in': set(matches)}
 
-    def get_groups_user_counts(self, project_ids, group_ids, environment_ids):
+    def get_groups_user_counts(self, project_ids, group_ids, environment_ids, start=None, end=None):
         # only the snuba backend supports multi project/env
         if len(project_ids) > 1 or environment_ids and len(environment_ids) > 1:
             raise NotImplementedError

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -257,6 +257,15 @@ class TagStorageTest(SnubaTestCase):
             self.proj1group2.id: 1,
         }
 
+        # test filtering by date range where there shouldn't be results
+        assert self.ts.get_groups_user_counts(
+            project_ids=[self.proj1.id],
+            group_ids=[self.proj1group1.id, self.proj1group2.id],
+            environment_ids=[self.proj1env1.id],
+            start=self.now - timedelta(days=5),
+            end=self.now - timedelta(days=4),
+        ) == {}
+
     def test_get_releases(self):
         assert self.ts.get_first_release(
             project_id=self.proj1.id,


### PR DESCRIPTION
this won't change anything right now since no endpoints are passing start/end, but figured it makes sense to get started on this refactoring based on our meeting on friday. this only applies the date filter to `userCount` -- I will address the overall count in another PR