### PR TITLE
perf: Don't show all teams when modifying/creating users

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/index.jsx
@@ -195,45 +195,24 @@ const InviteMember = createReactClass({
       });
   },
 
-  toggleTeam(slug) {
-    this.setState(state => {
-      const {selectedTeams} = state;
-      if (selectedTeams.has(slug)) {
-        selectedTeams.delete(slug);
-      } else {
-        selectedTeams.add(slug);
-      }
-      return {
-        selectedTeams,
-      };
-    });
-  },
-
-  allSelected() {
-    const {teams} = this.getOrganization();
+  handleAddTeam(slug) {
     const {selectedTeams} = this.state;
-    return teams.length === selectedTeams.size;
+    if (!selectedTeams.has(slug)) {
+      selectedTeams.add(slug);
+    }
+    this.setState({selectedTeams});
   },
 
-  handleSelectAll() {
-    const {teams} = this.getOrganization();
+  handleRemoveTeam(slug) {
+    const {selectedTeams} = this.state;
+    selectedTeams.delete(slug);
 
-    this.setState(state => {
-      let {selectedTeams} = state;
-      if (this.allSelected()) {
-        selectedTeams.clear();
-      } else {
-        selectedTeams = new Set(teams.map(({slug}) => slug));
-      }
-      return {
-        selectedTeams,
-      };
-    });
+    this.setState({selectedTeams});
   },
 
   render() {
     const {error, loading, roleList, selectedRole, selectedTeams} = this.state;
-    const {teams} = this.getOrganization();
+    const organization = this.getOrganization();
     const {invitesEnabled} = ConfigStore.getConfig();
     const {isSuperuser} = ConfigStore.get('user');
 
@@ -271,11 +250,10 @@ const InviteMember = createReactClass({
               setRole={slug => this.setState({selectedRole: slug})}
             />
             <TeamSelect
-              teams={teams}
-              selectedTeams={selectedTeams}
-              toggleTeam={this.toggleTeam}
-              onSelectAll={this.handleSelectAll}
-              allSelected={this.allSelected}
+              organization={organization}
+              selectedTeams={Array.from(selectedTeams.values())}
+              onAddTeam={this.handleAddTeam}
+              onRemoveTeam={this.handleRemoveTeam}
             />
             <Button
               priority="primary"

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/roleSelect.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/roleSelect.jsx
@@ -31,7 +31,7 @@ class RoleSelect extends React.Component {
     const {disabled, enforceAllowed, roleList, selectedRole} = this.props;
 
     return (
-      <Panel className="new-invite-team">
+      <Panel className="new-invite-role">
         <PanelHeader>{t('Role')}</PanelHeader>
 
         <PanelBody>

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/roleSelect.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/roleSelect.jsx
@@ -31,7 +31,7 @@ class RoleSelect extends React.Component {
     const {disabled, enforceAllowed, roleList, selectedRole} = this.props;
 
     return (
-      <Panel className="new-invite-role">
+      <Panel>
         <PanelHeader>{t('Role')}</PanelHeader>
 
         <PanelBody>

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/teamSelect.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/teamSelect.jsx
@@ -112,7 +112,7 @@ class TeamSelect extends React.Component {
 
   render() {
     return (
-      <Panel className="new-invite-team">
+      <Panel>
         <PanelHeader hasButtons={true}>
           {t('Team')}
           {this.renderTeamAddDropDown()}

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/teamSelect.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/teamSelect.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
+import {debounce} from 'lodash';
 
 import {Box} from 'grid-emotion';
 import {t} from 'app/locale';
@@ -32,14 +33,14 @@ class TeamSelect extends React.Component {
     this.fetchTeams();
   }
 
-  fetchTeams(query) {
+  fetchTeams = debounce(query => {
     const {organization} = this.props;
     this.props.api
       .requestPromise(`/organizations/${organization.slug}/teams/`, {
-        query,
+        query: {query},
       })
       .then(teams => this.setState({teams}));
-  }
+  }, 100);
 
   handleQueryUpdate = event => {
     this.fetchTeams(event.target.value);

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/teamSelect.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/teamSelect.jsx
@@ -2,84 +2,157 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
+import {Box} from 'grid-emotion';
 import {t} from 'app/locale';
 import Button from 'app/components/button';
-import Checkbox from 'app/components/checkbox';
-import IdBadge from 'app/components/idBadge';
+import SentryTypes from 'app/sentryTypes';
+import Link from 'app/components/link';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
+import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
+import DropdownButton from 'app/components/dropdownButton';
+import EmptyMessage from 'app/views/settings/components/emptyMessage';
+import space from 'app/styles/space';
+import withApi from 'app/utils/withApi';
 
 class TeamSelect extends React.Component {
   static propTypes = {
+    api: PropTypes.object.isRequired,
+    organization: SentryTypes.Organization.isRequired,
     disabled: PropTypes.bool,
-    selectedTeams: PropTypes.instanceOf(Set),
-    teams: PropTypes.array,
-    toggleTeam: PropTypes.func,
-    onSelectAll: PropTypes.func,
-    allSelected: PropTypes.func,
+    selectedTeams: PropTypes.array.isRequired,
+    onAddTeam: PropTypes.func.isRequired,
+    onRemoveTeam: PropTypes.func.isRequired,
   };
 
-  render() {
-    const {
-      disabled,
-      teams,
-      selectedTeams,
-      toggleTeam,
-      onSelectAll,
-      allSelected,
-    } = this.props;
-    //no need to select a team when there's only one option
-    if (teams.length < 2) return null;
-    const hasSelectAll = !!onSelectAll && !!allSelected;
+  state = {
+    teams: null,
+  };
+
+  componentDidMount() {
+    this.fetchTeams();
+  }
+
+  fetchTeams(query) {
+    const {organization} = this.props;
+    this.props.api
+      .requestPromise(`/organizations/${organization.slug}/teams/`, {
+        query,
+      })
+      .then(teams => this.setState({teams}));
+  }
+
+  handleQueryUpdate = event => {
+    this.fetchTeams(event.target.value);
+  };
+
+  handleAddTeam = option => {
+    this.props.onAddTeam(option.value);
+  };
+
+  handleRemove = value => {
+    this.props.onRemoveTeam(value);
+  };
+
+  renderTeamAddDropDown() {
+    const {disabled, selectedTeams} = this.props;
+    const {teams} = this.state;
+    const noTeams = teams === null || teams.length === 0;
+    const isDisabled = noTeams || disabled;
+
+    let options;
+    if (noTeams) {
+      options = [];
+    } else {
+      options = teams
+        .filter(team => {
+          return !selectedTeams.includes(team.slug);
+        })
+        .map(team => ({
+          value: team.slug,
+          searchKey: team.slug,
+          label: <TeamDropdownElement>#{team.slug}</TeamDropdownElement>,
+        }));
+    }
 
     return (
+      <DropdownAutoComplete
+        items={options}
+        onChange={this.handleQueryUpdate}
+        onSelect={this.handleAddTeam}
+        emptyMessage={t('No teams')}
+        disabled={isDisabled}
+      >
+        {({isOpen}) => (
+          <DropdownButton isOpen={isOpen} size="xsmall" disabled={isDisabled}>
+            {t('Add Team')}
+          </DropdownButton>
+        )}
+      </DropdownAutoComplete>
+    );
+  }
+
+  renderBody() {
+    const {organization, selectedTeams, disabled} = this.props;
+    if (selectedTeams.length === 0) {
+      return <EmptyMessage>{t('No Teams assigned')}</EmptyMessage>;
+    }
+
+    return selectedTeams.map(team => {
+      return (
+        <TeamRow
+          key={team}
+          orgId={organization.slug}
+          team={team}
+          onRemove={this.handleRemove}
+          disabled={disabled}
+        />
+      );
+    });
+  }
+
+  render() {
+    return (
       <Panel className="new-invite-team">
-        <PanelHeader hasButtons={hasSelectAll}>
+        <PanelHeader hasButtons={true}>
           {t('Team')}
-          {hasSelectAll && (
-            <Button
-              data-test-id="select-all"
-              size="small"
-              disabled={disabled}
-              onClick={onSelectAll}
-            >
-              <SelectAll>{allSelected() ? t('Deselect') : t('Select All')}</SelectAll>
-            </Button>
-          )}
+          {this.renderTeamAddDropDown()}
         </PanelHeader>
 
-        <PanelBody className="grouping-controls team-choices">
-          <PanelItem css={{flexWrap: 'wrap'}}>
-            {teams.map(team => (
-              <TeamItem key={team.slug}>
-                <label disabled={disabled} className="checkbox">
-                  <Checkbox
-                    id={team.slug}
-                    disabled={disabled}
-                    checked={selectedTeams.has(team.slug)}
-                    onChange={e => {
-                      toggleTeam(team.slug);
-                    }}
-                    style={{verticalAlign: 'middle'}}
-                  />
-                  <IdBadge team={team} hideAvatar />
-                </label>
-              </TeamItem>
-            ))}
-          </PanelItem>
-        </PanelBody>
+        <PanelBody>{this.renderBody()}</PanelBody>
       </Panel>
     );
   }
 }
 
-const TeamItem = styled.div`
-  width: 25%;
-  padding: 6px;
+const TeamRow = props => {
+  const {orgId, team, onRemove, disabled} = props;
+  return (
+    <PanelItem p={2} align="center">
+      <Box flex={1}>
+        <Link to={`/settings/${orgId}/teams/${team}/`}>#{team}</Link>
+      </Box>
+      <Button
+        size="xsmall"
+        icon="icon-circle-subtract"
+        onClick={() => onRemove(team)}
+        disabled={disabled}
+      >
+        {t('Remove')}
+      </Button>
+    </PanelItem>
+  );
+};
+
+TeamRow.propTypes = {
+  disabled: PropTypes.bool,
+  team: PropTypes.string.isRequired,
+  orgId: PropTypes.string.isRequired,
+  onRemove: PropTypes.func.isRequired,
+};
+
+const TeamDropdownElement = styled.div`
+  padding: ${space(0.5)} ${space(0.25)};
+  text-transform: none;
 `;
 
-const SelectAll = styled.span`
-  font-size: 13px;
-  color: ${p => (p.lightText ? p.theme.gray2 : p.theme.gray3)};
-`;
-
-export default TeamSelect;
+export default withApi(TeamSelect);

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberDetail.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberDetail.jsx
@@ -37,11 +37,9 @@ class OrganizationMemberDetail extends AsyncView {
 
   constructor(...args) {
     super(...args);
-    const {teams} = this.getOrganization();
 
     this.state = {
       ...this.state,
-      selectedTeams: new Set(teams.map(({slug}) => slug)),
       roleList: [],
       selectedRole: '',
       member: null,
@@ -115,44 +113,23 @@ class OrganizationMemberDetail extends AsyncView {
       });
   };
 
-  handleToggleTeam = slug => {
+  handleAddTeam = slug => {
     const {member} = this.state;
-    const selectedTeams = new Set(member.teams);
-    if (selectedTeams.has(slug)) {
-      selectedTeams.delete(slug);
-    } else {
-      selectedTeams.add(slug);
+    if (!member.teams.includes(slug)) {
+      member.teams.push(slug);
     }
+    this.setState({member});
+  };
+
+  handleRemoveTeam = slug => {
+    const {member} = this.state;
+    const teams = new Set(member.teams);
+    teams.delete(slug);
 
     this.setState({
       member: {
         ...member,
-        teams: Array.from(selectedTeams.values()),
-      },
-    });
-  };
-
-  allSelected = () => {
-    const {member} = this.state;
-    const {teams} = this.getOrganization();
-    return teams.length === member.teams.length;
-  };
-
-  handleSelectAll = () => {
-    let {selectedTeams} = this.state;
-    const {member} = this.state;
-    const {teams} = this.getOrganization();
-
-    if (this.allSelected()) {
-      selectedTeams.clear();
-    } else {
-      selectedTeams = new Set(teams.map(({slug}) => slug));
-    }
-
-    this.setState({
-      member: {
-        ...member,
-        teams: Array.from(selectedTeams.values()),
+        teams: Array.from(teams.values()),
       },
     });
   };
@@ -203,7 +180,8 @@ class OrganizationMemberDetail extends AsyncView {
 
   renderBody() {
     const {error, member} = this.state;
-    const {teams, access} = this.getOrganization();
+    const organization = this.getOrganization();
+    const access = organization.access;
 
     if (!member) return <NotFound />;
 
@@ -354,12 +332,11 @@ class OrganizationMemberDetail extends AsyncView {
         />
 
         <TeamSelect
-          teams={teams}
-          selectedTeams={new Set(member.teams)}
-          toggleTeam={this.handleToggleTeam}
+          organization={organization}
+          selectedTeams={member.teams}
           disabled={!canEdit}
-          onSelectAll={this.handleSelectAll}
-          allSelected={this.allSelected}
+          onAddTeam={this.handleAddTeam}
+          onRemoveTeam={this.handleRemoveTeam}
         />
 
         <Button

--- a/tests/acceptance/test_create_organization_member.py
+++ b/tests/acceptance/test_create_organization_member.py
@@ -34,13 +34,6 @@ class CreateOrganizationMemberTest(AcceptanceTestCase):
             u'/organizations/{}/members/new/'.format(self.org.slug))
         self.browser.wait_until_not('.loading')
 
-        # Open the autocomplete
-        self.browser.element('.new-invite-team button[role="button"]').click()
-
-        # Click first team
-        self.browser.wait_until('[class*="TeamDropdownElement"]')
-        self.browser.element('[class*="TeamDropdownElement"]').click()
-
         self.browser.element(
             'input#id-email').send_keys('test@gmail.com, invalidemail')
 

--- a/tests/acceptance/test_create_organization_member.py
+++ b/tests/acceptance/test_create_organization_member.py
@@ -33,7 +33,13 @@ class CreateOrganizationMemberTest(AcceptanceTestCase):
         self.browser.get(
             u'/organizations/{}/members/new/'.format(self.org.slug))
         self.browser.wait_until_not('.loading')
-        self.browser.element('.checkbox').click()
+
+        # Open the autocomplete
+        self.browser.element('.new-invite-team button[role="button"]').click()
+
+        # Click first team
+        self.browser.wait_until('[class*="TeamDropdownElement"]')
+        self.browser.element('[class*="TeamDropdownElement"]').click()
 
         self.browser.element(
             'input#id-email').send_keys('test@gmail.com, invalidemail')

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -146,14 +146,12 @@ exports[`CreateProject should render roles when available and allowed, and handl
         selectedRole="member"
         setRole={[Function]}
       >
-        <Panel
-          className="new-invite-role"
-        >
+        <Panel>
           <Component
-            className="new-invite-role css-yahxlu-Panel e1laxa7d0"
+            className="css-yahxlu-Panel e1laxa7d0"
           >
             <div
-              className="new-invite-role css-yahxlu-Panel e1laxa7d0"
+              className="css-yahxlu-Panel e1laxa7d0"
             >
               <PanelHeader>
                 <Component
@@ -398,14 +396,12 @@ exports[`CreateProject should render roles when available and allowed, and handl
           }
           selectedTeams={Array []}
         >
-          <Panel
-            className="new-invite-team"
-          >
+          <Panel>
             <Component
-              className="new-invite-team css-yahxlu-Panel e1laxa7d0"
+              className="css-yahxlu-Panel e1laxa7d0"
             >
               <div
-                className="new-invite-team css-yahxlu-Panel e1laxa7d0"
+                className="css-yahxlu-Panel e1laxa7d0"
               >
                 <PanelHeader
                   hasButtons={true}

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -347,457 +347,308 @@ exports[`CreateProject should render roles when available and allowed, and handl
           </Component>
         </Panel>
       </RoleSelect>
-      <TeamSelect
-        allSelected={[Function]}
-        onSelectAll={[Function]}
-        selectedTeams={
-          Set {
-            "bar",
+      <withApi(TeamSelect)
+        onAddTeam={[Function]}
+        onRemoveTeam={[Function]}
+        organization={
+          Object {
+            "id": "1",
+            "slug": "testOrg",
+            "teams": Array [
+              Object {
+                "hasAccess": true,
+                "id": "1",
+                "name": "bar",
+                "slug": "bar",
+              },
+              Object {
+                "hasAccess": false,
+                "id": "2",
+                "name": "foo",
+                "slug": "foo",
+              },
+            ],
           }
         }
-        teams={
-          Array [
-            Object {
-              "hasAccess": true,
-              "id": "1",
-              "name": "bar",
-              "slug": "bar",
-            },
-            Object {
-              "hasAccess": false,
-              "id": "2",
-              "name": "foo",
-              "slug": "foo",
-            },
-          ]
-        }
-        toggleTeam={[Function]}
+        selectedTeams={Array []}
       >
-        <Panel
-          className="new-invite-team"
+        <TeamSelect
+          api={Client {}}
+          onAddTeam={[Function]}
+          onRemoveTeam={[Function]}
+          organization={
+            Object {
+              "id": "1",
+              "slug": "testOrg",
+              "teams": Array [
+                Object {
+                  "hasAccess": true,
+                  "id": "1",
+                  "name": "bar",
+                  "slug": "bar",
+                },
+                Object {
+                  "hasAccess": false,
+                  "id": "2",
+                  "name": "foo",
+                  "slug": "foo",
+                },
+              ],
+            }
+          }
+          selectedTeams={Array []}
         >
-          <Component
-            className="new-invite-team css-yahxlu-Panel e1laxa7d0"
+          <Panel
+            className="new-invite-team"
           >
-            <div
+            <Component
               className="new-invite-team css-yahxlu-Panel e1laxa7d0"
             >
-              <PanelHeader
-                hasButtons={true}
+              <div
+                className="new-invite-team css-yahxlu-Panel e1laxa7d0"
               >
-                <Component
-                  className="css-jmvceg-PanelHeader-getPadding e1p8v8nv0"
+                <PanelHeader
                   hasButtons={true}
                 >
-                  <Flex
-                    align="center"
+                  <Component
                     className="css-jmvceg-PanelHeader-getPadding e1p8v8nv0"
-                    justify="space-between"
+                    hasButtons={true}
                   >
-                    <Base
+                    <Flex
                       align="center"
-                      className="e1p8v8nv0 css-19i62qd-PanelHeader-getPadding"
+                      className="css-jmvceg-PanelHeader-getPadding e1p8v8nv0"
                       justify="space-between"
                     >
-                      <div
+                      <Base
+                        align="center"
                         className="e1p8v8nv0 css-19i62qd-PanelHeader-getPadding"
-                        is={null}
+                        justify="space-between"
                       >
-                        Team
-                        <Button
-                          data-test-id="select-all"
-                          disabled={false}
-                          onClick={[Function]}
-                          size="small"
+                        <div
+                          className="e1p8v8nv0 css-19i62qd-PanelHeader-getPadding"
+                          is={null}
                         >
-                          <StyledButton
-                            data-test-id="select-all"
-                            disabled={false}
-                            onClick={[Function]}
-                            role="button"
-                            size="small"
+                          Team
+                          <DropdownAutoComplete
+                            alignMenu="right"
+                            disabled={true}
+                            emptyMessage="No teams"
+                            items={Array []}
+                            onChange={[Function]}
+                            onSelect={[Function]}
+                          >
+                            <DropdownAutoCompleteMenu
+                              alignMenu="right"
+                              blendCorner={true}
+                              disabled={true}
+                              emptyMessage="No teams"
+                              items={Array []}
+                              maxHeight={300}
+                              onChange={[Function]}
+                              onSelect={[Function]}
+                              searchPlaceholder="Filter search"
+                            >
+                              <AutoComplete
+                                closeOnSelect={true}
+                                disabled={true}
+                                inputIsActor={false}
+                                itemToString={[Function]}
+                                onSelect={[Function]}
+                                resetInputOnClose={true}
+                                shouldSelectWithEnter={true}
+                                shouldSelectWithTab={false}
+                              >
+                                <DropdownMenu
+                                  closeOnEscape={true}
+                                  isOpen={false}
+                                  keepMenuOpen={false}
+                                  onClickOutside={[Function]}
+                                >
+                                  <AutoCompleteRoot>
+                                    <Component
+                                      className="css-6v04yn-AutoCompleteRoot ejumqxq0"
+                                    >
+                                      <div
+                                        className="css-6v04yn-AutoCompleteRoot ejumqxq0"
+                                      >
+                                        <Actor
+                                          innerRef={[Function]}
+                                          isOpen={false}
+                                          onClick={[Function]}
+                                          onKeyDown={[Function]}
+                                          onMouseEnter={[Function]}
+                                          onMouseLeave={[Function]}
+                                          role="button"
+                                          style={
+                                            Object {
+                                              "outline": "none",
+                                            }
+                                          }
+                                          tabIndex={-1}
+                                        >
+                                          <div
+                                            className="css-17fe80j-Actor e53us8t0"
+                                            onClick={[Function]}
+                                            onKeyDown={[Function]}
+                                            onMouseEnter={[Function]}
+                                            onMouseLeave={[Function]}
+                                            role="button"
+                                            style={
+                                              Object {
+                                                "outline": "none",
+                                              }
+                                            }
+                                            tabIndex={-1}
+                                          >
+                                            <DropdownButton
+                                              disabled={true}
+                                              isOpen={false}
+                                              size="xsmall"
+                                            >
+                                              <StyledButton
+                                                disabled={true}
+                                                isOpen={false}
+                                                size="xsmall"
+                                              >
+                                                <Component
+                                                  className="css-o27a2e-StyledButton e1yghndz1"
+                                                  disabled={true}
+                                                  isOpen={false}
+                                                  size="xsmall"
+                                                >
+                                                  <Button
+                                                    className="css-o27a2e-StyledButton e1yghndz1"
+                                                    disabled={true}
+                                                    size="xsmall"
+                                                  >
+                                                    <StyledButton
+                                                      className="css-o27a2e-StyledButton e1yghndz1"
+                                                      disabled={true}
+                                                      href={null}
+                                                      onClick={[Function]}
+                                                      role="button"
+                                                      size="xsmall"
+                                                      to={null}
+                                                    >
+                                                      <Component
+                                                        className="e1yghndz1 css-1wbxhyw-StyledButton-getColors-StyledButton eqrebog0"
+                                                        disabled={true}
+                                                        href={null}
+                                                        onClick={[Function]}
+                                                        role="button"
+                                                        size="xsmall"
+                                                        to={null}
+                                                      >
+                                                        <button
+                                                          className="e1yghndz1 css-1wbxhyw-StyledButton-getColors-StyledButton eqrebog0"
+                                                          disabled={true}
+                                                          href={null}
+                                                          onClick={[Function]}
+                                                          role="button"
+                                                          size="xsmall"
+                                                          to={null}
+                                                        >
+                                                          <ButtonLabel
+                                                            size="xsmall"
+                                                          >
+                                                            <Component
+                                                              className="css-uthd1f-ButtonLabel eqrebog1"
+                                                              size="xsmall"
+                                                            >
+                                                              <span
+                                                                className="css-uthd1f-ButtonLabel eqrebog1"
+                                                              >
+                                                                Add Team
+                                                                <StyledChevronDown>
+                                                                  <Component
+                                                                    className="css-17v3tc-StyledChevronDown e1yghndz0"
+                                                                  >
+                                                                    <InlineSvg
+                                                                      className="css-17v3tc-StyledChevronDown e1yghndz0"
+                                                                      src="icon-chevron-down"
+                                                                    >
+                                                                      <StyledSvg
+                                                                        className="css-17v3tc-StyledChevronDown e1yghndz0"
+                                                                        height="1em"
+                                                                        viewBox={Object {}}
+                                                                        width="1em"
+                                                                      >
+                                                                        <svg
+                                                                          className="e1yghndz0 css-1gdv3x4-StyledSvg-StyledChevronDown e2idor0"
+                                                                          height="1em"
+                                                                          viewBox={Object {}}
+                                                                          width="1em"
+                                                                        >
+                                                                          <use
+                                                                            href="#test"
+                                                                            xlinkHref="#test"
+                                                                          />
+                                                                        </svg>
+                                                                      </StyledSvg>
+                                                                    </InlineSvg>
+                                                                  </Component>
+                                                                </StyledChevronDown>
+                                                              </span>
+                                                            </Component>
+                                                          </ButtonLabel>
+                                                        </button>
+                                                      </Component>
+                                                    </StyledButton>
+                                                  </Button>
+                                                </Component>
+                                              </StyledButton>
+                                            </DropdownButton>
+                                          </div>
+                                        </Actor>
+                                      </div>
+                                    </Component>
+                                  </AutoCompleteRoot>
+                                </DropdownMenu>
+                              </AutoComplete>
+                            </DropdownAutoCompleteMenu>
+                          </DropdownAutoComplete>
+                        </div>
+                      </Base>
+                    </Flex>
+                  </Component>
+                </PanelHeader>
+                <PanelBody
+                  direction="column"
+                  disablePadding={true}
+                  flex={false}
+                >
+                  <div
+                    className="css-9vq8an-textStyles"
+                  >
+                    <EmptyMessage>
+                      <Wrapper>
+                        <div
+                          className="css-ev9qm0-Wrapper eh488yo0"
+                        >
+                          <Description
+                            noMargin={true}
                           >
                             <Component
-                              className="css-dkprmi-StyledButton-getColors eqrebog0"
-                              data-test-id="select-all"
-                              disabled={false}
-                              onClick={[Function]}
-                              role="button"
-                              size="small"
+                              className="css-pwn5v-TextBlock-Description-MarginStyles eh488yo1"
+                              noMargin={true}
                             >
-                              <button
-                                className="css-dkprmi-StyledButton-getColors eqrebog0"
-                                data-test-id="select-all"
-                                disabled={false}
-                                onClick={[Function]}
-                                role="button"
-                                size="small"
+                              <div
+                                className="css-pwn5v-TextBlock-Description-MarginStyles eh488yo1"
                               >
-                                <ButtonLabel
-                                  size="small"
-                                >
-                                  <Component
-                                    className="css-7ui8bl-ButtonLabel eqrebog1"
-                                    size="small"
-                                  >
-                                    <span
-                                      className="css-7ui8bl-ButtonLabel eqrebog1"
-                                    >
-                                      <SelectAll>
-                                        <span
-                                          className="css-7qfmdl-SelectAll e1tbg1m41"
-                                        >
-                                          Select All
-                                        </span>
-                                      </SelectAll>
-                                    </span>
-                                  </Component>
-                                </ButtonLabel>
-                              </button>
+                                No Teams assigned
+                              </div>
                             </Component>
-                          </StyledButton>
-                        </Button>
-                      </div>
-                    </Base>
-                  </Flex>
-                </Component>
-              </PanelHeader>
-              <PanelBody
-                className="grouping-controls team-choices"
-                direction="column"
-                disablePadding={true}
-                flex={false}
-              >
-                <div
-                  className="css-9vq8an-textStyles grouping-controls team-choices"
-                >
-                  <PanelItem
-                    className="css-1jkp9i7"
-                    p={2}
-                  >
-                    <Base
-                      className="css-15ezwr8-PanelItem eo8n7lk0"
-                      p={2}
-                    >
-                      <div
-                        className="css-15ezwr8-PanelItem eo8n7lk0"
-                        is={null}
-                      >
-                        <TeamItem
-                          key="bar"
-                        >
-                          <div
-                            className="css-16v1fbz-TeamItem e1tbg1m40"
-                          >
-                            <label
-                              className="checkbox"
-                            >
-                              <Checkbox
-                                checked={false}
-                                id="bar"
-                                onChange={[Function]}
-                                style={
-                                  Object {
-                                    "verticalAlign": "middle",
-                                  }
-                                }
-                              >
-                                <input
-                                  checked={false}
-                                  className="chk-select"
-                                  id="bar"
-                                  onChange={[Function]}
-                                  style={
-                                    Object {
-                                      "verticalAlign": "middle",
-                                    }
-                                  }
-                                  type="checkbox"
-                                />
-                              </Checkbox>
-                              <IdBadge
-                                hideAvatar={true}
-                                team={
-                                  Object {
-                                    "hasAccess": true,
-                                    "id": "1",
-                                    "name": "bar",
-                                    "slug": "bar",
-                                  }
-                                }
-                              >
-                                <InlineErrorBoundary
-                                  mini={true}
-                                >
-                                  <ErrorBoundary
-                                    className="css-otlbo1-InlineErrorBoundary e83vi020"
-                                    mini={true}
-                                  >
-                                    <TeamBadgeContainer
-                                      hideAvatar={true}
-                                      team={
-                                        Object {
-                                          "hasAccess": true,
-                                          "id": "1",
-                                          "name": "bar",
-                                          "slug": "bar",
-                                        }
-                                      }
-                                    >
-                                      <TeamBadge
-                                        avatarSize={24}
-                                        hideAvatar={true}
-                                        hideOverflow={true}
-                                        team={
-                                          Object {
-                                            "hasAccess": true,
-                                            "id": "1",
-                                            "name": "bar",
-                                            "slug": "bar",
-                                          }
-                                        }
-                                      >
-                                        <BaseBadge
-                                          avatarProps={Object {}}
-                                          avatarSize={24}
-                                          displayName={
-                                            <BadgeDisplayName
-                                              hideOverflow={true}
-                                            >
-                                              #
-                                              bar
-                                            </BadgeDisplayName>
-                                          }
-                                          hideAvatar={true}
-                                          team={
-                                            Object {
-                                              "hasAccess": true,
-                                              "id": "1",
-                                              "name": "bar",
-                                              "slug": "bar",
-                                            }
-                                          }
-                                        >
-                                          <Flex
-                                            align="center"
-                                          >
-                                            <Base
-                                              align="center"
-                                              className="css-5ipae5"
-                                            >
-                                              <div
-                                                className="css-5ipae5"
-                                                is={null}
-                                              >
-                                                <DisplayNameAndDescription>
-                                                  <Base
-                                                    className="css-1h9j57p-DisplayNameAndDescription e165dl3i1"
-                                                  >
-                                                    <div
-                                                      className="css-1h9j57p-DisplayNameAndDescription e165dl3i1"
-                                                      is={null}
-                                                    >
-                                                      <DisplayName
-                                                        data-test-id="badge-display-name"
-                                                      >
-                                                        <span
-                                                          className="css-d0rtl9-DisplayName e165dl3i2"
-                                                          data-test-id="badge-display-name"
-                                                        >
-                                                          <BadgeDisplayName
-                                                            hideOverflow={true}
-                                                          >
-                                                            <Component
-                                                              className="css-1boiawc-BadgeDisplayName eeoia0v0"
-                                                              hideOverflow={true}
-                                                            >
-                                                              <span
-                                                                className="css-1boiawc-BadgeDisplayName eeoia0v0"
-                                                              >
-                                                                #
-                                                                bar
-                                                              </span>
-                                                            </Component>
-                                                          </BadgeDisplayName>
-                                                        </span>
-                                                      </DisplayName>
-                                                    </div>
-                                                  </Base>
-                                                </DisplayNameAndDescription>
-                                              </div>
-                                            </Base>
-                                          </Flex>
-                                        </BaseBadge>
-                                      </TeamBadge>
-                                    </TeamBadgeContainer>
-                                  </ErrorBoundary>
-                                </InlineErrorBoundary>
-                              </IdBadge>
-                            </label>
-                          </div>
-                        </TeamItem>
-                        <TeamItem
-                          key="foo"
-                        >
-                          <div
-                            className="css-16v1fbz-TeamItem e1tbg1m40"
-                          >
-                            <label
-                              className="checkbox"
-                            >
-                              <Checkbox
-                                checked={false}
-                                id="foo"
-                                onChange={[Function]}
-                                style={
-                                  Object {
-                                    "verticalAlign": "middle",
-                                  }
-                                }
-                              >
-                                <input
-                                  checked={false}
-                                  className="chk-select"
-                                  id="foo"
-                                  onChange={[Function]}
-                                  style={
-                                    Object {
-                                      "verticalAlign": "middle",
-                                    }
-                                  }
-                                  type="checkbox"
-                                />
-                              </Checkbox>
-                              <IdBadge
-                                hideAvatar={true}
-                                team={
-                                  Object {
-                                    "hasAccess": false,
-                                    "id": "2",
-                                    "name": "foo",
-                                    "slug": "foo",
-                                  }
-                                }
-                              >
-                                <InlineErrorBoundary
-                                  mini={true}
-                                >
-                                  <ErrorBoundary
-                                    className="css-otlbo1-InlineErrorBoundary e83vi020"
-                                    mini={true}
-                                  >
-                                    <TeamBadgeContainer
-                                      hideAvatar={true}
-                                      team={
-                                        Object {
-                                          "hasAccess": false,
-                                          "id": "2",
-                                          "name": "foo",
-                                          "slug": "foo",
-                                        }
-                                      }
-                                    >
-                                      <TeamBadge
-                                        avatarSize={24}
-                                        hideAvatar={true}
-                                        hideOverflow={true}
-                                        team={
-                                          Object {
-                                            "hasAccess": false,
-                                            "id": "2",
-                                            "name": "foo",
-                                            "slug": "foo",
-                                          }
-                                        }
-                                      >
-                                        <BaseBadge
-                                          avatarProps={Object {}}
-                                          avatarSize={24}
-                                          displayName={
-                                            <BadgeDisplayName
-                                              hideOverflow={true}
-                                            >
-                                              #
-                                              foo
-                                            </BadgeDisplayName>
-                                          }
-                                          hideAvatar={true}
-                                          team={
-                                            Object {
-                                              "hasAccess": false,
-                                              "id": "2",
-                                              "name": "foo",
-                                              "slug": "foo",
-                                            }
-                                          }
-                                        >
-                                          <Flex
-                                            align="center"
-                                          >
-                                            <Base
-                                              align="center"
-                                              className="css-5ipae5"
-                                            >
-                                              <div
-                                                className="css-5ipae5"
-                                                is={null}
-                                              >
-                                                <DisplayNameAndDescription>
-                                                  <Base
-                                                    className="css-1h9j57p-DisplayNameAndDescription e165dl3i1"
-                                                  >
-                                                    <div
-                                                      className="css-1h9j57p-DisplayNameAndDescription e165dl3i1"
-                                                      is={null}
-                                                    >
-                                                      <DisplayName
-                                                        data-test-id="badge-display-name"
-                                                      >
-                                                        <span
-                                                          className="css-d0rtl9-DisplayName e165dl3i2"
-                                                          data-test-id="badge-display-name"
-                                                        >
-                                                          <BadgeDisplayName
-                                                            hideOverflow={true}
-                                                          >
-                                                            <Component
-                                                              className="css-1boiawc-BadgeDisplayName eeoia0v0"
-                                                              hideOverflow={true}
-                                                            >
-                                                              <span
-                                                                className="css-1boiawc-BadgeDisplayName eeoia0v0"
-                                                              >
-                                                                #
-                                                                foo
-                                                              </span>
-                                                            </Component>
-                                                          </BadgeDisplayName>
-                                                        </span>
-                                                      </DisplayName>
-                                                    </div>
-                                                  </Base>
-                                                </DisplayNameAndDescription>
-                                              </div>
-                                            </Base>
-                                          </Flex>
-                                        </BaseBadge>
-                                      </TeamBadge>
-                                    </TeamBadgeContainer>
-                                  </ErrorBoundary>
-                                </InlineErrorBoundary>
-                              </IdBadge>
-                            </label>
-                          </div>
-                        </TeamItem>
-                      </div>
-                    </Base>
-                  </PanelItem>
-                </div>
-              </PanelBody>
-            </div>
-          </Component>
-        </Panel>
-      </TeamSelect>
+                          </Description>
+                        </div>
+                      </Wrapper>
+                    </EmptyMessage>
+                  </div>
+                </PanelBody>
+              </div>
+            </Component>
+          </Panel>
+        </TeamSelect>
+      </withApi(TeamSelect)>
       <Button
         busy={false}
         className="invite-member-submit"

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -147,13 +147,13 @@ exports[`CreateProject should render roles when available and allowed, and handl
         setRole={[Function]}
       >
         <Panel
-          className="new-invite-team"
+          className="new-invite-role"
         >
           <Component
-            className="new-invite-team css-yahxlu-Panel e1laxa7d0"
+            className="new-invite-role css-yahxlu-Panel e1laxa7d0"
           >
             <div
-              className="new-invite-team css-yahxlu-Panel e1laxa7d0"
+              className="new-invite-role css-yahxlu-Panel e1laxa7d0"
             >
               <PanelHeader>
                 <Component

--- a/tests/js/spec/views/settings/organizationMembers/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/index.spec.jsx
@@ -83,6 +83,11 @@ describe('OrganizationMembers', function() {
         require_link: true,
       },
     });
+    Client.addMockResponse({
+      url: '/organizations/org-id/teams/',
+      method: 'GET',
+      body: TestStubs.Team(),
+    });
     browserHistory.push.mockReset();
     OrganizationsStore.load([organization]);
   });

--- a/tests/js/spec/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
@@ -65,6 +65,10 @@ describe('OrganizationMemberDetail', function() {
         url: `/organizations/${organization.slug}/members/${expiredMember.id}/`,
         body: expiredMember,
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/teams/`,
+        body: teams,
+      });
     });
 
     it('changes role to owner', function() {
@@ -101,37 +105,26 @@ describe('OrganizationMemberDetail', function() {
       );
     });
 
-    it('joins a team', function() {
+    it('joins a team', async function() {
       wrapper = mount(
         <OrganizationMemberDetail params={{memberId: member.id}} />,
         routerContext
       );
+      // Wait for team list to fetch.
+      await wrapper.update();
 
-      expect(
-        wrapper
-          .find('TeamSelect Checkbox')
-          .first()
-          .prop('checked')
-      ).toBe(true);
-      expect(
-        wrapper
-          .find('TeamSelect Checkbox')
-          .last()
-          .prop('checked')
-      ).toBe(false);
+      // Should have one team enabled
+      expect(wrapper.find('TeamSelect PanelItem')).toHaveLength(1);
 
       // Select new team to join
-      wrapper
-        .find('TeamSelect Checkbox')
-        .last()
-        .simulate('change');
+      // Open the dropdown
+      wrapper.find('TeamSelect DropdownButton').simulate('click');
 
-      expect(
-        wrapper
-          .find('TeamSelect Checkbox')
-          .last()
-          .prop('checked')
-      ).toBe(true);
+      // Click the first item
+      wrapper
+        .find('TeamSelect TeamDropdownElement')
+        .first()
+        .simulate('click');
 
       // Save Member
       wrapper.find('Button[priority="primary"]').simulate('click');
@@ -147,70 +140,31 @@ describe('OrganizationMemberDetail', function() {
     });
   });
 
-  it('can select and deselect all', function() {
-    wrapper = mount(
-      <OrganizationMemberDetail params={{memberId: member.id}} />,
-      routerContext
-    );
-
-    const first = 'TeamSelect Checkbox[id="team-slug"]';
-    const last = 'TeamSelect Checkbox[id="new-team"]';
-    const selectAllButton = wrapper.find('Button[data-test-id="select-all"]');
-
-    expect(selectAllButton).toHaveLength(1);
-    expect(wrapper.find(first).prop('checked')).toBe(true);
-    expect(wrapper.find(last).prop('checked')).toBe(false);
-    expect(wrapper.state('member').teams).toHaveLength(1);
-
-    // select and deselect all
-    selectAllButton.simulate('click');
-    expect(wrapper.find(first).prop('checked')).toBe(true);
-    expect(wrapper.find(last).prop('checked')).toBe(true);
-    expect(wrapper.state('member').teams).toHaveLength(2);
-
-    selectAllButton.simulate('click');
-    expect(wrapper.find(first).prop('checked')).toBe(false);
-    expect(wrapper.find(last).prop('checked')).toBe(false);
-    expect(wrapper.state('member').teams).toHaveLength(0);
-
-    // select one, then select all
-    wrapper.find(first).simulate('change');
-    expect(wrapper.state('member').teams).toHaveLength(1);
-    selectAllButton.simulate('click');
-    expect(wrapper.state('member').teams).toHaveLength(2);
-    selectAllButton.simulate('click');
-    expect(wrapper.state('member').teams).toHaveLength(0);
-
-    // select both, then deselect all
-    wrapper.find(first).simulate('change');
-    expect(wrapper.state('member').teams).toHaveLength(1);
-    wrapper.find(last).simulate('change');
-    expect(wrapper.state('member').teams).toHaveLength(2);
-    selectAllButton.simulate('click');
-    expect(wrapper.state('member').teams).toHaveLength(0);
-  });
-
   describe('Cannot Edit', function() {
     beforeAll(function() {
       organization = TestStubs.Organization({teams, access: ['org:read']});
       routerContext = TestStubs.routerContext([{organization}]);
     });
 
-    it('can not change roles, teams, or save', function() {
+    it('can not change roles, teams, or save', async function() {
       wrapper = mount(
         <OrganizationMemberDetail params={{memberId: member.id}} />,
         routerContext
       );
+      await wrapper.update();
 
       // Should have 4 roles
       expect(wrapper.find('RoleSelect').prop('disabled')).toBe(true);
       expect(wrapper.find('TeamSelect').prop('disabled')).toBe(true);
       expect(
+        wrapper
+          .find('TeamRow Button')
+          .first()
+          .prop('disabled')
+      ).toBe(true);
+      expect(
         wrapper.find('Button[className="invite-member-submit"]').prop('disabled')
       ).toBe(true);
-      expect(wrapper.find('Button[data-test-id="select-all"]').prop('disabled')).toBe(
-        true
-      );
     });
   });
 
@@ -336,6 +290,10 @@ describe('OrganizationMemberDetail', function() {
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/members/${multipleOrgs.id}/`,
         body: multipleOrgs,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/teams/`,
+        body: teams,
       });
     });
 

--- a/tests/js/spec/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
@@ -105,6 +105,30 @@ describe('OrganizationMemberDetail', function() {
       );
     });
 
+    it('leaves a team', async function() {
+      wrapper = mount(
+        <OrganizationMemberDetail params={{memberId: member.id}} />,
+        routerContext
+      );
+
+      // Remove our one team
+      const button = wrapper.find('TeamSelect TeamRow Button');
+      expect(button).toHaveLength(1);
+      button.simulate('click');
+
+      // Save Member
+      wrapper.find('Button[priority="primary"]').simulate('click');
+
+      expect(updateMember).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            teams: [],
+          }),
+        })
+      );
+    });
+
     it('joins a team', async function() {
       wrapper = mount(
         <OrganizationMemberDetail params={{memberId: member.id}} />,


### PR DESCRIPTION
Some users have 100s of teams, rendering them all results in poor performance and isn't great to use. Instead only render the active teams and use our typeahead pattern for adding teams. Typeahead results are fetched from the server as necessary. 

New component looks like:

![screen shot 2019-03-06 at 12 57 41 pm](https://user-images.githubusercontent.com/24086/53911288-02b61b00-4024-11e9-96ee-d3a4f6493723.png)


Fixes SEN-233