### PR TITLE
feat(ui): Remove "sentry 10" alert message [SEN-415]

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.jsx
@@ -20,7 +20,6 @@ import {
   updateParamsWithoutHistory,
   updateProjects,
 } from 'app/actionCreators/globalSelection';
-import AlertActions from 'app/actions/alertActions';
 import BackToIssues from 'app/components/organizations/backToIssues';
 import Header from 'app/components/organizations/header';
 import HeaderItemPosition from 'app/components/organizations/headerItemPosition';
@@ -101,21 +100,6 @@ class GlobalSelectionHeader extends React.Component {
   componentDidMount() {
     if (this.props.hasCustomRouting) {
       return;
-    }
-
-    const hasSentry10 = new Set(this.props.organization.features).has('sentry10');
-
-    if (hasSentry10) {
-      AlertActions.addAlert({
-        message:
-          'Hi! You are seeing some new changes to Sentry which we are rolling out. Click to read more.',
-        type: 'info',
-        url:
-          'https://forum.sentry.io/t/new-product-changes-now-available-for-preview/5805',
-        neverExpire: true,
-        noDuplicates: true,
-        id: 'visibility-changes-alert-message',
-      });
     }
 
     const hasMultipleProjectFeature = this.hasMultipleProjectSelection();


### PR DESCRIPTION
Remove the sentry10 alert message that pointed users to forum post. Not really needed anymore and there is a bug that it always expires after a week.

Fixes SEN-415