### PR TITLE
fix(ui) Make disabled dropdowns look like other disabled buttons

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownButton.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownButton.jsx
@@ -29,7 +29,7 @@ const StyledButton = styled(({isOpen, ...props}) => <Button {...props} />)`
   border-bottom-left-radius: ${p => (p.isOpen ? 0 : p.theme.borderRadius)};
   position: relative;
   z-index: 2;
-  box-shadow: ${p => (p.isOpen ? 'none' : p.theme.dropShadowLight)};
+  box-shadow: ${p => (p.isOpen || p.disabled ? 'none' : p.theme.dropShadowLight)};
 
   &,
   &:hover {

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -507,19 +507,19 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                                 size="xsmall"
                                               >
                                                 <Component
-                                                  className="css-o27a2e-StyledButton e1yghndz1"
+                                                  className="css-w99oc4-StyledButton e1yghndz1"
                                                   disabled={true}
                                                   isOpen={false}
                                                   size="xsmall"
                                                 >
                                                   <Button
-                                                    className="css-o27a2e-StyledButton e1yghndz1"
+                                                    className="css-w99oc4-StyledButton e1yghndz1"
                                                     disabled={true}
                                                     size="xsmall"
                                                   >
                                                     <StyledButton
                                                       aria-disabled={true}
-                                                      className="css-o27a2e-StyledButton e1yghndz1"
+                                                      className="css-w99oc4-StyledButton e1yghndz1"
                                                       disabled={true}
                                                       href={null}
                                                       onClick={[Function]}
@@ -529,7 +529,7 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                                     >
                                                       <Component
                                                         aria-disabled={true}
-                                                        className="e1yghndz1 css-1wbxhyw-StyledButton-getColors-StyledButton eqrebog0"
+                                                        className="e1yghndz1 css-10lmrhm-StyledButton-getColors-StyledButton eqrebog0"
                                                         href={null}
                                                         onClick={[Function]}
                                                         role="button"
@@ -538,7 +538,7 @@ exports[`CreateProject should render roles when available and allowed, and handl
                                                       >
                                                         <button
                                                           aria-disabled={true}
-                                                          className="e1yghndz1 css-1wbxhyw-StyledButton-getColors-StyledButton eqrebog0"
+                                                          className="e1yghndz1 css-10lmrhm-StyledButton-getColors-StyledButton eqrebog0"
                                                           href={null}
                                                           onClick={[Function]}
                                                           role="button"


### PR DESCRIPTION
Disabled buttons do not have drop shadows. Dropdown buttons should be consistent.

![Screen Shot 2019-03-15 at 10 56 54 AM](https://user-images.githubusercontent.com/24086/54441037-3ffc6600-4712-11e9-9159-cab2a4df095f.png)
