### PR TITLE
feat(api): Implement new search parser in group events endpoint (SEN-177)

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -513,7 +513,7 @@ def get_snuba_query_args(query=None, params=None):
 
         if snuba_name in ('start', 'end'):
             kwargs[snuba_name] = _filter.value.value
-        elif snuba_name == 'project_id':
+        elif snuba_name in ('project_id', 'issue'):
             kwargs['filter_keys'][snuba_name] = _filter.value.value
         else:
             converted_filter = convert_search_filter_to_snuba_query(_filter)

--- a/src/sentry/api/helpers/events.py
+++ b/src/sentry/api/helpers/events.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import
+
+from rest_framework.response import Response
+
+from sentry.api.event_search import get_snuba_query_args
+from sentry.models import SnubaEvent
+from sentry.utils.snuba import raw_query
+from sentry.utils.validators import is_event_id
+from sentry.api.serializers import serialize
+
+
+def get_direct_hit_response(request, query, snuba_params, referrer):
+    """
+    Checks whether a query is a direct hit for an event, and if so returns
+    a response. Otherwise returns None
+    """
+    if is_event_id(query):
+        snuba_args = get_snuba_query_args(
+            query=u'id:{}'.format(query),
+            params=snuba_params)
+
+        results = raw_query(
+            selected_columns=SnubaEvent.selected_columns,
+            referrer=referrer,
+            **snuba_args
+        )['data']
+
+        if len(results) == 1:
+            response = Response(
+                serialize([SnubaEvent(row) for row in results], request.user)
+            )
+            response['X-Sentry-Direct-Hit'] = '1'
+            return response


### PR DESCRIPTION
This endpoint was using the old parser when searching snuba, and so we weren't able to use new
search features. This converts the endpoint to use the new parser.

We change one piece of existing behaviour here: Previously, if a query looked like an event id we'd
search for it in the message and as an exact id match. I've changed this to match our existing
behaviour elsewhere, which just does an exact match and if we find a result we set
`X-Sentry-Direct-Hit`.