### PR TITLE
config: Attempt to yell and complain about misconfigurations in Snuba

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -42,6 +42,9 @@ from .manager import *  # NOQA
 #
 #   NOTE: The actor kwarg should be passed when it's expected that the handler
 #         needs context of the user.
+#
+#   NOTE: Features that require Snuba to function, add to the
+#         `requires_snuba` tuple.
 
 default_manager = FeatureManager()  # NOQA
 
@@ -92,6 +95,16 @@ default_manager.add('projects:similarity-indexing', ProjectFeature)  # NOQA
 
 # Project plugin features
 default_manager.add('projects:plugins', ProjectPluginFeature)  # NOQA
+
+# This is a gross hardcoded list, but there's no
+# other sensible way to manage this right now without augmenting
+# features themselves in the manager with detections like this.
+requires_snuba = (
+    'organizations:discover',
+    'organizations:events',
+    'organizations:global-views',
+    'organizations:sentry10',
+)
 
 # NOTE: Don't add features down here! Add them to their specific group and sort
 #       them alphabetically! The order features are registered is not important.

--- a/src/sentry/runner/importer.py
+++ b/src/sentry/runner/importer.py
@@ -11,13 +11,19 @@ import imp
 import six
 import sys
 
+import click
+
 
 def install(name, config_path, default_settings, callback=None):
     sys.meta_path.append(Importer(name, config_path, default_settings, callback))
 
 
-class ConfigurationError(ValueError):
-    pass
+class ConfigurationError(ValueError, click.ClickException):
+    def show(self, file=None):
+        if file is None:
+            from click._compat import get_text_stderr
+            file = get_text_stderr()
+        click.secho('!! Configuration error: %s' % self.format_message(), file=file, fg='red')
 
 
 class Importer(object):

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -319,6 +319,8 @@ def initialize_app(config, skip_service_validation=False):
 
     validate_options(settings)
 
+    validate_snuba()
+
     configure_sdk()
 
     setup_services(validate=not skip_service_validation)
@@ -400,15 +402,17 @@ def bind_cache_to_option_store():
 
 def show_big_error(message):
     if isinstance(message, six.string_types):
-        lines = message.splitlines()
+        lines = message.strip().splitlines()
     else:
         lines = message
     maxline = max(map(len, lines))
     click.echo('', err=True)
-    click.secho('!! %s !!' % ('!' * min(maxline, 80), ), err=True, fg='red')
+    click.secho('!!!%s!!!' % ('!' * min(maxline, 80), ), err=True, fg='red')
+    click.secho('!! %s !!' % ''.center(maxline), err=True, fg='red')
     for line in lines:
         click.secho('!! %s !!' % line.center(maxline), err=True, fg='red')
-    click.secho('!! %s !!' % ('!' * min(maxline, 80), ), err=True, fg='red')
+    click.secho('!! %s !!' % ''.center(maxline), err=True, fg='red')
+    click.secho('!!!%s!!!' % ('!' * min(maxline, 80), ), err=True, fg='red')
     click.echo('', err=True)
 
 
@@ -539,3 +543,103 @@ def on_configure(config):
 
     if 'south' in settings.INSTALLED_APPS:
         skip_migration_if_applied(settings, 'social_auth', 'social_auth_association')
+
+
+def validate_snuba():
+    """
+    Make sure everything related to Snuba is in sync.
+
+    This covers a few cases:
+
+    * When you have features related to Snuba, you must also
+      have Snuba fully configured correctly to continue.
+    * If you have Snuba specific search/tagstore/tsdb backends,
+      you must also have a Snuba compatible eventstream backend
+      otherwise no data will be written into Snuba.
+    * If you only have Snuba related eventstream, yell that you
+      probably want the other backends otherwise things are weird.
+    """
+    if not settings.DEBUG:
+        return
+
+    # TODO: TSDB is left out since... just because for now.
+    has_any_snuba_required_backends = (
+        settings.SENTRY_SEARCH == 'sentry.search.snuba.SnubaSearchBackend' or
+        settings.SENTRY_TAGSTORE == 'sentry.tagstore.snuba.SnubaCompatibilityTagStorage'
+    )
+
+    has_all_snuba_required_backends = (
+        settings.SENTRY_SEARCH == 'sentry.search.snuba.SnubaSearchBackend' and
+        settings.SENTRY_TAGSTORE == 'sentry.tagstore.snuba.SnubaCompatibilityTagStorage'
+    )
+
+    eventstream_is_snuba = (
+        settings.SENTRY_EVENTSTREAM == 'sentry.eventstream.snuba.SnubaEventStream' or
+        settings.SENTRY_EVENTSTREAM == 'sentry.eventstream.kafka.KafkaEventStream'
+    )
+
+    # All good here, it doesn't matter what else is going on
+    if has_all_snuba_required_backends and eventstream_is_snuba:
+        return
+
+    from sentry.features import requires_snuba as snuba_features
+
+    snuba_enabled_features = set()
+
+    for feature in snuba_features:
+        if settings.SENTRY_FEATURES.get(feature, False):
+            snuba_enabled_features.add(feature)
+
+    if snuba_enabled_features and not eventstream_is_snuba:
+        from .importer import ConfigurationError
+        show_big_error('''
+You have features enabled which require Snuba,
+but you don't have any Snuba compatible configuration.
+
+Features you have enabled:
+%s
+
+See: https://github.com/getsentry/snuba#sentry--snuba
+''' % '\n'.join(snuba_enabled_features))
+        raise ConfigurationError('Cannot continue without Snuba configured.')
+
+    if has_any_snuba_required_backends and not eventstream_is_snuba:
+        from .importer import ConfigurationError
+        show_big_error('''
+It appears that you are requiring Snuba,
+but your SENTRY_EVENTSTREAM is not compatible.
+
+Current settings:
+
+SENTRY_SEARCH = %r
+SENTRY_TAGSTORE = %r
+SENTRY_TSDB = %r
+SENTRY_EVENTSTREAM = %r
+
+See: https://github.com/getsentry/snuba#sentry--snuba''' % (
+            settings.SENTRY_SEARCH,
+            settings.SENTRY_TAGSTORE,
+            settings.SENTRY_TSDB,
+            settings.SENTRY_EVENTSTREAM,
+        ))
+        raise ConfigurationError('Cannot continue without Snuba configured correctly.')
+
+    if eventstream_is_snuba and not has_all_snuba_required_backends:
+        show_big_error('''
+You are using a Snuba compatible eventstream
+without configuring search/tagstore/tsdb also to use Snuba.
+This is probably not what you want.
+
+Current settings:
+
+SENTRY_SEARCH = %r
+SENTRY_TAGSTORE = %r
+SENTRY_TSDB = %r
+SENTRY_EVENTSTREAM = %r
+
+See: https://github.com/getsentry/snuba#sentry--snuba''' % (
+            settings.SENTRY_SEARCH,
+            settings.SENTRY_TAGSTORE,
+            settings.SENTRY_TSDB,
+            settings.SENTRY_EVENTSTREAM,
+        ))


### PR DESCRIPTION
This covers 3 primary use cases:

* Only Snuba eventstream enabled, but everything else is missing. Only
yell but move on.
* Any other Snuba related backends enabled, but no eventstream. Yell and
abort.
* Feature switches that require Snuba are enabled, but no Snuba. Yell
and abort.