### PR TITLE
fix(ap): Remove `[]?` characters from wildcard chars

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -19,7 +19,7 @@ from sentry.search.utils import (
 from sentry.utils.dates import to_timestamp
 from sentry.utils.snuba import SENTRY_SNUBA_MAP
 
-WILDCARD_CHARS = re.compile(r'[\*\[\]\?]')
+WILDCARD_CHARS = re.compile(r'[\*]')
 
 
 def translate(pat):


### PR DESCRIPTION
This is causing the advanced search feature flag to treat queries containing these characters as
requiring this feature.