### PR TITLE
fix(monitors): Better handle deletion states

### DIFF
--- a/src/sentry/tasks/check_monitors.py
+++ b/src/sentry/tasks/check_monitors.py
@@ -24,7 +24,10 @@ def check_monitors(current_datetime=None):
         type__in=[MonitorType.HEARTBEAT, MonitorType.CRON_JOB],
         next_checkin__lt=current_datetime,
     ).exclude(
-        status=MonitorStatus.DISABLED,
+        status__in=[
+            MonitorStatus.DISABLED,
+            MonitorStatus.PENDING_DELETION,
+            MonitorStatus.DELETION_IN_PROGRESS],
     )[:10000]
     for monitor in qs:
         logger.info('monitor.missed-checkin', extra={

--- a/tests/sentry/api/endpoints/test_monitor_checkins.py
+++ b/tests/sentry/api/endpoints/test_monitor_checkins.py
@@ -67,3 +67,80 @@ class CreateMonitorCheckInTest(APITestCase):
         assert monitor.status == MonitorStatus.ERROR
         assert monitor.last_checkin == checkin.date_added
         assert monitor.next_checkin == monitor.get_next_scheduled_checkin(checkin.date_added)
+
+    def test_disabled(self):
+        user = self.create_user()
+        org = self.create_organization(owner=user)
+        team = self.create_team(organization=org, members=[user])
+        project = self.create_project(teams=[team])
+
+        monitor = Monitor.objects.create(
+            organization_id=org.id,
+            project_id=project.id,
+            next_checkin=timezone.now() - timedelta(minutes=1),
+            type=MonitorType.CRON_JOB,
+            status=MonitorStatus.DISABLED,
+            config={'schedule': '* * * * *'},
+        )
+
+        self.login_as(user=user)
+        with self.feature({'organizations:monitors': True}):
+            resp = self.client.post('/api/0/monitors/{}/checkins/'.format(monitor.guid), data={
+                'status': 'error'
+            })
+
+        assert resp.status_code == 201, resp.content
+
+        checkin = MonitorCheckIn.objects.get(guid=resp.data['id'])
+        assert checkin.status == CheckInStatus.ERROR
+
+        monitor = Monitor.objects.get(id=monitor.id)
+        assert monitor.status == MonitorStatus.DISABLED
+        assert monitor.last_checkin == checkin.date_added
+        assert monitor.next_checkin == monitor.get_next_scheduled_checkin(checkin.date_added)
+
+    def test_pending_deletion(self):
+        user = self.create_user()
+        org = self.create_organization(owner=user)
+        team = self.create_team(organization=org, members=[user])
+        project = self.create_project(teams=[team])
+
+        monitor = Monitor.objects.create(
+            organization_id=org.id,
+            project_id=project.id,
+            next_checkin=timezone.now() - timedelta(minutes=1),
+            type=MonitorType.CRON_JOB,
+            status=MonitorStatus.PENDING_DELETION,
+            config={'schedule': '* * * * *'},
+        )
+
+        self.login_as(user=user)
+        with self.feature({'organizations:monitors': True}):
+            resp = self.client.post('/api/0/monitors/{}/checkins/'.format(monitor.guid), data={
+                'status': 'error'
+            })
+
+        assert resp.status_code == 404, resp.content
+
+    def test_deletion_in_progress(self):
+        user = self.create_user()
+        org = self.create_organization(owner=user)
+        team = self.create_team(organization=org, members=[user])
+        project = self.create_project(teams=[team])
+
+        monitor = Monitor.objects.create(
+            organization_id=org.id,
+            project_id=project.id,
+            next_checkin=timezone.now() - timedelta(minutes=1),
+            type=MonitorType.CRON_JOB,
+            status=MonitorStatus.DELETION_IN_PROGRESS,
+            config={'schedule': '* * * * *'},
+        )
+
+        self.login_as(user=user)
+        with self.feature({'organizations:monitors': True}):
+            resp = self.client.post('/api/0/monitors/{}/checkins/'.format(monitor.guid), data={
+                'status': 'error'
+            })
+
+        assert resp.status_code == 404, resp.content

--- a/tests/sentry/tasks/test_check_monitors.py
+++ b/tests/sentry/tasks/test_check_monitors.py
@@ -29,6 +29,66 @@ class CheckMonitorsTest(TestCase):
             status=MonitorStatus.ERROR,
         ).exists()
 
+    def test_missing_checkin_but_disabled(self):
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+
+        monitor = Monitor.objects.create(
+            organization_id=org.id,
+            project_id=project.id,
+            next_checkin=timezone.now() - timedelta(minutes=1),
+            type=MonitorType.CRON_JOB,
+            config={'schedule': '* * * * *'},
+            status=MonitorStatus.DISABLED,
+        )
+
+        check_monitors()
+
+        assert Monitor.objects.filter(
+            id=monitor.id,
+            status=MonitorStatus.DISABLED,
+        ).exists()
+
+    def test_missing_checkin_but_pending_deletion(self):
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+
+        monitor = Monitor.objects.create(
+            organization_id=org.id,
+            project_id=project.id,
+            next_checkin=timezone.now() - timedelta(minutes=1),
+            type=MonitorType.CRON_JOB,
+            config={'schedule': '* * * * *'},
+            status=MonitorStatus.PENDING_DELETION,
+        )
+
+        check_monitors()
+
+        assert Monitor.objects.filter(
+            id=monitor.id,
+            status=MonitorStatus.PENDING_DELETION,
+        ).exists()
+
+    def test_missing_checkin_but_deletion_in_progress(self):
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+
+        monitor = Monitor.objects.create(
+            organization_id=org.id,
+            project_id=project.id,
+            next_checkin=timezone.now() - timedelta(minutes=1),
+            type=MonitorType.CRON_JOB,
+            config={'schedule': '* * * * *'},
+            status=MonitorStatus.DELETION_IN_PROGRESS,
+        )
+
+        check_monitors()
+
+        assert Monitor.objects.filter(
+            id=monitor.id,
+            status=MonitorStatus.DELETION_IN_PROGRESS,
+        ).exists()
+
     def test_not_missing_checkin(self):
         org = self.create_organization()
         project = self.create_project(organization=org)


### PR DESCRIPTION
- Dont allow new checkins on deleted monitors
- Dont update monitor status on paused monitors
- Dont fail monitors that are paused or deleted and haven't checked in