### PR TITLE
feat(dashboard): Change release widget to include all release data [SEN-237]

### DIFF
--- a/src/sentry/api/endpoints/organization_discover_query.py
+++ b/src/sentry/api/endpoints/organization_discover_query.py
@@ -136,8 +136,6 @@ class DiscoverQuerySerializer(serializers.Serializer):
         return attrs
 
     def get_array_field(self, field):
-        if not isinstance(field, six.string_types):
-            return None
         pattern = r"^(error|stack)\..+"
         return re.search(pattern, field)
 

--- a/src/sentry/api/endpoints/organization_discover_query.py
+++ b/src/sentry/api/endpoints/organization_discover_query.py
@@ -41,6 +41,11 @@ class DiscoverQuerySerializer(serializers.Serializer):
         required=False,
         allow_null=True,
     )
+    condition_fields = ListField(
+        child=ListField(),
+        required=False,
+        allow_null=True,
+    )
     limit = serializers.IntegerField(min_value=0, max_value=10000, required=False)
     rollup = serializers.IntegerField(required=False)
     orderby = serializers.CharField(required=False)
@@ -131,6 +136,8 @@ class DiscoverQuerySerializer(serializers.Serializer):
         return attrs
 
     def get_array_field(self, field):
+        if not isinstance(field, six.string_types):
+            return None
         pattern = r"^(error|stack)\..+"
         return re.search(pattern, field)
 
@@ -303,7 +310,8 @@ class OrganizationDiscoverQueryEndpoint(OrganizationEndpoint):
 
         has_aggregations = len(serialized.get('aggregations')) > 0
 
-        selected_columns = [] if has_aggregations else serialized.get('fields')
+        selected_columns = serialized.get(
+            'condition_fields') or [] if has_aggregations else serialized.get('fields')
 
         projects_map = {}
         for project in projects:

--- a/src/sentry/api/endpoints/organization_discover_query.py
+++ b/src/sentry/api/endpoints/organization_discover_query.py
@@ -309,7 +309,7 @@ class OrganizationDiscoverQueryEndpoint(OrganizationEndpoint):
         has_aggregations = len(serialized.get('aggregations')) > 0
 
         selected_columns = serialized.get(
-            'conditionFields') or [] if has_aggregations else serialized.get('fields')
+            'conditionFields', []) + [] if has_aggregations else serialized.get('fields', [])
 
         projects_map = {}
         for project in projects:

--- a/src/sentry/api/endpoints/organization_discover_query.py
+++ b/src/sentry/api/endpoints/organization_discover_query.py
@@ -41,7 +41,7 @@ class DiscoverQuerySerializer(serializers.Serializer):
         required=False,
         allow_null=True,
     )
-    condition_fields = ListField(
+    conditionFields = ListField(
         child=ListField(),
         required=False,
         allow_null=True,
@@ -309,7 +309,7 @@ class OrganizationDiscoverQueryEndpoint(OrganizationEndpoint):
         has_aggregations = len(serialized.get('aggregations')) > 0
 
         selected_columns = serialized.get(
-            'condition_fields') or [] if has_aggregations else serialized.get('fields')
+            'conditionFields') or [] if has_aggregations else serialized.get('fields')
 
         projects_map = {}
         for project in projects:

--- a/src/sentry/static/sentry/app/views/organizationDashboard/data/queries/eventsByRelease.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/data/queries/eventsByRelease.jsx
@@ -5,14 +5,71 @@ import {t} from 'app/locale';
 
 const eventsByRelease = {
   name: t('Events by Release'),
-  fields: ['release'],
+  fields: ['__release'],
+  constraints: ['top10Releases'],
   conditions: [],
   aggregations: [['count()', null, 'Events']],
-  limit: 2000,
+  limit: 5000,
 
   orderby: '-time',
-  groupby: ['time'],
+  groupby: ['time', '__release'],
   rollup: 86400,
 };
 
+export {eventsByRelease};
 export default eventsByRelease;
+
+// const test = {
+// orderby: '-time',
+// consistent: false,
+// aggregations: [['count()', null, 'count']],
+// project: [1],
+// from_date: '2019-02-26T23:10:27.180262',
+// selected_columns: [
+// [
+// 'if',
+// [
+// [
+// 'in',
+// [
+// 'tags[sentry:release]',
+// 'tuple',
+// ["'10828b2194ccaa8deeb49710a5eca007d43f552e'"],
+// ],
+// ],
+// 'tags[sentry:release]',
+// "'other'",
+// ],
+// 'release',
+// ],
+// ],
+// limit: 1000,
+// to_date: '2019-03-12T23:10:27.180262',
+// granularity: 86400,
+// conditions: [['project_id', 'IN', [1]]],
+// groupby: ['time', 'release'],
+// };
+
+// const foo = {
+// orderby: '-count',
+// consistent: false,
+// aggregations: [['count()', null, 'count']],
+// project: [2],
+// from_date: '2019-03-13T01:18:57',
+// selected_columns: [
+// [
+// 'if',
+// [
+// ['in', ['tags[sentry:release]', 'tuple', ["'foo'"]]],
+// 'tags[sentry:release]',
+// "'other'",
+// ],
+// '_release',
+// ],
+// ],
+// limit: 1000,
+// to_date: '2019-03-13T01:19:07',
+// granularity: 86400,
+// conditions: [['project_id', 'IN', [2]]],
+// groupby: ['time', 'tags[_release]'],
+// };

--- a/src/sentry/static/sentry/app/views/organizationDashboard/data/queries/eventsByRelease.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/data/queries/eventsByRelease.jsx
@@ -5,71 +5,15 @@ import {t} from 'app/locale';
 
 const eventsByRelease = {
   name: t('Events by Release'),
-  fields: ['__release'],
-  constraints: ['top10Releases'],
+  fields: ['release'],
+  constraints: ['recentReleases'],
   conditions: [],
   aggregations: [['count()', null, 'Events']],
   limit: 5000,
 
   orderby: '-time',
-  groupby: ['time', '__release'],
+  groupby: ['time', 'release'],
   rollup: 86400,
 };
 
-export {eventsByRelease};
 export default eventsByRelease;
-
-// const test = {
-// orderby: '-time',
-// consistent: false,
-// aggregations: [['count()', null, 'count']],
-// project: [1],
-// from_date: '2019-02-26T23:10:27.180262',
-// selected_columns: [
-// [
-// 'if',
-// [
-// [
-// 'in',
-// [
-// 'tags[sentry:release]',
-// 'tuple',
-// ["'10828b2194ccaa8deeb49710a5eca007d43f552e'"],
-// ],
-// ],
-// 'tags[sentry:release]',
-// "'other'",
-// ],
-// 'release',
-// ],
-// ],
-// limit: 1000,
-// to_date: '2019-03-12T23:10:27.180262',
-// granularity: 86400,
-// conditions: [['project_id', 'IN', [1]]],
-// groupby: ['time', 'release'],
-// };
-
-// const foo = {
-// orderby: '-count',
-// consistent: false,
-// aggregations: [['count()', null, 'count']],
-// project: [2],
-// from_date: '2019-03-13T01:18:57',
-// selected_columns: [
-// [
-// 'if',
-// [
-// ['in', ['tags[sentry:release]', 'tuple', ["'foo'"]]],
-// 'tags[sentry:release]',
-// "'other'",
-// ],
-// '_release',
-// ],
-// ],
-// limit: 1000,
-// to_date: '2019-03-13T01:19:07',
-// granularity: 86400,
-// conditions: [['project_id', 'IN', [2]]],
-// groupby: ['time', 'tags[_release]'],
-// };

--- a/src/sentry/static/sentry/app/views/organizationDashboard/discoverQuery.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/discoverQuery.jsx
@@ -16,7 +16,7 @@ const createReleaseFieldCondition = releases => [
       'tags[sentry:release]',
       "'other'",
     ],
-    '__release',
+    'release',
   ],
 ];
 

--- a/src/sentry/static/sentry/app/views/organizationDashboard/discoverQuery.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/discoverQuery.jsx
@@ -43,11 +43,10 @@ class DiscoverQuery extends React.Component {
 
     // Query builders based on `queries`
     this.queryBuilders = [];
-
-    this.createQueryBuilders();
   }
 
   componentDidMount() {
+    this.createQueryBuilders();
     this.fetchData();
   }
 

--- a/src/sentry/static/sentry/app/views/organizationDashboard/discoverQuery.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/discoverQuery.jsx
@@ -11,11 +11,7 @@ import createQueryBuilder from 'app/views/organizationDiscover/queryBuilder';
 const createReleaseFieldCondition = releases => [
   [
     'if',
-    [
-      ['in', ['tags[sentry:release]', 'tuple', releases.map(r => `'${r}'`)]],
-      'tags[sentry:release]',
-      "'other'",
-    ],
+    [['in', ['release', 'tuple', releases.map(r => `'${r}'`)]], 'release', "'other'"],
     'release',
   ],
 ];

--- a/src/sentry/static/sentry/app/views/organizationDashboard/discoverQuery.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/discoverQuery.jsx
@@ -92,7 +92,7 @@ class DiscoverQuery extends React.Component {
         const newQuery = {
           ...query,
           fields: [],
-          condition_fields:
+          conditionFields:
             this.props.releases &&
             createReleaseFieldCondition(this.props.releases.map(({version}) => version)),
         };

--- a/src/sentry/static/sentry/app/views/organizationDashboard/widget.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/widget.jsx
@@ -32,6 +32,7 @@ class Widget extends React.Component {
     return (
       <ErrorBoundary customComponent={<ErrorCard>{t('Error loading widget')}</ErrorCard>}>
         <DiscoverQuery
+          releases={releases}
           organization={organization}
           selection={selection}
           queries={widget.queries.discover}

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
@@ -220,9 +220,10 @@ function getDataWithKeys(data, query, options = {}) {
       return row;
     }
 
-    const key = fields.length
-      ? fields.map(field => getLabel(row[field], options)).join(',')
-      : aggregate;
+    const key =
+      fields && fields.length
+        ? fields.map(field => getLabel(row[field], options)).join(',')
+        : aggregate;
 
     return {
       ...row,

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
@@ -220,10 +220,9 @@ function getDataWithKeys(data, query, options = {}) {
       return row;
     }
 
-    const key =
-      fields && fields.length
-        ? fields.map(field => getLabel(row[field], options)).join(',')
-        : aggregate;
+    const key = fields.length
+      ? fields.map(field => getLabel(row[field], options)).join(',')
+      : aggregate;
 
     return {
       ...row,

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -299,14 +299,22 @@ def transform_aliases_and_query(**kwargs):
     filter_keys = kwargs['filter_keys']
 
     for (idx, col) in enumerate(selected_columns):
-        name = get_snuba_column_name(col)
-        selected_columns[idx] = name
-        translated_columns[name] = col
+        if isinstance(col, list):
+            # e.g. ['if', condition, '<name>']
+            # also ['in', ['<col>', 'tuple', ["<value>"]]]
+
+            selected_columns[idx] = col
+            translated_columns[col[2]] = col[2]
+        else:
+            name = get_snuba_column_name(col)
+            selected_columns[idx] = name
+            translated_columns[name] = col
 
     for (idx, col) in enumerate(groupby):
-        name = get_snuba_column_name(col)
-        groupby[idx] = name
-        translated_columns[name] = col
+        if not col.startswith('__'):
+            name = get_snuba_column_name(col)
+            groupby[idx] = name
+            translated_columns[name] = col
 
     for aggregation in aggregations or []:
         derived_columns.add(aggregation[2])

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -305,13 +305,14 @@ def transform_aliases_and_query(**kwargs):
 
             selected_columns[idx] = col
             translated_columns[col[2]] = col[2]
+            derived_columns.add(col[2])
         else:
             name = get_snuba_column_name(col)
             selected_columns[idx] = name
             translated_columns[name] = col
 
     for (idx, col) in enumerate(groupby):
-        if not col.startswith('__'):
+        if col not in derived_columns:
             name = get_snuba_column_name(col)
             groupby[idx] = name
             translated_columns[name] = col

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -356,8 +356,11 @@ def transform_aliases_and_query(**kwargs):
     for (idx, col) in enumerate(groupby):
         if col not in derived_columns:
             name = get_snuba_column_name(col)
-            groupby[idx] = name
-            translated_columns[name] = col
+        else:
+            name = col
+
+        groupby[idx] = name
+        translated_columns[name] = col
 
     for aggregation in aggregations or []:
         derived_columns.add(aggregation[2])

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -26,6 +26,10 @@ from sentry.utils.dates import to_timestamp
 MAX_ISSUES = 500
 MAX_HASHES = 5000
 
+SAFE_FUNCTION_RE = re.compile(r'-?[a-zA-Z_][a-zA-Z0-9_]*$')
+QUOTED_LITERAL_RE = re.compile(r"^'.*'$")
+
+
 # Global Snuba request option override dictionary. Only intended
 # to be used with the `options_override` contextmanager below.
 # NOT THREAD SAFE!
@@ -263,11 +267,91 @@ def zerofill(data, start, end, rollup, orderby):
 def get_snuba_column_name(name):
     """
     Get corresponding Snuba column name from Sentry snuba map, if not found
-    the column is assumed to be a tag. If name is falsy, leave unchanged.
+    the column is assumed to be a tag. If name is falsy or name is a quoted literal
+    (e.g. "'name'"), leave unchanged.
     """
-    if not name:
+    if not name or QUOTED_LITERAL_RE.match(name):
         return name
+
     return SENTRY_SNUBA_MAP.get(name, u'tags[{}]'.format(name))
+
+
+def get_function_index(column_expr, depth=0):
+    """
+    If column_expr list contains a function, returns the index of its function name
+    within column_expr (and assumption is that index + 1 is the list of arguments),
+    otherwise None.
+
+     A function expression is of the form:
+         [func, [arg1, arg2]]  => func(arg1, arg2)
+     If a string argument is followed by list arg, the pair of them is assumed
+    to be a nested function call, with extra args to the outer function afterward.
+         [func1, [func2, [arg1, arg2], arg3]]  => func1(func2(arg1, arg2), arg3)
+     Although at the top level, there is no outer function call, and the optional
+    3rd argument is interpreted as an alias for the entire expression.
+         [func, [arg1], alias] => function(arg1) AS alias
+     You can also have a function part of an argument list:
+         [func1, [arg1, func2, [arg2, arg3]]] => func1(arg1, func2(arg2, arg3))
+     """
+    index = None
+    if isinstance(column_expr, (tuple, list)):
+        i = 0
+        while i < len(column_expr) - 1:
+            # The assumption here is that a list that follows a string means
+            # the string is a function name
+            if isinstance(column_expr[i], six.string_types) and isinstance(
+                    column_expr[i + 1], (tuple, list)):
+                assert SAFE_FUNCTION_RE.match(column_expr[i])
+                index = i
+                break
+            else:
+                i = i + 1
+
+        return index
+    else:
+        return None
+
+
+def parse_columns_in_functions(col, context=None, index=None):
+    """
+    Checks expressions for arguments that should be considered a column while
+    ignoring strings that represent clickhouse function names
+
+    if col is a list, means the expression has functions and we need
+    to parse for arguments that should be considered column names.
+
+    Assumptions here:
+     * strings that represent clickhouse function names are always followed by a list or tuple
+     * strings that are quoted with single quotes are used as string literals for CH
+     * otherwise we should attempt to get the snuba column name (or custom tag)
+    """
+
+    function_name_index = get_function_index(col)
+
+    if function_name_index is not None:
+        # if this is non zero, that means there are strings before this index
+        # that should be converted to snuba column names
+        # e.g. ['func1', ['column', 'func2', ['arg1']]]
+        if function_name_index > 0:
+            for i in xrange(0, function_name_index):
+                if context is not None:
+                    context[i] = get_snuba_column_name(col[i])
+
+        args = col[function_name_index + 1]
+
+        # check for nested functions in args
+        if get_function_index(args):
+            # look for columns
+            return parse_columns_in_functions(args, args)
+
+        # check each argument for column names
+        else:
+            for (i, arg) in enumerate(args):
+                parse_columns_in_functions(arg, args, i)
+    else:
+        # probably a column name
+        if context is not None and index is not None:
+            context[index] = get_snuba_column_name(col)
 
 
 def get_arrayjoin(column):
@@ -298,53 +382,11 @@ def transform_aliases_and_query(**kwargs):
     conditions = kwargs['conditions'] or []
     filter_keys = kwargs['filter_keys']
 
-    def parse_selected_column_condition(column):
-        new_column = [column[0]]
-        new_condition = []
-
-        if column[0] == 'if':
-            if_condition = column[1][0]
-            new_if_condition = []
-
-            if isinstance(if_condition, list) and if_condition[0] == 'in':
-                new_if_condition.append(if_condition[0])
-                in_clause = if_condition[1]
-
-                # ["in", [<column name> , <str literal e.g. "tuple">, <list>]]
-                if in_clause[1] != 'tuple' or not isinstance(in_clause[2], list):
-                    # This is an invalid query, raise something
-                    raise
-                else:
-                    new_if_condition.append([
-                        get_snuba_column_name(in_clause[0]),
-                        in_clause[1],
-                        in_clause[2],
-                    ])
-                new_condition.append(new_if_condition)
-            else:
-                # raise invalid query or something
-                raise
-
-            # column[1][1] and column[1][2] can be string literals OR a snuba column name
-            # TODO make `get_snuba_column_name` aware of literals
-            # for now, only treat the success condition as snuba column
-            new_condition.append(get_snuba_column_name(column[1][1]))
-            new_condition.append(column[1][2])
-        else:
-            # what should we raise if we fail to parse conditions
-            raise
-
-        new_column.append(new_condition)
-        new_column.append(column[2])
-        return new_column
-
     for (idx, col) in enumerate(selected_columns):
         if isinstance(col, list):
-            # e.g. ['if', <if_condition>, '<alias>']
-            # where if_condition is [<condition>, <column name, if true>, <string literal, if false>]
-            # and condition can be [<op>, column name?, string]
-            # op currently only supports ['in', [<column name>, "tuple", string[]]]
-            col = parse_selected_column_condition(col)
+            # if list, means there are potentially nested functions and need to
+            # iterate and translate potential columns
+            parse_columns_in_functions(col)
             selected_columns[idx] = col
             translated_columns[col[2]] = col[2]
             derived_columns.add(col[2])

--- a/tests/js/spec/views/organizationDashboard/discoverQuery.spec.jsx
+++ b/tests/js/spec/views/organizationDashboard/discoverQuery.spec.jsx
@@ -193,8 +193,8 @@ describe('DiscoverQuery', function() {
             [
               'if',
               [
-                ['in', ['tags[sentry:release]', 'tuple', [`'${release.version}'`]]],
-                'tags[sentry:release]',
+                ['in', ['release', 'tuple', [`'${release.version}'`]]],
+                'release',
                 "'other'",
               ],
               'release',

--- a/tests/js/spec/views/organizationDashboard/discoverQuery.spec.jsx
+++ b/tests/js/spec/views/organizationDashboard/discoverQuery.spec.jsx
@@ -189,7 +189,7 @@ describe('DiscoverQuery', function() {
       expect.objectContaining({
         data: expect.objectContaining({
           aggregations: [['count()', null, 'Events']],
-          condition_fields: [
+          conditionFields: [
             [
               'if',
               [

--- a/tests/snuba/api/endpoints/test_organization_discover_query.py
+++ b/tests/snuba/api/endpoints/test_organization_discover_query.py
@@ -154,20 +154,20 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
                             [
                                 'in',
                                 [
-                                    'tags[sentry:release]',
+                                    'release',
                                     'tuple',
                                     ["'foo'"],
                                 ],
                             ],
-                            'tags[sentry:release]',
+                            'release',
                             "'other'",
                         ],
-                        '__release',
+                        'release',
                     ],
                 ],
                 'start': (datetime.now() - timedelta(seconds=10)).strftime('%Y-%m-%dT%H:%M:%S'),
                 'end': (datetime.now()).strftime('%Y-%m-%dT%H:%M:%S'),
-                'groupby': ['time', '__release'],
+                'groupby': ['time', 'release'],
                 'rollup': 86400,
                 'limit': 1000,
                 'orderby': '-time',
@@ -177,9 +177,12 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert len(response.data['data']) == 2
         assert response.data['data'][0]['count'] == 2
-        assert response.data['data'][0]['__release'] == 'other'
+
+        # note this "release" key represents the alias for the column condition
+        # and is also used in `groupby`, it is NOT the release tag
+        assert response.data['data'][0]['release'] == 'other'
         assert response.data['data'][1]['count'] == 1
-        assert response.data['data'][1]['__release'] == 'foo'
+        assert response.data['data'][1]['release'] == 'foo'
 
     def test_invalid_range_value(self):
         with self.feature('organizations:discover'):

--- a/tests/snuba/api/endpoints/test_organization_discover_query.py
+++ b/tests/snuba/api/endpoints/test_organization_discover_query.py
@@ -147,7 +147,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'aggregations': [['count()', None, 'count']],
-                'condition_fields': [
+                'conditionFields': [
                     [
                         'if',
                         [

--- a/tests/snuba/api/endpoints/test_organization_discover_query.py
+++ b/tests/snuba/api/endpoints/test_organization_discover_query.py
@@ -175,14 +175,17 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
             })
 
         assert response.status_code == 200, response.content
-        assert len(response.data['data']) == 2
-        assert response.data['data'][0]['count'] == 2
 
-        # note this "release" key represents the alias for the column condition
-        # and is also used in `groupby`, it is NOT the release tag
-        assert response.data['data'][0]['release'] == 'other'
-        assert response.data['data'][1]['count'] == 1
-        assert response.data['data'][1]['release'] == 'foo'
+        # rollup is by one day and diff of start/end is 10 seconds, so we only have one day
+        assert len(response.data['data']) == 2
+
+        for data in response.data['data']:
+            # note this "release" key represents the alias for the column condition
+            # and is also used in `groupby`, it is NOT the release tag
+            if data['release'] == 'foo':
+                assert data['count'] == 1
+            elif data['release'] == 'other':
+                assert data['count'] == 2
 
     def test_invalid_range_value(self):
         with self.feature('organizations:discover'):


### PR DESCRIPTION

* Adds an additional query field `condition_fields` to discover query endpoint that current only
 supports an "if" clause when selecting a column. i.e. we can do a query like
 "select [if <condition> is true, use <column> value, else use literal value] as alias"

 * adds support for a "<column> is in <list>" condition

* Updates release widget to use releases that the rest of the dashboard has access to
  and fetches event stats for each of those releases (and group into "Other" category otherwise)


Fixes SEN-237
