### PR TITLE
feat(grouping): Update event grouping path to include project

### DIFF
--- a/src/sentry/api/endpoints/event_grouping_info.py
+++ b/src/sentry/api/endpoints/event_grouping_info.py
@@ -4,18 +4,15 @@ import six
 
 from django.http import HttpResponse
 
-from sentry.api.base import Endpoint
-from sentry.api.bases.group import GroupPermission
+from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.grouping.api import ConfigNotFoundException
 from sentry.models import Event
 from sentry.utils import json
 
 
-class EventGroupingInfoEndpoint(Endpoint):
-    permission_classes = (GroupPermission, )
-
-    def get(self, request, event_id):
+class EventGroupingInfoEndpoint(ProjectEndpoint):
+    def get(self, request, project, event_id):
         """
         Returns the grouping information for an event
         `````````````````````````````````````````````
@@ -23,11 +20,9 @@ class EventGroupingInfoEndpoint(Endpoint):
         This endpoint returns a JSON dump of the metadata that went into the
         grouping algorithm.
         """
-        event = Event.objects.from_event_id(event_id, project_id=None)
+        event = Event.objects.from_event_id(event_id, project_id=project.id)
         if event is None:
             raise ResourceDoesNotExist
-
-        self.check_object_permissions(request, event.group)
 
         Event.objects.bind_nodes([event], 'data')
 

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -864,6 +864,11 @@ urlpatterns = patterns(
         name='sentry-api-0-project-event-details'
     ),
     url(
+        r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/events/(?P<event_id>[\w-]+)/grouping-info/$',
+        EventGroupingInfoEndpoint.as_view(),
+        name='sentry-api-0-event-grouping-info'
+    ),
+    url(
         r'^projects/(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/events/(?P<event_id>[\w-]+)/attachments/$',
         EventAttachmentsEndpoint.as_view(),
         name='sentry-api-0-event-attachments'
@@ -1235,11 +1240,6 @@ urlpatterns = patterns(
         r'^events/(?P<event_id>\d+)/apple-crash-report$',
         EventAppleCrashReportEndpoint.as_view(),
         name='sentry-api-0-event-apple-crash-report'
-    ),
-    url(
-        r'^events/(?P<event_id>\d+)/grouping-info/$',
-        EventGroupingInfoEndpoint.as_view(),
-        name='sentry-api-0-event-grouping-info'
     ),
 
     # Sentry Apps

--- a/src/sentry/static/sentry/app/components/events/groupingInfo.jsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo.jsx
@@ -12,7 +12,7 @@ import SentryTypes from 'app/sentryTypes';
 import {t} from 'app/locale';
 import KeyValueList from 'app/components/events/interfaces/keyValueList';
 
-import withApi from 'app/utils/withApi';
+import withOrganization from 'app/utils/withOrganization';
 
 const GroupVariantList = styled('ul')`
   padding: 0;
@@ -247,12 +247,16 @@ class GroupingConfigSelect extends AsyncComponent {
 class EventGroupingInfo extends AsyncComponent {
   static propTypes = {
     api: PropTypes.object,
+    organization: SentryTypes.Organization.isRequired,
     group: SentryTypes.Group.isRequired,
     event: SentryTypes.Event.isRequired,
   };
 
   getEndpoints() {
-    let path = `/events/${this.props.event.id}/grouping-info/`;
+    const {organization, group, event} = this.props;
+
+    let path = `/projects/${organization.slug}/${group.project
+      .slug}/events/${event.id}/grouping-info/`;
     if (this.state && this.state.configOverride) {
       path = `${path}?config=${this.state.configOverride}`;
     }
@@ -365,4 +369,4 @@ class EventGroupingInfo extends AsyncComponent {
   }
 }
 
-export default withApi(EventGroupingInfo);
+export default withOrganization(EventGroupingInfo);


### PR DESCRIPTION
We'll need to have a project specified in order to get the event
grouping when using event_ids instead of database ids.