### PR TITLE
 feat(app-platform): Add external request mediators

### DIFF
--- a/src/sentry/mediators/external_requests/__init__.py
+++ b/src/sentry/mediators/external_requests/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import
 
-from .requester import Requester
+from .select_requester import SelectRequester  # NOQA

--- a/src/sentry/mediators/external_requests/__init__.py
+++ b/src/sentry/mediators/external_requests/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+
+from .requester import Requester

--- a/src/sentry/mediators/external_requests/__init__.py
+++ b/src/sentry/mediators/external_requests/__init__.py
@@ -1,3 +1,4 @@
 from __future__ import absolute_import
 
 from .select_requester import SelectRequester  # NOQA
+from .issue_link_requester import IssueLinkRequester  # NOQA

--- a/src/sentry/mediators/external_requests/issue_link_requester.py
+++ b/src/sentry/mediators/external_requests/issue_link_requester.py
@@ -51,8 +51,7 @@ class IssueLinkRequester(Mediator):
     fields = Param(object)
 
     def call(self):
-        self._make_request()
-        return self.response
+        return self._make_request()
 
     def _build_url(self):
         domain = urlparse(self.sentry_app.webhook_url).netloc
@@ -83,11 +82,10 @@ class IssueLinkRequester(Mediator):
             )
             response = {}
 
-        is_valid = self._validate_response(response)
-        if not is_valid:
+        if not self._validate_response(response):
             raise APIError()
 
-        self.response = response
+        return response
 
     def _validate_response(self, resp):
         return validate(instance=resp, schema_type='issue_link')
@@ -101,7 +99,7 @@ class IssueLinkRequester(Mediator):
             'Sentry-App-Signature': self.sentry_app.build_signature(self.body)
         }
 
-    @property
+    @memoize
     def body(self):
         body = {}
         for name, value in six.iteritems(self.fields):

--- a/src/sentry/mediators/external_requests/issue_link_requester.py
+++ b/src/sentry/mediators/external_requests/issue_link_requester.py
@@ -14,8 +14,32 @@ from sentry.utils import json
 
 class IssueLinkRequester(Mediator):
     """
-    Makes a request to another service and returns
-    the response.
+    1. Makes a POST request to another service with data used for creating or
+    linking a Sentry issue to an issue in the other service.
+
+    The data sent to the other service is always in the following format:
+        {
+            'installtionId': <install_uuid>,
+            'issueId': <sentry_group_id>,
+            'webUrl': <sentry_group_web_url>,
+            <fields>,
+        }
+
+    <fields> are any of the 'create' or 'link' form fields (determined by
+    the schema for that particular service)
+
+    2. Validates the response format from the other service and returns the
+    payload.
+
+    The data sent to the other service is always in the following format:
+        {
+            'identifier': <some_identifier>,
+            'webUrl': <external_issue_web_url>,
+            'project': <top_level_identifier>,
+        }
+
+    The project and identifier are use to generate the display text for the linked
+    issue in the UI (i.e. <project>#<identifier>)
     """
 
     install = Param('sentry.models.SentryAppInstallation')

--- a/src/sentry/mediators/external_requests/issue_link_requester.py
+++ b/src/sentry/mediators/external_requests/issue_link_requester.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import six
+import logging
 from uuid import uuid4
 
 from six.moves.urllib.parse import urlparse
@@ -8,8 +9,10 @@ from sentry.http import safe_urlopen, safe_urlread
 from sentry.coreapi import APIError
 from sentry.mediators import Mediator, Param
 from sentry.mediators.external_requests.util import validate
-from sentry.utils.cache import memoize
 from sentry.utils import json
+from sentry.utils.cache import memoize
+
+logger = logging.getLogger('sentry.mediators.external-requests')
 
 
 class IssueLinkRequester(Mediator):
@@ -64,8 +67,22 @@ class IssueLinkRequester(Mediator):
             data=self.body,
         )
 
-        body = safe_urlread(req)
-        response = json.loads(body)
+        try:
+            body = safe_urlread(req)
+            response = json.loads(body)
+        except Exception:
+            logger.info(
+                'issue-link-requester.error',
+                extra={
+                    'sentry_app': self.sentry_app.slug,
+                    'install': self.install.uuid,
+                    'project': self.group.project.slug,
+                    'group': self.group.id,
+                    'uri': self.uri,
+                }
+            )
+            response = {}
+
         is_valid = self._validate_response(response)
         if not is_valid:
             raise APIError()

--- a/src/sentry/mediators/external_requests/issue_link_requester.py
+++ b/src/sentry/mediators/external_requests/issue_link_requester.py
@@ -1,26 +1,27 @@
 from __future__ import absolute_import
 
 import six
-from sentry.utils import json
 from uuid import uuid4
 
-from six.moves.urllib.parse import urlparse, urlencode
+from six.moves.urllib.parse import urlparse
 from sentry.http import safe_urlopen, safe_urlread
 from sentry.coreapi import APIError
 from sentry.mediators import Mediator, Param
 from sentry.mediators.external_requests.util import validate
 from sentry.utils.cache import memoize
+from sentry.utils import json
 
 
-class SelectRequester(Mediator):
+class IssueLinkRequester(Mediator):
     """
     Makes a request to another service and returns
     the response.
     """
 
     install = Param('sentry.models.SentryAppInstallation')
-    project = Param('sentry.models.Project')
     uri = Param(six.string_types)
+    group = Param('sentry.models.Group')
+    fields = Param(object)
 
     def call(self):
         self._make_request()
@@ -29,21 +30,18 @@ class SelectRequester(Mediator):
     def _build_url(self):
         domain = urlparse(self.sentry_app.webhook_url).netloc
         url = u'https://{}{}'.format(domain, self.uri)
-        url += '?' + urlencode({
-            'installationId': self.install.uuid,
-            'project': self.project.slug,
-        })
         return url
 
     def _make_request(self):
         req = safe_urlopen(
             url=self._build_url(),
             headers=self._build_headers(),
+            method='POST',
+            data=self.body,
         )
 
         body = safe_urlread(req)
         response = json.loads(body)
-
         is_valid = self._validate_response(response)
         if not is_valid:
             raise APIError()
@@ -51,7 +49,7 @@ class SelectRequester(Mediator):
         self.response = response
 
     def _validate_response(self, resp):
-        return validate(instance=resp, schema_type='select')
+        return validate(instance=resp, schema_type='issue_link')
 
     def _build_headers(self):
         request_uuid = uuid4().hex
@@ -59,8 +57,19 @@ class SelectRequester(Mediator):
         return {
             'Content-Type': 'application/json',
             'Request-ID': request_uuid,
-            'Sentry-App-Signature': self.sentry_app.build_signature('')
+            'Sentry-App-Signature': self.sentry_app.build_signature(self.body)
         }
+
+    @property
+    def body(self):
+        body = {}
+        for name, value in six.iteritems(self.fields):
+            body[name] = value
+
+        body['issueId'] = self.group.id
+        body['installationId'] = self.install.uuid
+        body['webUrl'] = self.group.get_absolute_url()
+        return json.dumps(body)
 
     @memoize
     def sentry_app(self):

--- a/src/sentry/mediators/external_requests/select_request.py
+++ b/src/sentry/mediators/external_requests/select_request.py
@@ -1,0 +1,62 @@
+from __future__ import absolute_import
+
+import six
+import pytz
+
+from datetime import datetime
+
+from six.moves.urllib.parse import urlparse, urlencode
+from sentry.coreapi import APIUnauthorized
+from sentry.mediators import Mediator, Param
+from sentry.mediators.token_exchange.validator import Validator
+from sentry.mediators.token_exchange.util import token_expiration
+from sentry.models import ApiApplication, ApiToken, SentryApp
+from sentry.utils.cache import memoize
+
+
+class SelectRequester(Mediator):
+    """
+    Makes a request to another service and returns
+    the response.
+    """
+
+    install = Param('sentry.models.SentryAppInstallation')
+    project = Param('sentry.models.Project')
+    uri = Param(six.string_types)
+
+    def call(self):
+        self._make_request()
+
+    def _build_url(self):
+        domain = urlparse(self.sentry_app.webhook_url).netloc
+        url = u'https://{}{}'.format(base, self.uri)
+        url += '?' + urlencode({
+            'installationId': self.install.uuid,
+            'project': self.project.slug,
+        })
+        return url
+
+    def _make_request(self):
+        req = safe_urlopen(
+            url=self._build_url(),
+            headers=self._build_headers(),
+        )
+
+        try:
+            body = safe_urlread(req)
+            payload = json.loads(body)
+        except Exception as e:
+            raise
+
+    def _build_headers(self):
+        request_uuid = uuid4().hex
+
+        return {
+            'Content-Type': 'application/json',
+            'Request-ID': request_uuid,
+            'Sentry-App-Signature': self.install.sentry_app.build_signature(self.body)
+        }
+
+    @memoize
+    def sentry_app(self):
+        return self.install.sentry_app

--- a/src/sentry/mediators/external_requests/select_requester.py
+++ b/src/sentry/mediators/external_requests/select_requester.py
@@ -30,8 +30,7 @@ class SelectRequester(Mediator):
     uri = Param(six.string_types)
 
     def call(self):
-        self._make_request()
-        return self.response
+        return self._make_request()
 
     def _build_url(self):
         domain = urlparse(self.sentry_app.webhook_url).netloc
@@ -63,11 +62,10 @@ class SelectRequester(Mediator):
             )
             response = {}
 
-        is_valid = self._validate_response(response)
-        if not is_valid:
+        if not self._validate_response(response):
             raise APIError()
 
-        self.response = response
+        return response
 
     def _validate_response(self, resp):
         return validate(instance=resp, schema_type='select')

--- a/src/sentry/mediators/external_requests/select_requester.py
+++ b/src/sentry/mediators/external_requests/select_requester.py
@@ -14,8 +14,12 @@ from sentry.utils.cache import memoize
 
 class SelectRequester(Mediator):
     """
-    Makes a request to another service and returns
-    the response.
+    1. Makes a GET request to another service to fetch data needed to populate
+    the SelectField dropdown in the UI.
+
+    `installationId` and `project` are included in the params of the request
+
+    2. Validates and formats the response.
     """
 
     install = Param('sentry.models.SentryAppInstallation')
@@ -31,7 +35,7 @@ class SelectRequester(Mediator):
         url = u'https://{}{}'.format(domain, self.uri)
         url += '?' + urlencode({
             'installationId': self.install.uuid,
-            'project': self.project.slug,
+            'projectSlug': self.project.slug,
         })
         return url
 

--- a/src/sentry/mediators/external_requests/util.py
+++ b/src/sentry/mediators/external_requests/util.py
@@ -1,0 +1,39 @@
+from __future__ import absolute_import
+
+from jsonschema import Draft4Validator
+
+SELECT_OPTIONS_SCHEMA = {
+    'type': 'array',
+    'definitions': {
+        'select-option': {
+            'type': 'object',
+            'properties': {
+                'label': {
+                    'type': 'string',
+                },
+                'value': {
+                    'type': 'string',
+                }
+            },
+            'required': ['label', 'value'],
+        }
+    },
+    'properties': {
+        'type': 'array',
+        'items': {'$ref': '#definitions/select-option'}
+    }
+}
+
+SCHEMA_LIST = {
+    'select': SELECT_OPTIONS_SCHEMA,
+}
+
+
+def validate(instance, schema_type):
+    schema = SCHEMA_LIST[schema_type]
+    v = Draft4Validator(schema)
+
+    if not v.is_valid(instance):
+        return False
+
+    return True

--- a/src/sentry/mediators/external_requests/util.py
+++ b/src/sentry/mediators/external_requests/util.py
@@ -24,8 +24,25 @@ SELECT_OPTIONS_SCHEMA = {
     }
 }
 
+ISSUE_LINKER_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'webUrl': {
+            'type': 'string',
+        },
+        'identifier': {
+            'type': 'string',
+        },
+        'project': {
+            'type': 'string',
+        }
+    },
+    'required': ['webUrl', 'identifier', 'project'],
+}
+
 SCHEMA_LIST = {
     'select': SELECT_OPTIONS_SCHEMA,
+    'issue_link': ISSUE_LINKER_SCHEMA,
 }
 
 

--- a/tests/sentry/mediators/external_requests/__init__.py
+++ b/tests/sentry/mediators/external_requests/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/mediators/external_requests/test_issue_link_requester.py
+++ b/tests/sentry/mediators/external_requests/test_issue_link_requester.py
@@ -1,0 +1,100 @@
+from __future__ import absolute_import
+
+import responses
+
+from sentry.coreapi import APIError
+from sentry.mediators.external_requests import IssueLinkRequester
+from sentry.testutils import TestCase
+from sentry.utils import json
+
+
+class TestIssueLinkRequester(TestCase):
+    def setUp(self):
+        super(TestIssueLinkRequester, self).setUp()
+
+        self.user = self.create_user(name='foo')
+        self.org = self.create_organization(owner=self.user)
+        self.project = self.create_project(slug='boop', organization=self.org)
+        self.group = self.create_group(project=self.project)
+
+        self.sentry_app = self.create_sentry_app(
+            name='foo',
+            organization=self.org,
+            webhook_url='https://example.com',
+            scopes=(),
+        )
+
+        self.install = self.create_sentry_app_installation(
+            slug='foo',
+            organization=self.org,
+            user=self.user,
+        )
+
+    @responses.activate
+    def test_makes_request(self):
+        fields = {
+            'title': 'An Issue',
+            'description': 'a bug was found',
+            'assignee': 'user-1',
+        }
+
+        responses.add(
+            method=responses.POST,
+            url='https://example.com/link-issue',
+            json={
+                'project': 'ProjectName',
+                'webUrl': 'https://example.com/project/issue-id',
+                'identifier': 'issue-1',
+            },
+            status=200,
+            content_type='application/json',
+        )
+
+        result = IssueLinkRequester.run(
+            install=self.install,
+            project=self.project,
+            group=self.group,
+            uri='/link-issue',
+            fields=fields,
+        )
+        assert result == {
+            'project': 'ProjectName',
+            'webUrl': 'https://example.com/project/issue-id',
+            'identifier': 'issue-1',
+        }
+
+        request = responses.calls[0].request
+        assert request.headers['Sentry-App-Signature']
+        data = {
+            'title': 'An Issue',
+            'description': 'a bug was found',
+            'assignee': 'user-1',
+            'issueId': self.group.id,
+            'installationId': self.install.uuid,
+            'webUrl': self.group.get_absolute_url(),
+        }
+        payload = json.loads(request.body)
+        assert payload == data
+
+    @responses.activate
+    def test_invalid_response_format(self):
+        # missing 'identifier'
+        invalid_format = {
+            'project': 'ProjectName',
+            'webUrl': 'https://example.com/project/issue-id'
+        }
+        responses.add(
+            method=responses.POST,
+            url='https://example.com/link-issue',
+            json=invalid_format,
+            status=200,
+            content_type='application/json',
+        )
+        with self.assertRaises(APIError):
+            IssueLinkRequester.run(
+                install=self.install,
+                project=self.project,
+                group=self.group,
+                uri='/link-issue',
+                fields={},
+            )

--- a/tests/sentry/mediators/external_requests/test_issue_link_requester.py
+++ b/tests/sentry/mediators/external_requests/test_issue_link_requester.py
@@ -98,3 +98,21 @@ class TestIssueLinkRequester(TestCase):
                 uri='/link-issue',
                 fields={},
             )
+
+    @responses.activate
+    def test_500_response(self):
+        responses.add(
+            method=responses.POST,
+            url='https://example.com/link-issue',
+            body='Something failed',
+            status=500,
+        )
+
+        with self.assertRaises(APIError):
+            IssueLinkRequester.run(
+                install=self.install,
+                project=self.project,
+                group=self.group,
+                uri='/link-issue',
+                fields={},
+            )

--- a/tests/sentry/mediators/external_requests/test_select_requester.py
+++ b/tests/sentry/mediators/external_requests/test_select_requester.py
@@ -33,7 +33,7 @@ class TestSelectRequester(TestCase):
 
         responses.add(
             method=responses.GET,
-            url='https://example.com/get-issues?project=boop&installationId=f3d37e3a-9a87-4651-8463-d375118f4996',
+            url='https://example.com/get-issues?projectSlug=boop&installationId=f3d37e3a-9a87-4651-8463-d375118f4996',
             body='[{"label": "An Issue", "value": "12345"}]',
             status=200,
             content_type='application/json',
@@ -57,7 +57,7 @@ class TestSelectRequester(TestCase):
         }
         responses.add(
             method=responses.GET,
-            url='https://example.com/get-issues?project=boop&installationId=f3d37e3a-9a87-4651-8463-d375118f4996',
+            url='https://example.com/get-issues?projectSlug=boop&installationId=f3d37e3a-9a87-4651-8463-d375118f4996',
             json=invalid_format,
             status=200,
             content_type='application/json',

--- a/tests/sentry/mediators/external_requests/test_select_requester.py
+++ b/tests/sentry/mediators/external_requests/test_select_requester.py
@@ -71,3 +71,21 @@ class TestSelectRequester(TestCase):
                 uri='/get-issues',
                 fields={},
             )
+
+    @responses.activate
+    def test_500_response(self):
+        responses.add(
+            method=responses.GET,
+            url='https://example.com/get-issues?projectSlug=boop&installationId=f3d37e3a-9a87-4651-8463-d375118f4996',
+            body='Something failed',
+            status=500,
+        )
+
+        with self.assertRaises(APIError):
+            SelectRequester.run(
+                install=self.install,
+                project=self.project,
+                group=self.group,
+                uri='/get-issues',
+                fields={},
+            )

--- a/tests/sentry/mediators/external_requests/test_select_requester.py
+++ b/tests/sentry/mediators/external_requests/test_select_requester.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import responses
 
+from sentry.coreapi import APIError
 from sentry.mediators.external_requests import SelectRequester
 from sentry.testutils import TestCase
 
@@ -43,5 +44,30 @@ class TestSelectRequester(TestCase):
             project=self.project,
             uri='/get-issues',
         )
-
         assert result == [{'value': '12345', 'label': 'An Issue'}]
+
+        request = responses.calls[0].request
+        assert request.headers['Sentry-App-Signature']
+
+    @responses.activate
+    def test_invalid_response_format(self):
+        # missing 'label'
+        invalid_format = {
+            'value': '12345',
+        }
+        responses.add(
+            method=responses.GET,
+            url='https://example.com/get-issues?project=boop&installationId=f3d37e3a-9a87-4651-8463-d375118f4996',
+            json=invalid_format,
+            status=200,
+            content_type='application/json',
+        )
+
+        with self.assertRaises(APIError):
+            SelectRequester.run(
+                install=self.install,
+                project=self.project,
+                group=self.group,
+                uri='/get-issues',
+                fields={},
+            )

--- a/tests/sentry/mediators/external_requests/test_select_requester.py
+++ b/tests/sentry/mediators/external_requests/test_select_requester.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import
+
+import responses
+
+from sentry.mediators.external_requests import SelectRequester
+from sentry.testutils import TestCase
+
+
+class TestSelectRequester(TestCase):
+    def setUp(self):
+        super(TestSelectRequester, self).setUp()
+
+        self.user = self.create_user(name='foo')
+        self.org = self.create_organization(owner=self.user)
+        self.project = self.create_project(slug='boop', organization=self.org)
+
+        self.sentry_app = self.create_sentry_app(
+            name='foo',
+            organization=self.org,
+            webhook_url='https://example.com',
+            scopes=(),
+        )
+
+        self.install = self.create_sentry_app_installation(
+            slug='foo',
+            organization=self.org,
+            user=self.user,
+        )
+
+    @responses.activate
+    def test_makes_request(self):
+
+        responses.add(
+            method=responses.GET,
+            url='https://example.com/get-issues?project=boop&installationId=f3d37e3a-9a87-4651-8463-d375118f4996',
+            body='[{"label": "An Issue", "value": "12345"}]',
+            status=200,
+            content_type='application/json',
+        )
+
+        result = SelectRequester.run(
+            install=self.install,
+            project=self.project,
+            uri='/get-issues',
+        )
+
+        assert result == [{'value': '12345', 'label': 'An Issue'}]


### PR DESCRIPTION
This adds two new mediators that will be used to make requests to external services. These will be used for any sentry apps that specify a `issue-link` schema.

**`SelectRequester:`**
 1.  makes `GET` request to external service to fetch data to populate the `SelectField` in the UI. 
 2. validates the payload that we get from a successful response
 3. returns this data if valid (in the following format):
```
[
   {'label': 'Option', 'value': 'option-id'},
   ...
]
```


**`IssueLinkRequester:`**
1. makes `POST` request to external service to either `create` a new issue/story/etc. or `link` an existing issue/story/etc. 
2. validates the payload we get from a successful response
3. returns this data if valid (in the following format):
```
{  
   'webUrl': <external_issue_url>,
   'project': <top_level_identifier>,
   'identifier': <id_or_short_identifier>,
}
```

* `project` and `identifier` will be used in the UI to render external issue (`meredith-project#123`)
