### PR TITLE
fix: Always use estimated result on pages > 0

### DIFF
--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -556,7 +556,7 @@ class SnubaSearchTest(SnubaTestCase):
             count_hits=True,
         )
         assert list(results) == [self.group1]
-        assert results.hits == 1  # TODO this is actually wrong because of the cursor
+        assert results.hits == 2
 
         results = self.backend.query(
             [self.project],
@@ -567,7 +567,7 @@ class SnubaSearchTest(SnubaTestCase):
             count_hits=True,
         )
         assert list(results) == []
-        assert results.hits == 1  # TODO this is actually wrong because of the cursor
+        assert results.hits == 2
 
     def test_active_at_filter(self):
         results = self.make_query(


### PR DESCRIPTION
Stops us from returning smaller total hit counts as we page through the
result set.

The "estimate" in this case is actually always accurate for lower group
counts, and is only an estimate once we have so many candidate groups
that we prob don't care about the exact count anyway.