### PR TITLE
fix: Add sentry tag to renormalized events

### DIFF
--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -35,6 +35,7 @@ from sentry.utils.cache import memoize
 from sentry.utils.canonical import CanonicalKeyDict, CanonicalKeyView
 from sentry.utils.safe import get_path
 from sentry.utils.strings import truncatechars
+from sentry.utils.sdk import configure_scope
 
 
 def _should_skip_to_python(event_data):
@@ -58,6 +59,10 @@ class EventDict(CanonicalKeyDict):
 
         metrics.incr('rust.renormalized',
                      tags={'value': rust_renormalized})
+
+        with configure_scope() as scope:
+            scope.set_tag("rust.renormalized", rust_renormalized)
+
         CanonicalKeyDict.__init__(self, data, **kwargs)
 
 


### PR DESCRIPTION
ref https://github.com/getsentry/sentry/pull/12375/

This should make it easier to identify issues that happen *only* because of our sampling experiment vs issues that happen independently.

Setting this tag within the event model seems a bit dicy to me but I think it will be fine.