### PR TITLE
fix(filter) Don't filter out APIs-Google requests

### DIFF
--- a/src/sentry/filters/web_crawlers.py
+++ b/src/sentry/filters/web_crawlers.py
@@ -16,8 +16,8 @@ CRAWLERS = re.compile(
             r'AdsBot',
             # Google Adsense
             r'Mediapartners',
-            # Google+ and Google web search
-            r'Google',
+            # Google+ and Google web search, but not apis-google
+            r'(?<!APIs-)Google',
             # Bing search
             r'BingBot',
             r'BingPreview',

--- a/tests/sentry/filters/test_web_crawlers.py
+++ b/tests/sentry/filters/test_web_crawlers.py
@@ -1,14 +1,16 @@
 from __future__ import absolute_import
 
+from sentry.models import Project
 from sentry.filters.web_crawlers import WebCrawlersFilter
-from sentry.testutils import TestCase
+from unittest import TestCase
 
 
 class WebCrawlersFilterTest(TestCase):
     filter_cls = WebCrawlersFilter
 
     def apply_filter(self, data):
-        return self.filter_cls(self.project).test(data)
+        project = Project()
+        return self.filter_cls(project).test(data)
 
     def get_mock_data(self, user_agent):
         return {
@@ -50,3 +52,7 @@ class WebCrawlersFilterTest(TestCase):
             'Mozilla/5.0 (Linux; Android 6.0.1; Calypso AppCrawler Build/MMB30Y; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.124 Mobile Safari/537.36'
         )
         assert self.apply_filter(data)
+
+    def test_filters_google_apis(self):
+        data = self.get_mock_data('APIs-Google')
+        assert not self.apply_filter(data)


### PR DESCRIPTION
The APIs-Google user agent is used by pub/sub to send notifications and any errors from that user agent could be important to users.

I've also removed the database dependency in this test speeding it up from 7s to 0.6s on my machine.

Fixes #12339