### PR TITLE
fix(integrations) Allow admin role users to create repositories

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -84,6 +84,15 @@ class OrganizationIntegrationsPermission(OrganizationPermission):
     }
 
 
+class OrganizationRepositoryPermission(OrganizationPermission):
+    scope_map = {
+        'GET': ['org:read', 'org:write', 'org:admin', 'org:integrations'],
+        'POST': ['org:write', 'org:admin', 'org:integrations'],
+        'PUT': ['org:write', 'org:admin'],
+        'DELETE': ['org:admin'],
+    }
+
+
 class OrganizationAdminPermission(OrganizationPermission):
     scope_map = {
         'GET': ['org:admin'],

--- a/src/sentry/api/endpoints/organization_repositories.py
+++ b/src/sentry/api/endpoints/organization_repositories.py
@@ -4,7 +4,10 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.base import DocSection
-from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.bases.organization import (
+    OrganizationEndpoint,
+    OrganizationRepositoryPermission
+)
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.constants import ObjectStatus
@@ -15,6 +18,7 @@ from sentry.utils.sdk import capture_exception
 
 class OrganizationRepositoriesEndpoint(OrganizationEndpoint):
     doc_section = DocSection.ORGANIZATIONS
+    permission_classes = (OrganizationRepositoryPermission,)
 
     def has_feature(self, request, organization):
         return features.has(

--- a/src/sentry/api/endpoints/organization_repository_details.py
+++ b/src/sentry/api/endpoints/organization_repository_details.py
@@ -7,7 +7,10 @@ from rest_framework.response import Response
 from uuid import uuid4
 
 from sentry.api.base import DocSection
-from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.bases.organization import (
+    OrganizationEndpoint,
+    OrganizationRepositoryPermission
+)
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.constants import ObjectStatus
@@ -32,6 +35,7 @@ class RepositorySerializer(serializers.Serializer):
 
 class OrganizationRepositoryDetailsEndpoint(OrganizationEndpoint):
     doc_section = DocSection.ORGANIZATIONS
+    permission_classes = (OrganizationRepositoryPermission,)
 
     def put(self, request, organization, repo_id):
         if not request.user.is_authenticated():


### PR DESCRIPTION
Admin users can create and delete integrations, but cannot create repositories. This is problematic for some folks and allowing admin role users makes permissions more consistent for integrations.

Fixes SEN-244