### PR TITLE
fix: Fix switching back to relative time in date time selector

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
@@ -207,6 +207,7 @@ class TimeRangeSelector extends React.PureComponent {
       end: null,
       utc: this.state.utc,
     };
+    this.setState(newDateTime);
     this.callCallback(onChange, newDateTime);
     this.handleUpdate(newDateTime);
   };


### PR DESCRIPTION
Fixes a bug that caused the displayed date time to not be updated
correctly when switching from a relative time to absolute and then
immediately back again.

Fixes SEN-192