### PR TITLE
ref(app-platform): Add project to external issue requester

### DIFF
--- a/src/sentry/mediators/external_requests/issue_link_requester.py
+++ b/src/sentry/mediators/external_requests/issue_link_requester.py
@@ -101,13 +101,18 @@ class IssueLinkRequester(Mediator):
 
     @memoize
     def body(self):
-        body = {}
+        body = {'fields': {}}
         for name, value in six.iteritems(self.fields):
-            body[name] = value
+            body['fields'][name] = value
 
         body['issueId'] = self.group.id
         body['installationId'] = self.install.uuid
         body['webUrl'] = self.group.get_absolute_url()
+        project = self.group.project
+        body['project'] = {
+            'slug': project.slug,
+            'id': project.id,
+        }
         return json.dumps(body)
 
     @memoize

--- a/tests/sentry/mediators/external_requests/test_issue_link_requester.py
+++ b/tests/sentry/mediators/external_requests/test_issue_link_requester.py
@@ -66,12 +66,18 @@ class TestIssueLinkRequester(TestCase):
         request = responses.calls[0].request
         assert request.headers['Sentry-App-Signature']
         data = {
-            'title': 'An Issue',
-            'description': 'a bug was found',
-            'assignee': 'user-1',
+            'fields': {
+                'title': 'An Issue',
+                'description': 'a bug was found',
+                'assignee': 'user-1',
+            },
             'issueId': self.group.id,
             'installationId': self.install.uuid,
             'webUrl': self.group.get_absolute_url(),
+            'project': {
+                'id': self.project.id,
+                'slug': self.project.slug,
+            }
         }
         payload = json.loads(request.body)
         assert payload == data


### PR DESCRIPTION
We already include the `projectSlug` in the `SelectRequester` to make it easier to filter. Adding in the project (both `id` and `slug`) so the external services can use that info if needed when creating or linking an issue on their end. 

Also separating out the `fields` as it's own attribute so the `project` or `issueId` don't get overridden by any fields with the same name.