### PR TITLE
ref(navigation): Use sso over 'sso-saml2' for nav id

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.jsx
@@ -43,7 +43,7 @@ const organizationNavigation = [
         path: `${pathPrefix}/auth/`,
         title: t('Auth'),
         description: t('Configure single sign-on'),
-        id: 'sso-saml2',
+        id: 'sso',
       },
       {
         path: `${pathPrefix}/api-keys/`,


### PR DESCRIPTION
This makes more semantic sense