### PR TITLE
fix(dev) Don't start relay for snuba HTTP backend

### DIFF
--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -21,3 +21,6 @@ class SnubaEventStream(KafkaEventStream):
             return resp
         except urllib3.exceptions.HTTPError as err:
             raise snuba.SnubaError(err)
+
+    def requires_post_process_forwarder(self):
+        return False


### PR DESCRIPTION
The snuba HTTP backend doesn't need relay or kafka running.