### PR TITLE
perf: Avoid uncached feature checks on /store

### DIFF
--- a/tests/sentry/quotas/test_base.py
+++ b/tests/sentry/quotas/test_base.py
@@ -37,6 +37,7 @@ class QuotaTest(TestCase):
         )
         assert self.backend.get_key_quota(key) == (60, 5)
 
+    def test_get_key_quota_empty(self):
         key = ProjectKey.objects.create(
             project=self.project, rate_limit_window=None, rate_limit_count=None
         )


### PR DESCRIPTION
This a performance regresson in getsentry where we were making an
excessive numer of calls to the `plan_trial` table to determine if the
user has the rate-limtis feature via a plan trial.

This introduces a 10 minute cache on the feature check to stop the query
from hammering the database.