### PR TITLE
fix: Skip renormalization in workerrelay

### DIFF
--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -4,7 +4,7 @@ import pytz
 import logging
 from datetime import datetime
 
-from sentry.models import Event
+from sentry.models import Event, EventDict
 from sentry.utils import json, metrics
 
 
@@ -27,6 +27,12 @@ def basic_protocol_handler(unsupported_operations):
             event_data['datetime'],
             "%Y-%m-%dT%H:%M:%S.%fZ",
         ).replace(tzinfo=pytz.utc)
+
+        # This data is already normalized as we're currently in the
+        # ingestion pipeline and the event was in store
+        # normalization just a few seconds ago. Running it through
+        # Rust (re)normalization here again would be too slow.
+        event_data['data'] = EventDict(event_data['data'], skip_renormalization=True)
 
         kwargs = {
             'event': Event(**{


### PR DESCRIPTION
cont #12375 

**NOTE**: This code is glitchy as creating an event with `skip_renormalization` will not affect `Event.interfaces`, which will still sample by event ID. I don't think this will have any impact though, and fixing this would change how sampling works, again. This buggy code will go away after the rollout anyway.