### PR TITLE
ref(ui) Remove now redundant span tags

### DIFF
--- a/src/sentry/static/sentry/app/components/betaTag.jsx
+++ b/src/sentry/static/sentry/app/components/betaTag.jsx
@@ -12,11 +12,9 @@ const BetaTag = () => (
       placement: 'right',
     }}
   >
-    <span>
-      <StyledTag priority="beta" size="small">
-        beta
-      </StyledTag>
-    </span>
+    <StyledTag priority="beta" size="small">
+      beta
+    </StyledTag>
   </Tooltip>
 );
 

--- a/src/sentry/static/sentry/app/components/group/seenInfo.jsx
+++ b/src/sentry/static/sentry/app/components/group/seenInfo.jsx
@@ -75,9 +75,7 @@ const SeenInfo = createReactClass({
         {date ? (
           <dd key={1}>
             <Tooltip title={this.getTooltipTitle()} tooltipOptions={{html: true}}>
-              <span>
-                <TimeSince className="dotted-underline" date={date} />
-              </span>
+              <TimeSince className="dotted-underline" date={date} />
             </Tooltip>
             <br />
             <small>
@@ -87,9 +85,7 @@ const SeenInfo = createReactClass({
         ) : dateGlobal && environment === '' ? (
           <dd key={1}>
             <Tooltip title={this.getTooltipTitle()} tooltipOptions={{html: true}}>
-              <span>
-                <TimeSince date={dateGlobal} />
-              </span>
+              <TimeSince date={dateGlobal} />
             </Tooltip>
             <br />
             <small>

--- a/src/sentry/static/sentry/app/components/modals/integrationDetailsModal.jsx
+++ b/src/sentry/static/sentry/app/components/modals/integrationDetailsModal.jsx
@@ -169,9 +169,7 @@ class IntegrationDetailsModal extends React.Component {
                     title={t('You must be an Owner, Manager or Admin to install this.')}
                     disabled={hasAccess}
                   >
-                    <span>
-                      <AddButton disabled={disabled || !hasAccess} />
-                    </span>
+                    <AddButton disabled={disabled || !hasAccess} />
                   </Tooltip>
                 )}
               </Access>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegrationButton.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegrationButton.jsx
@@ -31,19 +31,17 @@ export default class AddIntegrationButton extends React.Component {
         disabled={provider.canAdd}
         title={`Integration cannot be added on Sentry. Enable this integration via the ${provider.name} instance.`}
       >
-        <span>
-          <AddIntegration provider={provider} onInstall={onAddIntegration}>
-            {onClick => (
-              <Button
-                disabled={!provider.canAdd}
-                {...buttonProps}
-                onClick={() => onClick()}
-              >
-                {label}
-              </Button>
-            )}
-          </AddIntegration>
-        </span>
+        <AddIntegration provider={provider} onInstall={onAddIntegration}>
+          {onClick => (
+            <Button
+              disabled={!provider.canAdd}
+              {...buttonProps}
+              onClick={() => onClick()}
+            >
+              {label}
+            </Button>
+          )}
+        </AddIntegration>
       </Tooltip>
     );
   }

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.jsx
@@ -133,16 +133,14 @@ export default class InstalledIntegration extends React.Component {
                   tooltipOptions={{placement: 'left'}}
                   title="Integration not configurable"
                 >
-                  <span>
-                    <StyledButton
-                      borderless
-                      icon="icon-settings"
-                      disabled={!this.hasConfiguration() || !hasAccess}
-                      to={`/settings/${orgId}/integrations/${provider.key}/${integration.id}/`}
-                    >
-                      Configure
-                    </StyledButton>
-                  </span>
+                  <StyledButton
+                    borderless
+                    icon="icon-settings"
+                    disabled={!this.hasConfiguration() || !hasAccess}
+                    to={`/settings/${orgId}/integrations/${provider.key}/${integration.id}/`}
+                  >
+                    Configure
+                  </StyledButton>
                 </Tooltip>
               )}
             </Box>

--- a/src/sentry/static/sentry/app/views/projectDebugFiles.jsx
+++ b/src/sentry/static/sentry/app/views/projectDebugFiles.jsx
@@ -134,7 +134,9 @@ class ProjectDebugSymbols extends AsyncComponent {
               {features &&
                 features.map(feature => (
                   <Tooltip key={feature} title={getFeatureTooltip(feature)}>
-                    <Tag inline>{feature}</Tag>
+                    <span>
+                      <Tag inline>{feature}</Tag>
+                    </span>
                   </Tooltip>
                 ))}
             </DebugSymbolDetails>

--- a/src/sentry/static/sentry/app/views/projectDebugFiles.jsx
+++ b/src/sentry/static/sentry/app/views/projectDebugFiles.jsx
@@ -134,9 +134,7 @@ class ProjectDebugSymbols extends AsyncComponent {
               {features &&
                 features.map(feature => (
                   <Tooltip key={feature} title={getFeatureTooltip(feature)}>
-                    <span>
-                      <Tag inline>{feature}</Tag>
-                    </span>
+                    <Tag inline>{feature}</Tag>
                   </Tooltip>
                 ))}
             </DebugSymbolDetails>
@@ -163,21 +161,19 @@ class ProjectDebugSymbols extends AsyncComponent {
                   disabled={hasAccess}
                   title={t('You do not have permission to delete debug files.')}
                 >
-                  <span>
-                    <Confirm
-                      title={t('Delete')}
-                      message={t('Are you sure you wish to delete this file?')}
-                      onConfirm={() => this.onDelete(dsym.id)}
+                  <Confirm
+                    title={t('Delete')}
+                    message={t('Are you sure you wish to delete this file?')}
+                    onConfirm={() => this.onDelete(dsym.id)}
+                    disabled={!hasAccess}
+                  >
+                    <Button
+                      priority="danger"
+                      icon="icon-trash"
+                      size="xsmall"
                       disabled={!hasAccess}
-                    >
-                      <Button
-                        priority="danger"
-                        icon="icon-trash"
-                        size="xsmall"
-                        disabled={!hasAccess}
-                      />
-                    </Confirm>
-                  </span>
+                    />
+                  </Confirm>
                 </Tooltip>
               )}
             </Access>

--- a/src/sentry/static/sentry/app/views/projectTags.jsx
+++ b/src/sentry/static/sentry/app/views/projectTags.jsx
@@ -95,21 +95,19 @@ export default class ProjectTags extends AsyncView {
                               : t('You do not have permission to remove tags.')
                           }
                         >
-                          <span>
-                            <LinkWithConfirmation
-                              title={'Remove tag?'}
-                              message={'Are you sure you want to remove this tag?'}
-                              onConfirm={() => this.onDelete(key, idx)}
+                          <LinkWithConfirmation
+                            title={'Remove tag?'}
+                            message={'Are you sure you want to remove this tag?'}
+                            onConfirm={() => this.onDelete(key, idx)}
+                            disabled={!enabled}
+                          >
+                            <Button
+                              size="xsmall"
+                              icon="icon-trash"
+                              data-test-id="delete"
                               disabled={!enabled}
-                            >
-                              <Button
-                                size="xsmall"
-                                icon="icon-trash"
-                                data-test-id="delete"
-                                disabled={!enabled}
-                              />
-                            </LinkWithConfirmation>
-                          </span>
+                            />
+                          </LinkWithConfirmation>
                         </Tooltip>
                       </Flex>
                     </PanelItem>

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityDetails.jsx
@@ -137,11 +137,9 @@ class AccountSecurityDetails extends AsyncView {
                 )}
                 disabled={!deleteDisabled}
               >
-                <span>
-                  <RemoveConfirm onConfirm={this.handleRemove} disabled={deleteDisabled}>
-                    <Button priority="danger">{authenticator.removeButton}</Button>
-                  </RemoveConfirm>
-                </span>
+                <RemoveConfirm onConfirm={this.handleRemove} disabled={deleteDisabled}>
+                  <Button priority="danger">{authenticator.removeButton}</Button>
+                </RemoveConfirm>
               </Tooltip>
             )
           }

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/index.jsx
@@ -161,16 +161,14 @@ class AccountSecurity extends AsyncView {
                             )}
                             disabled={!deleteDisabled}
                           >
-                            <span>
-                              <RemoveConfirm
-                                onConfirm={() => onDisable(auth)}
-                                disabled={deleteDisabled}
-                              >
-                                <Button css={{marginLeft: 6}} size="small">
-                                  <span className="icon icon-trash" />
-                                </Button>
-                              </RemoveConfirm>
-                            </span>
+                            <RemoveConfirm
+                              onConfirm={() => onDisable(auth)}
+                              disabled={deleteDisabled}
+                            >
+                              <Button css={{marginLeft: 6}} size="small">
+                                <span className="icon icon-trash" />
+                              </Button>
+                            </RemoveConfirm>
                           </Tooltip>
                         )}
 

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow.jsx
@@ -114,9 +114,7 @@ export default class SentryApplicationRow extends React.PureComponent {
                 this.renderRemoveApp(app)
               ) : (
                 <Tooltip title={t('Published apps cannot be removed.')}>
-                  <span>
-                    <Button disabled={true} size="small" icon="icon-trash" />
-                  </span>
+                  <Button disabled={true} size="small" icon="icon-trash" />
                 </Tooltip>
               )}
             </Box>

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberDetail.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberDetail.jsx
@@ -300,21 +300,19 @@ class OrganizationMemberDetail extends AsyncView {
                   disabled={this.showResetButton()}
                   title={this.getTooltip()}
                 >
-                  <span>
-                    <Confirm
-                      disabled={!this.showResetButton()}
-                      message={tct(
-                        'Are you sure you want to disable all two-factor authentication methods for [name]?',
-                        {name: member.name ? member.name : 'this member'}
-                      )}
-                      onConfirm={this.handle2faReset}
-                      data-test-id="reset-2fa-confirm"
-                    >
-                      <Button data-test-id="reset-2fa" priority="danger">
-                        {t('Reset two-factor authentication')}
-                      </Button>
-                    </Confirm>
-                  </span>
+                  <Confirm
+                    disabled={!this.showResetButton()}
+                    message={tct(
+                      'Are you sure you want to disable all two-factor authentication methods for [name]?',
+                      {name: member.name ? member.name : 'this member'}
+                    )}
+                    onConfirm={this.handle2faReset}
+                    data-test-id="reset-2fa-confirm"
+                  >
+                    <Button data-test-id="reset-2fa" priority="danger">
+                      {t('Reset two-factor authentication')}
+                    </Button>
+                  </Confirm>
                 </Tooltip>
               </Field>
             </PanelBody>

--- a/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
@@ -122,18 +122,16 @@ const SaveSearchButton = withApi(
             title="You must select issues from a single project to create new saved searches"
             disabled={!disabled}
           >
-            <span>
-              <Button
-                title={tooltip || buttonTitle}
-                size="xsmall"
-                priority="default"
-                disabled={disabled}
-                onClick={this.onToggle.bind(this)}
-                style={style}
-              >
-                {children}
-              </Button>
-            </span>
+            <Button
+              title={tooltip || buttonTitle}
+              size="xsmall"
+              priority="default"
+              disabled={disabled}
+              onClick={this.onToggle.bind(this)}
+              style={style}
+            >
+              {children}
+            </Button>
           </Tooltip>
           <Modal
             show={this.state.isModalOpen}
@@ -287,16 +285,14 @@ const SavedSearchSelector = withApi(
                 title="You must select issues from a single project to manage saved searches"
                 disabled={hasProject}
               >
-                <span>
-                  <Button
-                    size="xsmall"
-                    priority="default"
-                    to={`/${orgId}/${projectId}/settings/saved-searches/`}
-                    disabled={!hasProject}
-                  >
-                    {t('Manage')}
-                  </Button>
-                </span>
+                <Button
+                  size="xsmall"
+                  priority="default"
+                  to={`/${orgId}/${projectId}/settings/saved-searches/`}
+                  disabled={!hasProject}
+                >
+                  {t('Manage')}
+                </Button>
               </Tooltip>
             </ButtonBar>
           </StyledDropdownLink>

--- a/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
+++ b/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
@@ -621,103 +621,128 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
               disabled={true}
               title="You must be an Owner, Manager or Admin to install this."
             >
-              <span>
-                <AddButton
+              <AddButton
+                disabled={false}
+              >
+                <AddIntegrationButton
                   disabled={false}
-                >
-                  <AddIntegrationButton
-                    disabled={false}
-                    onAddIntegration={[Function]}
-                    priority="primary"
-                    provider={
-                      Object {
-                        "canAdd": true,
-                        "config": Array [],
-                        "externalIssues": Array [],
-                        "features": Array [],
-                        "key": "github",
-                        "metadata": Object {
-                          "aspects": Object {
-                            "alerts": Array [
-                              Object {
-                                "text": "This is a an alert example",
-                                "type": "warning",
-                              },
-                            ],
-                          },
-                          "author": "Morty",
-                          "description": "*markdown* formatted _description_",
-                          "features": Array [
+                  onAddIntegration={[Function]}
+                  priority="primary"
+                  provider={
+                    Object {
+                      "canAdd": true,
+                      "config": Array [],
+                      "externalIssues": Array [],
+                      "features": Array [],
+                      "key": "github",
+                      "metadata": Object {
+                        "aspects": Object {
+                          "alerts": Array [
                             Object {
-                              "description": "*markdown* feature description",
+                              "text": "This is a an alert example",
+                              "type": "warning",
                             },
                           ],
-                          "issue_url": "http://example.com/integration_issue_url",
-                          "noun": "Installation",
-                          "source_url": "http://example.com/integration_source_url",
                         },
-                        "name": "GitHub",
-                        "setupDialog": Object {
-                          "height": 100,
-                          "url": "/github-integration-setup-uri/",
-                          "width": 100,
-                        },
-                      }
+                        "author": "Morty",
+                        "description": "*markdown* formatted _description_",
+                        "features": Array [
+                          Object {
+                            "description": "*markdown* feature description",
+                          },
+                        ],
+                        "issue_url": "http://example.com/integration_issue_url",
+                        "noun": "Installation",
+                        "source_url": "http://example.com/integration_source_url",
+                      },
+                      "name": "GitHub",
+                      "setupDialog": Object {
+                        "height": 100,
+                        "url": "/github-integration-setup-uri/",
+                        "width": 100,
+                      },
                     }
-                    size="small"
-                    style={
-                      Object {
-                        "marginLeft": "8px",
-                      }
+                  }
+                  size="small"
+                  style={
+                    Object {
+                      "marginLeft": "8px",
                     }
+                  }
+                >
+                  <Tooltip
+                    disabled={true}
+                    title="Integration cannot be added on Sentry. Enable this integration via the GitHub instance."
                   >
-                    <Tooltip
-                      disabled={true}
-                      title="Integration cannot be added on Sentry. Enable this integration via the GitHub instance."
-                    >
-                      <span>
-                        <AddIntegration
-                          onInstall={[Function]}
-                          provider={
-                            Object {
-                              "canAdd": true,
-                              "config": Array [],
-                              "externalIssues": Array [],
-                              "features": Array [],
-                              "key": "github",
-                              "metadata": Object {
-                                "aspects": Object {
-                                  "alerts": Array [
-                                    Object {
-                                      "text": "This is a an alert example",
-                                      "type": "warning",
-                                    },
-                                  ],
+                    <AddIntegration
+                      onInstall={[Function]}
+                      provider={
+                        Object {
+                          "canAdd": true,
+                          "config": Array [],
+                          "externalIssues": Array [],
+                          "features": Array [],
+                          "key": "github",
+                          "metadata": Object {
+                            "aspects": Object {
+                              "alerts": Array [
+                                Object {
+                                  "text": "This is a an alert example",
+                                  "type": "warning",
                                 },
-                                "author": "Morty",
-                                "description": "*markdown* formatted _description_",
-                                "features": Array [
-                                  Object {
-                                    "description": "*markdown* feature description",
-                                  },
-                                ],
-                                "issue_url": "http://example.com/integration_issue_url",
-                                "noun": "Installation",
-                                "source_url": "http://example.com/integration_source_url",
+                              ],
+                            },
+                            "author": "Morty",
+                            "description": "*markdown* formatted _description_",
+                            "features": Array [
+                              Object {
+                                "description": "*markdown* feature description",
                               },
-                              "name": "GitHub",
-                              "setupDialog": Object {
-                                "height": 100,
-                                "url": "/github-integration-setup-uri/",
-                                "width": 100,
-                              },
+                            ],
+                            "issue_url": "http://example.com/integration_issue_url",
+                            "noun": "Installation",
+                            "source_url": "http://example.com/integration_source_url",
+                          },
+                          "name": "GitHub",
+                          "setupDialog": Object {
+                            "height": 100,
+                            "url": "/github-integration-setup-uri/",
+                            "width": 100,
+                          },
+                        }
+                      }
+                    >
+                      <Button
+                        disabled={false}
+                        onClick={[Function]}
+                        priority="primary"
+                        size="small"
+                        style={
+                          Object {
+                            "marginLeft": "8px",
+                          }
+                        }
+                      >
+                        <StyledButton
+                          aria-disabled={false}
+                          aria-label="Add Installation"
+                          disabled={false}
+                          onClick={[Function]}
+                          priority="primary"
+                          role="button"
+                          size="small"
+                          style={
+                            Object {
+                              "marginLeft": "8px",
                             }
                           }
                         >
-                          <Button
-                            disabled={false}
+                          <Component
+                            aria-disabled={false}
+                            aria-label="Add Installation"
+                            className="css-zvpqlo-StyledButton-getColors eqrebog0"
                             onClick={[Function]}
-                            priority="primary"
+                            role="button"
                             size="small"
                             style={
                               Object {
@@ -725,12 +750,11 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
                               }
                             }
                           >
-                            <StyledButton
+                            <button
                               aria-disabled={false}
                               aria-label="Add Installation"
-                              disabled={false}
+                              className="css-zvpqlo-StyledButton-getColors eqrebog0"
                               onClick={[Function]}
-                              priority="primary"
                               role="button"
                               size="small"
                               style={
@@ -739,58 +763,30 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
                                 }
                               }
                             >
-                              <Component
-                                aria-disabled={false}
-                                aria-label="Add Installation"
-                                className="css-zvpqlo-StyledButton-getColors eqrebog0"
-                                onClick={[Function]}
-                                role="button"
+                              <ButtonLabel
+                                priority="primary"
                                 size="small"
-                                style={
-                                  Object {
-                                    "marginLeft": "8px",
-                                  }
-                                }
                               >
-                                <button
-                                  aria-disabled={false}
-                                  aria-label="Add Installation"
-                                  className="css-zvpqlo-StyledButton-getColors eqrebog0"
-                                  onClick={[Function]}
-                                  role="button"
+                                <Component
+                                  className="css-7ui8bl-ButtonLabel eqrebog1"
+                                  priority="primary"
                                   size="small"
-                                  style={
-                                    Object {
-                                      "marginLeft": "8px",
-                                    }
-                                  }
                                 >
-                                  <ButtonLabel
-                                    priority="primary"
-                                    size="small"
+                                  <span
+                                    className="css-7ui8bl-ButtonLabel eqrebog1"
                                   >
-                                    <Component
-                                      className="css-7ui8bl-ButtonLabel eqrebog1"
-                                      priority="primary"
-                                      size="small"
-                                    >
-                                      <span
-                                        className="css-7ui8bl-ButtonLabel eqrebog1"
-                                      >
-                                        Add Installation
-                                      </span>
-                                    </Component>
-                                  </ButtonLabel>
-                                </button>
-                              </Component>
-                            </StyledButton>
-                          </Button>
-                        </AddIntegration>
-                      </span>
-                    </Tooltip>
-                  </AddIntegrationButton>
-                </AddButton>
-              </span>
+                                    Add Installation
+                                  </span>
+                                </Component>
+                              </ButtonLabel>
+                            </button>
+                          </Component>
+                        </StyledButton>
+                      </Button>
+                    </AddIntegration>
+                  </Tooltip>
+                </AddIntegrationButton>
+              </AddButton>
             </Tooltip>
           </Access>
         </AccessContainer>

--- a/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
@@ -450,43 +450,50 @@ exports[`ProjectTags renders 1`] = `
                                     disabled={true}
                                     title="This tag cannot be deleted."
                                   >
-                                    <span>
-                                      <LinkWithConfirmation
+                                    <LinkWithConfirmation
+                                      disabled={false}
+                                      message="Are you sure you want to remove this tag?"
+                                      onConfirm={[Function]}
+                                      title="Remove tag?"
+                                    >
+                                      <Confirm
+                                        cancelText="Cancel"
+                                        confirmText="Confirm"
+                                        disableConfirmButton={false}
                                         disabled={false}
                                         message="Are you sure you want to remove this tag?"
                                         onConfirm={[Function]}
-                                        title="Remove tag?"
+                                        priority="primary"
                                       >
-                                        <Confirm
-                                          cancelText="Cancel"
-                                          confirmText="Confirm"
-                                          disableConfirmButton={false}
+                                        <a
+                                          className=""
                                           disabled={false}
-                                          message="Are you sure you want to remove this tag?"
-                                          onConfirm={[Function]}
-                                          priority="primary"
+                                          onClick={[Function]}
+                                          title="Remove tag?"
                                         >
-                                          <a
-                                            className=""
+                                          <Button
+                                            data-test-id="delete"
                                             disabled={false}
-                                            onClick={[Function]}
-                                            title="Remove tag?"
+                                            icon="icon-trash"
+                                            size="xsmall"
                                           >
-                                            <Button
+                                            <StyledButton
+                                              aria-disabled={false}
                                               data-test-id="delete"
                                               disabled={false}
-                                              icon="icon-trash"
+                                              onClick={[Function]}
+                                              role="button"
                                               size="xsmall"
                                             >
-                                              <StyledButton
+                                              <Component
                                                 aria-disabled={false}
+                                                className="css-dkprmi-StyledButton-getColors eqrebog0"
                                                 data-test-id="delete"
-                                                disabled={false}
                                                 onClick={[Function]}
                                                 role="button"
                                                 size="xsmall"
                                               >
-                                                <Component
+                                                <button
                                                   aria-disabled={false}
                                                   className="css-dkprmi-StyledButton-getColors eqrebog0"
                                                   data-test-id="delete"
@@ -494,83 +501,99 @@ exports[`ProjectTags renders 1`] = `
                                                   role="button"
                                                   size="xsmall"
                                                 >
-                                                  <button
-                                                    aria-disabled={false}
-                                                    className="css-dkprmi-StyledButton-getColors eqrebog0"
-                                                    data-test-id="delete"
-                                                    onClick={[Function]}
-                                                    role="button"
+                                                  <ButtonLabel
                                                     size="xsmall"
                                                   >
-                                                    <ButtonLabel
+                                                    <Component
+                                                      className="css-uthd1f-ButtonLabel eqrebog1"
                                                       size="xsmall"
                                                     >
-                                                      <Component
+                                                      <span
                                                         className="css-uthd1f-ButtonLabel eqrebog1"
-                                                        size="xsmall"
                                                       >
-                                                        <span
-                                                          className="css-uthd1f-ButtonLabel eqrebog1"
+                                                        <Icon
+                                                          hasChildren={false}
+                                                          size="xsmall"
                                                         >
-                                                          <Icon
+                                                          <Component
+                                                            className="css-ljhpxy-Icon eqrebog2"
                                                             hasChildren={false}
                                                             size="xsmall"
                                                           >
-                                                            <Component
+                                                            <span
                                                               className="css-ljhpxy-Icon eqrebog2"
-                                                              hasChildren={false}
                                                               size="xsmall"
                                                             >
-                                                              <span
-                                                                className="css-ljhpxy-Icon eqrebog2"
-                                                                size="xsmall"
+                                                              <StyledInlineSvg
+                                                                size="12px"
+                                                                src="icon-trash"
                                                               >
-                                                                <StyledInlineSvg
+                                                                <InlineSvg
+                                                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
                                                                   size="12px"
                                                                   src="icon-trash"
                                                                 >
-                                                                  <InlineSvg
+                                                                  <StyledSvg
                                                                     className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                    size="12px"
-                                                                    src="icon-trash"
+                                                                    height="12px"
+                                                                    viewBox={Object {}}
+                                                                    width="12px"
                                                                   >
-                                                                    <StyledSvg
-                                                                      className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                                    <svg
+                                                                      className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
                                                                       height="12px"
                                                                       viewBox={Object {}}
                                                                       width="12px"
                                                                     >
-                                                                      <svg
-                                                                        className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                        height="12px"
-                                                                        viewBox={Object {}}
-                                                                        width="12px"
-                                                                      >
-                                                                        <use
-                                                                          href="#test"
-                                                                          xlinkHref="#test"
-                                                                        />
-                                                                      </svg>
-                                                                    </StyledSvg>
-                                                                  </InlineSvg>
-                                                                </StyledInlineSvg>
-                                                              </span>
-                                                            </Component>
-                                                          </Icon>
-                                                        </span>
-                                                      </Component>
-                                                    </ButtonLabel>
-                                                  </button>
-                                                </Component>
-                                              </StyledButton>
-                                            </Button>
-                                          </a>
+                                                                      <use
+                                                                        href="#test"
+                                                                        xlinkHref="#test"
+                                                                      />
+                                                                    </svg>
+                                                                  </StyledSvg>
+                                                                </InlineSvg>
+                                                              </StyledInlineSvg>
+                                                            </span>
+                                                          </Component>
+                                                        </Icon>
+                                                      </span>
+                                                    </Component>
+                                                  </ButtonLabel>
+                                                </button>
+                                              </Component>
+                                            </StyledButton>
+                                          </Button>
+                                        </a>
+                                        <Modal
+                                          animation={false}
+                                          autoFocus={true}
+                                          backdrop={true}
+                                          bsClass="modal"
+                                          dialogComponentClass={[Function]}
+                                          enforceFocus={true}
+                                          keyboard={true}
+                                          manager={
+                                            ModalManager {
+                                              "add": [Function],
+                                              "containers": Array [],
+                                              "data": Array [],
+                                              "handleContainerOverflow": true,
+                                              "hideSiblingNodes": true,
+                                              "isTopModal": [Function],
+                                              "modals": Array [],
+                                              "remove": [Function],
+                                            }
+                                          }
+                                          onHide={[Function]}
+                                          renderBackdrop={[Function]}
+                                          restoreFocus={true}
+                                          show={false}
+                                        >
                                           <Modal
-                                            animation={false}
                                             autoFocus={true}
                                             backdrop={true}
-                                            bsClass="modal"
-                                            dialogComponentClass={[Function]}
+                                            backdropClassName="modal-backdrop"
+                                            containerClassName="modal-open"
                                             enforceFocus={true}
                                             keyboard={true}
                                             manager={
@@ -585,41 +608,16 @@ exports[`ProjectTags renders 1`] = `
                                                 "remove": [Function],
                                               }
                                             }
+                                            onEntering={[Function]}
+                                            onExited={[Function]}
                                             onHide={[Function]}
                                             renderBackdrop={[Function]}
                                             restoreFocus={true}
                                             show={false}
-                                          >
-                                            <Modal
-                                              autoFocus={true}
-                                              backdrop={true}
-                                              backdropClassName="modal-backdrop"
-                                              containerClassName="modal-open"
-                                              enforceFocus={true}
-                                              keyboard={true}
-                                              manager={
-                                                ModalManager {
-                                                  "add": [Function],
-                                                  "containers": Array [],
-                                                  "data": Array [],
-                                                  "handleContainerOverflow": true,
-                                                  "hideSiblingNodes": true,
-                                                  "isTopModal": [Function],
-                                                  "modals": Array [],
-                                                  "remove": [Function],
-                                                }
-                                              }
-                                              onEntering={[Function]}
-                                              onExited={[Function]}
-                                              onHide={[Function]}
-                                              renderBackdrop={[Function]}
-                                              restoreFocus={true}
-                                              show={false}
-                                            />
-                                          </Modal>
-                                        </Confirm>
-                                      </LinkWithConfirmation>
-                                    </span>
+                                          />
+                                        </Modal>
+                                      </Confirm>
+                                    </LinkWithConfirmation>
                                   </Tooltip>
                                 </div>
                               </Base>
@@ -680,43 +678,50 @@ exports[`ProjectTags renders 1`] = `
                                     disabled={true}
                                     title="This tag cannot be deleted."
                                   >
-                                    <span>
-                                      <LinkWithConfirmation
+                                    <LinkWithConfirmation
+                                      disabled={false}
+                                      message="Are you sure you want to remove this tag?"
+                                      onConfirm={[Function]}
+                                      title="Remove tag?"
+                                    >
+                                      <Confirm
+                                        cancelText="Cancel"
+                                        confirmText="Confirm"
+                                        disableConfirmButton={false}
                                         disabled={false}
                                         message="Are you sure you want to remove this tag?"
                                         onConfirm={[Function]}
-                                        title="Remove tag?"
+                                        priority="primary"
                                       >
-                                        <Confirm
-                                          cancelText="Cancel"
-                                          confirmText="Confirm"
-                                          disableConfirmButton={false}
+                                        <a
+                                          className=""
                                           disabled={false}
-                                          message="Are you sure you want to remove this tag?"
-                                          onConfirm={[Function]}
-                                          priority="primary"
+                                          onClick={[Function]}
+                                          title="Remove tag?"
                                         >
-                                          <a
-                                            className=""
+                                          <Button
+                                            data-test-id="delete"
                                             disabled={false}
-                                            onClick={[Function]}
-                                            title="Remove tag?"
+                                            icon="icon-trash"
+                                            size="xsmall"
                                           >
-                                            <Button
+                                            <StyledButton
+                                              aria-disabled={false}
                                               data-test-id="delete"
                                               disabled={false}
-                                              icon="icon-trash"
+                                              onClick={[Function]}
+                                              role="button"
                                               size="xsmall"
                                             >
-                                              <StyledButton
+                                              <Component
                                                 aria-disabled={false}
+                                                className="css-dkprmi-StyledButton-getColors eqrebog0"
                                                 data-test-id="delete"
-                                                disabled={false}
                                                 onClick={[Function]}
                                                 role="button"
                                                 size="xsmall"
                                               >
-                                                <Component
+                                                <button
                                                   aria-disabled={false}
                                                   className="css-dkprmi-StyledButton-getColors eqrebog0"
                                                   data-test-id="delete"
@@ -724,83 +729,99 @@ exports[`ProjectTags renders 1`] = `
                                                   role="button"
                                                   size="xsmall"
                                                 >
-                                                  <button
-                                                    aria-disabled={false}
-                                                    className="css-dkprmi-StyledButton-getColors eqrebog0"
-                                                    data-test-id="delete"
-                                                    onClick={[Function]}
-                                                    role="button"
+                                                  <ButtonLabel
                                                     size="xsmall"
                                                   >
-                                                    <ButtonLabel
+                                                    <Component
+                                                      className="css-uthd1f-ButtonLabel eqrebog1"
                                                       size="xsmall"
                                                     >
-                                                      <Component
+                                                      <span
                                                         className="css-uthd1f-ButtonLabel eqrebog1"
-                                                        size="xsmall"
                                                       >
-                                                        <span
-                                                          className="css-uthd1f-ButtonLabel eqrebog1"
+                                                        <Icon
+                                                          hasChildren={false}
+                                                          size="xsmall"
                                                         >
-                                                          <Icon
+                                                          <Component
+                                                            className="css-ljhpxy-Icon eqrebog2"
                                                             hasChildren={false}
                                                             size="xsmall"
                                                           >
-                                                            <Component
+                                                            <span
                                                               className="css-ljhpxy-Icon eqrebog2"
-                                                              hasChildren={false}
                                                               size="xsmall"
                                                             >
-                                                              <span
-                                                                className="css-ljhpxy-Icon eqrebog2"
-                                                                size="xsmall"
+                                                              <StyledInlineSvg
+                                                                size="12px"
+                                                                src="icon-trash"
                                                               >
-                                                                <StyledInlineSvg
+                                                                <InlineSvg
+                                                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
                                                                   size="12px"
                                                                   src="icon-trash"
                                                                 >
-                                                                  <InlineSvg
+                                                                  <StyledSvg
                                                                     className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                    size="12px"
-                                                                    src="icon-trash"
+                                                                    height="12px"
+                                                                    viewBox={Object {}}
+                                                                    width="12px"
                                                                   >
-                                                                    <StyledSvg
-                                                                      className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                                    <svg
+                                                                      className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
                                                                       height="12px"
                                                                       viewBox={Object {}}
                                                                       width="12px"
                                                                     >
-                                                                      <svg
-                                                                        className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                        height="12px"
-                                                                        viewBox={Object {}}
-                                                                        width="12px"
-                                                                      >
-                                                                        <use
-                                                                          href="#test"
-                                                                          xlinkHref="#test"
-                                                                        />
-                                                                      </svg>
-                                                                    </StyledSvg>
-                                                                  </InlineSvg>
-                                                                </StyledInlineSvg>
-                                                              </span>
-                                                            </Component>
-                                                          </Icon>
-                                                        </span>
-                                                      </Component>
-                                                    </ButtonLabel>
-                                                  </button>
-                                                </Component>
-                                              </StyledButton>
-                                            </Button>
-                                          </a>
+                                                                      <use
+                                                                        href="#test"
+                                                                        xlinkHref="#test"
+                                                                      />
+                                                                    </svg>
+                                                                  </StyledSvg>
+                                                                </InlineSvg>
+                                                              </StyledInlineSvg>
+                                                            </span>
+                                                          </Component>
+                                                        </Icon>
+                                                      </span>
+                                                    </Component>
+                                                  </ButtonLabel>
+                                                </button>
+                                              </Component>
+                                            </StyledButton>
+                                          </Button>
+                                        </a>
+                                        <Modal
+                                          animation={false}
+                                          autoFocus={true}
+                                          backdrop={true}
+                                          bsClass="modal"
+                                          dialogComponentClass={[Function]}
+                                          enforceFocus={true}
+                                          keyboard={true}
+                                          manager={
+                                            ModalManager {
+                                              "add": [Function],
+                                              "containers": Array [],
+                                              "data": Array [],
+                                              "handleContainerOverflow": true,
+                                              "hideSiblingNodes": true,
+                                              "isTopModal": [Function],
+                                              "modals": Array [],
+                                              "remove": [Function],
+                                            }
+                                          }
+                                          onHide={[Function]}
+                                          renderBackdrop={[Function]}
+                                          restoreFocus={true}
+                                          show={false}
+                                        >
                                           <Modal
-                                            animation={false}
                                             autoFocus={true}
                                             backdrop={true}
-                                            bsClass="modal"
-                                            dialogComponentClass={[Function]}
+                                            backdropClassName="modal-backdrop"
+                                            containerClassName="modal-open"
                                             enforceFocus={true}
                                             keyboard={true}
                                             manager={
@@ -815,41 +836,16 @@ exports[`ProjectTags renders 1`] = `
                                                 "remove": [Function],
                                               }
                                             }
+                                            onEntering={[Function]}
+                                            onExited={[Function]}
                                             onHide={[Function]}
                                             renderBackdrop={[Function]}
                                             restoreFocus={true}
                                             show={false}
-                                          >
-                                            <Modal
-                                              autoFocus={true}
-                                              backdrop={true}
-                                              backdropClassName="modal-backdrop"
-                                              containerClassName="modal-open"
-                                              enforceFocus={true}
-                                              keyboard={true}
-                                              manager={
-                                                ModalManager {
-                                                  "add": [Function],
-                                                  "containers": Array [],
-                                                  "data": Array [],
-                                                  "handleContainerOverflow": true,
-                                                  "hideSiblingNodes": true,
-                                                  "isTopModal": [Function],
-                                                  "modals": Array [],
-                                                  "remove": [Function],
-                                                }
-                                              }
-                                              onEntering={[Function]}
-                                              onExited={[Function]}
-                                              onHide={[Function]}
-                                              renderBackdrop={[Function]}
-                                              restoreFocus={true}
-                                              show={false}
-                                            />
-                                          </Modal>
-                                        </Confirm>
-                                      </LinkWithConfirmation>
-                                    </span>
+                                          />
+                                        </Modal>
+                                      </Confirm>
+                                    </LinkWithConfirmation>
                                   </Tooltip>
                                 </div>
                               </Base>
@@ -910,43 +906,50 @@ exports[`ProjectTags renders 1`] = `
                                     disabled={true}
                                     title="This tag cannot be deleted."
                                   >
-                                    <span>
-                                      <LinkWithConfirmation
+                                    <LinkWithConfirmation
+                                      disabled={false}
+                                      message="Are you sure you want to remove this tag?"
+                                      onConfirm={[Function]}
+                                      title="Remove tag?"
+                                    >
+                                      <Confirm
+                                        cancelText="Cancel"
+                                        confirmText="Confirm"
+                                        disableConfirmButton={false}
                                         disabled={false}
                                         message="Are you sure you want to remove this tag?"
                                         onConfirm={[Function]}
-                                        title="Remove tag?"
+                                        priority="primary"
                                       >
-                                        <Confirm
-                                          cancelText="Cancel"
-                                          confirmText="Confirm"
-                                          disableConfirmButton={false}
+                                        <a
+                                          className=""
                                           disabled={false}
-                                          message="Are you sure you want to remove this tag?"
-                                          onConfirm={[Function]}
-                                          priority="primary"
+                                          onClick={[Function]}
+                                          title="Remove tag?"
                                         >
-                                          <a
-                                            className=""
+                                          <Button
+                                            data-test-id="delete"
                                             disabled={false}
-                                            onClick={[Function]}
-                                            title="Remove tag?"
+                                            icon="icon-trash"
+                                            size="xsmall"
                                           >
-                                            <Button
+                                            <StyledButton
+                                              aria-disabled={false}
                                               data-test-id="delete"
                                               disabled={false}
-                                              icon="icon-trash"
+                                              onClick={[Function]}
+                                              role="button"
                                               size="xsmall"
                                             >
-                                              <StyledButton
+                                              <Component
                                                 aria-disabled={false}
+                                                className="css-dkprmi-StyledButton-getColors eqrebog0"
                                                 data-test-id="delete"
-                                                disabled={false}
                                                 onClick={[Function]}
                                                 role="button"
                                                 size="xsmall"
                                               >
-                                                <Component
+                                                <button
                                                   aria-disabled={false}
                                                   className="css-dkprmi-StyledButton-getColors eqrebog0"
                                                   data-test-id="delete"
@@ -954,83 +957,99 @@ exports[`ProjectTags renders 1`] = `
                                                   role="button"
                                                   size="xsmall"
                                                 >
-                                                  <button
-                                                    aria-disabled={false}
-                                                    className="css-dkprmi-StyledButton-getColors eqrebog0"
-                                                    data-test-id="delete"
-                                                    onClick={[Function]}
-                                                    role="button"
+                                                  <ButtonLabel
                                                     size="xsmall"
                                                   >
-                                                    <ButtonLabel
+                                                    <Component
+                                                      className="css-uthd1f-ButtonLabel eqrebog1"
                                                       size="xsmall"
                                                     >
-                                                      <Component
+                                                      <span
                                                         className="css-uthd1f-ButtonLabel eqrebog1"
-                                                        size="xsmall"
                                                       >
-                                                        <span
-                                                          className="css-uthd1f-ButtonLabel eqrebog1"
+                                                        <Icon
+                                                          hasChildren={false}
+                                                          size="xsmall"
                                                         >
-                                                          <Icon
+                                                          <Component
+                                                            className="css-ljhpxy-Icon eqrebog2"
                                                             hasChildren={false}
                                                             size="xsmall"
                                                           >
-                                                            <Component
+                                                            <span
                                                               className="css-ljhpxy-Icon eqrebog2"
-                                                              hasChildren={false}
                                                               size="xsmall"
                                                             >
-                                                              <span
-                                                                className="css-ljhpxy-Icon eqrebog2"
-                                                                size="xsmall"
+                                                              <StyledInlineSvg
+                                                                size="12px"
+                                                                src="icon-trash"
                                                               >
-                                                                <StyledInlineSvg
+                                                                <InlineSvg
+                                                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
                                                                   size="12px"
                                                                   src="icon-trash"
                                                                 >
-                                                                  <InlineSvg
+                                                                  <StyledSvg
                                                                     className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                    size="12px"
-                                                                    src="icon-trash"
+                                                                    height="12px"
+                                                                    viewBox={Object {}}
+                                                                    width="12px"
                                                                   >
-                                                                    <StyledSvg
-                                                                      className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                                    <svg
+                                                                      className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
                                                                       height="12px"
                                                                       viewBox={Object {}}
                                                                       width="12px"
                                                                     >
-                                                                      <svg
-                                                                        className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                        height="12px"
-                                                                        viewBox={Object {}}
-                                                                        width="12px"
-                                                                      >
-                                                                        <use
-                                                                          href="#test"
-                                                                          xlinkHref="#test"
-                                                                        />
-                                                                      </svg>
-                                                                    </StyledSvg>
-                                                                  </InlineSvg>
-                                                                </StyledInlineSvg>
-                                                              </span>
-                                                            </Component>
-                                                          </Icon>
-                                                        </span>
-                                                      </Component>
-                                                    </ButtonLabel>
-                                                  </button>
-                                                </Component>
-                                              </StyledButton>
-                                            </Button>
-                                          </a>
+                                                                      <use
+                                                                        href="#test"
+                                                                        xlinkHref="#test"
+                                                                      />
+                                                                    </svg>
+                                                                  </StyledSvg>
+                                                                </InlineSvg>
+                                                              </StyledInlineSvg>
+                                                            </span>
+                                                          </Component>
+                                                        </Icon>
+                                                      </span>
+                                                    </Component>
+                                                  </ButtonLabel>
+                                                </button>
+                                              </Component>
+                                            </StyledButton>
+                                          </Button>
+                                        </a>
+                                        <Modal
+                                          animation={false}
+                                          autoFocus={true}
+                                          backdrop={true}
+                                          bsClass="modal"
+                                          dialogComponentClass={[Function]}
+                                          enforceFocus={true}
+                                          keyboard={true}
+                                          manager={
+                                            ModalManager {
+                                              "add": [Function],
+                                              "containers": Array [],
+                                              "data": Array [],
+                                              "handleContainerOverflow": true,
+                                              "hideSiblingNodes": true,
+                                              "isTopModal": [Function],
+                                              "modals": Array [],
+                                              "remove": [Function],
+                                            }
+                                          }
+                                          onHide={[Function]}
+                                          renderBackdrop={[Function]}
+                                          restoreFocus={true}
+                                          show={false}
+                                        >
                                           <Modal
-                                            animation={false}
                                             autoFocus={true}
                                             backdrop={true}
-                                            bsClass="modal"
-                                            dialogComponentClass={[Function]}
+                                            backdropClassName="modal-backdrop"
+                                            containerClassName="modal-open"
                                             enforceFocus={true}
                                             keyboard={true}
                                             manager={
@@ -1045,41 +1064,16 @@ exports[`ProjectTags renders 1`] = `
                                                 "remove": [Function],
                                               }
                                             }
+                                            onEntering={[Function]}
+                                            onExited={[Function]}
                                             onHide={[Function]}
                                             renderBackdrop={[Function]}
                                             restoreFocus={true}
                                             show={false}
-                                          >
-                                            <Modal
-                                              autoFocus={true}
-                                              backdrop={true}
-                                              backdropClassName="modal-backdrop"
-                                              containerClassName="modal-open"
-                                              enforceFocus={true}
-                                              keyboard={true}
-                                              manager={
-                                                ModalManager {
-                                                  "add": [Function],
-                                                  "containers": Array [],
-                                                  "data": Array [],
-                                                  "handleContainerOverflow": true,
-                                                  "hideSiblingNodes": true,
-                                                  "isTopModal": [Function],
-                                                  "modals": Array [],
-                                                  "remove": [Function],
-                                                }
-                                              }
-                                              onEntering={[Function]}
-                                              onExited={[Function]}
-                                              onHide={[Function]}
-                                              renderBackdrop={[Function]}
-                                              restoreFocus={true}
-                                              show={false}
-                                            />
-                                          </Modal>
-                                        </Confirm>
-                                      </LinkWithConfirmation>
-                                    </span>
+                                          />
+                                        </Modal>
+                                      </Confirm>
+                                    </LinkWithConfirmation>
                                   </Tooltip>
                                 </div>
                               </Base>
@@ -1140,48 +1134,55 @@ exports[`ProjectTags renders 1`] = `
                                     disabled={false}
                                     title="This tag cannot be deleted."
                                   >
-                                    <span
+                                    <LinkWithConfirmation
                                       className="tip"
+                                      disabled={true}
+                                      message="Are you sure you want to remove this tag?"
+                                      onConfirm={[Function]}
                                       title="This tag cannot be deleted."
                                     >
-                                      <LinkWithConfirmation
+                                      <Confirm
+                                        cancelText="Cancel"
+                                        confirmText="Confirm"
+                                        disableConfirmButton={false}
                                         disabled={true}
                                         message="Are you sure you want to remove this tag?"
                                         onConfirm={[Function]}
-                                        title="Remove tag?"
+                                        priority="primary"
                                       >
-                                        <Confirm
-                                          cancelText="Cancel"
-                                          confirmText="Confirm"
-                                          disableConfirmButton={false}
+                                        <a
+                                          className="tip disabled"
                                           disabled={true}
-                                          message="Are you sure you want to remove this tag?"
-                                          onConfirm={[Function]}
-                                          priority="primary"
+                                          onClick={[Function]}
+                                          title="This tag cannot be deleted."
                                         >
-                                          <a
-                                            className="disabled"
+                                          <Button
+                                            data-test-id="delete"
                                             disabled={true}
-                                            onClick={[Function]}
-                                            title="Remove tag?"
+                                            icon="icon-trash"
+                                            size="xsmall"
                                           >
-                                            <Button
+                                            <StyledButton
+                                              aria-disabled={true}
                                               data-test-id="delete"
                                               disabled={true}
-                                              icon="icon-trash"
+                                              href={null}
+                                              onClick={[Function]}
+                                              role="button"
                                               size="xsmall"
+                                              to={null}
                                             >
-                                              <StyledButton
+                                              <Component
                                                 aria-disabled={true}
+                                                className="css-1ujzp8g-StyledButton-getColors eqrebog0"
                                                 data-test-id="delete"
-                                                disabled={true}
                                                 href={null}
                                                 onClick={[Function]}
                                                 role="button"
                                                 size="xsmall"
                                                 to={null}
                                               >
-                                                <Component
+                                                <button
                                                   aria-disabled={true}
                                                   className="css-1ujzp8g-StyledButton-getColors eqrebog0"
                                                   data-test-id="delete"
@@ -1191,85 +1192,99 @@ exports[`ProjectTags renders 1`] = `
                                                   size="xsmall"
                                                   to={null}
                                                 >
-                                                  <button
-                                                    aria-disabled={true}
-                                                    className="css-1ujzp8g-StyledButton-getColors eqrebog0"
-                                                    data-test-id="delete"
-                                                    href={null}
-                                                    onClick={[Function]}
-                                                    role="button"
+                                                  <ButtonLabel
                                                     size="xsmall"
-                                                    to={null}
                                                   >
-                                                    <ButtonLabel
+                                                    <Component
+                                                      className="css-uthd1f-ButtonLabel eqrebog1"
                                                       size="xsmall"
                                                     >
-                                                      <Component
+                                                      <span
                                                         className="css-uthd1f-ButtonLabel eqrebog1"
-                                                        size="xsmall"
                                                       >
-                                                        <span
-                                                          className="css-uthd1f-ButtonLabel eqrebog1"
+                                                        <Icon
+                                                          hasChildren={false}
+                                                          size="xsmall"
                                                         >
-                                                          <Icon
+                                                          <Component
+                                                            className="css-ljhpxy-Icon eqrebog2"
                                                             hasChildren={false}
                                                             size="xsmall"
                                                           >
-                                                            <Component
+                                                            <span
                                                               className="css-ljhpxy-Icon eqrebog2"
-                                                              hasChildren={false}
                                                               size="xsmall"
                                                             >
-                                                              <span
-                                                                className="css-ljhpxy-Icon eqrebog2"
-                                                                size="xsmall"
+                                                              <StyledInlineSvg
+                                                                size="12px"
+                                                                src="icon-trash"
                                                               >
-                                                                <StyledInlineSvg
+                                                                <InlineSvg
+                                                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
                                                                   size="12px"
                                                                   src="icon-trash"
                                                                 >
-                                                                  <InlineSvg
+                                                                  <StyledSvg
                                                                     className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                    size="12px"
-                                                                    src="icon-trash"
+                                                                    height="12px"
+                                                                    viewBox={Object {}}
+                                                                    width="12px"
                                                                   >
-                                                                    <StyledSvg
-                                                                      className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                                    <svg
+                                                                      className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
                                                                       height="12px"
                                                                       viewBox={Object {}}
                                                                       width="12px"
                                                                     >
-                                                                      <svg
-                                                                        className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                        height="12px"
-                                                                        viewBox={Object {}}
-                                                                        width="12px"
-                                                                      >
-                                                                        <use
-                                                                          href="#test"
-                                                                          xlinkHref="#test"
-                                                                        />
-                                                                      </svg>
-                                                                    </StyledSvg>
-                                                                  </InlineSvg>
-                                                                </StyledInlineSvg>
-                                                              </span>
-                                                            </Component>
-                                                          </Icon>
-                                                        </span>
-                                                      </Component>
-                                                    </ButtonLabel>
-                                                  </button>
-                                                </Component>
-                                              </StyledButton>
-                                            </Button>
-                                          </a>
+                                                                      <use
+                                                                        href="#test"
+                                                                        xlinkHref="#test"
+                                                                      />
+                                                                    </svg>
+                                                                  </StyledSvg>
+                                                                </InlineSvg>
+                                                              </StyledInlineSvg>
+                                                            </span>
+                                                          </Component>
+                                                        </Icon>
+                                                      </span>
+                                                    </Component>
+                                                  </ButtonLabel>
+                                                </button>
+                                              </Component>
+                                            </StyledButton>
+                                          </Button>
+                                        </a>
+                                        <Modal
+                                          animation={false}
+                                          autoFocus={true}
+                                          backdrop={true}
+                                          bsClass="modal"
+                                          dialogComponentClass={[Function]}
+                                          enforceFocus={true}
+                                          keyboard={true}
+                                          manager={
+                                            ModalManager {
+                                              "add": [Function],
+                                              "containers": Array [],
+                                              "data": Array [],
+                                              "handleContainerOverflow": true,
+                                              "hideSiblingNodes": true,
+                                              "isTopModal": [Function],
+                                              "modals": Array [],
+                                              "remove": [Function],
+                                            }
+                                          }
+                                          onHide={[Function]}
+                                          renderBackdrop={[Function]}
+                                          restoreFocus={true}
+                                          show={false}
+                                        >
                                           <Modal
-                                            animation={false}
                                             autoFocus={true}
                                             backdrop={true}
-                                            bsClass="modal"
-                                            dialogComponentClass={[Function]}
+                                            backdropClassName="modal-backdrop"
+                                            containerClassName="modal-open"
                                             enforceFocus={true}
                                             keyboard={true}
                                             manager={
@@ -1284,41 +1299,16 @@ exports[`ProjectTags renders 1`] = `
                                                 "remove": [Function],
                                               }
                                             }
+                                            onEntering={[Function]}
+                                            onExited={[Function]}
                                             onHide={[Function]}
                                             renderBackdrop={[Function]}
                                             restoreFocus={true}
                                             show={false}
-                                          >
-                                            <Modal
-                                              autoFocus={true}
-                                              backdrop={true}
-                                              backdropClassName="modal-backdrop"
-                                              containerClassName="modal-open"
-                                              enforceFocus={true}
-                                              keyboard={true}
-                                              manager={
-                                                ModalManager {
-                                                  "add": [Function],
-                                                  "containers": Array [],
-                                                  "data": Array [],
-                                                  "handleContainerOverflow": true,
-                                                  "hideSiblingNodes": true,
-                                                  "isTopModal": [Function],
-                                                  "modals": Array [],
-                                                  "remove": [Function],
-                                                }
-                                              }
-                                              onEntering={[Function]}
-                                              onExited={[Function]}
-                                              onHide={[Function]}
-                                              renderBackdrop={[Function]}
-                                              restoreFocus={true}
-                                              show={false}
-                                            />
-                                          </Modal>
-                                        </Confirm>
-                                      </LinkWithConfirmation>
-                                    </span>
+                                          />
+                                        </Modal>
+                                      </Confirm>
+                                    </LinkWithConfirmation>
                                   </Tooltip>
                                 </div>
                               </Base>
@@ -1378,48 +1368,55 @@ exports[`ProjectTags renders 1`] = `
                                   <Tooltip
                                     title="This tag cannot be deleted."
                                   >
-                                    <span
+                                    <LinkWithConfirmation
                                       className="tip"
+                                      disabled={true}
+                                      message="Are you sure you want to remove this tag?"
+                                      onConfirm={[Function]}
                                       title="This tag cannot be deleted."
                                     >
-                                      <LinkWithConfirmation
+                                      <Confirm
+                                        cancelText="Cancel"
+                                        confirmText="Confirm"
+                                        disableConfirmButton={false}
                                         disabled={true}
                                         message="Are you sure you want to remove this tag?"
                                         onConfirm={[Function]}
-                                        title="Remove tag?"
+                                        priority="primary"
                                       >
-                                        <Confirm
-                                          cancelText="Cancel"
-                                          confirmText="Confirm"
-                                          disableConfirmButton={false}
+                                        <a
+                                          className="tip disabled"
                                           disabled={true}
-                                          message="Are you sure you want to remove this tag?"
-                                          onConfirm={[Function]}
-                                          priority="primary"
+                                          onClick={[Function]}
+                                          title="This tag cannot be deleted."
                                         >
-                                          <a
-                                            className="disabled"
+                                          <Button
+                                            data-test-id="delete"
                                             disabled={true}
-                                            onClick={[Function]}
-                                            title="Remove tag?"
+                                            icon="icon-trash"
+                                            size="xsmall"
                                           >
-                                            <Button
+                                            <StyledButton
+                                              aria-disabled={true}
                                               data-test-id="delete"
                                               disabled={true}
-                                              icon="icon-trash"
+                                              href={null}
+                                              onClick={[Function]}
+                                              role="button"
                                               size="xsmall"
+                                              to={null}
                                             >
-                                              <StyledButton
+                                              <Component
                                                 aria-disabled={true}
+                                                className="css-1ujzp8g-StyledButton-getColors eqrebog0"
                                                 data-test-id="delete"
-                                                disabled={true}
                                                 href={null}
                                                 onClick={[Function]}
                                                 role="button"
                                                 size="xsmall"
                                                 to={null}
                                               >
-                                                <Component
+                                                <button
                                                   aria-disabled={true}
                                                   className="css-1ujzp8g-StyledButton-getColors eqrebog0"
                                                   data-test-id="delete"
@@ -1429,85 +1426,99 @@ exports[`ProjectTags renders 1`] = `
                                                   size="xsmall"
                                                   to={null}
                                                 >
-                                                  <button
-                                                    aria-disabled={true}
-                                                    className="css-1ujzp8g-StyledButton-getColors eqrebog0"
-                                                    data-test-id="delete"
-                                                    href={null}
-                                                    onClick={[Function]}
-                                                    role="button"
+                                                  <ButtonLabel
                                                     size="xsmall"
-                                                    to={null}
                                                   >
-                                                    <ButtonLabel
+                                                    <Component
+                                                      className="css-uthd1f-ButtonLabel eqrebog1"
                                                       size="xsmall"
                                                     >
-                                                      <Component
+                                                      <span
                                                         className="css-uthd1f-ButtonLabel eqrebog1"
-                                                        size="xsmall"
                                                       >
-                                                        <span
-                                                          className="css-uthd1f-ButtonLabel eqrebog1"
+                                                        <Icon
+                                                          hasChildren={false}
+                                                          size="xsmall"
                                                         >
-                                                          <Icon
+                                                          <Component
+                                                            className="css-ljhpxy-Icon eqrebog2"
                                                             hasChildren={false}
                                                             size="xsmall"
                                                           >
-                                                            <Component
+                                                            <span
                                                               className="css-ljhpxy-Icon eqrebog2"
-                                                              hasChildren={false}
                                                               size="xsmall"
                                                             >
-                                                              <span
-                                                                className="css-ljhpxy-Icon eqrebog2"
-                                                                size="xsmall"
+                                                              <StyledInlineSvg
+                                                                size="12px"
+                                                                src="icon-trash"
                                                               >
-                                                                <StyledInlineSvg
+                                                                <InlineSvg
+                                                                  className="css-1ov3rcq-StyledInlineSvg eqrebog3"
                                                                   size="12px"
                                                                   src="icon-trash"
                                                                 >
-                                                                  <InlineSvg
+                                                                  <StyledSvg
                                                                     className="css-1ov3rcq-StyledInlineSvg eqrebog3"
-                                                                    size="12px"
-                                                                    src="icon-trash"
+                                                                    height="12px"
+                                                                    viewBox={Object {}}
+                                                                    width="12px"
                                                                   >
-                                                                    <StyledSvg
-                                                                      className="css-1ov3rcq-StyledInlineSvg eqrebog3"
+                                                                    <svg
+                                                                      className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
                                                                       height="12px"
                                                                       viewBox={Object {}}
                                                                       width="12px"
                                                                     >
-                                                                      <svg
-                                                                        className="eqrebog3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                        height="12px"
-                                                                        viewBox={Object {}}
-                                                                        width="12px"
-                                                                      >
-                                                                        <use
-                                                                          href="#test"
-                                                                          xlinkHref="#test"
-                                                                        />
-                                                                      </svg>
-                                                                    </StyledSvg>
-                                                                  </InlineSvg>
-                                                                </StyledInlineSvg>
-                                                              </span>
-                                                            </Component>
-                                                          </Icon>
-                                                        </span>
-                                                      </Component>
-                                                    </ButtonLabel>
-                                                  </button>
-                                                </Component>
-                                              </StyledButton>
-                                            </Button>
-                                          </a>
+                                                                      <use
+                                                                        href="#test"
+                                                                        xlinkHref="#test"
+                                                                      />
+                                                                    </svg>
+                                                                  </StyledSvg>
+                                                                </InlineSvg>
+                                                              </StyledInlineSvg>
+                                                            </span>
+                                                          </Component>
+                                                        </Icon>
+                                                      </span>
+                                                    </Component>
+                                                  </ButtonLabel>
+                                                </button>
+                                              </Component>
+                                            </StyledButton>
+                                          </Button>
+                                        </a>
+                                        <Modal
+                                          animation={false}
+                                          autoFocus={true}
+                                          backdrop={true}
+                                          bsClass="modal"
+                                          dialogComponentClass={[Function]}
+                                          enforceFocus={true}
+                                          keyboard={true}
+                                          manager={
+                                            ModalManager {
+                                              "add": [Function],
+                                              "containers": Array [],
+                                              "data": Array [],
+                                              "handleContainerOverflow": true,
+                                              "hideSiblingNodes": true,
+                                              "isTopModal": [Function],
+                                              "modals": Array [],
+                                              "remove": [Function],
+                                            }
+                                          }
+                                          onHide={[Function]}
+                                          renderBackdrop={[Function]}
+                                          restoreFocus={true}
+                                          show={false}
+                                        >
                                           <Modal
-                                            animation={false}
                                             autoFocus={true}
                                             backdrop={true}
-                                            bsClass="modal"
-                                            dialogComponentClass={[Function]}
+                                            backdropClassName="modal-backdrop"
+                                            containerClassName="modal-open"
                                             enforceFocus={true}
                                             keyboard={true}
                                             manager={
@@ -1522,41 +1533,16 @@ exports[`ProjectTags renders 1`] = `
                                                 "remove": [Function],
                                               }
                                             }
+                                            onEntering={[Function]}
+                                            onExited={[Function]}
                                             onHide={[Function]}
                                             renderBackdrop={[Function]}
                                             restoreFocus={true}
                                             show={false}
-                                          >
-                                            <Modal
-                                              autoFocus={true}
-                                              backdrop={true}
-                                              backdropClassName="modal-backdrop"
-                                              containerClassName="modal-open"
-                                              enforceFocus={true}
-                                              keyboard={true}
-                                              manager={
-                                                ModalManager {
-                                                  "add": [Function],
-                                                  "containers": Array [],
-                                                  "data": Array [],
-                                                  "handleContainerOverflow": true,
-                                                  "hideSiblingNodes": true,
-                                                  "isTopModal": [Function],
-                                                  "modals": Array [],
-                                                  "remove": [Function],
-                                                }
-                                              }
-                                              onEntering={[Function]}
-                                              onExited={[Function]}
-                                              onHide={[Function]}
-                                              renderBackdrop={[Function]}
-                                              restoreFocus={true}
-                                              show={false}
-                                            />
-                                          </Modal>
-                                        </Confirm>
-                                      </LinkWithConfirmation>
-                                    </span>
+                                          />
+                                        </Modal>
+                                      </Confirm>
+                                    </LinkWithConfirmation>
                                   </Tooltip>
                                 </div>
                               </Base>

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
@@ -713,40 +713,45 @@ exports[`Organization Developer Settings with published apps trash button is dis
                                       <Tooltip
                                         title="Published apps cannot be removed."
                                       >
-                                        <span
+                                        <Button
                                           className="tip"
+                                          disabled={true}
+                                          icon="icon-trash"
+                                          size="small"
                                           title="Published apps cannot be removed."
                                         >
-                                          <Button
-                                            disabled={true}
-                                            icon="icon-trash"
-                                            size="small"
+                                          <Tooltip
+                                            title="Published apps cannot be removed."
                                           >
                                             <StyledButton
                                               aria-disabled={true}
+                                              className="tip tip"
                                               disabled={true}
                                               href={null}
                                               onClick={[Function]}
                                               role="button"
                                               size="small"
+                                              title="Published apps cannot be removed."
                                               to={null}
                                             >
                                               <Component
                                                 aria-disabled={true}
-                                                className="css-1ujzp8g-StyledButton-getColors eqrebog0"
+                                                className="tip tip css-1ujzp8g-StyledButton-getColors eqrebog0"
                                                 href={null}
                                                 onClick={[Function]}
                                                 role="button"
                                                 size="small"
+                                                title="Published apps cannot be removed."
                                                 to={null}
                                               >
                                                 <button
                                                   aria-disabled={true}
-                                                  className="css-1ujzp8g-StyledButton-getColors eqrebog0"
+                                                  className="tip tip css-1ujzp8g-StyledButton-getColors eqrebog0"
                                                   href={null}
                                                   onClick={[Function]}
                                                   role="button"
                                                   size="small"
+                                                  title="Published apps cannot be removed."
                                                   to={null}
                                                 >
                                                   <ButtonLabel
@@ -810,8 +815,8 @@ exports[`Organization Developer Settings with published apps trash button is dis
                                                 </button>
                                               </Component>
                                             </StyledButton>
-                                          </Button>
-                                        </span>
+                                          </Tooltip>
+                                        </Button>
                                       </Tooltip>
                                     </div>
                                   </Base>


### PR DESCRIPTION
Remove span tags that we no longer need. Tooltip has recently been refactored so that it can work with components in addition to elements. This allows us to remove wrapping dom nodes.