### PR TITLE
fix(api): Handle enforcing of types on search columns more consistently. (SEN-167)

### DIFF
--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -127,21 +127,20 @@ class ParseSearchQueryTest(TestCase):
                 value=SearchValue(raw_value=500),
             ),
         ]
-        # Non numeric shouldn't match
-        assert parse_search_query('times_seen:<hello') == [
-            SearchFilter(
-                key=SearchKey(name='times_seen'),
-                operator="=",
-                value=SearchValue(raw_value="<hello"),
-            ),
+        invalid_queries = [
+            'times_seen:<hello',
+            'times_seen:<512.1.0',
+            'times_seen:2018-01-01',
+            'times_seen:+7d',
+            'times_seen:>2018-01-01',
+            'times_seen:"<10"',
         ]
-        assert parse_search_query('times_seen:<512.1.0') == [
-            SearchFilter(
-                key=SearchKey(name='times_seen'),
-                operator="=",
-                value=SearchValue(raw_value="<512.1.0"),
-            ),
-        ]
+        for invalid_query in invalid_queries:
+            with self.assertRaises(
+                InvalidSearchQuery,
+                expected_regex='Invalid format for numeric search',
+            ):
+                parse_search_query(invalid_query)
 
 
 class ConvertQueryValuesTest(TestCase):


### PR DESCRIPTION
This handles numeric/date searches more effectively in the parser. Originally the plan was to build
this into the grammar, but with renaming in the visitor it didn't seem to make sense. So just
improved the visitor code to better handle date/time filters.

Now, if a field is numeric, but we enter a non-numeric value into it then we'll show a user friendly
error rather than throwing a 500.