### PR TITLE
ref: Only put un-deleted projects & teams into request.access

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -119,13 +119,8 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
         return super(DetailedOrganizationSerializer, self).get_attrs(item_list, user)
 
     def _project_list(self, organization, access):
-        member_project_ids = []
-        member_projects = []
-        for project in access.projects:
-            if project.status == ProjectStatus.VISIBLE:
-                member_project_ids.append(project.id)
-                member_projects.append(project)
-
+        member_projects = list(access.projects)
+        member_project_ids = [p.id for p in member_projects]
         other_projects = list(Project.objects.filter(
             organization=organization,
             status=ProjectStatus.VISIBLE,
@@ -137,13 +132,8 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
         return project_list
 
     def _team_list(self, organization, access):
-        member_team_ids = []
-        member_teams = []
-        for team in access.teams:
-            if team.status == TeamStatus.VISIBLE:
-                member_team_ids.append(team.id)
-                member_teams.append(team)
-
+        member_teams = list(access.teams)
+        member_team_ids = [p.id for p in member_teams]
         other_teams = list(Team.objects.filter(
             organization=organization,
             status=TeamStatus.VISIBLE,

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -10,7 +10,8 @@ from django.utils.functional import cached_property
 from sentry import roles
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import (
-    AuthIdentity, AuthProvider, OrganizationMember, Project, SentryApp, UserPermission
+    AuthIdentity, AuthProvider, OrganizationMember, Project, SentryApp, UserPermission,
+    ProjectStatus
 )
 
 
@@ -281,7 +282,10 @@ def from_sentry_app(user, organization=None):
         return NoAccess()
 
     team_list = list(sentry_app.teams.all())
-    project_list = list(Project.objects.filter(teams__in=team_list).distinct())
+    project_list = list(Project.objects.filter(
+        status=ProjectStatus.VISIBLE,
+        teams__in=team_list
+    ).distinct())
 
     return Access(
         scopes=sentry_app.scope_list,
@@ -327,7 +331,10 @@ def from_member(member, scopes=None):
     requires_sso, sso_is_valid = _sso_params(member)
 
     team_list = member.get_teams()
-    project_list = list(Project.objects.filter(teams__in=team_list).distinct())
+    project_list = list(Project.objects.filter(
+        status=ProjectStatus.VISIBLE,
+        teams__in=team_list
+    ).distinct())
 
     if scopes is not None:
         scopes = set(scopes) & member.get_scopes()

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -10,8 +10,8 @@ from django.utils.functional import cached_property
 from sentry import roles
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import (
-    AuthIdentity, AuthProvider, OrganizationMember, Project, SentryApp, UserPermission,
-    ProjectStatus
+    AuthIdentity, AuthProvider, OrganizationMember, Project, ProjectStatus,
+    SentryApp, UserPermission
 )
 
 

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -23,8 +23,10 @@ from six.moves.urllib.parse import urlencode
 
 from sentry import roles
 from sentry.db.models import (
-    BaseModel, BoundedAutoField, BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr
+    BaseModel, BoundedAutoField, BoundedPositiveIntegerField, FlexibleForeignKey,
+    Model, sane_repr
 )
+from sentry.models.team import TeamStatus
 from sentry.utils.http import absolute_uri
 
 INVITE_DAYS_VALID = 30
@@ -298,6 +300,7 @@ class OrganizationMember(Model):
         from sentry.models import Team
 
         return Team.objects.filter(
+            status=TeamStatus.VISIBLE,
             id__in=OrganizationMemberTeam.objects.filter(
                 organizationmember=self,
                 is_active=True,


### PR DESCRIPTION
Only load visible teams and projects into request.access. This prevents situations where a user queues a project for deletion and continues to see that project inconsistently in different parts of the application.

Both projects and teams have no cancel delete feature that would require permission checks to continue working for them.

Fixes SEN-425