### PR TITLE
fix(ui): Fix TimeSelector with invalid numbers [SEN-398]

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/dateRange.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/dateRange.jsx
@@ -105,6 +105,10 @@ class DateRange extends React.Component {
     const {start, end, onChange} = this.props;
     const startTime = e.target.value;
 
+    if (!startTime) {
+      return;
+    }
+
     analytics('dateselector.time_changed', {
       field_changed: 'start',
       time: startTime,
@@ -121,6 +125,10 @@ class DateRange extends React.Component {
   handleChangeEnd = e => {
     const {start, end, onChange} = this.props;
     const endTime = e.target.value;
+
+    if (!endTime) {
+      return;
+    }
 
     analytics('dateselector.time_changed', {
       field_changed: 'end',


### PR DESCRIPTION
Sentry would hard crash if you entered invalid integers in absolute date pickers time inputs.

Fixes JAVASCRIPT-57Y