### PR TITLE
Revert "fix(integration): Fix timeout error when adding slack integration rules if org has many channels (SEN-231)

### DIFF
--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -178,14 +178,8 @@ class SlackNotifyServiceAction(EventAction):
 
         # Look for channel ID
         channels_payload = dict(token_payload, **{
-            'exclude_archived': True,
+            'exclude_archived': False,
             'exclude_members': True,
-            # XXX: This endpoint started timing out for certain organizations
-            # that have many channels. Setting any limit causes the endpoint to
-            # not time out, even if that limit is higher than the number of
-            # returned results. Setting to 1500 since this is the most results
-            # that the endpoint will return (as per documentation).
-            'limit': 1500,
         })
 
         resp = session.get('https://slack.com/api/channels.list', params=channels_payload)


### PR DESCRIPTION
This reverts commit 8ec94beb28030a2551d5bc8509b6c284b9df17a8.

This fix doesn't resolve the issue for the customer, and seems to be causing additional issues for other customers. I think this is because adding the limit on causes some internal change in the slack api so that it starts paging, and we never actually page through results. We need to either switch to the new api, or at very least implement paging on this one.