### PR TITLE
build(jest): Run jest update on pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,18 +130,22 @@
   "proxyURL": "http://localhost:8000",
   "scripts": {
     "test": "node scripts/test.js",
-    "test-precommit": "yarn test --bail --findRelatedTests",
-    "test-ci": "JEST_JUNIT_OUTPUT=.artifacts/jest.junit.xml yarn test --runInBand --ci --coverage --testResultsProcessor=jest-junit",
+    "test-precommit": "yarn test --bail --findRelatedTests -u",
+    "test-ci":
+      "JEST_JUNIT_OUTPUT=.artifacts/jest.junit.xml yarn test --runInBand --ci --coverage --testResultsProcessor=jest-junit",
     "test-debug": "node --inspect-brk scripts/test.js --runInBand",
     "test-staged": "yarn test --findRelatedTests $(git diff --name-only --cached)",
-    "lint": "node_modules/.bin/eslint tests/js src/sentry/static/sentry/app --ext .js,.jsx",
+    "lint":
+      "node_modules/.bin/eslint tests/js src/sentry/static/sentry/app --ext .js,.jsx",
     "lint:css": "stylelint 'src/sentry/static/sentry/app/**/*.jsx'",
     "dev": "(yarn check --verify-tree || yarn) && sentry devserver --browser-reload",
     "dev-proxy": "node scripts/devproxy.js",
     "dev-server": "webpack-dev-server",
     "storybook": "start-storybook -p 9001 -c .storybook",
-    "storybook-build": "build-storybook -c .storybook -o .storybook-out && sed -i -e 's/\\/sb_dll/sb_dll/g' .storybook-out/index.html",
-    "snapshot": "build-storybook && PERCY_TOKEN=$STORYBOOK_PERCY_TOKEN PERCY_PROJECT=$STORYBOOK_PERCY_PROJECT percy-storybook --widths=1280",
+    "storybook-build":
+      "build-storybook -c .storybook -o .storybook-out && sed -i -e 's/\\/sb_dll/sb_dll/g' .storybook-out/index.html",
+    "snapshot":
+      "build-storybook && PERCY_TOKEN=$STORYBOOK_PERCY_TOKEN PERCY_PROJECT=$STORYBOOK_PERCY_PROJECT percy-storybook --widths=1280",
     "webpack-profile": "yarn -s webpack --profile --json > stats.json"
   },
   "toolchain": {


### PR DESCRIPTION
Run jest with the "update snapshot" flag on the pre commit hook, this should save some time since this is generally what you would want to do after snapshot failures and you don't need to stage the snapshot updates if you don't want to.