### PR TITLE
fix(bin/load-mocks): Added transaction atomic to `Repository.get_or_create`.

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -450,15 +450,16 @@ def main(num_events=1, extra_events=False):
             raw_commits = generate_commits(user)
 
             try:
-                repo, _ = Repository.objects.get_or_create(
-                    organization_id=org.id,
-                    provider='integrations:github',
-                    external_id='example/example',
-                    defaults={
-                        'name': 'Example Repo',
-                        'url': 'https://github.com/example/example',
-                    }
-                )
+                with transaction.atomic():
+                    repo, _ = Repository.objects.get_or_create(
+                        organization_id=org.id,
+                        provider='integrations:github',
+                        external_id='example/example',
+                        defaults={
+                            'name': 'Example Repo',
+                            'url': 'https://github.com/example/example',
+                        }
+                    )
             except IntegrityError:
                 # for users with legacy github plugin
                 # upgrade to the new integration


### PR DESCRIPTION
I realized this did need transaction.atomic to work correctly. I thought I had checked but must have glossed over it, the case where an `IntegrityError` is thrown. Added now to avoid any further errors.