### PR TITLE
ref(project-selector): more obvious submit button

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -227,6 +227,7 @@ class DropdownAutoCompleteMenu extends React.Component {
           {({width}) => (
             <List
               width={width}
+              style={{outline: 'none'}}
               height={Math.min(items.length * virtualizedHeight, maxHeight)}
               rowCount={items.length}
               rowHeight={virtualizedHeight}

--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -363,7 +363,7 @@ class DropdownAutoCompleteMenu extends React.Component {
             typeof menuFooter === 'function' ? menuFooter({actions}) : menuFooter;
 
           const renderedInputActions =
-            typeof inputActions === 'function' ? inputActions({actions}) : inputActions;
+            typeof inputActions === 'function' ? inputActions() : inputActions;
 
           return (
             <AutoCompleteRoot {...getRootProps()} className={rootClassName}>

--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -363,7 +363,7 @@ class DropdownAutoCompleteMenu extends React.Component {
             typeof menuFooter === 'function' ? menuFooter({actions}) : menuFooter;
 
           const renderedInputActions =
-            typeof inputActions === 'function' ? inputActions() : inputActions;
+            typeof inputActions === 'function' ? inputActions({actions}) : inputActions;
 
           return (
             <AutoCompleteRoot {...getRootProps()} className={rootClassName}>

--- a/src/sentry/static/sentry/app/components/globalSelectionHeaderRow.jsx
+++ b/src/sentry/static/sentry/app/components/globalSelectionHeaderRow.jsx
@@ -69,8 +69,8 @@ const Checkbox = styled(CheckboxFancy)`
 `;
 
 const CheckboxWrapper = styled('div')`
-  margin: 0 -${space(0.5)} 0 0; /* pushes the click box to be flush with the edge of the menu */
-  padding: 0 ${space(1.25)} 0 ${space(1)};
+  margin: 0 -${space(1)} 0 0; /* pushes the click box to be flush with the edge of the menu */
+  padding: 0 ${space(1.5)} 0 ${space(1.25)};
   height: 100%;
   display: flex;
   justify-content: flex-end;

--- a/src/sentry/static/sentry/app/components/organizations/headerItem.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/headerItem.jsx
@@ -28,22 +28,12 @@ class HeaderItem extends React.Component {
     this.props.onClear();
   };
 
-  handleChevronClick = e => {
-    if (!this.props.hasChanges) {
-      return;
-    }
-
-    e.stopPropagation();
-    this.props.onSubmit();
-  };
-
   render() {
     const {
       className,
       children,
       isOpen,
       hasSelected,
-      hasChanges,
       allowClear,
       icon,
       locked,
@@ -74,11 +64,7 @@ class HeaderItem extends React.Component {
           />
         )}
         {!locked && (
-          <StyledChevron
-            isOpen={isOpen}
-            hasChanges={hasChanges}
-            onClick={this.handleChevronClick}
-          >
+          <StyledChevron isOpen={isOpen}>
             <InlineSvg src="icon-chevron-down" />
           </StyledChevron>
         )}
@@ -143,17 +129,6 @@ const StyledChevron = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;
-  ${p =>
-    p.hasChanges
-      ? `
-    background: ${p.theme.purple};
-    border-radius: 2em;
-    width: 20px;
-    height: 20px;
-    color: #fff;
-    transform: rotate(270deg);
-  `
-      : ''};
 `;
 
 const StyledLock = styled(InlineSvg)`

--- a/src/sentry/static/sentry/app/components/organizations/headerItem.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/headerItem.jsx
@@ -11,7 +11,6 @@ class HeaderItem extends React.Component {
     allowClear: PropTypes.bool,
     icon: PropTypes.element,
     onClear: PropTypes.func,
-    onSubmit: PropTypes.func,
     hasChanges: PropTypes.bool,
     hasSelected: PropTypes.bool,
     isOpen: PropTypes.bool,
@@ -39,7 +38,6 @@ class HeaderItem extends React.Component {
       locked,
       lockedMessage,
       onClear, // eslint-disable-line no-unused-vars
-      onSubmit, // eslint-disable-line no-unused-vars
       ...props
     } = this.props;
 

--- a/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
@@ -259,8 +259,6 @@ class MultipleEnvironmentSelector extends React.PureComponent {
             icon={<StyledInlineSvg src="icon-window" />}
             isOpen={isOpen}
             hasSelected={value && !!value.length}
-            hasChanges={this.state.hasChanges}
-            onSubmit={() => this.handleUpdate(actions)}
             onClear={this.handleClear}
             {...getActorProps({
               isStyled: true,

--- a/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
@@ -11,6 +11,7 @@ import GlobalSelectionHeaderRow from 'app/components/globalSelectionHeaderRow';
 import HeaderItem from 'app/components/organizations/headerItem';
 import Highlight from 'app/components/highlight';
 import InlineSvg from 'app/components/inlineSvg';
+import MultipleSelectorSubmitRow from 'app/components/organizations/multipleSelectorSubmitRow';
 import SentryTypes from 'app/sentryTypes';
 import theme from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
@@ -234,6 +235,11 @@ class MultipleEnvironmentSelector extends React.PureComponent {
         virtualizedHeight={theme.headerSelectorRowHeight}
         emptyHidesInput
         menuProps={{style: {position: 'relative'}}}
+        menuFooter={({actions}) =>
+          this.state.hasChanges && (
+            <MultipleSelectorSubmitRow onSubmit={() => this.handleUpdate(actions)} />
+          )
+        }
         items={environments.map(env => ({
           value: env,
           searchKey: env,

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -1,6 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled, {css} from 'react-emotion';
+import Button from 'app/components/button';
+import {growIn} from 'app/styles/animations';
+import space from 'app/styles/space';
+
 
 import SentryTypes from 'app/sentryTypes';
 import {analytics} from 'app/utils/analytics';
@@ -129,6 +133,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
   render() {
     const {value, projects, multi, forceProject} = this.props;
     const selectedProjectIds = new Set(value);
+    const showSubmitButton = multi && this.state.hasChanges;
 
     const selected = projects.filter(project =>
       selectedProjectIds.has(parseInt(project.id, 10))
@@ -154,6 +159,19 @@ export default class MultipleProjectSelector extends React.PureComponent {
         onMultiSelect={this.handleMultiSelect}
         onUpdate={this.handleUpdate}
         rootClassName={rootContainerStyles}
+        menuFooter={({actions}) => {
+          return showSubmitButton && (
+              <SubmitButtonContainer>
+                <SubmitButton
+                  onClick={() => this.handleUpdate(actions)}
+                  size="xsmall"
+                  priority="primary"
+                >
+                  Apply
+                </SubmitButton>
+              </SubmitButtonContainer>
+          )
+        }}
       >
         {({
           getActorProps,
@@ -192,6 +210,16 @@ const StyledProjectSelector = styled(ProjectSelector)`
   margin: 1px 0 0 -1px;
   border-radius: 0 0 4px 4px;
   width: 110%;
+`;
+
+const SubmitButtonContainer = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const SubmitButton = styled(Button)`
+  animation: 0.1s ${growIn} ease-in;
+  margin: ${space(0.5)} 0;
 `;
 
 const StyledHeaderItem = styled(HeaderItem)`

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -164,7 +164,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
                 size="xsmall"
                 priority="primary"
               >
-                Apply
+                {t('Apply')}
               </SubmitButton>
             </SubmitButtonContainer>
           )

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -149,8 +149,10 @@ export default class MultipleProjectSelector extends React.PureComponent {
         selectedProjects={selected}
         multiProjects={projects}
         onSelect={this.handleQuickSelect}
+        hasChanges={this.state.hasChanges}
         onClose={this.handleClose}
         onMultiSelect={this.handleMultiSelect}
+        onUpdate={this.handleUpdate}
         rootClassName={rootContainerStyles}
       >
         {({
@@ -173,7 +175,6 @@ export default class MultipleProjectSelector extends React.PureComponent {
               hasSelected={hasSelected}
               hasChanges={this.state.hasChanges}
               isOpen={isOpen}
-              onSubmit={() => this.handleUpdate(actions)}
               onClear={this.handleClear}
               allowClear={multi}
               {...getActorProps()}

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -5,7 +5,6 @@ import Button from 'app/components/button';
 import {growIn} from 'app/styles/animations';
 import space from 'app/styles/space';
 
-
 import SentryTypes from 'app/sentryTypes';
 import {analytics} from 'app/utils/analytics';
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
@@ -157,17 +156,19 @@ export default class MultipleProjectSelector extends React.PureComponent {
         onClose={this.handleClose}
         onMultiSelect={this.handleMultiSelect}
         rootClassName={rootContainerStyles}
-        menuFooter={({actions}) => showSubmitButton && (
-          <SubmitButtonContainer>
-            <SubmitButton
-              onClick={() => this.handleUpdate(actions)}
-              size="xsmall"
-              priority="primary"
-            >
-              Apply
-            </SubmitButton>
-          </SubmitButtonContainer>
-        )}
+        menuFooter={({actions}) =>
+          showSubmitButton && (
+            <SubmitButtonContainer>
+              <SubmitButton
+                onClick={() => this.handleUpdate(actions)}
+                size="xsmall"
+                priority="primary"
+              >
+                Apply
+              </SubmitButton>
+            </SubmitButtonContainer>
+          )
+        }
       >
         {({
           getActorProps,

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -157,19 +157,17 @@ export default class MultipleProjectSelector extends React.PureComponent {
         onClose={this.handleClose}
         onMultiSelect={this.handleMultiSelect}
         rootClassName={rootContainerStyles}
-        menuFooter={({actions}) => {
-          return showSubmitButton && (
-              <SubmitButtonContainer>
-                <SubmitButton
-                  onClick={() => this.handleUpdate(actions)}
-                  size="xsmall"
-                  priority="primary"
-                >
-                  Apply
-                </SubmitButton>
-              </SubmitButtonContainer>
-          )
-        }}
+        menuFooter={({actions}) => showSubmitButton && (
+          <SubmitButtonContainer>
+            <SubmitButton
+              onClick={() => this.handleUpdate(actions)}
+              size="xsmall"
+              priority="primary"
+            >
+              Apply
+            </SubmitButton>
+          </SubmitButtonContainer>
+        )}
       >
         {({
           getActorProps,

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -154,10 +154,8 @@ export default class MultipleProjectSelector extends React.PureComponent {
         selectedProjects={selected}
         multiProjects={projects}
         onSelect={this.handleQuickSelect}
-        hasChanges={this.state.hasChanges}
         onClose={this.handleClose}
         onMultiSelect={this.handleMultiSelect}
-        onUpdate={this.handleUpdate}
         rootClassName={rootContainerStyles}
         menuFooter={({actions}) => {
           return showSubmitButton && (

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -1,9 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled, {css} from 'react-emotion';
-import Button from 'app/components/button';
-import {growIn} from 'app/styles/animations';
-import space from 'app/styles/space';
 
 import SentryTypes from 'app/sentryTypes';
 import {analytics} from 'app/utils/analytics';
@@ -13,6 +10,7 @@ import ProjectSelector from 'app/components/projectSelector';
 import InlineSvg from 'app/components/inlineSvg';
 
 import HeaderItem from 'app/components/organizations/headerItem';
+import MultipleSelectorSubmitRow from 'app/components/organizations/multipleSelectorSubmitRow';
 
 const rootContainerStyles = css`
   display: flex;
@@ -132,7 +130,6 @@ export default class MultipleProjectSelector extends React.PureComponent {
   render() {
     const {value, projects, multi, forceProject} = this.props;
     const selectedProjectIds = new Set(value);
-    const showSubmitButton = multi && this.state.hasChanges;
 
     const selected = projects.filter(project =>
       selectedProjectIds.has(parseInt(project.id, 10))
@@ -157,16 +154,8 @@ export default class MultipleProjectSelector extends React.PureComponent {
         onMultiSelect={this.handleMultiSelect}
         rootClassName={rootContainerStyles}
         menuFooter={({actions}) =>
-          showSubmitButton && (
-            <SubmitButtonContainer>
-              <SubmitButton
-                onClick={() => this.handleUpdate(actions)}
-                size="xsmall"
-                priority="primary"
-              >
-                {t('Apply')}
-              </SubmitButton>
-            </SubmitButtonContainer>
+          this.state.hasChanges && (
+            <MultipleSelectorSubmitRow onSubmit={() => this.handleUpdate(actions)} />
           )
         }
       >
@@ -207,16 +196,6 @@ const StyledProjectSelector = styled(ProjectSelector)`
   margin: 1px 0 0 -1px;
   border-radius: 0 0 4px 4px;
   width: 110%;
-`;
-
-const SubmitButtonContainer = styled('div')`
-  display: flex;
-  justify-content: flex-end;
-`;
-
-const SubmitButton = styled(Button)`
-  animation: 0.1s ${growIn} ease-in;
-  margin: ${space(0.5)} 0;
 `;
 
 const StyledHeaderItem = styled(HeaderItem)`

--- a/src/sentry/static/sentry/app/components/organizations/multipleSelectorSubmitRow.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleSelectorSubmitRow.jsx
@@ -1,0 +1,37 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'react-emotion';
+import Button from 'app/components/button';
+import {growIn} from 'app/styles/animations';
+import space from 'app/styles/space';
+import {t} from 'app/locale';
+
+class MultipleSelectorSubmitRow extends React.Component {
+  static propTypes = {
+    onSubmit: PropTypes.func,
+  };
+
+  render() {
+    const {onSubmit} = this.props;
+
+    return (
+      <SubmitButtonContainer>
+        <SubmitButton onClick={onSubmit} size="xsmall" priority="primary">
+          {t('Apply')}
+        </SubmitButton>
+      </SubmitButtonContainer>
+    );
+  }
+}
+
+const SubmitButtonContainer = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const SubmitButton = styled(Button)`
+  animation: 0.1s ${growIn} ease-in;
+  margin: ${space(0.5)} 0;
+`;
+
+export default MultipleSelectorSubmitRow;

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
@@ -310,11 +310,11 @@ class TimeRangeSelector extends React.PureComponent {
             <StyledHeaderItem
               icon={<StyledInlineSvg src="icon-calendar" />}
               isOpen={isOpen}
-              hasChanges={this.state.hasChanges}
               hasSelected={
                 (!!this.props.relative && this.props.relative !== DEFAULT_STATS_PERIOD) ||
                 isAbsoluteSelected
               }
+              hasChanges={this.state.hasChanges}
               onClear={this.handleClear}
               allowClear={true}
               {...getActorProps({isStyled: true})}

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
@@ -311,7 +311,10 @@ class TimeRangeSelector extends React.PureComponent {
               icon={<StyledInlineSvg src="icon-calendar" />}
               isOpen={isOpen}
               hasChanges={this.state.hasChanges}
-              hasSelected={this.props.relative !== DEFAULT_STATS_PERIOD}
+              hasSelected={
+                (!!this.props.relative && this.props.relative !== DEFAULT_STATS_PERIOD) ||
+                isAbsoluteSelected
+              }
               onClear={this.handleClear}
               allowClear={true}
               {...getActorProps({isStyled: true})}

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
@@ -20,9 +20,11 @@ import DateSummary from 'app/components/organizations/timeRangeSelector/dateSumm
 import DropdownMenu from 'app/components/dropdownMenu';
 import HeaderItem from 'app/components/organizations/headerItem';
 import InlineSvg from 'app/components/inlineSvg';
+import MultipleSelectorSubmitRow from 'app/components/organizations/multipleSelectorSubmitRow';
 import RelativeSelector from 'app/components/organizations/timeRangeSelector/dateRange/relativeSelector';
 import SelectorItem from 'app/components/organizations/timeRangeSelector/dateRange/selectorItem';
 import SentryTypes from 'app/sentryTypes';
+import space from 'app/styles/space';
 import getDynamicText from 'app/utils/getDynamicText';
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
 
@@ -344,15 +346,24 @@ class TimeRangeSelector extends React.PureComponent {
                   )}
                 </SelectorList>
                 {isAbsoluteSelected && (
-                  <DateRange
-                    showTimePicker
-                    utc={this.state.utc}
-                    start={start}
-                    end={end}
-                    onChange={this.handleSelectDateRange}
-                    onChangeUtc={this.handleUseUtc}
-                    organization={organization}
-                  />
+                  <div>
+                    <DateRange
+                      showTimePicker
+                      utc={this.state.utc}
+                      start={start}
+                      end={end}
+                      onChange={this.handleSelectDateRange}
+                      onChangeUtc={this.handleUseUtc}
+                      organization={organization}
+                    />
+                    {this.state.hasChanges && (
+                      <SubmitRow>
+                        <MultipleSelectorSubmitRow
+                          onSubmit={() => this.handleCloseMenu()}
+                        />
+                      </SubmitRow>
+                    )}
+                  </div>
                 )}
               </Menu>
             )}
@@ -399,6 +410,12 @@ const SelectorList = styled(({isAbsoluteSelected, ...props}) => <Flex {...props}
   flex-shrink: 0;
   width: ${p => (p.isAbsoluteSelected ? '160px' : '220px')};
   min-height: 305px;
+`;
+
+const SubmitRow = styled('div')`
+  padding: ${space(0.5)} ${space(1)};
+  border-top: 1px solid ${p => p.theme.borderLight};
+  border-left: 1px solid ${p => p.theme.borderLight};
 `;
 
 export default TimeRangeSelector;

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
@@ -310,14 +310,10 @@ class TimeRangeSelector extends React.PureComponent {
             <StyledHeaderItem
               icon={<StyledInlineSvg src="icon-calendar" />}
               isOpen={isOpen}
-              hasSelected={
-                (!!this.props.relative && this.props.relative !== DEFAULT_STATS_PERIOD) ||
-                isAbsoluteSelected
-              }
               hasChanges={this.state.hasChanges}
+              hasSelected={this.props.relative !== DEFAULT_STATS_PERIOD}
               onClear={this.handleClear}
               allowClear={true}
-              onSubmit={this.handleCloseMenu}
               {...getActorProps({isStyled: true})}
             >
               {getDynamicText({value: summary, fixed: 'start to end'})}

--- a/src/sentry/static/sentry/app/components/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectSelector.jsx
@@ -6,7 +6,7 @@ import {Link} from 'react-router';
 import {analytics} from 'app/utils/analytics';
 import {sortArray} from 'app/utils';
 import {t} from 'app/locale';
-import {alertHighlight, pulse} from 'app/styles/animations';
+import {alertHighlight, growIn, pulse} from 'app/styles/animations';
 import Button from 'app/components/button';
 import ConfigStore from 'app/stores/configStore';
 import InlineSvg from 'app/components/inlineSvg';
@@ -22,6 +22,7 @@ import withProjects from 'app/utils/withProjects';
 
 class ProjectSelector extends React.Component {
   static propTypes = {
+    hasChanges: PropTypes.bool,
     // Accepts a project id (slug) and not a project *object* because ProjectSelector
     // is created from Django templates, and only organization is serialized
     projectId: PropTypes.string,
@@ -54,6 +55,10 @@ class ProjectSelector extends React.Component {
     // Callback when projects are selected via the multiple project selector
     // Calls back with (projects[], event)
     onMultiSelect: PropTypes.func,
+
+    // Callback to trigger a multiSelect update
+    onUpdate: PropTypes.func,
+
     rootClassName: PropTypes.string,
   };
 
@@ -175,9 +180,11 @@ class ProjectSelector extends React.Component {
       organization: org,
       menuFooter,
       multi,
+      hasChanges,
       className,
       rootClassName,
       onClose,
+      onUpdate,
     } = this.props;
     const {activeProject} = this.state;
     const access = new Set(org.access);
@@ -209,17 +216,29 @@ class ProjectSelector extends React.Component {
         noResultsMessage={t('No projects found')}
         virtualizedHeight={theme.headerSelectorRowHeight}
         emptyHidesInput
-        inputActions={() => (
-          <AddButton
-            disabled={!hasProjectWrite}
-            to={`/organizations/${org.slug}/projects/new/`}
-            size="xsmall"
-            title={
-              hasProjectWrite ? null : t("You don't have permission to add a project")
-            }
-          >
-            <StyledAddIcon src="icon-circle-add" /> {t('Project')}
-          </AddButton>
+        inputActions={({actions}) => (
+          <React.Fragment>
+            {multi &&
+              hasChanges && (
+                <SubmitButton
+                  onClick={() => onUpdate(actions)}
+                  size="xsmall"
+                  priority="primary"
+                >
+                  Submit
+                </SubmitButton>
+              )}
+              <AddButton
+                disabled={!hasProjectWrite}
+                to={`/organizations/${org.slug}/projects/new/`}
+                size="xsmall"
+                title={
+                  hasProjectWrite ? null : t("You don't have permission to add a project")
+                }
+              >
+                <StyledAddIcon src="icon-circle-add" /> {t('Project')}
+              </AddButton>
+          </React.Fragment>
         )}
         menuFooter={renderProps => {
           const renderedFooter =
@@ -393,6 +412,10 @@ const AddButton = styled(Button)`
   &:hover {
     color: ${p => p.theme.gray3};
   }
+`;
+
+const SubmitButton = styled(Button)`
+  animation: 0.1s ${growIn} ease-in;
 `;
 
 const BadgeWrapper = styled('div')`

--- a/src/sentry/static/sentry/app/components/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectSelector.jsx
@@ -217,40 +217,40 @@ class ProjectSelector extends React.Component {
         virtualizedHeight={theme.headerSelectorRowHeight}
         emptyHidesInput
         inputActions={({actions}) => (
-          <React.Fragment>
-            {multi &&
-              hasChanges && (
-                <SubmitButton
-                  onClick={() => onUpdate(actions)}
-                  size="xsmall"
-                  priority="primary"
-                >
-                  Submit
-                </SubmitButton>
-              )}
-              <AddButton
-                disabled={!hasProjectWrite}
-                to={`/organizations/${org.slug}/projects/new/`}
-                size="xsmall"
-                title={
-                  hasProjectWrite ? null : t("You don't have permission to add a project")
-                }
-              >
-                <StyledAddIcon src="icon-circle-add" /> {t('Project')}
-              </AddButton>
-          </React.Fragment>
+          <AddButton
+            disabled={!hasProjectWrite}
+            to={`/organizations/${org.slug}/projects/new/`}
+            size="xsmall"
+            title={
+              hasProjectWrite ? null : t("You don't have permission to add a project")
+            }
+          >
+            <StyledAddIcon src="icon-circle-add" /> {t('Project')}
+          </AddButton>
         )}
         menuFooter={renderProps => {
           const renderedFooter =
             typeof menuFooter === 'function' ? menuFooter(renderProps) : menuFooter;
           const showCreateProjectButton = !hasProjects && hasProjectWrite;
+          const showSubmitButton = multi && hasChanges;
 
-          if (!renderedFooter && !showCreateProjectButton) {
+          if (!renderedFooter && !showCreateProjectButton && !showSubmitButton) {
             return null;
           }
 
           return (
             <React.Fragment>
+              {showSubmitButton && (
+                  <SubmitButtonContainer>
+                    <SubmitButton
+                      onClick={() => onUpdate(actions)}
+                      size="xsmall"
+                      priority="primary"
+                    >
+                      Submit
+                    </SubmitButton>
+                  </SubmitButtonContainer>
+              )}
               {showCreateProjectButton && (
                 <CreateProjectButton
                   priority="primary"
@@ -414,8 +414,14 @@ const AddButton = styled(Button)`
   }
 `;
 
+const SubmitButtonContainer = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+`;
+
 const SubmitButton = styled(Button)`
   animation: 0.1s ${growIn} ease-in;
+  margin: ${space(0.5)} 0;
 `;
 
 const BadgeWrapper = styled('div')`

--- a/src/sentry/static/sentry/app/components/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectSelector.jsx
@@ -6,7 +6,7 @@ import {Link} from 'react-router';
 import {analytics} from 'app/utils/analytics';
 import {sortArray} from 'app/utils';
 import {t} from 'app/locale';
-import {alertHighlight, growIn, pulse} from 'app/styles/animations';
+import {alertHighlight, pulse} from 'app/styles/animations';
 import Button from 'app/components/button';
 import ConfigStore from 'app/stores/configStore';
 import InlineSvg from 'app/components/inlineSvg';
@@ -232,25 +232,13 @@ class ProjectSelector extends React.Component {
           const renderedFooter =
             typeof menuFooter === 'function' ? menuFooter(renderProps) : menuFooter;
           const showCreateProjectButton = !hasProjects && hasProjectWrite;
-          const showSubmitButton = multi && hasChanges;
 
-          if (!renderedFooter && !showCreateProjectButton && !showSubmitButton) {
+          if (!renderedFooter && !showCreateProjectButton) {
             return null;
           }
 
           return (
             <React.Fragment>
-              {showSubmitButton && (
-                  <SubmitButtonContainer>
-                    <SubmitButton
-                      onClick={() => onUpdate(actions)}
-                      size="xsmall"
-                      priority="primary"
-                    >
-                      Submit
-                    </SubmitButton>
-                  </SubmitButtonContainer>
-              )}
               {showCreateProjectButton && (
                 <CreateProjectButton
                   priority="primary"
@@ -412,16 +400,6 @@ const AddButton = styled(Button)`
   &:hover {
     color: ${p => p.theme.gray3};
   }
-`;
-
-const SubmitButtonContainer = styled('div')`
-  display: flex;
-  justify-content: flex-end;
-`;
-
-const SubmitButton = styled(Button)`
-  animation: 0.1s ${growIn} ease-in;
-  margin: ${space(0.5)} 0;
 `;
 
 const BadgeWrapper = styled('div')`

--- a/src/sentry/static/sentry/app/components/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectSelector.jsx
@@ -22,7 +22,6 @@ import withProjects from 'app/utils/withProjects';
 
 class ProjectSelector extends React.Component {
   static propTypes = {
-    hasChanges: PropTypes.bool,
     // Accepts a project id (slug) and not a project *object* because ProjectSelector
     // is created from Django templates, and only organization is serialized
     projectId: PropTypes.string,
@@ -55,10 +54,6 @@ class ProjectSelector extends React.Component {
     // Callback when projects are selected via the multiple project selector
     // Calls back with (projects[], event)
     onMultiSelect: PropTypes.func,
-
-    // Callback to trigger a multiSelect update
-    onUpdate: PropTypes.func,
-
     rootClassName: PropTypes.string,
   };
 
@@ -180,11 +175,9 @@ class ProjectSelector extends React.Component {
       organization: org,
       menuFooter,
       multi,
-      hasChanges,
       className,
       rootClassName,
       onClose,
-      onUpdate,
     } = this.props;
     const {activeProject} = this.state;
     const access = new Set(org.access);
@@ -216,7 +209,7 @@ class ProjectSelector extends React.Component {
         noResultsMessage={t('No projects found')}
         virtualizedHeight={theme.headerSelectorRowHeight}
         emptyHidesInput
-        inputActions={({actions}) => (
+        inputActions={() => (
           <AddButton
             disabled={!hasProjectWrite}
             to={`/organizations/${org.slug}/projects/new/`}

--- a/src/sentry/static/sentry/app/styles/animations.jsx
+++ b/src/sentry/static/sentry/app/styles/animations.jsx
@@ -4,9 +4,11 @@ import theme from 'app/utils/theme';
 
 export const growIn = keyframes`
   0% {
-    transform: scale(0);
+    opacity: 0;
+    transform: scale(0.75);
   }
   100% {
+    opacity: 1;
     transform: scale(1);
   }
 `;

--- a/tests/js/spec/components/forms/__snapshots__/radioGroup.spec.jsx.snap
+++ b/tests/js/spec/components/forms/__snapshots__/radioGroup.spec.jsx.snap
@@ -156,11 +156,11 @@ exports[`RadioGroup render() renders disabled 1`] = `
               >
                 <Component
                   animate={true}
-                  className="css-18ziuuc-RadioLineButtonFill eeb3g7x2"
+                  className="css-14bkqla-RadioLineButtonFill eeb3g7x2"
                   disabled={true}
                 >
                   <div
-                    className="css-18ziuuc-RadioLineButtonFill eeb3g7x2"
+                    className="css-14bkqla-RadioLineButtonFill eeb3g7x2"
                   />
                 </Component>
               </RadioLineButtonFill>

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -989,7 +989,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                           <ForwardRef
                                                             active={false}
                                                             allowClear={false}
-                                                            className="css-12jjx2u-StyledHeaderItem ewlipse3"
+                                                            className="css-12jjx2u-StyledHeaderItem ewlipse1"
                                                             hasChanges={false}
                                                             hasSelected={false}
                                                             icon={
@@ -1013,7 +1013,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                             <HeaderItem
                                                               active={false}
                                                               allowClear={false}
-                                                              className="css-12jjx2u-StyledHeaderItem ewlipse3"
+                                                              className="css-12jjx2u-StyledHeaderItem ewlipse1"
                                                               hasChanges={false}
                                                               hasSelected={false}
                                                               icon={
@@ -1037,7 +1037,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                             >
                                                               <StyledHeaderItem
                                                                 active={false}
-                                                                className="css-12jjx2u-StyledHeaderItem ewlipse3"
+                                                                className="css-12jjx2u-StyledHeaderItem ewlipse1"
                                                                 hasChanges={false}
                                                                 hasSelected={false}
                                                                 innerRef={null}
@@ -1054,7 +1054,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                                 tabIndex={-1}
                                                               >
                                                                 <div
-                                                                  className="ewlipse3 css-11wumjj-StyledHeaderItem-StyledHeaderItem enk2k7v0"
+                                                                  className="ewlipse1 css-11wumjj-StyledHeaderItem-StyledHeaderItem enk2k7v0"
                                                                   onClick={[Function]}
                                                                   onKeyDown={[Function]}
                                                                   onMouseEnter={[Function]}
@@ -1076,17 +1076,17 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                                         src="icon-project"
                                                                       >
                                                                         <InlineSvg
-                                                                          className="css-1ibtmti-StyledInlineSvg ewlipse4"
+                                                                          className="css-1ibtmti-StyledInlineSvg ewlipse2"
                                                                           src="icon-project"
                                                                         >
                                                                           <StyledSvg
-                                                                            className="css-1ibtmti-StyledInlineSvg ewlipse4"
+                                                                            className="css-1ibtmti-StyledInlineSvg ewlipse2"
                                                                             height="1em"
                                                                             viewBox={Object {}}
                                                                             width="1em"
                                                                           >
                                                                             <svg
-                                                                              className="ewlipse4 css-1ux8cow-StyledSvg-StyledInlineSvg e2idor0"
+                                                                              className="ewlipse2 css-1ux8cow-StyledSvg-StyledInlineSvg e2idor0"
                                                                               height="1em"
                                                                               viewBox={Object {}}
                                                                               width="1em"
@@ -1283,6 +1283,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                     }
                                     items={Array []}
                                     maxHeight={500}
+                                    menuFooter={[Function]}
                                     menuProps={
                                       Object {
                                         "style": Object {
@@ -1316,6 +1317,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                       }
                                       items={Array []}
                                       maxHeight={500}
+                                      menuFooter={[Function]}
                                       menuProps={
                                         Object {
                                           "style": Object {
@@ -1348,6 +1350,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                         }
                                         items={Array []}
                                         maxHeight={500}
+                                        menuFooter={[Function]}
                                         menuProps={
                                           Object {
                                             "style": Object {

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -1424,7 +1424,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                       tabIndex={-1}
                                                     >
                                                       <StyledHeaderItem
-                                                        hasChanges={false}
                                                         hasSelected={false}
                                                         icon={
                                                           <StyledInlineSvg
@@ -1438,7 +1437,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                         onKeyDown={[Function]}
                                                         onMouseEnter={[Function]}
                                                         onMouseLeave={[Function]}
-                                                        onSubmit={[Function]}
                                                         style={
                                                           Object {
                                                             "outline": "none",
@@ -1448,7 +1446,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                       >
                                                         <ForwardRef
                                                           className="css-22y332-StyledHeaderItem e1gsuvme0"
-                                                          hasChanges={false}
                                                           hasSelected={false}
                                                           icon={
                                                             <StyledInlineSvg
@@ -1461,7 +1458,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                           onKeyDown={[Function]}
                                                           onMouseEnter={[Function]}
                                                           onMouseLeave={[Function]}
-                                                          onSubmit={[Function]}
                                                           style={
                                                             Object {
                                                               "outline": "none",
@@ -1472,7 +1468,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                           <HeaderItem
                                                             allowClear={true}
                                                             className="css-22y332-StyledHeaderItem e1gsuvme0"
-                                                            hasChanges={false}
                                                             hasSelected={false}
                                                             icon={
                                                               <StyledInlineSvg
@@ -1486,7 +1481,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                             onKeyDown={[Function]}
                                                             onMouseEnter={[Function]}
                                                             onMouseLeave={[Function]}
-                                                            onSubmit={[Function]}
                                                             style={
                                                               Object {
                                                                 "outline": "none",
@@ -1496,7 +1490,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                           >
                                                             <StyledHeaderItem
                                                               className="css-22y332-StyledHeaderItem e1gsuvme0"
-                                                              hasChanges={false}
                                                               hasSelected={false}
                                                               innerRef={[Function]}
                                                               isOpen={false}
@@ -1693,7 +1686,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                     >
                                       <StyledHeaderItem
                                         allowClear={true}
-                                        hasChanges={false}
                                         hasSelected={false}
                                         icon={
                                           <StyledInlineSvg
@@ -1707,7 +1699,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                         onKeyDown={[Function]}
                                         onMouseEnter={[Function]}
                                         onMouseLeave={[Function]}
-                                        onSubmit={[Function]}
                                         style={
                                           Object {
                                             "outline": "none",
@@ -1718,7 +1709,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                         <ForwardRef
                                           allowClear={true}
                                           className="css-22y332-StyledHeaderItem e1u8612l1"
-                                          hasChanges={false}
                                           hasSelected={false}
                                           icon={
                                             <StyledInlineSvg
@@ -1731,7 +1721,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                           onKeyDown={[Function]}
                                           onMouseEnter={[Function]}
                                           onMouseLeave={[Function]}
-                                          onSubmit={[Function]}
                                           style={
                                             Object {
                                               "outline": "none",
@@ -1742,7 +1731,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                           <HeaderItem
                                             allowClear={true}
                                             className="css-22y332-StyledHeaderItem e1u8612l1"
-                                            hasChanges={false}
                                             hasSelected={false}
                                             icon={
                                               <StyledInlineSvg
@@ -1756,7 +1744,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                             onKeyDown={[Function]}
                                             onMouseEnter={[Function]}
                                             onMouseLeave={[Function]}
-                                            onSubmit={[Function]}
                                             style={
                                               Object {
                                                 "outline": "none",
@@ -1766,7 +1753,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                           >
                                             <StyledHeaderItem
                                               className="css-22y332-StyledHeaderItem e1u8612l1"
-                                              hasChanges={false}
                                               hasSelected={false}
                                               innerRef={[Function]}
                                               isOpen={false}

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -685,6 +685,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                               >
                                 <StyledProjectSelector
                                   hasChanges={false}
+                                  menuFooter={[Function]}
                                   multi={false}
                                   multiProjects={Array []}
                                   onChange={[Function]}
@@ -741,6 +742,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                   <withProjects(ProjectSelector)
                                     className="css-iw79rr-StyledProjectSelector ewlipse0"
                                     hasChanges={false}
+                                    menuFooter={[Function]}
                                     multi={false}
                                     multiProjects={Array []}
                                     onChange={[Function]}
@@ -797,6 +799,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                     <ProjectSelector
                                       className="css-iw79rr-StyledProjectSelector ewlipse0"
                                       hasChanges={false}
+                                      menuFooter={[Function]}
                                       multi={false}
                                       multiProjects={Array []}
                                       onChange={[Function]}
@@ -989,7 +992,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                           <ForwardRef
                                                             active={false}
                                                             allowClear={false}
-                                                            className="css-12jjx2u-StyledHeaderItem ewlipse1"
+                                                            className="css-12jjx2u-StyledHeaderItem ewlipse3"
                                                             hasChanges={false}
                                                             hasSelected={false}
                                                             icon={
@@ -1013,7 +1016,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                             <HeaderItem
                                                               active={false}
                                                               allowClear={false}
-                                                              className="css-12jjx2u-StyledHeaderItem ewlipse1"
+                                                              className="css-12jjx2u-StyledHeaderItem ewlipse3"
                                                               hasChanges={false}
                                                               hasSelected={false}
                                                               icon={
@@ -1037,7 +1040,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                             >
                                                               <StyledHeaderItem
                                                                 active={false}
-                                                                className="css-12jjx2u-StyledHeaderItem ewlipse1"
+                                                                className="css-12jjx2u-StyledHeaderItem ewlipse3"
                                                                 hasChanges={false}
                                                                 hasSelected={false}
                                                                 innerRef={null}
@@ -1054,7 +1057,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                                 tabIndex={-1}
                                                               >
                                                                 <div
-                                                                  className="ewlipse1 css-11wumjj-StyledHeaderItem-StyledHeaderItem enk2k7v0"
+                                                                  className="ewlipse3 css-11wumjj-StyledHeaderItem-StyledHeaderItem enk2k7v0"
                                                                   onClick={[Function]}
                                                                   onKeyDown={[Function]}
                                                                   onMouseEnter={[Function]}
@@ -1076,17 +1079,17 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                                         src="icon-project"
                                                                       >
                                                                         <InlineSvg
-                                                                          className="css-1ibtmti-StyledInlineSvg ewlipse2"
+                                                                          className="css-1ibtmti-StyledInlineSvg ewlipse4"
                                                                           src="icon-project"
                                                                         >
                                                                           <StyledSvg
-                                                                            className="css-1ibtmti-StyledInlineSvg ewlipse2"
+                                                                            className="css-1ibtmti-StyledInlineSvg ewlipse4"
                                                                             height="1em"
                                                                             viewBox={Object {}}
                                                                             width="1em"
                                                                           >
                                                                             <svg
-                                                                              className="ewlipse2 css-1ux8cow-StyledSvg-StyledInlineSvg e2idor0"
+                                                                              className="ewlipse4 css-1ux8cow-StyledSvg-StyledInlineSvg e2idor0"
                                                                               height="1em"
                                                                               viewBox={Object {}}
                                                                               width="1em"

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -1686,6 +1686,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                     >
                                       <StyledHeaderItem
                                         allowClear={true}
+                                        hasChanges={false}
                                         hasSelected={false}
                                         icon={
                                           <StyledInlineSvg
@@ -1709,6 +1710,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                         <ForwardRef
                                           allowClear={true}
                                           className="css-22y332-StyledHeaderItem e1u8612l1"
+                                          hasChanges={false}
                                           hasSelected={false}
                                           icon={
                                             <StyledInlineSvg
@@ -1731,6 +1733,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                           <HeaderItem
                                             allowClear={true}
                                             className="css-22y332-StyledHeaderItem e1u8612l1"
+                                            hasChanges={false}
                                             hasSelected={false}
                                             icon={
                                               <StyledInlineSvg
@@ -1753,6 +1756,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                           >
                                             <StyledHeaderItem
                                               className="css-22y332-StyledHeaderItem e1u8612l1"
+                                              hasChanges={false}
                                               hasSelected={false}
                                               innerRef={[Function]}
                                               isOpen={false}

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -684,6 +684,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                 value={Array []}
                               >
                                 <StyledProjectSelector
+                                  hasChanges={false}
                                   multi={false}
                                   multiProjects={Array []}
                                   onChange={[Function]}
@@ -739,6 +740,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                 >
                                   <withProjects(ProjectSelector)
                                     className="css-iw79rr-StyledProjectSelector ewlipse0"
+                                    hasChanges={false}
                                     multi={false}
                                     multiProjects={Array []}
                                     onChange={[Function]}
@@ -794,6 +796,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                   >
                                     <ProjectSelector
                                       className="css-iw79rr-StyledProjectSelector ewlipse0"
+                                      hasChanges={false}
                                       multi={false}
                                       multiProjects={Array []}
                                       onChange={[Function]}
@@ -976,7 +979,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                           onKeyDown={[Function]}
                                                           onMouseEnter={[Function]}
                                                           onMouseLeave={[Function]}
-                                                          onSubmit={[Function]}
                                                           style={
                                                             Object {
                                                               "outline": "none",
@@ -1001,7 +1003,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                             onKeyDown={[Function]}
                                                             onMouseEnter={[Function]}
                                                             onMouseLeave={[Function]}
-                                                            onSubmit={[Function]}
                                                             style={
                                                               Object {
                                                                 "outline": "none",
@@ -1027,7 +1028,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                               onKeyDown={[Function]}
                                                               onMouseEnter={[Function]}
                                                               onMouseLeave={[Function]}
-                                                              onSubmit={[Function]}
                                                               style={
                                                                 Object {
                                                                   "outline": "none",
@@ -1038,6 +1038,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                               <StyledHeaderItem
                                                                 active={false}
                                                                 className="css-12jjx2u-StyledHeaderItem ewlipse1"
+                                                                hasChanges={false}
                                                                 hasSelected={false}
                                                                 innerRef={null}
                                                                 isOpen={false}
@@ -1108,13 +1109,10 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                                     </div>
                                                                   </Content>
                                                                   <StyledChevron
-                                                                    hasChanges={false}
                                                                     isOpen={false}
-                                                                    onClick={[Function]}
                                                                   >
                                                                     <div
-                                                                      className="css-ft4nwy-StyledChevron enk2k7v4"
-                                                                      onClick={[Function]}
+                                                                      className="css-1dsiezd-StyledChevron enk2k7v4"
                                                                     >
                                                                       <InlineSvg
                                                                         src="icon-chevron-down"
@@ -1495,6 +1493,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                           >
                                                             <StyledHeaderItem
                                                               className="css-22y332-StyledHeaderItem e1gsuvme0"
+                                                              hasChanges={false}
                                                               hasSelected={false}
                                                               innerRef={[Function]}
                                                               isOpen={false}
@@ -1565,13 +1564,10 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                                   </div>
                                                                 </Content>
                                                                 <StyledChevron
-                                                                  hasChanges={false}
                                                                   isOpen={false}
-                                                                  onClick={[Function]}
                                                                 >
                                                                   <div
-                                                                    className="css-ft4nwy-StyledChevron enk2k7v4"
-                                                                    onClick={[Function]}
+                                                                    className="css-1dsiezd-StyledChevron enk2k7v4"
                                                                   >
                                                                     <InlineSvg
                                                                       src="icon-chevron-down"
@@ -1767,6 +1763,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                           >
                                             <StyledHeaderItem
                                               className="css-22y332-StyledHeaderItem e1u8612l1"
+                                              hasChanges={false}
                                               hasSelected={false}
                                               innerRef={[Function]}
                                               isOpen={false}
@@ -1837,13 +1834,10 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                   </div>
                                                 </Content>
                                                 <StyledChevron
-                                                  hasChanges={false}
                                                   isOpen={false}
-                                                  onClick={[Function]}
                                                 >
                                                   <div
-                                                    className="css-ft4nwy-StyledChevron enk2k7v4"
-                                                    onClick={[Function]}
+                                                    className="css-1dsiezd-StyledChevron enk2k7v4"
                                                   >
                                                     <InlineSvg
                                                       src="icon-chevron-down"

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -684,7 +684,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                 value={Array []}
                               >
                                 <StyledProjectSelector
-                                  hasChanges={false}
                                   menuFooter={[Function]}
                                   multi={false}
                                   multiProjects={Array []}
@@ -741,7 +740,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                 >
                                   <withProjects(ProjectSelector)
                                     className="css-iw79rr-StyledProjectSelector ewlipse0"
-                                    hasChanges={false}
                                     menuFooter={[Function]}
                                     multi={false}
                                     multiProjects={Array []}
@@ -798,7 +796,6 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                   >
                                     <ProjectSelector
                                       className="css-iw79rr-StyledProjectSelector ewlipse0"
-                                      hasChanges={false}
                                       menuFooter={[Function]}
                                       multi={false}
                                       multiProjects={Array []}


### PR DESCRIPTION
This moves the ambiguous "carrot" submit button to a new home where it tells ye of little intuition: "HAY THIS SUBMITS"

![submit-buttons](https://user-images.githubusercontent.com/435981/55658783-b2151780-57b3-11e9-9a64-79d69d0ec7b3.gif)


