### PR TITLE
fix(ui): Fix `logAjaxError` to handle promise rejections

### DIFF
--- a/src/sentry/static/sentry/app/utils/logging.jsx
+++ b/src/sentry/static/sentry/app/utils/logging.jsx
@@ -10,11 +10,13 @@ export function logException(ex, context) {
 }
 
 export function logAjaxError(error, context) {
-  const errorString = error.responseJSON
-    ? error.responseJSON.detail || JSON.stringify(error.responseJSON, null, 2)
-    : error.responseText ? error.responseText.substr(0, 255) : '<unknown response>'; // occassionally responseText is undefined
+  // Promises will reject with an error instead of response
+  const resp = error instanceof Error ? error.resp : error;
+  const errorString = resp.responseJSON
+    ? resp.responseJSON.detail || JSON.stringify(resp.responseJSON, null, 2)
+    : resp.responseText ? resp.responseText.substr(0, 255) : '<unknown response>'; // occassionally responseText is undefined
 
-  const message = `HTTP ${error.status}: ${errorString}`;
+  const message = `HTTP ${resp.status}: ${errorString}`;
   Sentry.withScope(scope => {
     scope.setExtra('context', context);
     Sentry.captureMessage(message);

--- a/tests/js/spec/utils/logging.spec.jsx
+++ b/tests/js/spec/utils/logging.spec.jsx
@@ -27,6 +27,20 @@ describe('logging', function() {
       );
     });
 
+    it('handles error objects', function() {
+      const error = new Error('An error');
+      error.resp = {
+        status: 500,
+        responseJSON: {detail: 'A bad thing happened'},
+      };
+      logAjaxError(error, {foo: 'bar'} /* context */);
+
+      expect(Sentry.captureMessage).toHaveBeenCalled();
+      expect(Sentry.captureMessage.mock.calls[0][0]).toEqual(
+        'HTTP 500: A bad thing happened'
+      );
+    });
+
     it('should handle text/html responses', function() {
       logAjaxError(
         {


### PR DESCRIPTION
Promises were changed to reject with an Error object instead of xhr
response.