### PR TITLE
feat(issues): show when resolved

### DIFF
--- a/src/sentry/static/sentry/app/components/resolutionBox.jsx
+++ b/src/sentry/static/sentry/app/components/resolutionBox.jsx
@@ -1,11 +1,19 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'react-emotion';
 
 import Avatar from 'app/components/avatar';
 import CommitLink from 'app/components/commitLink';
 import TimeSince from 'app/components/timeSince';
 import Version from 'app/components/version';
 import {t, tct} from 'app/locale';
+import space from 'app/styles/space';
+
+const StyledTimeSince = styled(TimeSince)`
+  color: ${p => p.theme.gray2};
+  margin-left: ${space(0.5)};
+  font-size: ${p => p.theme.fontSizeSmall};
+`;
 
 export default class ResolutionBox extends React.Component {
   static propTypes = {
@@ -58,7 +66,7 @@ export default class ResolutionBox extends React.Component {
               commitId={statusDetails.inCommit.id}
               repository={statusDetails.inCommit.repository}
             />
-            <TimeSince className="issue-time" date={statusDetails.inCommit.dateCreated} />
+            <StyledTimeSince date={statusDetails.inCommit.dateCreated} />
           </React.Fragment>
         ),
       });

--- a/src/sentry/static/sentry/app/components/resolutionBox.jsx
+++ b/src/sentry/static/sentry/app/components/resolutionBox.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import Avatar from 'app/components/avatar';
 import CommitLink from 'app/components/commitLink';
+import TimeSince from 'app/components/timeSince';
 import Version from 'app/components/version';
 import {t, tct} from 'app/locale';
 
@@ -52,10 +53,13 @@ export default class ResolutionBox extends React.Component {
     } else if (!!statusDetails.inCommit) {
       return tct('This issue has been marked as resolved by [commit]', {
         commit: (
-          <CommitLink
-            commitId={statusDetails.inCommit.id}
-            repository={statusDetails.inCommit.repository}
-          />
+          <React.Fragment>
+            <CommitLink
+              commitId={statusDetails.inCommit.id}
+              repository={statusDetails.inCommit.repository}
+            />
+            <TimeSince className="issue-time" date={statusDetails.inCommit.dateCreated} />
+          </React.Fragment>
         ),
       });
     }

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -824,12 +824,6 @@
         box-shadow: inset 0 2px 0 rgba(0, 0, 0, 0.03);
         border-top: 0;
       }
-
-      .issue-time {
-        color: #968ba0;
-        margin-left: 5px;
-        font-size: 12px;
-      }
     }
 
     .box.alert-block {

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -824,6 +824,12 @@
         box-shadow: inset 0 2px 0 rgba(0, 0, 0, 0.03);
         border-top: 0;
       }
+
+      .issue-time {
+        color: #968ba0;
+        margin-left: 5px;
+        font-size: 12px;
+      }
     }
 
     .box.alert-block {

--- a/tests/js/spec/components/__snapshots__/resolutionBox.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/resolutionBox.spec.jsx.snap
@@ -75,7 +75,6 @@ exports[`ResolutionBox render() handles inCommit 1`] = `
       </span>
       <CommitLink
         commitId="f7f395d14b2fe29a4e253bf1d3094d61e6ad4434"
-        key="1"
         repository={
           Object {
             "externalSlug": "example/repo-name",
@@ -86,6 +85,11 @@ exports[`ResolutionBox render() handles inCommit 1`] = `
             "url": "https://github.com/example/repo-name",
           }
         }
+      />
+      <TimeSince
+        className="issue-time"
+        date="2018-11-30T18:46:31Z"
+        suffix="ago"
       />
     </span>
   </p>

--- a/tests/js/spec/components/__snapshots__/resolutionBox.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/resolutionBox.spec.jsx.snap
@@ -86,10 +86,8 @@ exports[`ResolutionBox render() handles inCommit 1`] = `
           }
         }
       />
-      <TimeSince
-        className="issue-time"
+      <StyledTimeSince
         date="2018-11-30T18:46:31Z"
-        suffix="ago"
       />
     </span>
   </p>


### PR DESCRIPTION
Adds the time since relative date to the issue details section when an issue is resolved from a git commit.

Should the snapshot be committed as well? It looks like it's being created after my commit.

<img width="853" alt="issue-details-date" src="https://user-images.githubusercontent.com/354604/55107213-20b4ef80-50a7-11e9-96df-3d1716ffdebd.png">

Closes #9895