### PR TITLE
fix(deletions): Don't call nodestore.delete twice on Events

### DIFF
--- a/src/sentry/deletions/defaults/event.py
+++ b/src/sentry/deletions/defaults/event.py
@@ -28,6 +28,12 @@ class EventDeletionTask(ModelDeletionTask):
         return relations
 
     def get_child_relations_bulk(self, instance_list):
-        node_ids = [i.data.id for i in instance_list]
+        node_ids = []
+        for i in instance_list:
+            node_ids.append(i.data.id)
+            # Unbind the NodeField so it doesn't attempt to get
+            # get deleted a second time after NodeDeletionTask
+            # runs, when the Event itself is deleted.
+            i.data = None
 
         return [BaseRelation({'nodes': node_ids}, NodeDeletionTask)]


### PR DESCRIPTION
The way this work is in the `EventDeletionTask`, we conveniently pull
off all the node ids, and pass them along to the `NodeDeletionTask` to
call `nodestore.delete_multi()` in an attempt to bulk delete all the
node ids as efficiently as possible.

But then down in `ModelDeletionTask.delete_instance()` for each Event,
the `instance.delete()` call ends up cascading down into the
`NodeField`'s `on_delete()` behavior, in turn triggering _another_
delete call for each Event's node value.

This change instead collects the node ids, but then removes the
`NodeField` so we're left with the single `nodestore.bulk_delete` call
for all node ids.