### PR TITLE
fix(ui) Fix ReferenceError in Button

### DIFF
--- a/src/sentry/static/sentry/app/components/button/index.jsx
+++ b/src/sentry/static/sentry/app/components/button/index.jsx
@@ -88,7 +88,6 @@ class Button extends React.Component {
       onClick,
       ...buttonProps
     } = this.props;
-
     // For `aria-label`
     const screenReaderLabel =
       label || (typeof children === 'string' ? children : undefined);
@@ -191,9 +190,12 @@ const getColors = ({priority, disabled, borderless, theme}) => {
   `;
 };
 
-const shouldForwardProp = p => p !== 'disabled' && isPropValid(p);
+const customProps = ['external', 'size'];
+const shouldForwardProp = p =>
+  (p !== 'disabled' && isPropValid(p)) || customProps.includes(p);
+
 const StyledButton = styled(
-  props => {
+  ({external, ...props}) => {
     // Get component to use based on existance of `to` or `href` properties
     // Can be react-router `Link`, `a`, or `button`
     if (props.to) {

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -1258,6 +1258,7 @@ exports[`Sidebar SidebarPanel can show Incidents in Sidebar Panel 1`] = `
                 aria-disabled={false}
                 aria-label="Learn more"
                 className="css-dkprmi-StyledButton-getColors eqrebog0"
+                external={true}
                 href="https://status.sentry.io"
                 onClick={[Function]}
                 role="button"

--- a/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
@@ -447,44 +447,30 @@ exports[`Configure should render correctly render() should render platform docs 
                                                         role="button"
                                                         size="small"
                                                       >
-                                                        <ExternalLink
+                                                        <a
                                                           aria-disabled={false}
                                                           aria-label="< Back"
                                                           className="css-dkprmi-StyledButton-getColors eqrebog0"
                                                           href="/testOrg/project-slug/getting-started/"
                                                           onClick={[Function]}
-                                                          rel="noreferrer noopener"
                                                           role="button"
                                                           size="small"
-                                                          target="_blank"
                                                         >
-                                                          <a
-                                                            aria-disabled={false}
-                                                            aria-label="< Back"
-                                                            className="css-dkprmi-StyledButton-getColors eqrebog0"
-                                                            href="/testOrg/project-slug/getting-started/"
-                                                            onClick={[Function]}
-                                                            rel="noreferrer noopener"
-                                                            role="button"
+                                                          <ButtonLabel
                                                             size="small"
-                                                            target="_blank"
                                                           >
-                                                            <ButtonLabel
+                                                            <Component
+                                                              className="css-7ui8bl-ButtonLabel eqrebog1"
                                                               size="small"
                                                             >
-                                                              <Component
+                                                              <span
                                                                 className="css-7ui8bl-ButtonLabel eqrebog1"
-                                                                size="small"
                                                               >
-                                                                <span
-                                                                  className="css-7ui8bl-ButtonLabel eqrebog1"
-                                                                >
-                                                                  &lt; Back
-                                                                </span>
-                                                              </Component>
-                                                            </ButtonLabel>
-                                                          </a>
-                                                        </ExternalLink>
+                                                                &lt; Back
+                                                              </span>
+                                                            </Component>
+                                                          </ButtonLabel>
+                                                        </a>
                                                       </Component>
                                                     </StyledButton>
                                                   </Button>
@@ -522,6 +508,7 @@ exports[`Configure should render correctly render() should render platform docs 
                                                         aria-disabled={false}
                                                         aria-label="Full Documentation"
                                                         className="css-dkprmi-StyledButton-getColors eqrebog0"
+                                                        external={true}
                                                         href="https://docs.getsentry.com/hosted/clients/csharp/"
                                                         onClick={[Function]}
                                                         role="button"

--- a/tests/js/spec/views/organizationProjectsDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationProjectsDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -779,6 +779,7 @@ exports[`ProjectCard renders 1`] = `
                                   aria-disabled={false}
                                   aria-label="Track deploys"
                                   className="css-dkprmi-StyledButton-getColors eqrebog0"
+                                  external={true}
                                   href="https://docs.sentry.io/learn/releases/"
                                   onClick={[Function]}
                                   role="button"


### PR DESCRIPTION
external was not defined inside StyledButton. In dev it was working because the ExternalLink button was mangled into `external`, but prod builds created different variable names.

Fixes JAVASCRIPT-5PT