### PR TITLE
refs(api): Completely stop calling old parser for search. (SEN-181)

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -165,7 +165,13 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         context = serialize(results, request.user, serializer())
 
         # HACK: remove auto resolved entries
-        if query_kwargs.get('status') == GroupStatus.UNRESOLVED:
+        # TODO: We should try to integrate this into the search backend, since
+        # this can cause us to arbitrarily return fewer results than requested.
+        status = [
+            search_filter for search_filter in query_kwargs.get('search_filters', [])
+            if search_filter.key.name == 'status'
+        ]
+        if status and status[0].value.raw_value == GroupStatus.UNRESOLVED:
             context = [r for r in context if r['status'] == 'unresolved']
 
         response = Response(context)

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -191,7 +191,13 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
         context = serialize(results, request.user, serializer())
 
         # HACK: remove auto resolved entries
-        if query_kwargs.get('status') == GroupStatus.UNRESOLVED:
+        # TODO: We should try to integrate this into the search backend, since
+        # this can cause us to arbitrarily return fewer results than requested.
+        status = [
+            search_filter for search_filter in query_kwargs.get('search_filters', [])
+            if search_filter.key.name == 'status'
+        ]
+        if status and status[0].value.raw_value == GroupStatus.UNRESOLVED:
             context = [r for r in context if r['status'] == 'unresolved']
 
         response = Response(context)

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -28,7 +28,6 @@ from sentry.models import (
     Team, User, UserOption
 )
 from sentry.models.group import looks_like_short_id
-from sentry.search.utils import InvalidQuery, parse_query
 from sentry.api.issue_search import (
     convert_query_values,
     InvalidSearchQuery,
@@ -72,13 +71,6 @@ def build_query_params_from_request(request, organization, projects, environment
 
     query = request.GET.get('query', 'is:unresolved').strip()
     if query:
-        try:
-            query_kwargs.update(parse_query(projects, query, request.user, environments))
-        except InvalidQuery as e:
-            raise ValidationError(
-                u'Your search query could not be parsed: {}'.format(
-                    e.message)
-            )
         try:
             search_filters = convert_query_values(
                 parse_search_query(query),

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -81,7 +81,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
         response = self.get_response(sort_by='date', query='timesSeen:>1k')
         assert response.status_code == 400
-        assert 'could not' in response.data['detail']
+        assert 'Invalid format for numeric search' in response.data['detail']
 
     def test_simple_pagination(self):
         now = timezone.now()


### PR DESCRIPTION
This removes all uses of the old parser around issue search. Leaving the parser itself around for a
while because it's useful for comparing results in case we're not sure how things worked in the
past.