### PR TITLE
fix: Update field name to match broadcast serializer

### DIFF
--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -152,7 +152,7 @@ class BroadcastIndexEndpoint(Endpoint):
                 message=result['message'],
                 link=result['link'],
                 is_active=result.get('isActive') or False,
-                date_expires=result.get('expiresAt'),
+                date_expires=result.get('dateExpires'),
             )
             logger.info('broadcasts.create', extra={
                 'ip_address': request.META['REMOTE_ADDR'],


### PR DESCRIPTION
Mismatched field name means we haven't been capturing any[ end dates/expiration dates](https://redash.getsentry.net/queries/1539/source) for broadcasts. 