### PR TITLE
ref(app-platform): Update service hook events when sentry app events change

### DIFF
--- a/src/sentry/mediators/sentry_apps/updater.py
+++ b/src/sentry/mediators/sentry_apps/updater.py
@@ -7,7 +7,7 @@ from sentry.coreapi import APIError
 
 from sentry.constants import SentryAppStatus
 from sentry.mediators import Mediator, Param
-from sentry.mediators.service_hooks import Updater as ServiceHookUpdater
+from sentry.mediators import service_hooks
 from sentry.mediators.param import if_param
 from sentry.models import SentryAppComponent, ServiceHook
 from sentry.models.sentryapp import REQUIRED_EVENT_PERMISSIONS
@@ -62,7 +62,7 @@ class Updater(Mediator):
     def _update_service_hook_events(self):
         hooks = ServiceHook.objects.filter(application=self.sentry_app.application)
         for hook in hooks:
-            ServiceHookUpdater.run(service_hook=hook, events=self.events)
+            service_hooks.Updater.run(service_hook=hook, events=self.events)
 
     @if_param('webhook_url')
     def _update_webhook_url(self):

--- a/src/sentry/mediators/sentry_apps/updater.py
+++ b/src/sentry/mediators/sentry_apps/updater.py
@@ -7,8 +7,9 @@ from sentry.coreapi import APIError
 
 from sentry.constants import SentryAppStatus
 from sentry.mediators import Mediator, Param
+from sentry.mediators.service_hooks import Updater as ServiceHookUpdater
 from sentry.mediators.param import if_param
-from sentry.models import SentryAppComponent
+from sentry.models import SentryAppComponent, ServiceHook
 from sentry.models.sentryapp import REQUIRED_EVENT_PERMISSIONS
 
 
@@ -56,6 +57,12 @@ class Updater(Mediator):
 
         from sentry.mediators.service_hooks.creator import expand_events
         self.sentry_app.events = expand_events(self.events)
+        self._update_service_hook_events()
+
+    def _update_service_hook_events(self):
+        hooks = ServiceHook.objects.filter(application=self.sentry_app.application)
+        for hook in hooks:
+            ServiceHookUpdater.run(service_hook=hook, events=self.events)
 
     @if_param('webhook_url')
     def _update_webhook_url(self):

--- a/src/sentry/mediators/service_hooks/updater.py
+++ b/src/sentry/mediators/service_hooks/updater.py
@@ -6,6 +6,7 @@ from collections import Iterable
 
 from sentry.mediators import Mediator, Param
 from sentry.mediators.param import if_param
+from sentry.mediators.service_hooks.creator import expand_events
 
 
 class Updater(Mediator):
@@ -21,6 +22,7 @@ class Updater(Mediator):
         self._update_actor()
         self._update_events()
         self._update_url()
+        self.service_hook.save()
         return self.service_hook
 
     @if_param('application')
@@ -33,7 +35,7 @@ class Updater(Mediator):
 
     @if_param('events')
     def _update_events(self):
-        self.service_hook.events = self.events
+        self.service_hook.events = expand_events(self.events)
 
     @if_param('url')
     def _update_url(self):

--- a/tests/sentry/mediators/sentry_apps/test_updater.py
+++ b/tests/sentry/mediators/sentry_apps/test_updater.py
@@ -60,6 +60,7 @@ class TestUpdater(TestCase):
             name='sentry',
             organization=self.org,
             scopes=('project:read', 'event:read',),
+            events=('event.alert',),
         )
         self.create_sentry_app_installation(slug='sentry')
         updater = Updater(sentry_app=sentry_app, events=('issue',))

--- a/tests/sentry/mediators/sentry_apps/test_updater.py
+++ b/tests/sentry/mediators/sentry_apps/test_updater.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import
 
 from sentry.coreapi import APIError
 from sentry.mediators.sentry_apps import Updater
-from sentry.models import SentryAppComponent
+from sentry.mediators.service_hooks.creator import expand_events
+from sentry.models import SentryAppComponent, ServiceHook
 from sentry.testutils import TestCase
 
 
@@ -53,6 +54,19 @@ class TestUpdater(TestCase):
         updater.events = ('issue',)
         with self.assertRaises(APIError):
             updater.call()
+
+    def test_updates_service_hook_events(self):
+        sentry_app = self.create_sentry_app(
+            name='sentry',
+            organization=self.org,
+            scopes=('project:read', 'event:read',),
+        )
+        self.create_sentry_app_installation(slug='sentry')
+        updater = Updater(sentry_app=sentry_app, events=('issue',))
+        updater.call()
+        assert set(sentry_app.events) == expand_events(['issue'])
+        service_hook = ServiceHook.objects.filter(application=sentry_app.application)[0]
+        assert set(service_hook.events) == expand_events(['issue'])
 
     def test_updates_webhook_url(self):
         self.updater.webhook_url = 'http://example.com/hooks'


### PR DESCRIPTION
Service hooks get created when a user installs a sentry app, but if the owner of the app decides to update the events, we don't actually update the service hooks to do so. This PR does so.

As a follow up, since adding new events could mean adding new permissions, I think we'll need to handle letting the app users (the organizations that have the app installed) that the permissions have changed/give them a way to accept these permissions changes. 