### PR TITLE
fix(integrations) Make logger name consistent

### DIFF
--- a/src/sentry/identity/gitlab/provider.py
+++ b/src/sentry/identity/gitlab/provider.py
@@ -8,7 +8,7 @@ from sentry.http import safe_urlopen, safe_urlread
 from sentry.identity.oauth2 import OAuth2Provider
 from sentry.utils import json
 
-logger = logging.getLogger('sentry.integrations.gitlab')
+logger = logging.getLogger('sentry.integration.gitlab')
 
 
 def get_oauth_data(payload):

--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -314,7 +314,12 @@ class OAuth2CallbackView(PipelineView):
             return pipeline.error(error)
 
         if state != pipeline.fetch_state('state'):
-            pipeline.logger.info('identity.token-exchange-error', extra={'error': 'invalid_state'})
+            pipeline.logger.info('identity.token-exchange-error', extra={
+                'error': 'invalid_state',
+                'state': state,
+                'pipeline_state': pipeline.fetch_state('state'),
+                'code': code
+            })
             return pipeline.error(ERR_INVALID_STATE)
 
         data = self.exchange_token(request, pipeline, code)


### PR DESCRIPTION
Other parts of the gitlab integration use `sentry.integration.gitlab`. Match that convention here as well.