### PR TITLE
ref(api) Optimize organization details to not load data twice

### DIFF
--- a/src/sentry/api/endpoints/accept_project_transfer.py
+++ b/src/sentry/api/endpoints/accept_project_transfer.py
@@ -67,7 +67,12 @@ class AcceptProjectTransferEndpoint(Endpoint):
         )
 
         return Response({
-            'organizations': serialize(list(organizations), request.user, DetailedOrganizationSerializer()),
+            'organizations': serialize(
+                list(organizations),
+                request.user,
+                DetailedOrganizationSerializer(),
+                access=request.access
+            ),
             'project': {
                 'slug': project.slug,
                 'id': project.id,

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -313,6 +313,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
             organization,
             request.user,
             org_serializers.DetailedOrganizationSerializer(),
+            access=request.access,
         )
         return self.respond(context)
 
@@ -380,6 +381,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                     organization,
                     request.user,
                     org_serializers.DetailedOrganizationSerializer(),
+                    access=request.access,
                 )
             )
         return self.respond(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -450,5 +452,6 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
             organization,
             request.user,
             org_serializers.DetailedOrganizationSerializer(),
+            access=request.access,
         )
         return self.respond(context, status=202)

--- a/src/sentry/templatetags/sentry_api.py
+++ b/src/sentry/templatetags/sentry_api.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from django import template
 from django.http import HttpRequest
 
+from sentry.auth.access import from_user, NoAccess
 from sentry.api.serializers.base import serialize as serialize_func
 from sentry.api.serializers.models.organization import (DetailedOrganizationSerializer)
 from sentry.utils import json
@@ -29,13 +30,16 @@ def convert_to_json(obj):
 def serialize_detailed_org(context, obj):
     if 'request' in context:
         user = context['request'].user
+        access = from_user(user, obj)
     else:
         user = None
+        access = NoAccess()
 
     context = serialize_func(
         obj,
         user,
         DetailedOrganizationSerializer(),
+        access=access
     )
 
     return convert_to_json(context)

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -27,13 +27,10 @@ from sentry.testutils import APITestCase, TwoFactorAPITestCase
 
 class OrganizationDetailsTest(APITestCase):
     def test_simple(self):
-        org = self.create_organization(owner=self.user)
-        self.create_team(
-            name='appy',
-            organization=org,
-            members=[self.user])
+        user = self.create_user('owner@example.org')
+        org = self.create_organization(owner=user)
 
-        self.login_as(user=self.user)
+        self.login_as(user=user)
         url = reverse(
             'sentry-api-0-organization-details', kwargs={
                 'organization_slug': org.slug,
@@ -43,9 +40,23 @@ class OrganizationDetailsTest(APITestCase):
         assert response.data['onboardingTasks'] == []
         assert response.status_code == 200, response.content
         assert response.data['id'] == six.text_type(org.id)
-        assert len(response.data['teams']) == 1
+        assert len(response.data['teams']) == 0
+        assert len(response.data['projects']) == 0
 
-        for i in range(5):
+    def test_with_projects(self):
+        user = self.create_user('owner@example.org')
+        org = self.create_organization(owner=user)
+        team = self.create_team(
+            name='appy',
+            organization=org,
+            members=[user])
+        # Create non-member team to test response shape
+        self.create_team(name='no-member', organization=org)
+
+        # Some projects with membership and some without.
+        for i in range(3):
+            self.create_project(organization=org, teams=[team])
+        for i in range(2):
             self.create_project(organization=org)
 
         url = reverse(
@@ -53,6 +64,8 @@ class OrganizationDetailsTest(APITestCase):
                 'organization_slug': org.slug,
             }
         )
+        self.login_as(user=user)
+
         # TODO(dcramer): we need to pare this down -- lots of duplicate queries
         # for membership data
         with self.assertNumQueries(35, using='default'):
@@ -60,6 +73,25 @@ class OrganizationDetailsTest(APITestCase):
             response = self.client.get(url, format='json')
             pprint(connections['default'].queries)
         assert len(response.data['projects']) == 5
+        assert len(response.data['teams']) == 2
+
+    def test_as_superuser(self):
+        self.user = self.create_user('super@example.org', is_superuser=True)
+        org = self.create_organization(owner=self.user)
+        team = self.create_team(name='appy', organization=org)
+
+        self.login_as(user=self.user)
+        for i in range(5):
+            self.create_project(organization=org, teams=[team])
+
+        url = reverse(
+            'sentry-api-0-organization-details', kwargs={
+                'organization_slug': org.slug,
+            }
+        )
+        response = self.client.get(url, format='json')
+        assert len(response.data['projects']) == 5
+        assert len(response.data['teams']) == 1
 
     def test_onboarding_tasks(self):
         org = self.create_organization(owner=self.user)


### PR DESCRIPTION
Don't load the projects & teams that have already been loaded into the access object. This avoids transferring data out of the database that we already have.

I've not changed the shape/number of projects & teams returned in organization details as there are still several front-end features relying on it, but this should help improve performance when a user is assigned to a large percentage of an organization's projects.

Re-purposes several changes from #12342

Fixes SEN-390