### PR TITLE
fix(ui): LazyLoad should not refetch on any prop change

### DIFF
--- a/src/sentry/static/sentry/app/components/lazyLoad.jsx
+++ b/src/sentry/static/sentry/app/components/lazyLoad.jsx
@@ -40,6 +40,9 @@ class LazyLoad extends React.Component {
   }
 
   componentWillReceiveProps(nextProps, nextState) {
+    // No need to refetch when component does not change
+    if (nextProps.component && nextProps.component === this.props.component) return;
+
     // This is to handle the following case:
     // <Route path="a/">
     //   <Route path="b/" component={LazyLoad} componentPromise={...} />


### PR DESCRIPTION
Fixes the case where the LazyLoad component was given a `component`, but
would always refetch the component when any props change, not just the
`component` loader prop itself.