### PR TITLE
fix: Skip null values in keyvaluelist

### DIFF
--- a/src/sentry/data/samples/javascript.json
+++ b/src/sentry/data/samples/javascript.json
@@ -217,16 +217,6 @@
             "name": "Chrome"
         }
     },
-    "sentry.interfaces.Http": {
-        "url": "https://sentry.io/sentry/sentry/issues/231/",
-        "query_string": "foo=bar&bam=baz",
-        "headers": [
-            [
-                "User-Agent",
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36"
-            ]
-        ]
-    },
     "sentry.interfaces.User": {
         "ip_address": "127.0.0.1",
         "email": "mail@example.org",

--- a/src/sentry/static/sentry/app/components/events/interfaces/keyValueList.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/keyValueList.jsx
@@ -28,6 +28,8 @@ class KeyValueList extends React.Component {
       data = [];
     } else if (!(data instanceof Array)) {
       data = Object.keys(data).map(key => [key, data[key]]);
+    } else {
+      data = data.filter(kv => kv !== null);
     }
 
     data = this.props.isSorted ? _.sortBy(data, [([key]) => key]) : data;

--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -146,13 +146,13 @@ def load_data(platform, default=None, sample_name=None):
     # XXX: Message is a legacy alias for logentry. Do not overwrite if set.
     if 'message' not in data:
         data['message'] = 'This is an example %s exception' % (sample_name or platform, )
-    data['user'] = generate_user(
+    data.setdefault('user', generate_user(
         ip_address='127.0.0.1',
         username='sentry',
         id=1,
         email='sentry@example.com',
-    )
-    data['extra'] = {
+    ))
+    data.setdefault('extra', {
         'session': {
             'foo': 'bar',
         },
@@ -162,11 +162,11 @@ def load_data(platform, default=None, sample_name=None):
         'length': 10837790,
         'unauthorized': False,
         'url': 'http://example.org/foo/bar/',
-    }
-    data['modules'] = {
+    })
+    data.setdefault('modules', {
         'my.package': '1.0.0',
-    }
-    data['request'] = {
+    })
+    data.setdefault('request', {
         "cookies": 'foo=bar;biz=baz',
         "url": "http://example.com/foo",
         "headers": {
@@ -183,7 +183,7 @@ def load_data(platform, default=None, sample_name=None):
         "query_string": "foo=bar",
         "data": '{"hello": "world"}',
         "method": "GET"
-    }
+    })
 
     return data
 


### PR DESCRIPTION
This is a continuation of #12436. Previously we would forcibly overwrite the query string interface in samples, so the test was entirely broken. Fix it for real this time.

Fix JAVASCRIPT-5S5