### PR TITLE
feat(app-platform): Issue Link UI

### DIFF
--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -188,7 +188,6 @@ class SentryAppInstallationsBaseEndpoint(Endpoint):
             organization = organizations.get(slug=organization_slug)
         except Organization.DoesNotExist:
             raise Http404
-
         self.check_object_permissions(request, organization)
 
         kwargs['organization'] = organization
@@ -199,6 +198,14 @@ class SentryAppInstallationPermission(SentryPermission):
     scope_map = {
         'GET': ('org:read', 'org:integrations', 'org:write', 'org:admin'),
         'DELETE': ('org:integrations', 'org:write', 'org:admin'),
+        # NOTE(mn): The only POST endpoint right now is to create External
+        # Issues, which uses this baseclass since it's nested under an
+        # installation.
+        #
+        # The scopes below really only make sense for that endpoint. Any other
+        # nested endpoints will probably need different scopes - figure out how
+        # to deal with that when it happens.
+        'POST': ('org:integrations', 'event:write', 'event:admin'),
     }
 
     def has_object_permission(self, request, view, installation):

--- a/src/sentry/api/endpoints/sentry_app_components.py
+++ b/src/sentry/api/endpoints/sentry_app_components.py
@@ -1,10 +1,13 @@
 from __future__ import absolute_import
 
+from rest_framework.response import Response
+
 from sentry.api.bases import OrganizationEndpoint, SentryAppBaseEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.features.helpers import requires_feature
-from sentry.models import SentryAppComponent, SentryApp
+from sentry.mediators import sentry_app_components
+from sentry.models import Project, SentryAppComponent
 
 
 class SentryAppComponentsEndpoint(SentryAppBaseEndpoint):
@@ -21,13 +24,36 @@ class SentryAppComponentsEndpoint(SentryAppBaseEndpoint):
 class OrganizationSentryAppComponentsEndpoint(OrganizationEndpoint):
     @requires_feature('organizations:sentry-apps')
     def get(self, request, organization):
+        try:
+            project = Project.objects.get(
+                id=request.GET['projectId'],
+                organization_id=organization.id,
+            )
+        except Project.DoesNotExist:
+            return Response([], status=404)
+
+        components = []
+
+        for install in organization.sentry_app_installations.all():
+            _components = SentryAppComponent.objects.filter(
+                sentry_app_id=install.sentry_app_id,
+            )
+
+            if 'filter' in request.GET:
+                _components = _components.filter(type=request.GET['filter'])
+
+            for component in _components:
+                sentry_app_components.Preparer.run(
+                    component=component,
+                    install=install,
+                    project=project,
+                )
+
+            components.extend(_components)
+
         return self.paginate(
             request=request,
-            queryset=SentryAppComponent.objects.filter(
-                sentry_app_id__in=SentryApp.objects.filter(
-                    installations__in=organization.sentry_app_installations.all(),
-                )
-            ),
+            queryset=components,
             paginator_cls=OffsetPaginator,
             on_results=lambda x: serialize(x, request.user),
         )

--- a/src/sentry/api/serializers/models/sentry_app_component.py
+++ b/src/sentry/api/serializers/models/sentry_app_component.py
@@ -13,5 +13,9 @@ class SentryAppComponentSerializer(Serializer):
             'uuid': six.binary_type(obj.uuid),
             'type': obj.type,
             'schema': obj.schema,
-            'sentryAppId': obj.sentry_app_id,
+            'sentryApp': {
+                'uuid': obj.sentry_app.uuid,
+                'slug': obj.sentry_app.slug,
+                'name': obj.sentry_app.name,
+            }
         }

--- a/src/sentry/mediators/__init__.py
+++ b/src/sentry/mediators/__init__.py
@@ -11,3 +11,4 @@ from .token_exchange import (  # NOQA
     GrantExchanger,
     Refresher,
 )
+from .sentry_app_components import *  # NOQA

--- a/src/sentry/mediators/external_issues/issue_link_creator.py
+++ b/src/sentry/mediators/external_issues/issue_link_creator.py
@@ -35,10 +35,12 @@ class IssueLinkCreator(Mediator):
 
     def _format_response_data(self):
         web_url = self.response['webUrl']
+
         display_name = u'{}#{}'.format(
             self.response['project'],
             self.response['identifier'],
         )
+
         return [web_url, display_name]
 
     def _create_external_issue(self):

--- a/src/sentry/mediators/external_requests/issue_link_requester.py
+++ b/src/sentry/mediators/external_requests/issue_link_requester.py
@@ -54,9 +54,8 @@ class IssueLinkRequester(Mediator):
         return self._make_request()
 
     def _build_url(self):
-        domain = urlparse(self.sentry_app.webhook_url).netloc
-        url = u'https://{}{}'.format(domain, self.uri)
-        return url
+        urlparts = urlparse(self.sentry_app.webhook_url)
+        return u'{}://{}{}'.format(urlparts.scheme, urlparts.netloc, self.uri)
 
     def _make_request(self):
         req = safe_urlopen(

--- a/src/sentry/mediators/sentry_app_components/__init__.py
+++ b/src/sentry/mediators/sentry_app_components/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+
+from .preparer import Preparer  # NOQA

--- a/src/sentry/mediators/sentry_app_components/preparer.py
+++ b/src/sentry/mediators/sentry_app_components/preparer.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import
+
+from sentry.mediators import Mediator, Param
+from sentry.mediators.external_requests import SelectRequester
+
+
+class Preparer(Mediator):
+    component = Param('sentry.models.SentryAppComponent')
+    install = Param('sentry.models.SentryAppInstallation')
+    project = Param('sentry.models.Project')
+
+    def call(self):
+        if self.component.type == 'issue-link':
+            return self._prepare_issue_link()
+
+    def _prepare_issue_link(self):
+        schema = self.component.schema.copy()
+
+        link = schema.get('link', {})
+        create = schema.get('create', {})
+
+        for field in link.get('required_fields', []):
+            self._prepare_field(field)
+
+        for field in link.get('optional_fields', []):
+            self._prepare_field(field)
+
+        for field in create.get('required_fields', []):
+            self._prepare_field(field)
+
+        for field in create.get('optional_fields', []):
+            self._prepare_field(field)
+
+    def _prepare_field(self, field):
+        if 'options' in field:
+            field.update({'choices': field['options']})
+
+        if 'uri' in field:
+            field.update(self._request(field['uri']))
+
+    def _request(self, uri):
+        return SelectRequester.run(
+            install=self.install,
+            project=self.project,
+            uri=uri,
+        )

--- a/src/sentry/static/sentry/app/components/group/externalIssueForm.jsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueForm.jsx
@@ -1,0 +1,258 @@
+import $ from 'jquery';
+import React from 'react';
+import PropTypes from 'prop-types';
+import queryString from 'query-string';
+import {debounce} from 'lodash';
+
+import {addSuccessMessage} from 'app/actionCreators/indicator';
+import AsyncComponent from 'app/components/asyncComponent';
+import FieldFromConfig from 'app/views/settings/components/forms/fieldFromConfig';
+import Form from 'app/views/settings/components/forms/form';
+import SentryTypes from 'app/sentryTypes';
+import {t} from 'app/locale';
+import ExternalIssueStore from 'app/stores/externalIssueStore';
+
+const MESSAGES_BY_ACTION = {
+  link: t('Successfully linked issue.'),
+  create: t('Successfully created issue.'),
+};
+
+const SUBMIT_LABEL_BY_ACTION = {
+  link: t('Link Issue'),
+  create: t('Create Issue'),
+};
+
+class ExternalIssueForm extends AsyncComponent {
+  static propTypes = {
+    group: SentryTypes.Group.isRequired,
+    integration: PropTypes.object.isRequired,
+    action: PropTypes.oneOf(['link', 'create']),
+    onSubmitSuccess: PropTypes.func.isRequired,
+  };
+
+  shouldRenderBadRequests = true;
+
+  getEndpoints() {
+    const {group, integration, action} = this.props;
+    return [
+      [
+        'integrationDetails',
+        `/groups/${group.id}/integrations/${integration.id}/?action=${action}`,
+      ],
+    ];
+  }
+
+  onSubmitSuccess = data => {
+    addSuccessMessage(MESSAGES_BY_ACTION[this.props.action]);
+    this.props.onSubmitSuccess(data);
+  };
+
+  onRequestSuccess({stateKey, data, jqXHR}) {
+    if (stateKey === 'integrationDetails' && !this.state.dynamicFieldValues) {
+      this.setState({
+        dynamicFieldValues: this.getDynamicFields(data),
+      });
+    }
+  }
+
+  refetchConfig = () => {
+    const {dynamicFieldValues} = this.state;
+    const {action, group, integration} = this.props;
+    const endpoint = `/groups/${group.id}/integrations/${integration.id}/`;
+    const query = {action, ...dynamicFieldValues};
+
+    this.api.request(endpoint, {
+      method: 'GET',
+      query,
+      success: (data, _, jqXHR) => {
+        this.handleRequestSuccess({stateKey: 'integrationDetails', data, jqXHR}, true);
+      },
+      error: error => {
+        this.handleError(error, ['integrationDetails', endpoint, null, null]);
+      },
+    });
+  };
+
+  getDynamicFields(integrationDetails) {
+    integrationDetails = integrationDetails || this.state.integrationDetails;
+    const {action} = this.props;
+    const config = integrationDetails[`${action}IssueConfig`];
+
+    return config
+      .filter(field => field.updatesForm)
+      .reduce((a, field) => ({...a, [field.name]: field.default}), {});
+  }
+
+  onFieldChange = (label, value) => {
+    const dynamicFields = this.getDynamicFields();
+    if (label in dynamicFields) {
+      const dynamicFieldValues = this.state.dynamicFieldValues || {};
+      dynamicFieldValues[label] = value;
+
+      this.setState(
+        {
+          dynamicFieldValues,
+          reloading: true,
+          error: false,
+          remainingRequests: 1,
+        },
+        this.refetchConfig
+      );
+    }
+  };
+
+  getOptions = (field, input) => {
+    if (!input) {
+      const options = (field.choices || []).map(([value, label]) => ({value, label}));
+      return Promise.resolve({options});
+    }
+    return new Promise(resolve => {
+      this.debouncedOptionLoad(field, input, resolve);
+    });
+  };
+
+  debouncedOptionLoad = debounce(
+    (field, input, resolve) => {
+      const query = queryString.stringify({
+        ...this.state.dynamicFieldValues,
+        field: field.name,
+        query: input,
+      });
+
+      const url = field.url;
+      const separator = url.includes('?') ? '&' : '?';
+
+      const request = {
+        url: [url, separator, query].join(''),
+        method: 'GET',
+      };
+
+      // We can't use the API client here since the URL is not scoped under the
+      // API endpoints (which the client prefixes)
+      $.ajax(request).then(data => resolve({options: data}));
+    },
+    200,
+    {trailing: true}
+  );
+
+  getFieldProps = field =>
+    field.url
+      ? {
+          loadOptions: input => this.getOptions(field, input),
+          async: true,
+          cache: false,
+          onSelectResetsInput: false,
+          onCloseResetsInput: false,
+          onBlurResetsInput: false,
+          autoload: true,
+        }
+      : {};
+
+  renderBody() {
+    const {integrationDetails} = this.state;
+    const {action, group, integration} = this.props;
+    const config = integrationDetails[`${action}IssueConfig`];
+
+    const initialData = {};
+    config.forEach(field => {
+      // passing an empty array breaks multi select
+      // TODO(jess): figure out why this is breaking and fix
+      initialData[field.name] = field.multiple ? '' : field.default;
+    });
+
+    return (
+      <Form
+        apiEndpoint={`/groups/${group.id}/integrations/${integration.id}/`}
+        apiMethod={action === 'create' ? 'POST' : 'PUT'}
+        onSubmitSuccess={this.onSubmitSuccess}
+        initialData={initialData}
+        onFieldChange={this.onFieldChange}
+        submitLabel={SUBMIT_LABEL_BY_ACTION[action]}
+        submitDisabled={this.state.reloading}
+        footerClass="modal-footer"
+      >
+        {config.map(field => (
+          <FieldFromConfig
+            key={`${field.name}-${field.default}`}
+            field={field}
+            inline={false}
+            stacked
+            flexibleControlStateSize
+            disabled={this.state.reloading}
+            {...this.getFieldProps(field)}
+          />
+        ))}
+      </Form>
+    );
+  }
+}
+
+export class SentryAppExternalIssueForm extends React.Component {
+  static propTypes = {
+    group: SentryTypes.Group.isRequired,
+    sentryAppInstallation: PropTypes.object,
+    config: PropTypes.object.isRequired,
+    action: PropTypes.oneOf(['link', 'create']),
+    onSubmitSuccess: PropTypes.func,
+  };
+
+  onSubmitSuccess = issue => {
+    ExternalIssueStore.add(issue);
+    this.props.onSubmitSuccess(issue);
+  };
+
+  render() {
+    const {sentryAppInstallation} = this.props;
+    const config = this.props.config[this.props.action];
+    const requiredFields = config.required_fields || [];
+    const optionalFields = config.optional_fields || [];
+
+    if (!sentryAppInstallation) {
+      return '';
+    }
+
+    return (
+      <Form
+        apiEndpoint={`/sentry-app-installations/${sentryAppInstallation.uuid}/external-issues/`}
+        apiMethod="POST"
+        onSubmitSuccess={this.onSubmitSuccess}
+        initialData={{
+          action: this.props.action,
+          groupId: this.props.group.id,
+          uri: config.uri,
+        }}
+      >
+        {requiredFields.map(field => {
+          field.choices = field.choices || [];
+
+          return (
+            <FieldFromConfig
+              key={`${field.name}`}
+              field={field}
+              inline={false}
+              stacked
+              flexibleControlStateSize
+              required={true}
+            />
+          );
+        })}
+
+        {optionalFields.map(field => {
+          field.choices = field.choices || [];
+
+          return (
+            <FieldFromConfig
+              key={`${field.name}`}
+              field={field}
+              inline={false}
+              stacked
+              flexibleControlStateSize
+            />
+          );
+        })}
+      </Form>
+    );
+  }
+}
+
+export default ExternalIssueForm;

--- a/src/sentry/static/sentry/app/components/group/externalIssuesList.jsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssuesList.jsx
@@ -1,17 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import withApi from 'app/utils/withApi';
 import AsyncComponent from 'app/components/asyncComponent';
-import ExternalIssueActions from 'app/components/group/externalIssueActions';
+import ExternalIssueActions, {
+  SentryAppExternalIssueActions,
+} from 'app/components/group/externalIssueActions';
 import IssueSyncListElement from 'app/components/issueSyncListElement';
 import AlertLink from 'app/components/alertLink';
 import SentryTypes from 'app/sentryTypes';
 import PluginActions from 'app/components/group/pluginActions';
 import {Box} from 'grid-emotion';
 import {t} from 'app/locale';
+import SentryAppInstallationStore from 'app/stores/sentryAppInstallationsStore';
+import ExternalIssueStore from 'app/stores/externalIssueStore';
 
 class ExternalIssueList extends AsyncComponent {
   static propTypes = {
+    api: PropTypes.object.isRequired,
     group: SentryTypes.Group.isRequired,
     project: SentryTypes.Project.isRequired,
     orgId: PropTypes.string,
@@ -20,6 +26,71 @@ class ExternalIssueList extends AsyncComponent {
   getEndpoints() {
     const {group} = this.props;
     return [['integrations', `/groups/${group.id}/integrations/`]];
+  }
+
+  constructor(props) {
+    super(props);
+    this.unsubscribables = [];
+    this.state = {
+      components: [],
+      sentryAppInstallations: [],
+      externalIssues: [],
+    };
+  }
+
+  componentWillMount() {
+    super.componentWillMount();
+
+    this.unsubscribables = [
+      SentryAppInstallationStore.listen(this.onSentryAppInstallationChange),
+      ExternalIssueStore.listen(this.onExternalIssueChange),
+    ];
+
+    this.fetchSentryAppData();
+  }
+
+  componentWillUnmount() {
+    this.unsubscribables.forEach(u => u.unsubscribe());
+  }
+
+  onSentryAppInstallationChange = sentryAppInstallations => {
+    this.setState({sentryAppInstallations});
+  };
+
+  onExternalIssueChange = externalIssues => {
+    this.setState({externalIssues});
+  };
+
+  // We want to do this explicitly so that we can handle errors gracefully,
+  // instead of the entire component not rendering.
+  //
+  // Part of the API request here is fetching data from the Sentry App, so
+  // we need to be more conservative about error cases since we don't have
+  // control over those services.
+  //
+  fetchSentryAppData() {
+    const {api, orgId, group, project} = this.props;
+
+    api
+      .requestPromise(
+        `/organizations/${orgId}/sentry-app-components/?filter=issue-link&projectId=${project.id}`
+      )
+      .then(data => {
+        this.setState({components: data});
+      })
+      .catch(error => {
+        return;
+      });
+
+    api
+      .requestPromise(`/groups/${group.id}/external-issues/`)
+      .then(data => {
+        ExternalIssueStore.load(data);
+        this.setState({externalIssues: data});
+      })
+      .catch(error => {
+        return;
+      });
   }
 
   renderIntegrationIssues(integrations = []) {
@@ -38,6 +109,34 @@ class ExternalIssueList extends AsyncComponent {
           />
         ))
       : null;
+  }
+
+  renderSentryAppIssues() {
+    const {externalIssues, sentryAppInstallations, components} = this.state;
+    const {group} = this.props;
+    const issueLinkComponents = components.filter(c => c.type === 'issue-link');
+
+    if (issueLinkComponents.length == 0) {
+      return null;
+    }
+
+    return issueLinkComponents.map(component => {
+      const {sentryApp} = component;
+      const installation = sentryAppInstallations.find(
+        i => i.sentryApp.uuid === sentryApp.uuid
+      );
+      const issue = (externalIssues || []).find(i => i.serviceType == sentryApp.slug);
+
+      return (
+        <SentryAppExternalIssueActions
+          key={sentryApp.slug}
+          group={group}
+          sentryAppComponent={component}
+          sentryAppInstallation={installation}
+          externalIssue={issue}
+        />
+      );
+    });
   }
 
   renderPluginIssues() {
@@ -67,11 +166,12 @@ class ExternalIssueList extends AsyncComponent {
   }
 
   renderBody() {
+    const sentryAppIssues = this.renderSentryAppIssues();
     const integrationIssues = this.renderIntegrationIssues(this.state.integrations);
     const pluginIssues = this.renderPluginIssues();
     const pluginActions = this.renderPluginActions();
 
-    if (!integrationIssues && !pluginIssues && !pluginActions)
+    if (!sentryAppIssues && !integrationIssues && !pluginIssues && !pluginActions) {
       return (
         <React.Fragment>
           <h6 data-test-id="linked-issues">
@@ -87,12 +187,14 @@ class ExternalIssueList extends AsyncComponent {
           </AlertLink>
         </React.Fragment>
       );
+    }
 
     return (
       <React.Fragment>
         <h6 data-test-id="linked-issues">
           <span>Linked Issues</span>
         </h6>
+        {sentryAppIssues && <Box mb={2}>{sentryAppIssues}</Box>}
         {integrationIssues && <Box mb={2}>{integrationIssues}</Box>}
         {pluginIssues && <Box mb={2}>{pluginIssues}</Box>}
         {pluginActions && <Box mb={2}>{pluginActions}</Box>}
@@ -101,4 +203,4 @@ class ExternalIssueList extends AsyncComponent {
   }
 }
 
-export default ExternalIssueList;
+export default withApi(ExternalIssueList);

--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -25,6 +25,7 @@ const GroupSidebar = createReactClass({
     group: SentryTypes.Group,
     event: SentryTypes.Event,
     environments: PropTypes.arrayOf(SentryTypes.Environment),
+    sentryAppInstallations: PropTypes.array,
   },
 
   contextTypes: {
@@ -232,7 +233,7 @@ const GroupSidebar = createReactClass({
   },
 
   render() {
-    const {group, project} = this.props;
+    const {group, project, sentryAppInstallations} = this.props;
     const projectId = project.slug;
     const organization = this.getOrganization();
 
@@ -252,6 +253,7 @@ const GroupSidebar = createReactClass({
           group={this.props.group}
           project={project}
           orgId={organization.slug}
+          sentryAppInstallations={sentryAppInstallations}
         />
 
         {this.renderPluginIssue()}

--- a/src/sentry/static/sentry/app/components/issueSyncListElement.jsx
+++ b/src/sentry/static/sentry/app/components/issueSyncListElement.jsx
@@ -12,7 +12,7 @@ const hoverCardContainer = css`
   min-width: 0; /* flex-box overflow workaround */
 `;
 
-class IssueSyncElement extends React.Component {
+class IssueSyncListElement extends React.Component {
   static propTypes = {
     externalIssueLink: PropTypes.string,
     externalIssueId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -120,7 +120,7 @@ class IssueSyncElement extends React.Component {
   }
 }
 
-const IssueSyncListElementContainer = styled('div')`
+export const IssueSyncListElementContainer = styled('div')`
   line-height: 0;
   display: flex;
   align-items: center;
@@ -131,7 +131,7 @@ const IssueSyncListElementContainer = styled('div')`
   }
 `;
 
-const IntegrationIcon = styled(InlineSvg)`
+export const IntegrationIcon = styled(InlineSvg)`
   color: ${p => p.theme.gray4};
   width: ${space(3)};
   height: ${space(3)};
@@ -139,7 +139,7 @@ const IntegrationIcon = styled(InlineSvg)`
   flex-shrink: 0;
 `;
 
-const IntegrationLink = styled('a')`
+export const IntegrationLink = styled('a')`
   text-decoration: none;
   padding-bottom: ${space(0.25)};
   margin-left: ${space(1)};
@@ -157,7 +157,7 @@ const IntegrationLink = styled('a')`
   }
 `;
 
-const OpenCloseIcon = styled(InlineSvg)`
+export const OpenCloseIcon = styled(InlineSvg)`
   height: ${space(1.5)};
   color: ${p => p.theme.gray4};
   transition: 0.2s transform;
@@ -168,4 +168,4 @@ const OpenCloseIcon = styled(InlineSvg)`
   ${p => (p.isLinked ? '' : 'transform: rotate(45deg) scale(0.9);')};
 `;
 
-export default IssueSyncElement;
+export default IssueSyncListElement;

--- a/src/sentry/static/sentry/app/stores/externalIssueStore.jsx
+++ b/src/sentry/static/sentry/app/stores/externalIssueStore.jsx
@@ -1,0 +1,33 @@
+import Reflux from 'reflux';
+
+const ExternalIssueStore = Reflux.createStore({
+  init() {
+    this.items = [];
+  },
+
+  getInitialState() {
+    return this.items;
+  },
+
+  load(items) {
+    this.items = items;
+    this.trigger(items);
+  },
+
+  get(id) {
+    return this.items.find(item => item.id === id);
+  },
+
+  getAll() {
+    return this.items;
+  },
+
+  add(issue) {
+    if (!this.items.some(i => i.id === issue.id)) {
+      this.items = this.items.concat([issue]);
+      this.trigger(this.items);
+    }
+  },
+});
+
+export default ExternalIssueStore;

--- a/src/sentry/static/sentry/app/stores/sentryAppInstallationsStore.jsx
+++ b/src/sentry/static/sentry/app/stores/sentryAppInstallationsStore.jsx
@@ -1,0 +1,26 @@
+import Reflux from 'reflux';
+
+const SentryAppInstallationStore = Reflux.createStore({
+  init() {
+    this.items = [];
+  },
+
+  getInitialState() {
+    return this.items;
+  },
+
+  load(items) {
+    this.items = items;
+    this.trigger(items);
+  },
+
+  get(uuid) {
+    return this.items.find(item => item.uuid === uuid);
+  },
+
+  getAll() {
+    return this.items;
+  },
+});
+
+export default SentryAppInstallationStore;

--- a/src/sentry/static/sentry/app/stores/sentryAppStore.jsx
+++ b/src/sentry/static/sentry/app/stores/sentryAppStore.jsx
@@ -1,0 +1,26 @@
+import Reflux from 'reflux';
+
+const SentryAppStore = Reflux.createStore({
+  init() {
+    this.items = [];
+  },
+
+  getInitialState() {
+    return this.items;
+  },
+
+  load(items) {
+    this.items = items;
+    this.trigger(items);
+  },
+
+  get(slug) {
+    return this.items.find(item => item.slug === slug);
+  },
+
+  getAll() {
+    return this.items;
+  },
+});
+
+export default SentryAppStore;

--- a/src/sentry/static/sentry/app/utils/fetchSentryAppInstallations.jsx
+++ b/src/sentry/static/sentry/app/utils/fetchSentryAppInstallations.jsx
@@ -1,0 +1,37 @@
+import {Client} from 'app/api';
+
+import SentryAppInstallationStore from 'app/stores/sentryAppInstallationsStore';
+import SentryAppStore from 'app/stores/sentryAppStore';
+
+const fetchSentryAppInstallations = orgSlug => {
+  const api = new Client();
+  const sentryAppsUri = '/sentry-apps/';
+  const installsUri = `/organizations/${orgSlug}/sentry-app-installations/`;
+
+  function updateSentryAppStore(sentryApps) {
+    SentryAppStore.load(sentryApps);
+  }
+
+  function fetchInstalls() {
+    api
+      .requestPromise(installsUri)
+      .then(installs => installs.map(setSentryApp))
+      .then(updateInstallStore);
+  }
+
+  function setSentryApp(install) {
+    install.sentryApp = SentryAppStore.get(install.app.slug);
+    return install;
+  }
+
+  function updateInstallStore(installs) {
+    SentryAppInstallationStore.load(installs);
+  }
+
+  api
+    .requestPromise(sentryAppsUri)
+    .then(updateSentryAppStore)
+    .then(fetchInstalls);
+};
+
+export default fetchSentryAppInstallations;

--- a/src/sentry/static/sentry/app/utils/withSentryAppInstallations.jsx
+++ b/src/sentry/static/sentry/app/utils/withSentryAppInstallations.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+import {Client} from 'app/api';
+import SentryTypes from 'app/sentryTypes';
+import getDisplayName from 'app/utils/getDisplayName';
+import SentryAppInstallationStore from 'app/stores/sentryAppInstallationsStore';
+
+const withSentryAppInstallations = WrappedComponent => {
+  class WithSentryAppInstallations extends React.Component {
+    static displayName = `withSentryAppInstallations(${getDisplayName(
+      WrappedComponent
+    )})`;
+
+    static propTypes = {
+      project: SentryTypes.Project,
+    };
+
+    constructor(props) {
+      super(props);
+      this.api = new Client();
+      this.sentryApps = [];
+    }
+
+    componentWillMount() {
+      this.fetchData();
+    }
+
+    componentWillUnmount() {
+      this.api.clear();
+    }
+
+    fetchData() {
+      const slug = this.props.project.organization.slug;
+
+      this.api
+        .requestPromise(`/organizations/${slug}/sentry-apps/`)
+        .then(data => {
+          this.sentryApps = data;
+          this.fetchInstallations();
+        })
+        .catch(this.gracefullyFail);
+    }
+
+    fetchInstallations() {
+      const slug = this.props.project.organization.slug;
+
+      this.api
+        .requestPromise(`/organizations/${slug}/sentry-app-installations/`)
+        .then(data => {
+          data.forEach(this.addSentryApp);
+          SentryAppInstallationStore.load(data);
+        })
+        .catch(this.gracefullyFail);
+    }
+
+    addSentryApp = install => {
+      install.sentryApp = this.sentryAppByUuid(install.app.uuid);
+    };
+
+    sentryAppByUuid = uuid => {
+      return this.sentryApps.find(a => a.uuid === uuid);
+    };
+
+    gracefullyFail = () => {
+      this.installations = [];
+    };
+
+    render() {
+      return (
+        <WrappedComponent sentryAppInstallations={this.installations} {...this.props} />
+      );
+    }
+  }
+
+  return WithSentryAppInstallations;
+};
+
+export default withSentryAppInstallations;

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/groupEventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/groupEventDetails.jsx
@@ -10,6 +10,7 @@ import LoadingIndicator from 'app/components/loadingIndicator';
 import ResolutionBox from 'app/components/resolutionBox';
 import MutedBox from 'app/components/mutedBox';
 import withOrganization from 'app/utils/withOrganization';
+import fetchSentryAppInstallations from 'app/utils/fetchSentryAppInstallations';
 
 import GroupEventToolbar from './eventToolbar';
 import {fetchGroupEventAndMarkSeen} from './utils';
@@ -68,7 +69,10 @@ class GroupEventDetails extends React.Component {
           loading: false,
         });
       });
+
+    fetchSentryAppInstallations(orgSlug);
   };
+
   render() {
     const {group, project, organization, environments} = this.props;
     const evt = withMeta(this.state.event);

--- a/tests/js/fixtures/platformExternalIssue.js
+++ b/tests/js/fixtures/platformExternalIssue.js
@@ -1,0 +1,9 @@
+export function PlatformExternalIssue(params = {}) {
+  return {
+    groupId: 1,
+    serviceType: 'foo',
+    displayName: 'project#1',
+    webUrl: 'https://example.com/1',
+    ...params,
+  };
+}

--- a/tests/js/fixtures/sentryAppComponent.js
+++ b/tests/js/fixtures/sentryAppComponent.js
@@ -1,0 +1,16 @@
+export function SentryAppComponent(params = {}) {
+  return {
+    uuid: 'ed517da4-a324-44c0-aeea-1894cd9923fb',
+    type: 'issue-link',
+    schema: {
+      link: {required_fields: [{type: 'text', name: 'a', label: 'A'}]},
+      create: {required_fields: [{type: 'text', name: 'b', label: 'B'}]},
+    },
+    sentryApp: {
+      uuid: 'b468fed3-afba-4917-80d6-bdac99c1ec05',
+      slug: 'foo',
+      name: 'Foo',
+    },
+    ...params,
+  };
+}

--- a/tests/js/spec/components/group/__snapshots__/externalIssueActions.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/externalIssueActions.spec.jsx.snap
@@ -1,194 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ExternalIssueActions with an external issue linked renders 1`] = `
-<IssueSyncElement
-  externalIssueId={100}
-  externalIssueKey="getsentry/sentry#2"
-  externalIssueLink="https://github.com/MeredithAnya/testing/issues/2"
-  hoverCardBody={
-    <IntegrationItem
-      integration={
-        Object {
-          "configData": Object {},
-          "configOrganization": Array [],
-          "domainName": "github.com/test-integration",
-          "externalIssues": Array [
-            Object {
-              "id": 100,
-              "key": "getsentry/sentry#2",
-              "url": "https://github.com/MeredithAnya/testing/issues/2",
-            },
-          ],
-          "icon": "http://example.com/integration_icon.png",
-          "id": "1",
-          "name": "Test Integration",
-          "projects": Array [],
-          "provider": Object {
-            "canAdd": true,
-            "features": Array [],
-            "key": "github",
-            "name": "GitHub",
-          },
-        }
-      }
-    />
-  }
-  hoverCardHeader="Linked GitHub Integration"
-  integrationName="Test Integration"
-  integrationType="github"
-  onClose={[Function]}
-  onOpen={[Function]}
->
-  <IssueSyncListElementContainer>
-    <div
-      className="css-lh3vnw-IssueSyncListElementContainer e1vaar1z0"
-    >
-      <Hovercard
-        body={
-          <IntegrationItem
-            integration={
-              Object {
-                "configData": Object {},
-                "configOrganization": Array [],
-                "domainName": "github.com/test-integration",
-                "externalIssues": Array [
-                  Object {
-                    "id": 100,
-                    "key": "getsentry/sentry#2",
-                    "url": "https://github.com/MeredithAnya/testing/issues/2",
-                  },
-                ],
-                "icon": "http://example.com/integration_icon.png",
-                "id": "1",
-                "name": "Test Integration",
-                "projects": Array [],
-                "provider": Object {
-                  "canAdd": true,
-                  "features": Array [],
-                  "key": "github",
-                  "name": "GitHub",
-                },
-              }
-            }
-          />
-        }
-        containerClassName="css-1kx7hlk-hoverCardContainer"
-        displayTimeout={100}
-        header="Linked GitHub Integration"
-      >
-        <Container
-          className="css-1kx7hlk-hoverCardContainer"
-          innerRef={
-            Object {
-              "current": <span
-                class="css-86d5c-Container-hoverCardContainer e38w1je1"
-              >
-                <svg
-                  class="e1vaar1z1 css-ihls3x-StyledSvg-IntegrationIcon e2idor0"
-                  height="1em"
-                  viewBox="[object Object]"
-                  width="1em"
-                >
-                  <use
-                    href="#test"
-                    xlink:href="#test"
-                  />
-                </svg>
-                <a
-                  class="css-1g8yzea-IntegrationLink e1vaar1z2"
-                  href="https://github.com/MeredithAnya/testing/issues/2"
-                >
-                  getsentry/sentry#2
-                </a>
-              </span>,
-            }
-          }
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-        >
-          <span
-            className="css-86d5c-Container-hoverCardContainer e38w1je1"
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-          >
-            <IntegrationIcon
-              src="icon-github"
-            >
-              <InlineSvg
-                className="css-jn9d7y-IntegrationIcon e1vaar1z1"
-                src="icon-github"
-              >
-                <StyledSvg
-                  className="css-jn9d7y-IntegrationIcon e1vaar1z1"
-                  height="1em"
-                  viewBox={Object {}}
-                  width="1em"
-                >
-                  <svg
-                    className="e1vaar1z1 css-ihls3x-StyledSvg-IntegrationIcon e2idor0"
-                    height="1em"
-                    viewBox={Object {}}
-                    width="1em"
-                  >
-                    <use
-                      href="#test"
-                      xlinkHref="#test"
-                    />
-                  </svg>
-                </StyledSvg>
-              </InlineSvg>
-            </IntegrationIcon>
-            <IntegrationLink
-              href="https://github.com/MeredithAnya/testing/issues/2"
-            >
-              <a
-                className="css-1g8yzea-IntegrationLink e1vaar1z2"
-                href="https://github.com/MeredithAnya/testing/issues/2"
-              >
-                getsentry/sentry#2
-              </a>
-            </IntegrationLink>
-          </span>
-        </Container>
-      </Hovercard>
-      <OpenCloseIcon
-        isLinked={100}
-        onClick={[Function]}
-        src="icon-close"
-      >
-        <InlineSvg
-          className="css-92xk5s-OpenCloseIcon e1vaar1z3"
-          isLinked={100}
-          onClick={[Function]}
-          src="icon-close"
-        >
-          <StyledSvg
-            className="css-92xk5s-OpenCloseIcon e1vaar1z3"
-            height="1em"
-            isLinked={100}
-            onClick={[Function]}
-            viewBox={Object {}}
-            width="1em"
-          >
-            <svg
-              className="e1vaar1z3 css-1iszbb4-StyledSvg-OpenCloseIcon e2idor0"
-              height="1em"
-              onClick={[Function]}
-              viewBox={Object {}}
-              width="1em"
-            >
-              <use
-                href="#test"
-                xlinkHref="#test"
-              />
-            </svg>
-          </StyledSvg>
-        </InlineSvg>
-      </OpenCloseIcon>
-    </div>
-  </IssueSyncListElementContainer>
-</IssueSyncElement>
-`;
+exports[`ExternalIssueActions with an external issue linked renders 1`] = `null`;
 
 exports[`ExternalIssueActions with no external issues linked renders 1`] = `
 <ExternalIssueActions
@@ -244,7 +56,7 @@ exports[`ExternalIssueActions with no external issues linked renders 1`] = `
     }
   }
 >
-  <IssueSyncElement
+  <IssueSyncListElement
     externalIssueDisplayName={null}
     externalIssueId={null}
     externalIssueKey={null}
@@ -420,7 +232,7 @@ exports[`ExternalIssueActions with no external issues linked renders 1`] = `
         </OpenCloseIcon>
       </div>
     </IssueSyncListElementContainer>
-  </IssueSyncElement>
+  </IssueSyncListElement>
   <Modal
     animation={false}
     autoFocus={true}

--- a/tests/js/spec/components/group/externalIssueForm.spec.jsx
+++ b/tests/js/spec/components/group/externalIssueForm.spec.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import {SentryAppExternalIssueForm} from 'app/components/group/externalIssueForm';
+
+describe('SentryAppExternalIssueForm', () => {
+  let wrapper;
+  let group;
+  let sentryAppInstallation;
+  let component;
+
+  beforeEach(() => {
+    group = TestStubs.Group();
+    component = TestStubs.SentryAppComponent();
+    sentryAppInstallation = TestStubs.SentryAppInstallation();
+  });
+
+  describe('create', () => {
+    beforeEach(() => {
+      wrapper = mount(
+        <SentryAppExternalIssueForm
+          group={group}
+          sentryAppInstallation={sentryAppInstallation}
+          config={component.schema}
+          action="create"
+        />,
+        TestStubs.routerContext()
+      );
+    });
+
+    it('specifies the action', () => {
+      expect(wrapper.find('Form').prop('initialData').action).toEqual('create');
+    });
+
+    it('specifies the group', () => {
+      expect(wrapper.find('Form').prop('initialData').groupId).toEqual(group.id);
+    });
+
+    it('renders each required_fields field', () => {
+      component.schema.create.required_fields.forEach(field => {
+        expect(wrapper.exists(`#${field.name}`)).toBe(true);
+      });
+    });
+
+    it('submits to the New External Issue endpoint', () => {
+      const url = `/sentry-app-installations/${sentryAppInstallation.uuid}/external-issues/`;
+      expect(wrapper.find('Form').prop('apiEndpoint')).toEqual(url);
+      expect(wrapper.find('Form').prop('apiMethod')).toEqual('POST');
+    });
+  });
+});

--- a/tests/js/spec/components/group/sidebar.spec.jsx
+++ b/tests/js/spec/components/group/sidebar.spec.jsx
@@ -69,7 +69,7 @@ describe('GroupSidebar', function() {
     it('renders', function() {
       expect(wrapper.find('SuggestedOwners')).toHaveLength(1);
       expect(wrapper.find('GroupReleaseStats')).toHaveLength(1);
-      expect(wrapper.find('ExternalIssueList')).toHaveLength(1);
+      expect(wrapper.find('withApi(ExternalIssueList)')).toHaveLength(1);
       expect(wrapper.find('[data-test-id="group-tag"]')).toHaveLength(5);
     });
   });

--- a/tests/sentry/api/endpoints/test_sentry_app_components.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_components.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import six
 
 from django.core.urlresolvers import reverse
+from mock import patch, call
 
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import with_feature
@@ -41,7 +42,11 @@ class SentryAppComponentsTest(APITestCase):
             'uuid': six.binary_type(self.component.uuid),
             'type': 'issue-link',
             'schema': self.component.schema,
-            'sentryAppId': self.sentry_app.id,
+            'sentryApp': {
+                'uuid': self.sentry_app.uuid,
+                'slug': self.sentry_app.slug,
+                'name': self.sentry_app.name,
+            },
         }
 
 
@@ -49,6 +54,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
     def setUp(self):
         self.user = self.create_user()
         self.org = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.org)
 
         self.sentry_app1 = self.create_sentry_app(
             schema={
@@ -68,12 +74,12 @@ class OrganizationSentryAppComponentsTest(APITestCase):
             }
         )
 
-        self.create_sentry_app_installation(
+        self.install1 = self.create_sentry_app_installation(
             slug=self.sentry_app1.slug,
             organization=self.org,
         )
 
-        self.create_sentry_app_installation(
+        self.install2 = self.create_sentry_app_installation(
             slug=self.sentry_app2.slug,
             organization=self.org,
         )
@@ -82,15 +88,19 @@ class OrganizationSentryAppComponentsTest(APITestCase):
         self.component2 = self.sentry_app2.components.first()
         self.component3 = self.sentry_app3.components.first()
 
-        self.url = reverse(
-            'sentry-api-0-org-sentry-app-components',
-            args=[self.org.slug],
+        self.url = u'{}?projectId={}'.format(
+            reverse(
+                'sentry-api-0-org-sentry-app-components',
+                args=[self.org.slug],
+            ),
+            self.project.id,
         )
 
         self.login_as(user=self.user)
 
     @with_feature('organizations:sentry-apps')
-    def test_retrieves_all_components_for_installed_apps(self):
+    @patch('sentry.mediators.sentry_app_components.Preparer.run')
+    def test_retrieves_all_components_for_installed_apps(self, run):
         response = self.client.get(self.url, format='json')
 
         assert response.status_code == 200
@@ -100,12 +110,91 @@ class OrganizationSentryAppComponentsTest(APITestCase):
                 'uuid': six.binary_type(self.component1.uuid),
                 'type': 'issue-link',
                 'schema': self.component1.schema,
-                'sentryAppId': self.sentry_app1.id,
+                'sentryApp': {
+                    'uuid': self.sentry_app1.uuid,
+                    'slug': self.sentry_app1.slug,
+                    'name': self.sentry_app1.name,
+                },
             },
             {
                 'uuid': six.binary_type(self.component2.uuid),
                 'type': 'issue-link',
                 'schema': self.component2.schema,
-                'sentryAppId': self.sentry_app2.id,
+                'sentryApp': {
+                    'uuid': self.sentry_app2.uuid,
+                    'slug': self.sentry_app2.slug,
+                    'name': self.sentry_app2.name,
+                },
             },
         ]
+
+    @with_feature('organizations:sentry-apps')
+    @patch('sentry.mediators.sentry_app_components.Preparer.run')
+    def test_project_not_owned_by_org(self, run):
+        org = self.create_organization(owner=self.create_user())
+        project = self.create_project(organization=org)
+
+        response = self.client.get(
+            '{}?projectId={}'.format(
+                reverse('sentry-api-0-org-sentry-app-components', args=[self.org.slug]),
+                project.id,
+            ),
+            format='json',
+        )
+
+        assert response.status_code == 404
+        assert response.data == []
+
+    @with_feature('organizations:sentry-apps')
+    @patch('sentry.mediators.sentry_app_components.Preparer.run')
+    def test_filter_by_type(self, run):
+        sentry_app = self.create_sentry_app(
+            schema={
+                'elements': [{'type': 'alert-rule'}],
+            }
+        )
+
+        self.create_sentry_app_installation(
+            slug=sentry_app.slug,
+            organization=self.org,
+        )
+
+        component = sentry_app.components.first()
+
+        response = self.client.get(
+            u'{}&filter=alert-rule'.format(self.url),
+            format='json',
+        )
+
+        assert response.data == [
+            {
+                'uuid': six.binary_type(component.uuid),
+                'type': 'alert-rule',
+                'schema': component.schema,
+                'sentryApp': {
+                    'uuid': sentry_app.uuid,
+                    'slug': sentry_app.slug,
+                    'name': sentry_app.name,
+                },
+            }
+        ]
+
+    @with_feature('organizations:sentry-apps')
+    @patch('sentry.mediators.sentry_app_components.Preparer.run')
+    def test_prepares_each_component(self, run):
+        self.client.get(self.url, format='json')
+
+        calls = [
+            call(
+                component=self.component1,
+                install=self.install1,
+                project=self.project,
+            ),
+            call(
+                component=self.component2,
+                install=self.install2,
+                project=self.project,
+            ),
+        ]
+
+        run.assert_has_calls(calls, any_order=True)

--- a/tests/sentry/api/endpoints/test_sentry_app_installation_external_requests.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_installation_external_requests.py
@@ -52,7 +52,7 @@ class SentryAppInstallationExternalRequestsEndpointTest(APITestCase):
         response = self.client.get(url, format='json')
         assert response.status_code == 200
         assert response.data == {
-            'choices': [['Project Name', '1234']]
+            'choices': [['1234', 'Project Name']]
         }
 
     @responses.activate

--- a/tests/sentry/mediators/external_requests/test_select_requester.py
+++ b/tests/sentry/mediators/external_requests/test_select_requester.py
@@ -44,7 +44,10 @@ class TestSelectRequester(TestCase):
         ]
         responses.add(
             method=responses.GET,
-            url='https://example.com/get-issues?projectSlug=boop&installationId=f3d37e3a-9a87-4651-8463-d375118f4996',
+            url=u'https://example.com/get-issues?installationId={}&projectSlug={}'.format(
+                self.install.uuid,
+                self.project.slug,
+            ),
             json=options,
             status=200,
             content_type='application/json',
@@ -55,12 +58,13 @@ class TestSelectRequester(TestCase):
             project=self.project,
             uri='/get-issues',
         )
+
         assert result == {
             'choices': [
-                ['An Issue', '123'],
-                ['Another Issue', '456']
+                ['123', 'An Issue'],
+                ['456', 'Another Issue']
             ],
-            'default': ['An Issue', '123'],
+            'defaultValue': '123',
         }
 
         request = responses.calls[0].request
@@ -74,7 +78,10 @@ class TestSelectRequester(TestCase):
         }
         responses.add(
             method=responses.GET,
-            url='https://example.com/get-issues?projectSlug=boop&installationId=f3d37e3a-9a87-4651-8463-d375118f4996',
+            url=u'https://example.com/get-issues?installationId={}&projectSlug={}'.format(
+                self.install.uuid,
+                self.project.slug,
+            ),
             json=invalid_format,
             status=200,
             content_type='application/json',
@@ -93,7 +100,10 @@ class TestSelectRequester(TestCase):
     def test_500_response(self):
         responses.add(
             method=responses.GET,
-            url='https://example.com/get-issues?projectSlug=boop&installationId=f3d37e3a-9a87-4651-8463-d375118f4996',
+            url=u'https://example.com/get-issues?installationId={}&projectSlug={}'.format(
+                self.install.uuid,
+                self.project.slug,
+            ),
             body='Something failed',
             status=500,
         )

--- a/tests/sentry/mediators/sentry_app_components/test_preparer.py
+++ b/tests/sentry/mediators/sentry_app_components/test_preparer.py
@@ -1,0 +1,89 @@
+from __future__ import absolute_import
+
+from mock import patch, call
+
+from sentry.mediators.sentry_app_components import Preparer
+from sentry.testutils import TestCase
+
+
+class TestPreparerIssueLink(TestCase):
+    def setUp(self):
+        super(TestPreparerIssueLink, self).setUp()
+
+        self.sentry_app = self.create_sentry_app(
+            schema={
+                'elements': [self.create_issue_link_schema()]
+            }
+        )
+
+        self.install = self.create_sentry_app_installation(
+            slug=self.sentry_app.slug,
+        )
+
+        self.component = self.sentry_app.components.first()
+        self.project = self.install.organization.project_set.first()
+
+        self.preparer = Preparer(
+            component=self.component,
+            install=self.install,
+            project=self.project,
+        )
+
+    @patch('sentry.mediators.external_requests.SelectRequester.run')
+    def test_prepares_components_requiring_requests(self, run):
+        self.component.schema = {
+            'link': {
+                'required_fields': [{
+                    'type': 'select',
+                    'name': 'foo',
+                    'label': 'Foo',
+                    'uri': '/sentry/foo',
+                }],
+                'optional_fields': [{
+                    'type': 'select',
+                    'name': 'beep',
+                    'label': 'Beep',
+                    'uri': '/sentry/beep',
+                }],
+            },
+            'create': {
+                'required_fields': [{
+                    'type': 'select',
+                    'name': 'bar',
+                    'label': 'Bar',
+                    'uri': '/sentry/bar',
+                }],
+                'optional_fields': [{
+                    'type': 'select',
+                    'name': 'baz',
+                    'label': 'Baz',
+                    'uri': '/sentry/baz',
+                }],
+            }
+        }
+
+        self.preparer.call()
+
+        assert call(
+            install=self.install,
+            project=self.project,
+            uri='/sentry/foo',
+        ) in run.mock_calls
+
+        assert call(
+            install=self.install,
+            project=self.project,
+            uri='/sentry/beep',
+        ) in run.mock_calls
+
+        assert call(
+            install=self.install,
+            project=self.project,
+            uri='/sentry/bar',
+        ) in run.mock_calls
+
+        assert call(
+            install=self.install,
+            project=self.project,
+            uri='/sentry/baz',
+        ) in run.mock_calls


### PR DESCRIPTION
**TL;DR:** Adds the necessary UI components (and some backend pieces) to render a Sentry App's "Issue Link" integration alongside the explicit ones for JIRA/GitHub/Azure/etc.

## Summary

This essentially adds copies of the existing "External Issue" components. It adds copies, instead of modifying the existing ones, because the existing ones are so tightly coupled with Integrations that it'd be a nightmare to tease apart, but also very messy (I tried).

## Preparing Sentry App Components

When we request the list of Sentry App Components for an Org, we preemptively "prepare" them. Many of these components require making a request to the Sentry App service to get things like `SelectField` options. We do this ahead of time, instead of JIT, so that if something goes wrong in the process, we can gracefully handle the error by simply not rendering the React component at all.

## Not Using `getEndpoints()`

To retrieve the above, prepared, data we explicitly make a request using `this.api` inside of `ExternalIssuesList`, instead of using `getEndpoints`. We do this so that we can control what happens when an error arises (since this process potentially includes two distributed systems). When this does happen, we simply don't render anything.

Handling every error condition when there's two systems, one of which we have no control over, is not realistically achievable, so we bank on this conservative approach.

## Minor Changes

- Moved `ExternalIssueForm` into it's own file.
- Renamed `IssueSyncElement` to `IssueSyncListElement` to match its filename and how other components were consuming it.
- Added the ability to `filter` Sentry App Components via the API.