### PR TITLE
ref: Consolidate on the organization endpoints for tags & members

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/members.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/members.jsx
@@ -16,16 +16,6 @@ export function fetchOrgMembers(api, orgId, projectIds = null) {
   });
 }
 
-export function fetchProjectMembers(api, orgId, projectId) {
-  const url = `/projects/${orgId}/${projectId}/members/`;
-  return api.requestPromise(url, {method: 'GET'}).then(members => {
-    members = members.filter(m => m.user).map(m => m.user);
-    MemberListStore.loadInitialData(members);
-
-    return members;
-  });
-}
-
 /**
  * Convert a list of members with user & project data
  * into a object that maps project slugs : users in that project.

--- a/src/sentry/static/sentry/app/actionCreators/tags.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/tags.jsx
@@ -118,19 +118,3 @@ export function fetchTagValues(api, orgId, tagKey, search = null, projectIds = n
     query,
   });
 }
-
-/**
- * Fetch tag values for a single project
- */
-export function fetchProjectTagValues(api, orgId, projectId, tagKey, query = null) {
-  const url = `/projects/${orgId}/${projectId}/tags/${tagKey}/values/`;
-
-  if (query) {
-    query = {query};
-  }
-
-  return api.requestPromise(url, {
-    method: 'GET',
-    query,
-  });
-}

--- a/src/sentry/static/sentry/app/components/assigneeSelector.jsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.jsx
@@ -97,6 +97,15 @@ const AssigneeSelectorComponent = createReactClass({
       return true;
     }
 
+    // If the memberList in props has changed, re-render as
+    // props have updated, and we won't use internal state anyways.
+    if (
+      nextProps.memberList &&
+      !valueIsEqual(this.props.memberList, nextProps.memberList)
+    ) {
+      return true;
+    }
+
     const currentMembers = this.memberList();
     // XXX(billyvg): this means that once `memberList` is not-null, this component will never update due to `memberList` changes
     // Note: this allows us to show a "loading" state for memberList, but only before `MemberListStore.loadInitialData`

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import {Link} from 'react-router';
 import ApiMixin from 'app/mixins/apiMixin';
-import {fetchProjectMembers} from 'app/actionCreators/members';
+import {fetchOrgMembers} from 'app/actionCreators/members';
 import AssigneeSelector from 'app/components/assigneeSelector';
 import Count from 'app/components/count';
 import IndicatorStore from 'app/stores/indicatorStore';
@@ -42,12 +42,11 @@ const GroupHeader = createReactClass({
 
   componentDidMount() {
     const {organization} = this.context;
-    const {group} = this.props;
-    fetchProjectMembers(
-      this.api,
-      organization.slug,
-      group.project.slug
-    ).then(memberList => this.setState({memberList}));
+    const {project} = this.props.group;
+
+    fetchOrgMembers(this.api, organization.slug, project.id).then(memberList =>
+      this.setState({memberList})
+    );
   },
 
   onToggleMute() {

--- a/src/sentry/static/sentry/app/views/projects/projectContext.jsx
+++ b/src/sentry/static/sentry/app/views/projects/projectContext.jsx
@@ -6,7 +6,7 @@ import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 
 import {loadEnvironments} from 'app/actionCreators/environments';
-import {fetchProjectMembers} from 'app/actionCreators/members';
+import {fetchOrgMembers} from 'app/actionCreators/members';
 import {setActiveProject} from 'app/actionCreators/projects';
 import {t} from 'app/locale';
 import ApiMixin from 'app/mixins/apiMixin';
@@ -183,7 +183,7 @@ const ProjectContext = createReactClass({
         }
       );
 
-      fetchProjectMembers(this.api, orgId, projectId);
+      fetchOrgMembers(this.api, orgId, activeProject.id);
     } else if (activeProject && !activeProject.isMember) {
       this.setState({
         loading: false,

--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -21,7 +21,7 @@ import ConfigStore from 'app/stores/configStore';
 import EnvironmentStore from 'app/stores/environmentStore';
 import ErrorRobot from 'app/components/errorRobot';
 import {fetchSavedSearches} from 'app/actionCreators/savedSearches';
-import {fetchProjectTagValues} from 'app/actionCreators/tags';
+import {fetchTagValues} from 'app/actionCreators/tags';
 import GroupStore from 'app/stores/groupStore';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
@@ -656,8 +656,9 @@ const Stream = createReactClass({
   },
 
   tagValueLoader(key, search) {
-    const {orgId, projectId} = this.props.params;
-    return fetchProjectTagValues(this.api, orgId, projectId, key, search);
+    const {orgId} = this.props.params;
+    const project = this.getProject();
+    return fetchTagValues(this.api, orgId, key, search, project.id);
   },
 
   render() {

--- a/tests/js/spec/views/onboarding/configure/index.spec.jsx
+++ b/tests/js/spec/views/onboarding/configure/index.spec.jsx
@@ -18,7 +18,7 @@ describe('Configure should render correctly', function() {
       body: {},
     });
     MockApiClient.addMockResponse({
-      url: '/projects/testOrg/project-slug/members/',
+      url: '/organizations/testOrg/users/',
       body: [],
     });
     MockApiClient.addMockResponse({

--- a/tests/js/spec/views/projectGeneralSettings.spec.jsx
+++ b/tests/js/spec/views/projectGeneralSettings.spec.jsx
@@ -41,7 +41,7 @@ describe('projectGeneralSettings', function() {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: `/projects/${org.slug}/${project.slug}/members/`,
+      url: `/organizations/${org.slug}/users/`,
       method: 'GET',
       body: [],
     });
@@ -288,7 +288,7 @@ describe('projectGeneralSettings', function() {
       body: [],
     });
     const newProjectMembers = MockApiClient.addMockResponse({
-      url: `/projects/${org.slug}/new-project/members/`,
+      url: `/organizations/${org.slug}/users/`,
       method: 'GET',
       body: [],
     });


### PR DESCRIPTION
Use the organization endpoints for tags and members. This lets us support less code in the front-end and removes our internal usage of the project endpoints which removes one blocker for any future deprecations we want to do.

Fixes SEN-141