### PR TITLE
feat(saved-search) Add delete button to org saved searches

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/savedSearches.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/savedSearches.jsx
@@ -69,3 +69,22 @@ export function fetchRecentSearches(api, orgId, type, query) {
 
   return promise;
 }
+
+/**
+ * Send a DELETE rquest to remove a saved search
+ *
+ * @param {Object} api API client
+ * @param {String} orgId Organization slug
+ * @param {Object} search The search to remove.
+ */
+export function deleteSavedSearch(api, orgId, search) {
+  const url = `/organizations/${orgId}/searches/${search.id}/`;
+
+  const promise = api
+    .requestPromise(url, {
+      method: 'DELETE',
+    })
+    .catch(handleXhrErrorResponse('Unable to delete a saved search'));
+
+  return promise;
+}

--- a/src/sentry/static/sentry/app/components/confirm.jsx
+++ b/src/sentry/static/sentry/app/components/confirm.jsx
@@ -27,6 +27,9 @@ class Confirm extends React.PureComponent {
     onConfirming: PropTypes.func,
     onCancel: PropTypes.func,
     header: PropTypes.node,
+
+    // Stop event propgation when opening the confirm modal
+    stopPropagation: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -34,6 +37,7 @@ class Confirm extends React.PureComponent {
     disableConfirmButton: false,
     cancelText: t('Cancel'),
     confirmText: t('Confirm'),
+    stopPropagation: false,
   };
 
   static getDerivedStateFromProps(props, state) {
@@ -103,6 +107,10 @@ class Confirm extends React.PureComponent {
     const {disabled, bypass} = this.props;
     if (disabled) {
       return;
+    }
+
+    if (e && this.props.stopPropagation) {
+      e.stopPropagation();
     }
 
     if (bypass) {

--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -19,7 +19,7 @@ import {Panel, PanelBody} from 'app/components/panels';
 import StreamGroup from 'app/components/stream/group';
 import {fetchOrganizationTags, fetchTagValues} from 'app/actionCreators/tags';
 import {fetchOrgMembers, indexMembersByProject} from 'app/actionCreators/members';
-import {fetchSavedSearches} from 'app/actionCreators/savedSearches';
+import {fetchSavedSearches, deleteSavedSearch} from 'app/actionCreators/savedSearches';
 import ConfigStore from 'app/stores/configStore';
 import GroupStore from 'app/stores/groupStore';
 import SelectedGroupStore from 'app/stores/selectedGroupStore';
@@ -213,10 +213,6 @@ const OrganizationStream = createReactClass({
     return pickBy(params, v => utils.defined(v));
   },
 
-  getAccess() {
-    return new Set(this.props.organization.access);
-  },
-
   getFeatures() {
     return new Set(this.props.organization.features);
   },
@@ -340,10 +336,6 @@ const OrganizationStream = createReactClass({
     const params = this.props.params;
 
     return `/organizations/${params.orgId}/issues/`;
-  },
-
-  onSavedSearchSelect(search) {
-    this.setState({savedSearch: search, issuesLoading: true}, this.transitionTo);
   },
 
   onRealtimeChange(realtime) {
@@ -601,6 +593,26 @@ const OrganizationStream = createReactClass({
     this.setState({savedSearch: data}, this.transitionTo);
   },
 
+  onSavedSearchSelect(search) {
+    this.setState({savedSearch: search, issuesLoading: true}, this.transitionTo);
+  },
+
+  onSavedSearchDelete(search) {
+    const {orgId} = this.props.params;
+    const {savedSearchList} = this.state;
+
+    deleteSavedSearch(this.api, orgId, search).then(() => {
+      this.setState(
+        {
+          savedSearchList: savedSearchList.filter(s => s.id != search.id),
+          savedSearch: null,
+          issuesLoading: true,
+        },
+        this.transitionTo
+      );
+    });
+  },
+
   renderAwaitingEvents(projects) {
     const {organization} = this.props;
     const project = projects.length > 0 ? projects[0] : null;
@@ -627,13 +639,12 @@ const OrganizationStream = createReactClass({
     if (this.state.savedSearchLoading) {
       return this.renderLoading();
     }
-    const params = this.props.params;
     const classes = ['stream-row'];
     if (this.state.isSidebarVisible) {
       classes.push('show-sidebar');
     }
-    const {orgId, searchId} = this.props.params;
-    const access = this.getAccess();
+
+    const {params, organization} = this.props;
     const query = this.getQuery();
 
     // If we have a selected project set release data up
@@ -659,10 +670,9 @@ const OrganizationStream = createReactClass({
       <div className={classNames(classes)}>
         <div className="stream-content">
           <StreamFilters
-            access={access}
-            orgId={orgId}
+            organization={organization}
             projectId={projectId}
-            searchId={searchId}
+            searchId={params.searchId}
             query={query}
             sort={this.getSort()}
             queryCount={this.state.queryCount}
@@ -671,6 +681,7 @@ const OrganizationStream = createReactClass({
             onSearch={this.onSearch}
             onSavedSearchCreate={this.onSavedSearchCreate}
             onSavedSearchSelect={this.onSavedSearchSelect}
+            onSavedSearchDelete={this.onSavedSearchDelete}
             onSidebarToggle={this.onSidebarToggle}
             isSearchDisabled={this.state.isSidebarVisible}
             savedSearchList={this.state.savedSearchList}
@@ -680,7 +691,7 @@ const OrganizationStream = createReactClass({
 
           <Panel>
             <StreamActions
-              orgId={params.orgId}
+              orgId={organization.slug}
               projectId={projectId}
               selection={this.props.selection}
               hasReleases={hasReleases}
@@ -710,7 +721,7 @@ const OrganizationStream = createReactClass({
           tags={this.state.tags}
           query={query}
           onQueryChange={this.onSearch}
-          orgId={params.orgId}
+          orgId={organization.slug}
           tagValueLoader={this.tagValueLoader}
         />
       </div>

--- a/src/sentry/static/sentry/app/views/stream/filters.jsx
+++ b/src/sentry/static/sentry/app/views/stream/filters.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import Feature from 'app/components/acl/feature';
 
+import SentryTypes from 'app/sentryTypes';
 import SearchBar from './searchBar';
 import SortOptions from './sortOptions';
 import SavedSearchSelector from './savedSearchSelector';
@@ -10,9 +11,8 @@ import OrganizationSavedSearchSelector from './organizationSavedSearchSelector';
 
 class StreamFilters extends React.Component {
   static propTypes = {
-    orgId: PropTypes.string.isRequired,
     projectId: PropTypes.string,
-    access: PropTypes.object.isRequired,
+    organization: SentryTypes.Organization,
 
     searchId: PropTypes.string,
     savedSearchList: PropTypes.array.isRequired,
@@ -28,6 +28,7 @@ class StreamFilters extends React.Component {
     onSidebarToggle: PropTypes.func,
     onSavedSearchCreate: PropTypes.func.isRequired,
     onSavedSearchSelect: PropTypes.func.isRequired,
+    onSavedSearchDelete: PropTypes.func.isRequired,
     tagValueLoader: PropTypes.func.isRequired,
     tags: PropTypes.object.isRequired,
   };
@@ -47,8 +48,7 @@ class StreamFilters extends React.Component {
 
   render() {
     const {
-      access,
-      orgId,
+      organization,
       projectId,
       searchId,
       queryCount,
@@ -62,6 +62,7 @@ class StreamFilters extends React.Component {
       onSearch,
       onSavedSearchCreate,
       onSavedSearchSelect,
+      onSavedSearchDelete,
       onSortChange,
       tagValueLoader,
       tags,
@@ -75,8 +76,7 @@ class StreamFilters extends React.Component {
               features={['org-saved-searches']}
               renderDisabled={() => (
                 <SavedSearchSelector
-                  access={access}
-                  orgId={orgId}
+                  organization={organization}
                   projectId={projectId}
                   searchId={searchId}
                   queryCount={queryCount}
@@ -89,8 +89,10 @@ class StreamFilters extends React.Component {
               )}
             >
               <OrganizationSavedSearchSelector
+                organization={organization}
                 savedSearchList={savedSearchList}
                 onSavedSearchSelect={onSavedSearchSelect}
+                onSavedSearchDelete={onSavedSearchDelete}
                 queryCount={queryCount}
                 queryMaxCount={queryMaxCount}
               />
@@ -103,7 +105,7 @@ class StreamFilters extends React.Component {
               </div>
 
               <SearchBar
-                orgId={orgId}
+                orgId={organization.slug}
                 query={query || ''}
                 onSearch={onSearch}
                 disabled={isSearchDisabled}

--- a/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
@@ -9,6 +9,7 @@ import IndicatorStore from 'app/stores/indicatorStore';
 import DropdownLink from 'app/components/dropdownLink';
 import QueryCount from 'app/components/queryCount';
 import MenuItem from 'app/components/menuItem';
+import SentryTypes from 'app/sentryTypes';
 import Tooltip from 'app/components/tooltip';
 import Tag from 'app/views/settings/components/tag';
 import {BooleanField, FormState, TextField} from 'app/components/forms';
@@ -18,9 +19,8 @@ import space from 'app/styles/space';
 const SaveSearchButton = withApi(
   class SaveSearchButton extends React.Component {
     static propTypes = {
-      orgId: PropTypes.string.isRequired,
+      organization: SentryTypes.Organization.isRequired,
       projectId: PropTypes.string,
-      access: PropTypes.object.isRequired,
       api: PropTypes.object.isRequired,
       query: PropTypes.string.isRequired,
       disabled: PropTypes.bool,
@@ -85,8 +85,8 @@ const SaveSearchButton = withApi(
         },
         () => {
           const loadingIndicator = IndicatorStore.add(t('Saving changes..'));
-          const {orgId, projectId} = this.props;
-          api.request(`/projects/${orgId}/${projectId}/searches/`, {
+          const {organization, projectId} = this.props;
+          api.request(`/projects/${organization.slug}/${projectId}/searches/`, {
             method: 'POST',
             data: this.state.formData,
             success: data => {
@@ -115,7 +115,8 @@ const SaveSearchButton = withApi(
 
     render() {
       const isSaving = this.state.state === FormState.SAVING;
-      const {tooltip, buttonTitle, style, children, disabled} = this.props;
+      const {tooltip, buttonTitle, style, children, disabled, organization} = this.props;
+      const access = new Set(organization.access);
       return (
         <React.Fragment>
           <Tooltip
@@ -175,7 +176,7 @@ const SaveSearchButton = withApi(
                   label={t('Make this the default view for myself.')}
                   onChange={this.onFieldChange.bind(this, 'isUserDefault')}
                 />
-                {this.props.access.has('project:write') && (
+                {access.has('project:write') && (
                   <BooleanField
                     key="isDefault"
                     name="is-default"
@@ -209,10 +210,9 @@ const SaveSearchButton = withApi(
 const SavedSearchSelector = withApi(
   class SavedSearchSelector extends React.Component {
     static propTypes = {
-      orgId: PropTypes.string.isRequired,
+      organization: SentryTypes.Organization.isRequired,
       projectId: PropTypes.string,
       searchId: PropTypes.string,
-      access: PropTypes.object.isRequired,
       query: PropTypes.string,
       savedSearchList: PropTypes.array.isRequired,
       queryCount: PropTypes.number,
@@ -236,7 +236,7 @@ const SavedSearchSelector = withApi(
 
     render() {
       const {
-        orgId,
+        organization,
         projectId,
         queryCount,
         queryMaxCount,
@@ -288,7 +288,7 @@ const SavedSearchSelector = withApi(
                 <Button
                   size="xsmall"
                   priority="default"
-                  to={`/${orgId}/${projectId}/settings/saved-searches/`}
+                  to={`/${organization.slug}/${projectId}/settings/saved-searches/`}
                   disabled={!hasProject}
                 >
                   {t('Manage')}

--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -670,16 +670,13 @@ const Stream = createReactClass({
     if (this.state.loading) {
       return this.renderLoading();
     }
-    const params = this.props.params;
     const classes = ['stream-row'];
     if (this.state.isSidebarVisible) {
       classes.push('show-sidebar');
     }
-    const {orgId, projectId} = this.props.params;
     const {organization} = this.context;
 
     const searchId = this.state.searchId;
-    const access = this.getAccess();
     const projectFeatures = this.getProjectFeatures();
     const project = this.getProject();
 
@@ -694,9 +691,8 @@ const Stream = createReactClass({
       <div className={classNames(classes)}>
         <div className="stream-content">
           <StreamFilters
-            access={access}
-            orgId={orgId}
-            projectId={projectId}
+            organization={organization}
+            projectId={project.slug}
             query={this.state.query}
             sort={this.state.sort}
             searchId={searchId}
@@ -706,6 +702,7 @@ const Stream = createReactClass({
             onSearch={this.onSearch}
             onSavedSearchCreate={this.onSavedSearchCreate}
             onSavedSearchSelect={this.onSavedSearchSelect}
+            onSavedSearchDelete={() => {}}
             onSidebarToggle={this.onSidebarToggle}
             isSearchDisabled={this.state.isSidebarVisible}
             savedSearchList={this.state.savedSearchList}
@@ -714,8 +711,8 @@ const Stream = createReactClass({
           />
           <Panel>
             <StreamActions
-              orgId={params.orgId}
-              projectId={params.projectId}
+              orgId={organization.slug}
+              projectId={project.slug}
               selection={selection}
               hasReleases={projectFeatures.has('releases')}
               latestRelease={this.context.project.latestRelease}
@@ -744,8 +741,8 @@ const Stream = createReactClass({
           tags={this.props.tags}
           query={this.state.query}
           onQueryChange={this.onSearch}
-          orgId={params.orgId}
-          projectId={params.projectId}
+          orgId={organization.slug}
+          projectId={project.slug}
           tagValueLoader={this.tagValueLoader}
         />
       </div>

--- a/tests/js/spec/components/actions/__snapshots__/ignore.spec.jsx.snap
+++ b/tests/js/spec/components/actions/__snapshots__/ignore.spec.jsx.snap
@@ -249,6 +249,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
           message="Yoooooo"
           onConfirm={[Function]}
           priority="primary"
+          stopPropagation={false}
         >
           <a
             className="btn btn-default btn-sm"
@@ -477,6 +478,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                 message="Yoooooo"
                                 onConfirm={[Function]}
                                 priority="primary"
+                                stopPropagation={false}
                               >
                                 <a
                                   onClick={[Function]}
@@ -572,6 +574,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                 message="Yoooooo"
                                 onConfirm={[Function]}
                                 priority="primary"
+                                stopPropagation={false}
                               >
                                 <a
                                   onClick={[Function]}
@@ -667,6 +670,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                 message="Yoooooo"
                                 onConfirm={[Function]}
                                 priority="primary"
+                                stopPropagation={false}
                               >
                                 <a
                                   onClick={[Function]}
@@ -762,6 +766,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                 message="Yoooooo"
                                 onConfirm={[Function]}
                                 priority="primary"
+                                stopPropagation={false}
                               >
                                 <a
                                   onClick={[Function]}
@@ -857,6 +862,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                 message="Yoooooo"
                                 onConfirm={[Function]}
                                 priority="primary"
+                                stopPropagation={false}
                               >
                                 <a
                                   onClick={[Function]}
@@ -1077,6 +1083,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -1166,6 +1173,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -1255,6 +1263,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -1344,6 +1353,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -1485,6 +1495,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -1574,6 +1585,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -1663,6 +1675,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -1752,6 +1765,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -1893,6 +1907,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -1982,6 +1997,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -2071,6 +2087,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -2160,6 +2177,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -2301,6 +2319,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -2390,6 +2409,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -2479,6 +2499,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -2568,6 +2589,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -2709,6 +2731,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -2798,6 +2821,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -2887,6 +2911,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -2976,6 +3001,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -3117,6 +3143,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -3206,6 +3233,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -3295,6 +3323,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -3384,6 +3413,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -3603,6 +3633,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -3692,6 +3723,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -3781,6 +3813,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -3870,6 +3903,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -4011,6 +4045,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -4100,6 +4135,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -4189,6 +4225,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -4278,6 +4315,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -4419,6 +4457,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -4508,6 +4547,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -4597,6 +4637,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -4686,6 +4727,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -4827,6 +4869,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -4916,6 +4959,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -5005,6 +5049,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -5094,6 +5139,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -5235,6 +5281,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -5324,6 +5371,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -5413,6 +5461,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -5502,6 +5551,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -5643,6 +5693,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -5732,6 +5783,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -5821,6 +5873,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}
@@ -5910,6 +5963,7 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                                           message="Yoooooo"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <a
                                             onClick={[Function]}

--- a/tests/js/spec/components/actions/__snapshots__/resolve.spec.jsx.snap
+++ b/tests/js/spec/components/actions/__snapshots__/resolve.spec.jsx.snap
@@ -98,6 +98,7 @@ exports[`ResolveActions with confirmation step renders 1`] = `
           message="Are you sure???"
           onConfirm={[Function]}
           priority="primary"
+          stopPropagation={false}
         >
           <a
             className="btn btn-default btn-sm"
@@ -283,6 +284,7 @@ exports[`ResolveActions with confirmation step renders 1`] = `
                         message="Are you sure???"
                         onConfirm={[Function]}
                         priority="primary"
+                        stopPropagation={false}
                       >
                         <a
                           className="tip"
@@ -366,6 +368,7 @@ exports[`ResolveActions with confirmation step renders 1`] = `
                         message="Are you sure???"
                         onConfirm={[Function]}
                         priority="primary"
+                        stopPropagation={false}
                       >
                         <a
                           className="tip"

--- a/tests/js/spec/components/confirm.spec.jsx
+++ b/tests/js/spec/components/confirm.spec.jsx
@@ -73,4 +73,25 @@ describe('Confirm', function() {
     expect(mock).toHaveBeenCalled();
     expect(mock.mock.calls).toHaveLength(1);
   });
+
+  it('can stop propagation on the event', function() {
+    const mock = jest.fn();
+    const wrapper = mount(
+      <Confirm message="Are you sure?" onConfirm={mock} stopPropagation>
+        <button>Confirm?</button>
+      </Confirm>,
+      TestStubs.routerContext()
+    );
+
+    expect(mock).not.toHaveBeenCalled();
+
+    const event = {
+      stopPropagation: jest.fn(),
+    };
+
+    wrapper.find('button').simulate('click', event);
+    wrapper.update();
+
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
@@ -733,6 +733,7 @@ exports[`projectAlertRules renders 1`] = `
                                       message="Are you sure you want to remove this rule?"
                                       onConfirm={[Function]}
                                       priority="primary"
+                                      stopPropagation={false}
                                     >
                                       <Button
                                         disabled={false}

--- a/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
@@ -363,6 +363,7 @@ exports[`ProjectSavedSearches renders 1`] = `
                                           message="Are you sure you want to remove this?"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <Button
                                             disabled={false}
@@ -676,6 +677,7 @@ exports[`ProjectSavedSearches renders 1`] = `
                                           message="Are you sure you want to remove this?"
                                           onConfirm={[Function]}
                                           priority="primary"
+                                          stopPropagation={false}
                                         >
                                           <Button
                                             disabled={false}

--- a/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
@@ -464,6 +464,7 @@ exports[`ProjectTags renders 1`] = `
                                         message="Are you sure you want to remove this tag?"
                                         onConfirm={[Function]}
                                         priority="primary"
+                                        stopPropagation={false}
                                       >
                                         <a
                                           className=""
@@ -692,6 +693,7 @@ exports[`ProjectTags renders 1`] = `
                                         message="Are you sure you want to remove this tag?"
                                         onConfirm={[Function]}
                                         priority="primary"
+                                        stopPropagation={false}
                                       >
                                         <a
                                           className=""
@@ -920,6 +922,7 @@ exports[`ProjectTags renders 1`] = `
                                         message="Are you sure you want to remove this tag?"
                                         onConfirm={[Function]}
                                         priority="primary"
+                                        stopPropagation={false}
                                       >
                                         <a
                                           className=""
@@ -1149,6 +1152,7 @@ exports[`ProjectTags renders 1`] = `
                                         message="Are you sure you want to remove this tag?"
                                         onConfirm={[Function]}
                                         priority="primary"
+                                        stopPropagation={false}
                                       >
                                         <a
                                           className="tip disabled"
@@ -1383,6 +1387,7 @@ exports[`ProjectTags renders 1`] = `
                                         message="Are you sure you want to remove this tag?"
                                         onConfirm={[Function]}
                                         priority="primary"
+                                        stopPropagation={false}
                                       >
                                         <a
                                           className="tip disabled"

--- a/tests/js/spec/views/groupDetails/__snapshots__/groupSimilar.spec.jsx.snap
+++ b/tests/js/spec/views/groupDetails/__snapshots__/groupSimilar.spec.jsx.snap
@@ -450,6 +450,7 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                 message="Are you sure you want to merge these issues?"
                                 onConfirm={[Function]}
                                 priority="primary"
+                                stopPropagation={false}
                               >
                                 <a
                                   className="btn btn-sm btn-default disabled"

--- a/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -506,6 +506,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
                               message="Are you sure you want to remove this API key?"
                               onConfirm={[Function]}
                               priority="primary"
+                              stopPropagation={false}
                             >
                               <a
                                 className="btn btn-default btn-sm"

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
@@ -1448,6 +1448,7 @@ exports[`Organization Developer Settings with unpublished apps displays all Apps
                                                 }
                                                 onConfirm={[Function]}
                                                 priority="danger"
+                                                stopPropagation={false}
                                               >
                                                 <Button
                                                   disabled={false}

--- a/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
@@ -1666,6 +1666,7 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                               }
                                               onConfirm={[Function]}
                                               priority="danger"
+                                              stopPropagation={false}
                                             >
                                               <StyledButton
                                                 borderless={true}
@@ -3109,6 +3110,7 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                               }
                                               onConfirm={[Function]}
                                               priority="danger"
+                                              stopPropagation={false}
                                             >
                                               <StyledButton
                                                 borderless={true}

--- a/tests/js/spec/views/stream/__snapshots__/stream.spec.jsx.snap
+++ b/tests/js/spec/views/stream/__snapshots__/stream.spec.jsx.snap
@@ -15,7 +15,7 @@ exports[`Stream render() displays the group list 1`] = `
       onSearch={[Function]}
       onSidebarToggle={[Function]}
       onSortChange={[Function]}
-      organiation={
+      organization={
         Object {
           "access": Array [
             "org:read",
@@ -328,7 +328,7 @@ exports[`Stream toggles environment select all environments 1`] = `
       onSearch={[Function]}
       onSidebarToggle={[Function]}
       onSortChange={[Function]}
-      organiation={
+      organization={
         Object {
           "access": Array [
             "org:read",

--- a/tests/js/spec/views/stream/__snapshots__/stream.spec.jsx.snap
+++ b/tests/js/spec/views/stream/__snapshots__/stream.spec.jsx.snap
@@ -8,27 +8,41 @@ exports[`Stream render() displays the group list 1`] = `
     className="stream-content"
   >
     <StreamFilters
-      access={
-        Set {
-          "org:read",
-          "org:write",
-          "org:admin",
-          "org:integrations",
-          "project:read",
-          "project:write",
-          "project:admin",
-          "team:read",
-          "team:write",
-          "team:admin",
-        }
-      }
       isSearchDisabled={false}
       onSavedSearchCreate={[Function]}
+      onSavedSearchDelete={[Function]}
       onSavedSearchSelect={[Function]}
       onSearch={[Function]}
       onSidebarToggle={[Function]}
       onSortChange={[Function]}
-      orgId="org-slug"
+      organiation={
+        Object {
+          "access": Array [
+            "org:read",
+            "org:write",
+            "org:admin",
+            "org:integrations",
+            "project:read",
+            "project:write",
+            "project:admin",
+            "team:read",
+            "team:write",
+            "team:admin",
+          ],
+          "features": Array [],
+          "id": "1337",
+          "name": "Organization Name",
+          "onboardingTasks": Array [],
+          "projects": Array [],
+          "scrapeJavaScript": true,
+          "slug": "org-slug",
+          "status": Object {
+            "id": "active",
+            "name": "active",
+          },
+          "teams": Array [],
+        }
+      }
       projectId="project-slug"
       query="is:unresolved"
       queryCount={0}
@@ -307,27 +321,41 @@ exports[`Stream toggles environment select all environments 1`] = `
     className="stream-content"
   >
     <StreamFilters
-      access={
-        Set {
-          "org:read",
-          "org:write",
-          "org:admin",
-          "org:integrations",
-          "project:read",
-          "project:write",
-          "project:admin",
-          "team:read",
-          "team:write",
-          "team:admin",
-        }
-      }
       isSearchDisabled={false}
       onSavedSearchCreate={[Function]}
+      onSavedSearchDelete={[Function]}
       onSavedSearchSelect={[Function]}
       onSearch={[Function]}
       onSidebarToggle={[Function]}
       onSortChange={[Function]}
-      orgId="org-slug"
+      organiation={
+        Object {
+          "access": Array [
+            "org:read",
+            "org:write",
+            "org:admin",
+            "org:integrations",
+            "project:read",
+            "project:write",
+            "project:admin",
+            "team:read",
+            "team:write",
+            "team:admin",
+          ],
+          "features": Array [],
+          "id": "1337",
+          "name": "Organization Name",
+          "onboardingTasks": Array [],
+          "projects": Array [],
+          "scrapeJavaScript": true,
+          "slug": "org-slug",
+          "status": Object {
+            "id": "active",
+            "name": "active",
+          },
+          "teams": Array [],
+        }
+      }
       projectId="project-slug"
       query="is:unresolved"
       queryCount={0}

--- a/tests/js/spec/views/stream/organizationSavedSearchSelector.spec.jsx
+++ b/tests/js/spec/views/stream/organizationSavedSearchSelector.spec.jsx
@@ -4,29 +4,35 @@ import {mount} from 'enzyme';
 import OrganizationSavedSearchSelector from 'app/views/stream/organizationSavedSearchSelector';
 
 describe('OrganizationSavedSearchSelector', function() {
-  let wrapper, onSelect;
+  let wrapper, onSelect, onDelete, organization, savedSearchList;
   beforeEach(function() {
+    organization = TestStubs.Organization();
     onSelect = jest.fn();
-    const savedSearchList = [
+    onDelete = jest.fn();
+    savedSearchList = [
       {
         id: '789',
         query: 'is:unresolved',
         name: 'Unresolved',
         isPinned: false,
+        isGlobal: true,
       },
       {
         id: '122',
         query: 'is:unresolved assigned:me',
         name: 'Assigned to me',
         isPinned: false,
+        isGlobal: false,
       },
     ];
-
     wrapper = mount(
       <OrganizationSavedSearchSelector
+        organization={organization}
         savedSearchList={savedSearchList}
         onSavedSearchSelect={onSelect}
-      />
+        onSavedSearchDelete={onDelete}
+      />,
+      TestStubs.routerContext()
     );
   });
 
@@ -56,6 +62,62 @@ describe('OrganizationSavedSearchSelector', function() {
 
       item.simulate('click');
       expect(onSelect).toHaveBeenCalled();
+    });
+  });
+
+  describe('removing a saved search', function() {
+    it('shows a delete button with access', async function() {
+      wrapper.find('DropdownLink').simulate('click');
+      await wrapper.update();
+
+      // Second item should have a delete button as it is not a global search
+      const button = wrapper
+        .find('StyledMenuItem')
+        .at(1)
+        .find('Button[icon="icon-trash"]');
+      expect(button).toHaveLength(1);
+    });
+
+    it('does not show a delete button without access', async function() {
+      organization.access = [];
+      wrapper.setProps({organization});
+
+      wrapper.find('DropdownLink').simulate('click');
+      await wrapper.update();
+
+      const button = wrapper
+        .find('StyledMenuItem')
+        .at(1)
+        .find('Button[icon="icon-trash"]');
+      expect(button).toHaveLength(0);
+    });
+
+    it('does not show a delete button for global search', async function() {
+      wrapper.find('DropdownLink').simulate('click');
+      await wrapper.update();
+
+      // First item should not have a delete button as it is a global search
+      const button = wrapper
+        .find('StyledMenuItem')
+        .first()
+        .find('Button[icon="icon-trash"]');
+      expect(button).toHaveLength(0);
+    });
+
+    it('sends a request when delete button is clicked', async function() {
+      wrapper.find('DropdownLink').simulate('click');
+      await wrapper.update();
+
+      // Second item should have a delete button as it is not a global search
+      const button = wrapper
+        .find('StyledMenuItem')
+        .at(1)
+        .find('Button[icon="icon-trash"]');
+      button.simulate('click');
+      await wrapper.update();
+
+      wrapper.find('Modal Button[priority="primary"]').simulate('click');
+      expect(onDelete).toHaveBeenCalledWith(savedSearchList[1]);
     });
   });
 });

--- a/tests/js/spec/views/stream/savedSearchSelector.spec.jsx
+++ b/tests/js/spec/views/stream/savedSearchSelector.spec.jsx
@@ -7,7 +7,7 @@ describe('SavedSearchSelector', function() {
   let wrapper;
   let props;
 
-  let orgId;
+  let organization;
   let projectId;
   let savedSearchList;
   const onCreate = jest.fn();
@@ -15,7 +15,7 @@ describe('SavedSearchSelector', function() {
 
   beforeEach(function() {
     projectId = 'test-project';
-    orgId = 'test-org';
+    organization = TestStubs.Organization({slug: 'test-org'});
     savedSearchList = [
       {
         id: '789',
@@ -35,7 +35,7 @@ describe('SavedSearchSelector', function() {
 
     props = {
       projectId,
-      orgId,
+      organization,
       savedSearchList,
       access,
       onSavedSearchCreate: onCreate,


### PR DESCRIPTION
Add a delete button to organization saved search dropdown. While the visuals of this component are likely to change this gets the behavior for delete in-place.

This depends on the delete API in #12502

![Screen Shot 2019-03-25 at 2 51 55 PM](https://user-images.githubusercontent.com/24086/54952543-993b7500-4f1c-11e9-8b5d-2ef3a8567400.png)


Fixes SEN-397