### PR TITLE
fix(ui) Add word break to tooltips

### DIFF
--- a/src/sentry/static/sentry/less/includes/tooltips.less
+++ b/src/sentry/static/sentry/less/includes/tooltips.less
@@ -4,9 +4,9 @@
 
 .tooltip-inner {
   font-weight: bold;
-  // border: 1px solid @trim;
   padding: 5px 10px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
+  overflow-wrap: break-word;
 
   hr {
     border: 0px;


### PR DESCRIPTION
The contents of tooltips would overflow when they contained long unbreakable strings in chrome. Setting overflow-wrap will enable mid word breakage if it is necessary.

Aiming to fix problems like

![image](https://user-images.githubusercontent.com/24086/53761195-f8b0e280-3e92-11e9-99aa-57674cb9cfc9.png)


Fixes SEN-221