### PR TITLE
fix(perf) Don't fetch organization details twice

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -64,16 +64,16 @@ const OrganizationContext = createReactClass({
     this.fetchData();
   },
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     const hasOrgIdAndChanged =
-      nextProps.params.orgId &&
+      prevProps.params.orgId &&
       this.props.params.orgId &&
-      nextProps.params.orgId !== this.props.params.orgId;
+      prevProps.params.orgId !== this.props.params.orgId;
 
     if (
       hasOrgIdAndChanged ||
-      nextProps.location.state === 'refresh' ||
-      this.props.organizations !== nextProps.organizations
+      prevProps.organizationsLoading !== this.props.organizationsLoading ||
+      (this.props.location.state === 'refresh' && prevProps.location.state !== 'refresh')
     ) {
       this.remountComponent();
     }


### PR DESCRIPTION
On a hard reload we were fetching organization details twice, which is expensive for large organizations. The first fetch would happen on mount, then when the withOrganizations() HOC resolved, it would update the `organizations` prop which would trigger another data load.

I've also moved this component away from the deprecated willReceiveProps to didUpdate so that future us has less work to do when the deprecated lifecycle methods are removed.

Fixes SEN-375