### PR TITLE
ref(feedback): Add enhanced privacy to feedback alerts

### DIFF
--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -368,6 +368,9 @@ class MailPlugin(NotificationPlugin):
         if not participants:
             return
 
+        org = group.organization
+        enhanced_privacy = org.flags.enhanced_privacy
+
         context = {
             'project': project,
             'project_link': absolute_uri(u'/{}/{}/'.format(
@@ -387,6 +390,7 @@ class MailPlugin(NotificationPlugin):
             )),
             'group': group,
             'report': payload['report'],
+            'enhanced_privacy': enhanced_privacy,
         }
 
         subject_prefix = self.get_option('subject_prefix', project) or self._subject_prefix()

--- a/src/sentry/templates/sentry/emails/activity/generic.html
+++ b/src/sentry/templates/sentry/emails/activity/generic.html
@@ -28,7 +28,7 @@
 
   {% endblock %}
 
-  {% if group %}
+  {% if group and not enhanced_privacy %}
     {% include "sentry/emails/group_header.html" %}
   {% endif %}
 

--- a/src/sentry/templates/sentry/emails/activity/new-user-feedback.html
+++ b/src/sentry/templates/sentry/emails/activity/new-user-feedback.html
@@ -7,17 +7,25 @@
 {% block activity %}
   <h3>New Feedback from {{ report.name }}</h3>
 
-  <table class="note">
-    <tr>
-      <td class="avatar-column">
-        {% email_avatar report.name report.email size 48 %}
-      </td>
-      <td class="notch-column">
-        <img width="7" height="48" src="{% absolute_asset_url 'sentry' 'images/email/avatar-notch.png' %}">
-      </td>
-      <td>
-        <div class="note-body">{{ report.comments|urlize|linebreaks }}</div>
-      </td>
-    </tr>
-  </table>
+  {% if enhanced_privacy %}
+    <div class="notice">
+      Details about this feedback are not shown in this notification since enhanced privacy
+        controls are enabled. For more details about this feedback, <a href="{{ link }}">view on Sentry</a>.
+    </div>
+
+  {% else %}
+    <table class="note">
+      <tr>
+        <td class="avatar-column">
+          {% email_avatar report.name report.email size 48 %}
+        </td>
+        <td class="notch-column">
+          <img width="7" height="48" src="{% absolute_asset_url 'sentry' 'images/email/avatar-notch.png' %}">
+        </td>
+        <td>
+          <div class="note-body">{{ report.comments|urlize|linebreaks }}</div>
+        </td>
+      </tr>
+    </table>
+  {% endif %}
 {% endblock %}

--- a/src/sentry/templates/sentry/emails/activity/new-user-feedback.txt
+++ b/src/sentry/templates/sentry/emails/activity/new-user-feedback.txt
@@ -4,8 +4,14 @@
 
 {{ report.name }} left a new comment:
 
+{% if enhanced_privacy %}
+Details about this feedback are not shown in this notification since enhanced privacy
+controls are enabled. For more details about this feedback, view on Sentry.
+
+{% else %}
 {{ report.comments }}
 
+{% endif %}
 
 ## Details
 

--- a/src/sentry/web/frontend/debug/debug_new_user_feedback_email.py
+++ b/src/sentry/web/frontend/debug/debug_new_user_feedback_email.py
@@ -2,9 +2,12 @@ from __future__ import absolute_import
 
 from django.views.generic import View
 
-from sentry.models import Group, Organization, Project
+from sentry.models import Organization, Project
 
 from .mail import MailPreview
+
+from sentry.utils.http import absolute_uri
+from sentry.utils.samples import create_sample_event
 
 
 class DebugNewUserFeedbackEmailView(View):
@@ -20,10 +23,20 @@ class DebugNewUserFeedbackEmailView(View):
             slug='project',
             name='My Project',
         )
-        group = Group(
-            id=1,
+
+        event = create_sample_event(
             project=project,
+            platform='python',
+            event_id='595',
+            timestamp=1452683305,
         )
+
+        group = event.group
+        link = absolute_uri(u'/{}/{}/issues/{}/feedback/'.format(
+            project.organization.slug,
+            project.slug,
+            group.id,
+        ))
 
         return MailPreview(
             html_template='sentry/emails/activity/new-user-feedback.html',
@@ -35,5 +48,8 @@ class DebugNewUserFeedbackEmailView(View):
                     'email': 'homer.simpson@example.com',
                     'comments': 'I hit a bug.\n\nI went to https://example.com, hit the any key, and then it stopped working. DOH!',
                 },
+                'link': link,
+                'reason': 'are subscribed to this issue',
+                'enhanced_privacy': False,
             },
         ).render(request)


### PR DESCRIPTION
If the organization enhanced privacy flag is enabled, hide user feedback comments in email notifications. For healthcare companies, for example, PHI can be left in user feedback and shouldn't be sent via email.

<img width="726" alt="Screen Shot 2019-03-14 at 10 35 58 PM" src="https://user-images.githubusercontent.com/16394317/54449011-569ebf00-470a-11e9-9a11-a4147f89594c.png">
<img width="725" alt="Screen Shot 2019-03-14 at 10 35 00 PM" src="https://user-images.githubusercontent.com/16394317/54449001-543c6500-470a-11e9-92e2-6abd60161ae9.png">

