### PR TITLE
feat(app-platform): Add external issues endpoint

### DIFF
--- a/src/sentry/api/endpoints/group_external_issues.py
+++ b/src/sentry/api/endpoints/group_external_issues.py
@@ -1,0 +1,27 @@
+from __future__ import absolute_import
+
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.bases.group import GroupEndpoint
+from sentry.api.serializers import serialize
+from sentry.models import PlatformExternalIssue
+
+
+class GroupExternalIssuesEndpoint(GroupEndpoint):
+    def get(self, request, group):
+        if not features.has('organizations:sentry-apps',
+                            group.organization,
+                            actor=request.user):
+            return Response(status=404)
+
+        external_issues = PlatformExternalIssue.objects.filter(
+            group_id=group.id,
+        )
+
+        return self.paginate(
+            request=request,
+            queryset=external_issues,
+            order_by='id',
+            on_results=lambda x: serialize(x, request.user),
+        )

--- a/src/sentry/api/serializers/models/platformexternalissue.py
+++ b/src/sentry/api/serializers/models/platformexternalissue.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+import six
+
+from sentry.api.serializers import register, Serializer
+from sentry.models import PlatformExternalIssue
+
+
+@register(PlatformExternalIssue)
+class PlatformExternalIssueSerializer(Serializer):
+    def serialize(self, obj, attrs, user):
+        return {
+            'id': six.text_type(obj.id),
+            'groupId': six.text_type(obj.group_id),
+            'serviceType': obj.service_type,
+            'displayName': obj.display_name,
+            'webUrl': obj.web_url
+        }

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -38,6 +38,7 @@ from .endpoints.group_integrations import GroupIntegrationsEndpoint
 from .endpoints.group_notes import GroupNotesEndpoint
 from .endpoints.group_notes_details import GroupNotesDetailsEndpoint
 from .endpoints.group_participants import GroupParticipantsEndpoint
+from .endpoints.group_external_issues import GroupExternalIssuesEndpoint
 from .endpoints.group_similar_issues import GroupSimilarIssuesEndpoint
 from .endpoints.group_stats import GroupStatsEndpoint
 from .endpoints.group_tags import GroupTagsEndpoint
@@ -1166,6 +1167,11 @@ urlpatterns = patterns(
         r'^(?:issues|groups)/(?P<issue_id>\d+)/similar/$',
         GroupSimilarIssuesEndpoint.as_view(),
         name='sentry-api-0-group-similar-issues'
+    ),
+    url(
+        r'^(?:issues|groups)/(?P<issue_id>\d+)/external-issues/$',
+        GroupExternalIssuesEndpoint.as_view(),
+        name='sentry-api-0-group-external-issues'
     ),
     url(
         r'^(?:issues|groups)/(?P<issue_id>\d+)/integrations/$',

--- a/tests/sentry/api/endpoints/test_group_external_issues.py
+++ b/tests/sentry/api/endpoints/test_group_external_issues.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import, print_function
+
+import six
+
+from sentry.models import PlatformExternalIssue
+from sentry.testutils import APITestCase
+from sentry.testutils.helpers import with_feature
+
+
+class GroupExternalIssuesEndpointTest(APITestCase):
+    @with_feature('organizations:sentry-apps')
+    def test_simple(self):
+        self.login_as(user=self.user)
+
+        group = self.create_group()
+
+        PlatformExternalIssue.objects.create(
+            group_id=group.id,
+            service_type='sentry-app',
+            display_name='App#issue-1',
+            web_url='https://example.com/app/issues/1',
+        )
+
+        url = u'/api/0/issues/{}/external-issues/'.format(group.id)
+        response = self.client.get(url, format='json')
+        external_issue = PlatformExternalIssue.objects.first()
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data == [{
+            'id': six.text_type(external_issue.id),
+            'groupId': six.text_type(group.id),
+            'serviceType': 'sentry-app',
+            'displayName': 'App#issue-1',
+            'webUrl': 'https://example.com/app/issues/1',
+        }]


### PR DESCRIPTION
For right now this endpoint will only be used for external issues associated with sentry apps (aka from the `PlaftformExternalIssue table`. Ideally, in the future, we could use this for integration external issues as well. 