### PR TITLE
fix(ui) Going to a global saved search from a project based one

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -464,7 +464,7 @@ const OrganizationStream = createReactClass({
       }
 
       // If the saved search is project-less and the user doesn't have
-      // globao-views we retain their current project filter
+      // global-views we retain their current project filter
       // so that the backend doesn't reject their request.
       const hasMultipleProjectSelection = organization.features.includes('global-views');
       if (!savedSearch.projectId && !hasMultipleProjectSelection) {

--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -462,16 +462,19 @@ const OrganizationStream = createReactClass({
       if (savedSearch.projectId) {
         query.project = [savedSearch.projectId];
       }
+
+      // If the saved search is project-less and the user doesn't have
+      // globao-views we retain their current project filter
+      // so that the backend doesn't reject their request.
+      const hasMultipleProjectSelection = organization.features.includes('global-views');
+      if (!savedSearch.projectId && !hasMultipleProjectSelection) {
+        query.project = this.props.selection.projects;
+      }
     } else {
       path = `/organizations/${organization.slug}/issues/`;
     }
 
     if (path !== this.props.location.path && !isEqual(query, this.props.location.query)) {
-      // TODO: Delete/revert this after testing production counts cc/ @wedamija
-      if (this.props.location.query[NEW_FILTERS_TEST]) {
-        query[NEW_FILTERS_TEST] = 1;
-      }
-
       browserHistory.push({
         pathname: path,
         query,

--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -43,8 +43,6 @@ const DEFAULT_QUERY = 'is:unresolved';
 const DEFAULT_SORT = 'date';
 const DEFAULT_STATS_PERIOD = '24h';
 const STATS_PERIODS = new Set(['14d', '24h']);
-// TODO: Delete this after testing production counts cc/ @wedamija
-const NEW_FILTERS_TEST = 'use_new_filters';
 
 const OrganizationStream = createReactClass({
   displayName: 'OrganizationStream',
@@ -261,12 +259,6 @@ const OrganizationStream = createReactClass({
     const currentQuery = this.props.location.query || {};
     if ('cursor' in currentQuery) {
       requestParams.cursor = currentQuery.cursor;
-    } else if (NEW_FILTERS_TEST in currentQuery) {
-      // TODO: Delete this after testing production counts cc/ @wedamija
-      requestParams[NEW_FILTERS_TEST] = currentQuery[NEW_FILTERS_TEST];
-    } else if (ConfigStore.get('user').isSuperuser) {
-      // TODO: Delete this after testing production counts cc/ @wedamija
-      requestParams[NEW_FILTERS_TEST] = 1;
     }
 
     if (this.lastRequest) {


### PR DESCRIPTION
Going from a project based saved search to a global one should retain the current global search so that users without global views don't get a backend error.

Fixes SEN-251