### PR TITLE
feat: Add symbolicator as optional devservice

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1416,6 +1416,12 @@ SENTRY_DEVSERVICES = {
         'image': 'memcached:1.5-alpine',
         'ports': {'11211/tcp': 11211},
     },
+    'symbolicator': {
+        'image': 'us.gcr.io/sentryio/symbolicator:latest',
+        'pull': True,
+        'ports': {'3021/tcp': 3021},
+        'command': ['run'],
+    }
 }
 
 # Max file size for avatar photo uploads

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -33,6 +33,7 @@ register('system.event-retention-days', default=0, flags=FLAG_ALLOW_EMPTY | FLAG
 register('system.secret-key', flags=FLAG_NOSTORE)
 # Absolute URL to the sentry root directory. Should not include a trailing slash.
 register('system.url-prefix', ttl=60, grace=3600, flags=FLAG_REQUIRED | FLAG_PRIORITIZE_DISK)
+register('system.internal-url-prefix', flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
 register('system.root-api-key', flags=FLAG_PRIORITIZE_DISK)
 register('system.logging-format', default=LoggingFormat.HUMAN, flags=FLAG_NOSTORE)
 # This is used for the chunk upload endpoint

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -109,8 +109,16 @@ register('filestore.options', default={'location': '/tmp/sentry-files'}, flags=F
 register('symbolserver.enabled', default=False, flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
 register(
     'symbolserver.options',
-    default={'url': 'http://127.0.0.1:3000'},
+    default={'url': 'http://127.0.0.1:3021'},
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK
+)
+
+# Symbolicator
+register('symbolicator.enabled', default=False, flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
+register(
+    'symbolicator.options',
+    default={'url': 'http://127.0.0.1:'},
+    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK,
 )
 
 # Analytics

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -109,7 +109,7 @@ register('filestore.options', default={'location': '/tmp/sentry-files'}, flags=F
 register('symbolserver.enabled', default=False, flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
 register(
     'symbolserver.options',
-    default={'url': 'http://127.0.0.1:3021'},
+    default={'url': 'http://127.0.0.1:3000'},
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK
 )
 
@@ -117,7 +117,7 @@ register(
 register('symbolicator.enabled', default=False, flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
 register(
     'symbolicator.options',
-    default={'url': 'http://127.0.0.1:'},
+    default={'url': 'http://127.0.0.1:3021'},
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK,
 )
 

--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -67,6 +67,7 @@ def up(project, exclude):
     configure()
 
     from django.conf import settings
+    from sentry import options as sentry_options
 
     import docker
     client = get_docker_client()
@@ -96,6 +97,9 @@ def up(project, exclude):
             err=True,
             fg='cyan')
         exclude |= {'kafka', 'zookeeper', 'snuba', 'clickhouse'}
+
+    if not sentry_options.get('symbolicator.enabled'):
+        exclude |= 'symbolicator'
 
     get_or_create(client, 'network', project)
 


### PR DESCRIPTION
This adds an option to enable the native symbolicator and adds it as an optional devservice.

Symbolicator is the new service that will perform all native symbolication. It will be an optional, although recommended, service for on-premise and should be included in single-tenant by default. It will not be required to run Sentry in development mode. When not configured, native stacktraces will simply not be symbolicated.

For now, we will run the symbolicator with default configuration. If we identify the need to override that, for local development, we can mount a config file from `~/.sentry/symbolicator.yml` and specify it via `run -c symbolicator.yml`.

Also this adds the `system.internal-url-prefix` option. If set, it is used in place of `system.url-prefix` as the base URL when sending endpoint URLs to the symbolicator. In development, we will require this to be set to `http://host.docker.internal:8000` to work with devservices. This will be documented in the symbolicator repository.

The actual functionality building on top of symbolicator will be merged with https://github.com/getsentry/sentry/pull/12517.