### PR TITLE
ref(minidump): Emit updated debug images schema

### DIFF
--- a/src/sentry/lang/native/cfi.py
+++ b/src/sentry/lang/native/cfi.py
@@ -68,8 +68,7 @@ class ThreadRef(object):
 
         return module, {
             'instruction_addr': '0x%x' % addr,
-            'function': '<unknown>',  # Required by interface
-            'package': module.name if module else None,
+            'package': module.code_file if module else None,
             'trust': trust,
         }
 

--- a/src/sentry/lang/native/unreal.py
+++ b/src/sentry/lang/native/unreal.py
@@ -53,7 +53,6 @@ def merge_apple_crash_report(apple_crash_report, event):
             'crashed': crashed,
             'stacktrace': {
                 'frames': [{
-                    'function': '<unknown>',  # Required by the interface
                     'instruction_addr': frame.get('instruction_addr'),
                     'package': frame.get('module'),
                     'lineno': frame.get('lineno'),
@@ -75,12 +74,12 @@ def merge_apple_crash_report(apple_crash_report, event):
 
     # Extract referenced (not all loaded) images
     images = [{
-        'type': 'symbolic',
-        'id': module.get('uuid'),
+        'type': 'macho',
+        'code_file': module.get('path'),
+        'debug_id': module.get('uuid'),
         'image_addr': module.get('addr'),
         'image_size': module.get('size'),
         'arch': module.get('arch'),
-        'name': module.get('path'),
     } for module in apple_crash_report.get('binary_images')]
     event.setdefault('debug_meta', {})['images'] = images
 
@@ -146,8 +145,8 @@ def merge_unreal_context_event(unreal_context, event, project):
                 # i.e: 0x0000000080db0000
                 # The image address should be used instead with the offset:
                 it = next(
-                    (item for item in images if item.get("name") is not None and re.search(
-                        my_regex, item.get("name"), re.IGNORECASE)), {})
+                    (image for image in images if image.get('code_file') is not None and re.search(
+                        my_regex, image.get('code_file'), re.IGNORECASE)), {})
 
                 image_addr = it.get('image_addr')
                 if image_addr:

--- a/tests/sentry/lang/native/snapshots/UnrealIntegrationTest/test_merge_apple_crash_report.pysnap
+++ b/tests/sentry/lang/native/snapshots/UnrealIntegrationTest/test_merge_apple_crash_report.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-21T13:32:33.987610Z'
+created: '2019-03-21T14:03:20.087375Z'
 creator: sentry
 source: tests/sentry/lang/native/test_unreal.py
 ---
@@ -11,1637 +11,1637 @@ contexts:
 debug_meta:
   images:
   - arch: x86_64
-    id: 2d903291-397d-3d14-bfca-52c7fb8c5e00
+    code_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    debug_id: 2d903291-397d-3d14-bfca-52c7fb8c5e00
     image_addr: '0x10864e000'
     image_size: 108797951
-    name: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 6deccee4-a052-3ea4-bb67-957b06f53ad1
+    code_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libPhysX3PROFILE.dylib
+    debug_id: 6deccee4-a052-3ea4-bb67-957b06f53ad1
     image_addr: '0x112bb2000'
     image_size: 2170879
-    name: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libPhysX3PROFILE.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 5e012a64-6cc5-36f1-9b4d-a0564049169b
+    code_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libPhysX3CookingPROFILE.dylib
+    debug_id: 5e012a64-6cc5-36f1-9b4d-a0564049169b
     image_addr: '0x112fc0000'
     image_size: 221183
-    name: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libPhysX3CookingPROFILE.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 9c198544-7194-3de6-b67e-4cc27eed2eab
+    code_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libPhysX3CommonPROFILE.dylib
+    debug_id: 9c198544-7194-3de6-b67e-4cc27eed2eab
     image_addr: '0x113013000'
     image_size: 1474559
-    name: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libPhysX3CommonPROFILE.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 890f0997-f904-3544-9af7-cf011f09a06e
+    code_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libPxFoundationPROFILE.dylib
+    debug_id: 890f0997-f904-3544-9af7-cf011f09a06e
     image_addr: '0x1131fa000'
     image_size: 28671
-    name: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libPxFoundationPROFILE.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 25f76547-27a1-32b3-ae90-53cc45709967
+    code_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libPxPvdSDKPROFILE.dylib
+    debug_id: 25f76547-27a1-32b3-ae90-53cc45709967
     image_addr: '0x113213000'
     image_size: 176127
-    name: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libPxPvdSDKPROFILE.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 025fd42f-3323-3cd3-a091-56b8adc3565e
+    code_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libAPEX_ClothingPROFILE.dylib
+    debug_id: 025fd42f-3323-3cd3-a091-56b8adc3565e
     image_addr: '0x113275000'
     image_size: 921599
-    name: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libAPEX_ClothingPROFILE.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 45484259-1ec2-3bf2-84d7-c220647e40a6
+    code_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libAPEX_LegacyPROFILE.dylib
+    debug_id: 45484259-1ec2-3bf2-84d7-c220647e40a6
     image_addr: '0x11342d000'
     image_size: 5156863
-    name: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libAPEX_LegacyPROFILE.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 389e4b37-9a61-36fd-b5d1-a0773d89dbc6
+    code_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libApexFrameworkPROFILE.dylib
+    debug_id: 389e4b37-9a61-36fd-b5d1-a0773d89dbc6
     image_addr: '0x1148b2000'
     image_size: 917503
-    name: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libApexFrameworkPROFILE.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 6cd65252-3e10-3d81-a120-55d40925699b
+    code_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libNvClothPROFILE.dylib
+    debug_id: 6cd65252-3e10-3d81-a120-55d40925699b
     image_addr: '0x114a76000'
     image_size: 208895
-    name: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libNvClothPROFILE.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 01d5fa06-e2cf-3e64-a056-247ea5f4384d
+    code_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/OpenVR/OpenVRv1_0_16/osx32/libopenvr_api.dylib
+    debug_id: 01d5fa06-e2cf-3e64-a056-247ea5f4384d
     image_addr: '0x114ad0000'
     image_size: 86015
-    name: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/OpenVR/OpenVRv1_0_16/osx32/libopenvr_api.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 44042edb-511f-34bd-a063-5d29f38d86dd
+    code_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/Ogg/Mac/libogg.dylib
+    debug_id: 44042edb-511f-34bd-a063-5d29f38d86dd
     image_addr: '0x114afb000'
     image_size: 16383
-    name: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/Ogg/Mac/libogg.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 0eca30b3-e726-3b8b-b18f-7346f79369cf
+    code_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/Vorbis/Mac/libvorbis.dylib
+    debug_id: 0eca30b3-e726-3b8b-b18f-7346f79369cf
     image_addr: '0x114b04000'
     image_size: 2936831
-    name: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/Vorbis/Mac/libvorbis.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 94ddf962-09e0-3b3e-b887-9a0301022190
+    code_file: /System/Library/Extensions/AppleHDA.kext/Contents/PlugIns/AppleHDAHALPlugIn.bundle/Contents/MacOS/AppleHDAHALPlugIn
+    debug_id: 94ddf962-09e0-3b3e-b887-9a0301022190
     image_addr: '0x115315000'
     image_size: 20479
-    name: /System/Library/Extensions/AppleHDA.kext/Contents/PlugIns/AppleHDAHALPlugIn.bundle/Contents/MacOS/AppleHDAHALPlugIn
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: d6199433-52cf-3d42-b152-90f8d6aa9396
+    code_file: /System/Library/Extensions/AppleGFXHDA.kext/Contents/PlugIns/AppleGFXHDAHALPlugIn.bundle/Contents/MacOS/AppleGFXHDAHALPlugIn
+    debug_id: d6199433-52cf-3d42-b152-90f8d6aa9396
     image_addr: '0x115335000'
     image_size: 20479
-    name: /System/Library/Extensions/AppleGFXHDA.kext/Contents/PlugIns/AppleGFXHDAHALPlugIn.bundle/Contents/MacOS/AppleGFXHDAHALPlugIn
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: b81473fa-927b-3852-bc34-66e66aae24f4
+    code_file: /usr/lib/libobjc-trampolines.dylib
+    debug_id: b81473fa-927b-3852-bc34-66e66aae24f4
     image_addr: '0x1156d9000'
     image_size: 16383
-    name: /usr/lib/libobjc-trampolines.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 1ebb28b5-fb09-3967-aea0-9883cfef9893
+    code_file: /System/Library/Components/CoreAudio.component/Contents/MacOS/CoreAudio
+    debug_id: 1ebb28b5-fb09-3967-aea0-9883cfef9893
     image_addr: '0x12a3d1000'
     image_size: 1728511
-    name: /System/Library/Components/CoreAudio.component/Contents/MacOS/CoreAudio
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 65d0b9b4-6758-398d-a22a-3746d5ab5739
+    code_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/Resources/RadioEffectUnit.component/Contents/MacOS/RadioEffectUnit
+    debug_id: 65d0b9b4-6758-398d-a22a-3746d5ab5739
     image_addr: '0x12a752000'
     image_size: 73727
-    name: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/Resources/RadioEffectUnit.component/Contents/MacOS/RadioEffectUnit
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: f311b880-6219-395b-8f79-02504dda0010
+    code_file: /System/Library/CoreServices/RawCamera.bundle/Contents/MacOS/RawCamera
+    debug_id: f311b880-6219-395b-8f79-02504dda0010
     image_addr: '0x7fff29814000'
     image_size: 3530751
-    name: /System/Library/CoreServices/RawCamera.bundle/Contents/MacOS/RawCamera
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 39929a89-44c7-3534-b6a4-aa31b027414a
+    code_file: /System/Library/Extensions/AMDMTLBronzeDriver.bundle/Contents/MacOS/AMDMTLBronzeDriver
+    debug_id: 39929a89-44c7-3534-b6a4-aa31b027414a
     image_addr: '0x7fff29b74000'
     image_size: 1359871
-    name: /System/Library/Extensions/AMDMTLBronzeDriver.bundle/Contents/MacOS/AMDMTLBronzeDriver
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: aa09048e-caa0-37b9-808e-f75c53c95200
+    code_file: /System/Library/Extensions/AppleIntelKBLGraphicsMTLDriver.bundle/Contents/MacOS/AppleIntelKBLGraphicsMTLDriver
+    debug_id: aa09048e-caa0-37b9-808e-f75c53c95200
     image_addr: '0x7fff2cf37000'
     image_size: 2658303
-    name: /System/Library/Extensions/AppleIntelKBLGraphicsMTLDriver.bundle/Contents/MacOS/AppleIntelKBLGraphicsMTLDriver
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 1ee74e35-f16b-3034-aea5-723198e519f8
+    code_file: /System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation
+    debug_id: 1ee74e35-f16b-3034-aea5-723198e519f8
     image_addr: '0x7fff30920000'
     image_size: 2027519
-    name: /System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 727a6d92-d1f2-3179-80d3-51f1481f5a87
+    code_file: /System/Library/Frameworks/AVFoundation.framework/Versions/A/Frameworks/AVFAudio.framework/Versions/A/AVFAudio
+    debug_id: 727a6d92-d1f2-3179-80d3-51f1481f5a87
     image_addr: '0x7fff30b0f000'
     image_size: 847871
-    name: /System/Library/Frameworks/AVFoundation.framework/Versions/A/Frameworks/AVFAudio.framework/Versions/A/AVFAudio
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 2c602ced-72ca-37c2-bdf5-31697fc9100b
+    code_file: /System/Library/Frameworks/Accelerate.framework/Versions/A/Accelerate
+    debug_id: 2c602ced-72ca-37c2-bdf5-31697fc9100b
     image_addr: '0x7fff30ceb000'
     image_size: 4095
-    name: /System/Library/Frameworks/Accelerate.framework/Versions/A/Accelerate
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 6455899e-bac7-34d1-802b-ffe19a2337e2
+    code_file: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/Libraries/libCGInterfaces.dylib
+    debug_id: 6455899e-bac7-34d1-802b-ffe19a2337e2
     image_addr: '0x7fff30cec000'
     image_size: 94207
-    name: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/Libraries/libCGInterfaces.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 65912afb-d4c1-3494-ae97-ddfdaf3be1eb
+    code_file: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/vImage
+    debug_id: 65912afb-d4c1-3494-ae97-ddfdaf3be1eb
     image_addr: '0x7fff30d03000'
     image_size: 6950911
-    name: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/vImage
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 76710990-ae2b-300e-88bb-797abad74956
+    code_file: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
+    debug_id: 76710990-ae2b-300e-88bb-797abad74956
     image_addr: '0x7fff313a4000'
     image_size: 2588671
-    name: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 5f3a4021-8ff8-30e8-b84a-aa2bd70f4151
+    code_file: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBNNS.dylib
+    debug_id: 5f3a4021-8ff8-30e8-b84a-aa2bd70f4151
     image_addr: '0x7fff3161c000'
     image_size: 471039
-    name: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBNNS.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 45722a8a-5788-3c4c-add9-1812763fa635
+    code_file: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib
+    debug_id: 45722a8a-5788-3c4c-add9-1812763fa635
     image_addr: '0x7fff3168f000'
     image_size: 3829759
-    name: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: e923da33-b142-3a73-a80a-642878d19099
+    code_file: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLinearAlgebra.dylib
+    debug_id: e923da33-b142-3a73-a80a-642878d19099
     image_addr: '0x7fff31a36000'
     image_size: 90111
-    name: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLinearAlgebra.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 6ffac142-415d-3af0-bc09-336302f11934
+    code_file: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libQuadrature.dylib
+    debug_id: 6ffac142-415d-3af0-bc09-336302f11934
     image_addr: '0x7fff31a4c000'
     image_size: 24575
-    name: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libQuadrature.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 0d7e71a4-10d2-3979-b386-d2426adaf6d7
+    code_file: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libSparse.dylib
+    debug_id: 0d7e71a4-10d2-3979-b386-d2426adaf6d7
     image_addr: '0x7fff31a52000'
     image_size: 516095
-    name: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libSparse.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 00d6fc17-b739-3259-90a4-92ac8bbe03d6
+    code_file: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libSparseBLAS.dylib
+    debug_id: 00d6fc17-b739-3259-90a4-92ac8bbe03d6
     image_addr: '0x7fff31ad0000'
     image_size: 81919
-    name: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libSparseBLAS.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 716585bd-04d7-30a9-b315-689184275e38
+    code_file: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvDSP.dylib
+    debug_id: 716585bd-04d7-30a9-b315-689184275e38
     image_addr: '0x7fff31ae4000'
     image_size: 1986559
-    name: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvDSP.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: eda66c06-a11f-3ee5-96d5-b20893448899
+    code_file: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvMisc.dylib
+    debug_id: eda66c06-a11f-3ee5-96d5-b20893448899
     image_addr: '0x7fff31cc9000'
     image_size: 745471
-    name: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvMisc.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: dadd83a2-550f-3570-8d71-16614c6a4ce0
+    code_file: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/vecLib
+    debug_id: dadd83a2-550f-3570-8d71-16614c6a4ce0
     image_addr: '0x7fff31d7f000'
     image_size: 4095
-    name: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/vecLib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: e1b2caf1-9231-3b3d-bd9e-b770fe87f407
+    code_file: /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
+    debug_id: e1b2caf1-9231-3b3d-bd9e-b770fe87f407
     image_addr: '0x7fff31f30000'
     image_size: 14811135
-    name: /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 1b71604b-9ac5-3a2f-8cb7-0efa34a20f12
+    code_file: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices
+    debug_id: 1b71604b-9ac5-3a2f-8cb7-0efa34a20f12
     image_addr: '0x7fff32da1000'
     image_size: 4095
-    name: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 7599e619-ee21-3eb7-875b-ae3b8d3e13bb
+    code_file: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/ATS
+    debug_id: 7599e619-ee21-3eb7-875b-ae3b8d3e13bb
     image_addr: '0x7fff32da2000'
     image_size: 442367
-    name: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/ATS
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: e800074f-62cf-340a-a5a7-b8be5b560045
+    code_file: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontParser.dylib
+    debug_id: e800074f-62cf-340a-a5a7-b8be5b560045
     image_addr: '0x7fff32ea6000'
     image_size: 1179647
-    name: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontParser.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 480d472d-c8fb-321d-86ec-2ea6927a97ad
+    code_file: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontRegistry.dylib
+    debug_id: 480d472d-c8fb-321d-86ec-2ea6927a97ad
     image_addr: '0x7fff32fc6000'
     image_size: 311295
-    name: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontRegistry.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: d23bfde4-8664-335a-b43b-a13a8ef29e40
+    code_file: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libTrueTypeScaler.dylib
+    debug_id: d23bfde4-8664-335a-b43b-a13a8ef29e40
     image_addr: '0x7fff33070000'
     image_size: 212991
-    name: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libTrueTypeScaler.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 90641b6b-d07b-3577-b594-965825544b60
+    code_file: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ColorSyncLegacy.framework/Versions/A/ColorSyncLegacy
+    debug_id: 90641b6b-d07b-3577-b594-965825544b60
     image_addr: '0x7fff3310d000'
     image_size: 20479
-    name: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ColorSyncLegacy.framework/Versions/A/ColorSyncLegacy
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 01f309d6-32e7-3c4f-a38b-8206ee3076cc
+    code_file: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/HIServices.framework/Versions/A/HIServices
+    debug_id: 01f309d6-32e7-3c4f-a38b-8206ee3076cc
     image_addr: '0x7fff331ae000'
     image_size: 339967
-    name: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/HIServices.framework/Versions/A/HIServices
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 67bc5855-b7a3-39e6-b5dd-52b287eb1532
+    code_file: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/LangAnalysis.framework/Versions/A/LangAnalysis
+    debug_id: 67bc5855-b7a3-39e6-b5dd-52b287eb1532
     image_addr: '0x7fff33201000'
     image_size: 61439
-    name: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/LangAnalysis.framework/Versions/A/LangAnalysis
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: c13bc56a-65f4-35b1-9e33-51fe6f3b06fd
+    code_file: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/PrintCore.framework/Versions/A/PrintCore
+    debug_id: c13bc56a-65f4-35b1-9e33-51fe6f3b06fd
     image_addr: '0x7fff33210000'
     image_size: 315391
-    name: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/PrintCore.framework/Versions/A/PrintCore
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 94a30038-c545-327a-b1c0-e19c79d62bab
+    code_file: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/QD.framework/Versions/A/QD
+    debug_id: 94a30038-c545-327a-b1c0-e19c79d62bab
     image_addr: '0x7fff3325d000'
     image_size: 245759
-    name: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/QD.framework/Versions/A/QD
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: a96c744b-b1ad-32e3-ba72-7a221684be3f
+    code_file: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/SpeechSynthesis.framework/Versions/A/SpeechSynthesis
+    debug_id: a96c744b-b1ad-32e3-ba72-7a221684be3f
     image_addr: '0x7fff33299000'
     image_size: 53247
-    name: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/SpeechSynthesis.framework/Versions/A/SpeechSynthesis
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 89d2529d-cf36-3081-a700-70892f888718
+    code_file: /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox
+    debug_id: 89d2529d-cf36-3081-a700-70892f888718
     image_addr: '0x7fff332a6000'
     image_size: 2740223
-    name: /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 8b9a5adb-e62c-3838-bb5e-af20cae449cc
+    code_file: /System/Library/Frameworks/AudioUnit.framework/Versions/A/AudioUnit
+    debug_id: 8b9a5adb-e62c-3838-bb5e-af20cae449cc
     image_addr: '0x7fff33544000'
     image_size: 4095
-    name: /System/Library/Frameworks/AudioUnit.framework/Versions/A/AudioUnit
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: acc604fa-5d40-34ce-9206-8091010306b7
+    code_file: /System/Library/Frameworks/CFNetwork.framework/Versions/A/CFNetwork
+    debug_id: acc604fa-5d40-34ce-9206-8091010306b7
     image_addr: '0x7fff338a8000'
     image_size: 3940351
-    name: /System/Library/Frameworks/CFNetwork.framework/Versions/A/CFNetwork
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: daf95685-b793-34eb-96ea-3e292a9e3378
+    code_file: /System/Library/Frameworks/Carbon.framework/Versions/A/Carbon
+    debug_id: daf95685-b793-34eb-96ea-3e292a9e3378
     image_addr: '0x7fff33c7e000'
     image_size: 4095
-    name: /System/Library/Frameworks/Carbon.framework/Versions/A/Carbon
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: f1e1c47b-fd1a-30a4-b41b-87bd8b178b56
+    code_file: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/CommonPanels.framework/Versions/A/CommonPanels
+    debug_id: f1e1c47b-fd1a-30a4-b41b-87bd8b178b56
     image_addr: '0x7fff33c7f000'
     image_size: 16383
-    name: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/CommonPanels.framework/Versions/A/CommonPanels
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: b2ed8b1c-fc3e-3fa0-8f6d-e7a448e6faa7
+    code_file: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/HIToolbox
+    debug_id: b2ed8b1c-fc3e-3fa0-8f6d-e7a448e6faa7
     image_addr: '0x7fff33c83000'
     image_size: 3178495
-    name: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/HIToolbox
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 4392a63f-9b58-3248-bf73-b46ad3744e6e
+    code_file: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Help.framework/Versions/A/Help
+    debug_id: 4392a63f-9b58-3248-bf73-b46ad3744e6e
     image_addr: '0x7fff33f8b000'
     image_size: 16383
-    name: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Help.framework/Versions/A/Help
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 364edc6b-6374-31a7-a637-0044b73f8dbf
+    code_file: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/ImageCapture.framework/Versions/A/ImageCapture
+    debug_id: 364edc6b-6374-31a7-a637-0044b73f8dbf
     image_addr: '0x7fff33f8f000'
     image_size: 24575
-    name: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/ImageCapture.framework/Versions/A/ImageCapture
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: d6503f37-7ebc-32c1-95cc-a35efc54e7ed
+    code_file: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Ink.framework/Versions/A/Ink
+    debug_id: d6503f37-7ebc-32c1-95cc-a35efc54e7ed
     image_addr: '0x7fff33f95000'
     image_size: 610303
-    name: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Ink.framework/Versions/A/Ink
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: d4a4d130-9c7b-3656-9d58-50f9d09c276e
+    code_file: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/OpenScripting.framework/Versions/A/OpenScripting
+    debug_id: d4a4d130-9c7b-3656-9d58-50f9d09c276e
     image_addr: '0x7fff3402a000'
     image_size: 110591
-    name: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/OpenScripting.framework/Versions/A/OpenScripting
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 5cd250df-98ad-30b8-a5d5-47634ff9e74d
+    code_file: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Print.framework/Versions/A/Print
+    debug_id: 5cd250df-98ad-30b8-a5d5-47634ff9e74d
     image_addr: '0x7fff34065000'
     image_size: 8191
-    name: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Print.framework/Versions/A/Print
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: c5308cbc-6736-31a7-905b-c635c6d43fde
+    code_file: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SecurityHI.framework/Versions/A/SecurityHI
+    debug_id: c5308cbc-6736-31a7-905b-c635c6d43fde
     image_addr: '0x7fff34067000'
     image_size: 12287
-    name: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SecurityHI.framework/Versions/A/SecurityHI
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 1c38b9cb-dd45-3a7b-9d4c-631855a4ee32
+    code_file: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SpeechRecognition.framework/Versions/A/SpeechRecognition
+    debug_id: 1c38b9cb-dd45-3a7b-9d4c-631855a4ee32
     image_addr: '0x7fff3406a000'
     image_size: 28671
-    name: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SpeechRecognition.framework/Versions/A/SpeechRecognition
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: a520d2a3-032b-3c06-81e1-efdd97c47ace
+    code_file: /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
+    debug_id: a520d2a3-032b-3c06-81e1-efdd97c47ace
     image_addr: '0x7fff34197000'
     image_size: 4095
-    name: /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 0618da46-5a5e-339d-bb2f-ed66a2bfccf9
+    code_file: /System/Library/Frameworks/ColorSync.framework/Versions/A/ColorSync
+    debug_id: 0618da46-5a5e-339d-bb2f-ed66a2bfccf9
     image_addr: '0x7fff341a5000'
     image_size: 839679
-    name: /System/Library/Frameworks/ColorSync.framework/Versions/A/ColorSync
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 5845d43b-bbb5-343b-a164-6f9e2c53cfa3
+    code_file: /System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio
+    debug_id: 5845d43b-bbb5-343b-a164-6f9e2c53cfa3
     image_addr: '0x7fff3440c000'
     image_size: 593919
-    name: /System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: d2f48e3d-79fc-32d7-b281-658ead2cc50b
+    code_file: /System/Library/Frameworks/CoreBluetooth.framework/Versions/A/CoreBluetooth
+    debug_id: d2f48e3d-79fc-32d7-b281-658ead2cc50b
     image_addr: '0x7fff34502000'
     image_size: 180223
-    name: /System/Library/Frameworks/CoreBluetooth.framework/Versions/A/CoreBluetooth
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 90a5058f-a5af-311a-81cc-b20c2ac9e85e
+    code_file: /System/Library/Frameworks/CoreData.framework/Versions/A/CoreData
+    debug_id: 90a5058f-a5af-311a-81cc-b20c2ac9e85e
     image_addr: '0x7fff3452e000'
     image_size: 3805183
-    name: /System/Library/Frameworks/CoreData.framework/Versions/A/CoreData
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 4ae5c221-b8e1-3a4f-91e0-96ed5926e82b
+    code_file: /System/Library/Frameworks/CoreDisplay.framework/Versions/A/CoreDisplay
+    debug_id: 4ae5c221-b8e1-3a4f-91e0-96ed5926e82b
     image_addr: '0x7fff348cf000'
     image_size: 958463
-    name: /System/Library/Frameworks/CoreDisplay.framework/Versions/A/CoreDisplay
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 4a4c87bc-4c8e-392a-abee-824d4074c485
+    code_file: /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
+    debug_id: 4a4c87bc-4c8e-392a-abee-824d4074c485
     image_addr: '0x7fff349b9000'
     image_size: 4521983
-    name: /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: ffffeaf0-14dd-38a3-bd68-aa9ab2c672c1
+    code_file: /System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics
+    debug_id: ffffeaf0-14dd-38a3-bd68-aa9ab2c672c1
     image_addr: '0x7fff34e0a000'
     image_size: 6873087
-    name: /System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: e9e7b27c-c4fd-3ad6-923e-df7eae36d1ff
+    code_file: /System/Library/Frameworks/CoreImage.framework/Versions/A/CoreImage
+    debug_id: e9e7b27c-c4fd-3ad6-923e-df7eae36d1ff
     image_addr: '0x7fff35499000'
     image_size: 3301375
-    name: /System/Library/Frameworks/CoreImage.framework/Versions/A/CoreImage
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 5e733d6b-b683-3931-9d02-82300a43378d
+    code_file: /System/Library/Frameworks/CoreMedia.framework/Versions/A/CoreMedia
+    debug_id: 5e733d6b-b683-3931-9d02-82300a43378d
     image_addr: '0x7fff35b10000'
     image_size: 1056767
-    name: /System/Library/Frameworks/CoreMedia.framework/Versions/A/CoreMedia
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: bfb3978a-fdbb-352b-a96d-e8761fc51370
+    code_file: /System/Library/Frameworks/CoreMediaIO.framework/Versions/A/CoreMediaIO
+    debug_id: bfb3978a-fdbb-352b-a96d-e8761fc51370
     image_addr: '0x7fff35c12000'
     image_size: 405503
-    name: /System/Library/Frameworks/CoreMediaIO.framework/Versions/A/CoreMediaIO
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: b79c910e-93b9-3686-8e72-e0b63083aae5
+    code_file: /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
+    debug_id: b79c910e-93b9-3686-8e72-e0b63083aae5
     image_addr: '0x7fff35c75000'
     image_size: 4095
-    name: /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: e795749d-ce50-3b8c-91a7-8c2618887288
+    code_file: /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/AE.framework/Versions/A/AE
+    debug_id: e795749d-ce50-3b8c-91a7-8c2618887288
     image_addr: '0x7fff35c76000'
     image_size: 520191
-    name: /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/AE.framework/Versions/A/AE
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 9fbe7bfb-3a81-37ac-8e15-e6f7932bbdc0
+    code_file: /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/CarbonCore
+    debug_id: 9fbe7bfb-3a81-37ac-8e15-e6f7932bbdc0
     image_addr: '0x7fff35cf5000'
     image_size: 2985983
-    name: /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/CarbonCore
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: d9388630-e7f2-321e-81ff-ebd5f3b47a52
+    code_file: /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/DictionaryServices.framework/Versions/A/DictionaryServices
+    debug_id: d9388630-e7f2-321e-81ff-ebd5f3b47a52
     image_addr: '0x7fff35fce000'
     image_size: 307199
-    name: /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/DictionaryServices.framework/Versions/A/DictionaryServices
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: e40a3c4a-79c7-37d8-999b-d1169a06870b
+    code_file: /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/FSEvents.framework/Versions/A/FSEvents
+    debug_id: e40a3c4a-79c7-37d8-999b-d1169a06870b
     image_addr: '0x7fff36019000'
     image_size: 36863
-    name: /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/FSEvents.framework/Versions/A/FSEvents
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 4614a4b4-c358-3460-9fa7-df8d6c466806
+    code_file: /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/LaunchServices
+    debug_id: 4614a4b4-c358-3460-9fa7-df8d6c466806
     image_addr: '0x7fff36022000'
     image_size: 1884159
-    name: /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/LaunchServices
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 6b9cca98-6f68-3908-a7a9-96d3e2ae5968
+    code_file: /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/Metadata.framework/Versions/A/Metadata
+    debug_id: 6b9cca98-6f68-3908-a7a9-96d3e2ae5968
     image_addr: '0x7fff361ee000'
     image_size: 667647
-    name: /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/Metadata.framework/Versions/A/Metadata
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: a92c846f-872d-3534-b60e-6cd445a9baee
+    code_file: /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/OSServices.framework/Versions/A/OSServices
+    debug_id: a92c846f-872d-3534-b60e-6cd445a9baee
     image_addr: '0x7fff36291000'
     image_size: 311295
-    name: /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/OSServices.framework/Versions/A/OSServices
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: c6a34d09-9707-3f28-838f-63b59b8a12d5
+    code_file: /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SearchKit.framework/Versions/A/SearchKit
+    debug_id: c6a34d09-9707-3f28-838f-63b59b8a12d5
     image_addr: '0x7fff362dd000'
     image_size: 454655
-    name: /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SearchKit.framework/Versions/A/SearchKit
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: b46a15e0-4c10-3616-be49-58e07ec463fe
+    code_file: /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SharedFileList.framework/Versions/A/SharedFileList
+    debug_id: b46a15e0-4c10-3616-be49-58e07ec463fe
     image_addr: '0x7fff3634c000'
     image_size: 151551
-    name: /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SharedFileList.framework/Versions/A/SharedFileList
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 5b55b533-f4de-32ce-8739-16fffa1a64f8
+    code_file: /System/Library/Frameworks/CoreText.framework/Versions/A/CoreText
+    debug_id: 5b55b533-f4de-32ce-8739-16fffa1a64f8
     image_addr: '0x7fff366b3000'
     image_size: 1466367
-    name: /System/Library/Frameworks/CoreText.framework/Versions/A/CoreText
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: c7bb7d0f-3af2-3046-a387-a802bca52a3a
+    code_file: /System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo
+    debug_id: c7bb7d0f-3af2-3046-a387-a802bca52a3a
     image_addr: '0x7fff36819000'
     image_size: 253951
-    name: /System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 19e41424-b956-34df-ae02-9822308fa3dc
+    code_file: /System/Library/Frameworks/CoreWLAN.framework/Versions/A/CoreWLAN
+    debug_id: 19e41424-b956-34df-ae02-9822308fa3dc
     image_addr: '0x7fff36857000'
     image_size: 618495
-    name: /System/Library/Frameworks/CoreWLAN.framework/Versions/A/CoreWLAN
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: c53c1905-9bcf-3ae8-8bb3-c8a2c7db7d25
+    code_file: /System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration
+    debug_id: c53c1905-9bcf-3ae8-8bb3-c8a2c7db7d25
     image_addr: '0x7fff36b6a000'
     image_size: 24575
-    name: /System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 0ccaf9af-f7af-3174-98d4-6c188b1079cc
+    code_file: /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
+    debug_id: 0ccaf9af-f7af-3174-98d4-6c188b1079cc
     image_addr: '0x7fff36d38000'
     image_size: 3993599
-    name: /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 74acb1a1-a5a4-3180-ac00-688c94aa4434
+    code_file: /System/Library/Frameworks/GSS.framework/Versions/A/GSS
+    debug_id: 74acb1a1-a5a4-3180-ac00-688c94aa4434
     image_addr: '0x7fff37177000'
     image_size: 200703
-    name: /System/Library/Frameworks/GSS.framework/Versions/A/GSS
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 6cb8a08e-1154-3333-83cc-2a939ac94562
+    code_file: /System/Library/Frameworks/IOBluetooth.framework/Versions/A/IOBluetooth
+    debug_id: 6cb8a08e-1154-3333-83cc-2a939ac94562
     image_addr: '0x7fff372c0000'
     image_size: 1089535
-    name: /System/Library/Frameworks/IOBluetooth.framework/Versions/A/IOBluetooth
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: da4ed91f-2cc9-3cfd-9200-9d5d31eee4f3
+    code_file: /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
+    debug_id: da4ed91f-2cc9-3cfd-9200-9d5d31eee4f3
     image_addr: '0x7fff3742b000'
     image_size: 598015
-    name: /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 538f0257-a408-36af-ab1e-1d7037d6359e
+    code_file: /System/Library/Frameworks/IOSurface.framework/Versions/A/IOSurface
+    debug_id: 538f0257-a408-36af-ab1e-1d7037d6359e
     image_addr: '0x7fff374be000'
     image_size: 45055
-    name: /System/Library/Frameworks/IOSurface.framework/Versions/A/IOSurface
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 9d078f50-bb75-3d04-8636-3fddab9c95da
+    code_file: /System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
+    debug_id: 9d078f50-bb75-3d04-8636-3fddab9c95da
     image_addr: '0x7fff3751f000'
     image_size: 1658879
-    name: /System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 93ad6fb9-03ba-350e-af98-d371a2bfd58f
+    code_file: /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libGIF.dylib
+    debug_id: 93ad6fb9-03ba-350e-af98-d371a2bfd58f
     image_addr: '0x7fff376b4000'
     image_size: 20479
-    name: /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libGIF.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 3780eb9b-5219-385d-9472-17b0397697a5
+    code_file: /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJP2.dylib
+    debug_id: 3780eb9b-5219-385d-9472-17b0397697a5
     image_addr: '0x7fff376b9000'
     image_size: 942079
-    name: /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJP2.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 83ca8beb-34bd-3b58-a704-c6a875984fad
+    code_file: /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJPEG.dylib
+    debug_id: 83ca8beb-34bd-3b58-a704-c6a875984fad
     image_addr: '0x7fff3779f000'
     image_size: 155647
-    name: /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJPEG.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 9f30fa63-8ab2-3646-a6a8-fce9f8436c35
+    code_file: /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libPng.dylib
+    debug_id: 9f30fa63-8ab2-3646-a6a8-fce9f8436c35
     image_addr: '0x7fff37a97000'
     image_size: 159743
-    name: /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libPng.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 2c07887c-0584-3538-a9ec-3988aa5b234b
+    code_file: /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libRadiance.dylib
+    debug_id: 2c07887c-0584-3538-a9ec-3988aa5b234b
     image_addr: '0x7fff37abe000'
     image_size: 12287
-    name: /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libRadiance.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: f420b0dc-d0f7-3dd5-9e17-00462441635c
+    code_file: /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libTIFF.dylib
+    debug_id: f420b0dc-d0f7-3dd5-9e17-00462441635c
     image_addr: '0x7fff37ac1000'
     image_size: 323583
-    name: /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libTIFF.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 8be3d524-257d-3663-a937-f1ac76bdf4d9
+    code_file: /System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos
+    debug_id: 8be3d524-257d-3663-a937-f1ac76bdf4d9
     image_addr: '0x7fff38ba5000'
     image_size: 106495
-    name: /System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 29d89f2b-6254-3d0d-bd0c-8472fca373f4
+    code_file: /System/Library/Frameworks/MediaAccessibility.framework/Versions/A/MediaAccessibility
+    debug_id: 29d89f2b-6254-3d0d-bd0c-8472fca373f4
     image_addr: '0x7fff38e7b000'
     image_size: 45055
-    name: /System/Library/Frameworks/MediaAccessibility.framework/Versions/A/MediaAccessibility
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: fb1c3dd9-a91b-3952-a892-9f009b854f8f
+    code_file: /System/Library/Frameworks/MediaToolbox.framework/Versions/A/MediaToolbox
+    debug_id: fb1c3dd9-a91b-3952-a892-9f009b854f8f
     image_addr: '0x7fff38f3f000'
     image_size: 6934527
-    name: /System/Library/Frameworks/MediaToolbox.framework/Versions/A/MediaToolbox
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 49cd402f-20cb-3930-b997-bbdc495abf64
+    code_file: /System/Library/Frameworks/Metal.framework/Versions/A/Metal
+    debug_id: 49cd402f-20cb-3930-b997-bbdc495abf64
     image_addr: '0x7fff395dd000'
     image_size: 606207
-    name: /System/Library/Frameworks/Metal.framework/Versions/A/Metal
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 9a841a76-43bc-3220-a4da-99137c42a0bc
+    code_file: /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSCore.framework/Versions/A/MPSCore
+    debug_id: 9a841a76-43bc-3220-a4da-99137c42a0bc
     image_addr: '0x7fff3968d000'
     image_size: 135167
-    name: /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSCore.framework/Versions/A/MPSCore
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: c469d1e5-f621-3e56-87ac-1bd889664fa3
+    code_file: /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSImage.framework/Versions/A/MPSImage
+    debug_id: c469d1e5-f621-3e56-87ac-1bd889664fa3
     image_addr: '0x7fff396ae000'
     image_size: 516095
-    name: /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSImage.framework/Versions/A/MPSImage
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 8c57a3a2-8ebb-3401-87fc-368d1be6daac
+    code_file: /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSMatrix.framework/Versions/A/MPSMatrix
+    debug_id: 8c57a3a2-8ebb-3401-87fc-368d1be6daac
     image_addr: '0x7fff3972c000'
     image_size: 167935
-    name: /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSMatrix.framework/Versions/A/MPSMatrix
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: ce3201a3-4ace-3e79-990b-8987c576b31b
+    code_file: /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSNeuralNetwork.framework/Versions/A/MPSNeuralNetwork
+    debug_id: ce3201a3-4ace-3e79-990b-8987c576b31b
     image_addr: '0x7fff39755000'
     image_size: 1212415
-    name: /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSNeuralNetwork.framework/Versions/A/MPSNeuralNetwork
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 8f02cfca-41e1-3194-915f-3106e8b48b32
+    code_file: /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSRayIntersector.framework/Versions/A/MPSRayIntersector
+    debug_id: 8f02cfca-41e1-3194-915f-3106e8b48b32
     image_addr: '0x7fff3987d000'
     image_size: 114687
-    name: /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSRayIntersector.framework/Versions/A/MPSRayIntersector
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 8b715d78-8357-38f4-a03c-926ee967ce71
+    code_file: /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/MetalPerformanceShaders
+    debug_id: 8b715d78-8357-38f4-a03c-926ee967ce71
     image_addr: '0x7fff39899000'
     image_size: 4095
-    name: /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/MetalPerformanceShaders
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 529e29a9-5e77-3a8c-a982-cf55f949fe5d
+    code_file: /System/Library/Frameworks/NetFS.framework/Versions/A/NetFS
+    debug_id: 529e29a9-5e77-3a8c-a982-cf55f949fe5d
     image_addr: '0x7fff3aa98000'
     image_size: 53247
-    name: /System/Library/Frameworks/NetFS.framework/Versions/A/NetFS
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 3eae5bc8-e948-3926-9319-9dac2a8b5484
+    code_file: /System/Library/Frameworks/OpenCL.framework/Versions/A/OpenCL
+    debug_id: 3eae5bc8-e948-3926-9319-9dac2a8b5484
     image_addr: '0x7fff3d564000'
     image_size: 368639
-    name: /System/Library/Frameworks/OpenCL.framework/Versions/A/OpenCL
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 7e4eff02-2596-31e6-88de-29c89e2837e4
+    code_file: /System/Library/Frameworks/OpenDirectory.framework/Versions/A/Frameworks/CFOpenDirectory.framework/Versions/A/CFOpenDirectory
+    debug_id: 7e4eff02-2596-31e6-88de-29c89e2837e4
     image_addr: '0x7fff3d5be000'
     image_size: 118783
-    name: /System/Library/Frameworks/OpenDirectory.framework/Versions/A/Frameworks/CFOpenDirectory.framework/Versions/A/CFOpenDirectory
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 52a3918e-0f7a-33fd-87ee-21a37b37d13b
+    code_file: /System/Library/Frameworks/OpenDirectory.framework/Versions/A/OpenDirectory
+    debug_id: 52a3918e-0f7a-33fd-87ee-21a37b37d13b
     image_addr: '0x7fff3d5db000'
     image_size: 53247
-    name: /System/Library/Frameworks/OpenDirectory.framework/Versions/A/OpenDirectory
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 38a18a32-bbf2-3a0f-ae37-51734b6ca91a
+    code_file: /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCVMSPluginSupport.dylib
+    debug_id: 38a18a32-bbf2-3a0f-ae37-51734b6ca91a
     image_addr: '0x7fff3df4a000'
     image_size: 12287
-    name: /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCVMSPluginSupport.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: bf8f04dd-c1a1-3d2a-bf3f-639fe907e28d
+    code_file: /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreFSCache.dylib
+    debug_id: bf8f04dd-c1a1-3d2a-bf3f-639fe907e28d
     image_addr: '0x7fff3df4d000'
     image_size: 24575
-    name: /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreFSCache.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 45a2c724-f3d1-316a-9a41-cab8e2a390ec
+    code_file: /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreVMClient.dylib
+    debug_id: 45a2c724-f3d1-316a-9a41-cab8e2a390ec
     image_addr: '0x7fff3df53000'
     image_size: 20479
-    name: /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreVMClient.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 267b40df-2939-3d76-89fa-e8dbdee96d92
+    code_file: /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGFXShared.dylib
+    debug_id: 267b40df-2939-3d76-89fa-e8dbdee96d92
     image_addr: '0x7fff3df58000'
     image_size: 36863
-    name: /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGFXShared.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 2e25a83b-b560-34a1-b474-3027c8b75ba4
+    code_file: /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib
+    debug_id: 2e25a83b-b560-34a1-b474-3027c8b75ba4
     image_addr: '0x7fff3df61000'
     image_size: 49151
-    name: /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 49c5f799-66e5-3a81-af88-948dd0e583fa
+    code_file: /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLImage.dylib
+    debug_id: 49c5f799-66e5-3a81-af88-948dd0e583fa
     image_addr: '0x7fff3df6d000'
     image_size: 241663
-    name: /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLImage.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 79555e42-b816-3106-8fa0-fc14a54ae8b3
+    code_file: /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLU.dylib
+    debug_id: 79555e42-b816-3106-8fa0-fc14a54ae8b3
     image_addr: '0x7fff3e11b000'
     image_size: 253951
-    name: /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLU.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: fa76eaa6-d035-3444-87f5-dd95446d651d
+    code_file: /System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL
+    debug_id: fa76eaa6-d035-3444-87f5-dd95446d651d
     image_addr: '0x7fff3eb08000'
     image_size: 65535
-    name: /System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 2c9e3279-3f97-3440-b937-e5fe888232e2
+    code_file: /System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore
+    debug_id: 2c9e3279-3f97-3440-b937-e5fe888232e2
     image_addr: '0x7fff3f973000'
     image_size: 2453503
-    name: /System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: aeb638d9-bfe9-319e-a70b-557acf41117a
+    code_file: /System/Library/Frameworks/Security.framework/Versions/A/Security
+    debug_id: aeb638d9-bfe9-319e-a70b-557acf41117a
     image_addr: '0x7fff40417000'
     image_size: 3305471
-    name: /System/Library/Frameworks/Security.framework/Versions/A/Security
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 770d67d1-3da6-3fd3-8531-376712ba4f60
+    code_file: /System/Library/Frameworks/SecurityFoundation.framework/Versions/A/SecurityFoundation
+    debug_id: 770d67d1-3da6-3fd3-8531-376712ba4f60
     image_addr: '0x7fff4073e000'
     image_size: 589823
-    name: /System/Library/Frameworks/SecurityFoundation.framework/Versions/A/SecurityFoundation
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 20db899d-3baf-36fd-86a6-f66a82074607
+    code_file: /System/Library/Frameworks/ServiceManagement.framework/Versions/A/ServiceManagement
+    debug_id: 20db899d-3baf-36fd-86a6-f66a82074607
     image_addr: '0x7fff407ff000'
     image_size: 20479
-    name: /System/Library/Frameworks/ServiceManagement.framework/Versions/A/ServiceManagement
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: eed5bc9b-ce8d-343c-bcdc-04a79f704828
+    code_file: /System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration
+    debug_id: eed5bc9b-ce8d-343c-bcdc-04a79f704828
     image_addr: '0x7fff40bc0000'
     image_size: 462847
-    name: /System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 468a9f6d-33ab-31d3-a8a3-a6a432033c9e
+    code_file: /System/Library/Frameworks/VideoToolbox.framework/Versions/A/VideoToolbox
+    debug_id: 468a9f6d-33ab-31d3-a8a3-a6a432033c9e
     image_addr: '0x7fff40e91000'
     image_size: 3551231
-    name: /System/Library/Frameworks/VideoToolbox.framework/Versions/A/VideoToolbox
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: cbe5ee83-7a5f-3c10-93ff-f6da84dfb875
+    code_file: /System/Library/PrivateFrameworks/APFS.framework/Versions/A/APFS
+    debug_id: cbe5ee83-7a5f-3c10-93ff-f6da84dfb875
     image_addr: '0x7fff43e95000'
     image_size: 679935
-    name: /System/Library/PrivateFrameworks/APFS.framework/Versions/A/APFS
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 1debbe36-8945-3ad8-bd48-2850ad845711
+    code_file: /System/Library/PrivateFrameworks/AggregateDictionary.framework/Versions/A/AggregateDictionary
+    debug_id: 1debbe36-8945-3ad8-bd48-2850ad845711
     image_addr: '0x7fff44976000'
     image_size: 8191
-    name: /System/Library/PrivateFrameworks/AggregateDictionary.framework/Versions/A/AggregateDictionary
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 79ebf155-eab2-37ee-bf8c-57bc453217b1
+    code_file: /System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Apple80211
+    debug_id: 79ebf155-eab2-37ee-bf8c-57bc453217b1
     image_addr: '0x7fff44f72000'
     image_size: 184319
-    name: /System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Apple80211
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: e093776e-c367-3ccf-bfd5-623476a89e9a
+    code_file: /System/Library/PrivateFrameworks/AppleFSCompression.framework/Versions/A/AppleFSCompression
+    debug_id: e093776e-c367-3ccf-bfd5-623476a89e9a
     image_addr: '0x7fff4527a000'
     image_size: 65535
-    name: /System/Library/PrivateFrameworks/AppleFSCompression.framework/Versions/A/AppleFSCompression
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 5362d9ad-a2ae-3436-97ce-c353124504e5
+    code_file: /System/Library/PrivateFrameworks/AppleIDAuthSupport.framework/Versions/A/AppleIDAuthSupport
+    debug_id: 5362d9ad-a2ae-3436-97ce-c353124504e5
     image_addr: '0x7fff45387000'
     image_size: 49151
-    name: /System/Library/PrivateFrameworks/AppleIDAuthSupport.framework/Versions/A/AppleIDAuthSupport
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 9a690e6e-f987-3660-bed6-b1a4d1906b6c
+    code_file: /System/Library/PrivateFrameworks/AppleJPEG.framework/Versions/A/AppleJPEG
+    debug_id: 9a690e6e-f987-3660-bed6-b1a4d1906b6c
     image_addr: '0x7fff453d3000'
     image_size: 303103
-    name: /System/Library/PrivateFrameworks/AppleJPEG.framework/Versions/A/AppleJPEG
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 60bb16d6-de7e-356a-b9de-f73ee179934a
+    code_file: /System/Library/PrivateFrameworks/AppleSauce.framework/Versions/A/AppleSauce
+    debug_id: 60bb16d6-de7e-356a-b9de-f73ee179934a
     image_addr: '0x7fff4566c000'
     image_size: 167935
-    name: /System/Library/PrivateFrameworks/AppleSauce.framework/Versions/A/AppleSauce
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: f7b8cd3a-8671-3b2c-b67c-ce39c1442207
+    code_file: /System/Library/PrivateFrameworks/AppleVA.framework/Versions/A/AppleVA
+    debug_id: f7b8cd3a-8671-3b2c-b67c-ce39c1442207
     image_addr: '0x7fff4575f000'
     image_size: 331775
-    name: /System/Library/PrivateFrameworks/AppleVA.framework/Versions/A/AppleVA
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 8fb0d908-6c46-3399-92d6-4e7d4b5f4f19
+    code_file: /System/Library/PrivateFrameworks/AssertionServices.framework/Versions/A/AssertionServices
+    debug_id: 8fb0d908-6c46-3399-92d6-4e7d4b5f4f19
     image_addr: '0x7fff457fa000'
     image_size: 94207
-    name: /System/Library/PrivateFrameworks/AssertionServices.framework/Versions/A/AssertionServices
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: ed375339-69f6-34ae-825d-f16bf0618e3e
+    code_file: /System/Library/PrivateFrameworks/AuthKit.framework/Versions/A/AuthKit
+    debug_id: ed375339-69f6-34ae-825d-f16bf0618e3e
     image_addr: '0x7fff45b40000'
     image_size: 2768895
-    name: /System/Library/PrivateFrameworks/AuthKit.framework/Versions/A/AuthKit
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 972f41b3-7df7-3bf1-acca-a093a4328adf
+    code_file: /System/Library/PrivateFrameworks/BackgroundTaskManagement.framework/Versions/A/BackgroundTaskManagement
+    debug_id: 972f41b3-7df7-3bf1-acca-a093a4328adf
     image_addr: '0x7fff45fb4000'
     image_size: 40959
-    name: /System/Library/PrivateFrameworks/BackgroundTaskManagement.framework/Versions/A/BackgroundTaskManagement
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 46534b04-dd0e-357b-9cb5-f88aac6af4ed
+    code_file: /System/Library/PrivateFrameworks/Backup.framework/Versions/A/Backup
+    debug_id: 46534b04-dd0e-357b-9cb5-f88aac6af4ed
     image_addr: '0x7fff45fbe000'
     image_size: 667647
-    name: /System/Library/PrivateFrameworks/Backup.framework/Versions/A/Backup
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 709ef03c-5bce-3f47-bd58-a48c1f9378a5
+    code_file: /System/Library/PrivateFrameworks/BaseBoard.framework/Versions/A/BaseBoard
+    debug_id: 709ef03c-5bce-3f47-bd58-a48c1f9378a5
     image_addr: '0x7fff46061000'
     image_size: 466943
-    name: /System/Library/PrivateFrameworks/BaseBoard.framework/Versions/A/BaseBoard
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 7105f266-35c3-3582-9383-a2a9d7184a7b
+    code_file: /System/Library/PrivateFrameworks/CommonAuth.framework/Versions/A/CommonAuth
+    debug_id: 7105f266-35c3-3582-9383-a2a9d7184a7b
     image_addr: '0x7fff47c81000'
     image_size: 40959
-    name: /System/Library/PrivateFrameworks/CommonAuth.framework/Versions/A/CommonAuth
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 288ec7ed-a86a-30d0-ade2-56c33cd93aa8
+    code_file: /System/Library/PrivateFrameworks/CoreAUC.framework/Versions/A/CoreAUC
+    debug_id: 288ec7ed-a86a-30d0-ade2-56c33cd93aa8
     image_addr: '0x7fff4813a000'
     image_size: 4030463
-    name: /System/Library/PrivateFrameworks/CoreAUC.framework/Versions/A/CoreAUC
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 507ac58b-4527-353b-99cb-67ff183bd4d5
+    code_file: /System/Library/PrivateFrameworks/CoreAVCHD.framework/Versions/A/CoreAVCHD
+    debug_id: 507ac58b-4527-353b-99cb-67ff183bd4d5
     image_addr: '0x7fff48512000'
     image_size: 204799
-    name: /System/Library/PrivateFrameworks/CoreAVCHD.framework/Versions/A/CoreAVCHD
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 011e7853-bdd6-3197-ba8d-d6b977ef56eb
+    code_file: /System/Library/PrivateFrameworks/CoreEmoji.framework/Versions/A/CoreEmoji
+    debug_id: 011e7853-bdd6-3197-ba8d-d6b977ef56eb
     image_addr: '0x7fff48987000'
     image_size: 81919
-    name: /System/Library/PrivateFrameworks/CoreEmoji.framework/Versions/A/CoreEmoji
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 401f5284-a984-32a1-a547-cc8156381070
+    code_file: /System/Library/PrivateFrameworks/CoreNLP.framework/Versions/A/CoreNLP
+    debug_id: 401f5284-a984-32a1-a547-cc8156381070
     image_addr: '0x7fff48f70000'
     image_size: 471039
-    name: /System/Library/PrivateFrameworks/CoreNLP.framework/Versions/A/CoreNLP
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: f47ca56f-6760-3282-bfd8-c8c8d2c33ecf
+    code_file: /System/Library/PrivateFrameworks/CorePhoneNumbers.framework/Versions/A/CorePhoneNumbers
+    debug_id: f47ca56f-6760-3282-bfd8-c8c8d2c33ecf
     image_addr: '0x7fff4929d000'
     image_size: 36863
-    name: /System/Library/PrivateFrameworks/CorePhoneNumbers.framework/Versions/A/CorePhoneNumbers
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 2d012eb3-83bf-3e51-a2be-41af26f2ddf0
+    code_file: /System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/CoreServicesInternal
+    debug_id: 2d012eb3-83bf-3e51-a2be-41af26f2ddf0
     image_addr: '0x7fff49434000'
     image_size: 204799
-    name: /System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/CoreServicesInternal
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 912c63c0-473b-3352-a255-60f7ca3fe3f2
+    code_file: /System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication
+    debug_id: 912c63c0-473b-3352-a255-60f7ca3fe3f2
     image_addr: '0x7fff4982a000'
     image_size: 585727
-    name: /System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 05f9736c-5a62-33b3-9607-551a332aef28
+    code_file: /System/Library/PrivateFrameworks/CoreUI.framework/Versions/A/CoreUI
+    debug_id: 05f9736c-5a62-33b3-9607-551a332aef28
     image_addr: '0x7fff49948000'
     image_size: 1232895
-    name: /System/Library/PrivateFrameworks/CoreUI.framework/Versions/A/CoreUI
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 2554ba12-16a2-399f-a13a-e5c8eb4fc1ec
+    code_file: /System/Library/PrivateFrameworks/CoreUtils.framework/Versions/A/CoreUtils
+    debug_id: 2554ba12-16a2-399f-a13a-e5c8eb4fc1ec
     image_addr: '0x7fff49a75000'
     image_size: 1572863
-    name: /System/Library/PrivateFrameworks/CoreUtils.framework/Versions/A/CoreUtils
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 5c6acf32-14d3-35fd-8a4a-629521090f41
+    code_file: /System/Library/PrivateFrameworks/CoreWiFi.framework/Versions/A/CoreWiFi
+    debug_id: 5c6acf32-14d3-35fd-8a4a-629521090f41
     image_addr: '0x7fff49c4b000'
     image_size: 409599
-    name: /System/Library/PrivateFrameworks/CoreWiFi.framework/Versions/A/CoreWiFi
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 36754bb2-680f-36ae-a5de-548b4f41f0ae
+    code_file: /System/Library/PrivateFrameworks/CrashReporterSupport.framework/Versions/A/CrashReporterSupport
+    debug_id: 36754bb2-680f-36ae-a5de-548b4f41f0ae
     image_addr: '0x7fff49caf000'
     image_size: 73727
-    name: /System/Library/PrivateFrameworks/CrashReporterSupport.framework/Versions/A/CrashReporterSupport
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 61ef0583-e946-3201-932d-7d117bc62cb2
+    code_file: /System/Library/PrivateFrameworks/DFRFoundation.framework/Versions/A/DFRFoundation
+    debug_id: 61ef0583-e946-3201-932d-7d117bc62cb2
     image_addr: '0x7fff49d43000'
     image_size: 65535
-    name: /System/Library/PrivateFrameworks/DFRFoundation.framework/Versions/A/DFRFoundation
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: b6b26bb3-2dc9-34d0-817e-eb612432ec96
+    code_file: /System/Library/PrivateFrameworks/DSExternalDisplay.framework/Versions/A/DSExternalDisplay
+    debug_id: b6b26bb3-2dc9-34d0-817e-eb612432ec96
     image_addr: '0x7fff49d53000'
     image_size: 20479
-    name: /System/Library/PrivateFrameworks/DSExternalDisplay.framework/Versions/A/DSExternalDisplay
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 2d4cff51-bcd4-3d08-ae73-ab2b8bec8659
+    code_file: /System/Library/PrivateFrameworks/DataDetectorsCore.framework/Versions/A/DataDetectorsCore
+    debug_id: 2d4cff51-bcd4-3d08-ae73-ab2b8bec8659
     image_addr: '0x7fff49dda000'
     image_size: 491519
-    name: /System/Library/PrivateFrameworks/DataDetectorsCore.framework/Versions/A/DataDetectorsCore
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 01f561da-4724-32fd-b2c7-6436f4ceb980
+    code_file: /System/Library/PrivateFrameworks/DebugSymbols.framework/Versions/A/DebugSymbols
+    debug_id: 01f561da-4724-32fd-b2c7-6436f4ceb980
     image_addr: '0x7fff49e9f000'
     image_size: 270335
-    name: /System/Library/PrivateFrameworks/DebugSymbols.framework/Versions/A/DebugSymbols
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 053d3a96-9263-3242-8625-101ddb9350de
+    code_file: /System/Library/PrivateFrameworks/DesktopServicesPriv.framework/Versions/A/DesktopServicesPriv
+    debug_id: 053d3a96-9263-3242-8625-101ddb9350de
     image_addr: '0x7fff49ee1000'
     image_size: 1417215
-    name: /System/Library/PrivateFrameworks/DesktopServicesPriv.framework/Versions/A/DesktopServicesPriv
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: ccbc466a-1ad4-3b0b-80b2-d6cfcbb37fc0
+    code_file: /System/Library/PrivateFrameworks/FaceCore.framework/Versions/A/FaceCore
+    debug_id: ccbc466a-1ad4-3b0b-80b2-d6cfcbb37fc0
     image_addr: '0x7fff4b07e000'
     image_size: 4362239
-    name: /System/Library/PrivateFrameworks/FaceCore.framework/Versions/A/FaceCore
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: f0c95234-16ba-3f0b-a11e-087abdc8dd6c
+    code_file: /System/Library/PrivateFrameworks/GPUCompiler.framework/Versions/3902/Libraries/libmetal_timestamp.dylib
+    debug_id: f0c95234-16ba-3f0b-a11e-087abdc8dd6c
     image_addr: '0x7fff4edc8000'
     image_size: 8191
-    name: /System/Library/PrivateFrameworks/GPUCompiler.framework/Versions/3902/Libraries/libmetal_timestamp.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: a7ff28dc-3576-3e53-afaf-0e29cb45e9ae
+    code_file: /System/Library/PrivateFrameworks/GPUWrangler.framework/Versions/A/GPUWrangler
+    debug_id: a7ff28dc-3576-3e53-afaf-0e29cb45e9ae
     image_addr: '0x7fff5046e000'
     image_size: 24575
-    name: /System/Library/PrivateFrameworks/GPUWrangler.framework/Versions/A/GPUWrangler
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: c7040cd7-6cab-3878-b29e-21f1665341d0
+    code_file: /System/Library/PrivateFrameworks/GraphVisualizer.framework/Versions/A/GraphVisualizer
+    debug_id: c7040cd7-6cab-3878-b29e-21f1665341d0
     image_addr: '0x7fff512d2000'
     image_size: 65535
-    name: /System/Library/PrivateFrameworks/GraphVisualizer.framework/Versions/A/GraphVisualizer
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 793e1d31-6166-37f2-a989-f98fe1706e5d
+    code_file: /System/Library/PrivateFrameworks/Heimdal.framework/Versions/A/Heimdal
+    debug_id: 793e1d31-6166-37f2-a989-f98fe1706e5d
     image_addr: '0x7fff513c8000'
     image_size: 479231
-    name: /System/Library/PrivateFrameworks/Heimdal.framework/Versions/A/Heimdal
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: a2e867b2-615d-393c-a2c7-d2b83b56756d
+    code_file: /System/Library/PrivateFrameworks/IOAccelMemoryInfo.framework/Versions/A/IOAccelMemoryInfo
+    debug_id: a2e867b2-615d-393c-a2c7-d2b83b56756d
     image_addr: '0x7fff5280e000'
     image_size: 40959
-    name: /System/Library/PrivateFrameworks/IOAccelMemoryInfo.framework/Versions/A/IOAccelMemoryInfo
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 01551ed8-6ae1-307d-a3f0-dca85faa5210
+    code_file: /System/Library/PrivateFrameworks/IOAccelerator.framework/Versions/A/IOAccelerator
+    debug_id: 01551ed8-6ae1-307d-a3f0-dca85faa5210
     image_addr: '0x7fff52818000'
     image_size: 32767
-    name: /System/Library/PrivateFrameworks/IOAccelerator.framework/Versions/A/IOAccelerator
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 751130a1-8639-3bda-bf8f-a3be54427e43
+    code_file: /System/Library/PrivateFrameworks/IOPresentment.framework/Versions/A/IOPresentment
+    debug_id: 751130a1-8639-3bda-bf8f-a3be54427e43
     image_addr: '0x7fff52823000'
     image_size: 106495
-    name: /System/Library/PrivateFrameworks/IOPresentment.framework/Versions/A/IOPresentment
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: be9e71b4-c00e-317d-9093-6e637c905a09
+    code_file: /System/Library/PrivateFrameworks/IconServices.framework/Versions/A/IconServices
+    debug_id: be9e71b4-c00e-317d-9093-6e637c905a09
     image_addr: '0x7fff52c4f000'
     image_size: 196607
-    name: /System/Library/PrivateFrameworks/IconServices.framework/Versions/A/IconServices
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: f0e300ad-1e67-3d57-b179-c2212f7cd00c
+    code_file: /System/Library/PrivateFrameworks/InternationalSupport.framework/Versions/A/InternationalSupport
+    debug_id: f0e300ad-1e67-3d57-b179-c2212f7cd00c
     image_addr: '0x7fff52da9000'
     image_size: 20479
-    name: /System/Library/PrivateFrameworks/InternationalSupport.framework/Versions/A/InternationalSupport
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 10a17a9d-564e-3841-a433-d6d7401ed733
+    code_file: /System/Library/PrivateFrameworks/KeychainCircle.framework/Versions/A/KeychainCircle
+    debug_id: 10a17a9d-564e-3841-a433-d6d7401ed733
     image_addr: '0x7fff52f1d000'
     image_size: 81919
-    name: /System/Library/PrivateFrameworks/KeychainCircle.framework/Versions/A/KeychainCircle
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: e524cc46-42c7-3046-ad6c-5d5d768ea478
+    code_file: /System/Library/PrivateFrameworks/LanguageModeling.framework/Versions/A/LanguageModeling
+    debug_id: e524cc46-42c7-3046-ad6c-5d5d768ea478
     image_addr: '0x7fff52f4b000'
     image_size: 1015807
-    name: /System/Library/PrivateFrameworks/LanguageModeling.framework/Versions/A/LanguageModeling
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 90c1cfe1-9935-3f4f-8a9b-1dd697f2ff3d
+    code_file: /System/Library/PrivateFrameworks/Lexicon.framework/Versions/A/Lexicon
+    debug_id: 90c1cfe1-9935-3f4f-8a9b-1dd697f2ff3d
     image_addr: '0x7fff53043000'
     image_size: 270335
-    name: /System/Library/PrivateFrameworks/Lexicon.framework/Versions/A/Lexicon
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: d27b30ba-3f5d-3af2-895c-3b64569eea1b
+    code_file: /System/Library/PrivateFrameworks/LinguisticData.framework/Versions/A/LinguisticData
+    debug_id: d27b30ba-3f5d-3af2-895c-3b64569eea1b
     image_addr: '0x7fff5308b000'
     image_size: 28671
-    name: /System/Library/PrivateFrameworks/LinguisticData.framework/Versions/A/LinguisticData
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 8744dbf9-3375-392c-8ee6-24373e0d19e8
+    code_file: /System/Library/PrivateFrameworks/Mangrove.framework/Versions/A/Mangrove
+    debug_id: 8744dbf9-3375-392c-8ee6-24373e0d19e8
     image_addr: '0x7fff538ee000'
     image_size: 16383
-    name: /System/Library/PrivateFrameworks/Mangrove.framework/Versions/A/Mangrove
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 7cd28a81-f0d6-3575-8f83-3d45d53f72bb
+    code_file: /System/Library/PrivateFrameworks/MetadataUtilities.framework/Versions/A/MetadataUtilities
+    debug_id: 7cd28a81-f0d6-3575-8f83-3d45d53f72bb
     image_addr: '0x7fff53deb000'
     image_size: 167935
-    name: /System/Library/PrivateFrameworks/MetadataUtilities.framework/Versions/A/MetadataUtilities
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 60be7793-d8de-3df1-94d7-503301ec1e72
+    code_file: /System/Library/PrivateFrameworks/MetalTools.framework/Versions/A/MetalTools
+    debug_id: 60be7793-d8de-3df1-94d7-503301ec1e72
     image_addr: '0x7fff53e14000'
     image_size: 602111
-    name: /System/Library/PrivateFrameworks/MetalTools.framework/Versions/A/MetalTools
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 0c9b7077-bfcf-3a2e-8f54-d7c2820893fd
+    code_file: /System/Library/PrivateFrameworks/MobileAsset.framework/Versions/A/MobileAsset
+    debug_id: 0c9b7077-bfcf-3a2e-8f54-d7c2820893fd
     image_addr: '0x7fff53ebb000'
     image_size: 106495
-    name: /System/Library/PrivateFrameworks/MobileAsset.framework/Versions/A/MobileAsset
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: e9f2ff73-22d0-35b5-bd2c-9dd8fdb12bcc
+    code_file: /System/Library/PrivateFrameworks/MobileKeyBag.framework/Versions/A/MobileKeyBag
+    debug_id: e9f2ff73-22d0-35b5-bd2c-9dd8fdb12bcc
     image_addr: '0x7fff54051000'
     image_size: 114687
-    name: /System/Library/PrivateFrameworks/MobileKeyBag.framework/Versions/A/MobileKeyBag
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: a2bb198c-0b1a-3988-8611-9a9bcce650b5
+    code_file: /System/Library/PrivateFrameworks/MultitouchSupport.framework/Versions/A/MultitouchSupport
+    debug_id: a2bb198c-0b1a-3988-8611-9a9bcce650b5
     image_addr: '0x7fff540fa000'
     image_size: 176127
-    name: /System/Library/PrivateFrameworks/MultitouchSupport.framework/Versions/A/MultitouchSupport
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 55dc741a-a01a-380c-b2d3-244241da1f2c
+    code_file: /System/Library/PrivateFrameworks/NetAuth.framework/Versions/A/NetAuth
+    debug_id: 55dc741a-a01a-380c-b2d3-244241da1f2c
     image_addr: '0x7fff54396000'
     image_size: 45055
-    name: /System/Library/PrivateFrameworks/NetAuth.framework/Versions/A/NetAuth
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: a0e0fc0b-b48f-3639-9c50-baecc72988d5
+    code_file: /System/Library/PrivateFrameworks/OTSVG.framework/Versions/A/OTSVG
+    debug_id: a0e0fc0b-b48f-3639-9c50-baecc72988d5
     image_addr: '0x7fff54c6b000'
     image_size: 356351
-    name: /System/Library/PrivateFrameworks/OTSVG.framework/Versions/A/OTSVG
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 8560f263-31f4-3cca-84b1-30c296dc1a7d
+    code_file: /System/Library/PrivateFrameworks/PerformanceAnalysis.framework/Versions/A/PerformanceAnalysis
+    debug_id: 8560f263-31f4-3cca-84b1-30c296dc1a7d
     image_addr: '0x7fff55e24000'
     image_size: 65535
-    name: /System/Library/PrivateFrameworks/PerformanceAnalysis.framework/Versions/A/PerformanceAnalysis
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: c5ac21fb-74ad-3fc2-b231-b1376751bbae
+    code_file: /System/Library/PrivateFrameworks/ProtocolBuffer.framework/Versions/A/ProtocolBuffer
+    debug_id: c5ac21fb-74ad-3fc2-b231-b1376751bbae
     image_addr: '0x7fff57dec000'
     image_size: 126975
-    name: /System/Library/PrivateFrameworks/ProtocolBuffer.framework/Versions/A/ProtocolBuffer
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 5437f6f7-453f-3d75-9e87-d2a090d82d25
+    code_file: /System/Library/PrivateFrameworks/ROCKit.framework/Versions/A/ROCKit
+    debug_id: 5437f6f7-453f-3d75-9e87-d2a090d82d25
     image_addr: '0x7fff57fb9000'
     image_size: 364543
-    name: /System/Library/PrivateFrameworks/ROCKit.framework/Versions/A/ROCKit
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: fb030135-1633-378f-a7a6-b1a81ad068a2
+    code_file: /System/Library/PrivateFrameworks/RemoteServiceDiscovery.framework/Versions/A/RemoteServiceDiscovery
+    debug_id: fb030135-1633-378f-a7a6-b1a81ad068a2
     image_addr: '0x7fff580d6000'
     image_size: 53247
-    name: /System/Library/PrivateFrameworks/RemoteServiceDiscovery.framework/Versions/A/RemoteServiceDiscovery
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 68530b4d-b2c0-3271-941b-d9ea62095727
+    code_file: /System/Library/PrivateFrameworks/RemoteViewServices.framework/Versions/A/RemoteViewServices
+    debug_id: 68530b4d-b2c0-3271-941b-d9ea62095727
     image_addr: '0x7fff580f5000'
     image_size: 147455
-    name: /System/Library/PrivateFrameworks/RemoteViewServices.framework/Versions/A/RemoteViewServices
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 1e00a78b-1934-39a0-8f35-48cbeb93d04c
+    code_file: /System/Library/PrivateFrameworks/RemoteXPC.framework/Versions/A/RemoteXPC
+    debug_id: 1e00a78b-1934-39a0-8f35-48cbeb93d04c
     image_addr: '0x7fff58119000'
     image_size: 86015
-    name: /System/Library/PrivateFrameworks/RemoteXPC.framework/Versions/A/RemoteXPC
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 9881aead-5410-33f7-a852-770c7fe677c9
+    code_file: /System/Library/PrivateFrameworks/Sharing.framework/Versions/A/Sharing
+    debug_id: 9881aead-5410-33f7-a852-770c7fe677c9
     image_addr: '0x7fff59a86000'
     image_size: 1179647
-    name: /System/Library/PrivateFrameworks/Sharing.framework/Versions/A/Sharing
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 5f7d2312-0003-354c-82bc-dc346b1a98e6
+    code_file: /System/Library/PrivateFrameworks/SkyLight.framework/Versions/A/SkyLight
+    debug_id: 5f7d2312-0003-354c-82bc-dc346b1a98e6
     image_addr: '0x7fff5a957000'
     image_size: 2822143
-    name: /System/Library/PrivateFrameworks/SkyLight.framework/Versions/A/SkyLight
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 816ec315-3e76-37b7-a495-b4ae031da439
+    code_file: /System/Library/PrivateFrameworks/SpeechRecognitionCore.framework/Versions/A/SpeechRecognitionCore
+    debug_id: 816ec315-3e76-37b7-a495-b4ae031da439
     image_addr: '0x7fff5b3d6000'
     image_size: 57343
-    name: /System/Library/PrivateFrameworks/SpeechRecognitionCore.framework/Versions/A/SpeechRecognitionCore
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 3f13dfee-a6c9-3815-9120-b5ca6987662e
+    code_file: /System/Library/PrivateFrameworks/StreamingZip.framework/Versions/A/StreamingZip
+    debug_id: 3f13dfee-a6c9-3815-9120-b5ca6987662e
     image_addr: '0x7fff5bac8000'
     image_size: 262143
-    name: /System/Library/PrivateFrameworks/StreamingZip.framework/Versions/A/StreamingZip
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 7d5fb79e-1121-3db0-9cbe-c023835ace60
+    code_file: /System/Library/PrivateFrameworks/Symbolication.framework/Versions/A/Symbolication
+    debug_id: 7d5fb79e-1121-3db0-9cbe-c023835ace60
     image_addr: '0x7fff5c244000'
     image_size: 581631
-    name: /System/Library/PrivateFrameworks/Symbolication.framework/Versions/A/Symbolication
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 55c045f7-d8ab-3be6-970b-9457fa78e7e3
+    code_file: /System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC
+    debug_id: 55c045f7-d8ab-3be6-970b-9457fa78e7e3
     image_addr: '0x7fff5c7da000'
     image_size: 57343
-    name: /System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: f9d5f55d-9a33-326e-8b2f-b533cc91dd64
+    code_file: /System/Library/PrivateFrameworks/TextureIO.framework/Versions/A/TextureIO
+    debug_id: f9d5f55d-9a33-326e-8b2f-b533cc91dd64
     image_addr: '0x7fff5ca56000'
     image_size: 819199
-    name: /System/Library/PrivateFrameworks/TextureIO.framework/Versions/A/TextureIO
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 1caaa3ac-1477-3e24-b55c-07a704d7ca03
+    code_file: /System/Library/PrivateFrameworks/UIFoundation.framework/Versions/A/UIFoundation
+    debug_id: 1caaa3ac-1477-3e24-b55c-07a704d7ca03
     image_addr: '0x7fff5cbde000'
     image_size: 1814527
-    name: /System/Library/PrivateFrameworks/UIFoundation.framework/Versions/A/UIFoundation
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 0bcca232-710b-3f84-8341-a30f77b3a4e9
+    code_file: /System/Library/PrivateFrameworks/ViewBridge.framework/Versions/A/ViewBridge
+    debug_id: 0bcca232-710b-3f84-8341-a30f77b3a4e9
     image_addr: '0x7fff5da86000'
     image_size: 958463
-    name: /System/Library/PrivateFrameworks/ViewBridge.framework/Versions/A/ViewBridge
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 63a533f6-988d-3fed-a1c7-20bc725a0d4b
+    code_file: /System/Library/PrivateFrameworks/XCTTargetBootstrap.framework/Versions/A/XCTTargetBootstrap
+    debug_id: 63a533f6-988d-3fed-a1c7-20bc725a0d4b
     image_addr: '0x7fff5e38a000'
     image_size: 16383
-    name: /System/Library/PrivateFrameworks/XCTTargetBootstrap.framework/Versions/A/XCTTargetBootstrap
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 5f1e000d-0674-3413-ab3e-83f7974666fb
+    code_file: /System/Library/PrivateFrameworks/login.framework/Versions/A/Frameworks/loginsupport.framework/Versions/A/loginsupport
+    debug_id: 5f1e000d-0674-3413-ab3e-83f7974666fb
     image_addr: '0x7fff5e7be000'
     image_size: 12287
-    name: /System/Library/PrivateFrameworks/login.framework/Versions/A/Frameworks/loginsupport.framework/Versions/A/loginsupport
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 62edd39f-6d1b-334b-a9a2-5800714255bb
+    code_file: /usr/lib/libCRFSuite.dylib
+    debug_id: 62edd39f-6d1b-334b-a9a2-5800714255bb
     image_addr: '0x7fff5ea7a000'
     image_size: 233471
-    name: /usr/lib/libCRFSuite.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 8cd1c213-7f62-3f02-bfb1-d0a5eff92ab0
+    code_file: /usr/lib/libChineseTokenizer.dylib
+    debug_id: 8cd1c213-7f62-3f02-bfb1-d0a5eff92ab0
     image_addr: '0x7fff5eab5000'
     image_size: 49151
-    name: /usr/lib/libChineseTokenizer.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: c542cb3c-aa44-3d7f-b88c-79cc31b481ab
+    code_file: /usr/lib/libDiagnosticMessagesClient.dylib
+    debug_id: c542cb3c-aa44-3d7f-b88c-79cc31b481ab
     image_addr: '0x7fff5eb51000'
     image_size: 8191
-    name: /usr/lib/libDiagnosticMessagesClient.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 6ef1cb2a-2bda-3458-b631-f794d72660fd
+    code_file: /usr/lib/libFosl_dynamic.dylib
+    debug_id: 6ef1cb2a-2bda-3458-b631-f794d72660fd
     image_addr: '0x7fff5eb89000'
     image_size: 1851391
-    name: /usr/lib/libFosl_dynamic.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: a2c32318-0e35-3963-b9b7-e1e92ad33ba6
+    code_file: /usr/lib/libMobileGestalt.dylib
+    debug_id: a2c32318-0e35-3963-b9b7-e1e92ad33ba6
     image_addr: '0x7fff5eda2000'
     image_size: 131071
-    name: /usr/lib/libMobileGestalt.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 2eebf84d-9e00-3570-ac0c-c49c8d25a8bf
+    code_file: /usr/lib/libOpenScriptingUtil.dylib
+    debug_id: 2eebf84d-9e00-3570-ac0c-c49c8d25a8bf
     image_addr: '0x7fff5edc2000'
     image_size: 4095
-    name: /usr/lib/libOpenScriptingUtil.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: d5133811-9d66-3deb-9521-0a67347c9a54
+    code_file: /usr/lib/libSystem.B.dylib
+    debug_id: d5133811-9d66-3deb-9521-0a67347c9a54
     image_addr: '0x7fff5ef03000'
     image_size: 8191
-    name: /usr/lib/libSystem.B.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: a8235b04-f541-3856-be2e-b58ee0483ad9
+    code_file: /usr/lib/libThaiTokenizer.dylib
+    debug_id: a8235b04-f541-3856-be2e-b58ee0483ad9
     image_addr: '0x7fff5ef8e000'
     image_size: 8191
-    name: /usr/lib/libThaiTokenizer.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: b8d45114-3868-3154-bc35-22597e3e7d8a
+    code_file: /usr/lib/libapple_nghttp2.dylib
+    debug_id: b8d45114-3868-3154-bc35-22597e3e7d8a
     image_addr: '0x7fff5efa2000'
     image_size: 94207
-    name: /usr/lib/libapple_nghttp2.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: b47c54a0-3a30-374a-bd99-2304b9b0ec82
+    code_file: /usr/lib/libarchive.2.dylib
+    debug_id: b47c54a0-3a30-374a-bd99-2304b9b0ec82
     image_addr: '0x7fff5efb9000'
     image_size: 172031
-    name: /usr/lib/libarchive.2.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: c647a80f-6f80-3fda-a9b4-92800999f963
+    code_file: /usr/lib/libate.dylib
+    debug_id: c647a80f-6f80-3fda-a9b4-92800999f963
     image_addr: '0x7fff5efe3000'
     image_size: 524287
-    name: /usr/lib/libate.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 01824e49-f2ef-3fc1-abf3-782efdf6ca17
+    code_file: /usr/lib/libauto.dylib
+    debug_id: 01824e49-f2ef-3fc1-abf3-782efdf6ca17
     image_addr: '0x7fff5f066000'
     image_size: 4095
-    name: /usr/lib/libauto.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 5e5098d0-f7b2-32a1-8038-e709f6718d4e
+    code_file: /usr/lib/libbsm.0.dylib
+    debug_id: 5e5098d0-f7b2-32a1-8038-e709f6718d4e
     image_addr: '0x7fff5f13e000'
     image_size: 69631
-    name: /usr/lib/libbsm.0.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 4ee3c5e8-bef3-3910-a231-b1ae2b437e01
+    code_file: /usr/lib/libbz2.1.0.dylib
+    debug_id: 4ee3c5e8-bef3-3910-a231-b1ae2b437e01
     image_addr: '0x7fff5f14f000'
     image_size: 61439
-    name: /usr/lib/libbz2.1.0.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: d4ab366f-48a9-3c7d-91bd-41198f69dd57
+    code_file: /usr/lib/libc++.1.dylib
+    debug_id: d4ab366f-48a9-3c7d-91bd-41198f69dd57
     image_addr: '0x7fff5f15e000'
     image_size: 360447
-    name: /usr/lib/libc++.1.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: ba948a32-9024-3e55-98d4-18e31f6aed25
+    code_file: /usr/lib/libc++abi.dylib
+    debug_id: ba948a32-9024-3e55-98d4-18e31f6aed25
     image_addr: '0x7fff5f1b6000'
     image_size: 90111
-    name: /usr/lib/libc++abi.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: d998a58b-e4a8-3685-9a6a-43afc28100eb
+    code_file: /usr/lib/libcharset.1.dylib
+    debug_id: d998a58b-e4a8-3685-9a6a-43afc28100eb
     image_addr: '0x7fff5f1cc000'
     image_size: 4095
-    name: /usr/lib/libcharset.1.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 5d776ff6-df7f-3edd-b920-c07ed76c672b
+    code_file: /usr/lib/libcmph.dylib
+    debug_id: 5d776ff6-df7f-3edd-b920-c07ed76c672b
     image_addr: '0x7fff5f1cd000'
     image_size: 69631
-    name: /usr/lib/libcmph.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: ea767836-cbdc-318d-ac14-963c90d6cc67
+    code_file: /usr/lib/libcompression.dylib
+    debug_id: ea767836-cbdc-318d-ac14-963c90d6cc67
     image_addr: '0x7fff5f1de000'
     image_size: 102399
-    name: /usr/lib/libcompression.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 6e68f922-752c-311f-b56d-ee391e6ae1f7
+    code_file: /usr/lib/libcoretls.dylib
+    debug_id: 6e68f922-752c-311f-b56d-ee391e6ae1f7
     image_addr: '0x7fff5f4a1000'
     image_size: 94207
-    name: /usr/lib/libcoretls.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 7300ba76-39d2-349e-9fb8-ebe5947a708a
+    code_file: /usr/lib/libcoretls_cfhelpers.dylib
+    debug_id: 7300ba76-39d2-349e-9fb8-ebe5947a708a
     image_addr: '0x7fff5f4b8000'
     image_size: 8191
-    name: /usr/lib/libcoretls_cfhelpers.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 51e06e95-891f-3b88-a8c3-35b514c57239
+    code_file: /usr/lib/libcups.2.dylib
+    debug_id: 51e06e95-891f-3b88-a8c3-35b514c57239
     image_addr: '0x7fff5fb30000'
     image_size: 356351
-    name: /usr/lib/libcups.2.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: d62ed169-b91c-3ccb-adf5-e66ae4007b51
+    code_file: /usr/lib/libenergytrace.dylib
+    debug_id: d62ed169-b91c-3ccb-adf5-e66ae4007b51
     image_addr: '0x7fff5fcbe000'
     image_size: 4095
-    name: /usr/lib/libenergytrace.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 9cbf0658-e83b-32e6-b674-3ee72d22c041
+    code_file: /usr/lib/libgermantok.dylib
+    debug_id: 9cbf0658-e83b-32e6-b674-3ee72d22c041
     image_addr: '0x7fff5fcf0000'
     image_size: 24575
-    name: /usr/lib/libgermantok.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 58971629-3850-3905-a9a1-09fcf7a32815
+    code_file: /usr/lib/libheimdal-asn1.dylib
+    debug_id: 58971629-3850-3905-a9a1-09fcf7a32815
     image_addr: '0x7fff5fcf6000'
     image_size: 24575
-    name: /usr/lib/libheimdal-asn1.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 3240a278-f537-3ec8-be0c-983797520a50
+    code_file: /usr/lib/libiconv.2.dylib
+    debug_id: 3240a278-f537-3ec8-be0c-983797520a50
     image_addr: '0x7fff5fd27000'
     image_size: 991231
-    name: /usr/lib/libiconv.2.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: eae6fc43-3ad2-3a53-9f7a-4e5e5f66d006
+    code_file: /usr/lib/libicucore.A.dylib
+    debug_id: eae6fc43-3ad2-3a53-9f7a-4e5e5f66d006
     image_addr: '0x7fff5fe19000'
     image_size: 2506751
-    name: /usr/lib/libicucore.A.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: f79b6250-c0b1-3e8e-851f-6ca33b4311a3
+    code_file: /usr/lib/liblangid.dylib
+    debug_id: f79b6250-c0b1-3e8e-851f-6ca33b4311a3
     image_addr: '0x7fff600c9000'
     image_size: 8191
-    name: /usr/lib/liblangid.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 3addfa63-f37a-3c9c-91e4-58ee3113b9a1
+    code_file: /usr/lib/liblzma.5.dylib
+    debug_id: 3addfa63-f37a-3c9c-91e4-58ee3113b9a1
     image_addr: '0x7fff600cb000'
     image_size: 102399
-    name: /usr/lib/liblzma.5.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 6a38fcda-17ce-30c3-ab66-a714cf645384
+    code_file: /usr/lib/libmecab.1.0.0.dylib
+    debug_id: 6a38fcda-17ce-30c3-ab66-a714cf645384
     image_addr: '0x7fff600fb000'
     image_size: 724991
-    name: /usr/lib/libmecab.1.0.0.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 30e102aa-f3d3-3572-a1ae-1f2287def696
+    code_file: /usr/lib/libmecabra.dylib
+    debug_id: 30e102aa-f3d3-3572-a1ae-1f2287def696
     image_addr: '0x7fff601ac000'
     image_size: 2351103
-    name: /usr/lib/libmecabra.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: ad59d28c-ccb2-3b34-b904-8ccceb2cf320
+    code_file: /usr/lib/libnetwork.dylib
+    debug_id: ad59d28c-ccb2-3b34-b904-8ccceb2cf320
     image_addr: '0x7fff605c1000'
     image_size: 3510271
-    name: /usr/lib/libnetwork.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 2e868147-8818-359e-8cd7-a8b80665928f
+    code_file: /usr/lib/libobjc.A.dylib
+    debug_id: 2e868147-8818-359e-8cd7-a8b80665928f
     image_addr: '0x7fff609aa000'
     image_size: 7892991
-    name: /usr/lib/libobjc.A.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 8c419238-675a-3c41-b8d4-95e391ca630f
+    code_file: /usr/lib/libpam.2.dylib
+    debug_id: 8c419238-675a-3c41-b8d4-95e391ca630f
     image_addr: '0x7fff61143000'
     image_size: 20479
-    name: /usr/lib/libpam.2.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 5939ab23-b2a9-3c03-b6c1-4f0e5a21d9fc
+    code_file: /usr/lib/libpcap.A.dylib
+    debug_id: 5939ab23-b2a9-3c03-b6c1-4f0e5a21d9fc
     image_addr: '0x7fff6114a000'
     image_size: 225279
-    name: /usr/lib/libpcap.A.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 0feaeb01-b926-37fa-ab47-99bac481c10b
+    code_file: /usr/lib/libresolv.9.dylib
+    debug_id: 0feaeb01-b926-37fa-ab47-99bac481c10b
     image_addr: '0x7fff6129a000'
     image_size: 102399
-    name: /usr/lib/libresolv.9.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 0e60d709-0a48-3905-acd1-9dde6fd8b476
+    code_file: /usr/lib/libspindump.dylib
+    debug_id: 0e60d709-0a48-3905-acd1-9dde6fd8b476
     image_addr: '0x7fff61304000'
     image_size: 8191
-    name: /usr/lib/libspindump.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 4434b695-bc65-30d6-afed-1b6488db3d2e
+    code_file: /usr/lib/libsqlite3.dylib
+    debug_id: 4434b695-bc65-30d6-afed-1b6488db3d2e
     image_addr: '0x7fff61306000'
     image_size: 1933311
-    name: /usr/lib/libsqlite3.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 91ee9bf4-fb06-3260-b502-7efdad5af59b
+    code_file: /usr/lib/libutil.dylib
+    debug_id: 91ee9bf4-fb06-3260-b502-7efdad5af59b
     image_addr: '0x7fff6176a000'
     image_size: 16383
-    name: /usr/lib/libutil.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 4b4d0206-0b62-3e89-ad07-e7bb9e4dfa68
+    code_file: /usr/lib/libxar.1.dylib
+    debug_id: 4b4d0206-0b62-3e89-ad07-e7bb9e4dfa68
     image_addr: '0x7fff6176e000'
     image_size: 57343
-    name: /usr/lib/libxar.1.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: bff70f01-6755-36b9-b7aa-724743e63503
+    code_file: /usr/lib/libxml2.2.dylib
+    debug_id: bff70f01-6755-36b9-b7aa-724743e63503
     image_addr: '0x7fff61780000'
     image_size: 933887
-    name: /usr/lib/libxml2.2.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: f191e8b9-7530-30ca-873b-2fa2bf2d6374
+    code_file: /usr/lib/libxslt.1.dylib
+    debug_id: f191e8b9-7530-30ca-873b-2fa2bf2d6374
     image_addr: '0x7fff61864000'
     image_size: 167935
-    name: /usr/lib/libxslt.1.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 99a3d725-8388-38b4-b66c-5e9006e6f072
+    code_file: /usr/lib/libz.1.dylib
+    debug_id: 99a3d725-8388-38b4-b66c-5e9006e6f072
     image_addr: '0x7fff6188d000'
     image_size: 77823
-    name: /usr/lib/libz.1.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: fe21a7e9-dbeb-33ac-836b-785ad036acf4
+    code_file: /usr/lib/system/libcache.dylib
+    debug_id: fe21a7e9-dbeb-33ac-836b-785ad036acf4
     image_addr: '0x7fff61910000'
     image_size: 20479
-    name: /usr/lib/system/libcache.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 78093d4f-91db-35c8-981a-13375778b2e7
+    code_file: /usr/lib/system/libcommonCrypto.dylib
+    debug_id: 78093d4f-91db-35c8-981a-13375778b2e7
     image_addr: '0x7fff61915000'
     image_size: 45055
-    name: /usr/lib/system/libcommonCrypto.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: a4d9cf37-d076-3ce9-95f1-da89da1601b6
+    code_file: /usr/lib/system/libcompiler_rt.dylib
+    debug_id: a4d9cf37-d076-3ce9-95f1-da89da1601b6
     image_addr: '0x7fff61920000'
     image_size: 32767
-    name: /usr/lib/system/libcompiler_rt.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 4bcdadbf-79f5-3829-b47d-64da0d44bcbf
+    code_file: /usr/lib/system/libcopyfile.dylib
+    debug_id: 4bcdadbf-79f5-3829-b47d-64da0d44bcbf
     image_addr: '0x7fff61928000'
     image_size: 40959
-    name: /usr/lib/system/libcopyfile.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 7aec5b72-0b92-37e8-808b-6732db714139
+    code_file: /usr/lib/system/libcorecrypto.dylib
+    debug_id: 7aec5b72-0b92-37e8-808b-6732db714139
     image_addr: '0x7fff61932000'
     image_size: 544767
-    name: /usr/lib/system/libcorecrypto.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: b8962879-ad55-3cf0-9b0a-5f1d57d1e14b
+    code_file: /usr/lib/system/libdispatch.dylib
+    debug_id: b8962879-ad55-3cf0-9b0a-5f1d57d1e14b
     image_addr: '0x7fff61a3c000'
     image_size: 241663
-    name: /usr/lib/system/libdispatch.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 4b16c209-83d4-3817-9b62-c2f7ffb23755
+    code_file: /usr/lib/system/libdyld.dylib
+    debug_id: 4b16c209-83d4-3817-9b62-c2f7ffb23755
     image_addr: '0x7fff61a77000'
     image_size: 196607
-    name: /usr/lib/system/libdyld.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: a73aa788-c35c-3284-bfca-95b1bbdf0cf3
+    code_file: /usr/lib/system/libkeymgr.dylib
+    debug_id: a73aa788-c35c-3284-bfca-95b1bbdf0cf3
     image_addr: '0x7fff61aa7000'
     image_size: 4095
-    name: /usr/lib/system/libkeymgr.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: eaf1cf8d-3843-33be-8126-30994685b8f0
+    code_file: /usr/lib/system/libkxld.dylib
+    debug_id: eaf1cf8d-3843-33be-8126-30994685b8f0
     image_addr: '0x7fff61aa8000'
     image_size: 53247
-    name: /usr/lib/system/libkxld.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 43e6698e-155e-3eae-baff-ca5fcb35325c
+    code_file: /usr/lib/system/liblaunch.dylib
+    debug_id: 43e6698e-155e-3eae-baff-ca5fcb35325c
     image_addr: '0x7fff61ab5000'
     image_size: 4095
-    name: /usr/lib/system/liblaunch.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 17bf7038-9c70-3ee1-9e96-3ae10d49669e
+    code_file: /usr/lib/system/libmacho.dylib
+    debug_id: 17bf7038-9c70-3ee1-9e96-3ae10d49669e
     image_addr: '0x7fff61ab6000'
     image_size: 24575
-    name: /usr/lib/system/libmacho.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: c70da995-0d6e-302c-a15e-f7f03a3857b4
+    code_file: /usr/lib/system/libquarantine.dylib
+    debug_id: c70da995-0d6e-302c-a15e-f7f03a3857b4
     image_addr: '0x7fff61abc000'
     image_size: 12287
-    name: /usr/lib/system/libquarantine.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: d74a307b-3dc7-3992-b16c-dacb8207be13
+    code_file: /usr/lib/system/libremovefile.dylib
+    debug_id: d74a307b-3dc7-3992-b16c-dacb8207be13
     image_addr: '0x7fff61abf000'
     image_size: 8191
-    name: /usr/lib/system/libremovefile.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: ec9d8ad4-e5cb-3765-804a-9e1e9dc045d2
+    code_file: /usr/lib/system/libsystem_asl.dylib
+    debug_id: ec9d8ad4-e5cb-3765-804a-9e1e9dc045d2
     image_addr: '0x7fff61ac1000'
     image_size: 98303
-    name: /usr/lib/system/libsystem_asl.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 26419398-c30c-30f1-b656-a92afa9560f6
+    code_file: /usr/lib/system/libsystem_blocks.dylib
+    debug_id: 26419398-c30c-30f1-b656-a92afa9560f6
     image_addr: '0x7fff61ad9000'
     image_size: 4095
-    name: /usr/lib/system/libsystem_blocks.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 3deee96e-6df6-35ad-8654-d69ac26b907b
+    code_file: /usr/lib/system/libsystem_c.dylib
+    debug_id: 3deee96e-6df6-35ad-8654-d69ac26b907b
     image_addr: '0x7fff61ada000'
     image_size: 561151
-    name: /usr/lib/system/libsystem_c.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 02cc3996-b34e-333c-8806-ae2699d34424
+    code_file: /usr/lib/system/libsystem_configuration.dylib
+    debug_id: 02cc3996-b34e-333c-8806-ae2699d34424
     image_addr: '0x7fff61b63000'
     image_size: 16383
-    name: /usr/lib/system/libsystem_configuration.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 254b6849-2c8f-302c-8616-b8324a11ab30
+    code_file: /usr/lib/system/libsystem_coreservices.dylib
+    debug_id: 254b6849-2c8f-302c-8616-b8324a11ab30
     image_addr: '0x7fff61b67000'
     image_size: 16383
-    name: /usr/lib/system/libsystem_coreservices.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 974e9ef7-de72-34b7-b056-0a81c10df8eb
+    code_file: /usr/lib/system/libsystem_darwin.dylib
+    debug_id: 974e9ef7-de72-34b7-b056-0a81c10df8eb
     image_addr: '0x7fff61b6b000'
     image_size: 28671
-    name: /usr/lib/system/libsystem_darwin.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: ffc665aa-b257-35ad-bd8b-32fd42c2eec1
+    code_file: /usr/lib/system/libsystem_dnssd.dylib
+    debug_id: ffc665aa-b257-35ad-bd8b-32fd42c2eec1
     image_addr: '0x7fff61b72000'
     image_size: 28671
-    name: /usr/lib/system/libsystem_dnssd.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 0707c387-d7de-372e-8ff1-3de5c91932d6
+    code_file: /usr/lib/system/libsystem_info.dylib
+    debug_id: 0707c387-d7de-372e-8ff1-3de5c91932d6
     image_addr: '0x7fff61b79000'
     image_size: 315391
-    name: /usr/lib/system/libsystem_info.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 45faa4c0-d553-34fd-adf8-884886ae0d2a
+    code_file: /usr/lib/system/libsystem_kernel.dylib
+    debug_id: 45faa4c0-d553-34fd-adf8-884886ae0d2a
     image_addr: '0x7fff61bc6000'
     image_size: 163839
-    name: /usr/lib/system/libsystem_kernel.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 43d1796b-954f-37d6-b1ac-9d80df0655a2
+    code_file: /usr/lib/system/libsystem_m.dylib
+    debug_id: 43d1796b-954f-37d6-b1ac-9d80df0655a2
     image_addr: '0x7fff61bee000'
     image_size: 311295
-    name: /usr/lib/system/libsystem_m.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 846f6898-117c-3427-a8fb-3772ffc2410b
+    code_file: /usr/lib/system/libsystem_malloc.dylib
+    debug_id: 846f6898-117c-3427-a8fb-3772ffc2410b
     image_addr: '0x7fff61c3a000'
     image_size: 151551
-    name: /usr/lib/system/libsystem_malloc.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: f84d5474-4dc1-3e1a-ae00-8ce9593278b4
+    code_file: /usr/lib/system/libsystem_networkextension.dylib
+    debug_id: f84d5474-4dc1-3e1a-ae00-8ce9593278b4
     image_addr: '0x7fff61c5f000'
     image_size: 49151
-    name: /usr/lib/system/libsystem_networkextension.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: bccb222f-dc64-3954-a836-dcce6659ca5a
+    code_file: /usr/lib/system/libsystem_notify.dylib
+    debug_id: bccb222f-dc64-3954-a836-dcce6659ca5a
     image_addr: '0x7fff61c6b000'
     image_size: 32767
-    name: /usr/lib/system/libsystem_notify.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: b75b04ad-69fe-3ade-84d2-c17972fc8f49
+    code_file: /usr/lib/system/libsystem_platform.dylib
+    debug_id: b75b04ad-69fe-3ade-84d2-c17972fc8f49
     image_addr: '0x7fff61c73000'
     image_size: 40959
-    name: /usr/lib/system/libsystem_platform.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 87a6b136-e423-3b6d-a58a-137f392d7d9d
+    code_file: /usr/lib/system/libsystem_pthread.dylib
+    debug_id: 87a6b136-e423-3b6d-a58a-137f392d7d9d
     image_addr: '0x7fff61c7d000'
     image_size: 45055
-    name: /usr/lib/system/libsystem_pthread.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: fba7e09b-f10f-3424-90ea-b4999b7fb461
+    code_file: /usr/lib/system/libsystem_sandbox.dylib
+    debug_id: fba7e09b-f10f-3424-90ea-b4999b7fb461
     image_addr: '0x7fff61c88000'
     image_size: 16383
-    name: /usr/lib/system/libsystem_sandbox.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: cbeab62b-f0a0-342f-9878-cadc14a3cb0d
+    code_file: /usr/lib/system/libsystem_secinit.dylib
+    debug_id: cbeab62b-f0a0-342f-9878-cadc14a3cb0d
     image_addr: '0x7fff61c8c000'
     image_size: 12287
-    name: /usr/lib/system/libsystem_secinit.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: b6e22fa8-0f7b-36fd-9d99-284056d3cb47
+    code_file: /usr/lib/system/libsystem_symptoms.dylib
+    debug_id: b6e22fa8-0f7b-36fd-9d99-284056d3cb47
     image_addr: '0x7fff61c8f000'
     image_size: 32767
-    name: /usr/lib/system/libsystem_symptoms.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 7983ed77-18b5-39a5-be19-ae4f2832adea
+    code_file: /usr/lib/system/libsystem_trace.dylib
+    debug_id: 7983ed77-18b5-39a5-be19-ae4f2832adea
     image_addr: '0x7fff61c97000'
     image_size: 90111
-    name: /usr/lib/system/libsystem_trace.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 41222ef6-2233-3cf4-947a-15d48cb8c030
+    code_file: /usr/lib/system/libunwind.dylib
+    debug_id: 41222ef6-2233-3cf4-947a-15d48cb8c030
     image_addr: '0x7fff61cae000'
     image_size: 24575
-    name: /usr/lib/system/libunwind.dylib
-    type: symbolic
+    type: macho
   - arch: x86_64
-    id: 0a8747d1-33aa-37e1-b97a-ba9b95fe4e8c
+    code_file: /usr/lib/system/libxpc.dylib
+    debug_id: 0a8747d1-33aa-37e1-b97a-ba9b95fe4e8c
     image_addr: '0x7fff61cb4000'
     image_size: 200703
-    name: /usr/lib/system/libxpc.dylib
-    type: symbolic
+    type: macho
 environment: null
 event_id: 12852a74acc943a790c8f1cd23907caa
 level: fatal
@@ -1653,67 +1653,54 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61a8e085'
       lineno: null
       package: libdyld.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x108b702a6'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x108b7092b'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff31f4375d'
       lineno: null
       package: AppKit
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff31f496fa'
       lineno: null
       package: AppKit
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff31f4a95b'
       lineno: null
       package: AppKit
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff33c8d348'
       lineno: null
       package: HIToolbox
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff33c8d5cb'
       lineno: null
       package: HIToolbox
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff33c8d895'
       lineno: null
       package: HIToolbox
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff349f3ce4'
       lineno: null
       package: CoreFoundation
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff349f45ad'
       lineno: null
       package: CoreFoundation
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff349f505e'
       lineno: null
       package: CoreFoundation
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bc6c2a'
       lineno: null
       package: libsystem_kernel.dylib
@@ -1724,17 +1711,14 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x54485244'
       lineno: null
       package: null
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f415'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bc85be'
       lineno: null
       package: libsystem_kernel.dylib
@@ -1745,17 +1729,14 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x54485244'
       lineno: null
       package: null
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f415'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bc85be'
       lineno: null
       package: libsystem_kernel.dylib
@@ -1766,12 +1747,10 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f415'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bc85be'
       lineno: null
       package: libsystem_kernel.dylib
@@ -1782,17 +1761,14 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x54485244'
       lineno: null
       package: null
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f415'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bc85be'
       lineno: null
       package: libsystem_kernel.dylib
@@ -1803,97 +1779,78 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff36d4a234'
       lineno: null
       package: Foundation
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1095aab27'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x108b6fd8e'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x108b65169'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x108b55d76'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10c28647e'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10c2a6f41'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10ce48e4a'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10ce4f8f5'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10cfadb9e'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10c2e4621'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10cfe80be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10bc5eb21'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10bc5fc29'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10bc3b85b'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1090a0132'
       lineno: null
       package: YetAnotherMac
@@ -1925,42 +1882,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff31f53581'
       lineno: null
       package: AppKit
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff349f3ce4'
       lineno: null
       package: CoreFoundation
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff349f45ad'
       lineno: null
       package: CoreFoundation
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff349f505e'
       lineno: null
       package: CoreFoundation
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bc6c2a'
       lineno: null
       package: libsystem_kernel.dylib
@@ -1971,52 +1920,42 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109432156'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094312e8'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109433182'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482f6f'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2027,52 +1966,42 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109432156'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094312e8'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109433182'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482f6f'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2083,52 +2012,42 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109432156'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094312e8'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109433182'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482f6f'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2139,52 +2058,42 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109432156'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094312e8'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109433182'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482f6f'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2195,52 +2104,42 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109432156'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094312e8'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109433182'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482f6f'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2251,52 +2150,42 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109432156'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094312e8'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109433182'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482f6f'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2307,52 +2196,42 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109432156'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094312e8'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109433182'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482f6f'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2363,52 +2242,42 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109432156'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094312e8'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109433182'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482f6f'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2419,52 +2288,42 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109432156'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094312e8'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109433182'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482f6f'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2475,57 +2334,46 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1097a01a8'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109430351'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109434103'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094358c3'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482f6f'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2536,42 +2384,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10951d7f1'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2582,42 +2422,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10951d7f1'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2628,42 +2460,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10951d7f1'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2674,42 +2498,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10951d7f1'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2720,42 +2536,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10951d7f1'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2766,17 +2574,14 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x54485244'
       lineno: null
       package: null
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f415'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bc85be'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2787,17 +2592,14 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x54485244'
       lineno: null
       package: null
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f415'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bc85be'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2808,17 +2610,14 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x70001989cba0'
       lineno: null
       package: null
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f415'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bc85be'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2829,17 +2628,14 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x54485244'
       lineno: null
       package: null
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f415'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bc85be'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2850,42 +2646,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1096b1e4d'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61b55724'
       lineno: null
       package: libsystem_c.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca876'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2896,42 +2684,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x108e4c4c5'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2942,42 +2722,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10951d7f1'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -2988,42 +2760,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10951d7f1'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -3034,42 +2798,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10951d7f1'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -3080,42 +2836,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10951d7f1'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -3126,42 +2874,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10a44a1eb'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -3172,57 +2912,46 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10a874ab6'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109430351'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109434103'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094358c3'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482f6f'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -3233,92 +2962,74 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10a875ba7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10a86402c'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109430351'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109434103'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109435e23'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10c7c83da'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10c7f8302'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1093cd746'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1093c61d9'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1093c3c67'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1092abd6f'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109266ff1'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c74969'
       lineno: null
       package: libsystem_platform.dylib
@@ -3329,47 +3040,38 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10a87c821'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109481b6e'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61b55724'
       lineno: null
       package: libsystem_c.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca876'
       lineno: null
       package: libsystem_kernel.dylib
@@ -3380,42 +3082,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x108ddca01'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -3426,42 +3120,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x108ddca01'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -3472,42 +3158,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x108ddca01'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -3518,42 +3196,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x108ddca01'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -3564,42 +3234,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x108ddca01'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -3610,42 +3272,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x108ddca01'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -3656,42 +3310,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x108ddca01'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -3702,42 +3348,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x108ddca01'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -3748,42 +3386,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10bbea8b8'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -3794,42 +3424,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10dc214e1'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -3840,42 +3462,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10951d7f1'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -3886,42 +3500,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10951d7f1'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -3932,42 +3538,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10951d7f1'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -3978,42 +3576,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10951d7f1'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -4024,42 +3614,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10951d7f1'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -4070,42 +3652,34 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10951d7f1'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482d68'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib
@@ -4116,32 +3690,26 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61a4db5a'
       lineno: null
       package: libdispatch.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61a40b19'
       lineno: null
       package: libdispatch.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bc6c7e'
       lineno: null
       package: libsystem_kernel.dylib
@@ -4152,47 +3720,38 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff344410d6'
       lineno: null
       package: CoreAudio
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff344415ee'
       lineno: null
       package: CoreAudio
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff34441b84'
       lineno: null
       package: CoreAudio
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff3444580d'
       lineno: null
       package: CoreAudio
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff3444589a'
       lineno: null
       package: CoreAudio
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bc6c2a'
       lineno: null
       package: libsystem_kernel.dylib
@@ -4203,57 +3762,46 @@ threads:
   stacktrace:
     frames:
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c7f425'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c832a7'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61c8033d'
       lineno: null
       package: libsystem_pthread.dylib
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094ba0b7'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094dd7be'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x10be5f7ce'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109430351'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109434103'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x1094358c3'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x109482f6f'
       lineno: null
       package: YetAnotherMac
     - filename: null
-      function: <unknown>
       instruction_addr: '0x7fff61bca1b2'
       lineno: null
       package: libsystem_kernel.dylib

--- a/tests/sentry/lang/native/snapshots/test_minidump/test_minidump_linux.pysnap
+++ b/tests/sentry/lang/native/snapshots/test_minidump/test_minidump_linux.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-21T11:57:01.040399Z'
+created: '2019-03-21T13:58:25.633488Z'
 creator: sentry
 source: tests/sentry/lang/native/test_minidump.py
 ---
@@ -13,46 +13,62 @@ contexts:
     version: 4.9.60-linuxkit-aufs
 debug_meta:
   images:
-  - id: c0bcc3f1-9827-fe65-3058-404b2831d9e6
+  - code_file: /work/linux/build/crash
+    code_id: f1c3bcc0279865fe3058404b2831d9e64135386c
+    debug_file: /work/linux/build/crash
+    debug_id: c0bcc3f1-9827-fe65-3058-404b2831d9e6
     image_addr: '0x400000'
     image_size: 106496
-    name: /work/linux/build/crash
-    type: symbolic
-  - id: e45db8df-af2d-09fd-640c-8fe377d572de
+    type: elf
+  - code_file: /lib/x86_64-linux-gnu/libm-2.23.so
+    code_id: dfb85de42daffd09640c8fe377d572de3e168920
+    debug_file: /lib/x86_64-linux-gnu/libm-2.23.so
+    debug_id: e45db8df-af2d-09fd-640c-8fe377d572de
     image_addr: '0x7f513fe54000'
     image_size: 1081344
-    name: /lib/x86_64-linux-gnu/libm-2.23.so
-    type: symbolic
-  - id: 451a38b5-0679-79d2-0738-22a5ceb24c4b
+    type: elf
+  - code_file: /lib/x86_64-linux-gnu/libc-2.23.so
+    code_id: b5381a457906d279073822a5ceb24c4bfef94ddb
+    debug_file: /lib/x86_64-linux-gnu/libc-2.23.so
+    debug_id: 451a38b5-0679-79d2-0738-22a5ceb24c4b
     image_addr: '0x7f514015d000'
     image_size: 1835008
-    name: /lib/x86_64-linux-gnu/libc-2.23.so
-    type: symbolic
-  - id: e20a2268-5dc6-c165-b6aa-a12fa6765a6e
+    type: elf
+  - code_file: /lib/x86_64-linux-gnu/libgcc_s.so.1
+    code_id: 68220ae2c65d65c1b6aaa12fa6765a6ec2f5f434
+    debug_file: /lib/x86_64-linux-gnu/libgcc_s.so.1
+    debug_id: e20a2268-5dc6-c165-b6aa-a12fa6765a6e
     image_addr: '0x7f5140527000'
     image_size: 90112
-    name: /lib/x86_64-linux-gnu/libgcc_s.so.1
-    type: symbolic
-  - id: 81c893cb-9b92-3c52-01ac-ef171b52d526
+    type: elf
+  - code_file: /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21
+    code_id: cb93c881929b523c01acef171b52d5261f026029
+    debug_file: /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21
+    debug_id: 81c893cb-9b92-3c52-01ac-ef171b52d526
     image_addr: '0x7f514073d000'
     image_size: 1515520
-    name: /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21
-    type: symbolic
-  - id: 23e017ce-2254-fc65-11d9-bc8f534bb4f0
+    type: elf
+  - code_file: /lib/x86_64-linux-gnu/libpthread-2.23.so
+    code_id: ce17e023542265fc11d9bc8f534bb4f070493d30
+    debug_file: /lib/x86_64-linux-gnu/libpthread-2.23.so
+    debug_id: 23e017ce-2254-fc65-11d9-bc8f534bb4f0
     image_addr: '0x7f5140abf000'
     image_size: 98304
-    name: /lib/x86_64-linux-gnu/libpthread-2.23.so
-    type: symbolic
-  - id: 59627b5d-2255-a375-c17b-d4c3fd05f5a6
+    type: elf
+  - code_file: /lib/x86_64-linux-gnu/ld-2.23.so
+    code_id: 5d7b6259552275a3c17bd4c3fd05f5a6bf40caa5
+    debug_file: /lib/x86_64-linux-gnu/ld-2.23.so
+    debug_id: 59627b5d-2255-a375-c17b-d4c3fd05f5a6
     image_addr: '0x7f5140cdc000'
     image_size: 155648
-    name: /lib/x86_64-linux-gnu/ld-2.23.so
-    type: symbolic
-  - id: 75185f6c-04b9-b48f-b8df-d832e74ad31a
+    type: elf
+  - code_file: linux-gate.so
+    code_id: 6c5f1875b9048fb4b8dfd832e74ad31a9aafb38f
+    debug_file: linux-gate.so
+    debug_id: 75185f6c-04b9-b48f-b8df-d832e74ad31a
     image_addr: '0x7fff5aef1000'
     image_size: 8192
-    name: linux-gate.so
-    type: symbolic
+    type: elf
 exception:
   mechanism:
     handled: false
@@ -60,76 +76,58 @@ exception:
     type: minidump
   stacktrace:
     frames:
-    - function: <unknown>
-      instruction_addr: '0x401dc0'
+    - instruction_addr: '0x401dc0'
       package: /work/linux/build/crash
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x7f5140cdc000'
+    - instruction_addr: '0x7f5140cdc000'
       package: null
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x400040'
+    - instruction_addr: '0x400040'
       package: /work/linux/build/crash
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x7fff5aef1000'
+    - instruction_addr: '0x7fff5aef1000'
       package: null
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x401de9'
+    - instruction_addr: '0x401de9'
       package: /work/linux/build/crash
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x401dc0'
+    - instruction_addr: '0x401dc0'
       package: /work/linux/build/crash
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x414ca0'
+    - instruction_addr: '0x414ca0'
       package: /work/linux/build/crash
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x401c70'
+    - instruction_addr: '0x401c70'
       package: /work/linux/build/crash
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x401dc0'
+    - instruction_addr: '0x401dc0'
       package: /work/linux/build/crash
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x401c70'
+    - instruction_addr: '0x401c70'
       package: /work/linux/build/crash
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x7f514017d830'
+    - instruction_addr: '0x7f514017d830'
       package: /lib/x86_64-linux-gnu/libc-2.23.so
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x414c30'
+    - instruction_addr: '0x414c30'
       package: /work/linux/build/crash
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x401ec0'
+    - instruction_addr: '0x401ec0'
       package: /work/linux/build/crash
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x7f5140cebac6'
+    - instruction_addr: '0x7f5140cebac6'
       package: /lib/x86_64-linux-gnu/ld-2.23.so
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x400000'
+    - instruction_addr: '0x400000'
       package: null
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x7f51401e4800'
+    - instruction_addr: '0x7f51401e4800'
       package: /lib/x86_64-linux-gnu/libc-2.23.so
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x7f514025002e'
+    - instruction_addr: '0x7f514025002e'
       package: /lib/x86_64-linux-gnu/libc-2.23.so
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x401d72'
+    - instruction_addr: '0x401d72'
       package: /work/linux/build/crash
       trust: context
     registers:

--- a/tests/sentry/lang/native/snapshots/test_minidump/test_minidump_macos.pysnap
+++ b/tests/sentry/lang/native/snapshots/test_minidump/test_minidump_macos.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-21T11:57:01.069667Z'
+created: '2019-03-21T13:58:25.667837Z'
 creator: sentry
 source: tests/sentry/lang/native/test_minidump.py
 ---
@@ -13,221 +13,307 @@ contexts:
     version: 10.12.6
 debug_meta:
   images:
-  - id: 67e9247c-814e-392b-a027-dbde6748fcbf
+  - code_file: /Users/travis/build/getsentry/breakpad-tools/macos/build/./crash
+    code_id: null
+    debug_file: crash
+    debug_id: 67e9247c-814e-392b-a027-dbde6748fcbf
     image_addr: '0x109b9b000'
     image_size: 69632
-    name: /Users/travis/build/getsentry/breakpad-tools/macos/build/./crash
-    type: symbolic
-  - id: 36385a3a-60d3-32db-bf55-c6d8931a7aa6
+    type: macho
+  - code_file: /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
+    code_id: null
+    debug_file: CoreFoundation
+    debug_id: 36385a3a-60d3-32db-bf55-c6d8931a7aa6
     image_addr: '0x7fffd229c000'
     image_size: 4800512
-    name: /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
-    type: symbolic
-  - id: 84a04d24-0e60-3810-a8c0-90a65e2df61a
+    type: macho
+  - code_file: /usr/lib/libDiagnosticMessagesClient.dylib
+    code_id: null
+    debug_file: libDiagnosticMessagesClient.dylib
+    debug_id: 84a04d24-0e60-3810-a8c0-90a65e2df61a
     image_addr: '0x7fffe668e000'
     image_size: 8192
-    name: /usr/lib/libDiagnosticMessagesClient.dylib
-    type: symbolic
-  - id: f18ac1e7-c6f1-34b1-8069-be571b3231d4
+    type: macho
+  - code_file: /usr/lib/libSystem.B.dylib
+    code_id: null
+    debug_file: libSystem.B.dylib
+    debug_id: f18ac1e7-c6f1-34b1-8069-be571b3231d4
     image_addr: '0x7fffe68cd000'
     image_size: 8192
-    name: /usr/lib/libSystem.B.dylib
-    type: symbolic
-  - id: 0b43bb5d-e6eb-3464-8de9-b41ac8ed9d1c
+    type: macho
+  - code_file: /usr/lib/libc++.1.dylib
+    code_id: null
+    debug_file: libc++.1.dylib
+    debug_id: 0b43bb5d-e6eb-3464-8de9-b41ac8ed9d1c
     image_addr: '0x7fffe6a80000'
     image_size: 356352
-    name: /usr/lib/libc++.1.dylib
-    type: symbolic
-  - id: bc271ad3-831b-362a-9da7-e8c51f285fe4
+    type: macho
+  - code_file: /usr/lib/libc++abi.dylib
+    code_id: null
+    debug_file: libc++abi.dylib
+    debug_id: bc271ad3-831b-362a-9da7-e8c51f285fe4
     image_addr: '0x7fffe6ad7000'
     image_size: 172032
-    name: /usr/lib/libc++abi.dylib
-    type: symbolic
-  - id: ccd2ed24-3071-383b-925d-8d763bb12a6f
+    type: macho
+  - code_file: /usr/lib/libicucore.A.dylib
+    code_id: null
+    debug_file: libicucore.A.dylib
+    debug_id: ccd2ed24-3071-383b-925d-8d763bb12a6f
     image_addr: '0x7fffe7041000'
     image_size: 2252800
-    name: /usr/lib/libicucore.A.dylib
-    type: symbolic
-  - id: 4df3c25c-52c2-3f01-a3ef-0d9d53a73c1c
+    type: macho
+  - code_file: /usr/lib/libobjc.A.dylib
+    code_id: null
+    debug_file: libobjc.A.dylib
+    debug_id: 4df3c25c-52c2-3f01-a3ef-0d9d53a73c1c
     image_addr: '0x7fffe75f5000'
     image_size: 4022272
-    name: /usr/lib/libobjc.A.dylib
-    type: symbolic
-  - id: 46e3ffa2-4328-327a-8d34-a03e20bffb8e
+    type: macho
+  - code_file: /usr/lib/libz.1.dylib
+    code_id: null
+    debug_file: libz.1.dylib
+    debug_id: 46e3ffa2-4328-327a-8d34-a03e20bffb8e
     image_addr: '0x7fffe7def000'
     image_size: 73728
-    name: /usr/lib/libz.1.dylib
-    type: symbolic
-  - id: 093a4dab-8385-3d47-a350-e20cb7ccf7bf
+    type: macho
+  - code_file: /usr/lib/system/libcache.dylib
+    code_id: null
+    debug_file: libcache.dylib
+    debug_id: 093a4dab-8385-3d47-a350-e20cb7ccf7bf
     image_addr: '0x7fffe7e0f000'
     image_size: 20480
-    name: /usr/lib/system/libcache.dylib
-    type: symbolic
-  - id: 8a64d1b0-c70e-385c-92f0-e669079fda90
+    type: macho
+  - code_file: /usr/lib/system/libcommonCrypto.dylib
+    code_id: null
+    debug_file: libcommonCrypto.dylib
+    debug_id: 8a64d1b0-c70e-385c-92f0-e669079fda90
     image_addr: '0x7fffe7e14000'
     image_size: 45056
-    name: /usr/lib/system/libcommonCrypto.dylib
-    type: symbolic
-  - id: 55d47421-772a-32ab-b529-1a46c2f43b4d
+    type: macho
+  - code_file: /usr/lib/system/libcompiler_rt.dylib
+    code_id: null
+    debug_file: libcompiler_rt.dylib
+    debug_id: 55d47421-772a-32ab-b529-1a46c2f43b4d
     image_addr: '0x7fffe7e1f000'
     image_size: 32768
-    name: /usr/lib/system/libcompiler_rt.dylib
-    type: symbolic
-  - id: 819bea3c-df11-3e3d-a1a1-5a51c5bf1961
+    type: macho
+  - code_file: /usr/lib/system/libcopyfile.dylib
+    code_id: null
+    debug_file: libcopyfile.dylib
+    debug_id: 819bea3c-df11-3e3d-a1a1-5a51c5bf1961
     image_addr: '0x7fffe7e27000'
     image_size: 36864
-    name: /usr/lib/system/libcopyfile.dylib
-    type: symbolic
-  - id: 65d7165e-2e71-335d-a2d6-33f78e2df0c1
+    type: macho
+  - code_file: /usr/lib/system/libcorecrypto.dylib
+    code_id: null
+    debug_file: libcorecrypto.dylib
+    debug_id: 65d7165e-2e71-335d-a2d6-33f78e2df0c1
     image_addr: '0x7fffe7e30000'
     image_size: 540672
-    name: /usr/lib/system/libcorecrypto.dylib
-    type: symbolic
-  - id: 6582bad6-ed27-3b30-b620-90b1c5a4ae3c
+    type: macho
+  - code_file: /usr/lib/system/libdispatch.dylib
+    code_id: null
+    debug_file: libdispatch.dylib
+    debug_id: 6582bad6-ed27-3b30-b620-90b1c5a4ae3c
     image_addr: '0x7fffe7eb4000'
     image_size: 204800
-    name: /usr/lib/system/libdispatch.dylib
-    type: symbolic
-  - id: 9b2ac56d-107c-3541-a127-9094a751f2c9
+    type: macho
+  - code_file: /usr/lib/system/libdyld.dylib
+    code_id: null
+    debug_file: libdyld.dylib
+    debug_id: 9b2ac56d-107c-3541-a127-9094a751f2c9
     image_addr: '0x7fffe7ee6000'
     image_size: 24576
-    name: /usr/lib/system/libdyld.dylib
-    type: symbolic
-  - id: 7aa011a9-dc21-3488-bf73-3b5b14d1fdd6
+    type: macho
+  - code_file: /usr/lib/system/libkeymgr.dylib
+    code_id: null
+    debug_file: libkeymgr.dylib
+    debug_id: 7aa011a9-dc21-3488-bf73-3b5b14d1fdd6
     image_addr: '0x7fffe7eec000'
     image_size: 4096
-    name: /usr/lib/system/libkeymgr.dylib
-    type: symbolic
-  - id: b856abd2-896e-3de0-b2c8-146a6af8e2a7
+    type: macho
+  - code_file: /usr/lib/system/liblaunch.dylib
+    code_id: null
+    debug_file: liblaunch.dylib
+    debug_id: b856abd2-896e-3de0-b2c8-146a6af8e2a7
     image_addr: '0x7fffe7efa000'
     image_size: 4096
-    name: /usr/lib/system/liblaunch.dylib
-    type: symbolic
-  - id: 17d5d855-f6c3-3b04-b680-e9bf02ef8aed
+    type: macho
+  - code_file: /usr/lib/system/libmacho.dylib
+    code_id: null
+    debug_file: libmacho.dylib
+    debug_id: 17d5d855-f6c3-3b04-b680-e9bf02ef8aed
     image_addr: '0x7fffe7efb000'
     image_size: 24576
-    name: /usr/lib/system/libmacho.dylib
-    type: symbolic
-  - id: 12448cc2-378e-35f3-be33-9dc395a5b970
+    type: macho
+  - code_file: /usr/lib/system/libquarantine.dylib
+    code_id: null
+    debug_file: libquarantine.dylib
+    debug_id: 12448cc2-378e-35f3-be33-9dc395a5b970
     image_addr: '0x7fffe7f01000'
     image_size: 12288
-    name: /usr/lib/system/libquarantine.dylib
-    type: symbolic
-  - id: 38d4cb9c-10cd-30d3-8b7b-a515ec75fe85
+    type: macho
+  - code_file: /usr/lib/system/libremovefile.dylib
+    code_id: null
+    debug_file: libremovefile.dylib
+    debug_id: 38d4cb9c-10cd-30d3-8b7b-a515ec75fe85
     image_addr: '0x7fffe7f04000'
     image_size: 8192
-    name: /usr/lib/system/libremovefile.dylib
-    type: symbolic
-  - id: 096e4228-3b7c-30a6-8b13-ec909a64499a
+    type: macho
+  - code_file: /usr/lib/system/libsystem_asl.dylib
+    code_id: null
+    debug_file: libsystem_asl.dylib
+    debug_id: 096e4228-3b7c-30a6-8b13-ec909a64499a
     image_addr: '0x7fffe7f06000'
     image_size: 102400
-    name: /usr/lib/system/libsystem_asl.dylib
-    type: symbolic
-  - id: 10dc5404-73ab-35b3-a277-a8afecb476eb
+    type: macho
+  - code_file: /usr/lib/system/libsystem_blocks.dylib
+    code_id: null
+    debug_file: libsystem_blocks.dylib
+    debug_id: 10dc5404-73ab-35b3-a277-a8afecb476eb
     image_addr: '0x7fffe7f1f000'
     image_size: 4096
-    name: /usr/lib/system/libsystem_blocks.dylib
-    type: symbolic
-  - id: e5ae5244-7d0c-36ac-8bb6-c7ae7ea52a4b
+    type: macho
+  - code_file: /usr/lib/system/libsystem_c.dylib
+    code_id: null
+    debug_file: libsystem_c.dylib
+    debug_id: e5ae5244-7d0c-36ac-8bb6-c7ae7ea52a4b
     image_addr: '0x7fffe7f20000'
     image_size: 581632
-    name: /usr/lib/system/libsystem_c.dylib
-    type: symbolic
-  - id: becc01a2-ca8d-31e6-bcdf-d452965fa976
+    type: macho
+  - code_file: /usr/lib/system/libsystem_configuration.dylib
+    code_id: null
+    debug_file: libsystem_configuration.dylib
+    debug_id: becc01a2-ca8d-31e6-bcdf-d452965fa976
     image_addr: '0x7fffe7fae000'
     image_size: 16384
-    name: /usr/lib/system/libsystem_configuration.dylib
-    type: symbolic
-  - id: 7d26de79-b424-3450-85e1-f7fab32714ab
+    type: macho
+  - code_file: /usr/lib/system/libsystem_coreservices.dylib
+    code_id: null
+    debug_file: libsystem_coreservices.dylib
+    debug_id: 7d26de79-b424-3450-85e1-f7fab32714ab
     image_addr: '0x7fffe7fb2000'
     image_size: 16384
-    name: /usr/lib/system/libsystem_coreservices.dylib
-    type: symbolic
-  - id: ec6fcf07-dcfb-3a03-9cc9-6dd3709974c6
+    type: macho
+  - code_file: /usr/lib/system/libsystem_coretls.dylib
+    code_id: null
+    debug_file: libsystem_coretls.dylib
+    debug_id: ec6fcf07-dcfb-3a03-9cc9-6dd3709974c6
     image_addr: '0x7fffe7fb6000'
     image_size: 102400
-    name: /usr/lib/system/libsystem_coretls.dylib
-    type: symbolic
-  - id: cc960215-0b1b-3822-a13a-3dde96fa796f
+    type: macho
+  - code_file: /usr/lib/system/libsystem_dnssd.dylib
+    code_id: null
+    debug_file: libsystem_dnssd.dylib
+    debug_id: cc960215-0b1b-3822-a13a-3dde96fa796f
     image_addr: '0x7fffe7fcf000'
     image_size: 28672
-    name: /usr/lib/system/libsystem_dnssd.dylib
-    type: symbolic
-  - id: 611db84c-bf70-3f92-8702-b9f28a900920
+    type: macho
+  - code_file: /usr/lib/system/libsystem_info.dylib
+    code_id: null
+    debug_file: libsystem_info.dylib
+    debug_id: 611db84c-bf70-3f92-8702-b9f28a900920
     image_addr: '0x7fffe7fd6000'
     image_size: 172032
-    name: /usr/lib/system/libsystem_info.dylib
-    type: symbolic
-  - id: 34b1f16c-bc9c-3c5f-9045-0cae91cb5914
+    type: macho
+  - code_file: /usr/lib/system/libsystem_kernel.dylib
+    code_id: null
+    debug_file: libsystem_kernel.dylib
+    debug_id: 34b1f16c-bc9c-3c5f-9045-0cae91cb5914
     image_addr: '0x7fffe8000000'
     image_size: 143360
-    name: /usr/lib/system/libsystem_kernel.dylib
-    type: symbolic
-  - id: 86d499b5-bbdc-3d3b-8a4e-97ae8e6672a4
+    type: macho
+  - code_file: /usr/lib/system/libsystem_m.dylib
+    code_id: null
+    debug_file: libsystem_m.dylib
+    debug_id: 86d499b5-bbdc-3d3b-8a4e-97ae8e6672a4
     image_addr: '0x7fffe8023000'
     image_size: 294912
-    name: /usr/lib/system/libsystem_m.dylib
-    type: symbolic
-  - id: a3d15f17-99a6-3367-8c7e-4280e8619c95
+    type: macho
+  - code_file: /usr/lib/system/libsystem_malloc.dylib
+    code_id: null
+    debug_file: libsystem_malloc.dylib
+    debug_id: a3d15f17-99a6-3367-8c7e-4280e8619c95
     image_addr: '0x7fffe806b000'
     image_size: 126976
-    name: /usr/lib/system/libsystem_malloc.dylib
-    type: symbolic
-  - id: 369d0221-56ca-3c3e-9ede-94b41cae77b7
+    type: macho
+  - code_file: /usr/lib/system/libsystem_network.dylib
+    code_id: null
+    debug_file: libsystem_network.dylib
+    debug_id: 369d0221-56ca-3c3e-9ede-94b41cae77b7
     image_addr: '0x7fffe808a000'
     image_size: 368640
-    name: /usr/lib/system/libsystem_network.dylib
-    type: symbolic
-  - id: b021f2b3-8a75-3633-abb0-fc012b8e9b0c
+    type: macho
+  - code_file: /usr/lib/system/libsystem_networkextension.dylib
+    code_id: null
+    debug_file: libsystem_networkextension.dylib
+    debug_id: b021f2b3-8a75-3633-abb0-fc012b8e9b0c
     image_addr: '0x7fffe80e4000'
     image_size: 40960
-    name: /usr/lib/system/libsystem_networkextension.dylib
-    type: symbolic
-  - id: b8160190-a069-3b3a-bdf6-2aa408221fae
+    type: macho
+  - code_file: /usr/lib/system/libsystem_notify.dylib
+    code_id: null
+    debug_file: libsystem_notify.dylib
+    debug_id: b8160190-a069-3b3a-bdf6-2aa408221fae
     image_addr: '0x7fffe80ee000'
     image_size: 40960
-    name: /usr/lib/system/libsystem_notify.dylib
-    type: symbolic
-  - id: 897462fd-b318-321b-a554-e61982630f7e
+    type: macho
+  - code_file: /usr/lib/system/libsystem_platform.dylib
+    code_id: null
+    debug_file: libsystem_platform.dylib
+    debug_id: 897462fd-b318-321b-a554-e61982630f7e
     image_addr: '0x7fffe80f8000'
     image_size: 36864
-    name: /usr/lib/system/libsystem_platform.dylib
-    type: symbolic
-  - id: b8fb5e20-3295-39e2-b5eb-b464d1d4b104
+    type: macho
+  - code_file: /usr/lib/system/libsystem_pthread.dylib
+    code_id: null
+    debug_file: libsystem_pthread.dylib
+    debug_id: b8fb5e20-3295-39e2-b5eb-b464d1d4b104
     image_addr: '0x7fffe8101000'
     image_size: 45056
-    name: /usr/lib/system/libsystem_pthread.dylib
-    type: symbolic
-  - id: 4b92ec49-acd0-36ae-b07a-a2b8152eaf9d
+    type: macho
+  - code_file: /usr/lib/system/libsystem_sandbox.dylib
+    code_id: null
+    debug_file: libsystem_sandbox.dylib
+    debug_id: 4b92ec49-acd0-36ae-b07a-a2b8152eaf9d
     image_addr: '0x7fffe810c000'
     image_size: 16384
-    name: /usr/lib/system/libsystem_sandbox.dylib
-    type: symbolic
-  - id: f78b847b-3565-3e4b-98a6-f7ad40392e2d
+    type: macho
+  - code_file: /usr/lib/system/libsystem_secinit.dylib
+    code_id: null
+    debug_file: libsystem_secinit.dylib
+    debug_id: f78b847b-3565-3e4b-98a6-f7ad40392e2d
     image_addr: '0x7fffe8110000'
     image_size: 8192
-    name: /usr/lib/system/libsystem_secinit.dylib
-    type: symbolic
-  - id: 3390e07c-c1ce-348f-adbd-2c5440b45eaa
+    type: macho
+  - code_file: /usr/lib/system/libsystem_symptoms.dylib
+    code_id: null
+    debug_file: libsystem_symptoms.dylib
+    debug_id: 3390e07c-c1ce-348f-adbd-2c5440b45eaa
     image_addr: '0x7fffe8112000'
     image_size: 32768
-    name: /usr/lib/system/libsystem_symptoms.dylib
-    type: symbolic
-  - id: ac63a7fe-50d9-3a30-96e6-f6b7ff16e465
+    type: macho
+  - code_file: /usr/lib/system/libsystem_trace.dylib
+    code_id: null
+    debug_file: libsystem_trace.dylib
+    debug_id: ac63a7fe-50d9-3a30-96e6-f6b7ff16e465
     image_addr: '0x7fffe811a000'
     image_size: 81920
-    name: /usr/lib/system/libsystem_trace.dylib
-    type: symbolic
-  - id: 3d50d8a8-c460-334d-a519-2da841102c6b
+    type: macho
+  - code_file: /usr/lib/system/libunwind.dylib
+    code_id: null
+    debug_file: libunwind.dylib
+    debug_id: 3d50d8a8-c460-334d-a519-2da841102c6b
     image_addr: '0x7fffe812e000'
     image_size: 24576
-    name: /usr/lib/system/libunwind.dylib
-    type: symbolic
-  - id: bf896df0-d8e9-31a8-a4b3-01120bfeee52
+    type: macho
+  - code_file: /usr/lib/system/libxpc.dylib
+    code_id: null
+    debug_file: libxpc.dylib
+    debug_id: bf896df0-d8e9-31a8-a4b3-01120bfeee52
     image_addr: '0x7fffe8134000'
     image_size: 172032
-    name: /usr/lib/system/libxpc.dylib
-    type: symbolic
+    type: macho
 exception:
   mechanism:
     handled: false
@@ -235,20 +321,16 @@ exception:
     type: minidump
   stacktrace:
     frames:
-    - function: <unknown>
-      instruction_addr: '0x7fffe7eeb235'
+    - instruction_addr: '0x7fffe7eeb235'
       package: /usr/lib/system/libdyld.dylib
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x7fffe7eeb235'
+    - instruction_addr: '0x7fffe7eeb235'
       package: /usr/lib/system/libdyld.dylib
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x109ba8c70'
+    - instruction_addr: '0x109ba8c70'
       package: /Users/travis/build/getsentry/breakpad-tools/macos/build/./crash
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x109ba8c15'
+    - instruction_addr: '0x109ba8c15'
       package: /Users/travis/build/getsentry/breakpad-tools/macos/build/./crash
       trust: context
     registers:

--- a/tests/sentry/lang/native/snapshots/test_minidump/test_minidump_windows.pysnap
+++ b/tests/sentry/lang/native/snapshots/test_minidump/test_minidump_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-21T11:57:01.095945Z'
+created: '2019-03-21T13:58:25.694809Z'
 creator: sentry
 source: tests/sentry/lang/native/test_minidump.py
 ---
@@ -13,91 +13,125 @@ contexts:
     version: 10.0.14393
 debug_meta:
   images:
-  - id: 3249d99d-0c40-4931-8610-f4e4fb0b6936-1
+  - code_file: C:\projects\breakpad-tools\windows\Release\crash.exe
+    code_id: 5AB380779000
+    debug_file: C:\projects\breakpad-tools\windows\Release\crash.pdb
+    debug_id: 3249d99d-0c40-4931-8610-f4e4fb0b6936-1
     image_addr: '0x2a0000'
     image_size: 36864
-    name: C:\projects\breakpad-tools\windows\Release\crash.exe
-    type: symbolic
-  - id: 9c2a902b-6fdf-40ad-8308-588a41d572a0-1
+    type: pe
+  - code_file: C:\Windows\System32\dbghelp.dll
+    code_id: 57898E12145000
+    debug_file: dbghelp.pdb
+    debug_id: 9c2a902b-6fdf-40ad-8308-588a41d572a0-1
     image_addr: '0x70850000'
     image_size: 1331200
-    name: C:\Windows\System32\dbghelp.dll
-    type: symbolic
-  - id: bf5257f7-8c26-43dd-9bb7-901625e1136a-1
+    type: pe
+  - code_file: C:\Windows\System32\msvcp140.dll
+    code_id: 589ABC846c000
+    debug_file: msvcp140.i386.pdb
+    debug_id: bf5257f7-8c26-43dd-9bb7-901625e1136a-1
     image_addr: '0x709a0000'
     image_size: 442368
-    name: C:\Windows\System32\msvcp140.dll
-    type: symbolic
-  - id: 8daf7773-372f-460a-af38-944e193f7e33-1
+    type: pe
+  - code_file: C:\Windows\System32\apphelp.dll
+    code_id: 57898EEB92000
+    debug_file: apphelp.pdb
+    debug_id: 8daf7773-372f-460a-af38-944e193f7e33-1
     image_addr: '0x70a10000'
     image_size: 598016
-    name: C:\Windows\System32\apphelp.dll
-    type: symbolic
-  - id: aec7ef2f-df4b-4642-a471-4c3e5fe8760a-1
+    type: pe
+  - code_file: C:\Windows\System32\dbgcore.dll
+    code_id: 57898DAB25000
+    debug_file: dbgcore.pdb
+    debug_id: aec7ef2f-df4b-4642-a471-4c3e5fe8760a-1
     image_addr: '0x70b70000'
     image_size: 151552
-    name: C:\Windows\System32\dbgcore.dll
-    type: symbolic
-  - id: 0ed80a50-ecda-472b-86a4-eb6c833f8e1b-1
+    type: pe
+  - code_file: C:\Windows\System32\VCRUNTIME140.dll
+    code_id: 589ABC7714000
+    debug_file: vcruntime140.i386.pdb
+    debug_id: 0ed80a50-ecda-472b-86a4-eb6c833f8e1b-1
     image_addr: '0x70c60000'
     image_size: 81920
-    name: C:\Windows\System32\VCRUNTIME140.dll
-    type: symbolic
-  - id: 147c51fb-7ca1-408f-85b5-285f2ad6f9c5-1
+    type: pe
+  - code_file: C:\Windows\System32\CRYPTBASE.dll
+    code_id: 57899141a000
+    debug_file: cryptbase.pdb
+    debug_id: 147c51fb-7ca1-408f-85b5-285f2ad6f9c5-1
     image_addr: '0x73ba0000'
     image_size: 40960
-    name: C:\Windows\System32\CRYPTBASE.dll
-    type: symbolic
-  - id: 51e432b1-0450-4b19-8ed1-6d4335f9f543-1
+    type: pe
+  - code_file: C:\Windows\System32\sspicli.dll
+    code_id: 59BF30E31f000
+    debug_file: wsspicli.pdb
+    debug_id: 51e432b1-0450-4b19-8ed1-6d4335f9f543-1
     image_addr: '0x73bb0000'
     image_size: 126976
-    name: C:\Windows\System32\sspicli.dll
-    type: symbolic
-  - id: 0c799483-b549-417d-8433-4331852031fe-1
+    type: pe
+  - code_file: C:\Windows\System32\advapi32.dll
+    code_id: 5A49BB7677000
+    debug_file: advapi32.pdb
+    debug_id: 0c799483-b549-417d-8433-4331852031fe-1
     image_addr: '0x73c70000'
     image_size: 487424
-    name: C:\Windows\System32\advapi32.dll
-    type: symbolic
-  - id: 6f6409b3-d520-43c7-9b2f-62e00bfe761c-1
+    type: pe
+  - code_file: C:\Windows\System32\msvcrt.dll
+    code_id: 57899155be000
+    debug_file: msvcrt.pdb
+    debug_id: 6f6409b3-d520-43c7-9b2f-62e00bfe761c-1
     image_addr: '0x73cf0000'
     image_size: 778240
-    name: C:\Windows\System32\msvcrt.dll
-    type: symbolic
-  - id: 6f6a05dd-0a80-478b-a419-9b88703bf75b-1
+    type: pe
+  - code_file: C:\Windows\System32\sechost.dll
+    code_id: 598942C741000
+    debug_file: sechost.pdb
+    debug_id: 6f6a05dd-0a80-478b-a419-9b88703bf75b-1
     image_addr: '0x74450000'
     image_size: 266240
-    name: C:\Windows\System32\sechost.dll
-    type: symbolic
-  - id: d3474559-96f7-47d6-bf43-c176b2171e68-1
+    type: pe
+  - code_file: C:\Windows\System32\kernel32.dll
+    code_id: 590285E9e0000
+    debug_file: wkernel32.pdb
+    debug_id: d3474559-96f7-47d6-bf43-c176b2171e68-1
     image_addr: '0x75050000'
     image_size: 917504
-    name: C:\Windows\System32\kernel32.dll
-    type: symbolic
-  - id: 287b19c3-9209-4a2b-bb8f-bcc37f411b11-1
+    type: pe
+  - code_file: C:\Windows\System32\bcryptPrimitives.dll
+    code_id: 59B0DF8F5a000
+    debug_file: bcryptprimitives.pdb
+    debug_id: 287b19c3-9209-4a2b-bb8f-bcc37f411b11-1
     image_addr: '0x75130000'
     image_size: 368640
-    name: C:\Windows\System32\bcryptPrimitives.dll
-    type: symbolic
-  - id: ae131c67-27a7-4fa1-9916-b5a4aef41190-1
+    type: pe
+  - code_file: C:\Windows\System32\rpcrt4.dll
+    code_id: 5A49BB75c1000
+    debug_file: wrpcrt4.pdb
+    debug_id: ae131c67-27a7-4fa1-9916-b5a4aef41190-1
     image_addr: '0x75810000'
     image_size: 790528
-    name: C:\Windows\System32\rpcrt4.dll
-    type: symbolic
-  - id: 6bedcbce-0a3a-40e9-8040-81c2c8c6cc2f-1
+    type: pe
+  - code_file: C:\Windows\System32\ucrtbase.dll
+    code_id: 59BF2B5Ae0000
+    debug_file: ucrtbase.pdb
+    debug_id: 6bedcbce-0a3a-40e9-8040-81c2c8c6cc2f-1
     image_addr: '0x758f0000'
     image_size: 917504
-    name: C:\Windows\System32\ucrtbase.dll
-    type: symbolic
-  - id: 8462294a-c645-402d-ac82-a4e95f61ddf9-1
+    type: pe
+  - code_file: C:\Windows\System32\KERNELBASE.dll
+    code_id: 59BF2BCF1a1000
+    debug_file: wkernelbase.pdb
+    debug_id: 8462294a-c645-402d-ac82-a4e95f61ddf9-1
     image_addr: '0x76db0000'
     image_size: 1708032
-    name: C:\Windows\System32\KERNELBASE.dll
-    type: symbolic
-  - id: 971f98e5-ce60-41ff-b2d7-235bbeb34578-1
+    type: pe
+  - code_file: C:\Windows\System32\ntdll.dll
+    code_id: 59B0D8F3183000
+    debug_file: wntdll.pdb
+    debug_id: 971f98e5-ce60-41ff-b2d7-235bbeb34578-1
     image_addr: '0x77170000'
     image_size: 1585152
-    name: C:\Windows\System32\ntdll.dll
-    type: symbolic
+    type: pe
 exception:
   mechanism:
     handled: false
@@ -105,52 +139,40 @@ exception:
     type: minidump
   stacktrace:
     frames:
-    - function: <unknown>
-      instruction_addr: '0x771d0f44'
+    - instruction_addr: '0x771d0f44'
       package: C:\Windows\System32\ntdll.dll
       trust: fp
-    - function: <unknown>
-      instruction_addr: '0x771d0f79'
+    - instruction_addr: '0x771d0f79'
       package: C:\Windows\System32\ntdll.dll
       trust: fp
-    - function: <unknown>
-      instruction_addr: '0x750662c4'
+    - instruction_addr: '0x750662c4'
       package: C:\Windows\System32\kernel32.dll
       trust: fp
-    - function: <unknown>
-      instruction_addr: '0x2a2d97'
+    - instruction_addr: '0x2a2d97'
       package: C:\projects\breakpad-tools\windows\Release\crash.exe
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x2a3435'
+    - instruction_addr: '0x2a3435'
       package: C:\projects\breakpad-tools\windows\Release\crash.exe
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x7584e9c0'
+    - instruction_addr: '0x7584e9c0'
       package: C:\Windows\System32\rpcrt4.dll
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x75810000'
+    - instruction_addr: '0x75810000'
       package: null
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x70b7ae40'
+    - instruction_addr: '0x70b7ae40'
       package: C:\Windows\System32\dbgcore.dll
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x70850000'
+    - instruction_addr: '0x70850000'
       package: null
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x7584e9c0'
+    - instruction_addr: '0x7584e9c0'
       package: C:\Windows\System32\rpcrt4.dll
       trust: scan
-    - function: <unknown>
-      instruction_addr: '0x2a28d0'
+    - instruction_addr: '0x2a28d0'
       package: C:\projects\breakpad-tools\windows\Release\crash.exe
       trust: fp
-    - function: <unknown>
-      instruction_addr: '0x2a2a3d'
+    - instruction_addr: '0x2a2a3d'
       package: C:\projects\breakpad-tools\windows\Release\crash.exe
       trust: context
     registers:
@@ -177,20 +199,16 @@ threads:
   id: 3580
   stacktrace:
     frames:
-    - function: <unknown>
-      instruction_addr: '0x771d0f44'
+    - instruction_addr: '0x771d0f44'
       package: C:\Windows\System32\ntdll.dll
       trust: fp
-    - function: <unknown>
-      instruction_addr: '0x771d0f79'
+    - instruction_addr: '0x771d0f79'
       package: C:\Windows\System32\ntdll.dll
       trust: fp
-    - function: <unknown>
-      instruction_addr: '0x750662c4'
+    - instruction_addr: '0x750662c4'
       package: C:\Windows\System32\kernel32.dll
       trust: fp
-    - function: <unknown>
-      instruction_addr: '0x771e016c'
+    - instruction_addr: '0x771e016c'
       package: C:\Windows\System32\ntdll.dll
       trust: context
     registers:
@@ -208,20 +226,16 @@ threads:
   id: 2600
   stacktrace:
     frames:
-    - function: <unknown>
-      instruction_addr: '0x771d0f44'
+    - instruction_addr: '0x771d0f44'
       package: C:\Windows\System32\ntdll.dll
       trust: fp
-    - function: <unknown>
-      instruction_addr: '0x771d0f79'
+    - instruction_addr: '0x771d0f79'
       package: C:\Windows\System32\ntdll.dll
       trust: fp
-    - function: <unknown>
-      instruction_addr: '0x750662c4'
+    - instruction_addr: '0x750662c4'
       package: C:\Windows\System32\kernel32.dll
       trust: fp
-    - function: <unknown>
-      instruction_addr: '0x771e016c'
+    - instruction_addr: '0x771e016c'
       package: C:\Windows\System32\ntdll.dll
       trust: context
     registers:
@@ -239,8 +253,7 @@ threads:
   id: 2920
   stacktrace:
     frames:
-    - function: <unknown>
-      instruction_addr: '0x771df3dc'
+    - instruction_addr: '0x771df3dc'
       package: C:\Windows\System32\ntdll.dll
       trust: context
     registers:

--- a/tests/sentry/lang/native/test_cfi.py
+++ b/tests/sentry/lang/native/test_cfi.py
@@ -14,19 +14,16 @@ from sentry.testutils import TestCase
 
 RAW_STACKTRACE = [
     {
-        'function': '<unknown>',
         'instruction_addr': '0x7f51401e4800',
         'package': u'/lib/x86_64-linux-gnu/libc-2.23.so',
         'trust': 'scan',
     },
     {
-        'function': '<unknown>',
         'instruction_addr': '0x7f514025002e',
         'package': u'/lib/x86_64-linux-gnu/libc-2.23.so',
         'trust': 'scan',
     },
     {
-        'function': '<unknown>',
         'instruction_addr': '0x401d72',
         'package': u'/work/linux/build/crash',
         'trust': 'context',
@@ -35,79 +32,66 @@ RAW_STACKTRACE = [
 
 CFI_STACKTRACE = [
     {
-        'function': '<unknown>',
         'instruction_addr': '0x401dc0',
         'package': u'/work/linux/build/crash',
         'trust': 'scan'
     },
     {
-        'function': '<unknown>',
         'instruction_addr': '0x7f5140cdc000',
         'package': None,
         'trust': 'scan'
     },
     {
-        'function': '<unknown>',
         'instruction_addr': '0x400040',
         'package': u'/work/linux/build/crash',
         'trust': 'scan'
     },
     {
-        'function': '<unknown>',
         'instruction_addr': '0x7fff5aef1000',
         'package': None,
         'trust': 'scan'
     },
     {
-        'function': '<unknown>',
         'instruction_addr': '0x7fff5ae4ac88',
         'package': None,
         'trust': 'cfi'
     },
     {
-        'function': '<unknown>',
         'instruction_addr': '0x401de9',
         'package': u'/work/linux/build/crash',
         'trust': 'scan'
     },
     {
-        'function': '<unknown>',
         'instruction_addr': '0x401dc0',
         'package': u'/work/linux/build/crash',
         'trust': 'scan'
     },
     {
-        'function': '<unknown>',
         'instruction_addr': '0x414ca0',
         'package': u'/work/linux/build/crash',
         'trust': 'scan'
     },
     {
-        'function': '<unknown>',
         'instruction_addr': '0x401c70',
         'package': u'/work/linux/build/crash',
         'trust': 'scan'
     },
     {
-        'function': '<unknown>',
         'instruction_addr': '0x401dc0',
         'package': u'/work/linux/build/crash',
         'trust': 'scan'
     },
     {
-        'function': '<unknown>',
         'instruction_addr': '0x401c70',
         'package': u'/work/linux/build/crash',
         'trust': 'scan'
     },
     {
-        'function': '<unknown>',
         'instruction_addr': '0x7f514017d830',
         'package': u'/lib/x86_64-linux-gnu/libc-2.23.so',
         'trust': 'cfi'
     },
     {
-        'function': '<unknown>',
         'instruction_addr': '0x401d72',
         'package': u'/work/linux/build/crash',
         'trust': 'context',


### PR DESCRIPTION
This emits debug images in the updated schema containing `debug_file` and `code_id`. Also, this cleans up some code that's no longer needed.

This is based on some other PRs and will not pass CI until they are merged:

Requires https://github.com/getsentry/sentry/pull/12453
Requires https://github.com/getsentry/symbolic/pull/131