### PR TITLE
fix(seach): Ensure an `aggregated_def` is not a user-created tag

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -251,8 +251,7 @@ class SearchVisitor(NodeVisitor):
             SearchValue(value),
         )
 
-    def visit_numeric_filter(self, node, xxx_todo_changeme):
-        (search_key, _, operator, search_value) = xxx_todo_changeme
+    def visit_numeric_filter(self, node, (search_key, _, operator, search_value)):
         operator = operator[0] if not isinstance(operator, Node) else '='
 
         if search_key.name in self.numeric_keys:
@@ -267,8 +266,7 @@ class SearchVisitor(NodeVisitor):
             )
             return self._handle_basic_filter(search_key, '=', search_value)
 
-    def visit_time_filter(self, node, xxx_todo_changeme1):
-        (search_key, _, operator, search_value) = xxx_todo_changeme1
+    def visit_time_filter(self, node, (search_key, _, operator, search_value)):
         if search_key.name in self.date_keys:
             try:
                 search_value = parse_datetime_string(search_value)
@@ -279,8 +277,7 @@ class SearchVisitor(NodeVisitor):
             search_value = operator + search_value if operator != '=' else search_value
             return self._handle_basic_filter(search_key, '=', SearchValue(search_value))
 
-    def visit_rel_time_filter(self, node, xxx_todo_changeme2):
-        (search_key, _, value) = xxx_todo_changeme2
+    def visit_rel_time_filter(self, node, (search_key, _, value)):
         if search_key.name in self.date_keys:
             try:
                 from_val, to_val = parse_datetime_range(value.text)
@@ -298,11 +295,10 @@ class SearchVisitor(NodeVisitor):
         else:
             return self._handle_basic_filter(search_key, '=', SearchValue(value.text))
 
-    def visit_specific_time_filter(self, node, xxx_todo_changeme3):
+    def visit_specific_time_filter(self, node, (search_key, _, date_value)):
         # If we specify a specific date, it means any event on that day, and if
         # we specify a specific datetime then it means a few minutes interval
         # on either side of that datetime
-        (search_key, _, date_value) = xxx_todo_changeme3
         if search_key.name not in self.date_keys:
             return self._handle_basic_filter(search_key, '=', SearchValue(date_value))
 
@@ -342,8 +338,7 @@ class SearchVisitor(NodeVisitor):
 
         return node.text == '!'
 
-    def visit_basic_filter(self, node, xxx_todo_changeme4):
-        (negation, search_key, _, search_value) = xxx_todo_changeme4
+    def visit_basic_filter(self, node, (negation, search_key, _, search_value)):
         operator = '!=' if self.is_negated(negation) else '='
         return self._handle_basic_filter(search_key, operator, search_value)
 

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -251,7 +251,8 @@ class SearchVisitor(NodeVisitor):
             SearchValue(value),
         )
 
-    def visit_numeric_filter(self, node, (search_key, _, operator, search_value)):
+    def visit_numeric_filter(self, node, xxx_todo_changeme):
+        (search_key, _, operator, search_value) = xxx_todo_changeme
         operator = operator[0] if not isinstance(operator, Node) else '='
 
         if search_key.name in self.numeric_keys:
@@ -266,7 +267,8 @@ class SearchVisitor(NodeVisitor):
             )
             return self._handle_basic_filter(search_key, '=', search_value)
 
-    def visit_time_filter(self, node, (search_key, _, operator, search_value)):
+    def visit_time_filter(self, node, xxx_todo_changeme1):
+        (search_key, _, operator, search_value) = xxx_todo_changeme1
         if search_key.name in self.date_keys:
             try:
                 search_value = parse_datetime_string(search_value)
@@ -277,7 +279,8 @@ class SearchVisitor(NodeVisitor):
             search_value = operator + search_value if operator != '=' else search_value
             return self._handle_basic_filter(search_key, '=', SearchValue(search_value))
 
-    def visit_rel_time_filter(self, node, (search_key, _, value)):
+    def visit_rel_time_filter(self, node, xxx_todo_changeme2):
+        (search_key, _, value) = xxx_todo_changeme2
         if search_key.name in self.date_keys:
             try:
                 from_val, to_val = parse_datetime_range(value.text)
@@ -295,10 +298,11 @@ class SearchVisitor(NodeVisitor):
         else:
             return self._handle_basic_filter(search_key, '=', SearchValue(value.text))
 
-    def visit_specific_time_filter(self, node, (search_key, _, date_value)):
+    def visit_specific_time_filter(self, node, xxx_todo_changeme3):
         # If we specify a specific date, it means any event on that day, and if
         # we specify a specific datetime then it means a few minutes interval
         # on either side of that datetime
+        (search_key, _, date_value) = xxx_todo_changeme3
         if search_key.name not in self.date_keys:
             return self._handle_basic_filter(search_key, '=', SearchValue(date_value))
 
@@ -338,7 +342,8 @@ class SearchVisitor(NodeVisitor):
 
         return node.text == '!'
 
-    def visit_basic_filter(self, node, (negation, search_key, _, search_value)):
+    def visit_basic_filter(self, node, xxx_todo_changeme4):
+        (negation, search_key, _, search_value) = xxx_todo_changeme4
         operator = '!=' if self.is_negated(negation) else '='
         return self._handle_basic_filter(search_key, operator, search_value)
 

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -415,7 +415,9 @@ def snuba_search(start, end, project_ids, environment_ids, sort_field,
         ):
             continue
         converted_filter = convert_search_filter_to_snuba_query(search_filter)
-        if search_filter.key.name in aggregation_defs:
+
+        # Ensure that no user-generated tags that clashes with aggregation_defs is added to having
+        if search_filter.key.name in aggregation_defs and not search_filter.key.is_tag:
             having.append(converted_filter)
         else:
             conditions.append(converted_filter)

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -500,10 +500,27 @@ class SnubaSearchTest(SnubaTestCase):
 
     def test_search_filter_query_with_custom_priority_tag_and_priority_sort(self):
         priority = 'high'
+        for i in range(1, 10):
+            self.store_event(
+                data={
+                    'fingerprint': ['put-me-in-group1'],
+                    'timestamp': (self.group2.last_seen + timedelta(days=i)).isoformat()[:19],
+                    'stacktrace': {
+                        'frames': [{
+                            'module': 'group1'
+                        }]
+                    },
+                    'message': 'group1',
+                    'tags': {
+                        'priority': priority,
+                    },
+                },
+                project_id=self.project.id,
+            )
         self.store_event(
             data={
                 'fingerprint': ['put-me-in-group2'],
-                'timestamp': (self.group2.first_seen + timedelta(days=1)).isoformat()[:19],
+                'timestamp': (self.group2.last_seen + timedelta(days=2)).isoformat()[:19],
                 'stacktrace': {
                     'frames': [{
                         'module': 'group2'
@@ -516,38 +533,12 @@ class SnubaSearchTest(SnubaTestCase):
             },
             project_id=self.project.id,
         )
-        self.store_event(
-            data={
-                'fingerprint': ['put-me-in-group1'],
-                'timestamp': (self.group1.first_seen + timedelta(days=1)).isoformat()[:19],
-                'stacktrace': {
-                    'frames': [{
-                        'module': 'group1'
-                    }]
-                },
-                'message': 'group1',
-                'tags': {
-                    'priority': priority,
-                },
-            },
-            project_id=self.project.id,
-        )
-
-        self.group1.times_seen = 6
-        self.group2.times_seen = 3
-        self.group1.save()
-        self.group2.save()
-
-        group1_score = Group.calculate_score(self.group1.times_seen, self.group1.last_seen)
-        group2_score = Group.calculate_score(self.group2.times_seen, self.group2.last_seen)
-        assert group1_score > group2_score
-
         results = self.make_query(
             search_filter_query='priority:%s' % priority,
             tags={'priority': priority},
             sort_by='priority',
         )
-        assert set(results) == set([self.group1, self.group2])
+        assert list(results) == [self.group1, self.group2]
 
     def test_project(self):
         results = self.make_query([self.create_project(name='other')])

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -500,7 +500,7 @@ class SnubaSearchTest(SnubaTestCase):
 
     def test_search_filter_query_with_custom_priority_tag_and_priority_sort(self):
         priority = 'high'
-        for i in range(1, 10):
+        for i in range(1, 3):
             self.store_event(
                 data={
                     'fingerprint': ['put-me-in-group1'],


### PR DESCRIPTION
If a user has a custom tag name `priority` and entered `priority:high` in the search box, the result would be a `500`. This is because `priority` is also the name of a possible aggregation that could clash with this. This PR adds a check to ensure that a user-created tag is not treated as a reserved word for an aggregation.  