### PR TITLE
fix(integration): Fix timeout error when adding slack integration rules if org has many channels (SEN-231)

### DIFF
--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -178,8 +178,14 @@ class SlackNotifyServiceAction(EventAction):
 
         # Look for channel ID
         channels_payload = dict(token_payload, **{
-            'exclude_archived': False,
+            'exclude_archived': True,
             'exclude_members': True,
+            # XXX: This endpoint started timing out for certain organizations
+            # that have many channels. Setting any limit causes the endpoint to
+            # not time out, even if that limit is higher than the number of
+            # returned results. Setting to 1500 since this is the most results
+            # that the endpoint will return (as per documentation).
+            'limit': 1500,
         })
 
         resp = session.get('https://slack.com/api/channels.list', params=channels_payload)


### PR DESCRIPTION
https://slack.com/api/channels.list is just timing out for orgs with a lot of channels. This
endpoint is actually deprecated, but changing to the conversations api is a little more work so
punting on it for the moment. Through testing I found that just adding a limit (even if the limit is
higher than the number of returned channels) causes the endpoint to return quickly again, so I guess
it triggers some optimization.

Also started filtering out archived channels, since there's no reason to try and set up an alert for
a channel that is archived.