### PR TITLE
fix: Use `<div>` instead of `<p>` for container component

### DIFF
--- a/src/sentry/static/sentry/app/components/errors/detailedError.jsx
+++ b/src/sentry/static/sentry/app/components/errors/detailedError.jsx
@@ -49,7 +49,7 @@ class DetailedError extends React.Component {
         <div className="detailed-error-content">
           <h4>{heading}</h4>
 
-          <p className="detailed-error-content-body">{message}</p>
+          <div className="detailed-error-content-body">{message}</div>
 
           {showFooter && (
             <div className="detailed-error-content-footer">

--- a/tests/js/spec/components/__snapshots__/detailedError.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/detailedError.spec.jsx.snap
@@ -17,13 +17,13 @@ exports[`DetailedError can hide support links 1`] = `
     <h4>
       Error heading
     </h4>
-    <p
+    <div
       className="detailed-error-content-body"
     >
       <div>
         Message
       </div>
-    </p>
+    </div>
     <div
       className="detailed-error-content-footer"
     >
@@ -57,13 +57,13 @@ exports[`DetailedError hides footer when no "Retry" and no support links 1`] = `
     <h4>
       Error heading
     </h4>
-    <p
+    <div
       className="detailed-error-content-body"
     >
       <div>
         Message
       </div>
-    </p>
+    </div>
   </div>
 </div>
 `;
@@ -85,13 +85,13 @@ exports[`DetailedError renders 1`] = `
     <h4>
       Error heading
     </h4>
-    <p
+    <div
       className="detailed-error-content-body"
     >
       <div>
         Message
       </div>
-    </p>
+    </div>
     <div
       className="detailed-error-content-footer"
     >
@@ -132,13 +132,13 @@ exports[`DetailedError renders with "Retry" button 1`] = `
     <h4>
       Error heading
     </h4>
-    <p
+    <div
       className="detailed-error-content-body"
     >
       <div>
         Message
       </div>
-    </p>
+    </div>
     <div
       className="detailed-error-content-footer"
     >


### PR DESCRIPTION
Fixes `<p>` cannot be descendent of `<p>` type errors