### PR TITLE
fix(eventstream): Ensure synchronous Snuba backend still dispatches post-process task

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -31,8 +31,9 @@ class EventStream(Service):
         'run_post_process_forwarder',
     )
 
-    def insert(self, group, event, is_new, is_sample, is_regression,
-               is_new_group_environment, primary_hash, skip_consume=False):
+    def _dispatch_post_process_group_task(self, group, event, is_new, is_sample,
+                                          is_regression, is_new_group_environment,
+                                          primary_hash, skip_consume=False):
         if skip_consume:
             logger.info('post_process.skip.raw_event', extra={'event_id': event.id})
         else:
@@ -45,6 +46,12 @@ class EventStream(Service):
                 is_new_group_environment=is_new_group_environment,
                 primary_hash=primary_hash,
             )
+
+    def insert(self, group, event, is_new, is_sample, is_regression,
+               is_new_group_environment, primary_hash, skip_consume=False):
+        self._dispatch_post_process_group_task(group, event, is_new, is_sample,
+                                               is_regression, is_new_group_environment,
+                                               primary_hash, skip_consume)
 
     def start_delete_groups(self, project_id, group_ids):
         pass

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -9,7 +9,6 @@ from django.utils.functional import cached_property
 from sentry.eventstream.kafka.consumer import SynchronizedConsumer
 from sentry.eventstream.kafka.protocol import get_task_kwargs_for_message
 from sentry.eventstream.snuba import SnubaProtocolEventStream
-from sentry.tasks.post_process import post_process_group
 from sentry.utils import json
 
 
@@ -190,7 +189,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
 
                 task_kwargs = get_task_kwargs_for_message(message.value())
                 if task_kwargs is not None:
-                    post_process_group.delay(**task_kwargs)
+                    self._dispatch_post_process_group_task(**task_kwargs)
 
                 if i % commit_batch_size == 0:
                     commit_offsets()

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -260,3 +260,12 @@ class SnubaEventStream(SnubaProtocolEventStream):
 
     def requires_post_process_forwarder(self):
         return False
+
+    def insert(self, group, event, is_new, is_sample, is_regression,
+               is_new_group_environment, primary_hash, skip_consume=False):
+        super(SnubaEventStream, self).insert(group, event, is_new, is_sample,
+                                             is_regression, is_new_group_environment,
+                                             primary_hash, skip_consume)
+        self._dispatch_post_process_group_task(group, event, is_new, is_sample,
+                                               is_regression, is_new_group_environment,
+                                               primary_hash, skip_consume)


### PR DESCRIPTION
It looks like this got broken during some shuffling a while back.