### PR TITLE
fix(api): Fix negative checks for promoted tags in search (SEN-253)

### DIFF
--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -568,7 +568,7 @@ class GetSnubaQueryArgsTest(TestCase):
             'conditions': [
                 ['email', '=', 'foo@example.com'],
                 ['tags[sentry:release]', '=', '1.2.1'],
-                ['tags[fruit]', '=', 'apple'],
+                [['ifNull', ['tags[fruit]', "''"]], '=', 'apple'],
                 [['positionCaseInsensitive', ['message', "'hello'"]], '!=', 0],
             ],
             'filter_keys': {'project_id': [1, 2, 3]},


### PR DESCRIPTION
These were failing because while tags are array columns and are always an empty string, promoted
tags are actual columns and so can be null. So just for tags we always is `isNull` to convert to an
empty string.

Fixes SEN-253