### PR TITLE
fix: Use @sentry/browser@5.0.0-rc.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.0.0",
-    "@sentry/browser": "5.0.0-beta1",
+    "@sentry/browser": "5.0.0-rc.0",
     "algoliasearch": "^3.32.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1200,56 +1200,56 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@sentry/browser@5.0.0-beta1":
-  version "5.0.0-beta1"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.0.0-beta1.tgz#790d822d4847ceed2973a1718061ba829774b60d"
-  integrity sha512-/eHaCCYpq9/cFRpUcrhjOvkyutYC1hI/N59NTPAUBefLxWc3p4aIuDyaP6knKSwpMTa9RKv7XC4j2KERPtwyyQ==
+"@sentry/browser@5.0.0-rc.0":
+  version "5.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.0.0-rc.0.tgz#8259add3413d37c231ce84b12fd276c8257d99f3"
+  integrity sha512-Y4jfIHOl7IEe0w2oDj50ZSNU66J/EhDv3P6zjnyCAXfxKd2H1kSZVLMpnmKQBeIg7dwUTb6U3kK3sA2kaB2VGg==
   dependencies:
-    "@sentry/core" "5.0.0-beta1"
-    "@sentry/types" "5.0.0-beta1"
-    "@sentry/utils" "5.0.0-beta1"
+    "@sentry/core" "5.0.0-rc.0"
+    "@sentry/types" "5.0.0-rc.0"
+    "@sentry/utils" "5.0.0-rc.0"
     tslib "^1.9.3"
 
-"@sentry/core@5.0.0-beta1":
-  version "5.0.0-beta1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.0.0-beta1.tgz#f884a3acc1b90b7a76a3f70976427742cb771fd7"
-  integrity sha512-qNOt2cv07CFtWZMuYXF2i5XJtdGWwNWY86MdLbHel2I3LdosUsK3GCxirS6E9UbmV2Te1Vp+lfS381uO/yzrJA==
+"@sentry/core@5.0.0-rc.0":
+  version "5.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.0.0-rc.0.tgz#adca51ab76d43b9378998fe04ae1f26c85d89e16"
+  integrity sha512-ZqpbFCLgWSixjRbwyoByOsSjUMdYRyStcS4rHrF6Wc/r8fu2qe44CD6lZsvUWfnne3GNb5fob51o7qPnnHPfIQ==
   dependencies:
-    "@sentry/hub" "5.0.0-beta1"
-    "@sentry/minimal" "5.0.0-beta1"
-    "@sentry/types" "5.0.0-beta1"
-    "@sentry/utils" "5.0.0-beta1"
+    "@sentry/hub" "5.0.0-rc.0"
+    "@sentry/minimal" "5.0.0-rc.0"
+    "@sentry/types" "5.0.0-rc.0"
+    "@sentry/utils" "5.0.0-rc.0"
     tslib "^1.9.3"
 
-"@sentry/hub@5.0.0-beta1":
-  version "5.0.0-beta1"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.0.0-beta1.tgz#9818721182c07d0568d93ad594f44f597cd1c3b7"
-  integrity sha512-vvUBvzYKW/uV9fDT+k+tsZb6jZAkrTBOHtSxXvMV9pEXzS3AZGIxsig4CR9Md6HfQa3I6wi6/heuRcCdaEQ5pA==
+"@sentry/hub@5.0.0-rc.0":
+  version "5.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.0.0-rc.0.tgz#cc94601a3e5ea3b3a649a4da88a9fba856e4dbfe"
+  integrity sha512-fkXJmySt0T35gAzCeevGXX8yFzU2tHWQceS/mePlMMFuSD+KnKsFWRBGYiFUdj5hJCEYR25UN721BPb8TLeA5Q==
   dependencies:
-    "@sentry/types" "5.0.0-beta1"
-    "@sentry/utils" "5.0.0-beta1"
+    "@sentry/types" "5.0.0-rc.0"
+    "@sentry/utils" "5.0.0-rc.0"
     tslib "^1.9.3"
 
-"@sentry/minimal@5.0.0-beta1":
-  version "5.0.0-beta1"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.0.0-beta1.tgz#16a9131490aca9a5568a5a3a1dd409df63a10fec"
-  integrity sha512-X0+tSxELgbNUzn1weLC1gEto8TsyH/DGx7XEraCSLl2NJ9vi7pdFaM2KCfUp1rS6p9F3v7z0Sfb6V6DlKutoRQ==
+"@sentry/minimal@5.0.0-rc.0":
+  version "5.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.0.0-rc.0.tgz#eb0f3dec46195f387ab74959dc12ba9c0a689dca"
+  integrity sha512-6vLWKBqTI2UxIn+lBoHshPk2kbWqiAVezTaGnfyVVxjw//SRreiuGO3NePgF08fgzI0VvtfX26/Dm1EjqwPoOQ==
   dependencies:
-    "@sentry/hub" "5.0.0-beta1"
-    "@sentry/types" "5.0.0-beta1"
+    "@sentry/hub" "5.0.0-rc.0"
+    "@sentry/types" "5.0.0-rc.0"
     tslib "^1.9.3"
 
-"@sentry/types@5.0.0-beta1":
-  version "5.0.0-beta1"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.0.0-beta1.tgz#26e52c5e8725d56f062f7b5b31945258785a995e"
-  integrity sha512-1jGT+/e2BEvd8fTBpGChjiwND7G0RIPwXWfJ4wnYrR9L61DQYjtzA6uOL2fZlSZmYoEJWQVqKMLOz7ORVRg2LA==
+"@sentry/types@5.0.0-rc.0":
+  version "5.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.0.0-rc.0.tgz#251d0da6ab9cf9bfc4ffaad6bf1c671ba1ba7786"
+  integrity sha512-IWfRENU2jk2hT0CXl6R3Ie4xyfHfJkN2GPZvZIPYUpX4cixyhMZUMYpylDyRM+ZMpVeLVS+RjzzMEeFggcMJUQ==
 
-"@sentry/utils@5.0.0-beta1":
-  version "5.0.0-beta1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.0.0-beta1.tgz#f1403105d88f9d292f2439f9b7ff32763356cea5"
-  integrity sha512-yJs0+YRB+A4xiUz7y0hdVl18cSoclUidh22zk8ZlHzW2qZY8r3s7LG2EFDAstsoEP3rcvAtmp4bT8mu1+VJDYw==
+"@sentry/utils@5.0.0-rc.0":
+  version "5.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.0.0-rc.0.tgz#168909c43cdabc79b7fdbacfc00c17d544a36604"
+  integrity sha512-JKG9izxwHu8wALWEYRkqAte436h+PcKbYf+WSmwLgETyI+1fyv1sCav2WkSGQtVqVD7tavAuMYBTaBOBS5xigA==
   dependencies:
-    "@sentry/types" "5.0.0-beta1"
+    "@sentry/types" "5.0.0-rc.0"
     tslib "^1.9.3"
 
 "@storybook/addon-a11y@^4.1.3":


### PR DESCRIPTION
We had to unpublish `@sentry/browser@5.0.0-beta1` because it was tagged as `latest`.
This fixes the dependency and locks it to `@sentry/browser@5.0.0-rc.0`.