### PR TITLE
ref(releases): Added tests to all release serializers.

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-
+import unittest
 from mock import patch
 from datetime import datetime
 from django.core.urlresolvers import reverse
@@ -8,7 +8,7 @@ from sentry.constants import VERSION_LENGTH
 from sentry.models import (
     Activity, Environment, File, Release, ReleaseCommit, ReleaseFile, ReleaseProject, ReleaseProjectEnvironment, Repository
 )
-from sentry.testutils import APITestCase, TestCase
+from sentry.testutils import APITestCase
 from sentry.api.endpoints.organization_release_details import ReleaseSerializer
 
 
@@ -682,8 +682,9 @@ class ReleaseDeleteTest(APITestCase):
         assert response.data == {'commits': ['id: This field is required.']}
 
 
-class ReleaseSerializerTest(TestCase):
+class ReleaseSerializerTest(unittest.TestCase):
     def setUp(self):
+        super(ReleaseSerializerTest, self).setUp()
         self.repo_name = 'repo/name'
         self.repo2_name = 'repo2/name'
         self.commits = [{'id': 'a' * 40}, {'id': 'b' * 40}]

--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -4,10 +4,12 @@ from mock import patch
 from datetime import datetime
 from django.core.urlresolvers import reverse
 
+from sentry.constants import VERSION_LENGTH
 from sentry.models import (
     Activity, Environment, File, Release, ReleaseCommit, ReleaseFile, ReleaseProject, ReleaseProjectEnvironment, Repository
 )
-from sentry.testutils import APITestCase
+from sentry.testutils import APITestCase, TestCase
+from sentry.api.endpoints.organization_release_details import ReleaseSerializer
 
 
 class ReleaseDetailsTest(APITestCase):
@@ -678,3 +680,89 @@ class ReleaseDeleteTest(APITestCase):
         )
         assert response.status_code == 400
         assert response.data == {'commits': ['id: This field is required.']}
+
+
+class ReleaseSerializerTest(TestCase):
+    def setUp(self):
+        self.repo_name = 'repo/name'
+        self.repo2_name = 'repo2/name'
+        self.commits = [{'id': 'a' * 40}, {'id': 'b' * 40}]
+        self.ref = 'master'
+        self.url = 'https://example.com'
+        self.dateReleased = '1000-10-10T06:06'
+        self.headCommits = [
+            {
+                'currentId': '0' * 40,
+                'repository': self.repo_name
+            },
+            {
+                'currentId': '0' * 40,
+                'repository': self.repo2_name
+            },
+        ]
+        self.refs = [
+            {
+                'commit': 'a' * 40,
+                'previousCommit': '',
+                'repository': self.repo_name
+            },
+            {
+                'commit': 'b' * 40,
+                'previousCommit': '',
+                'repository': self.repo2_name
+            },
+        ]
+
+    def test_simple(self):
+        serializer = ReleaseSerializer(data={
+            'ref': self.ref,
+            'url': self.url,
+            'dateReleased': self.dateReleased,
+            'commits': self.commits,
+            'headCommits': self.headCommits,
+            'refs': self.refs,
+        })
+
+        assert serializer.is_valid()
+        assert sorted(serializer.fields.keys()) == sorted(
+            ['ref', 'url', 'dateReleased', 'commits', 'headCommits', 'refs'])
+
+        result = serializer.object
+        assert result['ref'] == self.ref
+        assert result['url'] == self.url
+        assert result['dateReleased'] == datetime(1000, 10, 10, 6, 6)
+        assert result['commits'] == self.commits
+        assert result['headCommits'] == self.headCommits
+        assert result['refs'] == self.refs
+
+    def test_fields_not_required(self):
+        serializer = ReleaseSerializer(data={})
+        assert serializer.is_valid()
+
+    def test_do_not_allow_null_commits(self):
+        serializer = ReleaseSerializer(data={
+            'commits': None,
+        })
+        assert not serializer.is_valid()
+
+    def test_do_not_allow_null_head_commits(self):
+        serializer = ReleaseSerializer(data={
+            'headCommits': None,
+        })
+        assert not serializer.is_valid()
+
+    def test_do_not_allow_null_refs(self):
+        serializer = ReleaseSerializer(data={
+            'refs': None,
+        })
+        assert not serializer.is_valid()
+
+    def test_ref_limited_by_max_version_length(self):
+        serializer = ReleaseSerializer(data={
+            'ref': 'a' * VERSION_LENGTH,
+        })
+        assert serializer.is_valid()
+        serializer = ReleaseSerializer(data={
+            'ref': 'a' * (VERSION_LENGTH + 1),
+        })
+        assert not serializer.is_valid()

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -10,10 +10,13 @@ from datetime import (
 from django.core.urlresolvers import reverse
 from exam import fixture
 
+from sentry.api.endpoints.organization_releases import ReleaseSerializerWithProjects
+from sentry.constants import VERSION_LENGTH
 from sentry.models import (
     Activity,
     ApiKey,
     ApiToken,
+    BAD_RELEASE_CHARS,
     Commit,
     CommitAuthor,
     CommitFileChange,
@@ -26,7 +29,7 @@ from sentry.models import (
     Repository,
 )
 from sentry.plugins.providers.dummy.repository import DummyRepositoryProvider
-from sentry.testutils import APITestCase, ReleaseCommitPatchTest, SetRefsTestCase
+from sentry.testutils import APITestCase, ReleaseCommitPatchTest, SetRefsTestCase, TestCase
 
 
 class OrganizationReleaseListTest(APITestCase):
@@ -1343,3 +1346,156 @@ class OrganizationReleaseCreateCommitPatch(ReleaseCommitPatchTest):
         self.assert_file_change(file_changes[1], 'A', 'templates/goodbye.html', commits[1].id)
         self.assert_file_change(file_changes[2], 'M', 'templates/hello.html', commits[1].id)
         self.assert_file_change(file_changes[3], 'D', 'templates/hola.html', commits[0].id)
+
+
+class ReleaseSerializerWithProjectsTest(TestCase):
+    def setUp(self):
+        self.version = '1234567890'
+        self.repo_name = 'repo/name'
+        self.repo2_name = 'repo2/name'
+        self.commits = [{'id': 'a' * 40}, {'id': 'b' * 40}]
+        self.ref = 'master'
+        self.url = 'https://example.com'
+        self.dateReleased = '1000-10-10T06:06'
+        self.headCommits = [
+            {
+                'currentId': '0' * 40,
+                'repository': self.repo_name
+            },
+            {
+                'currentId': '0' * 40,
+                'repository': self.repo2_name
+            },
+        ]
+        self.refs = [
+            {
+                'commit': 'a' * 40,
+                'previousCommit': '',
+                'repository': self.repo_name
+            },
+            {
+                'commit': 'b' * 40,
+                'previousCommit': '',
+                'repository': self.repo2_name
+            },
+        ]
+        self.projects = ['project_slug', 'project2_slug']
+
+    def test_simple(self):
+        serializer = ReleaseSerializerWithProjects(data={
+            'version': self.version,
+            'owner': self.user.username,
+            'ref': self.ref,
+            'url': self.url,
+            'dateReleased': self.dateReleased,
+            'commits': self.commits,
+            'headCommits': self.headCommits,
+            'refs': self.refs,
+            'projects': self.projects,
+        })
+
+        assert serializer.is_valid()
+        assert sorted(serializer.fields.keys()) == sorted(
+            ['version', 'owner', 'ref', 'url', 'dateReleased', 'commits', 'headCommits', 'refs', 'projects'])
+        result = serializer.object
+        assert result['version'] == self.version
+        assert result['owner'] == self.user
+        assert result['ref'] == self.ref
+        assert result['url'] == self.url
+        assert result['dateReleased'] == datetime(1000, 10, 10, 6, 6)
+        assert result['commits'] == self.commits
+        assert result['headCommits'] == self.headCommits
+        assert result['refs'] == self.refs
+        assert result['projects'] == self.projects
+
+    def test_fields_not_required(self):
+        serializer = ReleaseSerializerWithProjects(data={
+            'version': self.version,
+            'projects': self.projects,
+        })
+        assert serializer.is_valid()
+        result = serializer.object
+        assert result['version'] == self.version
+        assert result['projects'] == self.projects
+
+    def test_do_not_allow_null_commits(self):
+        serializer = ReleaseSerializerWithProjects(data={
+            'version': self.version,
+            'projects': self.projects,
+            'commits': None,
+        })
+        assert not serializer.is_valid()
+
+    def test_do_not_allow_null_head_commits(self):
+        serializer = ReleaseSerializerWithProjects(data={
+            'version': self.version,
+            'projects': self.projects,
+            'headCommits': None,
+        })
+        assert not serializer.is_valid()
+
+    def test_do_not_allow_null_refs(self):
+        serializer = ReleaseSerializerWithProjects(data={
+            'version': self.version,
+            'projects': self.projects,
+            'refs': None,
+        })
+        assert not serializer.is_valid()
+
+    def test_ref_limited_by_max_version_length(self):
+        serializer = ReleaseSerializerWithProjects(data={
+            'version': self.version,
+            'projects': self.projects,
+            'ref': 'a' * VERSION_LENGTH,
+        })
+        assert serializer.is_valid()
+        serializer = ReleaseSerializerWithProjects(data={
+            'version': self.version,
+            'projects': self.projects,
+            'ref': 'a' * (VERSION_LENGTH + 1),
+        })
+        assert not serializer.is_valid()
+
+    def test_version_limited_by_max_version_length(self):
+        serializer = ReleaseSerializerWithProjects(data={
+            'version': 'a' * VERSION_LENGTH,
+            'projects': self.projects,
+        })
+        assert serializer.is_valid()
+        serializer = ReleaseSerializerWithProjects(data={
+            'version': 'a' * (VERSION_LENGTH + 1),
+            'projects': self.projects,
+        })
+        assert not serializer.is_valid()
+
+    def test_version_does_not_allow_whitespace(self):
+        for char in BAD_RELEASE_CHARS:
+            serializer = ReleaseSerializerWithProjects(data={
+                'version': char,
+                'projects': self.projects,
+            })
+            assert not serializer.is_valid()
+
+    def test_version_does_not_allow_current_dir_path(self):
+        serializer = ReleaseSerializerWithProjects(data={
+            'version': '.',
+            'projects': self.projects,
+        })
+        assert not serializer.is_valid()
+        serializer = ReleaseSerializerWithProjects(data={
+            'version': '..',
+            'projects': self.projects,
+        })
+        assert not serializer.is_valid()
+
+    def test_version_does_not_allow_null_or_empty_value(self):
+        serializer = ReleaseSerializerWithProjects(data={
+            'version': None,
+            'projects': self.projects,
+        })
+        assert not serializer.is_valid()
+        serializer = ReleaseSerializerWithProjects(data={
+            'version': '',
+            'projects': self.projects,
+        })
+        assert not serializer.is_valid()

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -1350,6 +1350,7 @@ class OrganizationReleaseCreateCommitPatch(ReleaseCommitPatchTest):
 
 class ReleaseSerializerWithProjectsTest(TestCase):
     def setUp(self):
+        super(ReleaseSerializerWithProjectsTest, self).setUp()
         self.version = '1234567890'
         self.repo_name = 'repo/name'
         self.repo2_name = 'repo2/name'

--- a/tests/sentry/api/endpoints/test_project_release_details.py
+++ b/tests/sentry/api/endpoints/test_project_release_details.py
@@ -3,8 +3,10 @@ from __future__ import absolute_import
 from datetime import datetime
 from django.core.urlresolvers import reverse
 
+from sentry.api.endpoints.project_release_details import ReleaseSerializer
+from sentry.constants import VERSION_LENGTH
 from sentry.models import (Activity, File, Release, ReleaseCommit, ReleaseFile, ReleaseProject)
-from sentry.testutils import APITestCase
+from sentry.testutils import APITestCase, TestCase
 
 
 class ReleaseDetailsTest(APITestCase):
@@ -254,3 +256,48 @@ class ReleaseDeleteTest(APITestCase):
         assert response.status_code == 400, response.content
 
         assert Release.objects.filter(id=release.id).exists()
+
+
+class ReleaseSerializerTest(TestCase):
+    def setUp(self):
+        self.commits = [{'id': 'a' * 40}, {'id': 'b' * 40}]
+        self.ref = 'master'
+        self.url = 'https://example.com'
+        self.dateReleased = '1000-10-10T06:06'
+
+    def test_simple(self):
+        serializer = ReleaseSerializer(data={
+            'ref': self.ref,
+            'url': self.url,
+            'dateReleased': self.dateReleased,
+            'commits': self.commits,
+        })
+
+        assert serializer.is_valid()
+        assert sorted(serializer.fields.keys()) == sorted(['ref', 'url', 'dateReleased', 'commits'])
+
+        result = serializer.object
+        assert result['ref'] == self.ref
+        assert result['url'] == self.url
+        assert result['dateReleased'] == datetime(1000, 10, 10, 6, 6)
+        assert result['commits'] == self.commits
+
+    def test_fields_not_required(self):
+        serializer = ReleaseSerializer(data={})
+        assert serializer.is_valid()
+
+    def test_do_not_allow_null_commits(self):
+        serializer = ReleaseSerializer({
+            'commits': None,
+        })
+        assert not serializer.is_valid()
+
+    def test_ref_limited_by_max_version_length(self):
+        serializer = ReleaseSerializer(data={
+            'ref': 'a' * VERSION_LENGTH,
+        })
+        assert serializer.is_valid()
+        serializer = ReleaseSerializer(data={
+            'ref': 'a' * (VERSION_LENGTH + 1),
+        })
+        assert not serializer.is_valid()

--- a/tests/sentry/api/endpoints/test_project_release_details.py
+++ b/tests/sentry/api/endpoints/test_project_release_details.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import
-
+import unittest
 from datetime import datetime
 from django.core.urlresolvers import reverse
 
 from sentry.api.endpoints.project_release_details import ReleaseSerializer
 from sentry.constants import VERSION_LENGTH
 from sentry.models import (Activity, File, Release, ReleaseCommit, ReleaseFile, ReleaseProject)
-from sentry.testutils import APITestCase, TestCase
+from sentry.testutils import APITestCase
 
 
 class ReleaseDetailsTest(APITestCase):
@@ -258,8 +258,9 @@ class ReleaseDeleteTest(APITestCase):
         assert Release.objects.filter(id=release.id).exists()
 
 
-class ReleaseSerializerTest(TestCase):
+class ReleaseSerializerTest(unittest.TestCase):
     def setUp(self):
+        super(ReleaseSerializerTest, self).setUp()
         self.commits = [{'id': 'a' * 40}, {'id': 'b' * 40}]
         self.ref = 'master'
         self.url = 'https://example.com'

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -5,7 +5,10 @@ from django.utils import timezone
 from django.core.urlresolvers import reverse
 from exam import fixture
 
+from sentry.api.endpoints.project_releases import ReleaseSerializer
+from sentry.constants import VERSION_LENGTH
 from sentry.models import (
+    BAD_RELEASE_CHARS,
     CommitAuthor,
     CommitFileChange,
     Environment,
@@ -15,7 +18,7 @@ from sentry.models import (
     ReleaseProjectEnvironment,
     Repository,
 )
-from sentry.testutils import APITestCase, ReleaseCommitPatchTest
+from sentry.testutils import APITestCase, ReleaseCommitPatchTest, TestCase
 
 
 class ProjectReleaseListTest(APITestCase):
@@ -690,3 +693,97 @@ class ProjectReleaseCreateCommitPatch(ReleaseCommitPatchTest):
         assert response.status_code == 400
         assert response.data == {
             'commits': [u'patch_set: type: Commit patch_set type Z is not supported.']}
+
+
+class ReleaseSerializerTest(TestCase):
+    def setUp(self):
+        self.version = '1234567890'
+        self.repo_name = 'repo/name'
+        self.repo2_name = 'repo2/name'
+        self.commits = [{'id': 'a' * 40}, {'id': 'b' * 40}]
+        self.ref = 'master'
+        self.url = 'https://example.com'
+        self.dateReleased = '1000-10-10T06:06'
+
+    def test_simple(self):
+        serializer = ReleaseSerializer(data={
+            'version': self.version,
+            'owner': self.user.username,
+            'ref': self.ref,
+            'url': self.url,
+            'dateReleased': self.dateReleased,
+            'commits': self.commits,
+
+        })
+
+        assert serializer.is_valid()
+        assert sorted(serializer.fields.keys()) == sorted(
+            ['version', 'owner', 'ref', 'url', 'dateReleased', 'commits'])
+
+        result = serializer.object
+        assert result['version'] == self.version
+        assert result['owner'] == self.user
+        assert result['ref'] == self.ref
+        assert result['url'] == self.url
+        assert result['dateReleased'] == datetime(1000, 10, 10, 6, 6)
+        assert result['commits'] == self.commits
+
+    def test_fields_not_required(self):
+        serializer = ReleaseSerializer(data={'version': self.version})
+        assert serializer.is_valid()
+
+    def test_do_not_allow_null_commits(self):
+        serializer = ReleaseSerializer(data={
+            'version': self.version,
+            'commits': None,
+        })
+        assert not serializer.is_valid()
+
+    def test_ref_limited_by_max_version_length(self):
+        serializer = ReleaseSerializer(data={
+            'version': self.version,
+            'ref': 'a' * VERSION_LENGTH,
+        })
+        assert serializer.is_valid()
+        serializer = ReleaseSerializer(data={
+            'version': self.version,
+            'ref': 'a' * (VERSION_LENGTH + 1),
+        })
+        assert not serializer.is_valid()
+
+    def test_version_limited_by_max_version_length(self):
+        serializer = ReleaseSerializer(data={
+            'version': 'a' * VERSION_LENGTH,
+        })
+        assert serializer.is_valid()
+        serializer = ReleaseSerializer(data={
+            'version': 'a' * (VERSION_LENGTH + 1),
+        })
+        assert not serializer.is_valid()
+
+    def test_version_does_not_allow_whitespace(self):
+        for char in BAD_RELEASE_CHARS:
+            serializer = ReleaseSerializer(data={
+                'version': char,
+            })
+            assert not serializer.is_valid()
+
+    def test_version_does_not_allow_current_dir_path(self):
+        serializer = ReleaseSerializer(data={
+            'version': '.',
+        })
+        assert not serializer.is_valid()
+        serializer = ReleaseSerializer(data={
+            'version': '..',
+        })
+        assert not serializer.is_valid()
+
+    def test_version_does_not_allow_null_or_empty_value(self):
+        serializer = ReleaseSerializer(data={
+            'version': None,
+        })
+        assert not serializer.is_valid()
+        serializer = ReleaseSerializer(data={
+            'version': '',
+        })
+        assert not serializer.is_valid()

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -697,6 +697,7 @@ class ProjectReleaseCreateCommitPatch(ReleaseCommitPatchTest):
 
 class ReleaseSerializerTest(TestCase):
     def setUp(self):
+        super(ReleaseSerializerTest, self).setUp()
         self.version = '1234567890'
         self.repo_name = 'repo/name'
         self.repo2_name = 'repo2/name'


### PR DESCRIPTION
Adding these test as I'm preparing to unify the various `ReleaseSerializer`s in a central location. These tests are to hopefully ensure that no significant changes are made to the serializers.