### PR TITLE
fix(api): Stop treating `[]?` as special characters in search (SEN-153)

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -40,26 +40,29 @@ def translate(pat):
             i += 1
         elif c == '*':
             res = res + '.*'
-        elif c == '?':
-            res = res + '.'
-        elif c == '[':
-            j = i
-            if j < n and pat[j] == '!':
-                j = j + 1
-            if j < n and pat[j] == ']':
-                j = j + 1
-            while j < n and pat[j] != ']':
-                j = j + 1
-            if j >= n:
-                res = res + '\\['
-            else:
-                stuff = pat[i:j].replace('\\', '\\\\')
-                i = j + 1
-                if stuff[0] == '!':
-                    stuff = '^' + stuff[1:]
-                elif stuff[0] == '^':
-                    stuff = '\\' + stuff
-                res = '%s[%s]' % (res, stuff)
+        # TODO: We're disabling everything except for wildcard matching for the
+        # moment. Just commenting this code out for the moment, since there's a
+        # reasonable chance we'll add this back in in the future.
+        # elif c == '?':
+        #     res = res + '.'
+        # elif c == '[':
+        #     j = i
+        #     if j < n and pat[j] == '!':
+        #         j = j + 1
+        #     if j < n and pat[j] == ']':
+        #         j = j + 1
+        #     while j < n and pat[j] != ']':
+        #         j = j + 1
+        #     if j >= n:
+        #         res = res + '\\['
+        #     else:
+        #         stuff = pat[i:j].replace('\\', '\\\\')
+        #         i = j + 1
+        #         if stuff[0] == '!':
+        #             stuff = '^' + stuff[1:]
+        #         elif stuff[0] == '^':
+        #             stuff = '\\' + stuff
+        #         res = '%s[%s]' % (res, stuff)
         else:
             res = res + re.escape(c)
     return '^' + res + '$'

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1292,18 +1292,21 @@ class SnubaSearchTest(SnubaTestCase):
         )
         assert set(results) == set()
         results = self.make_query(
-            search_filter_query='environment:production \[hing\]',
+            search_filter_query='environment:production [hing]',
         )
         assert set(results) == set([escaped_event.group])
         results = self.make_query(
-            search_filter_query='environment:production s*\]',
+            search_filter_query='environment:production s*]',
         )
         assert set(results) == set([escaped_event.group])
-        results = self.make_query(
-            search_filter_query='environment:production [s][of][mz]',
-        )
-        assert set(results) == set([escaped_event.group])
-        results = self.make_query(
-            search_filter_query='environment:production [z][of][mz]',
-        )
-        assert set(results) == set()
+        # TODO: Disabling tests that use [] syntax for the moment. Re-enable
+        # these if we decide to add back in, or remove if this comment has been
+        # here a while.
+        # results = self.make_query(
+        #     search_filter_query='environment:production [s][of][mz]',
+        # )
+        # assert set(results) == set([escaped_event.group])
+        # results = self.make_query(
+        #     search_filter_query='environment:production [z][of][mz]',
+        # )
+        # assert set(results) == set()


### PR DESCRIPTION
Treating these as special characters is breaking existing search syntax, so we want to just treat
them as normal characters for the moment.