### PR TITLE
feat: More event size metrics

### DIFF
--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -46,7 +46,7 @@ class NodeData(collections.MutableMapping):
         data={...} means, this is an object that should be saved to nodestore.
     """
 
-    def __init__(self, field, id, data=None, data_size=None):
+    def __init__(self, field, id, data=None):
         self.field = field
         self.id = id
         self.ref = None
@@ -55,7 +55,6 @@ class NodeData(collections.MutableMapping):
         #  in the case of something changing on the data model)
         self.ref_version = None
         self._node_data = data
-        self._data_size = data_size
 
     def __getstate__(self):
         data = dict(self.__dict__)
@@ -74,7 +73,6 @@ class NodeData(collections.MutableMapping):
         state.pop('data', None)
         if state.pop('_node_data_CANONICAL', False):
             state['_node_data'] = CanonicalKeyDict(state['_node_data'])
-        state.setdefault('_data_size', None)
         self.__dict__ = state
 
     def __getitem__(self, key):
@@ -187,12 +185,10 @@ class NodeField(GzippedDictField):
 
     def to_python(self, value):
         node_id = None
-        data_size = None
         # If value is a string, we assume this is a value we've loaded from the
         # database, it should be decompressed/unpickled, and we should end up
         # with a dict.
         if value and isinstance(value, six.string_types):
-            data_size = len(value)
             try:
                 value = pickle.loads(decompress(value))
             except Exception as e:
@@ -223,7 +219,7 @@ class NodeField(GzippedDictField):
         if value is not None and self.wrapper is not None:
             value = self.wrapper(value)
 
-        return NodeData(self, node_id, value, data_size=data_size)
+        return NodeData(self, node_id, value)
 
     def get_prep_value(self, value):
         """

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -982,12 +982,6 @@ class EventManager(object):
             tags={'project_id': project.id}
         )
 
-        metrics.timing(
-            'events.node_size.post_save',
-            event.node_size,
-            tags={'project_id': project.id}
-        )
-
         return event
 
     def _get_event_user(self, project, data):

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -976,6 +976,18 @@ class EventManager(object):
             },
         )
 
+        metrics.timing(
+            'events.size.data.post_save',
+            event.size,
+            tags={'project_id': project.id}
+        )
+
+        metrics.timing(
+            'events.node_size.post_save',
+            event.node_size,
+            tags={'project_id': project.id}
+        )
+
         return event
 
     def _get_event_user(self, project, data):

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -292,7 +292,7 @@ class EventCommon(object):
 
     @property
     def size(self):
-        return len(json.dumps(self.data.data))
+        return len(json.dumps(dict(self.data)))
 
     @property
     def transaction(self):

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -34,7 +34,7 @@ from sentry.db.models import (
 )
 from sentry.db.models.manager import EventManager, SnubaEventManager
 from sentry.interfaces.base import get_interfaces
-from sentry.utils import metrics
+from sentry.utils import json, metrics
 from sentry.utils.cache import memoize
 from sentry.utils.canonical import CanonicalKeyDict, CanonicalKeyView
 from sentry.utils.safe import get_path
@@ -291,11 +291,16 @@ class EventCommon(object):
         return dict(self.data.items())
 
     @property
+    def node_size(self):
+        """Estimate how much space this event's data takes on disk."""
+        data_len = self.data._data_size
+        if data_len is not None:
+            return data_len
+        return self.size
+
+    @property
     def size(self):
-        data_len = 0
-        for value in six.itervalues(self.data):
-            data_len += len(repr(value))
-        return data_len
+        return len(json.dumps(self.data.data))
 
     @property
     def transaction(self):

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -291,14 +291,6 @@ class EventCommon(object):
         return dict(self.data.items())
 
     @property
-    def node_size(self):
-        """Estimate how much space this event's data takes on disk."""
-        data_len = self.data._data_size
-        if data_len is not None:
-            return data_len
-        return self.size
-
-    @property
     def size(self):
         return len(json.dumps(self.data.data))
 

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -557,6 +557,12 @@ class StoreView(APIView):
             metrics.timing('events.size.rejected', data_size)
             raise APIForbidden("Event size exceeded 10MB after normalization.")
 
+        metrics.timing(
+            'events.size.data.post_storeendpoint',
+            data_size,
+            tags={'project_id': project.id}
+        )
+
         return process_event(event_manager, project,
                              key, remote_addr, helper, attachments)
 


### PR DESCRIPTION
ref #12375 
ref #12470 

We're currently trying to figure out why turning the sample rate to 1.0 creates a backlog in snuba *4-5 hours after turning it on*. There's also a slight hint/suspicion that this causes a spike in alerts.

We definetly know that the payload size in workerrelay increases by a lot. Try to figure out if we just happen to get payloads this big.