### PR TITLE
feat(AuditLog): Include Project Rate Limits in Audit Log

### DIFF
--- a/src/sentry/api/endpoints/project_key_details.py
+++ b/src/sentry/api/endpoints/project_key_details.py
@@ -123,7 +123,7 @@ class ProjectKeyDetailsEndpoint(ProjectEndpoint):
                 request=request,
                 organization=project.organization,
                 target_object=key.id,
-                event=AuditLogEntryEvent.PROJECTKEY_EDIT,
+                event=AuditLogEntryEvent.PROJECTKEY_EDIT_RATE_LIMIT,
                 data=key.get_audit_log_data(),
             )
 

--- a/src/sentry/api/serializers/models/auditlogentry.py
+++ b/src/sentry/api/serializers/models/auditlogentry.py
@@ -39,7 +39,7 @@ class AuditLogEntrySerializer(Serializer):
                 'actor': users[six.text_type(item.actor_id)] if item.actor_id else {
                     'name': item.get_actor_name(),
                 },
-                'targetUser': users.get(six.text_type(item.target_user_id)) or item.target_user_id
+                'targetUser': users.get(six.text_type(item.target_user_id)) or item.target_user_id,
             } for item in item_list
         }
 

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -242,6 +242,7 @@ class ProjectKey(Model):
             'status': self.status,
             'rate_limit_count': self.rate_limit_count,
             'rate_limit_window': self.rate_limit_window,
+            'project_id': self.project_id,
         }
 
     def get_scopes(self):

--- a/tests/sentry/api/endpoints/test_project_key_details.py
+++ b/tests/sentry/api/endpoints/test_project_key_details.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
 
-from sentry.models import ProjectKey
+from sentry.models import ProjectKey, AuditLogEntry, AuditLogEntryEvent
 from sentry.testutils import APITestCase
 
 
@@ -45,6 +45,10 @@ class UpdateProjectKeyTest(APITestCase):
         key = ProjectKey.objects.get(id=key.id)
         assert key.rate_limit_count is None
         assert key.rate_limit_window is None
+        assert AuditLogEntry.objects.filter(
+            organization=project.organization,
+            event=AuditLogEntryEvent.PROJECTKEY_EDIT_RATE_LIMIT,
+        ).exists()
 
     def test_unset_rate_limit(self):
         project = self.create_project()
@@ -67,6 +71,10 @@ class UpdateProjectKeyTest(APITestCase):
         key = ProjectKey.objects.get(id=key.id)
         assert key.rate_limit_count == 1
         assert key.rate_limit_window == 60
+        assert AuditLogEntry.objects.filter(
+            organization=project.organization,
+            event=AuditLogEntryEvent.PROJECTKEY_EDIT_RATE_LIMIT,
+        ).exists()
 
     def test_simple_rate_limit(self):
         project = self.create_project()
@@ -89,6 +97,10 @@ class UpdateProjectKeyTest(APITestCase):
         key = ProjectKey.objects.get(id=key.id)
         assert key.rate_limit_count == 1
         assert key.rate_limit_window == 60
+        assert AuditLogEntry.objects.filter(
+            organization=project.organization,
+            event=AuditLogEntryEvent.PROJECTKEY_EDIT_RATE_LIMIT,
+        ).exists()
 
 
 class DeleteProjectKeyTest(APITestCase):


### PR DESCRIPTION
Plans that have the option of project level rate limits now can see the changes made in the audit log.
![screen shot 2019-03-06 at 4 51 46 pm](https://user-images.githubusercontent.com/25037561/53924242-339c4d00-4030-11e9-9574-16544b0a9afe.png)