### PR TITLE
fix(require-2fa): Superuser access to require 2fa

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -34,8 +34,9 @@ class OrganizationPermission(SentryPermission):
         'DELETE': ['org:admin'],
     }
 
-    def is_not_2fa_compliant(self, user, organization):
-        return organization.flags.require_2fa and not Authenticator.objects.user_has_2fa(user)
+    def is_not_2fa_compliant(self, request, organization):
+        return organization.flags.require_2fa and not Authenticator.objects.user_has_2fa(
+            request.user) and not is_active_superuser(request)
 
     def needs_sso(self, request, organization):
         # XXX(dcramer): this is very similar to the server-rendered views

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -61,7 +61,7 @@ class SuperuserPermission(permissions.BasePermission):
 
 
 class SentryPermission(ScopedPermission):
-    def is_not_2fa_compliant(self, user, organization):
+    def is_not_2fa_compliant(self, request, organization):
         return False
 
     def needs_sso(self, request, organization):
@@ -111,7 +111,7 @@ class SentryPermission(ScopedPermission):
                     raise SsoRequired(organization)
 
                 if self.is_not_2fa_compliant(
-                        request.user, organization):
+                        request, organization):
                     logger.info(
                         'access.not-2fa-compliant',
                         extra={

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -108,8 +108,9 @@ class OrganizationMixin(object):
             organization=organization,
         ).exists()
 
-    def is_not_2fa_compliant(self, user, organization):
-        return organization.flags.require_2fa and not Authenticator.objects.user_has_2fa(user)
+    def is_not_2fa_compliant(self, request, organization):
+        return organization.flags.require_2fa and not Authenticator.objects.user_has_2fa(
+            request.user) and not is_active_superuser(request)
 
     def get_active_team(self, request, organization, team_slug):
         """
@@ -215,7 +216,7 @@ class BaseView(View, OrganizationMixin):
             return self.handle_permission_required(request, *args, **kwargs)
 
         if 'organization' in kwargs and self.is_not_2fa_compliant(
-                request.user, kwargs['organization']):
+                request, kwargs['organization']):
             return self.handle_not_2fa_compliant(request, *args, **kwargs)
 
         self.request = request

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from datetime import timedelta
 
+from django.db.models import F
 from django.test import RequestFactory
 from django.utils import timezone
 from exam import fixture
@@ -13,10 +14,10 @@ from sentry.api.bases.organization import (
     OrganizationEndpoint,
     OrganizationPermission,
 )
-from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.exceptions import ResourceDoesNotExist, TwoFactorRequired
 from sentry.api.utils import MAX_STATS_PERIOD
 from sentry.auth.access import from_request, NoAccess
-from sentry.models import ApiKey
+from sentry.models import ApiKey, Organization, TotpInterface
 from sentry.testutils import TestCase
 
 
@@ -42,6 +43,10 @@ class OrganizationPermissionBase(TestCase):
 
 
 class OrganizationPermissionTest(OrganizationPermissionBase):
+    def org_require_2fa(self):
+        self.org.update(flags=F('flags').bitor(Organization.flags.require_2fa))
+        assert self.org.flags.require_2fa.is_set is True
+
     def test_regular_user(self):
         user = self.create_user()
         assert not self.has_object_perm('GET', self.org, user=user)
@@ -93,6 +98,35 @@ class OrganizationPermissionTest(OrganizationPermissionBase):
             scope_list=['org:read'],
         )
         assert not self.has_object_perm('PUT', self.org, auth=key)
+
+    def test_org_requires_2fa_with_superuser(self):
+        self.org_require_2fa()
+        user = self.create_user(is_superuser=True)
+        assert self.has_object_perm('GET', self.org, user=user, is_superuser=True)
+
+    def test_org_requires_2fa_with_enrolled_user(self):
+        self.org_require_2fa()
+        user = self.create_user()
+        self.create_member(
+            user=user,
+            organization=self.org,
+            role='member',
+        )
+
+        TotpInterface().enroll(user)
+        assert self.has_object_perm('GET', self.org, user=user)
+
+    def test_org_requires_2fa_with_unenrolled_user(self):
+        self.org_require_2fa()
+        user = self.create_user()
+        self.create_member(
+            user=user,
+            organization=self.org,
+            role='member',
+        )
+
+        with self.assertRaises(TwoFactorRequired):
+            self.has_object_perm('GET', self.org, user=user)
 
 
 class BaseOrganizationEndpointTest(TestCase):

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -737,3 +737,8 @@ class OrganizationSettings2FATest(TwoFactorAPITestCase):
 
         Authenticator.objects.get(user=self.no_2fa_user).delete()
         self.assert_cannot_access_org_details(self.path)
+
+    def test_superuser_can_access_org_details(self):
+        user = self.create_user(is_superuser=True)
+        self.login_as(user, superuser=True)
+        self.assert_can_access_org_details(self.path)

--- a/tests/sentry/api/endpoints/test_organization_index.py
+++ b/tests/sentry/api/endpoints/test_organization_index.py
@@ -226,3 +226,8 @@ class OrganizationIndex2faTest(TwoFactorAPITestCase):
 
         Authenticator.objects.get(user=self.no_2fa_user).delete()
         self.assert_redirected_to_2fa()
+
+    def test_superuser_can_access_org_home(self):
+        user = self.create_user(is_superuser=True)
+        self.login_as(user, superuser=True)
+        self.assert_can_access_org_home()


### PR DESCRIPTION
Allow superusers to access orgs that require 2fa in Sentry and _admin without 2fa enabled.

Ref SE-181