### PR TITLE
fix(make): Fix a notion detection bug when bash is used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ install-system-pkgs: node-version-check
 	@echo "--> Installing system packages (from Brewfile)"
 	@command -v brew 2>&1 > /dev/null && brew bundle || (echo 'WARNING: homebrew not found or brew bundle failed - skipping system dependencies.')
 	@echo "--> Installing yarn $(YARN_VERSION) (via npm)"
-	@command -v notion 2>&1 > /dev/null || npm install -g "yarn@$(YARN_VERSION)"
+	@notion --version 2>&1 > /dev/null || npm install -g "yarn@$(YARN_VERSION)"
 
 install-yarn-pkgs:
 	@echo "--> Installing Yarn packages (for development)"


### PR DESCRIPTION
`command -v` seems to only work on ZSH because notion is a shell function.