### PR TITLE
fix(jira) Attempt to get issue create meta harder

### DIFF
--- a/src/sentry/integrations/jira/webhooks.py
+++ b/src/sentry/integrations/jira/webhooks.py
@@ -102,7 +102,6 @@ class JiraIssueUpdatedWebhook(Endpoint):
             logger.info(
                 'missing-changelog', extra={
                     'integration_id': integration.id,
-                    'data': data,
                 }
             )
             return self.respond()


### PR DESCRIPTION
Some users are not having a good experience when we only get the metadata from the first project. This change attempts to fetch metadata until it finds one or visits all projects.

This could negatively impact the performance of jira issue creation, but my hope is that we'll still end up more efficient than getting *all* projects at once which has proven to be very slow.

I've removed the webhook payload from the logs as it typically ends up split across multiple log messages in ElasticSearch and generally makes a mess.

Refs ISSUE-323