### PR TITLE
feat(grouping): Ignore exception type for unknown exceptions in grouping

### DIFF
--- a/src/sentry/grouping/strategies/exception.py
+++ b/src/sentry/grouping/strategies/exception.py
@@ -21,6 +21,12 @@ def single_exception_v1(exception, config, **meta):
         values=[exception.type] if exception.type else [],
     )
 
+    if exception.mechanism and exception.mechanism.synthetic:
+        type_component.update(
+            contributes=False,
+            hint='ignored because exception is synthetic'
+        )
+
     return GroupingComponent(
         id='exception',
         values=[

--- a/tests/sentry/grouping/inputs/native-complex-function-names.json
+++ b/tests/sentry/grouping/inputs/native-complex-function-names.json
@@ -23,7 +23,11 @@
           ]
         },
         "type": "log_demo",
-        "value": "Holy shit everything is on fire!"
+        "value": "Holy shit everything is on fire!",
+        "mechanism": {
+          "type": "minidump",
+          "synthetic": true
+        }
       }
     ]
   },

--- a/tests/sentry/grouping/inputs/native-no-filenames.json
+++ b/tests/sentry/grouping/inputs/native-no-filenames.json
@@ -96,7 +96,11 @@
           ]
         },
         "type": "log_demo",
-        "value": "Holy shit everything is on fire!"
+        "value": "Holy shit everything is on fire!",
+        "mechanism": {
+          "type": "minidump",
+          "synthetic": true
+        }
       }
     ]
   },

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/new:wip/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/new:wip/native_complex_function_names.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2019-03-16T14:31:51.956347Z'
+created: '2019-03-21T00:08:18.464103Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: 'fed4f6eb500e04f59e97d31e8743ec8f'
+  hash: None
   component:
-    app*
-      exception*
+    app (exception of system takes precedence)
+      exception
         stacktrace
           frame (non app frame)
             function* (isolated function)
@@ -15,11 +15,11 @@ app:
           frame (non app frame)
             function* (isolated function)
               u'Scaleform::GFx::AS3::IMEManager::DispatchEvent'
-        type*
+        type (ignored because exception is synthetic)
           u'log_demo'
 --------------------------------------------------------------------------
 system:
-  hash: 'd6125002ce075cab3755011dddefe9e1'
+  hash: '9b78cced1eefcd0c655a0a3d8ce2cdd2'
   component:
     system*
       exception*
@@ -30,5 +30,5 @@ system:
           frame*
             function* (isolated function)
               u'Scaleform::GFx::AS3::IMEManager::DispatchEvent'
-        type*
+        type (ignored because exception is synthetic)
           u'log_demo'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/new:wip/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/new:wip/native_no_filenames.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2019-03-20T23:12:41.922036Z'
+created: '2019-03-21T00:08:18.476445Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: '0069ba38208554530eed55f7647f7c5c'
+  hash: '418120a66f7031923031f5c52aca0724'
   component:
     app*
       exception*
@@ -51,11 +51,11 @@ app:
           frame (non app frame)
             function (ignored unknown function)
               u'<redacted>'
-        type*
+        type (ignored because exception is synthetic)
           u'log_demo'
 --------------------------------------------------------------------------
 system:
-  hash: '30f71d6ff287238ce1541e21e633a8c5'
+  hash: '06f8f02638bc75df5a5c88712055ee5f'
   component:
     system*
       exception*
@@ -102,5 +102,5 @@ system:
           frame
             function (ignored unknown function)
               u'<redacted>'
-        type*
+        type (ignored because exception is synthetic)
           u'log_demo'


### PR DESCRIPTION
This causes synthetic errors to be ignored in grouping. This is useful because these are often platform dependent and we do want to group them together still.