### PR TITLE
fix: Swap broken avatar in releases empty state

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "react-virtualized": "^9.20.1",
     "reflux": "0.4.1",
     "scroll-to-element": "^2.0.0",
-    "sentry-dreamy-components": "^1.0.0",
+    "sentry-dreamy-components": "^1.0.1",
     "sprintf-js": "1.0.3",
     "style-loader": "^0.23.1",
     "svg-sprite-loader": "^3.8.0",
@@ -131,20 +131,16 @@
   "scripts": {
     "test": "node scripts/test.js",
     "test-precommit": "yarn test --bail --findRelatedTests -u",
-    "test-ci":
-      "JEST_JUNIT_OUTPUT=.artifacts/jest.junit.xml yarn test --runInBand --ci --coverage --testResultsProcessor=jest-junit",
+    "test-ci": "JEST_JUNIT_OUTPUT=.artifacts/jest.junit.xml yarn test --runInBand --ci --coverage --testResultsProcessor=jest-junit",
     "test-debug": "node --inspect-brk scripts/test.js --runInBand",
     "test-staged": "yarn test --findRelatedTests $(git diff --name-only --cached)",
-    "lint":
-      "node_modules/.bin/eslint tests/js src/sentry/static/sentry/app --ext .js,.jsx",
+    "lint": "node_modules/.bin/eslint tests/js src/sentry/static/sentry/app --ext .js,.jsx",
     "lint:css": "stylelint 'src/sentry/static/sentry/app/**/*.jsx'",
     "dev": "(yarn check --verify-tree || yarn) && sentry devserver --browser-reload",
     "dev-server": "webpack-dev-server",
     "storybook": "start-storybook -p 9001 -c .storybook",
-    "storybook-build":
-      "build-storybook -c .storybook -o .storybook-out && sed -i -e 's/\\/sb_dll/sb_dll/g' .storybook-out/index.html",
-    "snapshot":
-      "build-storybook && PERCY_TOKEN=$STORYBOOK_PERCY_TOKEN PERCY_PROJECT=$STORYBOOK_PERCY_PROJECT percy-storybook --widths=1280",
+    "storybook-build": "build-storybook -c .storybook -o .storybook-out && sed -i -e 's/\\/sb_dll/sb_dll/g' .storybook-out/index.html",
+    "snapshot": "build-storybook && PERCY_TOKEN=$STORYBOOK_PERCY_TOKEN PERCY_PROJECT=$STORYBOOK_PERCY_PROJECT percy-storybook --widths=1280",
     "webpack-profile": "yarn -s webpack --profile --json > stats.json"
   },
   "toolchain": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12286,10 +12286,10 @@ send@0.16.2:
     range-parser "~1.2.0"
     statuses "~1.4.0"
 
-sentry-dreamy-components@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/sentry-dreamy-components/-/sentry-dreamy-components-1.0.0.tgz#e15a3f896e086961b43b611e3a1bb95481b98d01"
-  integrity sha512-8Ls2feP9yAjm/CCgByBNuSToky/rI0xWaqHpyCUXJ6EMELqyJWOlmOOVM50ODp1iKxEioGbalJHqHeUQb7w6Cw==
+sentry-dreamy-components@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sentry-dreamy-components/-/sentry-dreamy-components-1.0.1.tgz#ffa58fb5590a7f28f8979d470d6381f6024b4424"
+  integrity sha512-O4EWxxKVuAA4JAtcydt9cwuZqeEUsJnmByJk+80/ITzVoOodIhVan6aGAggvleNrzRLD+stp94KAtatcrD3SVQ==
 
 serialize-javascript@^1.4.0:
   version "1.5.0"


### PR DESCRIPTION
[Fixed broken avatar](https://github.com/getsentry/dreamy-components/commit/8440542f4793b84cb8dc67e35cfc71e01767413e) image in sentry-dreamy-components, Chrissy [upgraded the version](https://github.com/getsentry/dreamy-components/pull/16). This bumps the version here.


<img width="454" alt="Screen Shot 2019-03-27 at 4 42 19 PM" src="https://user-images.githubusercontent.com/16228317/55119502-5958c700-50af-11e9-892f-284a24cd16c4.png">
<img width="756" alt="Screen Shot 2019-03-27 at 4 42 02 PM" src="https://user-images.githubusercontent.com/16228317/55119503-5958c700-50af-11e9-86c6-f26d07bd8757.png">
