### PR TITLE
feat: Add concurrency to ConsumerWorker

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1560,22 +1560,40 @@ KAFKA_CLUSTERS = {
 }
 
 KAFKA_PREPROCESS = 'events-preprocess'
+KAFKA_PREPROCESS_DEAD = 'events-preprocess-dead'
 KAFKA_PROCESS = 'events-process'
+KAFKA_PROCESS_DEAD = 'events-process-dead'
 KAFKA_SAVE = 'events-save'
+KAFKA_SAVE_DEAD = 'events-save-dead'
 KAFKA_EVENTS = 'events'
 
 KAFKA_TOPICS = {
     KAFKA_PREPROCESS: {
         'cluster': 'default',
         'topic': KAFKA_PREPROCESS,
+        'dead-letter-key': KAFKA_PREPROCESS_DEAD,
+    },
+    KAFKA_PREPROCESS_DEAD: {
+        'cluster': 'default',
+        'topic': KAFKA_PREPROCESS_DEAD,
     },
     KAFKA_PROCESS: {
         'cluster': 'default',
         'topic': KAFKA_PROCESS,
+        'dead-letter-key': KAFKA_PROCESS_DEAD,
+    },
+    KAFKA_PROCESS_DEAD: {
+        'cluster': 'default',
+        'topic': KAFKA_PROCESS_DEAD,
     },
     KAFKA_SAVE: {
         'cluster': 'default',
         'topic': KAFKA_SAVE,
+        'dead-letter-key': KAFKA_SAVE_DEAD,
+    },
+    KAFKA_SAVE_DEAD: {
+        'cluster': 'default',
+        'topic': KAFKA_SAVE_DEAD,
     },
     KAFKA_EVENTS: {
         'cluster': 'default',

--- a/src/sentry/consumer.py
+++ b/src/sentry/consumer.py
@@ -8,62 +8,111 @@ import sentry.tasks.store as store_tasks
 from sentry.utils import json
 
 
+# We need a unique value to indicate when to stop multiprocessing queue
+# an identity on an object() isn't guaranteed to work between parent
+# and child proc
+_STOP_WORKER = '91650ec271ae4b3e8a67cdc909d80f8c'
+
+
+def handle_preprocess(message):
+    data = message['data']
+    event_id = data['event_id']
+    cache_key = message['cache_key']
+    start_time = message['start_time']
+    process_task = (
+        store_tasks.process_event_from_reprocessing
+        if message['from_reprocessing']
+        else store_tasks.process_event
+    )
+
+    store_tasks._do_preprocess_event(cache_key, data, start_time, event_id, process_task)
+
+
+def handle_process(message):
+    data = message['data']
+    event_id = data['event_id']
+    cache_key = message['cache_key']
+    start_time = message['start_time']
+
+    if message['from_reprocessing']:
+        task = store_tasks.process_event_from_reprocessing
+    else:
+        task = store_tasks.process_event
+
+    task.delay(cache_key=cache_key, start_time=start_time, event_id=event_id)
+
+
+def handle_save(message):
+    data = message['data']
+    event_id = data['event_id']
+    cache_key = message['cache_key']
+    start_time = message['start_time']
+    project_id = data['project']
+
+    store_tasks._do_save_event(cache_key, data, start_time, event_id, project_id)
+
+
+dispatch = {}
+for key, handler in (
+    (settings.KAFKA_PREPROCESS, handle_preprocess),
+    (settings.KAFKA_PROCESS, handle_process),
+    (settings.KAFKA_SAVE, handle_save)
+):
+    topic = settings.KAFKA_TOPICS[key]['topic']
+    dispatch[topic] = handler
+
+
+def multiprocess_worker(task_queue):
+    # Configure within each Process
+    configured = False
+
+    while True:
+        j = task_queue.get()
+        if j == _STOP_WORKER:
+            task_queue.task_done()
+            return
+
+        # On first task, configure Sentry environment
+        if not configured:
+            from sentry.runner import configure
+            configure()
+            configured = True
+
+        try:
+            topic, message = j
+            handler = dispatch[topic]
+            handler(message)
+        finally:
+            task_queue.task_done()
+
+
 class ConsumerWorker(AbstractBatchWorker):
-    def __init__(self):
-        self.dispatch = {}
-        for key, handler in (
-            (settings.KAFKA_PREPROCESS, self.handle_preprocess),
-            (settings.KAFKA_PROCESS, self.handle_process),
-            (settings.KAFKA_SAVE, self.handle_save)
-        ):
-            topic = settings.KAFKA_TOPICS[key]['topic']
-            self.dispatch[topic] = handler
+    def __init__(self, concurrency=2):
+        from multiprocessing import Process, JoinableQueue as Queue
 
-    def handle_preprocess(self, message):
-        data = message['data']
-        event_id = data['event_id']
-        cache_key = message['cache_key']
-        start_time = message['start_time']
-        process_task = (
-            store_tasks.process_event_from_reprocessing
-            if message['from_reprocessing']
-            else store_tasks.process_event
-        )
-
-        store_tasks._do_preprocess_event(cache_key, data, start_time, event_id, process_task)
-
-    def handle_process(self, message):
-        data = message['data']
-        event_id = data['event_id']
-        cache_key = message['cache_key']
-        start_time = message['start_time']
-
-        if message['from_reprocessing']:
-            task = store_tasks.process_event_from_reprocessing
-        else:
-            task = store_tasks.process_event
-
-        task.delay(cache_key=cache_key, start_time=start_time, event_id=event_id)
-
-    def handle_save(self, message):
-        data = message['data']
-        event_id = data['event_id']
-        cache_key = message['cache_key']
-        start_time = message['start_time']
-        project_id = data['project']
-
-        store_tasks._do_save_event(cache_key, data, start_time, event_id, project_id)
+        self.pool = []
+        self.task_queue = Queue(1000)
+        for _ in xrange(concurrency):
+            p = Process(target=multiprocess_worker, args=(self.task_queue,))
+            p.daemon = True
+            p.start()
+            self.pool.append(p)
 
     def process_message(self, message):
         topic = message.topic()
-        return self._handle(topic, json.loads(message.value()))
-
-    def _handle(self, topic, message):
-        handler = self.dispatch[topic]
-        return handler(message)
+        self.task_queue.put((topic, json.loads(message.value())))
 
     def flush_batch(self, batch):
-        pass
+        # Batch flush is when Kafka offsets are committed. We away the completion
+        # of all submitted tasks so that we don't publish offsets for anything
+        # that hasn't been processed.
+        self.task_queue.join()
 
     def shutdown(self):
-        pass
+        # Shut down our pool
+        for _ in self.pool:
+            self.task_queue.put(_STOP_WORKER)
+
+        # And wait for it to drain
+        for p in self.pool:
+            p.join()

--- a/src/sentry/consumer.py
+++ b/src/sentry/consumer.py
@@ -80,16 +80,19 @@ def multiprocess_worker(task_queue):
     configured = False
 
     while True:
+        if not configured:
+            from sentry.runner import configure
+            configure()
+
+            import signal
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+            configured = True
+
         task = task_queue.get()
         if task == _STOP_WORKER:
             task_queue.task_done()
             return
-
-        # On first task, configure Sentry environment
-        if not configured:
-            from sentry.runner import configure
-            configure()
-            configured = True
 
         try:
             handle_task(task)

--- a/src/sentry/runner/commands/consumer.py
+++ b/src/sentry/runner/commands/consumer.py
@@ -7,8 +7,6 @@ import signal
 @click.command()
 @click.option('--topic', multiple=True, required=True,
               help='Topic(s) to consume from.')
-@click.option('--dead-letter-topic', required=True,
-              help='Topic to produce failed messages into.')
 @click.option('--consumer-group', default='sentry-consumers',
               help='Consumer group name.')
 @click.option('--bootstrap-server', default=['localhost:9092'], multiple=True,
@@ -47,7 +45,6 @@ def consumer(**options):
         bootstrap_servers=options['bootstrap_server'],
         group_id=options['consumer_group'],
         auto_offset_reset=options['auto_offset_reset'],
-        dead_letter_topic=options['dead_letter_topic'],
     )
 
     def handler(signum, frame):

--- a/src/sentry/runner/commands/consumer.py
+++ b/src/sentry/runner/commands/consumer.py
@@ -14,8 +14,8 @@ from sentry.runner.decorators import configuration
               help='Consumer group name.')
 @click.option('--bootstrap-server', default=['localhost:9092'], multiple=True,
               help='Kafka bootstrap server(s) to use.')
-@click.option('--concurrency', default=2,
-              help='Number of worker subprocess to run that process messages.')
+@click.option('--concurrency', default=1,
+              help='Number of worker subprocess to run that process messages. If set to 1 they will be processed in the consumer.')
 @click.option('--max-batch-size', default=10000,
               help='Max number of messages to batch in memory before committing offsets to Kafka.')
 @click.option('--max-batch-time-ms', default=60000,

--- a/src/sentry/runner/commands/consumer.py
+++ b/src/sentry/runner/commands/consumer.py
@@ -14,6 +14,8 @@ from sentry.runner.decorators import configuration
               help='Consumer group name.')
 @click.option('--bootstrap-server', default=['localhost:9092'], multiple=True,
               help='Kafka bootstrap server(s) to use.')
+@click.option('--concurrency', default=2,
+              help='Number of worker subprocess to run that process messages.')
 @click.option('--max-batch-size', default=10000,
               help='Max number of messages to batch in memory before committing offsets to Kafka.')
 @click.option('--max-batch-time-ms', default=60000,
@@ -33,7 +35,7 @@ def consumer(**options):
 
     consumer = BatchingKafkaConsumer(
         topics=options['topic'],
-        worker=ConsumerWorker(),
+        worker=ConsumerWorker(concurrency=options['concurrency']),
         max_batch_size=options['max_batch_size'],
         max_batch_time=options['max_batch_time_ms'],
         bootstrap_servers=options['bootstrap_server'],

--- a/src/sentry/runner/commands/consumer.py
+++ b/src/sentry/runner/commands/consumer.py
@@ -8,6 +8,8 @@ from django.conf import settings
 @click.command()
 @click.option('--topic', multiple=True, required=True,
               help='Topic(s) to consume from.')
+@click.option('--dead-letter-topic', required=True,
+              help='Topic to produce failed messages into.')
 @click.option('--consumer-group', default='sentry-consumers',
               help='Consumer group name.')
 @click.option('--bootstrap-server', default=['localhost:9092'], multiple=True,
@@ -44,6 +46,7 @@ def consumer(**options):
         bootstrap_servers=options['bootstrap_server'],
         group_id=options['consumer_group'],
         auto_offset_reset=options['auto_offset_reset'],
+        dead_letter_topic=options['dead_letter_topic'],
     )
 
     def handler(signum, frame):

--- a/tests/sentry/consumer/test_consumer.py
+++ b/tests/sentry/consumer/test_consumer.py
@@ -43,7 +43,13 @@ class TestConsumer(PluginTestCase):
             def value(self):
                 return self._value
 
-        consumer = ConsumerWorker()
+            def partition(self):
+                return 0
+
+            def offset(self):
+                return 0
+
+        consumer = ConsumerWorker(concurrency=1)
         consumer.process_message(Msg(topic, kwargs['value']))
         consumer.flush_batch([])
 


### PR DESCRIPTION
(Optionally) run multiple worker processes under each Kafka consumer. This will allow us to process at capacities higher than N = number of Kafka partitions on the topic(s).

The task/queue code was all stolen from Matt's work on the cleanup task and has been tried locally.

A majority of the diff is moving some methods that didn't require any instance state up to the module level so that multiprocess workers can be as simple as possible (and not require constructing/owning a ConsumerWorker for no reason).

I've tried to test the concurrent code for hours and failed. Multiprocessing + mock, settings overrides, temporary Kafka topics and transactional tests is just not working out for me. Open to ideas. Reminder that this is till behind a feature flag and intended for testing out on internal projects or something for now.