### PR TITLE
fix: Fix NodeUnpopulated error when creating user feedback

### DIFF
--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -158,13 +158,13 @@ class ErrorPageEmbedView(View):
             try:
                 event = Event.objects.filter(project_id=report.project.id,
                                              event_id=report.event_id)[0]
-                Event.objects.bind_nodes([event])
             except IndexError:
                 try:
                     report.group = Group.objects.from_event_id(report.project, report.event_id)
                 except Group.DoesNotExist:
                     pass
             else:
+                Event.objects.bind_nodes([event])
                 report.environment = event.get_environment()
                 report.group = event.group
 

--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -158,6 +158,7 @@ class ErrorPageEmbedView(View):
             try:
                 event = Event.objects.filter(project_id=report.project.id,
                                              event_id=report.event_id)[0]
+                Event.objects.bind_nodes([event])
             except IndexError:
                 try:
                     report.group = Group.objects.from_event_id(report.project, report.event_id)


### PR DESCRIPTION
Don't fail to create user-feedback in DEBUG mode. By binding the nodestore data our save operation will always succeed and not fail/warn.

Refs #12291