### PR TITLE
fix(global issue stream): Re-enable resolve menu options

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -646,7 +646,7 @@ const OrganizationStream = createReactClass({
     const projects = this.getGlobalSearchProjects();
 
     if (selectedProject) {
-      hasReleases = this.getFeatures().has('releases');
+      hasReleases = new Set(selectedProject.features).has('releases');
       latestRelease = selectedProject.latestRelease;
       projectId = selectedProject.slug;
     } else if (projects.length == 1) {


### PR DESCRIPTION
Currently, none of the three options in the 'Resolve' menu at the top of the new issue stream work. Instead, they're all disabled because they erroneously think that there are no releases associated with the project the issue(s) is(are) in:

![image](https://user-images.githubusercontent.com/14812505/54860553-019a1480-4cd9-11e9-95eb-5a551eda46a9.png)

The [tooltip](https://github.com/getsentry/sentry/blob/1608add6038145c13b40197aae76f3d098e98d8b/src/sentry/static/sentry/app/components/actions/resolve.jsx#L108-L110) and menu items ([1](https://github.com/getsentry/sentry/blob/1608add6038145c13b40197aae76f3d098e98d8b/src/sentry/static/sentry/app/components/actions/resolve.jsx#L153-L155), [2](https://github.com/getsentry/sentry/blob/1608add6038145c13b40197aae76f3d098e98d8b/src/sentry/static/sentry/app/components/actions/resolve.jsx#L171-L173), [3](https://github.com/getsentry/sentry/blob/1608add6038145c13b40197aae76f3d098e98d8b/src/sentry/static/sentry/app/components/actions/resolve.jsx#L194)) are enabled and disabled, respectively, based on the `hasReleases`/`hasRelease` prop which is passed down from OrganizationStream to [StreamActions](https://github.com/getsentry/sentry/blob/3701666f0bb5679829888063381c229bc8193ee7/src/sentry/static/sentry/app/views/organizationStream/overview.jsx#L682) to [ResolveActions](https://github.com/getsentry/sentry/blob/40f739fb2a70c9f8a2ad2cff264f834402fd68cf/src/sentry/static/sentry/app/views/stream/actions.jsx#L343). OrganizationStream, in turn, sets it based on whether or not the organization [has `'releases'` in its feature list](https://github.com/getsentry/sentry/blob/3701666f0bb5679829888063381c229bc8193ee7/src/sentry/static/sentry/app/views/organizationStream/overview.jsx#L645).

This is all well and good, except it's not possible for an org to _have_ `'releases'` in its feature list. The features data comes from the [serializer](https://github.com/getsentry/sentry/blob/3701666f0bb5679829888063381c229bc8193ee7/src/sentry/api/serializers/models/organization.py#L102), which [doesn’t add it explicitly](https://github.com/getsentry/sentry/blob/3701666f0bb5679829888063381c229bc8193ee7/src/sentry/api/serializers/models/organization.py#L74-L87) and which otherwise [only includes features beginning with `'organizations:'`](https://github.com/getsentry/sentry/blob/3701666f0bb5679829888063381c229bc8193ee7/src/sentry/api/serializers/models/organization.py#L74-L87). But `'organizations:releases'` appears [nowhere in our codebase](https://github.com/search?q=org%3Agetsentry+%22organizations%3Areleases%22&type=Code), meaning `'releases'` can't appear in the feature list.

By contrast, the same dropdown on the Issue Details page (which works), sets `hasReleases` [_based on the project_](https://github.com/getsentry/sentry/blob/3701666f0bb5679829888063381c229bc8193ee7/src/sentry/static/sentry/app/views/groupDetails/shared/actions.jsx#L243), not the org. Even though releases now are global/org-wide entities, issues are still project-scoped, so they still resolve themselves based on a release _in their project_ (which really now means, "associated with their project," but the upshot is the same), so it still makes sense to check the project for the existence of releases rather than the org. This fixes the Issue Stream to do that. 

(Haven't added a test specifically around this (right now we just test the one on the issue details page against a snapshot, and the one on the issue stream not at all), because I feel like it's probably better to just get the fix out, but can if it seems like a good idea.)