### PR TITLE
feat(grouping): Ignore unknown functions in native

### DIFF
--- a/src/sentry/grouping/strategies/stacktrace.py
+++ b/src/sentry/grouping/strategies/stacktrace.py
@@ -247,12 +247,18 @@ def get_function_component_v1(function, platform):
             )
 
     elif platform in ('objc', 'cocoa', 'native'):
-        new_function = isolate_native_function_v1(function)
-        if new_function != function:
+        if function in ('<redacted>', '<unknown>'):
             function_component.update(
-                values=[new_function],
-                hint='isolated function'
+                contributes=False,
+                hint='ignored unknown function'
             )
+        else:
+            new_function = isolate_native_function_v1(function)
+            if new_function != function:
+                function_component.update(
+                    values=[new_function],
+                    hint='isolated function'
+                )
 
     return function_component
 

--- a/tests/sentry/grouping/inputs/native-no-filenames.json
+++ b/tests/sentry/grouping/inputs/native-no-filenames.json
@@ -80,6 +80,18 @@
               "package": "sentry",
               "in_app": false,
               "instruction_addr": "0x109225f53"
+            },
+            {
+              "function": "<unknown>",
+              "package": "sentry",
+              "in_app": false,
+              "instruction_addr": "0x109225c53"
+            },
+            {
+              "function": "<redacted>",
+              "package": "something",
+              "in_app": false,
+              "instruction_addr": "0x00123"
             }
           ]
         },

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy:2019_03_12/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy:2019_03_12/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-15T10:52:06.260025Z'
+created: '2019-03-20T23:12:41.265357Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -45,6 +45,12 @@ app:
           frame (non app frame)
             function (function name is used only if module or filename are available)
               u'sentry::hub::Hub::with_active::{{closure}}'
+          frame (non app frame)
+            function (function name is used only if module or filename are available)
+              u'<unknown>'
+          frame (non app frame)
+            function (function name is used only if module or filename are available)
+              u'<redacted>'
         type*
           u'log_demo'
         value*
@@ -92,6 +98,12 @@ system:
           frame
             function (function name is used only if module or filename are available)
               u'sentry::hub::Hub::with_active::{{closure}}'
+          frame
+            function (function name is used only if module or filename are available)
+              u'<unknown>'
+          frame
+            function (function name is used only if module or filename are available)
+              u'<redacted>'
         type*
           u'log_demo'
         value*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/new:wip/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/new:wip/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-15T18:37:00.151249Z'
+created: '2019-03-20T23:12:41.922036Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -45,6 +45,12 @@ app:
           frame (non app frame)
             function*
               u'sentry::hub::Hub::with_active::{{closure}}'
+          frame (non app frame)
+            function (ignored unknown function)
+              u'<unknown>'
+          frame (non app frame)
+            function (ignored unknown function)
+              u'<redacted>'
         type*
           u'log_demo'
 --------------------------------------------------------------------------
@@ -90,5 +96,11 @@ system:
           frame*
             function*
               u'sentry::hub::Hub::with_active::{{closure}}'
+          frame
+            function (ignored unknown function)
+              u'<unknown>'
+          frame
+            function (ignored unknown function)
+              u'<redacted>'
         type*
           u'log_demo'


### PR DESCRIPTION
This ignores functions like `<unknown>` and `<redacted>` in the work in
progress grouping algorithm.