### PR TITLE
meta: Adopt CODEOWNERS first pass

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# Legal
+/LICENSE  @getsentry/owners-legal
+
+# Migrations
+south_migrations/  @getsentry/owners-migrations
+
+# Snuba
+/src/sentry/eventstream/        @getsentry/owners-snuba
+/src/sentry/utils/snuba.py      @getsentry/owners-snuba
+/src/sentry/tsdb/snuba.py       @getsentry/owners-snuba
+/src/sentry/tsdb/redissnuba.py  @getsentry/owners-snuba
+/src/sentry/search/snuba/       @getsentry/owners-snuba
+/src/sentry/tagstore/snuba/     @getsentry/owners-snuba
+
+# Ted stuff
+/src/sentry/similarity/              @tkaemming
+/src/sentry/receivers/similarity.py  @tkaemming
+/src/sentry/digests/                 @tkaemming
+/src/sentry/tasks/reports.py         @tkaemming
+/src/sentry/tasks/digests.py         @tkaemming


### PR DESCRIPTION
I want feedback here, but this is first step. Right now, I've created two teams in GH for these two rules we have here:

https://github.com/orgs/getsentry/teams/codeowners/teams

<img width="1011" alt="image" src="https://user-images.githubusercontent.com/375744/54161555-c6adfc00-440f-11e9-8033-2d381065ca05.png">

Obviously, this can/should be fleshed out much more, but I'd like to get an initial pass of a couple teams and where obvious things can be assigned before collecting feedback from the rest of the team.