### PR TITLE
ref(project transfer): Add explanatory sentence to modal

### DIFF
--- a/src/sentry/static/sentry/app/views/acceptProjectTransfer.jsx
+++ b/src/sentry/static/sentry/app/views/acceptProjectTransfer.jsx
@@ -69,7 +69,9 @@ class AcceptProjectTransfer extends AsyncView {
         <p>
           {tct(
             'Projects must be transferred to a specific [organization]. ' +
-              'You can grant specific teams access to the project later under the [projectSettings].',
+              'You can grant specific teams access to the project later under the [projectSettings]. ' +
+              '(Note that granting access to at least one team is necessary for the project to ' +
+              'appear in all parts of the UI.)',
             {
               organization: <strong>{t('Organization')}</strong>,
               projectSettings: <strong>{t('Project Settings')}</strong>,


### PR DESCRIPTION
Customers sometimes get confused, when they accept a transfer project, why they can't see it in the UI anywhere except in Settings -> Projects. (It's because they haven't yet assigned it to a team.)

In the long run, we might consider having them add a team to the project directly in this modal, but in the meantime, hopefully this helps clarify things a bit.

Before:

![image](https://user-images.githubusercontent.com/14812505/54467505-bf099280-4742-11e9-8e59-be420e3c9c9b.png)

After:

![image](https://user-images.githubusercontent.com/14812505/54467473-85388c00-4742-11e9-8e54-33624414014f.png)
