### PR TITLE
feat(saved-search): Add a component for organization saved searches

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/filters.jsx
+++ b/src/sentry/static/sentry/app/views/stream/filters.jsx
@@ -1,9 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import SavedSearchSelector from 'app/views/stream/savedSearchSelector';
-import SearchBar from 'app/views/stream/searchBar';
-import SortOptions from 'app/views/stream/sortOptions';
+import Feature from 'app/components/acl/feature';
+
+import SearchBar from './searchBar';
+import SortOptions from './sortOptions';
+import SavedSearchSelector from './savedSearchSelector';
+import OrganizationSavedSearchSelector from './organizationSavedSearchSelector';
 
 class StreamFilters extends React.Component {
   static propTypes = {
@@ -68,18 +71,30 @@ class StreamFilters extends React.Component {
       <div className="stream-header">
         <div className="row">
           <div className="col-sm-5">
-            <SavedSearchSelector
-              access={access}
-              orgId={orgId}
-              projectId={projectId}
-              searchId={searchId}
-              queryCount={queryCount}
-              queryMaxCount={queryMaxCount}
-              query={query}
-              onSavedSearchCreate={onSavedSearchCreate}
-              onSavedSearchSelect={onSavedSearchSelect}
-              savedSearchList={savedSearchList}
-            />
+            <Feature
+              features={['org-saved-searches']}
+              renderDisabled={() => (
+                <SavedSearchSelector
+                  access={access}
+                  orgId={orgId}
+                  projectId={projectId}
+                  searchId={searchId}
+                  queryCount={queryCount}
+                  queryMaxCount={queryMaxCount}
+                  query={query}
+                  onSavedSearchCreate={onSavedSearchCreate}
+                  onSavedSearchSelect={onSavedSearchSelect}
+                  savedSearchList={savedSearchList}
+                />
+              )}
+            >
+              <OrganizationSavedSearchSelector
+                savedSearchList={savedSearchList}
+                onSavedSearchSelect={onSavedSearchSelect}
+                queryCount={queryCount}
+                queryMaxCount={queryMaxCount}
+              />
+            </Feature>
           </div>
           <div className="col-sm-7">
             <div className="search-container">

--- a/src/sentry/static/sentry/app/views/stream/organizationSavedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/stream/organizationSavedSearchSelector.jsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'react-emotion';
+
+import {t} from 'app/locale';
+import MenuItem from 'app/components/menuItem';
+import DropdownLink from 'app/components/dropdownLink';
+import QueryCount from 'app/components/queryCount';
+import space from 'app/styles/space';
+
+export default class OrganizationSavedSearchSelector extends React.Component {
+  static propTypes = {
+    savedSearchList: PropTypes.array.isRequired,
+    onSavedSearchSelect: PropTypes.func.isRequired,
+    query: PropTypes.string,
+    queryCount: PropTypes.number,
+    queryMaxCount: PropTypes.number,
+    searchId: PropTypes.string,
+  };
+
+  getTitle() {
+    const {searchId, query, savedSearchList} = this.props;
+    let result;
+
+    if (searchId) {
+      result = savedSearchList.find(search => searchId === search.id);
+    } else {
+      result = savedSearchList.find(search => query === search.query);
+    }
+
+    return result ? result.name : t('Custom Search');
+  }
+
+  renderList() {
+    const {savedSearchList, onSavedSearchSelect} = this.props;
+
+    if (savedSearchList.length === 0) {
+      return <EmptyItem>{t("There don't seem to be any saved searches yet.")}</EmptyItem>;
+    }
+
+    return savedSearchList.map(search => (
+      <StyledMenuItem onSelect={() => onSavedSearchSelect(search)} key={search.id}>
+        <span>
+          <strong>{search.name}</strong>
+        </span>
+        <code>{search.query}</code>
+      </StyledMenuItem>
+    ));
+  }
+
+  render() {
+    const {queryCount, queryMaxCount} = this.props;
+
+    return (
+      <Container>
+        <StyledDropdownLink
+          title={
+            <span>
+              <span>{this.getTitle()}</span>
+              <QueryCount count={queryCount} max={queryMaxCount} />
+            </span>
+          }
+        >
+          {this.renderList()}
+        </StyledDropdownLink>
+      </Container>
+    );
+  }
+}
+
+const Container = styled.div`
+  & .dropdown-menu {
+    max-width: 350px;
+    min-width: 275px;
+  }
+`;
+
+const StyledMenuItem = styled(MenuItem)`
+  & a {
+    /* override shared-components.less */
+    padding: ${space(0.25)} ${space(1)} !important;
+  }
+  & span,
+  & code {
+    display: block;
+    max-width: 100%;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    color: ${p => p.theme.gray5};
+    padding: 0;
+    background: inherit;
+  }
+`;
+
+const StyledDropdownLink = styled(DropdownLink)`
+  display: inline-block;
+  font-size: 22px;
+  color: ${p => p.theme.gray5};
+  line-height: 36px;
+  margin-right: 10px;
+  max-width: 100%;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+
+  & :hover,
+  & :focus {
+    color: ${p => p.theme.gray5};
+  }
+
+  & .icon-arrow-down {
+    display: inline-block;
+    margin-left: 5px;
+    top: 0;
+    vertical-align: middle;
+  }
+`;
+
+const EmptyItem = styled.li`
+  padding: 8px 10px 5px;
+  font-style: italic;
+`;

--- a/tests/js/spec/views/stream/organizationSavedSearchSelector.spec.jsx
+++ b/tests/js/spec/views/stream/organizationSavedSearchSelector.spec.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import OrganizationSavedSearchSelector from 'app/views/stream/organizationSavedSearchSelector';
+
+describe('OrganizationSavedSearchSelector', function() {
+  let wrapper, onSelect;
+  beforeEach(function() {
+    onSelect = jest.fn();
+    const savedSearchList = [
+      {
+        id: '789',
+        query: 'is:unresolved',
+        name: 'Unresolved',
+        isPinned: false,
+      },
+      {
+        id: '122',
+        query: 'is:unresolved assigned:me',
+        name: 'Assigned to me',
+        isPinned: false,
+      },
+    ];
+
+    wrapper = mount(
+      <OrganizationSavedSearchSelector
+        savedSearchList={savedSearchList}
+        onSavedSearchSelect={onSelect}
+      />
+    );
+  });
+
+  describe('getTitle()', function() {
+    it('defaults to custom search', function() {
+      expect(wrapper.instance().getTitle()).toEqual('Custom Search');
+    });
+
+    it('uses searchId to match', function() {
+      wrapper.setProps({searchId: '789'});
+      expect(wrapper.instance().getTitle()).toEqual('Unresolved');
+    });
+
+    it('uses query to match', function() {
+      wrapper.setProps({query: 'is:unresolved assigned:me'});
+      expect(wrapper.instance().getTitle()).toEqual('Assigned to me');
+    });
+  });
+
+  describe('selecting an option', function() {
+    it('calls onSelect when clicked', async function() {
+      wrapper.find('DropdownLink').simulate('click');
+      await wrapper.update();
+
+      const item = wrapper.find('StyledMenuItem a').first();
+      expect(item).toHaveLength(1);
+
+      item.simulate('click');
+      expect(onSelect).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
The new component is behind the `org_saved_searches` feature flag and currently just supports basic listing of saved searches.

Ref: SEN-395