### PR TITLE
fix(grouping): Fix an error with grouping infos

### DIFF
--- a/src/sentry/static/sentry/app/components/events/groupingInfo.jsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo.jsx
@@ -159,10 +159,10 @@ class GroupVariant extends React.Component {
         break;
       case 'custom-fingerprint':
         data.push(['Fingerprint values', variant.values]);
-        data.push(['Grouping Config', variant.config.id]);
         break;
       case 'salted-component':
         data.push(['Fingerprint values', variant.values]);
+        data.push(['Grouping Config', variant.config.id]);
         component = variant.component;
         break;
       default:


### PR DESCRIPTION
The UI code incorrectly accessed an attribute of the config that was unset
for fingerprinted variants.  The line of code was incorrectly moved to the
wrong location.