### PR TITLE
ref(processingissues) Use the organization endpoint for processing issues

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/processingIssues.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/processingIssues.jsx
@@ -4,15 +4,3 @@ export function fetchProcessingIssues(api, orgId, projectIds = null) {
     query: projectIds ? {project: projectIds} : null,
   });
 }
-
-export function fetchProjectProcessingIssues(api, orgId, projectId) {
-  // Use the project based endpoint as there is a permissions issue in the backend
-  // and calling the old endpoint is a simple short term solution.
-  return api
-    .requestPromise(`/projects/${orgId}/${projectId}/processingissues/`)
-    .then(data => {
-      // Normalize data to match what the organization endpoint would return
-      data.project = projectId;
-      return [data];
-    });
-}

--- a/src/sentry/static/sentry/app/components/stream/processingIssueList.jsx
+++ b/src/sentry/static/sentry/app/components/stream/processingIssueList.jsx
@@ -4,17 +4,13 @@ import PropTypes from 'prop-types';
 
 import {Client} from 'app/api';
 import {logAjaxError} from 'app/utils/logging';
-import {
-  fetchProcessingIssues,
-  fetchProjectProcessingIssues,
-} from 'app/actionCreators/processingIssues';
+import {fetchProcessingIssues} from 'app/actionCreators/processingIssues';
 import ProcessingIssueHint from 'app/components/stream/processingIssueHint';
 import SentryTypes from 'app/sentryTypes';
 
 class ProcessingIssueList extends React.Component {
   static propTypes = {
     organization: SentryTypes.Organization.isRequired,
-    project: SentryTypes.Project,
     projectIds: PropTypes.array,
     showProject: PropTypes.bool,
   };
@@ -47,13 +43,8 @@ class ProcessingIssueList extends React.Component {
   }
 
   fetchIssues() {
-    const {organization, project, projectIds} = this.props;
-    let promise;
-    if (project) {
-      promise = fetchProjectProcessingIssues(this.api, organization.slug, project.slug);
-    } else {
-      promise = fetchProcessingIssues(this.api, organization.slug, projectIds);
-    }
+    const {organization, projectIds} = this.props;
+    const promise = fetchProcessingIssues(this.api, organization.slug, projectIds);
 
     promise.then(
       data => {

--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -722,7 +722,10 @@ const Stream = createReactClass({
               allResultsVisible={this.allResultsVisible()}
             />
             <PanelBody>
-              <ProcessingIssueList organization={organization} project={project} />
+              <ProcessingIssueList
+                organization={organization}
+                projectIds={selection.projects}
+              />
               {this.renderStreamBody()}
             </PanelBody>
           </Panel>

--- a/tests/js/spec/components/stream/processingIssueList.spec.jsx
+++ b/tests/js/spec/components/stream/processingIssueList.spec.jsx
@@ -45,34 +45,6 @@ describe('ProcessingIssueList', function() {
     });
   });
 
-  describe('componentDidMount project prop', function() {
-    let instance, fetchRequest, project;
-
-    beforeEach(async function() {
-      fetchRequest = MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/processingissues/',
-        method: 'GET',
-        body: {
-          numIssues: 1,
-          hasIssues: true,
-          lastSeen: '2019-01-16T15:39:11.081Z',
-        },
-      });
-      project = TestStubs.Project();
-      wrapper = shallow(
-        <ProcessingIssueList organization={organization} project={project} />
-      );
-      instance = wrapper.instance();
-      await instance.componentDidMount();
-    });
-
-    it('fetches issues', function() {
-      expect(instance.state.issues).toBeTruthy();
-      expect(instance.state.issues[0].project).toEqual(project.slug);
-      expect(fetchRequest).toHaveBeenCalled();
-    });
-  });
-
   describe('render', function() {
     beforeEach(async function() {
       wrapper = shallow(

--- a/tests/js/spec/views/stream/__snapshots__/stream.spec.jsx.snap
+++ b/tests/js/spec/views/stream/__snapshots__/stream.spec.jsx.snap
@@ -111,44 +111,10 @@ exports[`Stream render() displays the group list 1`] = `
               "teams": Array [],
             }
           }
-          project={
-            Object {
-              "allowedDomains": Array [
-                "example.com",
-                "https://example.com",
-              ],
-              "dataScrubber": false,
-              "dataScrubberDefaults": false,
-              "digestsMaxDelay": 60,
-              "digestsMinDelay": 5,
-              "environments": Array [],
-              "features": Array [],
-              "firstEvent": true,
-              "hasAccess": true,
-              "id": 3559,
-              "isBookmarked": false,
-              "isMember": true,
-              "name": "Foo Project",
-              "resolveAge": 48,
-              "safeFields": Array [
-                "business-email",
-                "company",
-              ],
-              "scrapeJavaScript": true,
-              "scrubIPAddresses": false,
-              "securityToken": "security-token",
-              "securityTokenHeader": "x-security-header",
-              "sensitiveFields": Array [
-                "creditcard",
-                "ssn",
-              ],
-              "slug": "project-slug",
-              "storeCrashReports": false,
-              "subjectPrefix": "[my-org]",
-              "subjectTemplate": "[$project] \${tag:level}: $title",
-              "teams": Array [],
-              "verifySSL": true,
-            }
+          projectIds={
+            Array [
+              3559,
+            ]
           }
           showProject={false}
         />
@@ -382,44 +348,10 @@ exports[`Stream toggles environment select all environments 1`] = `
               "teams": Array [],
             }
           }
-          project={
-            Object {
-              "allowedDomains": Array [
-                "example.com",
-                "https://example.com",
-              ],
-              "dataScrubber": false,
-              "dataScrubberDefaults": false,
-              "digestsMaxDelay": 60,
-              "digestsMinDelay": 5,
-              "environments": Array [],
-              "features": Array [],
-              "firstEvent": true,
-              "hasAccess": true,
-              "id": 3559,
-              "isBookmarked": false,
-              "isMember": true,
-              "name": "Foo Project",
-              "resolveAge": 48,
-              "safeFields": Array [
-                "business-email",
-                "company",
-              ],
-              "scrapeJavaScript": true,
-              "scrubIPAddresses": false,
-              "securityToken": "security-token",
-              "securityTokenHeader": "x-security-header",
-              "sensitiveFields": Array [
-                "creditcard",
-                "ssn",
-              ],
-              "slug": "project-slug",
-              "storeCrashReports": false,
-              "subjectPrefix": "[my-org]",
-              "subjectTemplate": "[$project] \${tag:level}: $title",
-              "teams": Array [],
-              "verifySSL": true,
-            }
+          projectIds={
+            Array [
+              3559,
+            ]
           }
           showProject={false}
         />

--- a/tests/js/spec/views/stream/stream.spec.jsx
+++ b/tests/js/spec/views/stream/stream.spec.jsx
@@ -62,7 +62,7 @@ describe('Stream', function() {
       body: [savedSearch],
     });
     MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/processingissues/',
+      url: '/organizations/org-slug/processingissues/',
       method: 'GET',
     });
     sandbox.stub(browserHistory, 'push');


### PR DESCRIPTION
With permissions issues solved we can use the organization level processing issues endpoint in both stream views now. This will let us deprecate the project processing issues endpoint in the future more
easily.

Fixes SEN-58