### PR TITLE
Revert "fix: Remove unused component (#12293)"

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/organizationsLoader.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/organizationsLoader.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import createReactClass from 'create-react-class';
+
+import ApiMixin from 'app/mixins/apiMixin';
+import OrganizationsStore from 'app/stores/organizationsStore';
+
+const OrganizationsLoader = createReactClass({
+  displayName: 'OrganizationsLoader',
+  mixins: [ApiMixin],
+
+  componentWillMount() {
+    this.api.request('/organizations/', {
+      query: {
+        member: '1',
+      },
+      success: data => {
+        OrganizationsStore.load(data);
+        this.setState({
+          loading: false,
+        });
+      },
+      error: () => {
+        this.setState({
+          loading: false,
+          error: true,
+        });
+      },
+    });
+  },
+
+  componentWillUnmount() {
+    OrganizationsStore.load([]);
+  },
+
+  render() {
+    return <div>{this.props.children}</div>;
+  },
+});
+
+export default OrganizationsLoader;

--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -197,6 +197,8 @@ const globals = {
     OrganizationAuth: require('app/views/settings/organizationAuth').default,
     OrganizationHomeContainer: require('app/components/organizations/homeContainer')
       .default,
+    OrganizationsLoader: require('app/components/organizations/organizationsLoader')
+      .default,
     OrganizationMembersView: require('app/views/settings/organizationMembers').default,
     Panel: require('app/components/panels/panel').default,
     PanelHeader: require('app/components/panels/panelHeader').default,


### PR DESCRIPTION
This reverts commit 41d76d63152528b20680cf6b9b63d02005261854. The `OrganizationsLoader` was in use in the django template that is used for unsubscribe pages. I previously only check the react app code, and forgot about django templates.

Fixes JAVASCRIPT-5FX