### PR TITLE
feat(breadcrumbs): Add error boundary

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumb.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumb.jsx
@@ -6,6 +6,7 @@ import {defined} from 'app/utils';
 import HttpRenderer from 'app/components/events/interfaces/breadcrumbs/httpRenderer';
 import ErrorRenderer from 'app/components/events/interfaces/breadcrumbs/errorRenderer';
 import DefaultRenderer from 'app/components/events/interfaces/breadcrumbs/defaultRenderer';
+import ErrorBoundary from 'app/components/errorBoundary';
 
 const CUSTOM_RENDERERS = {
   http: HttpRenderer,
@@ -50,17 +51,19 @@ class Breadcrumb extends React.Component {
     const {crumb} = this.props;
     return (
       <li className={this.getClassName()}>
-        <span className="icon-container">
-          <span className="icon" />
-        </span>
-        {defined(crumb.timestamp) ? (
-          <span className="dt" title={moment(crumb.timestamp).format()}>
-            {moment(crumb.timestamp).format('HH:mm:ss')}
+        <ErrorBoundary mini css={{margin: 0, borderRadius: 0}}>
+          <span className="icon-container">
+            <span className="icon" />
           </span>
-        ) : (
-          <span className="dt" />
-        )}
-        {this.renderType()}
+          {defined(crumb.timestamp) ? (
+            <span className="dt" title={moment(crumb.timestamp).format()}>
+              {moment(crumb.timestamp).format('HH:mm:ss')}
+            </span>
+          ) : (
+            <span className="dt" />
+          )}
+          {this.renderType()}
+        </ErrorBoundary>
       </li>
     );
   }


### PR DESCRIPTION
Add an error boundary around breadcrumb component. Since we don't do a
lot of validation on breadcrumbs currently, data sent by the user might
be malformed. This prevents the entire event detail page crashing.

Refs ISSUE-350