### PR TITLE
feat: Do not error on queries with date ranges > 90 days

### DIFF
--- a/src/sentry/api/endpoints/organization_discover_query.py
+++ b/src/sentry/api/endpoints/organization_discover_query.py
@@ -98,7 +98,7 @@ class DiscoverQuerySerializer(serializers.Serializer):
                 'statsPeriod': data.get('statsPeriod') or data.get('range'),
                 'statsPeriodStart': data.get('statsPeriodStart'),
                 'statsPeriodEnd': data.get('statsPeriodEnd'),
-            }, optional=True, validate_window=False)
+            }, optional=True)
         except InvalidParams as exc:
             raise serializers.ValidationError(exc.message)
 

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -9,8 +9,6 @@ from sentry.utils.dates import parse_stats_period
 
 
 MAX_STATS_PERIOD = timedelta(days=90)
-# make sure to update this message if you are changing the max period
-INVALID_PERIOD_ERROR = 'Time window must be less than or equal to 90 days'
 
 
 class InvalidParams(Exception):
@@ -26,7 +24,7 @@ def get_datetime_from_stats_period(stats_period, now=None):
     return now - stats_period
 
 
-def get_date_range_from_params(params, optional=False, validate_window=True):
+def get_date_range_from_params(params, optional=False):
     """
     Gets a date range from standard date range params we pass to the api.
 
@@ -43,7 +41,6 @@ def get_date_range_from_params(params, optional=False, validate_window=True):
     If `start` end `end` are passed, validate them, convert to `datetime` and
     returns them if valid.
     :param optional: When True, if no params passed then return `(None, None)`.
-    :param validate_window: When True, validate against min / max time delta.
     :return: A length 2 tuple containing start/end or raises an `InvalidParams`
     exception
     """
@@ -78,10 +75,5 @@ def get_date_range_from_params(params, optional=False, validate_window=True):
 
     if start > end:
         raise InvalidParams('start must be before end')
-
-    if validate_window:
-        delta = end - start
-        if delta > MAX_STATS_PERIOD:
-            raise InvalidParams(INVALID_PERIOD_ERROR)
 
     return start, end

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -27,8 +27,8 @@ class GetDateRangeFromParamsTest(TestCase):
         start, end = get_date_range_from_params({'statsPeriod': '3600s'})
         assert end - datetime.timedelta(seconds=3600) == start
 
-        with self.assertRaises(InvalidParams):
-            get_date_range_from_params({'statsPeriod': '91d'})
+        start, end = get_date_range_from_params({'statsPeriod': '91d'})
+        assert end - datetime.timedelta(days=91) == start
 
     def test_date_range(self):
         start, end = get_date_range_from_params({
@@ -38,9 +38,6 @@ class GetDateRangeFromParamsTest(TestCase):
 
         assert start == datetime.datetime(2018, 11, 1, tzinfo=timezone.utc)
         assert end == datetime.datetime(2018, 11, 7, tzinfo=timezone.utc)
-
-        with self.assertRaises(InvalidParams):
-            get_date_range_from_params({'start': '2018-11-01'})
 
     @freeze_time("2018-12-11 03:21:34")
     def test_no_params(self):


### PR DESCRIPTION
Remove validation code that raises an error on any query on issues and
events that is over 90 days on any query. This causes a lot of bugs
since it is possible to select a date slightly over 90 days via the Sentry UI.