### PR TITLE
ref: Don't shadow the real user interface.

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -334,9 +334,7 @@ class SimpleEventSerializer(EventSerializer):
             if query:
                 tag['query'] = query
 
-        user = obj.get_interface('user')
-        if user is not None:
-            user = user.get_api_context()
+        user = obj.get_minimal_user()
 
         return {
             'id': six.text_type(obj.id),
@@ -349,7 +347,7 @@ class SimpleEventSerializer(EventSerializer):
             'title': obj.title,
             'location': obj.location,
             'culprit': obj.culprit,
-            'user': user,
+            'user': user and user.get_api_context(),
             'tags': tags,
             'platform': obj.platform,
             'dateCreated': obj.datetime,

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -287,6 +287,13 @@ class EventCommon(object):
 
         return self._environment_cache
 
+    def get_minimal_user(self):
+        """
+        A minimal 'User' interface object that gives us enough information
+        to render a user badge.
+        """
+        return self.get_interface('user')
+
     def as_dict(self):
         """Returns the data in normalized form for external consumers."""
         # We use a OrderedDict to keep elements ordered for a potential JSON serializer
@@ -449,27 +456,17 @@ class SnubaEvent(EventCommon):
             return sorted(zip(keys, values))
         return []
 
-    def get_interface(self, name):
-        """
-        Override of interface getter that lets us return some interfaces
-        directly from Snuba data.
-        """
-        if name in ['user']:
-            from sentry.interfaces.user import User
-            # This is a fake version of the User interface constructed
-            # from just the data we have in Snuba.
-            snuba_user = {
-                'id': self.user_id,
-                'email': self.email,
-                'username': self.username,
-                'ip_address': self.ip_address,
-            }
-            if any(v is not None for v in snuba_user.values()):
-                return User.to_python(snuba_user)
-        return self.interfaces.get(name)
-
     def get_event_type(self):
         return self.__dict__.get('type', 'default')
+
+    def get_minimal_user(self):
+        from sentry.interfaces.user import User
+        return User.to_python({
+            'id': self.user_id,
+            'email': self.email,
+            'username': self.username,
+            'ip_address': self.ip_address,
+        })
 
     # These should all have been normalized to the correct values on
     # the way in to snuba, so we should be able to just use them as is.

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -228,7 +228,7 @@ class SnubaEventSerializerTest(TestCase):
 
         # Make sure we didn't have to call out to Nodestore to get the data
         # required to serialize this event and the NodeData is still empty.
-        assert event.data._node_data is None
+        assert event.data._node_data is None, "Node data was populated"
 
         assert result['eventID'] == event.event_id
         assert result['projectID'] == six.text_type(event.project_id)


### PR DESCRIPTION
The previous pattern was not great as it meant that `SnubaEvent` was
always shadowing the `get_interface('user')` call with its own
implementation which was not necessarily compatible with the `Event`
version.

This changes it so the serializer can choose to grab the real User
interface (which requires a nodestore fetch) or the minimal one (which
doesn't if the event happens to be a `SnubaEvent`), leaving the decision
about which thing to grab up to the caller.