### PR TITLE
 perf(settings): Team projects fetches projects from API

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -106,6 +106,12 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
                     queryset = queryset.filter(Q(name__icontains=value) | Q(slug__icontains=value))
                 elif key == 'id':
                     queryset = queryset.filter(id__in=value)
+                elif key == "team":
+                    team_list = list(Team.objects.filter(slug__in=value))
+                    queryset = queryset.filter(teams__in=team_list)
+                elif key == "-team":
+                    team_list = list(Team.objects.filter(slug__in=value))
+                    queryset = queryset.exclude(teams__in=team_list)
                 else:
                     queryset = queryset.none()
 

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -109,7 +109,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
                 elif key == "team":
                     team_list = list(Team.objects.filter(slug__in=value))
                     queryset = queryset.filter(teams__in=team_list)
-                elif key == "-team":
+                elif key == "!team":
                     team_list = list(Team.objects.filter(slug__in=value))
                     queryset = queryset.exclude(teams__in=team_list)
                 else:

--- a/src/sentry/static/sentry/app/views/settings/organizationTeams/teamProjects.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationTeams/teamProjects.jsx
@@ -34,12 +34,21 @@ const TeamProjects = createReactClass({
     };
   },
 
-  componentWillMount() {
+  componentDidMount() {
     this.fetchAll();
   },
 
-  componentWillReceiveProps() {
-    this.fetchAll();
+  componentDidUpdate(prevProps) {
+    if (
+      prevProps.params.orgId !== this.props.params.orgId ||
+      prevProps.params.teamId !== this.props.params.teamId
+    ) {
+      this.fetchAll();
+    }
+
+    if (prevProps.location !== this.props.location) {
+      this.fetchTeamProjects();
+    }
   },
 
   fetchAll() {

--- a/src/sentry/static/sentry/app/views/settings/organizationTeams/teamProjects.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationTeams/teamProjects.jsx
@@ -70,8 +70,12 @@ const TeamProjects = createReactClass({
         includeAllArgs: true,
       })
       .then(([linkedProjects, _, jqXHR]) => {
-        this.setState({linkedProjects, pageLinks: jqXHR.getResponseHeader('Link')});
-        this.setState({loading: false});
+        this.setState({
+          loading: false,
+          error: false,
+          linkedProjects,
+          pageLinks: jqXHR.getResponseHeader('Link'),
+        });
       })
       .catch(() => {
         this.setState({loading: false, error: true});

--- a/src/sentry/static/sentry/app/views/settings/organizationTeams/teamProjects.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationTeams/teamProjects.jsx
@@ -88,7 +88,7 @@ const TeamProjects = createReactClass({
     this.api
       .requestPromise(`/organizations/${orgId}/projects/`, {
         query: {
-          query: query ? `-team:${teamId} ${query}` : `-team:${teamId}`,
+          query: query ? `!team:${teamId} ${query}` : `!team:${teamId}`,
         },
       })
       .then(unlinkedProjects => {

--- a/src/sentry/static/sentry/app/views/settings/organizationTeams/teamProjects.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationTeams/teamProjects.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
-import Reflux from 'reflux';
 import styled from 'react-emotion';
 
 import Tooltip from 'app/components/tooltip';
@@ -11,58 +10,85 @@ import Button from 'app/components/button';
 import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
 import DropdownButton from 'app/components/dropdownButton';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
-import ProjectsStore from 'app/stores/projectsStore';
+import LoadingIndicator from 'app/components/loadingIndicator';
 import LoadingError from 'app/components/loadingError';
 import OrganizationState from 'app/mixins/organizationState';
 import ProjectListItem from 'app/views/settings/components/settingsProjectItem';
 import {Panel, PanelHeader, PanelBody, PanelItem} from 'app/components/panels';
 import InlineSvg from 'app/components/inlineSvg';
+import Pagination from 'app/components/pagination';
 import {sortProjects} from 'app/utils';
 import {t} from 'app/locale';
 
 const TeamProjects = createReactClass({
   displayName: 'TeamProjects',
-  mixins: [
-    ApiMixin,
-    OrganizationState,
-    Reflux.listenTo(ProjectsStore, 'onProjectUpdate'),
-  ],
+  mixins: [ApiMixin, OrganizationState],
 
   getInitialState() {
-    const {teamId} = this.props.params;
-    const projectList = ProjectsStore.getAll();
     return {
-      allProjects: projectList,
       error: false,
-      projectListLinked: projectList.filter(p => p.teams.find(t1 => teamId === t1.slug)),
+      loading: true,
+      pageLinks: null,
+      unlinkedProjects: [],
+      linkedProjects: [],
     };
   },
 
-  componentWillReceiveProps(nextProps) {
-    const params = this.props.params;
-    if (
-      nextProps.params.teamId !== params.teamId ||
-      nextProps.params.orgId !== params.orgId
-    ) {
-      this.setState(this.getInitialState());
-    }
+  componentWillMount() {
+    this.fetchAll();
   },
 
-  onProjectUpdate() {
-    const {teamId} = this.props.params;
-    const projectList = ProjectsStore.getAll();
-    this.setState({
-      allProjects: projectList,
-      projectListLinked: projectList.filter(p => p.teams.find(t1 => teamId === t1.slug)),
-    });
+  componentWillReceiveProps() {
+    this.fetchAll();
+  },
+
+  fetchAll() {
+    this.fetchTeamProjects();
+    this.fetchUnlinkedProjects();
+  },
+
+  fetchTeamProjects() {
+    const {location, params: {orgId, teamId}} = this.props;
+
+    this.setState({loading: true});
+
+    this.api
+      .requestPromise(`/organizations/${orgId}/projects/`, {
+        query: {
+          query: `team:${teamId}`,
+          cursor: location.query.cursor || '',
+        },
+        includeAllArgs: true,
+      })
+      .then(([linkedProjects, _, jqXHR]) => {
+        this.setState({linkedProjects, pageLinks: jqXHR.getResponseHeader('Link')});
+        this.setState({loading: false});
+      })
+      .catch(() => {
+        this.setState({loading: false, error: true});
+      });
+  },
+
+  fetchUnlinkedProjects(query) {
+    const {params: {orgId, teamId}} = this.props;
+
+    this.api
+      .requestPromise(`/organizations/${orgId}/projects/`, {
+        query: {
+          query: query ? `-team:${teamId} ${query}` : `-team:${teamId}`,
+        },
+      })
+      .then(unlinkedProjects => {
+        this.setState({unlinkedProjects});
+      });
   },
 
   handleLinkProject(project, action) {
     const {orgId, teamId} = this.props.params;
     this.api.request(`/projects/${orgId}/${project.slug}/teams/${teamId}/`, {
       method: action === 'add' ? 'POST' : 'DELETE',
-      success: data => {
-        ProjectsStore.onUpdateSuccess(data);
+      success: () => {
+        this.fetchAll();
         addSuccessMessage(
           action === 'add'
             ? t('Successfully added project to team.')
@@ -76,14 +102,18 @@ const TeamProjects = createReactClass({
   },
 
   handleProjectSelected(selection) {
-    const project = this.state.allProjects.find(p => {
+    const project = this.state.unlinkedProjects.find(p => {
       return p.id === selection.value;
     });
 
     this.handleLinkProject(project, 'add');
   },
 
-  projectPanelcontents(projects) {
+  handleQueryUpdate(evt) {
+    this.fetchUnlinkedProjects(evt.target.value);
+  },
+
+  projectPanelContents(projects) {
     const access = this.getAccess();
     const canWrite = access.has('org:write');
 
@@ -115,55 +145,60 @@ const TeamProjects = createReactClass({
   },
 
   render() {
-    if (this.state.error) return <LoadingError onRetry={this.fetchData} />;
+    const {linkedProjects, unlinkedProjects, error, loading} = this.state;
 
-    const {projectListLinked, allProjects} = this.state;
+    if (error) {
+      return <LoadingError onRetry={this.fetchData} />;
+    }
+
+    if (loading) {
+      return <LoadingIndicator />;
+    }
+
     const access = this.getAccess();
 
-    const linkedProjectIds = new Set(projectListLinked.map(p => p.id));
-    const linkedProjects = allProjects.filter(p => linkedProjectIds.has(p.id));
-    const otherProjects = allProjects
-      .filter(p => {
-        return !linkedProjectIds.has(p.id);
-      })
-      .map(p => {
-        return {
-          value: p.id,
-          searchKey: p.slug,
-          label: <ProjectListElement>{p.slug}</ProjectListElement>,
-        };
-      });
+    const otherProjects = unlinkedProjects.map(p => {
+      return {
+        value: p.id,
+        searchKey: p.slug,
+        label: <ProjectListElement>{p.slug}</ProjectListElement>,
+      };
+    });
 
     return (
-      <Panel>
-        <PanelHeader hasButtons={true}>
-          <div>{t('Projects')}</div>
-          <div style={{textTransform: 'none'}}>
-            {!access.has('org:write') ? (
-              <DropdownButton
-                disabled
-                title={t('You do not have enough permission to associate a project.')}
-                size="xsmall"
-              >
-                {t('Add Project')}
-              </DropdownButton>
-            ) : (
-              <DropdownAutoComplete
-                items={otherProjects}
-                onSelect={this.handleProjectSelected}
-                emptyMessage={t('No projects')}
-              >
-                {({isOpen, selectedItem}) => (
-                  <DropdownButton isOpen={isOpen} size="xsmall">
-                    {t('Add Project')}
-                  </DropdownButton>
-                )}
-              </DropdownAutoComplete>
-            )}
-          </div>
-        </PanelHeader>
-        <PanelBody>{this.projectPanelcontents(linkedProjects)}</PanelBody>
-      </Panel>
+      <React.Fragment>
+        <Panel>
+          <PanelHeader hasButtons={true}>
+            <div>{t('Projects')}</div>
+            <div style={{textTransform: 'none'}}>
+              {!access.has('org:write') ? (
+                <DropdownButton
+                  disabled
+                  title={t('You do not have enough permission to associate a project.')}
+                  size="xsmall"
+                >
+                  {t('Add Project')}
+                </DropdownButton>
+              ) : (
+                <DropdownAutoComplete
+                  items={otherProjects}
+                  onChange={this.handleQueryUpdate}
+                  onSelect={this.handleProjectSelected}
+                  emptyMessage={t('No projects')}
+                >
+                  {({isOpen, selectedItem}) => (
+                    <DropdownButton isOpen={isOpen} size="xsmall">
+                      {t('Add Project')}
+                    </DropdownButton>
+                  )}
+                </DropdownAutoComplete>
+              )}
+            </div>
+          </PanelHeader>
+          <PanelBody>{this.projectPanelContents(linkedProjects)}</PanelBody>
+        </Panel>
+        <Pagination pageLinks={this.state.pageLinks} {...this.props} />
+      </React.Fragment>
     );
   },
 });

--- a/src/sentry/static/sentry/app/views/settings/organizationTeams/teamProjects.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationTeams/teamProjects.jsx
@@ -161,7 +161,7 @@ const TeamProjects = createReactClass({
     const {linkedProjects, unlinkedProjects, error, loading} = this.state;
 
     if (error) {
-      return <LoadingError onRetry={this.fetchData} />;
+      return <LoadingError onRetry={() => this.fetchAll()} />;
     }
 
     if (loading) {

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -2,6 +2,11 @@
 
 exports[`OrganizationTeamProjects Should render 1`] = `
 <TeamProjects
+  location={
+    Object {
+      "query": Object {},
+    }
+  }
   params={
     Object {
       "orgId": "org-slug",
@@ -54,6 +59,13 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                         Array [
                           Object {
                             "label": <ProjectListElement>
+                              project-slug
+                            </ProjectListElement>,
+                            "searchKey": "project-slug",
+                            "value": "2",
+                          },
+                          Object {
+                            "label": <ProjectListElement>
                               project-slug-2
                             </ProjectListElement>,
                             "searchKey": "project-slug-2",
@@ -61,6 +73,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                           },
                         ]
                       }
+                      onChange={[Function]}
                       onSelect={[Function]}
                     >
                       <DropdownAutoCompleteMenu
@@ -71,6 +84,13 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                           Array [
                             Object {
                               "label": <ProjectListElement>
+                                project-slug
+                              </ProjectListElement>,
+                              "searchKey": "project-slug",
+                              "value": "2",
+                            },
+                            Object {
+                              "label": <ProjectListElement>
                                 project-slug-2
                               </ProjectListElement>,
                               "searchKey": "project-slug-2",
@@ -79,6 +99,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                           ]
                         }
                         maxHeight={300}
+                        onChange={[Function]}
                         onSelect={[Function]}
                         searchPlaceholder="Filter search"
                       >
@@ -478,10 +499,233 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                 </div>
               </Base>
             </StyledPanelItem>
+            <StyledPanelItem
+              key="3"
+            >
+              <Base
+                className="css-15fe8h6-PanelItem-StyledPanelItem eqsa6vb1"
+              >
+                <div
+                  className="css-15fe8h6-PanelItem-StyledPanelItem eqsa6vb1"
+                  is={null}
+                >
+                  <ProjectItem
+                    organization={
+                      Object {
+                        "access": Array [
+                          "org:read",
+                          "org:write",
+                          "org:admin",
+                          "project:read",
+                          "project:write",
+                          "project:admin",
+                          "team:read",
+                          "team:write",
+                          "team:admin",
+                        ],
+                        "features": Array [],
+                        "id": "3",
+                        "name": "Organization Name",
+                        "onboardingTasks": Array [],
+                        "projects": Array [],
+                        "scrapeJavaScript": true,
+                        "slug": "org-slug",
+                        "status": Object {
+                          "id": "active",
+                          "name": "active",
+                        },
+                        "teams": Array [],
+                      }
+                    }
+                    project={
+                      Object {
+                        "environments": Array [],
+                        "hasAccess": true,
+                        "id": "3",
+                        "isBookmarked": false,
+                        "isMember": true,
+                        "name": "Project Name 2",
+                        "slug": "project-slug-2",
+                        "teams": Array [],
+                      }
+                    }
+                  >
+                    <div
+                      className={null}
+                      key="3"
+                    >
+                      <Tooltip
+                        title="Add to bookmarks"
+                      >
+                        <InlineButton
+                          className="tip"
+                          onClick={[Function]}
+                          title="Add to bookmarks"
+                        >
+                          <button
+                            className="tip css-1ybrnfd-InlineButton enngb6z0"
+                            onClick={[Function]}
+                            title="Add to bookmarks"
+                          >
+                            <span
+                              className="icon-star-outline bookmark"
+                            />
+                          </button>
+                        </InlineButton>
+                      </Tooltip>
+                      <Link
+                        to="/org-slug/project-slug-2/"
+                      >
+                        <Link
+                          onlyActiveOnIndex={false}
+                          style={Object {}}
+                          to="/org-slug/project-slug-2/"
+                        >
+                          <a
+                            onClick={[Function]}
+                            style={Object {}}
+                          >
+                            <ProjectLabel
+                              project={
+                                Object {
+                                  "environments": Array [],
+                                  "hasAccess": true,
+                                  "id": "3",
+                                  "isBookmarked": false,
+                                  "isMember": true,
+                                  "name": "Project Name 2",
+                                  "slug": "project-slug-2",
+                                  "teams": Array [],
+                                }
+                              }
+                            >
+                              <span
+                                className="project-label"
+                                project={
+                                  Object {
+                                    "environments": Array [],
+                                    "hasAccess": true,
+                                    "id": "3",
+                                    "isBookmarked": false,
+                                    "isMember": true,
+                                    "name": "Project Name 2",
+                                    "slug": "project-slug-2",
+                                    "teams": Array [],
+                                  }
+                                }
+                              >
+                                <span
+                                  className="project-name"
+                                >
+                                  project-slug-2
+                                </span>
+                              </span>
+                            </ProjectLabel>
+                          </a>
+                        </Link>
+                      </Link>
+                    </div>
+                  </ProjectItem>
+                  <Tooltip
+                    disabled={true}
+                    title="You do not have enough permission to change project association."
+                  >
+                    <Button
+                      disabled={false}
+                      onClick={[Function]}
+                      size="small"
+                    >
+                      <StyledButton
+                        disabled={false}
+                        onClick={[Function]}
+                        role="button"
+                        size="small"
+                      >
+                        <Component
+                          className="css-dkprmi-StyledButton-getColors eqrebog0"
+                          disabled={false}
+                          onClick={[Function]}
+                          role="button"
+                          size="small"
+                        >
+                          <button
+                            className="css-dkprmi-StyledButton-getColors eqrebog0"
+                            disabled={false}
+                            onClick={[Function]}
+                            role="button"
+                            size="small"
+                          >
+                            <ButtonLabel
+                              size="small"
+                            >
+                              <Component
+                                className="css-7ui8bl-ButtonLabel eqrebog1"
+                                size="small"
+                              >
+                                <span
+                                  className="css-7ui8bl-ButtonLabel eqrebog1"
+                                >
+                                  <RemoveIcon>
+                                    <Component
+                                      className="css-1e2j5j0-RemoveIcon eqsa6vb0"
+                                    >
+                                      <InlineSvg
+                                        className="css-1e2j5j0-RemoveIcon eqsa6vb0"
+                                        src="icon-circle-subtract"
+                                      >
+                                        <StyledSvg
+                                          className="css-1e2j5j0-RemoveIcon eqsa6vb0"
+                                          height="1em"
+                                          viewBox={Object {}}
+                                          width="1em"
+                                        >
+                                          <svg
+                                            className="eqsa6vb0 css-10g0ex9-StyledSvg-RemoveIcon e2idor0"
+                                            height="1em"
+                                            viewBox={Object {}}
+                                            width="1em"
+                                          >
+                                            <use
+                                              href="#test"
+                                              xlinkHref="#test"
+                                            />
+                                          </svg>
+                                        </StyledSvg>
+                                      </InlineSvg>
+                                    </Component>
+                                  </RemoveIcon>
+                                   
+                                  Remove
+                                </span>
+                              </Component>
+                            </ButtonLabel>
+                          </button>
+                        </Component>
+                      </StyledButton>
+                    </Button>
+                  </Tooltip>
+                </div>
+              </Base>
+            </StyledPanelItem>
           </div>
         </PanelBody>
       </div>
     </Component>
   </Panel>
+  <Pagination
+    className="stream-pagination"
+    location={
+      Object {
+        "query": Object {},
+      }
+    }
+    onCursor={[Function]}
+    params={
+      Object {
+        "orgId": "org-slug",
+        "teamId": "team-slug",
+      }
+    }
+  />
 </TeamProjects>
 `;

--- a/tests/js/spec/views/organizationTeamProjects.spec.jsx
+++ b/tests/js/spec/views/organizationTeamProjects.spec.jsx
@@ -65,7 +65,7 @@ describe('OrganizationTeamProjects', function() {
     expect(getMock).toHaveBeenCalledTimes(2);
 
     expect(getMock.mock.calls[0][1].query.query).toBe('team:team-slug');
-    expect(getMock.mock.calls[1][1].query.query).toBe('-team:team-slug');
+    expect(getMock.mock.calls[1][1].query.query).toBe('!team:team-slug');
   });
 
   it('Should render', async function() {
@@ -170,7 +170,7 @@ describe('OrganizationTeamProjects', function() {
       '/organizations/org-slug/projects/',
       expect.objectContaining({
         query: expect.objectContaining({
-          query: '-team:team-slug a',
+          query: '!team:team-slug a',
         }),
       })
     );

--- a/tests/js/spec/views/organizationTeamProjects.spec.jsx
+++ b/tests/js/spec/views/organizationTeamProjects.spec.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import {mount} from 'enzyme';
 
 import {Client} from 'app/api';
-import TeamStore from 'app/stores/teamStore';
-import ProjectsStore from 'app/stores/projectsStore';
 
 import OrganizationTeamProjects from 'app/views/settings/organizationTeams/teamProjects';
 
@@ -11,6 +9,7 @@ describe('OrganizationTeamProjects', function() {
   let project;
   let project2;
   let team;
+  let getMock;
   let putMock;
   let postMock;
   let deleteMock;
@@ -24,8 +23,10 @@ describe('OrganizationTeamProjects', function() {
       name: 'Project Name 2',
     });
 
-    TeamStore.loadInitialData([team]);
-    ProjectsStore.loadInitialData([project, project2]);
+    getMock = Client.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [project, project2],
+    });
 
     putMock = Client.addMockResponse({
       method: 'PUT',
@@ -52,28 +53,60 @@ describe('OrganizationTeamProjects', function() {
     Client.clearMockResponses();
   });
 
-  it('Should render', function() {
-    const wrapper = mount(
-      <OrganizationTeamProjects params={{orgId: 'org-slug', teamId: team.slug}} />,
+  it('fetches linked and unlinked projects', async function() {
+    mount(
+      <OrganizationTeamProjects
+        params={{orgId: 'org-slug', teamId: team.slug}}
+        location={{query: {}}}
+      />,
       TestStubs.routerContext()
     );
 
-    expect(wrapper).toMatchSnapshot();
-    expect(wrapper.find('.project-name').text()).toBe('project-slug');
+    expect(getMock).toHaveBeenCalledTimes(2);
+
+    expect(getMock.mock.calls[0][1].query.query).toBe('team:team-slug');
+    expect(getMock.mock.calls[1][1].query.query).toBe('-team:team-slug');
   });
 
-  it('Should allow bookmarking', function() {
+  it('Should render', async function() {
     const wrapper = mount(
-      <OrganizationTeamProjects params={{orgId: 'org-slug', teamId: team.slug}} />,
+      <OrganizationTeamProjects
+        params={{orgId: 'org-slug', teamId: team.slug}}
+        location={{query: {}}}
+      />,
       TestStubs.routerContext()
     );
 
+    await tick();
+    wrapper.update();
+
+    expect(wrapper).toMatchSnapshot();
+    expect(
+      wrapper
+        .find('.project-name')
+        .first()
+        .text()
+    ).toBe('project-slug');
+  });
+
+  it('Should allow bookmarking', async function() {
+    const wrapper = mount(
+      <OrganizationTeamProjects
+        params={{orgId: 'org-slug', teamId: team.slug}}
+        location={{query: {}}}
+      />,
+      TestStubs.routerContext()
+    );
+
+    await tick();
+    wrapper.update();
+
     let star = wrapper.find('.icon-star-outline');
-    expect(star).toHaveLength(1);
-    star.simulate('click');
+    expect(star).toHaveLength(2);
+    star.first().simulate('click');
 
     star = wrapper.find('.icon-star-outline');
-    expect(star).toHaveLength(0);
+    expect(star).toHaveLength(1);
     star = wrapper.find('.icon-star-solid');
     expect(star).toHaveLength(1);
 
@@ -82,14 +115,20 @@ describe('OrganizationTeamProjects', function() {
 
   it('Should allow adding and removing projects', async function() {
     const wrapper = mount(
-      <OrganizationTeamProjects params={{orgId: 'org-slug', teamId: team.slug}} />,
+      <OrganizationTeamProjects
+        params={{orgId: 'org-slug', teamId: team.slug}}
+        location={{query: {}}}
+      />,
       TestStubs.routerContext()
     );
+
+    await tick();
+    wrapper.update();
 
     const add = wrapper.find('DropdownButton').first();
     add.simulate('click');
 
-    const el = wrapper.find('AutoCompleteItem').first();
+    const el = wrapper.find('AutoCompleteItem').at(1);
     el.simulate('click');
 
     wrapper.update();
@@ -104,5 +143,36 @@ describe('OrganizationTeamProjects', function() {
     remove.simulate('click');
 
     expect(deleteMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles filtering unlinked projects', async function() {
+    const wrapper = mount(
+      <OrganizationTeamProjects
+        params={{orgId: 'org-slug', teamId: team.slug}}
+        location={{query: {}}}
+      />,
+      TestStubs.routerContext()
+    );
+
+    await tick();
+    wrapper.update();
+
+    expect(getMock).toHaveBeenCalledTimes(2);
+
+    const add = wrapper.find('DropdownButton').first();
+    add.simulate('click');
+
+    const input = wrapper.find('StyledInput');
+    input.simulate('change', {target: {value: 'a'}});
+
+    expect(getMock).toHaveBeenCalledTimes(3);
+    expect(getMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/projects/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          query: '-team:team-slug a',
+        }),
+      })
+    );
   });
 });

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -109,6 +109,21 @@ class OrganizationProjectsTest(APITestCase):
         response = self.client.get(self.path)
         self.check_valid_response(response, [project for project in projects])
 
+    def test_team_filter(self):
+        self.login_as(user=self.user)
+        other_team = self.create_team(organization=self.org)
+
+        project_bar = self.create_project(teams=[self.team], name='bar', slug='bar')
+        project_foo = self.create_project(teams=[other_team], name='foo', slug='foo')
+        project_baz = self.create_project(teams=[other_team], name='baz', slug='baz')
+        path = u'{}?query=team:{}'.format(self.path, self.team.slug)
+        response = self.client.get(path)
+        self.check_valid_response(response, [project_bar])
+
+        path = u'{}?query=-team:{}'.format(self.path, self.team.slug)
+        response = self.client.get(path)
+        self.check_valid_response(response, [project_baz, project_foo])
+
     def test_api_key(self):
         key = ApiKey.objects.create(
             organization=self.org,

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -120,7 +120,7 @@ class OrganizationProjectsTest(APITestCase):
         response = self.client.get(path)
         self.check_valid_response(response, [project_bar])
 
-        path = u'{}?query=-team:{}'.format(self.path, self.team.slug)
+        path = u'{}?query=!team:{}'.format(self.path, self.team.slug)
         response = self.client.get(path)
         self.check_valid_response(response, [project_baz, project_foo])
 


### PR DESCRIPTION
 Team projects does not rely on project list from organization context,
 but instead fetches (with pagination) from the organization endpoint.
 This will allow projects to be removed from the organization details
 endpoint in future as this causes problems in organizations with many
 (e.g. 500+) projects. Adding a project uses typeahead for filtering
 results.