### PR TITLE
fix: Fix key warnings when commits are missing their repository

### DIFF
--- a/src/sentry/static/sentry/app/components/repositoryFileSummary.jsx
+++ b/src/sentry/static/sentry/app/components/repositoryFileSummary.jsx
@@ -63,10 +63,10 @@ class RepositoryFileSummary extends React.Component {
         </h5>
         <ul className="list-group list-group-striped m-b-2">
           {files.map(filename => {
-            const {id, authors, types} = fileChangeSummary[filename];
+            const {authors, types} = fileChangeSummary[filename];
             return (
               <FileChange
-                key={id}
+                key={filename}
                 filename={filename}
                 authors={Object.values(authors)}
                 types={types}

--- a/src/sentry/static/sentry/app/views/releases/detail/organization/releaseOverview.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/organization/releaseOverview.jsx
@@ -76,7 +76,7 @@ export default class OrganizationReleaseOverview extends AsyncComponent {
                     : release.projects.map(project => {
                         return (
                           <ReleaseProjectStatSparkline
-                            key={project.id}
+                            key={project.slug}
                             orgId={orgId}
                             project={project}
                             version={version}


### PR DESCRIPTION
I removed a repository but kept commits and found a few key warnings. Using these properties will ensure we have unique child keys in all scenarios.