### PR TITLE
feat(group-event-json): Add support for Snuba event IDs

### DIFF
--- a/src/sentry/web/frontend/group_event_json.py
+++ b/src/sentry/web/frontend/group_event_json.py
@@ -31,8 +31,8 @@ class GroupEventJsonView(OrganizationView):
             event_cls = SnubaEvent if use_snuba else Event
             event = event_cls.objects.from_event_id(event_id_or_latest, group.project.id)
 
-        if event is None:
-            return Http404
+        if event is None or (event.group_id != int(group_id)):
+            raise Http404
 
         Event.objects.bind_nodes([event], 'data')
 

--- a/src/sentry/web/frontend/group_event_json.py
+++ b/src/sentry/web/frontend/group_event_json.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import, division
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404
 
-from sentry.models import Event, Group, GroupMeta, get_group_with_redirect
+from sentry import options
+from sentry.models import Event, SnubaEvent, Group, GroupMeta, get_group_with_redirect
 from sentry.utils import json
 from sentry.web.frontend.base import OrganizationView
 
@@ -12,6 +13,8 @@ class GroupEventJsonView(OrganizationView):
     required_scope = 'event:read'
 
     def get(self, request, organization, group_id, event_id_or_latest):
+        use_snuba = options.get('snuba.events-queries.enabled')
+
         try:
             # TODO(tkaemming): This should *actually* redirect, see similar
             # comment in ``GroupEndpoint.convert_args``.
@@ -26,9 +29,13 @@ class GroupEventJsonView(OrganizationView):
             # circumstances (such as a post_save signal failing)
             event = group.get_latest_event() or Event(group=group)
         else:
-            event = get_object_or_404(group.event_set, pk=event_id_or_latest)
+            if use_snuba:
+                event = SnubaEvent.objects.from_event_id(event_id_or_latest, group.project.id)
+            else:
+                event = get_object_or_404(group.event_set, pk=event_id_or_latest)
 
         Event.objects.bind_nodes([event], 'data')
+
         GroupMeta.objects.populate_cache([group])
 
         return HttpResponse(json.dumps(event.as_dict()), content_type='application/json')

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -420,12 +420,12 @@ urlpatterns += patterns(
         name='sentry-organization-issue-detail'
     ),
     url(
-        r'^organizations/(?P<organization_slug>[\w_-]+)/issues/(?P<group_id>\d+)/events/(?P<event_id_or_latest>(\d+|latest))/$',
+        r'^organizations/(?P<organization_slug>[\w_-]+)/issues/(?P<group_id>\d+)/events/(?P<event_id_or_latest>[\w-]+)/$',
         react_page_view,
         name='sentry-organization-event-detail'
     ),
     url(
-        r'^organizations/(?P<organization_slug>[\w_-]+)/issues/(?P<group_id>\d+)/events/(?P<event_id_or_latest>(\d+|latest))/json/$',
+        r'^organizations/(?P<organization_slug>[\w_-]+)/issues/(?P<group_id>\d+)/events/(?P<event_id_or_latest>[\w-]+)/json/$',
         GroupEventJsonView.as_view(),
         name='sentry-group-event-json'
     ),


### PR DESCRIPTION
Adds support for Snuba event IDs in the group event json endpoint
if the `snuba.events-queries.enabled` option is turned on