### PR TITLE
fix(api): Fix Access project/team membership checks for global roles

### DIFF
--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -297,9 +297,6 @@ class OrganizationMember(Model):
     def get_teams(self):
         from sentry.models import Team
 
-        if roles.get(self.role).is_global:
-            return self.organization.team_set.all()
-
         return Team.objects.filter(
             id__in=OrganizationMemberTeam.objects.filter(
                 organizationmember=self,

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -173,8 +173,8 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
         # Should get everything if super user
         self.run_test([self.project_1, self.project_2], user=self.user, active_superuser=True)
 
-        # owner does not projects they aren't members of if not included in query params
-        self.run_test([], user=self.owner,)
+        # owner does not see projects they aren't members of if not included in query params
+        self.run_test([], user=self.owner)
 
         # owner sees projects they have access to if they're included as query params
         self.run_test(

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -172,8 +172,16 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
         self.run_test([])
         # Should get everything if super user
         self.run_test([self.project_1, self.project_2], user=self.user, active_superuser=True)
+
+        # owner does not projects they aren't members of if not included in query params
+        self.run_test([], user=self.owner,)
+
         # owner sees projects they have access to if they're included as query params
-        self.run_test([self.project_1, self.project_2], user=self.owner)
+        self.run_test(
+            [self.project_1, self.project_2],
+            user=self.owner,
+            project_ids=[self.project_1.id, self.project_2.id],
+        )
         # Should get everything if org is public and ids are specified
         self.org.flags.allow_joinleave = True
         self.org.save()

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -63,7 +63,8 @@ class FromUserTest(TestCase):
         assert result.has_project_access(project)
         assert result.has_projects_access([project])
         assert result.has_project_scope(project, 'project:read')
-        assert result.has_project_membership(project)
+        # owners should have access but not membership
+        assert result.has_project_membership(project) is False
 
     def test_member_no_teams_closed_membership(self):
         user = self.create_user()


### PR DESCRIPTION
per a discussion in slack this:
- fixes a bug where for owners/managers, all projects are returned from `get_projects`
- renames a `open_access_policy` kwarg for `Access` to `has_global_access` so that it can be used more broadly without confusion