### PR TITLE
fix(ui) Fix team list synchronization issues

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/teamSelect.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/teamSelect.jsx
@@ -58,11 +58,13 @@ class TeamSelect extends React.Component {
   };
 
   handleAddTeam = option => {
-    this.props.onAddTeam(option.value);
+    const team = this.state.teams.find(tm => tm.slug === option.value);
+    this.props.onAddTeam(team);
   };
 
   handleRemove = value => {
-    this.props.onRemoveTeam(value);
+    const team = this.state.teams.find(tm => tm.slug === value);
+    this.props.onRemoveTeam(team);
   };
 
   renderTeamAddDropDown() {

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/index.jsx
@@ -195,17 +195,17 @@ const InviteMember = createReactClass({
       });
   },
 
-  handleAddTeam(slug) {
+  handleAddTeam(team) {
     const {selectedTeams} = this.state;
-    if (!selectedTeams.has(slug)) {
-      selectedTeams.add(slug);
+    if (!selectedTeams.has(team.slug)) {
+      selectedTeams.add(team.slug);
     }
     this.setState({selectedTeams});
   },
 
-  handleRemoveTeam(slug) {
+  handleRemoveTeam(team) {
     const {selectedTeams} = this.state;
-    selectedTeams.delete(slug);
+    selectedTeams.delete(team.slug);
 
     this.setState({selectedTeams});
   },

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberDetail.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberDetail.jsx
@@ -113,23 +113,21 @@ class OrganizationMemberDetail extends AsyncView {
       });
   };
 
-  handleAddTeam = slug => {
+  handleAddTeam = team => {
     const {member} = this.state;
-    if (!member.teams.includes(slug)) {
-      member.teams.push(slug);
+    if (!member.teams.includes(team.slug)) {
+      member.teams.push(team.slug);
     }
     this.setState({member});
   };
 
-  handleRemoveTeam = slug => {
+  handleRemoveTeam = team => {
     const {member} = this.state;
-    const teams = new Set(member.teams);
-    teams.delete(slug);
 
     this.setState({
       member: {
         ...member,
-        teams: Array.from(teams.values()),
+        teams: member.teams.filter(teamSlug => teamSlug !== team.slug),
       },
     });
   };

--- a/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
@@ -16,10 +16,7 @@ import space from 'app/styles/space';
 class ProjectTeams extends AsyncView {
   getEndpoints() {
     const {orgId, projectId} = this.props.params;
-    return [
-      ['projectTeams', `/projects/${orgId}/${projectId}/teams/`],
-      ['allTeams', `/organizations/${orgId}/teams/`],
-    ];
+    return [['projectTeams', `/projects/${orgId}/${projectId}/teams/`]];
   }
 
   canCreateTeam = () => {
@@ -30,13 +27,12 @@ class ProjectTeams extends AsyncView {
     );
   };
 
-  handleRemove = teamSlug => {
+  handleRemove = team => {
     if (this.state.loading) {
       return;
     }
 
     const {orgId, projectId} = this.props.params;
-    const team = this.state.allTeams.find(tm => tm.slug === teamSlug);
 
     removeTeamFromProject(this.api, orgId, projectId, team.slug)
       .then(() => this.handleRemovedTeam(team))
@@ -64,12 +60,10 @@ class ProjectTeams extends AsyncView {
     });
   };
 
-  handleAdd = teamSlug => {
+  handleAdd = team => {
     if (this.state.loading) {
       return;
     }
-
-    const team = this.state.allTeams.find(tm => tm.slug === teamSlug);
     const {orgId, projectId} = this.props.params;
 
     addTeamToProject(this.api, orgId, projectId, team).then(

--- a/tests/js/spec/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
@@ -110,6 +110,8 @@ describe('OrganizationMemberDetail', function() {
         <OrganizationMemberDetail params={{memberId: member.id}} />,
         routerContext
       );
+      // Wait for team list to load
+      await tick();
 
       // Remove our one team
       const button = wrapper.find('TeamSelect TeamRow Button');


### PR DESCRIPTION
In accounts with more than 100 teams the team list stored in ProjectTeams would become inaccurate if a user filtered to a team outside of the first list. We can remove the `allTeams` state key and have ProjectTeams respond to state changes in TeamSelect. This cleans up internals a bit and allows us to remove an API call.

Fixes SEN-394