### PR TITLE
fix(app-platform): Don't use Group create signal

### DIFF
--- a/src/sentry/receivers/sentry_apps.py
+++ b/src/sentry/receivers/sentry_apps.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 
-from django.db.models.signals import post_save
-from django.dispatch import receiver
-
-from sentry.models import Group, GroupAssignee, Organization
+from sentry.models import GroupAssignee, Organization
 from sentry.signals import (
     issue_ignored,
     issue_assigned,
@@ -11,25 +8,7 @@ from sentry.signals import (
     issue_resolved_in_release,
     resolved_with_commit,
 )
-from sentry.tasks.sentry_apps import (
-    process_resource_change_bound,
-    workflow_notification,
-)
-
-
-@receiver(post_save, sender=Group, weak=False)
-def issue_saved(sender, instance, created, **kwargs):
-    issue = instance
-
-    # We only send webhooks for creation right now.
-    if not created:
-        return
-
-    process_resource_change_bound.delay(
-        action='created',
-        sender=sender.__name__,
-        instance_id=issue.id,
-    )
+from sentry.tasks.sentry_apps import workflow_notification
 
 
 @issue_assigned.connect(weak=False)

--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -3,25 +3,8 @@ from __future__ import absolute_import
 from mock import patch
 
 from sentry.models import Commit, GroupAssignee, GroupLink, Repository, Release
-from sentry.testutils import APITestCase, TestCase
+from sentry.testutils import APITestCase
 from sentry.testutils.helpers.faux import faux
-
-
-@patch('sentry.tasks.sentry_apps.process_resource_change_bound.delay')
-class TestIssueSaved(TestCase):
-    def test_processes_created_issues(self, delay):
-        issue = self.create_group()
-        assert faux(delay).called_with(
-            action='created',
-            sender='Group',
-            instance_id=issue.id,
-        )
-
-    def test_does_not_process_unless_created(self, delay):
-        issue = self.create_group()
-        delay.reset_mock()
-        issue.update(message='Stuff blew up')
-        assert len(delay.mock_calls) == 0
 
 
 # This testcase needs to be an APITestCase because all of the logic to resolve

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -229,6 +229,25 @@ class PostProcessGroupTest(TestCase):
 
         assert not mock_process_service_hook.delay.mock_calls
 
+    @patch('sentry.tasks.sentry_apps.process_resource_change_bound.delay')
+    def test_processes_resource_change_task_on_new_group(self, delay):
+        group = self.create_group(project=self.project)
+        event = self.create_event(group=group)
+
+        post_process_group(
+            event=event,
+            is_new=True,
+            is_regression=False,
+            is_sample=False,
+            is_new_group_environment=False,
+        )
+
+        delay.assert_called_once_with(
+            action='created',
+            sender='Group',
+            instance_id=group.id,
+        )
+
 
 class IndexEventTagsTest(TestCase):
     def test_simple(self):


### PR DESCRIPTION
Instead of relying on the `post_save` signal, explicitly enqueue the Issue Created webhook from `post_process_group`.

This will hopefully fix a problem where we're reporting wayyy too may `DoesNotExist` errors due to some race condition related to using the signal.

FIXES SENTRY-98S