### PR TITLE
fix(api): Fix discover saved queries with absolute date [SEN-421]

### DIFF
--- a/src/sentry/api/bases/discoversavedquery.py
+++ b/src/sentry/api/bases/discoversavedquery.py
@@ -15,7 +15,7 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
     )
     start = serializers.DateTimeField(required=False)
     end = serializers.DateTimeField(required=False)
-    range = serializers.CharField(required=False)
+    range = serializers.CharField(required=False, allow_none=True)
     fields = ListField(
         child=serializers.CharField(),
         required=False,


### PR DESCRIPTION
`range` needed `allow_none` otherwise was being forced into an empty string

Fixes SEN-421