### PR TITLE
fix(api): Fix bug where parser didn't allow dates ending in `Z`, and didn't correctly report the parse fail to the user (ISSUE-376)

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -114,8 +114,8 @@ key             = ~r"[a-zA-Z0-9_\.-]+"
 # only allow colons in quoted keys
 quoted_key      = ~r"\"([a-zA-Z0-9_\.:-]+)\""
 
-date_format     = ~r"\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{1,6})?)?"
-rel_date_format = ~r"[\+\-][0-9]+[wdhm]"
+date_format     = ~r"\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{1,6})?)?Z?(?=\s|$)"
+rel_date_format = ~r"[\+\-][0-9]+[wdhm](?=\s|$)"
 
 # NOTE: the order in which these operators are listed matters
 # because for example, if < comes before <= it will match that

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -99,6 +99,25 @@ class ParseSearchQueryTest(TestCase):
             ),
         ]
 
+        # test date time format w microseconds and utc marker
+        assert parse_search_query('timestamp:>2015-05-18T10:15:01.103Z') == [
+            SearchFilter(
+                key=SearchKey(name='timestamp'),
+                operator=">",
+                value=SearchValue(
+                    raw_value=datetime.datetime(
+                        2015,
+                        5,
+                        18,
+                        10,
+                        15,
+                        1,
+                        103000,
+                        tzinfo=timezone.utc),
+                ),
+            ),
+        ]
+
     def test_other_dates(self):
         # test date format with other name
         assert parse_search_query('first_seen>2015-05-18') == [
@@ -177,6 +196,7 @@ class ParseSearchQueryTest(TestCase):
         invalid_queries = [
             'first_seen:hello',
             'first_seen:123',
+            'first_seen:2018-01-01T00:01ZZ'
         ]
         for invalid_query in invalid_queries:
             with self.assertRaises(

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -826,6 +826,17 @@ class SnubaSearchTest(SnubaTestCase):
         )
         assert set(results) == set([self.group1, self.group2])
 
+        # Test with `Z` utc marker, should be equivalent
+        results = self.make_query(
+            date_from=self.event1.datetime,
+            date_to=self.event2.datetime + timedelta(minutes=1),
+            search_filter_query='timestamp:>=%s timestamp:<=%s' % (
+                date_to_query_format(self.event1.datetime) + 'Z',
+                date_to_query_format(self.event2.datetime + timedelta(minutes=1)) + 'Z',
+            )
+        )
+        assert set(results) == set([self.group1, self.group2])
+
     @pytest.mark.xfail(
         not settings.SENTRY_TAGSTORE.startswith('sentry.tagstore.v2'),
         reason='unsupported on legacy backend due to insufficient index',


### PR DESCRIPTION
Our parser didn't allow for dates with `Z` at the end, so updated the regex to allow. Also fixed a
bug where if a date started with a valid date but ended with invalid input then we'd create a search
filter from the valid input, then shove the invalid input into `message` rather than raising a parse
error.

Fixes (ISSUE-376)