### PR TITLE
feat(api): Rename `type.name` to `event.type` for clarity

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -50,9 +50,7 @@ SENTRY_SNUBA_MAP = {
     'timestamp': 'timestamp',
     'time': 'time',
     # We support type as both tag and a real column
-    'type.name': 'type',
-    # We support version as both tag and a real column
-    'version.name': 'version',
+    'event.type': 'type',
     # user
     'user.id': 'user_id',
     'user.email': 'email',


### PR DESCRIPTION
After discussion with @dcramer we decided that this is more intuitive, so renaming.

Also dropped `version.name` after discussion with @mitsuhiko, since it's basically a meaningless value at this point.