### PR TITLE
fix(ui): Improve stack traces on uncaught rejections for API requests

### DIFF
--- a/src/sentry/static/sentry/app/api.jsx
+++ b/src/sentry/static/sentry/app/api.jsx
@@ -236,12 +236,17 @@ export class Client {
 
   requestPromise(path, {includeAllArgs, ...options} = {}) {
     return new Promise((resolve, reject) => {
+      // Create an error object here before we make any async calls so
+      // that we have a helpful stacktrace if it errors
+      const error = new Error('API Request Failed');
+
       this.request(path, {
         ...options,
         success: (data, ...args) => {
           includeAllArgs ? resolve([data, ...args]) : resolve(data);
         },
-        error: (error, ...args) => {
+        error: (resp, ...args) => {
+          error.resp = resp;
           reject(error);
         },
       });


### PR DESCRIPTION
Previously we were incorrectly rejecting with jQuerys response object. Instead, create an error object before we make any async requests so that we can have a helpful stacktrace, and reject with the error object.

![image](https://user-images.githubusercontent.com/79684/54627463-b8c03280-4a30-11e9-9df9-0af46da4aff3.png)
