### PR TITLE
fix: Fix problematic method signatures in serializers

### DIFF
--- a/src/sentry/api/serializers/base.py
+++ b/src/sentry/api/serializers/base.py
@@ -14,10 +14,7 @@ def serialize(objects, user=None, serializer=None, *args, **kwargs):
     # sets aren't predictable, so generally you should use a list, but it's
     # supported out of convenience
     elif not isinstance(objects, (list, tuple, set, frozenset)):
-        return serialize([objects], user=user, serializer=serializer, *args, **kwargs)[0]
-
-    # elif isinstance(obj, dict):
-    #     return dict((k, serialize(v, request=request)) for k, v in six.iteritems(obj))
+        return serialize([objects], user, serializer, *args, **kwargs)[0]
 
     if serializer is None:
         # find the first object that is in the registry
@@ -33,13 +30,13 @@ def serialize(objects, user=None, serializer=None, *args, **kwargs):
     attrs = serializer.get_attrs(
         # avoid passing NoneType's to the serializer as they're allowed and
         # filtered out of serialize()
-        item_list=[o for o in objects if o is not None],
-        user=user,
+        [o for o in objects if o is not None],
+        user,
         *args,
         **kwargs
     )
 
-    return [serializer(o, attrs=attrs.get(o, {}), user=user, *args, **kwargs) for o in objects]
+    return [serializer(o, attrs.get(o, {}), user, *args, **kwargs) for o in objects]
 
 
 def register(type):

--- a/src/sentry/api/serializers/base.py
+++ b/src/sentry/api/serializers/base.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import AnonymousUser
 registry = {}
 
 
-def serialize(objects, user=None, serializer=None, *args, **kwargs):
+def serialize(objects, user=None, serializer=None, **kwargs):
     if user is None:
         user = AnonymousUser()
 
@@ -14,7 +14,7 @@ def serialize(objects, user=None, serializer=None, *args, **kwargs):
     # sets aren't predictable, so generally you should use a list, but it's
     # supported out of convenience
     elif not isinstance(objects, (list, tuple, set, frozenset)):
-        return serialize([objects], user, serializer, *args, **kwargs)[0]
+        return serialize([objects], user=user, serializer=serializer, **kwargs)[0]
 
     if serializer is None:
         # find the first object that is in the registry
@@ -30,13 +30,12 @@ def serialize(objects, user=None, serializer=None, *args, **kwargs):
     attrs = serializer.get_attrs(
         # avoid passing NoneType's to the serializer as they're allowed and
         # filtered out of serialize()
-        [o for o in objects if o is not None],
-        user,
-        *args,
+        item_list=[o for o in objects if o is not None],
+        user=user,
         **kwargs
     )
 
-    return [serializer(o, attrs.get(o, {}), user, *args, **kwargs) for o in objects]
+    return [serializer(o, attrs=attrs.get(o, {}), user=user, **kwargs) for o in objects]
 
 
 def register(type):
@@ -48,13 +47,13 @@ def register(type):
 
 
 class Serializer(object):
-    def __call__(self, obj, attrs, user, *args, **kwargs):
+    def __call__(self, obj, attrs, user, **kwargs):
         if obj is None:
             return
-        return self.serialize(obj, attrs, user, *args, **kwargs)
+        return self.serialize(obj, attrs, user, **kwargs)
 
-    def get_attrs(self, item_list, user, *args, **kwargs):
+    def get_attrs(self, item_list, user, **kwargs):
         return {}
 
-    def serialize(self, obj, attrs, user, *args, **kwargs):
+    def serialize(self, obj, attrs, user, **kwargs):
         return {}

--- a/src/sentry/api/serializers/models/actor.py
+++ b/src/sentry/api/serializers/models/actor.py
@@ -6,7 +6,7 @@ from sentry.models import User, Team
 
 
 class ActorSerializer(Serializer):
-    def serialize(self, obj, attrs, *args, **kwargs):
+    def serialize(self, obj, attrs, **kwargs):
 
         if isinstance(obj, User):
             actor_type = 'user'

--- a/src/sentry/api/serializers/models/actor.py
+++ b/src/sentry/api/serializers/models/actor.py
@@ -6,8 +6,7 @@ from sentry.models import User, Team
 
 
 class ActorSerializer(Serializer):
-    def serialize(self, obj, attrs, **kwargs):
-
+    def serialize(self, obj, attrs, user, **kwargs):
         if isinstance(obj, User):
             actor_type = 'user'
             name = obj.get_display_name()

--- a/src/sentry/api/serializers/models/deploy.py
+++ b/src/sentry/api/serializers/models/deploy.py
@@ -8,7 +8,7 @@ from sentry.models import Deploy, Environment
 
 @register(Deploy)
 class DeploySerializer(Serializer):
-    def get_attrs(self, item_list, user, *args, **kwargs):
+    def get_attrs(self, item_list, user, **kwargs):
         environments = {
             id: name
             for id, name in Environment.objects.filter(
@@ -24,7 +24,7 @@ class DeploySerializer(Serializer):
 
         return result
 
-    def serialize(self, obj, attrs, user, *args, **kwargs):
+    def serialize(self, obj, attrs, user, **kwargs):
         return {
             'id': six.text_type(obj.id),
             'environment': attrs.get('environment'),

--- a/src/sentry/api/serializers/models/discoversavedquery.py
+++ b/src/sentry/api/serializers/models/discoversavedquery.py
@@ -7,7 +7,7 @@ from sentry.models import DiscoverSavedQuery
 
 @register(DiscoverSavedQuery)
 class DiscoverSavedQuerySerializer(Serializer):
-    def serialize(self, obj, attrs, user, *args, **kwargs):
+    def serialize(self, obj, attrs, user, **kwargs):
 
         query_keys = [
             'fields',

--- a/src/sentry/api/serializers/models/grouphash.py
+++ b/src/sentry/api/serializers/models/grouphash.py
@@ -42,7 +42,7 @@ class GroupHashSerializer(Serializer):
         GroupHash.State.LOCKED_IN_MIGRATION: 'locked',
     }
 
-    def get_attrs(self, item_list, user, *args, **kwargs):
+    def get_attrs(self, item_list, user, **kwargs):
         return {
             item: {
                 'latest_event': latest_event

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -139,7 +139,7 @@ class IntegrationIssueSerializer(IntegrationSerializer):
     def __init__(self, group):
         self.group = group
 
-    def get_attrs(self, item_list, user, *args, **kwargs):
+    def get_attrs(self, item_list, user, **kwargs):
         external_issues = ExternalIssue.objects.filter(
             id__in=GroupLink.objects.filter(
                 group_id=self.group.id,

--- a/src/sentry/api/serializers/models/organization_dashboard.py
+++ b/src/sentry/api/serializers/models/organization_dashboard.py
@@ -22,7 +22,7 @@ class WidgetSerializer(Serializer):
 
         return result
 
-    def serialize(self, obj, attrs, user, *args, **kwargs):
+    def serialize(self, obj, attrs, user, **kwargs):
         return {
             'id': six.text_type(obj.id),
             'order': six.text_type(obj.order),
@@ -38,7 +38,7 @@ class WidgetSerializer(Serializer):
 @register(WidgetDataSource)
 class WidgetDataSourceSerializer(Serializer):
 
-    def serialize(self, obj, attrs, user, *args, **kwargs):
+    def serialize(self, obj, attrs, user, **kwargs):
         return {
             'id': six.text_type(obj.id),
             'type': obj.type,
@@ -67,7 +67,7 @@ class DashboardWithWidgetsSerializer(Serializer):
 
         return result
 
-    def serialize(self, obj, attrs, user, *args, **kwargs):
+    def serialize(self, obj, attrs, user, **kwargs):
         data = {
             'id': six.text_type(obj.id),
             'title': obj.title,

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -210,7 +210,7 @@ class ReleaseSerializer(Serializer):
         )
         return first_seen, last_seen, issue_counts_by_release
 
-    def get_attrs(self, item_list, user, *args, **kwargs):
+    def get_attrs(self, item_list, user, **kwargs):
         project = kwargs.get('project')
         environment = kwargs.get('environment')
         if environment is None:
@@ -252,7 +252,7 @@ class ReleaseSerializer(Serializer):
             result[item].update(deploy_metadata_attrs[item])
         return result
 
-    def serialize(self, obj, attrs, user, *args, **kwargs):
+    def serialize(self, obj, attrs, user, **kwargs):
         d = {
             'version': obj.version,
             'shortVersion': obj.short_version,

--- a/src/sentry/api/serializers/models/role.py
+++ b/src/sentry/api/serializers/models/role.py
@@ -6,7 +6,7 @@ from sentry.api.serializers import Serializer
 
 class RoleSerializer(Serializer):
 
-    def serialize(self, obj, attrs, *args, **kwargs):
+    def serialize(self, obj, attrs, **kwargs):
         allowed_roles = kwargs.get('allowed_roles') or []
 
         return {

--- a/src/sentry/api/serializers/models/role.py
+++ b/src/sentry/api/serializers/models/role.py
@@ -6,7 +6,7 @@ from sentry.api.serializers import Serializer
 
 class RoleSerializer(Serializer):
 
-    def serialize(self, obj, attrs, **kwargs):
+    def serialize(self, obj, attrs, user, **kwargs):
         allowed_roles = kwargs.get('allowed_roles') or []
 
         return {

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -19,7 +19,7 @@ def _generate_rule_label(project, rule, data):
 
 @register(Rule)
 class RuleSerializer(Serializer):
-    def get_attrs(self, item_list, user, *args, **kwargs):
+    def get_attrs(self, item_list, user, **kwargs):
         environments = Environment.objects.in_bulk(
             filter(None, [i.environment_id for i in item_list]),
         )

--- a/src/sentry/api/serializers/models/user_notifications.py
+++ b/src/sentry/api/serializers/models/user_notifications.py
@@ -13,7 +13,7 @@ from sentry.models import UserOption
 # - reports:disabled-organizations
 # - mail:email
 class UserNotificationsSerializer(Serializer):
-    def get_attrs(self, item_list, user, *args, **kwargs):
+    def get_attrs(self, item_list, user, **kwargs):
         notification_option_key = kwargs['notification_option_key']
         filter_args = {}
 
@@ -35,7 +35,7 @@ class UserNotificationsSerializer(Serializer):
 
         return results
 
-    def serialize(self, obj, attrs, user, *args, **kwargs):
+    def serialize(self, obj, attrs, user, **kwargs):
         notification_option_key = kwargs['notification_option_key']
         data = {}
 

--- a/tests/sentry/api/serializers/test_base.py
+++ b/tests/sentry/api/serializers/test_base.py
@@ -15,6 +15,11 @@ class FooSerializer(Serializer):
         return 'lol'
 
 
+class VariadicSerializer(Serializer):
+    def serialize(self, obj, attrs, user, kw):
+        return {'kw': kw}
+
+
 class BaseSerializerTest(TestCase):
     def test_serialize(self):
         assert serialize([]) == []
@@ -46,3 +51,9 @@ class BaseSerializerTest(TestCase):
         assert len(rv) == 2
         assert rv[0] is None
         assert isinstance(rv[1], dict)
+
+    def test_serialize_additional_kwargs(self):
+        foo = Foo()
+        user = self.create_user()
+        result = serialize(foo, user, VariadicSerializer(), kw='keyword')
+        assert result['kw'] == 'keyword'


### PR DESCRIPTION
serialize() had `*args` following keyword arguments. This results in `*args` not being usable as python globs too many arguments into keyword args.

Refs SEN-64