### PR TITLE
ref(api docs): Be explicit about allowable values for `resolution` on stats endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_stats.py
+++ b/src/sentry/api/endpoints/organization_stats.py
@@ -40,10 +40,7 @@ class OrganizationStatsEndpoint(OrganizationEndpoint, EnvironmentMixin, StatsMix
         :qparam timestamp until: a timestamp to set the end of the query
                                  in seconds since UNIX epoch.
         :qparam string resolution: an explicit resolution to search
-                                   for (eg: ``10s``).  This should not be
-                                   used unless you are familiar with Sentry's
-                                   internals as it's restricted to pre-defined
-                                   values.
+                                   for (one of ``10s``, ``1h``, and ``1d``)
         :auth: required
         """
         group = request.GET.get('group', 'organization')

--- a/src/sentry/api/endpoints/project_stats.py
+++ b/src/sentry/api/endpoints/project_stats.py
@@ -47,10 +47,7 @@ class ProjectStatsEndpoint(ProjectEndpoint, EnvironmentMixin, StatsMixin):
         :qparam timestamp until: a timestamp to set the end of the query
                                  in seconds since UNIX epoch.
         :qparam string resolution: an explicit resolution to search
-                                   for (eg: ``10s``).  This should not be
-                                   used unless you are familiar with Sentry's
-                                   internals as it's restricted to pre-defined
-                                   values.
+                                   for (one of ``10s``, ``1h``, and ``1d``)
         :auth: required
         """
         stat = request.GET.get('stat', 'received')

--- a/src/sentry/api/endpoints/team_stats.py
+++ b/src/sentry/api/endpoints/team_stats.py
@@ -45,10 +45,7 @@ class TeamStatsEndpoint(TeamEndpoint, EnvironmentMixin, StatsMixin):
         :qparam timestamp until: a timestamp to set the end of the query
                                  in seconds since UNIX epoch.
         :qparam string resolution: an explicit resolution to search
-                                   for (eg: ``10s``).  This should not be
-                                   used unless you are familiar with Sentry's
-                                   internals as it's restricted to pre-defined
-                                   values.
+                                   for (one of ``10s``, ``1h``, and ``1d``)
         :auth: required
         """
         try:


### PR DESCRIPTION
We get periodic tickets from folks who try to set the resolution to something we don't allow. Let's just tell them what their options are.