### PR TITLE
feat(recent-search): List recent searches in Issues search bar [SEN-352]

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/savedSearches.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/savedSearches.jsx
@@ -1,3 +1,4 @@
+import {MAX_RECENT_SEARCHES} from 'app/constants';
 import handleXhrErrorResponse from 'app/utils/handleXhrErrorResponse';
 
 export function fetchSavedSearches(api, orgId, useOrgSavedSearches = false) {
@@ -63,6 +64,7 @@ export function fetchRecentSearches(api, orgId, type, query) {
       query: {
         query,
         type,
+        limit: MAX_RECENT_SEARCHES,
       },
     })
     .catch(handleXhrErrorResponse('Unable to fetch recent searches'));

--- a/src/sentry/static/sentry/app/components/smartSearchBar.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar.jsx
@@ -457,7 +457,7 @@ class SmartSearchBar extends React.Component {
         case 'firstSeen':
         case 'lastSeen':
         case 'event.timestamp':
-          out.className = 'icon-history';
+          out.className = 'icon-av_timer';
           break;
         default:
           out.className = 'icon-tag';

--- a/src/sentry/static/sentry/app/components/smartSearchBar.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar.jsx
@@ -183,7 +183,7 @@ class SmartSearchBar extends React.Component {
           onSavedRecentSearch(query);
         }
       } catch (err) {
-        // Ignore errors if it fails to save
+        // Silently capture errors if it fails to save
         Sentry.captureException(err);
       }
     }
@@ -287,7 +287,7 @@ class SmartSearchBar extends React.Component {
    * Returns array of tag values that substring match `query`; invokes `callback`
    * with results
    */
-  getPredefinedTagValues = async function(tag, query) {
+  getPredefinedTagValues = function(tag, query) {
     return tag.values.filter(value => value.indexOf(query) > -1);
   };
 

--- a/src/sentry/static/sentry/app/components/smartSearchBar.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar.jsx
@@ -425,8 +425,11 @@ class SmartSearchBar extends React.Component {
       const fetchTagValuesFn = tag.predefined
         ? this.getPredefinedTagValues
         : this.getTagValues;
-      const tagValues = await fetchTagValuesFn(tag, preparedQuery);
-      const recentSearches = await this.getRecentSearches();
+
+      const [tagValues, recentSearches] = await Promise.all([
+        fetchTagValuesFn(tag, preparedQuery),
+        this.getRecentSearches(),
+      ]);
 
       this.updateAutoCompleteState(tagValues, recentSearches, tag.key);
       return;

--- a/src/sentry/static/sentry/app/constants/index.jsx
+++ b/src/sentry/static/sentry/app/constants/index.jsx
@@ -152,3 +152,4 @@ export const RECENT_SEARCH_TYPES = {
   ISSUE: 0,
   EVENT: 1,
 };
+export const MAX_RECENT_SEARCHES = 3;

--- a/src/sentry/static/sentry/app/views/stream/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchBar.jsx
@@ -30,7 +30,7 @@ const SEARCH_ITEMS = [
     title: t('Time or Count'),
     desc: t('Time or Count related search'),
     example: 'firstSeen, lastSeen, event.timestamp, timesSeen',
-    className: 'icon-history',
+    className: 'icon-av_timer',
     value: '',
     type: 'default',
   },

--- a/src/sentry/static/sentry/app/views/stream/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchBar.jsx
@@ -58,8 +58,6 @@ const SEARCH_ITEMS = [
   },
 ];
 
-const MAX_RECENT_SEARCHES = 3;
-
 class SearchBar extends React.Component {
   static propTypes = {
     ...SmartSearchBar.propTypes,
@@ -98,7 +96,7 @@ class SearchBar extends React.Component {
     this.setState({
       defaultSearchItems: [
         ...(resp &&
-          resp.slice(0, MAX_RECENT_SEARCHES).map(query => ({
+          resp.map(query => ({
             desc: query,
             value: query,
             className: 'icon-clock',

--- a/src/sentry/static/sentry/app/views/stream/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchBar.jsx
@@ -2,8 +2,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {RECENT_SEARCH_TYPES} from 'app/constants';
+import {fetchRecentSearches} from 'app/actionCreators/savedSearches';
 import {t} from 'app/locale';
+import SentryTypes from 'app/sentryTypes';
 import SmartSearchBar from 'app/components/smartSearchBar';
+import withApi from 'app/utils/withApi';
+import withOrganization from 'app/utils/withOrganization';
 
 const SEARCH_ITEMS = [
   {
@@ -12,6 +16,7 @@ const SEARCH_ITEMS = [
     example: 'browser:"Chrome 34", has:browser',
     className: 'icon-tag',
     value: 'browser:',
+    type: 'default',
   },
   {
     title: t('Status'),
@@ -19,13 +24,15 @@ const SEARCH_ITEMS = [
     example: 'is:resolved, unresolved, ignored, assigned, unassigned',
     className: 'icon-toggle',
     value: 'is:',
+    type: 'default',
   },
   {
     title: t('Time or Count'),
     desc: t('Time or Count related search'),
     example: 'firstSeen, lastSeen, event.timestamp, timesSeen',
-    className: 'icon-clock',
+    className: 'icon-history',
     value: '',
+    type: 'default',
   },
   {
     title: t('Assigned'),
@@ -33,6 +40,7 @@ const SEARCH_ITEMS = [
     example: 'assigned:[me|user@example.com]',
     className: 'icon-user',
     value: 'assigned:',
+    type: 'default',
   },
   {
     title: t('Bookmarked By'),
@@ -40,19 +48,66 @@ const SEARCH_ITEMS = [
     example: 'bookmarks:[me|user@example.com]',
     className: 'icon-user',
     value: 'bookmarks:',
+    type: 'default',
   },
   {
     desc: t('or paste an event id to jump straight to it'),
     className: 'icon-hash',
     value: '',
+    type: 'default',
   },
 ];
+
+const MAX_RECENT_SEARCHES = 3;
 
 class SearchBar extends React.Component {
   static propTypes = {
     ...SmartSearchBar.propTypes,
 
+    organization: SentryTypes.Organization.isRequired,
     tagValueLoader: PropTypes.func.isRequired,
+  };
+
+  state = {
+    defaultSearchItems: SEARCH_ITEMS,
+    recentSearches: [],
+  };
+
+  componentDidMount() {
+    // Ideally, we would fetch on demand (e.g. when input gets focus)
+    // but `<SmartSearchBar>` is a bit complicated and this is the easiest route
+    this.fetchData();
+  }
+
+  hasRecentSearches = () => {
+    const {organization} = this.props;
+    return organization && organization.features.includes('recent-searches');
+  };
+
+  fetchData = async () => {
+    if (!this.hasRecentSearches()) {
+      this.setState({
+        defaultSearchItems: SEARCH_ITEMS,
+      });
+
+      return;
+    }
+
+    const resp = await this.getRecentSearches();
+
+    this.setState({
+      defaultSearchItems: [
+        ...(resp &&
+          resp.slice(0, MAX_RECENT_SEARCHES).map(query => ({
+            desc: query,
+            value: query,
+            className: 'icon-clock',
+            type: 'recent-search',
+          }))),
+        ...SEARCH_ITEMS,
+      ],
+      recentSearches: resp,
+    });
   };
 
   /**
@@ -70,6 +125,27 @@ class SearchBar extends React.Component {
     );
   };
 
+  getRecentSearches = async fullQuery => {
+    const {api, orgId} = this.props;
+    const recent = await fetchRecentSearches(
+      api,
+      orgId,
+      RECENT_SEARCH_TYPES.ISSUE,
+      fullQuery
+    );
+    return (recent && recent.map(({query}) => query)) || [];
+  };
+
+  handleSavedRecentSearch = () => {
+    // No need to refetch if recent searches feature is not enabled
+    if (!this.hasRecentSearches()) {
+      return;
+    }
+
+    // Reset recent searches
+    this.fetchData();
+  };
+
   render() {
     const {
       tagValueLoader, // eslint-disable-line no-unused-vars
@@ -79,13 +155,15 @@ class SearchBar extends React.Component {
     return (
       <SmartSearchBar
         onGetTagValues={this.getTagValues}
-        defaultSearchItems={SEARCH_ITEMS}
+        defaultSearchItems={this.state.defaultSearchItems}
         maxSearchItems={5}
         recentSearchType={RECENT_SEARCH_TYPES.ISSUE}
+        displayRecentSearches={this.hasRecentSearches()}
+        onSavedRecentSearch={this.handleSavedRecentSearch}
         {...props}
       />
     );
   }
 }
 
-export default SearchBar;
+export default withApi(withOrganization(SearchBar));

--- a/src/sentry/static/sentry/app/views/stream/searchDropdown.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchDropdown.jsx
@@ -17,10 +17,6 @@ class SearchDropdown extends React.PureComponent {
     onClick: function() {},
   };
 
-  onClick = itemValue => {
-    this.props.onClick(itemValue);
-  };
-
   renderDescription = item => {
     const searchSubstring = this.props.searchSubstring;
     if (!searchSubstring) {
@@ -60,7 +56,7 @@ class SearchDropdown extends React.PureComponent {
                     'search-autocomplete-item',
                     item.active && 'active'
                   )}
-                  onClick={this.onClick.bind(this, item.value)}
+                  onClick={this.props.onClick.bind(this, item.value, item)}
                 >
                   <span className={classNames('icon', item.className)} />
                   <h4>

--- a/tests/js/spec/components/smartSearchBar.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar.spec.jsx
@@ -290,45 +290,57 @@ describe('SmartSearchBar', function() {
       expect(searchBar.state.activeSearchItem).toEqual(0);
     });
 
-    it('sets state when incomplete tag', function() {
+    it('sets state when incomplete tag', async function() {
       const props = {
         orgId: '123',
         projectId: '456',
         query: 'fu',
         supportedTags,
       };
-      const searchBar = mount(<SmartSearchBar {...props} />, options).instance();
+      jest.useRealTimers();
+      const wrapper = mount(<SmartSearchBar {...props} />, options);
+      const searchBar = wrapper.instance();
       searchBar.updateAutoCompleteItems();
+      await tick();
+      wrapper.update();
       expect(searchBar.state.searchTerm).toEqual('fu');
       expect(searchBar.state.searchItems).toEqual([]);
       expect(searchBar.state.activeSearchItem).toEqual(0);
     });
 
-    it('sets state when incomplete tag has negation operator', function() {
+    it('sets state when incomplete tag has negation operator', async function() {
       const props = {
         orgId: '123',
         projectId: '456',
         query: '!fu',
         supportedTags,
       };
-      const searchBar = mount(<SmartSearchBar {...props} />, options).instance();
+      jest.useRealTimers();
+      const wrapper = mount(<SmartSearchBar {...props} />, options);
+      const searchBar = wrapper.instance();
       searchBar.updateAutoCompleteItems();
+      await tick();
+      wrapper.update();
       expect(searchBar.state.searchTerm).toEqual('fu');
       expect(searchBar.state.searchItems).toEqual([]);
       expect(searchBar.state.activeSearchItem).toEqual(0);
     });
 
-    it('sets state when incomplete tag as second input', function() {
+    it('sets state when incomplete tag as second input', async function() {
       const props = {
         orgId: '123',
         projectId: '456',
         query: 'is:unresolved fu',
         supportedTags,
       };
-      const searchBar = mount(<SmartSearchBar {...props} />, options).instance();
+      jest.useRealTimers();
+      const wrapper = mount(<SmartSearchBar {...props} />, options);
+      const searchBar = wrapper.instance();
       searchBar.getCursorPosition = jest.fn();
       searchBar.getCursorPosition.mockReturnValue(15); // end of line
       searchBar.updateAutoCompleteItems();
+      await tick();
+      wrapper.update();
       expect(searchBar.state.searchTerm).toEqual('fu');
       expect(searchBar.state.searchItems).toHaveLength(0);
       expect(searchBar.state.activeSearchItem).toEqual(0);

--- a/tests/js/spec/views/stream/searchBar.spec.jsx
+++ b/tests/js/spec/views/stream/searchBar.spec.jsx
@@ -190,6 +190,7 @@ describe('SearchBar', function() {
         expect.objectContaining({
           query: {
             query: 'is:',
+            limit: 3,
             type: 0,
           },
         })


### PR DESCRIPTION
It's at the top here because the items below are not interact-able. Will need some design/icon work from @Chrissy as a follow up. Also API does not currently filter by current search input.

![image](https://user-images.githubusercontent.com/79684/54790583-e30e1d80-4bf3-11e9-9090-0c18ebcf56aa.png)

## Tag Key
![image](https://user-images.githubusercontent.com/79684/54790653-1355bc00-4bf4-11e9-8fb7-184054ecde7e.png)

## Tag Value
![image](https://user-images.githubusercontent.com/79684/54790662-1c468d80-4bf4-11e9-9f5d-52257954962a.png)

Fixes SEN-352