### PR TITLE
fix(issues) Constrain environment options when a project is forced

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
@@ -325,6 +325,7 @@ class GlobalSelectionHeader extends React.Component {
   };
 
   getBackButton = () => {
+    const {organization, location} = this.props;
     return (
       <BackButtonWrapper>
         <Tooltip
@@ -332,8 +333,7 @@ class GlobalSelectionHeader extends React.Component {
           tooltipOptions={{placement: 'bottom'}}
         >
           <BackToIssues
-            to={`/organizations/${this.props.organization.slug}/issues/${window.location
-              .search}`}
+            to={`/organizations/${organization.slug}/issues/${location.search}`}
           >
             <InlineSvg src="icon-arrow-left" />
           </BackToIssues>
@@ -353,6 +353,11 @@ class GlobalSelectionHeader extends React.Component {
       showEnvironmentSelector,
     } = this.props;
     const {period, start, end, utc} = this.props.selection.datetime || {};
+
+    const selectedProjects = forceProject
+      ? [parseInt(forceProject.id, 10)]
+      : this.props.selection.projects;
+
     return (
       <Header className={className}>
         <HeaderItemPosition>
@@ -374,7 +379,7 @@ class GlobalSelectionHeader extends React.Component {
             <HeaderItemPosition>
               <MultipleEnvironmentSelector
                 organization={organization}
-                selectedProjects={this.props.selection.projects}
+                selectedProjects={selectedProjects}
                 value={this.state.environments || this.props.selection.environments}
                 onChange={this.handleChangeEnvironments}
                 onUpdate={this.handleUpdateEnvironmments}

--- a/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
@@ -79,7 +79,6 @@ class MultipleEnvironmentSelector extends React.PureComponent {
   replaceSelected(newSelection) {
     this.setState({selectedEnvs: new Set(newSelection)});
     this.props.onChange(newSelection);
-    this.props.onUpdate();
   }
 
   /**

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -31,11 +31,6 @@ describe('GlobalSelectionHeader', function() {
     jest.spyOn(globalActions, 'updateDateTime');
     jest.spyOn(globalActions, 'updateEnvironments');
     jest.spyOn(globalActions, 'updateProjects');
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/environments/`,
-      body: TestStubs.Environments(),
-    });
   });
 
   beforeEach(function() {
@@ -244,6 +239,41 @@ describe('GlobalSelectionHeader', function() {
       );
 
       expect(globalActions.updateProjects).toHaveBeenCalledWith([3]);
+    });
+  });
+
+  describe('forceProject selection mode', function() {
+    const initialData = initializeOrg({
+      organization: {features: ['global-views']},
+      projects: [
+        {id: 1, slug: 'staging-project', environments: ['staging']},
+        {id: 2, slug: 'prod-project', environments: ['prod']},
+      ],
+      router: {
+        location: {query: {}},
+      },
+    });
+
+    const wrapper = mount(
+      <GlobalSelectionHeader
+        organization={initialData.organization}
+        forceProject={initialData.organization.projects[0]}
+      />,
+      initialData.routerContext
+    );
+
+    it('renders a back button to the forced project', function() {
+      const back = wrapper.find('BackButtonWrapper');
+      expect(back).toHaveLength(1);
+    });
+
+    it('renders only environments from the forced project', async function() {
+      await wrapper.find('MultipleEnvironmentSelector HeaderItem').simulate('click');
+      await wrapper.update();
+
+      const items = wrapper.find('MultipleEnvironmentSelector EnvironmentSelectorItem');
+      expect(items.length).toEqual(1);
+      expect(items.at(0).text()).toBe('staging');
     });
   });
 });

--- a/tests/js/spec/components/organizations/multipleEnvironmentSelector.spec.jsx
+++ b/tests/js/spec/components/organizations/multipleEnvironmentSelector.spec.jsx
@@ -82,7 +82,6 @@ describe('MultipleEnvironmentSelector', function() {
     await wrapper.update();
 
     expect(onChange).toHaveBeenCalled();
-    expect(onUpdate).toHaveBeenCalled();
     const selector = wrapper.find('MultipleEnvironmentSelector').instance();
     expect(selector.state.selectedEnvs).toEqual(new Set([]));
   });


### PR DESCRIPTION
When a project is forced we should only show the environments for that project as the forced project overrules the project selection.

Fixes ISSUE-335