### PR TITLE
Fix(bin/load-mocks): GitHub integration IntegrityError issue

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -481,7 +481,7 @@ def main(num_events=1, extra_events=False):
                 )[0]
                 commit = Commit.objects.get_or_create(
                     organization_id=org.id,
-                    repository_id=repo[0].id,
+                    repository_id=repo.id,
                     key=raw_commit['key'],
                     defaults={
                         'author': author,
@@ -521,7 +521,7 @@ def main(num_events=1, extra_events=False):
             # create an unreleased commit
             Commit.objects.get_or_create(
                 organization_id=org.id,
-                repository_id=repo[0].id,
+                repository_id=repo.id,
                 key=sha1(uuid4().hex).hexdigest(),
                 defaults={
                     'author': CommitAuthor.objects.get_or_create(
@@ -675,7 +675,7 @@ def main(num_events=1, extra_events=False):
             if event5:
                 Commit.objects.get_or_create(
                     organization_id=org.id,
-                    repository_id=repo[0].id,
+                    repository_id=repo.id,
                     key=sha1(uuid4().hex).hexdigest(),
                     defaults={
                         'author': CommitAuthor.objects.get_or_create(

--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -449,6 +449,16 @@ def main(num_events=1, extra_events=False):
 
             raw_commits = generate_commits(user)
 
+            # for users with legacy github plugin
+            # just delete the repo in question to avoid
+            # an integrity error
+            Repository.objects.filter(
+                organization_id=org.id,
+                provider='github',
+                external_id='example/example',
+                name='Example Repo',
+            ).delete()
+
             repo = Repository.objects.get_or_create(
                 organization_id=org.id,
                 provider='integrations:github',

--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -449,25 +449,27 @@ def main(num_events=1, extra_events=False):
 
             raw_commits = generate_commits(user)
 
-            # for users with legacy github plugin
-            # just delete the repo in question to avoid
-            # an integrity error
-            Repository.objects.filter(
-                organization_id=org.id,
-                provider='github',
-                external_id='example/example',
-                name='Example Repo',
-            ).delete()
-
-            repo = Repository.objects.get_or_create(
-                organization_id=org.id,
-                provider='integrations:github',
-                external_id='example/example',
-                defaults={
-                    'name': 'Example Repo',
-                    'url': 'https://github.com/example/example',
-                }
-            )
+            try:
+                repo = Repository.objects.get_or_create(
+                    organization_id=org.id,
+                    provider='integrations:github',
+                    external_id='example/example',
+                    defaults={
+                        'name': 'Example Repo',
+                        'url': 'https://github.com/example/example',
+                    }
+                )
+            except IntegrityError:
+                # for users with legacy github plugin
+                # upgrade to the new integration
+                repo = Repository.objects.get(
+                    organization_id=org.id,
+                    provider='github',
+                    external_id='example/example',
+                    name='Example Repo',
+                )
+                repo.provider = 'integrations:github'
+                repo.save()
 
             authors = set()
 

--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -23,7 +23,7 @@ from sentry import buffer, roles, tsdb
 from sentry.event_manager import HashDiscarded
 from sentry.models import (
     Activity, Broadcast, Commit, CommitAuthor, CommitFileChange, Deploy, EventAttachment, Event,
-    Environment, File, Group, GroupMeta, GroupRelease, GroupTombstone, Organization,
+    Environment, File, Group, GroupRelease, GroupTombstone, Organization,
     OrganizationAccessRequest, OrganizationMember, Project, Release,
     ReleaseCommit, ReleaseEnvironment, ReleaseProjectEnvironment, ReleaseFile, Repository,
     Team, TOMBSTONE_FIELDS_FROM_GROUP, User, UserReport, Monitor, MonitorStatus, MonitorType, MonitorCheckIn, CheckInStatus
@@ -450,7 +450,7 @@ def main(num_events=1, extra_events=False):
             raw_commits = generate_commits(user)
 
             try:
-                repo = Repository.objects.get_or_create(
+                repo, _ = Repository.objects.get_or_create(
                     organization_id=org.id,
                     provider='integrations:github',
                     external_id='example/example',
@@ -693,16 +693,6 @@ def main(num_events=1, extra_events=False):
                 platform='csp',
             )
 
-            with transaction.atomic():
-                if event1:
-                    try:
-                        GroupMeta.objects.create(
-                            group=event1.group,
-                            key='github:tid',
-                            value='134',
-                        )
-                    except IntegrityError:
-                        pass
             if event3:
                 UserReport.objects.create(
                     project=project,


### PR DESCRIPTION
For users who had the legacy github plugin, this fixes the possible integrity error when running load mocks.