### PR TITLE
fix(stream): resolve prop type warning on old stream

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -684,8 +684,9 @@ const Stream = createReactClass({
     const project = this.getProject();
 
     // for compatibility with new filters/stream component
+
     const selection = {
-      projects: [project.id],
+      projects: [parseInt(project.id, 10)],
       environments: this.state.environment ? [this.state.environment.name] : [],
       datetime: {start: null, end: null, period: null, utc: null},
     };


### PR DESCRIPTION
Found this while testing views that don't have the new header.

![image](https://user-images.githubusercontent.com/435981/54968218-1e338800-4f37-11e9-9c10-410734ecb4f4.png)
