### PR TITLE
feat(api): Support filtering seen stats by date in group snuba serializer

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -575,6 +575,8 @@ class GroupSerializerSnuba(GroupSerializerBase):
                 project_ids,
                 group_ids,
                 self.environment_ids,
+                start=self.start,
+                end=self.end,
             )
 
             first_seen_data = {

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -312,13 +312,11 @@ class SnubaTagStorage(TagStorage):
             ) for issue, data in six.iteritems(result)
         }
 
-    def get_group_seen_values_for_environments(self, project_ids, group_id_list, environment_ids):
+    def get_group_seen_values_for_environments(self, project_ids, group_id_list, environment_ids,
+                                               start=None, end=None):
         # Get the total times seen, first seen, and last seen across multiple environments
-
-        # TODO(jess): this is mostly copy paste from above
-        # also, this is temporary and will probably need to be updated to
-        # filter correctly based on date filters -- waiting on some product decisions
-        start, end = self.get_time_range()
+        if start is None or end is None:
+            start, end = self.get_time_range()
         filters = {
             'project_id': project_ids,
             'issue': group_id_list,

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -357,7 +357,7 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
             end=self.week_ago + timedelta(hours=1),
         ))
         assert result['userCount'] == 1
-        print result['lastSeen'] == self.week_ago - \
+        assert result['lastSeen'] == self.week_ago - \
             timedelta(microseconds=self.week_ago.microsecond)
         assert result['firstSeen'] == group_env.first_seen
         assert result['count'] == '1'

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -349,13 +349,18 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         assert group_env2.first_seen > group_env.first_seen
         assert result['userCount'] == 3
 
-        # test userCount filtering correctly by time
+        # test userCount, count, lastSeen filtering correctly by time
+        # firstSeen should still be from GroupEnvironment
         result = serialize(group, serializer=GroupSerializerSnuba(
             environment_ids=[environment.id, environment2.id],
             start=self.week_ago - timedelta(hours=1),
             end=self.week_ago + timedelta(hours=1),
         ))
         assert result['userCount'] == 1
+        print result['lastSeen'] == self.week_ago - \
+            timedelta(microseconds=self.week_ago.microsecond)
+        assert result['firstSeen'] == group_env.first_seen
+        assert result['count'] == '1'
 
 
 class StreamGroupSerializerTestCase(APITestCase, SnubaTestCase):

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -518,3 +518,10 @@ class TagStorageTest(SnubaTestCase):
             'last_seen': self.now - timedelta(seconds=1),
             'times_seen': 2,
         }}
+
+        # test where there should be no results because of time filters
+        assert self.ts.get_group_seen_values_for_environments(
+            [self.proj1.id], [self.proj1group1.id], [self.proj1env1.id],
+            start=self.now - timedelta(hours=5),
+            end=self.now - timedelta(hours=4),
+        ) == {}


### PR DESCRIPTION
related to https://github.com/getsentry/sentry/pull/12211

doesn't actually change what endpoints return, but adds support to the serializer for filtering lastSeen and count (aka times seen) by date