### PR TITLE
feat: Use new URL format for group event json endpoint

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/shared/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/eventToolbar.jsx
@@ -150,7 +150,7 @@ const GroupEventToolbar = createReactClass({
 
     // TODO: possible to define this as a route in react-router, but without a corresponding
     //       React component?
-    const jsonUrl = `/${orgId}/${projectId}/issues/${groupId}/events/${evt.id}/json/`;
+    const jsonUrl = `/organizations/${orgId}/issues/${groupId}/events/${evt.id}/json/`;
     const style = {
       borderBottom: '1px dotted #dfe3ea',
     };

--- a/src/sentry/web/frontend/group_event_json.py
+++ b/src/sentry/web/frontend/group_event_json.py
@@ -5,19 +5,18 @@ from django.shortcuts import get_object_or_404
 
 from sentry.models import Event, Group, GroupMeta, get_group_with_redirect
 from sentry.utils import json
-from sentry.web.frontend.base import ProjectView
+from sentry.web.frontend.base import OrganizationView
 
 
-class GroupEventJsonView(ProjectView):
+class GroupEventJsonView(OrganizationView):
     required_scope = 'event:read'
 
-    def get(self, request, organization, project, group_id, event_id_or_latest):
+    def get(self, request, organization, group_id, event_id_or_latest):
         try:
             # TODO(tkaemming): This should *actually* redirect, see similar
             # comment in ``GroupEndpoint.convert_args``.
             group, _ = get_group_with_redirect(
                 group_id,
-                queryset=Group.objects.filter(project=project),
             )
         except Group.DoesNotExist:
             raise Http404

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -425,6 +425,12 @@ urlpatterns += patterns(
         name='sentry-organization-event-detail'
     ),
     url(
+        r'^organizations/(?P<organization_slug>[\w_-]+)/issues/(?P<group_id>\d+)/events/(?P<event_id_or_latest>(\d+|latest))/json/$',
+        GroupEventJsonView.as_view(),
+        name='sentry-group-event-json'
+    ),
+
+    url(
         r'^organizations/(?P<organization_slug>[\w_-]+)/projects/(?P<project_slug>[\w_-]+)/events/(?P<client_event_id>[\w_-]+)/$',
         ProjectEventRedirect.as_view(),
         name='sentry-project-event-redirect'
@@ -592,11 +598,6 @@ urlpatterns += patterns(
         r'^(?P<organization_slug>[\w_-]+)/(?P<project_id>[\w_-]+)/$',
         react_page_view,
         name='sentry-stream'
-    ),
-    url(
-        r'^(?P<organization_slug>[\w_-]+)/(?P<project_slug>[\w_-]+)/(?:group|issues)/(?P<group_id>\d+)/events/(?P<event_id_or_latest>(\d+|latest))/json/$',
-        GroupEventJsonView.as_view(),
-        name='sentry-group-event-json'
     ),
     url(
         r'^(?P<organization_slug>[\w_-]+)/(?P<project_slug>[\w_-]+)/issues/(?P<group_id>\d+)/tags/(?P<key>[^\/]+)/export/$',

--- a/tests/sentry/web/frontend/test_group_event_json.py
+++ b/tests/sentry/web/frontend/test_group_event_json.py
@@ -10,9 +10,8 @@ from sentry.testutils import TestCase
 class GroupEventJsonTest(TestCase):
     @fixture
     def path(self):
-        return u'/{}/{}/issues/{}/events/{}/json/'.format(
+        return u'/organizations/{}/issues/{}/events/{}/json/'.format(
             self.organization.slug,
-            self.project.slug,
             self.group.id,
             self.event.id,
         )


### PR DESCRIPTION
Make the URL format consistent with new URLs (no project slug in URL)

Addresses SEN-37