### PR TITLE
fix(ui) Don't overwrite store state in notifications

### DIFF
--- a/src/sentry/static/sentry/app/stores/projectsStore.jsx
+++ b/src/sentry/static/sentry/app/stores/projectsStore.jsx
@@ -156,21 +156,6 @@ const ProjectsStore = Reflux.createStore({
     });
   },
 
-  getAllGroupedByOrganization() {
-    return this.getAll().reduce((acc, project) => {
-      const orgSlug = project.organization.slug;
-      if (acc[orgSlug]) {
-        acc[orgSlug].projects.push(project);
-      } else {
-        acc[orgSlug] = {
-          organization: project.organization,
-          projects: [project],
-        };
-      }
-      return acc;
-    }, {});
-  },
-
   getById(id) {
     return this.getAll().find(project => project.id === id);
   },

--- a/src/sentry/static/sentry/app/views/settings/account/accountNotificationFineTuning.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountNotificationFineTuning.jsx
@@ -11,7 +11,6 @@ import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import Form from 'app/views/settings/components/forms/form';
 import JsonForm from 'app/views/settings/components/forms/jsonForm';
 import Pagination from 'app/components/pagination';
-import ProjectsStore from 'app/stores/projectsStore';
 import SelectField from 'app/views/settings/components/forms/selectField';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
@@ -87,6 +86,21 @@ const PanelBodyLineItem = styled(PanelBody)`
 // Which fine tuning parts are grouped by project
 const isGroupedByProject = type => ['alerts', 'workflow', 'email'].indexOf(type) > -1;
 
+function groupByOrganization(projects) {
+  return projects.reduce((acc, project) => {
+    const orgSlug = project.organization.slug;
+    if (acc[orgSlug]) {
+      acc[orgSlug].projects.push(project);
+    } else {
+      acc[orgSlug] = {
+        organization: project.organization,
+        projects: [project],
+      };
+    }
+    return acc;
+  }, {});
+}
+
 class AccountNotificationsByProject extends React.Component {
   static propTypes = {
     projects: PropTypes.array,
@@ -95,9 +109,7 @@ class AccountNotificationsByProject extends React.Component {
 
   getFieldData() {
     const {projects, field} = this.props;
-    ProjectsStore.loadInitialData(projects);
-
-    const projectsByOrg = ProjectsStore.getAllGroupedByOrganization();
+    const projectsByOrg = groupByOrganization(projects);
 
     // eslint-disable-next-line no-unused-vars
     const {title, description, ...fieldConfig} = field;


### PR DESCRIPTION
Account notifications was overwriting store state with a different representation of data than other pages require. This caused the project dashboard to break as data in stores was non-conformant.

The store method used in account notification settings was only used there, so I separated it from the store.

Fixes JAVASCRIPT-5QC