### PR TITLE
feat: Turn on Snuba for the project details endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -41,8 +41,7 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
         :auth: required
         """
 
-        use_snuba = request.GET.get('enable_snuba') == '1' and \
-            options.get('snuba.events-queries.enabled')
+        use_snuba = options.get('snuba.events-queries.enabled')
 
         if not use_snuba:
             return self.get_legacy(request, project, event_id)

--- a/src/sentry/db/models/manager.py
+++ b/src/sentry/db/models/manager.py
@@ -340,6 +340,8 @@ class SnubaEventManager(BaseManager):
 
             id_or_event_id = event.event_id
 
+            project_id = event.project_id
+
         return SnubaEvent.get_event(project_id, id_or_event_id)
 
 

--- a/src/sentry/db/models/manager.py
+++ b/src/sentry/db/models/manager.py
@@ -340,8 +340,6 @@ class SnubaEventManager(BaseManager):
 
             id_or_event_id = event.event_id
 
-            project_id = event.project_id
-
         return SnubaEvent.get_event(project_id, id_or_event_id)
 
 

--- a/tests/sentry/api/endpoints/test_group_events_latest.py
+++ b/tests/sentry/api/endpoints/test_group_events_latest.py
@@ -5,12 +5,11 @@ import six
 from datetime import timedelta
 from django.utils import timezone
 
-from sentry import options
 from sentry.models import Group
-from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils import APITestCase
 
 
-class GroupEventsLatestTest(APITestCase, SnubaTestCase):
+class GroupEventsLatestTest(APITestCase):
     def setUp(self):
         super(GroupEventsLatestTest, self).setUp()
         self.login_as(user=self.user)
@@ -41,18 +40,9 @@ class GroupEventsLatestTest(APITestCase, SnubaTestCase):
 
         self.group = Group.objects.first()
 
-    def test_snuba_no_environment(self):
-        options.set('snuba.events-queries.enabled', True)
+    def test_simple(self):
         url = u'/api/0/issues/{}/events/latest/'.format(self.group.id)
         response = self.client.get(url, format='json')
 
         assert response.status_code == 200
-        assert response.data['id'] == six.text_type(self.event2.event_id)
-
-    def test_snuba_environment(self):
-        options.set('snuba.events-queries.enabled', True)
-        url = u'/api/0/issues/{}/events/latest/'.format(self.group.id)
-        response = self.client.get(url, format='json', data={'environment': ['production']})
-
-        assert response.status_code == 200
-        assert response.data['id'] == six.text_type(self.event2.event_id)
+        assert response.data['id'] == six.text_type(self.event2.id)

--- a/tests/sentry/api/endpoints/test_group_events_oldest.py
+++ b/tests/sentry/api/endpoints/test_group_events_oldest.py
@@ -5,14 +5,13 @@ import six
 from datetime import timedelta
 from django.utils import timezone
 
-from sentry import options
 from sentry.models import Group
-from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils import APITestCase
 
 
-class GroupEventsLatestTest(APITestCase, SnubaTestCase):
+class GroupEventsOldestTest(APITestCase):
     def setUp(self):
-        super(GroupEventsLatestTest, self).setUp()
+        super(GroupEventsOldestTest, self).setUp()
         self.login_as(user=self.user)
 
         project = self.create_project()
@@ -41,18 +40,9 @@ class GroupEventsLatestTest(APITestCase, SnubaTestCase):
 
         self.group = Group.objects.first()
 
-    def test_snuba_no_environment(self):
-        options.set('snuba.events-queries.enabled', True)
-        url = u'/api/0/issues/{}/events/latest/'.format(self.group.id)
+    def test_simple(self):
+        url = u'/api/0/issues/{}/events/oldest/'.format(self.group.id)
         response = self.client.get(url, format='json')
 
         assert response.status_code == 200
-        assert response.data['id'] == six.text_type(self.event2.event_id)
-
-    def test_snuba_environment(self):
-        options.set('snuba.events-queries.enabled', True)
-        url = u'/api/0/issues/{}/events/latest/'.format(self.group.id)
-        response = self.client.get(url, format='json', data={'environment': ['production']})
-
-        assert response.status_code == 200
-        assert response.data['id'] == six.text_type(self.event2.event_id)
+        assert response.data['id'] == six.text_type(self.event1.id)

--- a/tests/snuba/api/endpoints/test_group_events_latest.py
+++ b/tests/snuba/api/endpoints/test_group_events_latest.py
@@ -50,12 +50,16 @@ class GroupEventsLatestTest(APITestCase, SnubaTestCase):
 
     def test_snuba_no_environment(self):
         options.set('snuba.events-queries.enabled', True)
-        self.test_simple()
+        url = u'/api/0/issues/{}/events/latest/'.format(self.group.id)
+        response = self.client.get(url, format='json')
 
-    def test_environment(self):
+        assert response.status_code == 200
+        assert response.data['id'] == six.text_type(self.event2.event_id)
+
+    def test_snuba_environment(self):
         options.set('snuba.events-queries.enabled', True)
         url = u'/api/0/issues/{}/events/latest/'.format(self.group.id)
         response = self.client.get(url, format='json', data={'environment': ['production']})
 
         assert response.status_code == 200
-        assert response.data['id'] == six.text_type(self.event2.id)
+        assert response.data['id'] == six.text_type(self.event2.event_id)

--- a/tests/snuba/api/endpoints/test_group_events_oldest.py
+++ b/tests/snuba/api/endpoints/test_group_events_oldest.py
@@ -41,13 +41,6 @@ class GroupEventsOldestTest(APITestCase, SnubaTestCase):
 
         self.group = Group.objects.first()
 
-    def test_simple(self):
-        url = u'/api/0/issues/{}/events/oldest/'.format(self.group.id)
-        response = self.client.get(url, format='json')
-
-        assert response.status_code == 200
-        assert response.data['id'] == six.text_type(self.event1.id)
-
     def test_snuba_no_environment(self):
         options.set('snuba.events-queries.enabled', True)
         url = u'/api/0/issues/{}/events/oldest/'.format(self.group.id)

--- a/tests/snuba/api/endpoints/test_group_events_oldest.py
+++ b/tests/snuba/api/endpoints/test_group_events_oldest.py
@@ -50,12 +50,16 @@ class GroupEventsOldestTest(APITestCase, SnubaTestCase):
 
     def test_snuba_no_environment(self):
         options.set('snuba.events-queries.enabled', True)
-        self.test_simple()
+        url = u'/api/0/issues/{}/events/oldest/'.format(self.group.id)
+        response = self.client.get(url, format='json')
 
-    def test_environment(self):
+        assert response.status_code == 200
+        assert response.data['id'] == six.text_type(self.event1.event_id)
+
+    def test_snuba_environment(self):
         options.set('snuba.events-queries.enabled', True)
         url = u'/api/0/issues/{}/events/oldest/'.format(self.group.id)
         response = self.client.get(url, format='json', data={'environment': ['production']})
 
         assert response.status_code == 200
-        assert response.data['id'] == six.text_type(self.event2.id)
+        assert response.data['id'] == six.text_type(self.event2.event_id)


### PR DESCRIPTION
Fixes an issue where latest/oldest event found by Snuba is not available in legacy.

Ref: SEN-401, JAVASCRIPT-5VE