### PR TITLE
feat(ui): Manipulate API error stacktrace to be at callsite

### DIFF
--- a/src/sentry/static/sentry/app/api.jsx
+++ b/src/sentry/static/sentry/app/api.jsx
@@ -235,18 +235,24 @@ export class Client {
   }
 
   requestPromise(path, {includeAllArgs, ...options} = {}) {
-    return new Promise((resolve, reject) => {
-      // Create an error object here before we make any async calls so
-      // that we have a helpful stacktrace if it errors
-      const error = new Error('API Request Failed');
+    // Create an error object here before we make any async calls so
+    // that we have a helpful stacktrace if it errors
+    const error = new Error(`${options.method || 'GET'} "${path}"`);
 
+    return new Promise((resolve, reject) => {
       this.request(path, {
         ...options,
         success: (data, ...args) => {
           includeAllArgs ? resolve([data, ...args]) : resolve(data);
         },
         error: (resp, ...args) => {
+          // Update error message with response status code
+          error.message = `${error.message} -> ${(resp && resp.status) || 'n/a'}`;
           error.resp = resp;
+
+          // Drop the Client.requestPromise frame so stacktrace starts at `requestPromise` callsite
+          const lines = error.stack.split('\n');
+          error.stack = [lines[0], ...lines.slice(2)].join('\n');
           reject(error);
         },
       });


### PR DESCRIPTION
This pops off a frame from the API error stacktrace so that it will be at the callsite instead of inside of `requestPromise`

## old
![image](https://user-images.githubusercontent.com/79684/54713056-f2656c00-4b0a-11e9-9bbf-9bf2683eadd5.png)
![image](https://user-images.githubusercontent.com/79684/54713042-ea0d3100-4b0a-11e9-9401-281eacec5e50.png)


## new (local)
![image](https://user-images.githubusercontent.com/79684/54713067-f72a2000-4b0a-11e9-9b26-d6e8d3ddeb53.png)
![image](https://user-images.githubusercontent.com/79684/54712925-b5997500-4b0a-11e9-9fb9-bd21f63b4b31.png)
