### PR TITLE
feat(api): Add endpoint to create recent searches (SEN-353)

### DIFF
--- a/tests/sentry/models/test_recentsearch.py
+++ b/tests/sentry/models/test_recentsearch.py
@@ -1,7 +1,15 @@
 from __future__ import absolute_import
 
+from datetime import timedelta
+
+from django.utils import timezone
+from mock import patch
+
 from sentry.testutils import TestCase
-from sentry.models.recentsearch import RecentSearch
+from sentry.models.recentsearch import (
+    RecentSearch,
+    remove_excess_recent_searches,
+)
 from sentry.utils.hashlib import md5_text
 
 
@@ -15,3 +23,25 @@ class RecentSearchTest(TestCase):
         )
         recent_search = RecentSearch.objects.get(id=recent_search.id)
         assert recent_search.query_hash == md5_text(recent_search.query).hexdigest()
+
+
+class RemoveExcessRecentSearchesTest(TestCase):
+    def test(self):
+        with patch('sentry.models.recentsearch.MAX_RECENT_SEARCHES', new=1):
+            RecentSearch.objects.create(
+                organization=self.organization,
+                user=self.user,
+                type=0,
+                query='hello',
+                last_seen=timezone.now() - timedelta(minutes=10)
+            )
+            remove_excess_recent_searches(self.organization, self.user, 0)
+            assert list(RecentSearch.objects.all().values_list('query', flat=True)) == ['hello']
+            RecentSearch.objects.create(
+                organization=self.organization,
+                user=self.user,
+                type=0,
+                query='goodbye',
+            )
+            remove_excess_recent_searches(self.organization, self.user, 0)
+            assert list(RecentSearch.objects.all().values_list('query', flat=True)) == ['goodbye']


### PR DESCRIPTION
This adds an endpoint for recording recent searches. Whenever we create a new recent search, we also check that we haven't gone over the maximum number of recent searches for that user and remove any extra ones. We do this inside of a lock to prevent multiple processes trying to delete the same rows and erroring.