### PR TITLE
fix(shared-issues): Fix shared issues page crashing

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -49,7 +49,8 @@ export const INTERFACES = {
 
 class EventEntries extends React.Component {
   static propTypes = {
-    organization: SentryTypes.Organization.isRequired,
+    // organization is not provided in the shared issue view
+    organization: SentryTypes.Organization,
     group: SentryTypes.Group.isRequired,
     event: SentryTypes.Event.isRequired,
     orgId: PropTypes.string.isRequired,

--- a/src/sentry/static/sentry/app/components/events/eventTags.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags.jsx
@@ -16,7 +16,8 @@ import InlineSvg from 'app/components/inlineSvg';
 
 class EventTags extends React.Component {
   static propTypes = {
-    organization: SentryTypes.Organization.isRequired,
+    // organization is not provided in the shared issue view
+    organization: SentryTypes.Organization,
     group: SentryTypes.Group.isRequired,
     event: SentryTypes.Event.isRequired,
     orgId: PropTypes.string.isRequired,
@@ -25,11 +26,14 @@ class EventTags extends React.Component {
 
   render() {
     const tags = this.props.event.tags;
+
     if (_.isEmpty(tags)) return null;
 
     const {event, group, organization, orgId, projectId} = this.props;
 
-    const hasSentry10 = new Set(organization.features).has('sentry10');
+    // Just use the sentry 10 paths if we are in a shared view since we
+    // don't have the organization object to check the feature list
+    const hasSentry10 = !organization || new Set(organization.features).has('sentry10');
 
     const streamPath = hasSentry10
       ? `/organizations/${orgId}/issues/`


### PR DESCRIPTION
Fix a bug where the shared issues page was crashing when there were tags to display.

We should follow up with tests for this component.