### PR TITLE
feat(api): Implement endpoints to create/delete org level saved searches (SEN-399)

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -135,6 +135,15 @@ class OrganizationPinnedSearchPermission(OrganizationPermission):
     }
 
 
+class OrganizationSearchPermission(OrganizationPermission):
+    scope_map = {
+        'GET': ['org:read', 'org:write', 'org:admin'],
+        'POST': ['org:write', 'org:admin'],
+        'PUT': ['org:write', 'org:admin'],
+        'DELETE': ['org:write', 'org:admin'],
+    }
+
+
 class OrganizationEndpoint(Endpoint):
     permission_classes = (OrganizationPermission, )
 

--- a/src/sentry/api/endpoints/organization_search_details.py
+++ b/src/sentry/api/endpoints/organization_search_details.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import
+
+from rest_framework.response import Response
+
+from sentry.api.bases.organization import (
+    OrganizationEndpoint,
+    OrganizationSearchPermission,
+)
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.models import SavedSearch
+
+
+class OrganizationSearchDetailsEndpoint(OrganizationEndpoint):
+    permission_classes = (OrganizationSearchPermission, )
+
+    def delete(self, request, organization, search_id):
+        """
+        Delete a saved search
+
+        Permanently remove a saved search.
+
+            {method} {path}
+
+        """
+        try:
+            search = SavedSearch.objects.get(
+                owner__isnull=True,
+                organization=organization,
+                id=search_id,
+            )
+        except SavedSearch.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        search.delete()
+        return Response(status=204)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -108,6 +108,7 @@ from .endpoints.organization_config_integrations import OrganizationConfigIntegr
 from .endpoints.organization_config_repositories import OrganizationConfigRepositoriesEndpoint
 from .endpoints.organization_repository_commits import OrganizationRepositoryCommitsEndpoint
 from .endpoints.organization_repository_details import OrganizationRepositoryDetailsEndpoint
+from .endpoints.organization_search_details import OrganizationSearchDetailsEndpoint
 from .endpoints.organization_searches import OrganizationSearchesEndpoint
 from .endpoints.organization_sentry_apps import OrganizationSentryAppsEndpoint
 from .endpoints.organization_tagkey_values import OrganizationTagKeyValuesEndpoint
@@ -597,6 +598,11 @@ urlpatterns = patterns(
         r'^organizations/(?P<organization_slug>[^\/]+)/recent-searches/$',
         OrganizationRecentSearchesEndpoint.as_view(),
         name='sentry-api-0-organization-recent-searches'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/searches/(?P<search_id>[^\/]+)/$',
+        OrganizationSearchDetailsEndpoint.as_view(),
+        name='sentry-api-0-organization-search-details'
     ),
     url(
         r'^organizations/(?P<organization_slug>[^\/]+)/searches/$',

--- a/tests/sentry/api/endpoints/test_organization_search_details.py
+++ b/tests/sentry/api/endpoints/test_organization_search_details.py
@@ -1,0 +1,71 @@
+from __future__ import absolute_import
+
+from exam import fixture
+
+from sentry.models import SavedSearch
+from sentry.testutils import APITestCase
+
+
+class DeleteOrganizationSearchTest(APITestCase):
+    endpoint = 'sentry-api-0-organization-search-details'
+    method = 'delete'
+
+    def setUp(self):
+        self.login_as(user=self.user)
+
+    @fixture
+    def member(self):
+        user = self.create_user('test@test.com')
+        self.create_member(organization=self.organization, user=user)
+        return user
+
+    def get_response(self, *args, **params):
+        return super(DeleteOrganizationSearchTest, self).get_response(
+            *((self.organization.slug,) + args),
+            **params
+        )
+
+    def test_owner_can_delete_org_searches(self):
+        search = SavedSearch.objects.create(
+            organization=self.organization,
+            name='foo',
+            query='',
+        )
+        response = self.get_response(search.id)
+        assert response.status_code == 204, response.content
+        assert not SavedSearch.objects.filter(id=search.id).exists()
+
+    def test_owners_cannot_delete_searches_they_do_not_own(self):
+        search = SavedSearch.objects.create(
+            organization=self.organization,
+            name='foo',
+            query='',
+            owner=self.create_user()
+        )
+
+        response = self.get_response(search.id)
+        assert response.status_code == 404, response.content
+        assert SavedSearch.objects.filter(id=search.id).exists()
+
+    def test_owners_cannot_delete_global_searches(self):
+        search = SavedSearch.objects.create(
+            name='foo',
+            query='',
+            is_global=True,
+        )
+
+        response = self.get_response(search.id)
+        assert response.status_code == 404, response.content
+        assert SavedSearch.objects.filter(id=search.id).exists()
+
+    def test_members_cannot_delete_shared_searches(self):
+        search = SavedSearch.objects.create(
+            organization=self.organization,
+            name='foo',
+            query=''
+        )
+
+        self.login_as(user=self.member)
+        response = self.get_response(search.id)
+        assert response.status_code == 403, response.content
+        assert SavedSearch.objects.filter(id=search.id).exists()


### PR DESCRIPTION
Allows org owners and admins to create/delete org wide saved searches