### PR TITLE
build(webpack): Only show errors in webpack output

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -296,9 +296,6 @@ const appConfig = {
     },
   },
   devtool: IS_PRODUCTION ? 'source-map' : 'cheap-module-eval-source-map',
-  watchOptions: {
-    ignored: ['node_modules'],
-  },
 };
 
 /**
@@ -361,6 +358,11 @@ if (USE_HOT_MODULE_RELOAD) {
     // If below is false, will reload on errors
     hotOnly: true,
     port: WEBPACK_DEV_PORT,
+    stats: 'errors-only',
+    overlay: true,
+    watchOptions: {
+      ignored: ['node_modules'],
+    },
   };
 
   // Required, without this we get this on updates:


### PR DESCRIPTION
Also adds an overlay to show webpack errors in browser.