### PR TITLE
ref(search):  Move `first_seen` to Django search.

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -310,6 +310,7 @@ class SnubaSearchBackend(SearchBackend):
                     lambda version: Q(
                         groupenvironment__first_release__organization_id=projects[0].organization_id,
                         groupenvironment__first_release__version=version,
+                        groupenvironment__environment_id__in=environment_ids,
                     )
                 ),
                 'first_seen': ScalarCondition(

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -52,7 +52,7 @@ aggregation_defs = {
 }
 issue_only_fields = set([
     'query', 'status', 'bookmarked_by', 'assigned_to', 'unassigned',
-    'subscribed_by', 'active_at', 'first_release',
+    'subscribed_by', 'active_at', 'first_release', 'first_seen',
 ])
 
 

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -110,8 +110,9 @@ class ScalarCondition(Condition):
         '<': 'lt',
     }
 
-    def __init__(self, field):
+    def __init__(self, field, extra=None):
         self.field = field
+        self.extra = extra
 
     def _get_operator(self, search_filter):
         django_operator = self.OPERATOR_TO_DJANGO.get(search_filter.operator, '')
@@ -121,12 +122,13 @@ class ScalarCondition(Condition):
 
     def apply(self, queryset, search_filter):
         django_operator = self._get_operator(search_filter)
-
         qs_method = queryset.exclude if search_filter.operator == '!=' else queryset.filter
 
-        return qs_method(
-            **{'{}{}'.format(self.field, django_operator): search_filter.value.raw_value}
-        )
+        q_dict = {'{}{}'.format(self.field, django_operator): search_filter.value.raw_value}
+        if self.extra:
+            q_dict.update(self.extra)
+
+        return qs_method(**q_dict)
 
 
 def assigned_to_filter(actor, projects):
@@ -310,7 +312,7 @@ class SnubaSearchBackend(SearchBackend):
                         groupenvironment__first_release__version=version,
                     )
                 ),
-                'first_seen': ds.SearchFilterScalarCondition(
+                'first_seen': ScalarCondition(
                     'groupenvironment__first_seen',
                     {'groupenvironment__environment_id__in': environment_ids}
                 ),
@@ -323,7 +325,7 @@ class SnubaSearchBackend(SearchBackend):
                         first_release__version=version,
                     ),
                 ),
-                'first_seen': ds.SearchFilterScalarCondition('first_seen'),
+                'first_seen': ScalarCondition('first_seen'),
             }).build(group_queryset, search_filters)
 
         now = timezone.now()

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -759,11 +759,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
             },
             project_id=self.project.id
         )
-        # GroupEnvironment.objects.get(group=self.group1, environment__name='development').first_seen
-        # Group.objects.filter(groupenvironment__environment__id=1).filter(groupenvironment__first_seen__gt=value)
-        # Group.objects.filter(groupenvironment__first_seen__gt=value,groupenvironment__environment__id=1)
-        # Group.objects.filter(groupenvironment__first_seen__gt=value)
-        # import pdb; pdb.set_trace()
+
         results = self.make_query(
             environments=[self.environments['production']],
             age_from=group1_first_seen,

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -41,6 +41,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         self.backend = SnubaSearchBackend()
         self.base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=pytz.utc)
 
+        event1_timestamp = (self.base_datetime - timedelta(days=21)).isoformat()[:19]
         self.event1 = self.store_event(
             data={
                 'fingerprint': ['put-me-in-group1'],
@@ -50,7 +51,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
                 'tags': {
                     'server': 'example.com',
                 },
-                'timestamp': (self.base_datetime - timedelta(days=21)).isoformat()[:19],
+                'timestamp': event1_timestamp,
                 'stacktrace': {
                     'frames': [{
                         'module': 'group1'
@@ -109,7 +110,6 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         )
 
         self.group2 = Group.objects.get(id=self.event2.group.id)
-
         assert self.group2.first_seen == self.group2.last_seen == self.event2.datetime
 
         self.group2.status = GroupStatus.RESOLVED
@@ -146,6 +146,17 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
             'production': self.event1.get_environment(),
             'staging': self.event2.get_environment(),
         }
+
+    def store_event(self, data, *args, **kwargs):
+        event = super(SnubaSearchTest, self).store_event(data, *args, **kwargs)
+        environment_name = data.get('environment')
+        if environment_name:
+            GroupEnvironment.objects.filter(
+                group_id=event.group_id,
+                environment__name=environment_name,
+                first_seen__gt=event.datetime,
+            ).update(first_seen=event.datetime)
+        return event
 
     def set_up_multi_project(self):
         self.project2 = self.create_project(organization=self.project.organization)
@@ -705,34 +716,39 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         assert set(results) == set([self.group1])
 
     def test_age_filter_with_environment(self):
+        # add time instead to make it greater than or less than as needed.
+        group1_first_seen = GroupEnvironment.objects.get(
+            environment=self.environments['production'],
+            group=self.group1,
+        ).first_seen
+
         results = self.make_query(
             environments=[self.environments['production']],
-            age_from=self.group1.first_seen,
+            age_from=group1_first_seen,
             age_from_inclusive=True,
-            search_filter_query='firstSeen:>=%s' % date_to_query_format(self.group1.first_seen),
+            search_filter_query='firstSeen:>=%s' % date_to_query_format(group1_first_seen),
         )
         assert set(results) == set([self.group1])
 
         results = self.make_query(
             environments=[self.environments['production']],
-            age_to=self.group1.first_seen,
+            age_to=group1_first_seen,
             age_to_inclusive=True,
-            search_filter_query='firstSeen:<=%s' % date_to_query_format(self.group1.first_seen),
+            search_filter_query='firstSeen:<=%s' % date_to_query_format(group1_first_seen),
         )
         assert set(results) == set([self.group1])
 
         results = self.make_query(
             environments=[self.environments['production']],
-            age_from=self.group1.first_seen,
+            age_from=group1_first_seen,
             age_from_inclusive=False,
-            search_filter_query='firstSeen:>%s' % date_to_query_format(self.group1.first_seen),
+            search_filter_query='firstSeen:>%s' % date_to_query_format(group1_first_seen),
         )
         assert set(results) == set([])
-
         self.store_event(
             data={
                 'fingerprint': ['put-me-in-group1'],
-                'timestamp': (self.group1.first_seen + timedelta(days=1)).isoformat()[:19],
+                'timestamp': (group1_first_seen + timedelta(days=1)).isoformat()[:19],
                 'message': 'group1',
                 'stacktrace': {
                     'frames': [{
@@ -743,20 +759,24 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
             },
             project_id=self.project.id
         )
-
+        # GroupEnvironment.objects.get(group=self.group1, environment__name='development').first_seen
+        # Group.objects.filter(groupenvironment__environment__id=1).filter(groupenvironment__first_seen__gt=value)
+        # Group.objects.filter(groupenvironment__first_seen__gt=value,groupenvironment__environment__id=1)
+        # Group.objects.filter(groupenvironment__first_seen__gt=value)
+        # import pdb; pdb.set_trace()
         results = self.make_query(
             environments=[self.environments['production']],
-            age_from=self.group1.first_seen,
+            age_from=group1_first_seen,
             age_from_inclusive=False,
-            search_filter_query='firstSeen:>%s' % date_to_query_format(self.group1.first_seen),
+            search_filter_query='firstSeen:>%s' % date_to_query_format(group1_first_seen),
         )
         assert set(results) == set([])
 
         results = self.make_query(
             environments=[Environment.objects.get(name='development')],
-            age_from=self.group1.first_seen,
+            age_from=group1_first_seen,
             age_from_inclusive=False,
-            search_filter_query='firstSeen:>%s' % date_to_query_format(self.group1.first_seen),
+            search_filter_query='firstSeen:>%s' % date_to_query_format(group1_first_seen),
         )
         assert set(results) == set([self.group1])
 

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1168,22 +1168,6 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
             **common_args
         )
 
-        self.make_query(
-            search_filter_query='age:>=%s foo' % date_to_query_format(timezone.now()),
-            query='foo',
-            age_from=timezone.now(),
-            sort_by='new',
-        )
-        assert query_mock.call_args == mock.call(
-            orderby=['-first_seen', 'issue'],
-            aggregations=[
-                ['toUInt64(min(timestamp)) * 1000', '', 'first_seen'],
-                ['uniq', 'issue', 'total'],
-            ],
-            having=[['first_seen', '>=', Any(int)]],
-            **common_args
-        )
-
     def test_pre_and_post_filtering(self):
         prev_max_pre = options.get('snuba.search.max-pre-snuba-candidates')
         options.set('snuba.search.max-pre-snuba-candidates', 1)


### PR DESCRIPTION
At the moment, we calculate `first_seen` for a group from the events we find in Snuba. This gives us strange results if the date range is for a small period of time.

To fix this, we should move filters on this parameter back out into Postgres. We might have an entirely Snuba solution at some point, but for now this is simplest.