### PR TITLE
feat(acl): <Feature> learns how to specify hook names

### DIFF
--- a/src/sentry/static/sentry/app/components/acl/feature.jsx
+++ b/src/sentry/static/sentry/app/components/acl/feature.jsx
@@ -65,6 +65,21 @@ class Feature extends React.Component {
     renderDisabled: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
 
     /**
+     * Specify the key to use for hookstore functionality.
+     *
+     * The hookstore key that will be checked is:
+     *
+     *     feature-disabled:{hookName}
+     *
+     * When specified, the hookstore will be checked if the feature is
+     * disabled, and the first available hook will be used as the render
+     * function.
+     *
+     * This takes precidence over the renderDisabled hookstore functionality.
+     */
+    hookName: PropTypes.string,
+
+    /**
      * If children is a function then will be treated as a render prop and
      * passed this object:
      *
@@ -125,6 +140,7 @@ class Feature extends React.Component {
       children,
       features,
       renderDisabled,
+      hookName,
       organization,
       project,
       requireAll,
@@ -143,10 +159,13 @@ class Feature extends React.Component {
 
     // Override the renderDisabled function with a hook store function if there
     // is one registered for the feature.
-    if (renderDisabled !== false && features.length === 1) {
-      HookStore.get(`feature-disabled:${descopeFeatureName(features[0])}`)
-        .slice(0, 1)
-        .map(hookFn => (customDisabledRender = hookFn));
+    if (hookName || (renderDisabled !== false && features.length === 1)) {
+      const hookKey = hookName || descopeFeatureName(features[0]);
+      const hooks = HookStore.get(`feature-disabled:${hookKey}`);
+
+      if (hooks.length > 0) {
+        customDisabledRender = hooks[0];
+      }
     }
 
     const renderProps = {
@@ -156,7 +175,7 @@ class Feature extends React.Component {
       hasFeature,
     };
 
-    if (!hasFeature && renderDisabled !== false) {
+    if (!hasFeature && customDisabledRender !== false) {
       return customDisabledRender({children, ...renderProps});
     }
 

--- a/tests/js/spec/components/acl/feature.spec.jsx
+++ b/tests/js/spec/components/acl/feature.spec.jsx
@@ -240,6 +240,7 @@ describe('Feature', function() {
     beforeEach(function() {
       hookFn = jest.fn(() => null);
       HookStore.hooks['feature-disabled:org-baz'] = [hookFn];
+      HookStore.hooks['feature-disabled:test-hook'] = [hookFn];
     });
 
     afterEach(function() {
@@ -280,6 +281,26 @@ describe('Feature', function() {
       expect(wrapper.find('Feature div')).toHaveLength(0);
       expect(hookFn).not.toHaveBeenCalled();
       expect(noFeatureRenderer).toHaveBeenCalled();
+    });
+
+    it('uses hookName if provided', function() {
+      const children = <div>The Child</div>;
+      const wrapper = mount(
+        <Feature features={['org-bazar']} hookName="test-hook">
+          {children}
+        </Feature>,
+        routerContext
+      );
+
+      expect(wrapper.find('Feature div')).toHaveLength(0);
+
+      expect(hookFn).toHaveBeenCalledWith({
+        hasFeature: false,
+        children,
+        organization,
+        project,
+        features: ['org-bazar'],
+      });
     });
   });
 });


### PR DESCRIPTION
Allows us to use the `Feature` component with HookStore when the specific feature gate needs different hook-store driven disabled states.

Eg:
Disabled sidebar items for discover / Disabled discover itself