### PR TITLE
fix: Respect user notification settings when sending notifications related to issue owners. (SEN-411)

### DIFF
--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -136,13 +136,16 @@ class NotificationPlugin(Plugin):
     def notify_about_activity(self, activity):
         pass
 
+    @property
+    def alert_option_key(self):
+        return '%s:alert' % self.get_conf_key()
+
     def get_sendable_users(self, project):
         """
         Return a collection of user IDs that are eligible to receive
         notifications for the provided project.
         """
-        user_option = '%s:alert' % self.get_conf_key()
-        return project.get_notification_recipients(user_option)
+        return project.get_notification_recipients(self.alert_option_key)
 
     def __is_rate_limited(self, group, event):
         return ratelimits.is_limited(


### PR DESCRIPTION
Whenever we send a notification for an event we check whether there is ownership information for the project, and whether it relates to the event. If it does, then we go down a different path to decide
which users to send notifications to. This path doesn't check the user's notification preferences
for the project.

This looks like it has been broken ever since we first implemented issue owners. We've heard more
reports of it recently, possibly we actually configured issue ownership for various projects in our
org.

Fix the issue by checking the user's alert settings and filtering out users that have alerts
disabled for the given project.