### PR TITLE
fix(access) Fix duplicate data being fetched

### DIFF
--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -281,9 +281,7 @@ def from_sentry_app(user, organization=None):
         return NoAccess()
 
     team_list = list(sentry_app.teams.all())
-    project_list = list(Project.objects.filter(
-        teams__in=team_list,
-    ))
+    project_list = list(Project.objects.filter(teams__in=team_list).distinct())
 
     return Access(
         scopes=sentry_app.scope_list,
@@ -329,7 +327,7 @@ def from_member(member, scopes=None):
     requires_sso, sso_is_valid = _sso_params(member)
 
     team_list = member.get_teams()
-    project_list = list(Project.objects.filter(teams__in=team_list))
+    project_list = list(Project.objects.filter(teams__in=team_list).distinct())
 
     if scopes is not None:
         scopes = set(scopes) & member.get_scopes()

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -26,6 +26,24 @@ class FromUserTest(TestCase):
         assert not result.has_project_scope(project, 'project:read')
         assert not result.has_project_membership(project)
 
+    def test_unique_projects(self):
+        user = self.create_user()
+        organization = self.create_organization(owner=self.user)
+
+        team = self.create_team(organization=organization)
+        other_team = self.create_team(organization=organization)
+        self.create_member(
+            organization=organization,
+            user=user,
+            role='owner',
+            teams=[team, other_team]
+        )
+        project = self.create_project(organization=organization, teams=[team, other_team])
+
+        result = access.from_user(user, organization)
+        assert result.has_project_access(project)
+        assert len(result.projects) == 1
+
     def test_mixed_access(self):
         user = self.create_user()
         organization = self.create_organization(flags=0)  # disable default allow_joinleave


### PR DESCRIPTION
When a user had access to a project via multiple teams, the access object would have N copies of the project in the list where N was the number of teams that the user had membership on.

Refs SEN-64