### PR TITLE
fix(issue-diff): Remove reference to invalid URL

### DIFF
--- a/src/sentry/static/sentry/app/components/issueDiff.jsx
+++ b/src/sentry/static/sentry/app/components/issueDiff.jsx
@@ -92,10 +92,6 @@ class IssueDiff extends React.Component {
   }
 
   getEndpoint(issueId, eventId) {
-    if (eventId !== 'latest') {
-      return `/events/${eventId}/`;
-    }
-
     return `/issues/${issueId}/events/${eventId}/`;
   }
 


### PR DESCRIPTION
`/events/latest/` is not a valid URL, the correct URL for the latest
event in a group is `/issues/:issueId/events/latest/`