### PR TITLE
fix(issues): Group details tabs keep querystring in URL

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
@@ -199,7 +199,7 @@ const GroupHeader = createReactClass({
         <GroupActions group={group} project={project} />
         <NavTabs>
           <ListLink
-            to={`${baseUrl}${groupId}/`}
+            to={`${baseUrl}${groupId}/${this.context.location.search}`}
             isActive={() => {
               const rootGroupPath = `${baseUrl}${groupId}/`;
               const pathname = this.context.location.pathname;
@@ -210,18 +210,24 @@ const GroupHeader = createReactClass({
           >
             {t('Details')}
           </ListLink>
-          <ListLink to={`${baseUrl}${groupId}/activity/`}>
+          <ListLink to={`${baseUrl}${groupId}/activity/${this.context.location.search}`}>
             {t('Comments')} <span className="badge animated">{group.numComments}</span>
           </ListLink>
-          <ListLink to={`${baseUrl}${groupId}/feedback/`}>
-            {t('User Feedback')}{' '}
+          <ListLink to={`${baseUrl}${groupId}/feedback/${this.context.location.search}`}>
+            {t('User Feedback')}
             <span className="badge animated">{group.userReportCount}</span>
           </ListLink>
-          <ListLink to={`${baseUrl}${groupId}/tags/`}>{t('Tags')}</ListLink>
-          <ListLink to={`${baseUrl}${groupId}/events/`}>{t('Events')}</ListLink>
-          <ListLink to={`${baseUrl}${groupId}/merged/`}>{t('Merged')}</ListLink>
+          <ListLink to={`${baseUrl}${groupId}/tags/${this.context.location.search}`}>
+            {t('Tags')}
+          </ListLink>
+          <ListLink to={`${baseUrl}${groupId}/events/${this.context.location.search}`}>
+            {t('Events')}
+          </ListLink>
+          <ListLink to={`${baseUrl}${groupId}/merged/${this.context.location.search}`}>
+            {t('Merged')}
+          </ListLink>
           {hasSimilarView && (
-            <ListLink to={`${baseUrl}${groupId}/similar/`}>
+            <ListLink to={`${baseUrl}${groupId}/similar/${this.context.location.search}`}>
               {t('Similar Issues')}
             </ListLink>
           )}


### PR DESCRIPTION
We need to pass the querystring to links when they are in the same
view. Since the global selection header does not get remounted,
these links do not get automatically checked and synced with their
store values.