### PR TITLE
feat(projects): Add more detailed document titles

### DIFF
--- a/src/sentry/static/sentry/app/views/projectDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectDashboard/index.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import {Link} from 'react-router';
+import DocumentTitle from 'react-document-title';
 
 import SentryTypes from 'app/sentryTypes';
 import ProjectState from 'app/mixins/projectState';
@@ -93,79 +94,84 @@ const ProjectDashboard = createReactClass({
     const dateSince = this.getStatsPeriodBeginTimestamp(statsPeriod);
     const resolution = this.getStatsPeriodResolution(statsPeriod);
     const {orgId, projectId} = this.props.params;
+    const {name: orgName} = this.getOrganization();
+    const {slug: projectSlug} = this.getProject();
     const url = `/${orgId}/${projectId}/dashboard/`;
     const routeQuery = this.props.location.query;
 
     return (
-      <div>
-        <div className="row" style={{marginBottom: '5px'}}>
-          <div className="col-sm-9">
-            <PageHeading withMargins>{t('Overview')}</PageHeading>
+      <DocumentTitle title={`Overview - ${projectSlug} - ${orgName} - Sentry`}>
+        <div>
+          <div className="row" style={{marginBottom: '5px'}}>
+            <div className="col-sm-9">
+              <PageHeading withMargins>{t('Overview')}</PageHeading>
+            </div>
+            <div className="col-sm-3" style={{textAlign: 'right', marginTop: '4px'}}>
+              <div className="btn-group">
+                <Link
+                  to={{
+                    pathname: url,
+                    query: {...routeQuery, statsPeriod: PERIOD_HOUR},
+                  }}
+                  className={
+                    'btn btn-sm btn-default' +
+                    (statsPeriod === PERIOD_HOUR ? ' active' : '')
+                  }
+                >
+                  {t('1 hour')}
+                </Link>
+                <Link
+                  to={{
+                    pathname: url,
+                    query: {...routeQuery, statsPeriod: PERIOD_DAY},
+                  }}
+                  className={
+                    'btn btn-sm btn-default' +
+                    (statsPeriod === PERIOD_DAY ? ' active' : '')
+                  }
+                >
+                  {t('1 day')}
+                </Link>
+                <Link
+                  to={{
+                    pathname: url,
+                    query: {...routeQuery, statsPeriod: PERIOD_WEEK},
+                  }}
+                  className={
+                    'btn btn-sm btn-default' +
+                    (statsPeriod === PERIOD_WEEK ? ' active' : '')
+                  }
+                >
+                  {t('1 week')}
+                </Link>
+              </div>
+            </div>
           </div>
-          <div className="col-sm-3" style={{textAlign: 'right', marginTop: '4px'}}>
-            <div className="btn-group">
-              <Link
-                to={{
-                  pathname: url,
-                  query: {...routeQuery, statsPeriod: PERIOD_HOUR},
-                }}
-                className={
-                  'btn btn-sm btn-default' +
-                  (statsPeriod === PERIOD_HOUR ? ' active' : '')
-                }
-              >
-                {t('1 hour')}
-              </Link>
-              <Link
-                to={{
-                  pathname: url,
-                  query: {...routeQuery, statsPeriod: PERIOD_DAY},
-                }}
-                className={
-                  'btn btn-sm btn-default' + (statsPeriod === PERIOD_DAY ? ' active' : '')
-                }
-              >
-                {t('1 day')}
-              </Link>
-              <Link
-                to={{
-                  pathname: url,
-                  query: {...routeQuery, statsPeriod: PERIOD_WEEK},
-                }}
-                className={
-                  'btn btn-sm btn-default' +
-                  (statsPeriod === PERIOD_WEEK ? ' active' : '')
-                }
-              >
-                {t('1 week')}
-              </Link>
+          <ProjectChart
+            dateSince={dateSince}
+            resolution={resolution}
+            environment={this.props.environment}
+          />
+          <div className="row">
+            <div className="col-md-6">
+              <EventList
+                type="priority"
+                environment={this.props.environment}
+                dateSince={dateSince}
+                params={this.props.params}
+              />
+            </div>
+            <div className="col-md-6">
+              <EventList
+                type="new"
+                environment={this.props.environment}
+                dateSince={dateSince}
+                params={this.props.params}
+              />
             </div>
           </div>
         </div>
-        <ProjectChart
-          dateSince={dateSince}
-          resolution={resolution}
-          environment={this.props.environment}
-        />
-        <div className="row">
-          <div className="col-md-6">
-            <EventList
-              type="priority"
-              environment={this.props.environment}
-              dateSince={dateSince}
-              params={this.props.params}
-            />
-          </div>
-          <div className="col-md-6">
-            <EventList
-              type="new"
-              environment={this.props.environment}
-              dateSince={dateSince}
-              params={this.props.params}
-            />
-          </div>
-        </div>
-      </div>
+      </DocumentTitle>
     );
   },
 });

--- a/src/sentry/static/sentry/app/views/releases/list/projectReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/projectReleases/index.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import {browserHistory} from 'react-router';
+import DocumentTitle from 'react-document-title';
 import {omit, isEqual} from 'lodash';
 import qs from 'query-string';
 
@@ -212,28 +213,32 @@ const ProjectReleases = createReactClass({
   },
 
   render() {
+    const {project: {slug: projectSlug}, organization: {name: orgName}} = this.context;
+
     return (
-      <div className="ref-project-releases">
-        <GuideAnchor target="releases" type="invisible" />
-        <div className="row" style={{marginBottom: '5px'}}>
-          <div className="col-sm-7">
-            <PageHeading withMargins>{t('Releases')}</PageHeading>
+      <DocumentTitle title={`Releases - ${projectSlug} - ${orgName} - Sentry`}>
+        <div className="ref-project-releases">
+          <GuideAnchor target="releases" type="invisible" />
+          <div className="row" style={{marginBottom: '5px'}}>
+            <div className="col-sm-7">
+              <PageHeading withMargins>{t('Releases')}</PageHeading>
+            </div>
+            <div className="col-sm-5 release-search" style={{marginTop: '5px'}}>
+              <SearchBar
+                defaultQuery=""
+                placeholder={t('Search for a release')}
+                query={this.state.query}
+                onSearch={this.onSearch}
+              />
+            </div>
           </div>
-          <div className="col-sm-5 release-search" style={{marginTop: '5px'}}>
-            <SearchBar
-              defaultQuery=""
-              placeholder={t('Search for a release')}
-              query={this.state.query}
-              onSearch={this.onSearch}
-            />
-          </div>
+          <Panel>
+            <ReleaseListHeader />
+            <PanelBody>{this.renderStreamBody()}</PanelBody>
+          </Panel>
+          <Pagination pageLinks={this.state.pageLinks} />
         </div>
-        <Panel>
-          <ReleaseListHeader />
-          <PanelBody>{this.renderStreamBody()}</PanelBody>
-        </Panel>
-        <Pagination pageLinks={this.state.pageLinks} />
-      </div>
+      </DocumentTitle>
     );
   },
 });

--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import Reflux from 'reflux';
 import classNames from 'classnames';
 import createReactClass from 'create-react-class';
+import DocumentTitle from 'react-document-title';
 import qs from 'query-string';
 
 import {Panel, PanelBody} from 'app/components/panels';
@@ -688,64 +689,66 @@ const Stream = createReactClass({
     };
 
     return (
-      <div className={classNames(classes)}>
-        <div className="stream-content">
-          <StreamFilters
-            organization={organization}
-            projectId={project.slug}
-            query={this.state.query}
-            sort={this.state.sort}
-            searchId={searchId}
-            queryCount={this.state.queryCount}
-            queryMaxCount={this.state.queryMaxCount}
-            onSortChange={this.onSortChange}
-            onSearch={this.onSearch}
-            onSavedSearchCreate={this.onSavedSearchCreate}
-            onSavedSearchSelect={this.onSavedSearchSelect}
-            onSavedSearchDelete={() => {}}
-            onSidebarToggle={this.onSidebarToggle}
-            isSearchDisabled={this.state.isSidebarVisible}
-            savedSearchList={this.state.savedSearchList}
-            tagValueLoader={this.tagValueLoader}
-            tags={this.props.tags}
-          />
-          <Panel>
-            <StreamActions
-              orgId={organization.slug}
+      <DocumentTitle title={`Issues - ${project.slug} - ${organization.name} - Sentry`}>
+        <div className={classNames(classes)}>
+          <div className="stream-content">
+            <StreamFilters
+              organization={organization}
               projectId={project.slug}
-              selection={selection}
-              hasReleases={projectFeatures.has('releases')}
-              latestRelease={this.context.project.latestRelease}
-              environment={this.state.environment}
               query={this.state.query}
+              sort={this.state.sort}
+              searchId={searchId}
               queryCount={this.state.queryCount}
-              onSelectStatsPeriod={this.onSelectStatsPeriod}
-              onRealtimeChange={this.onRealtimeChange}
-              realtimeActive={this.state.realtimeActive}
-              statsPeriod={this.state.statsPeriod}
-              groupIds={this.state.groupIds}
-              allResultsVisible={this.allResultsVisible()}
+              queryMaxCount={this.state.queryMaxCount}
+              onSortChange={this.onSortChange}
+              onSearch={this.onSearch}
+              onSavedSearchCreate={this.onSavedSearchCreate}
+              onSavedSearchSelect={this.onSavedSearchSelect}
+              onSavedSearchDelete={() => {}}
+              onSidebarToggle={this.onSidebarToggle}
+              isSearchDisabled={this.state.isSidebarVisible}
+              savedSearchList={this.state.savedSearchList}
+              tagValueLoader={this.tagValueLoader}
+              tags={this.props.tags}
             />
-            <PanelBody>
-              <ProcessingIssueList
-                organization={organization}
-                projectIds={selection.projects}
+            <Panel>
+              <StreamActions
+                orgId={organization.slug}
+                projectId={project.slug}
+                selection={selection}
+                hasReleases={projectFeatures.has('releases')}
+                latestRelease={this.context.project.latestRelease}
+                environment={this.state.environment}
+                query={this.state.query}
+                queryCount={this.state.queryCount}
+                onSelectStatsPeriod={this.onSelectStatsPeriod}
+                onRealtimeChange={this.onRealtimeChange}
+                realtimeActive={this.state.realtimeActive}
+                statsPeriod={this.state.statsPeriod}
+                groupIds={this.state.groupIds}
+                allResultsVisible={this.allResultsVisible()}
               />
-              {this.renderStreamBody()}
-            </PanelBody>
-          </Panel>
-          <Pagination pageLinks={this.state.pageLinks} />
+              <PanelBody>
+                <ProcessingIssueList
+                  organization={organization}
+                  projectIds={selection.projects}
+                />
+                {this.renderStreamBody()}
+              </PanelBody>
+            </Panel>
+            <Pagination pageLinks={this.state.pageLinks} />
+          </div>
+          <StreamSidebar
+            loading={this.props.tagsLoading}
+            tags={this.props.tags}
+            query={this.state.query}
+            onQueryChange={this.onSearch}
+            orgId={organization.slug}
+            projectId={project.slug}
+            tagValueLoader={this.tagValueLoader}
+          />
         </div>
-        <StreamSidebar
-          loading={this.props.tagsLoading}
-          tags={this.props.tags}
-          query={this.state.query}
-          onQueryChange={this.onSearch}
-          orgId={organization.slug}
-          projectId={project.slug}
-          tagValueLoader={this.tagValueLoader}
-        />
-      </div>
+      </DocumentTitle>
     );
   },
 });

--- a/src/sentry/static/sentry/app/views/userFeedback/projectUserFeedback.jsx
+++ b/src/sentry/static/sentry/app/views/userFeedback/projectUserFeedback.jsx
@@ -2,10 +2,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import {Link, browserHistory} from 'react-router';
+import DocumentTitle from 'react-document-title';
 import qs from 'query-string';
 import {omit, isEqual} from 'lodash';
+
 import SentryTypes from 'app/sentryTypes';
 import ApiMixin from 'app/mixins/apiMixin';
+import ProjectState from 'app/mixins/projectState';
 import GroupStore from 'app/stores/groupStore';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
@@ -33,7 +36,7 @@ const ProjectUserFeedback = createReactClass({
     project: SentryTypes.Project,
   },
 
-  mixins: [ApiMixin],
+  mixins: [ApiMixin, ProjectState],
 
   getDefaultProps() {
     return {
@@ -212,15 +215,18 @@ const ProjectUserFeedback = createReactClass({
 
   render() {
     const {location} = this.props;
+    const {project: {slug: projectSlug}, organization: {name: orgName}} = this.context;
 
     return (
-      <UserFeedbackContainer
-        pageLinks={this.state.pageLinks}
-        status={this.state.status}
-        location={location}
-      >
-        {this.renderStreamBody()}
-      </UserFeedbackContainer>
+      <DocumentTitle title={`User Feedback - ${projectSlug} - ${orgName} - Sentry`}>
+        <UserFeedbackContainer
+          pageLinks={this.state.pageLinks}
+          status={this.state.status}
+          location={location}
+        >
+          {this.renderStreamBody()}
+        </UserFeedbackContainer>
+      </DocumentTitle>
     );
   },
 });

--- a/tests/js/spec/views/stream/__snapshots__/stream.spec.jsx.snap
+++ b/tests/js/spec/views/stream/__snapshots__/stream.spec.jsx.snap
@@ -1,63 +1,244 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Stream render() displays the group list 1`] = `
-<div
-  className="stream-row"
+<SideEffect(DocumentTitle)
+  title="Issues - project-slug - Organization Name - Sentry"
 >
   <div
-    className="stream-content"
+    className="stream-row"
   >
-    <StreamFilters
-      isSearchDisabled={false}
-      onSavedSearchCreate={[Function]}
-      onSavedSearchDelete={[Function]}
-      onSavedSearchSelect={[Function]}
-      onSearch={[Function]}
-      onSidebarToggle={[Function]}
-      onSortChange={[Function]}
-      organization={
-        Object {
-          "access": Array [
-            "org:read",
-            "org:write",
-            "org:admin",
-            "org:integrations",
-            "project:read",
-            "project:write",
-            "project:admin",
-            "team:read",
-            "team:write",
-            "team:admin",
-          ],
-          "features": Array [],
-          "id": "1337",
-          "name": "Organization Name",
-          "onboardingTasks": Array [],
-          "projects": Array [],
-          "scrapeJavaScript": true,
-          "slug": "org-slug",
-          "status": Object {
-            "id": "active",
-            "name": "active",
-          },
-          "teams": Array [],
+    <div
+      className="stream-content"
+    >
+      <StreamFilters
+        isSearchDisabled={false}
+        onSavedSearchCreate={[Function]}
+        onSavedSearchDelete={[Function]}
+        onSavedSearchSelect={[Function]}
+        onSearch={[Function]}
+        onSidebarToggle={[Function]}
+        onSortChange={[Function]}
+        organization={
+          Object {
+            "access": Array [
+              "org:read",
+              "org:write",
+              "org:admin",
+              "org:integrations",
+              "project:read",
+              "project:write",
+              "project:admin",
+              "team:read",
+              "team:write",
+              "team:admin",
+            ],
+            "features": Array [],
+            "id": "1337",
+            "name": "Organization Name",
+            "onboardingTasks": Array [],
+            "projects": Array [],
+            "scrapeJavaScript": true,
+            "slug": "org-slug",
+            "status": Object {
+              "id": "active",
+              "name": "active",
+            },
+            "teams": Array [],
+          }
         }
-      }
+        projectId="project-slug"
+        query="is:unresolved"
+        queryCount={0}
+        queryMaxCount={0}
+        savedSearchList={
+          Array [
+            Object {
+              "id": "789",
+              "name": "test",
+              "query": "is:unresolved",
+            },
+          ]
+        }
+        searchId={null}
+        sort="date"
+        tagValueLoader={[Function]}
+        tags={
+          Object {
+            "assigned": Object {
+              "key": "assigned",
+              "name": "Assigned To",
+              "predefined": true,
+              "values": Array [],
+            },
+            "bookmarks": Object {
+              "key": "bookmarks",
+              "name": "Bookmarked By",
+              "predefined": true,
+              "values": Array [],
+            },
+            "event.timestamp": Object {
+              "key": "event.timestamp",
+              "name": "Event Timestamp",
+              "predefined": true,
+              "values": Array [
+                "2017-01-02",
+                ">=2017-01-02T01:00:00",
+                "<2017-01-02T02:00:00",
+              ],
+            },
+            "firstSeen": Object {
+              "key": "firstSeen",
+              "name": "First Seen",
+              "predefined": true,
+              "values": Array [
+                "-1h",
+                "+1d",
+                "-1w",
+              ],
+            },
+            "has": Object {
+              "key": "has",
+              "name": "Has Tag",
+              "predefined": true,
+              "values": Array [],
+            },
+            "is": Object {
+              "key": "is",
+              "name": "Status",
+              "predefined": true,
+              "values": Array [
+                "resolved",
+                "unresolved",
+                "ignored",
+                "muted",
+                "assigned",
+                "unassigned",
+              ],
+            },
+            "lastSeen": Object {
+              "key": "lastSeen",
+              "name": "Last Seen",
+              "predefined": true,
+              "values": Array [
+                "-1h",
+                "+1d",
+                "-1w",
+              ],
+            },
+            "timesSeen": Object {
+              "isInput": true,
+              "key": "timesSeen",
+              "name": "Times Seen",
+              "predefined": true,
+              "values": Array [],
+            },
+          }
+        }
+      />
+      <Panel>
+        <StreamActions
+          allResultsVisible={false}
+          groupIds={
+            Array [
+              "1",
+            ]
+          }
+          hasReleases={false}
+          latestRelease={null}
+          onRealtimeChange={[Function]}
+          onSelectStatsPeriod={[Function]}
+          orgId="org-slug"
+          projectId="project-slug"
+          query="is:unresolved"
+          queryCount={0}
+          realtimeActive={false}
+          selection={
+            Object {
+              "datetime": Object {
+                "end": null,
+                "period": null,
+                "start": null,
+                "utc": null,
+              },
+              "environments": Array [],
+              "projects": Array [
+                3559,
+              ],
+            }
+          }
+          statsPeriod="24h"
+        />
+        <PanelBody
+          direction="column"
+          disablePadding={true}
+          flex={false}
+        >
+          <ProcessingIssueList
+            organization={
+              Object {
+                "access": Array [
+                  "org:read",
+                  "org:write",
+                  "org:admin",
+                  "org:integrations",
+                  "project:read",
+                  "project:write",
+                  "project:admin",
+                  "team:read",
+                  "team:write",
+                  "team:admin",
+                ],
+                "features": Array [],
+                "id": "1337",
+                "name": "Organization Name",
+                "onboardingTasks": Array [],
+                "projects": Array [],
+                "scrapeJavaScript": true,
+                "slug": "org-slug",
+                "status": Object {
+                  "id": "active",
+                  "name": "active",
+                },
+                "teams": Array [],
+              }
+            }
+            projectIds={
+              Array [
+                3559,
+              ]
+            }
+            showProject={false}
+          />
+          <PanelBody
+            className="ref-group-list"
+            direction="column"
+            disablePadding={true}
+            flex={false}
+          >
+            <StreamGroup
+              canSelect={true}
+              hasGuideAnchor={false}
+              id="1"
+              key="1"
+              orgId="org-slug"
+              query="is:unresolved"
+              statsPeriod="24h"
+            />
+          </PanelBody>
+        </PanelBody>
+      </Panel>
+      <Pagination
+        className="stream-pagination"
+        onCursor={[Function]}
+        pageLinks="<http://127.0.0.1:8000/api/0/projects/org-slug/project-slug/issues/?cursor=1443575731:0:1>; rel=\\"previous\\"; results=\\"false\\"; cursor=\\"1443575731:0:1\\", <http://127.0.0.1:8000/api/0/projects/org-slug/project-slug/issues/?cursor=1443575731:0:0>; rel=\\"next\\"; results=\\"true\\"; cursor=\\"1443575731:0:0"
+      />
+    </div>
+    <StreamSidebar
+      loading={false}
+      onQueryChange={[Function]}
+      orgId="org-slug"
       projectId="project-slug"
       query="is:unresolved"
-      queryCount={0}
-      queryMaxCount={0}
-      savedSearchList={
-        Array [
-          Object {
-            "id": "789",
-            "name": "test",
-            "query": "is:unresolved",
-          },
-        ]
-      }
-      searchId={null}
-      sort="date"
       tagValueLoader={[Function]}
       tags={
         Object {
@@ -132,245 +313,249 @@ exports[`Stream render() displays the group list 1`] = `
         }
       }
     />
-    <Panel>
-      <StreamActions
-        allResultsVisible={false}
-        groupIds={
-          Array [
-            "1",
-          ]
-        }
-        hasReleases={false}
-        latestRelease={null}
-        onRealtimeChange={[Function]}
-        onSelectStatsPeriod={[Function]}
-        orgId="org-slug"
-        projectId="project-slug"
-        query="is:unresolved"
-        queryCount={0}
-        realtimeActive={false}
-        selection={
-          Object {
-            "datetime": Object {
-              "end": null,
-              "period": null,
-              "start": null,
-              "utc": null,
-            },
-            "environments": Array [],
-            "projects": Array [
-              3559,
-            ],
-          }
-        }
-        statsPeriod="24h"
-      />
-      <PanelBody
-        direction="column"
-        disablePadding={true}
-        flex={false}
-      >
-        <ProcessingIssueList
-          organization={
-            Object {
-              "access": Array [
-                "org:read",
-                "org:write",
-                "org:admin",
-                "org:integrations",
-                "project:read",
-                "project:write",
-                "project:admin",
-                "team:read",
-                "team:write",
-                "team:admin",
-              ],
-              "features": Array [],
-              "id": "1337",
-              "name": "Organization Name",
-              "onboardingTasks": Array [],
-              "projects": Array [],
-              "scrapeJavaScript": true,
-              "slug": "org-slug",
-              "status": Object {
-                "id": "active",
-                "name": "active",
-              },
-              "teams": Array [],
-            }
-          }
-          projectIds={
-            Array [
-              3559,
-            ]
-          }
-          showProject={false}
-        />
-        <PanelBody
-          className="ref-group-list"
-          direction="column"
-          disablePadding={true}
-          flex={false}
-        >
-          <StreamGroup
-            canSelect={true}
-            hasGuideAnchor={false}
-            id="1"
-            key="1"
-            orgId="org-slug"
-            query="is:unresolved"
-            statsPeriod="24h"
-          />
-        </PanelBody>
-      </PanelBody>
-    </Panel>
-    <Pagination
-      className="stream-pagination"
-      onCursor={[Function]}
-      pageLinks="<http://127.0.0.1:8000/api/0/projects/org-slug/project-slug/issues/?cursor=1443575731:0:1>; rel=\\"previous\\"; results=\\"false\\"; cursor=\\"1443575731:0:1\\", <http://127.0.0.1:8000/api/0/projects/org-slug/project-slug/issues/?cursor=1443575731:0:0>; rel=\\"next\\"; results=\\"true\\"; cursor=\\"1443575731:0:0"
-    />
   </div>
-  <StreamSidebar
-    loading={false}
-    onQueryChange={[Function]}
-    orgId="org-slug"
-    projectId="project-slug"
-    query="is:unresolved"
-    tagValueLoader={[Function]}
-    tags={
-      Object {
-        "assigned": Object {
-          "key": "assigned",
-          "name": "Assigned To",
-          "predefined": true,
-          "values": Array [],
-        },
-        "bookmarks": Object {
-          "key": "bookmarks",
-          "name": "Bookmarked By",
-          "predefined": true,
-          "values": Array [],
-        },
-        "event.timestamp": Object {
-          "key": "event.timestamp",
-          "name": "Event Timestamp",
-          "predefined": true,
-          "values": Array [
-            "2017-01-02",
-            ">=2017-01-02T01:00:00",
-            "<2017-01-02T02:00:00",
-          ],
-        },
-        "firstSeen": Object {
-          "key": "firstSeen",
-          "name": "First Seen",
-          "predefined": true,
-          "values": Array [
-            "-1h",
-            "+1d",
-            "-1w",
-          ],
-        },
-        "has": Object {
-          "key": "has",
-          "name": "Has Tag",
-          "predefined": true,
-          "values": Array [],
-        },
-        "is": Object {
-          "key": "is",
-          "name": "Status",
-          "predefined": true,
-          "values": Array [
-            "resolved",
-            "unresolved",
-            "ignored",
-            "muted",
-            "assigned",
-            "unassigned",
-          ],
-        },
-        "lastSeen": Object {
-          "key": "lastSeen",
-          "name": "Last Seen",
-          "predefined": true,
-          "values": Array [
-            "-1h",
-            "+1d",
-            "-1w",
-          ],
-        },
-        "timesSeen": Object {
-          "isInput": true,
-          "key": "timesSeen",
-          "name": "Times Seen",
-          "predefined": true,
-          "values": Array [],
-        },
-      }
-    }
-  />
-</div>
+</SideEffect(DocumentTitle)>
 `;
 
 exports[`Stream toggles environment select all environments 1`] = `
-<div
-  className="stream-row"
+<SideEffect(DocumentTitle)
+  title="Issues - project-slug - Organization Name - Sentry"
 >
   <div
-    className="stream-content"
+    className="stream-row"
   >
-    <StreamFilters
-      isSearchDisabled={false}
-      onSavedSearchCreate={[Function]}
-      onSavedSearchDelete={[Function]}
-      onSavedSearchSelect={[Function]}
-      onSearch={[Function]}
-      onSidebarToggle={[Function]}
-      onSortChange={[Function]}
-      organization={
-        Object {
-          "access": Array [
-            "org:read",
-            "org:write",
-            "org:admin",
-            "org:integrations",
-            "project:read",
-            "project:write",
-            "project:admin",
-            "team:read",
-            "team:write",
-            "team:admin",
-          ],
-          "features": Array [],
-          "id": "1337",
-          "name": "Organization Name",
-          "onboardingTasks": Array [],
-          "projects": Array [],
-          "scrapeJavaScript": true,
-          "slug": "org-slug",
-          "status": Object {
-            "id": "active",
-            "name": "active",
-          },
-          "teams": Array [],
+    <div
+      className="stream-content"
+    >
+      <StreamFilters
+        isSearchDisabled={false}
+        onSavedSearchCreate={[Function]}
+        onSavedSearchDelete={[Function]}
+        onSavedSearchSelect={[Function]}
+        onSearch={[Function]}
+        onSidebarToggle={[Function]}
+        onSortChange={[Function]}
+        organization={
+          Object {
+            "access": Array [
+              "org:read",
+              "org:write",
+              "org:admin",
+              "org:integrations",
+              "project:read",
+              "project:write",
+              "project:admin",
+              "team:read",
+              "team:write",
+              "team:admin",
+            ],
+            "features": Array [],
+            "id": "1337",
+            "name": "Organization Name",
+            "onboardingTasks": Array [],
+            "projects": Array [],
+            "scrapeJavaScript": true,
+            "slug": "org-slug",
+            "status": Object {
+              "id": "active",
+              "name": "active",
+            },
+            "teams": Array [],
+          }
         }
-      }
+        projectId="project-slug"
+        query="is:unresolved"
+        queryCount={0}
+        queryMaxCount={0}
+        savedSearchList={
+          Array [
+            Object {
+              "id": "789",
+              "name": "test",
+              "query": "is:unresolved",
+            },
+          ]
+        }
+        searchId={null}
+        sort="date"
+        tagValueLoader={[Function]}
+        tags={
+          Object {
+            "assigned": Object {
+              "key": "assigned",
+              "name": "Assigned To",
+              "predefined": true,
+              "values": Array [],
+            },
+            "bookmarks": Object {
+              "key": "bookmarks",
+              "name": "Bookmarked By",
+              "predefined": true,
+              "values": Array [],
+            },
+            "event.timestamp": Object {
+              "key": "event.timestamp",
+              "name": "Event Timestamp",
+              "predefined": true,
+              "values": Array [
+                "2017-01-02",
+                ">=2017-01-02T01:00:00",
+                "<2017-01-02T02:00:00",
+              ],
+            },
+            "firstSeen": Object {
+              "key": "firstSeen",
+              "name": "First Seen",
+              "predefined": true,
+              "values": Array [
+                "-1h",
+                "+1d",
+                "-1w",
+              ],
+            },
+            "has": Object {
+              "key": "has",
+              "name": "Has Tag",
+              "predefined": true,
+              "values": Array [],
+            },
+            "is": Object {
+              "key": "is",
+              "name": "Status",
+              "predefined": true,
+              "values": Array [
+                "resolved",
+                "unresolved",
+                "ignored",
+                "muted",
+                "assigned",
+                "unassigned",
+              ],
+            },
+            "lastSeen": Object {
+              "key": "lastSeen",
+              "name": "Last Seen",
+              "predefined": true,
+              "values": Array [
+                "-1h",
+                "+1d",
+                "-1w",
+              ],
+            },
+            "timesSeen": Object {
+              "isInput": true,
+              "key": "timesSeen",
+              "name": "Times Seen",
+              "predefined": true,
+              "values": Array [],
+            },
+          }
+        }
+      />
+      <Panel>
+        <StreamActions
+          allResultsVisible={false}
+          groupIds={
+            Array [
+              "1",
+            ]
+          }
+          hasReleases={false}
+          latestRelease={null}
+          onRealtimeChange={[Function]}
+          onSelectStatsPeriod={[Function]}
+          orgId="org-slug"
+          projectId="project-slug"
+          query="is:unresolved"
+          queryCount={0}
+          realtimeActive={false}
+          selection={
+            Object {
+              "datetime": Object {
+                "end": null,
+                "period": null,
+                "start": null,
+                "utc": null,
+              },
+              "environments": Array [],
+              "projects": Array [
+                3559,
+              ],
+            }
+          }
+          statsPeriod="24h"
+        />
+        <PanelBody
+          direction="column"
+          disablePadding={true}
+          flex={false}
+        >
+          <ProcessingIssueList
+            organization={
+              Object {
+                "access": Array [
+                  "org:read",
+                  "org:write",
+                  "org:admin",
+                  "org:integrations",
+                  "project:read",
+                  "project:write",
+                  "project:admin",
+                  "team:read",
+                  "team:write",
+                  "team:admin",
+                ],
+                "features": Array [],
+                "id": "1337",
+                "name": "Organization Name",
+                "onboardingTasks": Array [],
+                "projects": Array [],
+                "scrapeJavaScript": true,
+                "slug": "org-slug",
+                "status": Object {
+                  "id": "active",
+                  "name": "active",
+                },
+                "teams": Array [],
+              }
+            }
+            projectIds={
+              Array [
+                3559,
+              ]
+            }
+            showProject={false}
+          />
+          <PanelBody
+            className="ref-group-list"
+            direction="column"
+            disablePadding={true}
+            flex={false}
+          >
+            <StreamGroup
+              canSelect={true}
+              hasGuideAnchor={false}
+              id="1"
+              key="1"
+              orgId="org-slug"
+              query="is:unresolved"
+              statsPeriod="24h"
+            />
+          </PanelBody>
+        </PanelBody>
+      </Panel>
+      <Pagination
+        className="stream-pagination"
+        onCursor={[Function]}
+        pageLinks="<http://127.0.0.1:8000/api/0/projects/org-slug/project-slug/issues/?cursor=1443575731:0:1>; rel=\\"previous\\"; results=\\"false\\"; cursor=\\"1443575731:0:1\\", <http://127.0.0.1:8000/api/0/projects/org-slug/project-slug/issues/?cursor=1443575731:0:0>; rel=\\"next\\"; results=\\"true\\"; cursor=\\"1443575731:0:0"
+      />
+    </div>
+    <StreamSidebar
+      loading={false}
+      onQueryChange={[Function]}
+      orgId="org-slug"
       projectId="project-slug"
       query="is:unresolved"
-      queryCount={0}
-      queryMaxCount={0}
-      savedSearchList={
-        Array [
-          Object {
-            "id": "789",
-            "name": "test",
-            "query": "is:unresolved",
-          },
-        ]
-      }
-      searchId={null}
-      sort="date"
       tagValueLoader={[Function]}
       tags={
         Object {
@@ -445,183 +630,6 @@ exports[`Stream toggles environment select all environments 1`] = `
         }
       }
     />
-    <Panel>
-      <StreamActions
-        allResultsVisible={false}
-        groupIds={
-          Array [
-            "1",
-          ]
-        }
-        hasReleases={false}
-        latestRelease={null}
-        onRealtimeChange={[Function]}
-        onSelectStatsPeriod={[Function]}
-        orgId="org-slug"
-        projectId="project-slug"
-        query="is:unresolved"
-        queryCount={0}
-        realtimeActive={false}
-        selection={
-          Object {
-            "datetime": Object {
-              "end": null,
-              "period": null,
-              "start": null,
-              "utc": null,
-            },
-            "environments": Array [],
-            "projects": Array [
-              3559,
-            ],
-          }
-        }
-        statsPeriod="24h"
-      />
-      <PanelBody
-        direction="column"
-        disablePadding={true}
-        flex={false}
-      >
-        <ProcessingIssueList
-          organization={
-            Object {
-              "access": Array [
-                "org:read",
-                "org:write",
-                "org:admin",
-                "org:integrations",
-                "project:read",
-                "project:write",
-                "project:admin",
-                "team:read",
-                "team:write",
-                "team:admin",
-              ],
-              "features": Array [],
-              "id": "1337",
-              "name": "Organization Name",
-              "onboardingTasks": Array [],
-              "projects": Array [],
-              "scrapeJavaScript": true,
-              "slug": "org-slug",
-              "status": Object {
-                "id": "active",
-                "name": "active",
-              },
-              "teams": Array [],
-            }
-          }
-          projectIds={
-            Array [
-              3559,
-            ]
-          }
-          showProject={false}
-        />
-        <PanelBody
-          className="ref-group-list"
-          direction="column"
-          disablePadding={true}
-          flex={false}
-        >
-          <StreamGroup
-            canSelect={true}
-            hasGuideAnchor={false}
-            id="1"
-            key="1"
-            orgId="org-slug"
-            query="is:unresolved"
-            statsPeriod="24h"
-          />
-        </PanelBody>
-      </PanelBody>
-    </Panel>
-    <Pagination
-      className="stream-pagination"
-      onCursor={[Function]}
-      pageLinks="<http://127.0.0.1:8000/api/0/projects/org-slug/project-slug/issues/?cursor=1443575731:0:1>; rel=\\"previous\\"; results=\\"false\\"; cursor=\\"1443575731:0:1\\", <http://127.0.0.1:8000/api/0/projects/org-slug/project-slug/issues/?cursor=1443575731:0:0>; rel=\\"next\\"; results=\\"true\\"; cursor=\\"1443575731:0:0"
-    />
   </div>
-  <StreamSidebar
-    loading={false}
-    onQueryChange={[Function]}
-    orgId="org-slug"
-    projectId="project-slug"
-    query="is:unresolved"
-    tagValueLoader={[Function]}
-    tags={
-      Object {
-        "assigned": Object {
-          "key": "assigned",
-          "name": "Assigned To",
-          "predefined": true,
-          "values": Array [],
-        },
-        "bookmarks": Object {
-          "key": "bookmarks",
-          "name": "Bookmarked By",
-          "predefined": true,
-          "values": Array [],
-        },
-        "event.timestamp": Object {
-          "key": "event.timestamp",
-          "name": "Event Timestamp",
-          "predefined": true,
-          "values": Array [
-            "2017-01-02",
-            ">=2017-01-02T01:00:00",
-            "<2017-01-02T02:00:00",
-          ],
-        },
-        "firstSeen": Object {
-          "key": "firstSeen",
-          "name": "First Seen",
-          "predefined": true,
-          "values": Array [
-            "-1h",
-            "+1d",
-            "-1w",
-          ],
-        },
-        "has": Object {
-          "key": "has",
-          "name": "Has Tag",
-          "predefined": true,
-          "values": Array [],
-        },
-        "is": Object {
-          "key": "is",
-          "name": "Status",
-          "predefined": true,
-          "values": Array [
-            "resolved",
-            "unresolved",
-            "ignored",
-            "muted",
-            "assigned",
-            "unassigned",
-          ],
-        },
-        "lastSeen": Object {
-          "key": "lastSeen",
-          "name": "Last Seen",
-          "predefined": true,
-          "values": Array [
-            "-1h",
-            "+1d",
-            "-1w",
-          ],
-        },
-        "timesSeen": Object {
-          "isInput": true,
-          "key": "timesSeen",
-          "name": "Times Seen",
-          "predefined": true,
-          "values": Array [],
-        },
-      }
-    }
-  />
-</div>
+</SideEffect(DocumentTitle)>
 `;

--- a/tests/js/spec/views/userFeedback/__snapshots__/projectUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/projectUserFeedback.spec.jsx.snap
@@ -1,103 +1,107 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`projectUserFeedback renders 1`] = `
-<UserFeedbackContainer
-  location={
-    Object {
-      "query": Object {},
-    }
-  }
-  pageLinks="<https://sentry.io/api/0/organizations/sentry/user-feedback/?statsPeriod=14d&cursor=0:0:1>; rel=\\"previous\\"; results=\\"false\\"; cursor=\\"0:0:1\\", <https://sentry.io/api/0/organizations/sentry/user-feedback/?statsPeriod=14d&cursor=0:100:0>; rel=\\"next\\"; results=\\"true\\"; cursor=\\"0:100:0\\""
-  status="unresolved"
+<SideEffect(DocumentTitle)
+  title="User Feedback - project-slug - Organization Name - Sentry"
 >
-  <WithOrganizationMockWrapper
-    data={
+  <UserFeedbackContainer
+    location={
       Object {
-        "assignedTo": null,
-        "id": "1",
-        "project": Object {
-          "id": "2",
-          "slug": "project-slug",
-        },
-        "stats": Object {
-          "24h": Array [
-            Array [
-              1517281200,
-              2,
-            ],
-            Array [
-              1517310000,
-              1,
-            ],
-          ],
-          "30d": Array [
-            Array [
-              1514764800,
-              1,
-            ],
-            Array [
-              1515024000,
-              122,
-            ],
-          ],
-        },
-        "tags": Array [],
+        "query": Object {},
       }
     }
-    id="1"
-    key="123"
+    pageLinks="<https://sentry.io/api/0/organizations/sentry/user-feedback/?statsPeriod=14d&cursor=0:0:1>; rel=\\"previous\\"; results=\\"false\\"; cursor=\\"0:0:1\\", <https://sentry.io/api/0/organizations/sentry/user-feedback/?statsPeriod=14d&cursor=0:100:0>; rel=\\"next\\"; results=\\"true\\"; cursor=\\"0:100:0\\""
+    status="unresolved"
   >
-    <EventUserFeedback
-      issueId="1"
-      orgId="org-slug"
-      projectId="project-slug"
-      report={
+    <WithOrganizationMockWrapper
+      data={
         Object {
-          "comments": "Something bad happened",
-          "dateCreated": "2018-12-20T00:00:00.000Z",
-          "email": "lyn@sentry.io",
-          "event": Object {
-            "eventID": "12345678901234567890123456789012",
-            "groupID": "1",
-            "id": "1",
-            "message": "ApiException",
+          "assignedTo": null,
+          "id": "1",
+          "project": Object {
+            "id": "2",
+            "slug": "project-slug",
           },
-          "id": "123",
-          "issue": Object {
-            "assignedTo": null,
-            "id": "1",
-            "project": Object {
-              "id": "2",
-              "slug": "project-slug",
-            },
-            "stats": Object {
-              "24h": Array [
-                Array [
-                  1517281200,
-                  2,
-                ],
-                Array [
-                  1517310000,
-                  1,
-                ],
+          "stats": Object {
+            "24h": Array [
+              Array [
+                1517281200,
+                2,
               ],
-              "30d": Array [
-                Array [
-                  1514764800,
-                  1,
-                ],
-                Array [
-                  1515024000,
-                  122,
-                ],
+              Array [
+                1517310000,
+                1,
               ],
-            },
-            "tags": Array [],
+            ],
+            "30d": Array [
+              Array [
+                1514764800,
+                1,
+              ],
+              Array [
+                1515024000,
+                122,
+              ],
+            ],
           },
-          "name": "Lyn",
+          "tags": Array [],
         }
       }
-    />
-  </WithOrganizationMockWrapper>
-</UserFeedbackContainer>
+      id="1"
+      key="123"
+    >
+      <EventUserFeedback
+        issueId="1"
+        orgId="org-slug"
+        projectId="project-slug"
+        report={
+          Object {
+            "comments": "Something bad happened",
+            "dateCreated": "2018-12-20T00:00:00.000Z",
+            "email": "lyn@sentry.io",
+            "event": Object {
+              "eventID": "12345678901234567890123456789012",
+              "groupID": "1",
+              "id": "1",
+              "message": "ApiException",
+            },
+            "id": "123",
+            "issue": Object {
+              "assignedTo": null,
+              "id": "1",
+              "project": Object {
+                "id": "2",
+                "slug": "project-slug",
+              },
+              "stats": Object {
+                "24h": Array [
+                  Array [
+                    1517281200,
+                    2,
+                  ],
+                  Array [
+                    1517310000,
+                    1,
+                  ],
+                ],
+                "30d": Array [
+                  Array [
+                    1514764800,
+                    1,
+                  ],
+                  Array [
+                    1515024000,
+                    122,
+                  ],
+                ],
+              },
+              "tags": Array [],
+            },
+            "name": "Lyn",
+          }
+        }
+      />
+    </WithOrganizationMockWrapper>
+  </UserFeedbackContainer>
+</SideEffect(DocumentTitle)>
 `;


### PR DESCRIPTION
Adds more detailed document titles for project routes.

I opted to use the the project and organization name instead of the slug since it could be more descriptive or customized. I'm not sure if I accessed the project and organization model/data in the right way. Please let me know if you'd like to see this implemented in a different way or if you'd like to see the title strings refactored into a `getTitle` function.

Related to: #10007