### PR TITLE
feat(app-platform): Org Sentry App Components

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_components.py
+++ b/src/sentry/api/endpoints/sentry_app_components.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import
 
-from sentry.api.bases import SentryAppBaseEndpoint
+from sentry.api.bases import OrganizationEndpoint, SentryAppBaseEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.features.helpers import requires_feature
+from sentry.models import SentryAppComponent, SentryApp
 
 
 class SentryAppComponentsEndpoint(SentryAppBaseEndpoint):
@@ -12,6 +13,21 @@ class SentryAppComponentsEndpoint(SentryAppBaseEndpoint):
         return self.paginate(
             request=request,
             queryset=sentry_app.components.all(),
+            paginator_cls=OffsetPaginator,
+            on_results=lambda x: serialize(x, request.user),
+        )
+
+
+class OrganizationSentryAppComponentsEndpoint(OrganizationEndpoint):
+    @requires_feature('organizations:sentry-apps')
+    def get(self, request, organization):
+        return self.paginate(
+            request=request,
+            queryset=SentryAppComponent.objects.filter(
+                sentry_app_id__in=SentryApp.objects.filter(
+                    installations__in=organization.sentry_app_installations.all(),
+                )
+            ),
             paginator_cls=OffsetPaginator,
             on_results=lambda x: serialize(x, request.user),
         )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -174,7 +174,8 @@ from .endpoints.release_deploys import ReleaseDeploysEndpoint
 from .endpoints.debug_files import DebugFilesEndpoint, DifAssembleEndpoint, \
     UnknownDebugFilesEndpoint, AssociateDSymFilesEndpoint
 from .endpoints.sentry_apps import SentryAppsEndpoint
-from .endpoints.sentry_app_components import SentryAppComponentsEndpoint
+from .endpoints.sentry_app_components import SentryAppComponentsEndpoint, \
+    OrganizationSentryAppComponentsEndpoint
 from .endpoints.sentry_app_details import SentryAppDetailsEndpoint
 from .endpoints.sentry_app_authorizations import SentryAppAuthorizationsEndpoint
 from .endpoints.shared_group_details import SharedGroupDetailsEndpoint
@@ -1222,9 +1223,14 @@ urlpatterns = patterns(
         name='sentry-api-0-sentry-app-details'
     ),
     url(
-        r'^/sentry-apps/(?P<sentry_app_slug>[^\/]+)/components/$',
+        r'^sentry-apps/(?P<sentry_app_slug>[^\/]+)/components/$',
         SentryAppComponentsEndpoint.as_view(),
         name='sentry-api-0-sentry-app-components'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/sentry-app-components/$',
+        OrganizationSentryAppComponentsEndpoint.as_view(),
+        name='sentry-api-0-org-sentry-app-components'
     ),
     url(
         r'^sentry-app-installations/(?P<uuid>[^\/]+)/authorizations/$',


### PR DESCRIPTION
Endpoint to return a list of SentryAppComponents, gathered from the Sentry Apps installed to the Org in question.

This is a shortcut for:
→ give me all the installations for this Org
→ now give me each of those install's Sentry App
→ now give me each of those Sentry App's Components