### PR TITLE
style(integration tests): Fix typo in integration test

### DIFF
--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -490,7 +490,7 @@ class SentryRemoteTest(TestCase):
         assert instance.message == 'hello'
 
 
-class DepdendencyTest(TestCase):
+class DependencyTest(TestCase):
     def raise_import_error(self, package):
         def callable(package_name):
             if package_name != package:


### PR DESCRIPTION
Replace 'DepdendencyTest' to 'DependencyTest' to fix typo in test name