### PR TITLE
fix(eventstream): Remove unnecessary argument from `post_process_group.delay` calls

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -31,14 +31,13 @@ class EventStream(Service):
         'run_post_process_forwarder',
     )
 
-    def _dispatch_post_process_group_task(self, group, event, is_new, is_sample,
+    def _dispatch_post_process_group_task(self, event, is_new, is_sample,
                                           is_regression, is_new_group_environment,
                                           primary_hash, skip_consume=False):
         if skip_consume:
             logger.info('post_process.skip.raw_event', extra={'event_id': event.id})
         else:
             post_process_group.delay(
-                group=group,
                 event=event,
                 is_new=is_new,
                 is_sample=is_sample,
@@ -47,9 +46,9 @@ class EventStream(Service):
                 primary_hash=primary_hash,
             )
 
-    def insert(self, group, event, is_new, is_sample, is_regression,
+    def insert(self, event, is_new, is_sample, is_regression,
                is_new_group_environment, primary_hash, skip_consume=False):
-        self._dispatch_post_process_group_task(group, event, is_new, is_sample,
+        self._dispatch_post_process_group_task(event, is_new, is_sample,
                                                is_regression, is_new_group_environment,
                                                primary_hash, skip_consume)
 

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -46,7 +46,7 @@ class EventStream(Service):
                 primary_hash=primary_hash,
             )
 
-    def insert(self, event, is_new, is_sample, is_regression,
+    def insert(self, group, event, is_new, is_sample, is_regression,
                is_new_group_environment, primary_hash, skip_consume=False):
         self._dispatch_post_process_group_task(event, is_new, is_sample,
                                                is_regression, is_new_group_environment,

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -261,7 +261,7 @@ class SnubaEventStream(SnubaProtocolEventStream):
     def requires_post_process_forwarder(self):
         return False
 
-    def insert(self, event, is_new, is_sample, is_regression,
+    def insert(self, group, event, is_new, is_sample, is_regression,
                is_new_group_environment, primary_hash, skip_consume=False):
         super(SnubaEventStream, self).insert(event, is_new, is_sample,
                                              is_regression, is_new_group_environment,

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -261,11 +261,11 @@ class SnubaEventStream(SnubaProtocolEventStream):
     def requires_post_process_forwarder(self):
         return False
 
-    def insert(self, group, event, is_new, is_sample, is_regression,
+    def insert(self, event, is_new, is_sample, is_regression,
                is_new_group_environment, primary_hash, skip_consume=False):
-        super(SnubaEventStream, self).insert(group, event, is_new, is_sample,
+        super(SnubaEventStream, self).insert(event, is_new, is_sample,
                                              is_regression, is_new_group_environment,
                                              primary_hash, skip_consume)
-        self._dispatch_post_process_group_task(group, event, is_new, is_sample,
+        self._dispatch_post_process_group_task(event, is_new, is_sample,
                                                is_regression, is_new_group_environment,
                                                primary_hash, skip_consume)

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -263,7 +263,7 @@ class SnubaEventStream(SnubaProtocolEventStream):
 
     def insert(self, group, event, is_new, is_sample, is_regression,
                is_new_group_environment, primary_hash, skip_consume=False):
-        super(SnubaEventStream, self).insert(event, is_new, is_sample,
+        super(SnubaEventStream, self).insert(group, event, is_new, is_sample,
                                              is_regression, is_new_group_environment,
                                              primary_hash, skip_consume)
         self._dispatch_post_process_group_task(event, is_new, is_sample,


### PR DESCRIPTION
Turns out, prior to 2445603b97c1b6c5cfead56e806a69cafd3f6049, the base `EventStream` backend was calling `post_process_group.delay` with an unused `group` parameter:

https://github.com/getsentry/sentry/blob/5c5d2c978f68760bb655ca90c9ffd024e16b460c/src/sentry/tasks/post_process.py#L81

The task dispatch logic was consolidated in 2445603b97c1b6c5cfead56e806a69cafd3f6049 which used the base `EventStream` behavior, which was not compatible with the task arguments that are constructed in the Kafka backend:

https://github.com/getsentry/sentry/blob/2445603b97c1b6c5cfead56e806a69cafd3f6049/src/sentry/eventstream/kafka/backend.py#L190-L192

Fixes SENTRY-9QG.