### PR TITLE
ref(test): Tweak selenium options to work in standard Docker container

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -55,7 +55,7 @@ redis-py-cluster==1.3.4
 redis>=2.10.3,<2.10.6
 requests-oauthlib==0.3.3
 requests[security]>=2.20.0,<2.21.0
-selenium==3.11.0
+selenium==3.141.0
 semaphore>=0.4.19,<0.5.0
 sentry-sdk>=0.7.0
 setproctitle>=1.1.7,<1.2.0

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -222,6 +222,9 @@ class Browser(object):
                     **cookie)
             )
         else:
+            # XXX(dcramer): chromedriver (of certain versions) is complaining about this being
+            # an invalid kwarg
+            del cookie['secure']
             self.driver.add_cookie(cookie)
 
 
@@ -277,6 +280,7 @@ def browser(request, percy, live_server):
     if driver_type == 'chrome':
         options = webdriver.ChromeOptions()
         options.add_argument('headless')
+        options.add_argument('no-sandbox')
         options.add_argument('disable-gpu')
         options.add_argument(u'window-size={}'.format(window_size))
         chrome_path = request.config.getoption('chrome_path')


### PR DESCRIPTION
This implements various suggestions to resolve certain conditions of chromedriver in Docker containers.