### PR TITLE
fix(issues): Fix group environment filtering

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/organization/groupEvents.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/organization/groupEvents.jsx
@@ -1,7 +1,7 @@
 import {browserHistory} from 'react-router';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import {pickBy} from 'lodash';
+import {pick} from 'lodash';
 
 import SentryTypes from 'app/sentryTypes';
 import {Panel, PanelBody} from 'app/components/panels';
@@ -74,7 +74,7 @@ const GroupEvents = createReactClass({
     });
 
     const query = {
-      ...pickBy(this.props.location.query, ['cursor', 'environment']),
+      ...pick(this.props.location.query, ['cursor', 'environment']),
       limit: 50,
       query: this.state.query,
     };

--- a/tests/js/spec/views/groupDetails/organizationGroupEvents.spec.jsx
+++ b/tests/js/spec/views/groupDetails/organizationGroupEvents.spec.jsx
@@ -6,8 +6,9 @@ import {browserHistory} from 'react-router';
 import OrgnanizationGroupEvents from 'app/views/groupDetails/organization/groupEvents';
 
 describe('groupEvents', function() {
+  let request;
   beforeEach(function() {
-    MockApiClient.addMockResponse({
+    request = MockApiClient.addMockResponse({
       url: '/issues/1/events/',
       body: TestStubs.Events(),
     });
@@ -62,5 +63,27 @@ describe('groupEvents', function() {
         })
       );
     });
+  });
+
+  it('handles environment filtering', function() {
+    shallow(
+      <OrgnanizationGroupEvents
+        params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
+        group={TestStubs.Group()}
+        location={{query: {environment: ['prod', 'staging']}}}
+      />,
+      {
+        context: {...TestStubs.router()},
+        childContextTypes: {
+          router: PropTypes.object,
+        },
+      }
+    );
+    expect(request).toHaveBeenCalledWith(
+      '/issues/1/events/',
+      expect.objectContaining({
+        query: {limit: 50, query: '', environment: ['prod', 'staging']},
+      })
+    );
   });
 });


### PR DESCRIPTION
Fixes an incorrect lodash statement that was causing environment
filtering and pagination to not work on the issue detail event page.

Fixes SEN-239