### PR TITLE
fix(api) Organization details should reflect membership

### DIFF
--- a/src/sentry/api/endpoints/accept_project_transfer.py
+++ b/src/sentry/api/endpoints/accept_project_transfer.py
@@ -67,7 +67,12 @@ class AcceptProjectTransferEndpoint(Endpoint):
         )
 
         return Response({
-            'organizations': serialize(list(organizations), request.user, DetailedOrganizationSerializer()),
+            'organizations': serialize(
+                list(organizations),
+                request.user,
+                DetailedOrganizationSerializer(),
+                access=request.access
+            ),
             'project': {
                 'slug': project.slug,
                 'id': project.id,

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -313,6 +313,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
             organization,
             request.user,
             org_serializers.DetailedOrganizationSerializer(),
+            access=request.access,
         )
         return self.respond(context)
 
@@ -380,6 +381,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                     organization,
                     request.user,
                     org_serializers.DetailedOrganizationSerializer(),
+                    access=request.access,
                 )
             )
         return self.respond(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -450,5 +452,6 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
             organization,
             request.user,
             org_serializers.DetailedOrganizationSerializer(),
+            access=request.access,
         )
         return self.respond(context, status=202)

--- a/src/sentry/templatetags/sentry_api.py
+++ b/src/sentry/templatetags/sentry_api.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from django import template
 from django.http import HttpRequest
 
+from sentry.auth.access import NoAccess
 from sentry.api.serializers.base import serialize as serialize_func
 from sentry.api.serializers.models.organization import (DetailedOrganizationSerializer)
 from sentry.utils import json
@@ -29,13 +30,16 @@ def convert_to_json(obj):
 def serialize_detailed_org(context, obj):
     if 'request' in context:
         user = context['request'].user
+        access = context['request'].access
     else:
         user = None
+        access = NoAccess()
 
     context = serialize_func(
         obj,
         user,
         DetailedOrganizationSerializer(),
+        access=access
     )
 
     return convert_to_json(context)

--- a/src/sentry/templatetags/sentry_api.py
+++ b/src/sentry/templatetags/sentry_api.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django import template
 from django.http import HttpRequest
 
-from sentry.auth.access import NoAccess
+from sentry.auth.access import NoAccess, from_user
 from sentry.api.serializers.base import serialize as serialize_func
 from sentry.api.serializers.models.organization import (DetailedOrganizationSerializer)
 from sentry.utils import json
@@ -30,7 +30,7 @@ def convert_to_json(obj):
 def serialize_detailed_org(context, obj):
     if 'request' in context:
         user = context['request'].user
-        access = context['request'].access
+        access = from_user(user, obj)
     else:
         user = None
         access = NoAccess()


### PR DESCRIPTION
With the settings pages no longer using organization details to get the team and project lists we can update these properties to reflect actual membership. This lets us be more efficient for most users as we'll be loading and serializing only the data they actually use. Once this is out we can update the UI to skip membership checks as they will no longer be necessary.

~~This is blocked on #12332 being merged, and will be a draft until that point.~~

Fixes SEN-64