### PR TITLE
fix(ui) Remove teams by slug instead of by object

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/teamSelect.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/teamSelect.jsx
@@ -62,9 +62,8 @@ class TeamSelect extends React.Component {
     this.props.onAddTeam(team);
   };
 
-  handleRemove = value => {
-    const team = this.state.teams.find(tm => tm.slug === value);
-    this.props.onRemoveTeam(team);
+  handleRemove = teamSlug => {
+    this.props.onRemoveTeam(teamSlug);
   };
 
   renderTeamAddDropDown() {

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/index.jsx
@@ -205,9 +205,9 @@ const InviteMember = createReactClass({
     this.setState({selectedTeams});
   },
 
-  handleRemoveTeam(team) {
+  handleRemoveTeam(teamSlug) {
     const {selectedTeams} = this.state;
-    selectedTeams.delete(team.slug);
+    selectedTeams.delete(teamSlug);
 
     this.setState({selectedTeams});
   },

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberDetail.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberDetail.jsx
@@ -121,13 +121,13 @@ class OrganizationMemberDetail extends AsyncView {
     this.setState({member});
   };
 
-  handleRemoveTeam = team => {
+  handleRemoveTeam = removedTeam => {
     const {member} = this.state;
 
     this.setState({
       member: {
         ...member,
-        teams: member.teams.filter(teamSlug => teamSlug !== team.slug),
+        teams: member.teams.filter(slug => slug !== removedTeam),
       },
     });
   };

--- a/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
@@ -27,26 +27,26 @@ class ProjectTeams extends AsyncView {
     );
   };
 
-  handleRemove = team => {
+  handleRemove = teamSlug => {
     if (this.state.loading) {
       return;
     }
 
     const {orgId, projectId} = this.props.params;
 
-    removeTeamFromProject(this.api, orgId, projectId, team.slug)
-      .then(() => this.handleRemovedTeam(team))
+    removeTeamFromProject(this.api, orgId, projectId, teamSlug)
+      .then(() => this.handleRemovedTeam(teamSlug))
       .catch(() => {
-        addErrorMessage(t('Could not remove the %s team', team.slug));
+        addErrorMessage(t('Could not remove the %s team', teamSlug));
         this.setState({loading: false});
       });
   };
 
-  handleRemovedTeam = removedTeam => {
+  handleRemovedTeam = teamSlug => {
     this.setState(prevState => {
       return {
         projectTeams: this.state.projectTeams.filter(team => {
-          return team.slug !== removedTeam.slug;
+          return team.slug !== teamSlug;
         }),
       };
     });

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CreateProject should render loading 1`] = `
+exports[`InviteMember should render loading 1`] = `
 <div>
   <SettingsPageHeading
     noTitleStyles={false}
@@ -13,7 +13,7 @@ exports[`CreateProject should render loading 1`] = `
 </div>
 `;
 
-exports[`CreateProject should render roles when available and allowed, and handle submitting 1`] = `
+exports[`InviteMember should render roles when available and allowed, and handle submitting 1`] = `
 <InviteMember
   location={
     Object {
@@ -700,7 +700,7 @@ exports[`CreateProject should render roles when available and allowed, and handl
 </InviteMember>
 `;
 
-exports[`CreateProject should use invite/add language based on config 1`] = `
+exports[`InviteMember should use invite/add language based on config 1`] = `
 <TextBlock>
   You may add a user by their username if they already have an account. Multiple inputs delimited by commas.
 </TextBlock>


### PR DESCRIPTION
Currently selected teams may not always be in the loaded state which contains the first 100 teams. This results in the find() failing and downstream actions failing. Removing by slug avoids this problem and gives enough context to make delete API calls.

I've added more tests to the invite member view as there wasn't any coverage around adding/removing teams.

Fixes SEN-441
Fixes JAVASCRIPT-5XX