### PR TITLE
fix: SnubaEventManager does not inherit from BaseManager

### DIFF
--- a/src/sentry/db/models/manager.py
+++ b/src/sentry/db/models/manager.py
@@ -317,7 +317,7 @@ class BaseManager(Manager):
         return self._queryset_class(self.model, using=self._db)
 
 
-class SnubaEventManager(BaseManager):
+class SnubaEventManager:
     def from_event_id(self, id_or_event_id, project_id):
         """
         Get a SnubaEvent by either its id primary key or its hex event_id.


### PR DESCRIPTION
BaseManager contains unnecessary Django specific logic