### PR TITLE
fix(dashboard): Fix link to events

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDashboard/utils/getEventsUrlPathFromDiscoverQuery.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/utils/getEventsUrlPathFromDiscoverQuery.jsx
@@ -6,6 +6,7 @@ import {getUtcDateString} from 'app/utils/dates';
 
 export function getEventsUrlPathFromDiscoverQuery({organization, selection, query}) {
   const {
+    projects,
     datetime,
     environments, // eslint-disable-line no-unused-vars
     ...restSelection
@@ -14,6 +15,7 @@ export function getEventsUrlPathFromDiscoverQuery({organization, selection, quer
   return `/organizations/${organization.slug}/events/?${qs.stringify(
     pickBy({
       ...restSelection,
+      project: projects,
       start: datetime.start && getUtcDateString(datetime.start),
       end: datetime.end && getUtcDateString(datetime.end),
       statsPeriod: datetime.period,

--- a/tests/js/spec/views/organizationDashboard/utils/getEventsUrlPathFromDiscoverQuery.spec.jsx
+++ b/tests/js/spec/views/organizationDashboard/utils/getEventsUrlPathFromDiscoverQuery.spec.jsx
@@ -4,6 +4,7 @@ describe('getEventsUrlPathFromDiscoverQuery', function() {
   const organization = TestStubs.Organization();
   const query = {
     name: 'Known Users',
+    projects: [1],
     fields: [],
     conditions: [['user.email', 'IS NOT NULL', null]],
     aggregations: [['uniq', 'user.email', 'Known Users']],
@@ -47,6 +48,21 @@ describe('getEventsUrlPathFromDiscoverQuery', function() {
       })
     ).toBe(
       '/organizations/org-slug/events/?end=2017-10-17T02%3A41%3A20&query=%21user.email%3A%22%22&start=2017-10-17T02%3A41%3A20'
+    );
+  });
+
+  it('has projects', function() {
+    expect(
+      getEventsUrlPathFromDiscoverQuery({
+        organization,
+        selection: {
+          projects: [1],
+          datetime: {start: null, end: null, period: '14d'},
+        },
+        query,
+      })
+    ).toBe(
+      '/organizations/org-slug/events/?project=1&query=%21user.email%3A%22%22&statsPeriod=14d'
     );
   });
 });


### PR DESCRIPTION
Projects is incorrectly serialized as `projects` instead of `project` in
the generated event link