### PR TITLE
ref(app-platform): Handle slug validation

### DIFF
--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -5,9 +5,28 @@ from jsonschema.exceptions import ValidationError as SchemaValidationError
 from rest_framework import serializers
 from rest_framework.serializers import Serializer, ValidationError
 
+from django.template.defaultfilters import slugify
 from sentry.api.validators.sentry_apps.schema import validate as validate_schema
-from sentry.models import ApiScopes
+from sentry.models import ApiScopes, SentryApp
 from sentry.models.sentryapp import VALID_EVENT_RESOURCES, REQUIRED_EVENT_PERMISSIONS
+
+
+class NameField(serializers.CharField):
+    def from_native(self, data):
+        rv = super(NameField, self).from_native(data)
+        if not rv:
+            return
+        if not self.is_valid_slug(rv):
+            raise ValidationError(u'Name {} is already taken, please use another.'.format(data))
+        return rv
+
+    def is_valid_slug(self, value):
+        slug = slugify(value)
+
+        if SentryApp.objects.with_deleted().filter(slug=slug).exists():
+            return False
+
+        return True
 
 
 class ApiScopesField(serializers.WritableField):
@@ -41,7 +60,7 @@ class SchemaField(serializers.WritableField):
 
 
 class SentryAppSerializer(Serializer):
-    name = serializers.CharField()
+    name = NameField()
     scopes = ApiScopesField()
     events = EventListField(required=False)
     schema = SchemaField(required=False)

--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -23,7 +23,7 @@ class NameField(serializers.CharField):
     def is_valid_slug(self, value):
         slug = slugify(value)
 
-        if SentryApp.objects.with_deleted().filter(slug=slug).exists():
+        if SentryApp.with_deleted.filter(slug=slug).exists():
             return False
 
         return True

--- a/src/sentry/db/models/paranoia.py
+++ b/src/sentry/db/models/paranoia.py
@@ -26,6 +26,9 @@ class ParanoidManager(BaseManager):
         return ParanoidQuerySet(self.model, using=self._db).filter(
             date_deleted__isnull=True)
 
+    def with_deleted(self):
+        return ParanoidQuerySet(self.model, using=self._db).all()
+
 
 class ParanoidModel(Model):
     class Meta:

--- a/src/sentry/db/models/paranoia.py
+++ b/src/sentry/db/models/paranoia.py
@@ -26,9 +26,6 @@ class ParanoidManager(BaseManager):
         return ParanoidQuerySet(self.model, using=self._db).filter(
             date_deleted__isnull=True)
 
-    def with_deleted(self):
-        return ParanoidQuerySet(self.model, using=self._db).all()
-
 
 class ParanoidModel(Model):
     class Meta:
@@ -36,6 +33,7 @@ class ParanoidModel(Model):
 
     date_deleted = models.DateTimeField(null=True, blank=True)
     objects = ParanoidManager()
+    with_deleted = BaseManager()
 
     def delete(self):
         self.update(date_deleted=timezone.now())

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -10,7 +10,6 @@ from django.db.models import Q
 from django.utils import timezone
 from django.template.defaultfilters import slugify
 from hashlib import sha256
-
 from sentry.constants import SentryAppStatus, SENTRY_APP_SLUG_MAX_LENGTH
 from sentry.models import Organization
 from sentry.models.apiscopes import HasApiScopes

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -148,6 +148,20 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         assert response.data['webhookUrl'] == 'https://newurl.com'
 
     @with_feature('organizations:sentry-apps')
+    def test_cannot_update_name_with_non_unique_slug(self):
+        self.login_as(user=self.user)
+        response = self.client.put(
+            self.url,
+            data={
+                'name': 'test',
+            },
+            format='json',
+        )
+        assert response.status_code == 400
+        assert response.data == \
+            {"name": ["Name test is already taken, please use another."]}
+
+    @with_feature('organizations:sentry-apps')
     def test_cannot_update_events_without_permissions(self):
         self.login_as(user=self.user)
         url = reverse('sentry-api-0-sentry-app-details', args=[self.unpublished_app.slug])

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -149,17 +149,21 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
 
     @with_feature('organizations:sentry-apps')
     def test_cannot_update_name_with_non_unique_slug(self):
+        from sentry.mediators import sentry_apps
         self.login_as(user=self.user)
+        sentry_app = self.create_sentry_app(
+            name='Foo Bar',
+            organization=self.org,
+        )
+        sentry_apps.Destroyer.run(sentry_app=sentry_app)
         response = self.client.put(
             self.url,
-            data={
-                'name': 'test',
-            },
+            data={'name': sentry_app.name},
             format='json',
         )
         assert response.status_code == 400
         assert response.data == \
-            {"name": ["Name test is already taken, please use another."]}
+            {"name": ["Name Foo Bar is already taken, please use another."]}
 
     @with_feature('organizations:sentry-apps')
     def test_cannot_update_events_without_permissions(self):

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -131,6 +131,15 @@ class PostSentryAppsTest(SentryAppsTest):
         assert six.viewitems(expected) <= six.viewitems(json.loads(response.content))
 
     @with_feature('organizations:sentry-apps')
+    def test_non_unique_app_slug(self):
+        self.login_as(user=self.user)
+        self.create_sentry_app(name='MyApp')
+        response = self._post()
+        assert response.status_code == 422
+        assert response.data == \
+            {"name": ["Name MyApp is already taken, please use another."]}
+
+    @with_feature('organizations:sentry-apps')
     def test_cannot_create_app_without_correct_permissions(self):
         self.login_as(user=self.user)
         kwargs = {'scopes': ('project:read',)}

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -132,12 +132,17 @@ class PostSentryAppsTest(SentryAppsTest):
 
     @with_feature('organizations:sentry-apps')
     def test_non_unique_app_slug(self):
+        from sentry.mediators import sentry_apps
         self.login_as(user=self.user)
-        self.create_sentry_app(name='MyApp')
-        response = self._post()
+        sentry_app = self.create_sentry_app(
+            name='Foo Bar',
+            organization=self.org,
+        )
+        sentry_apps.Destroyer.run(sentry_app=sentry_app)
+        response = self._post(**{'name': sentry_app.name})
         assert response.status_code == 422
         assert response.data == \
-            {"name": ["Name MyApp is already taken, please use another."]}
+            {"name": ["Name Foo Bar is already taken, please use another."]}
 
     @with_feature('organizations:sentry-apps')
     def test_cannot_create_app_without_correct_permissions(self):


### PR DESCRIPTION
**Problem:** 
We don't show any validation errors when the name has already been taken (aka the slugified version of that name already exists). Since we soft delete sentry applications, this means we need to include those soft deleted slugs in the validation.

**Solution:**
Add a `with_delete` function to the base manager so we can include the apps that have been soft deleted.
Add the `NameField` validator that does the check and returns a `ValidationError` so users know what's going on. 