### PR TITLE
ref: Measure event size in eventstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,7 @@ matrix:
 
     # XXX(markus): Remove after rust interfaces are done
     - python: 2.7
-      env: TEST_SUITE=acceptance SENTRY_TEST_USE_RUST_INTERFACE_RENORMALIZATION=1
+      env: TEST_SUITE=acceptance SENTRY_TEST_USE_RUST_INTERFACE_RENORMALIZATION=1 PERCY_ENABLE=0
       services:
         - memcached
         - redis-server

--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -4,9 +4,8 @@ import pytz
 import logging
 from datetime import datetime
 
-from sentry import metrics
 from sentry.models import Event
-from sentry.utils import json
+from sentry.utils import json, metrics
 
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -4,6 +4,7 @@ import pytz
 import logging
 from datetime import datetime
 
+from sentry import metrics
 from sentry.models import Event
 from sentry.utils import json
 

--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -94,6 +94,8 @@ def get_task_kwargs_for_message(value):
     can be applied to a post-processing task, or ``None`` if no task should be
     dispatched.
     """
+
+    metrics.timing('evenstream.events.size.data', len(value))
     payload = json.loads(value)
 
     try:


### PR DESCRIPTION
Event size is already measured in `post_process_group`, so it should not be part of the reason #12375 can't be rolled out without post-process-forwarder/workerrelay being immediately backlogged, but I am running out of ideas.

I tried benching `Event` creation locally with both `0.0` and `1.0` as sample rates and there's no difference at all.