### PR TITLE
feat(discover): Support double quotes in string conditions

### DIFF
--- a/src/sentry/api/endpoints/organization_discover_query.py
+++ b/src/sentry/api/endpoints/organization_discover_query.py
@@ -154,6 +154,12 @@ class DiscoverQuerySerializer(serializers.Serializer):
         if isinstance(condition[2], bool):
             condition[2] = int(condition[2])
 
+        # Strip double quotes on strings
+        if isinstance(condition[2], six.string_types):
+            match = re.search(r'^"(.*)"$', condition[2])
+            if match:
+                condition[2] = match.group(1)
+
         # Apply has function to any array field if it's = / != and not part of arrayjoin
         if array_field and has_equality_operator and (array_field.group(1) != self.arrayjoin):
             value = condition[2]

--- a/src/sentry/static/sentry/app/views/organizationDiscover/conditions/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/conditions/utils.jsx
@@ -83,11 +83,6 @@ export function getExternal(internal, columns) {
       external[2] = internal.replace(strStart, '');
     }
 
-    // Ignore double quotes if they have been entered
-    if (external[2] !== null && external[2].match(/^".*"$/)) {
-      external[2] = external[2].slice(1, -1);
-    }
-
     const type = columns.find(({name}) => name === colValue).type;
 
     if (type === 'number') {

--- a/tests/js/spec/views/organizationDiscover/conditions/utils.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/conditions/utils.spec.jsx
@@ -55,10 +55,6 @@ describe('Conditions', function() {
     // datetime fields are expanded
     const expectedTimestamp = ['timestamp', '=', '2018-05-05T00:00:00'];
     expect(getExternal('timestamp = 2018-05-05', COLUMNS)).toEqual(expectedTimestamp);
-
-    // strips double quotes
-    const expectedValue = ['message', '=', 'test'];
-    expect(getExternal('message = "test"', COLUMNS)).toEqual(expectedValue);
   });
 
   it('getInternal()', function() {

--- a/tests/snuba/test_organization_discover_query.py
+++ b/tests/snuba/test_organization_discover_query.py
@@ -169,6 +169,21 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
         assert response.data['data'][0]['message'] == 'message!'
         assert response.data['data'][0]['platform.name'] == 'python'
 
+    def test_strip_double_quotes_in_condition_strings(self):
+        with self.feature('organizations:discover'):
+            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            response = self.client.post(url, {
+                'projects': [self.project.id],
+                'fields': ['message'],
+                'conditions': [['message', '=', '"message!"']],
+                'range': '14d',
+                'orderby': '-timestamp',
+            })
+
+        assert response.status_code == 200, response.content
+        assert len(response.data['data']) == 1
+        assert response.data['data'][0]['message'] == 'message!'
+
     def test_array_join(self):
         with self.feature('organizations:discover'):
             url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])


### PR DESCRIPTION
Strips any double quotes from conditions on string columns if they have
been provided. Remove the normalization on the frontend that previously
updated this immediately as it was entered.

Addresses SEN-220