### PR TITLE
fix: Use event_id from event.

### DIFF
--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -32,10 +32,6 @@ __all__ = ('NodeField', 'NodeData')
 logger = logging.getLogger('sentry')
 
 
-class NodeUnpopulated(Exception):
-    pass
-
-
 class NodeIntegrityFailure(Exception):
     pass
 
@@ -118,10 +114,7 @@ class NodeData(collections.MutableMapping):
             return self._node_data
 
         elif self.id:
-            if settings.DEBUG:
-                raise NodeUnpopulated('You should populate node data before accessing it.')
-            else:
-                warnings.warn('You should populate node data before accessing it.')
+            warnings.warn('You should populate node data before accessing it.')
             self.bind_data(nodestore.get(self.id) or {})
             return self._node_data
 

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -42,8 +42,7 @@ from sentry.utils.strings import truncatechars
 from sentry.utils.sdk import configure_scope
 
 
-def _should_skip_to_python(event_data):
-    event_id = event_data.get("event_id")
+def _should_skip_to_python(event_id):
     if not event_id:
         return False
 
@@ -56,7 +55,7 @@ def _should_skip_to_python(event_data):
 
 class EventDict(CanonicalKeyDict):
     def __init__(self, data, **kwargs):
-        rust_renormalized = _should_skip_to_python(data)
+        rust_renormalized = _should_skip_to_python(data.get('event_id'))
         if rust_renormalized:
             normalizer = StoreNormalizer(is_renormalize=True)
             data = normalizer.normalize_event(dict(data))
@@ -110,7 +109,7 @@ class EventCommon(object):
         self._project_cache = project
 
     def get_interfaces(self):
-        was_renormalized = _should_skip_to_python(self.data)
+        was_renormalized = _should_skip_to_python(self.event_id)
 
         return CanonicalKeyView(get_interfaces(self.data, rust_renormalized=was_renormalized))
 


### PR DESCRIPTION
There was an issue where we were trying to look up an event's event_id
from its data dict. In the case of SnubaEvent, the data dict is not
always populated (nor do we want it to be), but that's ok because we
have the event_id property anyway, without having to grab it from riak