### PR TITLE
fix(app-platform): Unsubscribe from Store changes

### DIFF
--- a/src/sentry/static/sentry/app/components/group/externalIssuesList.jsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssuesList.jsx
@@ -50,7 +50,8 @@ class ExternalIssueList extends AsyncComponent {
   }
 
   componentWillUnmount() {
-    this.unsubscribables.forEach(u => u.unsubscribe());
+    super.componentWillUnmount();
+    this.unsubscribables.forEach(unsubscribe => unsubscribe());
   }
 
   onSentryAppInstallationChange = sentryAppInstallations => {


### PR DESCRIPTION
This was using the interface for unsubscribing from Reflux actions, whereas we're just using the action-less version of Reflux. It changes that unsubscribing code to match what we're using.

FIXES JAVASCRIPT-5SC