### PR TITLE
fix(build) Remove numpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ script:
   # installing dependencies for after_* steps here ensures they get cached
   # since those steps execute after travis runs `store build cache`
   - pip install codecov
-  - pip uninstall numpy
   - npm install -g @zeus-ci/cli
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ script:
   # installing dependencies for after_* steps here ensures they get cached
   # since those steps execute after travis runs `store build cache`
   - pip install codecov
+  - pip uninstall numpy
   - npm install -g @zeus-ci/cli
 
 after_success:

--- a/bin/scan
+++ b/bin/scan
@@ -29,6 +29,9 @@ ignored=(
     # Description: The session backends in Django before 1.4.21, 1.5.x through 1.6.x, 1.7.x before 1.7.9, and 1.8.x before 1.8.3 allows remote attackers to cause a denial of service (session store consumption) via multiple requests with unique session keys.
     # Reason: This does not apply to us with the cookie based session backend.
     25725
+    # numpy, installed 1.13.1, affected <=1.16.0
+    # we don't use numpy it is provided by travis though.
+    36810
 )
 
 args="--full-report"


### PR DESCRIPTION
It currently has a security warning and is installed by default in travis. This results in safety blowing up at least until travis updates numpy.