### PR TITLE
fix(api): Fix errors with null checks on non-string snuba columns. Add missed columns to type lists. (SEN-229)

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -76,7 +76,7 @@ SENTRY_SNUBA_MAP = {
     'device.arch': 'device_arch',
     'device.battery_level': 'device_battery_level',
     'device.orientation': 'device_orientation',
-    'device.simulator': 'device_orientation',
+    'device.simulator': 'device_simulator',
     'device.online': 'device_online',
     'device.charging': 'device_charging',
     # geo

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -579,7 +579,10 @@ class GetSnubaQueryArgsTest(TestCase):
     def test_negation(self):
         assert get_snuba_query_args('!user.email:foo@example.com') == {
             'conditions': [
-                [['ifNull', ['email', "''"]], '!=', 'foo@example.com'],
+                [
+                    [['isNull', ['email']], '=', 1],
+                    ['email', '!=', 'foo@example.com']
+                ]
             ],
             'filter_keys': {},
         }
@@ -608,9 +611,11 @@ class GetSnubaQueryArgsTest(TestCase):
     def test_negated_wildcard(self):
         assert get_snuba_query_args('!release:3.1.* user.email:*@example.com') == {
             'conditions': [
-                [['match', [['ifNull', ['tags[sentry:release]', "''"]],
-                            "'(?i)^3\\.1\\..*$'"]], '!=', 1],
-                [['match', ['email', "'(?i)^.*\\@example\\.com$'"]], '=', 1],
+                [
+                    [['isNull', ['tags[sentry:release]']], '=', 1],
+                    [['match', ['tags[sentry:release]', "'(?i)^3\\.1\\..*$'"]], '!=', 1]
+                ],
+                [['match', ['email', "'(?i)^.*\\@example\\.com$'"]], '=', 1]
             ],
             'filter_keys': {},
         }
@@ -639,13 +644,13 @@ class GetSnubaQueryArgsTest(TestCase):
     def test_has(self):
         assert get_snuba_query_args('has:release') == {
             'filter_keys': {},
-            'conditions': [[['ifNull', ['tags[sentry:release]', "''"]], '!=', '']]
+            'conditions': [[['isNull', ['tags[sentry:release]']], '!=', 1]]
         }
 
     def test_not_has(self):
         assert get_snuba_query_args('!has:release') == {
             'filter_keys': {},
-            'conditions': [[['ifNull', ['tags[sentry:release]', "''"]], '=', '']]
+            'conditions': [[['isNull', ['tags[sentry:release]']], '=', 1]]
         }
 
     def test_message_negative(self):


### PR DESCRIPTION
Was looking into a fix for SENTRY-9PA, and while writing tests for it uncovered an extra class of
errors that occur when checking that a date/numeric column are null/not null. Since we were using
`ifNull` to convert them to strings, Clickhouse would end up throwing an error.

Change our null checks to use `isNull` instead so that things will be more generic. Also added in a
generic test to make sure that queries for all fields aren't hard failing due to schema issues,
although it won't validate the results are correct, just that the query had no issues validating/running..

Also added a bunch of missed columns to the int/date type lists.