### PR TITLE
fix(tests) Dismiss the assistant in tests

### DIFF
--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -27,6 +27,7 @@ class IssueDetailsTest(AcceptanceTestCase):
             name='Bengal',
         )
         self.login_as(self.user)
+        self.dismiss_assistant()
 
     def create_sample_event(self, platform, default=None, sample_name=None):
         event = create_sample_event(
@@ -47,7 +48,6 @@ class IssueDetailsTest(AcceptanceTestCase):
             platform='python',
         )
 
-        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
@@ -59,7 +59,6 @@ class IssueDetailsTest(AcceptanceTestCase):
             platform='cocoa',
         )
 
-        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
@@ -72,7 +71,6 @@ class IssueDetailsTest(AcceptanceTestCase):
             platform='csharp'
         )
 
-        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
@@ -85,7 +83,6 @@ class IssueDetailsTest(AcceptanceTestCase):
             platform='csharp'
         )
 
-        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
@@ -115,7 +112,6 @@ class IssueDetailsTest(AcceptanceTestCase):
             sample_name='Rust',
         )
 
-        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
@@ -138,8 +134,6 @@ class IssueDetailsTest(AcceptanceTestCase):
         event = self.create_sample_event(
             platform='pii'
         )
-
-        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
@@ -151,7 +145,6 @@ class IssueDetailsTest(AcceptanceTestCase):
             platform='empty-exception'
         )
 
-        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
@@ -163,7 +156,6 @@ class IssueDetailsTest(AcceptanceTestCase):
             platform='empty-stacktrace'
         )
 
-        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
@@ -175,7 +167,6 @@ class IssueDetailsTest(AcceptanceTestCase):
             platform='invalid-interfaces'
         )
 
-        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
@@ -189,7 +180,6 @@ class IssueDetailsTest(AcceptanceTestCase):
             platform='python',
         )
 
-        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/activity/'.format(
                 self.org.slug, self.project.slug, event.group.id)

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -205,3 +205,4 @@ class IssueDetailsTest(AcceptanceTestCase):
 
     def dismiss_assistant(self):
         self.client.put('/assistant/', data={'guide_id': 1, 'status': 'viewed', 'useful': True})
+        self.client.put('/assistant/', data={'guide_id': 3, 'status': 'viewed', 'useful': True})

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -47,6 +47,7 @@ class IssueDetailsTest(AcceptanceTestCase):
             platform='python',
         )
 
+        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
@@ -58,6 +59,7 @@ class IssueDetailsTest(AcceptanceTestCase):
             platform='cocoa',
         )
 
+        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
@@ -70,6 +72,7 @@ class IssueDetailsTest(AcceptanceTestCase):
             platform='csharp'
         )
 
+        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
@@ -82,6 +85,7 @@ class IssueDetailsTest(AcceptanceTestCase):
             platform='csharp'
         )
 
+        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
@@ -93,6 +97,7 @@ class IssueDetailsTest(AcceptanceTestCase):
             platform='javascript'
         )
 
+        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/events/{}/'.format(self.org.slug,
                                                   self.project.slug, event.group.id, event.id)
@@ -110,6 +115,7 @@ class IssueDetailsTest(AcceptanceTestCase):
             sample_name='Rust',
         )
 
+        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
@@ -121,6 +127,7 @@ class IssueDetailsTest(AcceptanceTestCase):
             platform='cordova'
         )
 
+        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
@@ -132,6 +139,7 @@ class IssueDetailsTest(AcceptanceTestCase):
             platform='pii'
         )
 
+        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
@@ -143,6 +151,7 @@ class IssueDetailsTest(AcceptanceTestCase):
             platform='empty-exception'
         )
 
+        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
@@ -154,6 +163,7 @@ class IssueDetailsTest(AcceptanceTestCase):
             platform='empty-stacktrace'
         )
 
+        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
@@ -165,6 +175,7 @@ class IssueDetailsTest(AcceptanceTestCase):
             platform='invalid-interfaces'
         )
 
+        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/'.format(self.org.slug, self.project.slug, event.group.id)
         )
@@ -178,6 +189,7 @@ class IssueDetailsTest(AcceptanceTestCase):
             platform='python',
         )
 
+        self.dismiss_assistant()
         self.browser.get(
             u'/{}/{}/issues/{}/activity/'.format(
                 self.org.slug, self.project.slug, event.group.id)
@@ -190,3 +202,6 @@ class IssueDetailsTest(AcceptanceTestCase):
         self.browser.wait_until('.entries')
         self.browser.wait_until('[data-test-id="linked-issues"]')
         self.browser.wait_until('[data-test-id="loaded-device-name"]')
+
+    def dismiss_assistant(self):
+        self.client.put('/assistant/', data={'guide_id': 1, 'status': 'viewed', 'useful': True})

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 
+import json
+
 from datetime import datetime
+from django.conf import settings
 from django.utils import timezone
 
 from sentry.testutils import AcceptanceTestCase
@@ -194,5 +197,17 @@ class IssueDetailsTest(AcceptanceTestCase):
         self.browser.wait_until('[data-test-id="loaded-device-name"]')
 
     def dismiss_assistant(self):
-        self.client.put('/assistant/', data={'guide_id': 1, 'status': 'viewed', 'useful': True})
-        self.client.put('/assistant/', data={'guide_id': 3, 'status': 'viewed', 'useful': True})
+        # Forward session cookie to django client.
+        self.client.cookies[settings.SESSION_COOKIE_NAME] = self.session.session_key
+
+        res = self.client.put(
+            '/api/0/assistant/',
+            content_type='application/json',
+            data=json.dumps({'guide_id': 1, 'status': 'viewed', 'useful': True}))
+        assert res.status_code == 201
+
+        res = self.client.put(
+            '/api/0/assistant/',
+            content_type='application/json',
+            data=json.dumps({'guide_id': 3, 'status': 'viewed', 'useful': True}))
+        assert res.status_code == 201


### PR DESCRIPTION
By dismissing the assistant ahead of time we shouldn't ever see it in visual snapshots.