### PR TITLE
fix(release) Fix project release API removing commit messages when not provided

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -418,6 +418,7 @@ class Release(Model):
                         author = authors[author_email]
 
                     commit_data = {}
+                    defaults = {}
 
                     # Update/set message and author if they are provided.
                     if author is not None:
@@ -427,12 +428,13 @@ class Release(Model):
                     if 'timestamp' in data:
                         commit_data['date_added'] = data['timestamp']
                     else:
-                        commit_data['date_added'] = timezone.now()
+                        defaults['date_added'] = timezone.now()
 
                     commit, created = Commit.objects.create_or_update(
                         organization_id=self.organization_id,
                         repository_id=repo.id,
                         key=data['id'],
+                        defaults=defaults,
                         values=commit_data)
                     if not created:
                         commit = Commit.objects.get(

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -417,13 +417,17 @@ class Release(Model):
                     else:
                         author = authors[author_email]
 
-                    commit_data = {
-                        'message': data.get('message'),
-                        'date_added': data.get('timestamp') or timezone.now(),
-                    }
-                    # If we didn't get an author don't overwrite an existing one.
+                    commit_data = {}
+
+                    # Update/set message and author if they are provided.
                     if author is not None:
                         commit_data['author'] = author
+                    if 'message' in data:
+                        commit_data['message'] = data['message']
+                    if 'timestamp' in data:
+                        commit_data['date_added'] = data['timestamp']
+                    else:
+                        commit_data['date_added'] = timezone.now()
 
                     commit, created = Commit.objects.create_or_update(
                         organization_id=self.organization_id,

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -342,7 +342,7 @@ class SetCommitsTestCase(TestCase):
             organization_id=org.id,
             key='b' * 40,
             author=author,
-            date_added='2019-03-13 12:00:00',
+            date_added='2019-03-01 12:00:00',
             message='fixed a thing'
         )
 
@@ -384,7 +384,7 @@ class SetCommitsTestCase(TestCase):
             key='b' * 40,
         )
         assert commit_b.message == 'fixed a thing'
-        assert commit_b.date_added.strftime(date_format) == '2019-03-13 12:00:00'
+        assert commit_b.date_added.strftime(date_format) == '2019-03-01 12:00:00'
 
         latest_commit = Commit.objects.get(
             repository_id=repo.id,


### PR DESCRIPTION
When the project release API is used and existing commit references are used, if the API request does not contain the commit message & timestamp those properties would be replaced with incorrect data. Which should not happen.