### PR TITLE
ref(discover): Prevent unnecessary chart rerenders

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {browserHistory, withRouter} from 'react-router';
 import PropTypes from 'prop-types';
-import {throttle} from 'lodash';
+import {throttle, isEqual} from 'lodash';
 
 import SentryTypes from 'app/sentryTypes';
 import {t} from 'app/locale';
@@ -75,6 +75,10 @@ class Result extends React.Component {
         search,
       });
     }
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return !isEqual(nextProps, this.props) || !isEqual(nextState, this.state);
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Prevent chart unnecessarily rerendering when interacting with the query
builder since the chart data isn't modified prior to a query run.

Unfortunately solving this problem in the base chart is a little tricky,
so prevent component updates in the Discover component that renders the
charts.