### PR TITLE
wontfix - fix(project settings): Make all teams available to ProjectTeams component

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/teamSelect.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/teamSelect.jsx
@@ -18,7 +18,6 @@ import withApi from 'app/utils/withApi';
 
 class TeamSelect extends React.Component {
   static propTypes = {
-    api: PropTypes.object.isRequired,
     organization: SentryTypes.Organization.isRequired,
     disabled: PropTypes.bool,
     // All teams in the organization
@@ -38,25 +37,7 @@ class TeamSelect extends React.Component {
     confirmLastTeamRemoveMessage: PropTypes.string,
   };
 
-  // state = {
-  //   teams: null,
-  // };
-
-  // componentDidMount() {
-  //   this.fetchTeams();
-  // }
-
-  // fetchTeams = debounce(query => {
-  //   const {organization} = this.props;
-  //   this.props.api
-  //     .requestPromise(`/organizations/${organization.slug}/teams/`, {
-  //       query: {query},
-  //     })
-  //     .then(teams => this.setState({teams}));
-  // }, 100);
-
   handleQueryUpdate = event => {
-    // this.fetchTeams(event.target.value);
     const {teams} = this.props;
     const query = event.target.value.toLowerCase();
     return teams.filter(team => {

--- a/src/sentry/static/sentry/app/views/settings/components/teamSelect.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/teamSelect.jsx
@@ -21,6 +21,8 @@ class TeamSelect extends React.Component {
     api: PropTypes.object.isRequired,
     organization: SentryTypes.Organization.isRequired,
     disabled: PropTypes.bool,
+    // All teams in the organization
+    teams: PropTypes.array.isRequired,
     // Teams that are already selected.
     selectedTeams: PropTypes.array.isRequired,
     // callback when teams are added
@@ -36,40 +38,44 @@ class TeamSelect extends React.Component {
     confirmLastTeamRemoveMessage: PropTypes.string,
   };
 
-  state = {
-    teams: null,
-  };
+  // state = {
+  //   teams: null,
+  // };
 
-  componentDidMount() {
-    this.fetchTeams();
-  }
+  // componentDidMount() {
+  //   this.fetchTeams();
+  // }
 
-  fetchTeams = debounce(query => {
-    const {organization} = this.props;
-    this.props.api
-      .requestPromise(`/organizations/${organization.slug}/teams/`, {
-        query: {query},
-      })
-      .then(teams => this.setState({teams}));
-  }, 100);
+  // fetchTeams = debounce(query => {
+  //   const {organization} = this.props;
+  //   this.props.api
+  //     .requestPromise(`/organizations/${organization.slug}/teams/`, {
+  //       query: {query},
+  //     })
+  //     .then(teams => this.setState({teams}));
+  // }, 100);
 
   handleQueryUpdate = event => {
-    this.fetchTeams(event.target.value);
+    // this.fetchTeams(event.target.value);
+    const {teams} = this.props;
+    const query = event.target.value.toLowerCase();
+    return teams.filter(team => {
+      return team.slug.contains(query) || team.name.contains(query);
+    });
   };
 
   handleAddTeam = option => {
-    const team = this.state.teams.find(tm => tm.slug === option.value);
+    const team = this.props.teams.find(tm => tm.slug === option.value);
     this.props.onAddTeam(team);
   };
 
   handleRemove = value => {
-    const team = this.state.teams.find(tm => tm.slug === value);
+    const team = this.props.teams.find(tm => tm.slug === value);
     this.props.onRemoveTeam(team);
   };
 
   renderTeamAddDropDown() {
-    const {disabled, selectedTeams, menuHeader} = this.props;
-    const {teams} = this.state;
+    const {disabled, teams, selectedTeams, menuHeader} = this.props;
     const noTeams = teams === null || teams.length === 0;
     const isDisabled = noTeams || disabled;
 

--- a/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
@@ -13,6 +13,7 @@ import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader
 import TeamSelect from 'app/views/settings/components/teamSelect';
 import Tooltip from 'app/components/tooltip';
 import space from 'app/styles/space';
+import withTeams from 'app/utils/withTeams';
 
 class ProjectTeams extends AsyncView {
   static PropTypes = {
@@ -108,7 +109,7 @@ class ProjectTeams extends AsyncView {
   };
 
   renderBody() {
-    const {params, organization} = this.props;
+    const {params, organization, teams} = this.props;
 
     const canCreateTeam = this.canCreateTeam();
     const hasAccess = organization.access.includes('project:write');
@@ -140,6 +141,7 @@ class ProjectTeams extends AsyncView {
         <SettingsPageHeader title={t('%s Teams', params.projectId)} />
         <TeamSelect
           organization={organization}
+          teams={teams}
           selectedTeams={projectTeams}
           onAddTeam={this.handleAdd}
           onRemoveTeam={this.handleRemove}
@@ -170,4 +172,4 @@ const StyledCreateTeamLink = styled(Link)`
     `};
 `;
 
-export default ProjectTeams;
+export default withTeams(ProjectTeams);

--- a/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled, {css} from 'react-emotion';
 
@@ -14,6 +15,11 @@ import Tooltip from 'app/components/tooltip';
 import space from 'app/styles/space';
 
 class ProjectTeams extends AsyncView {
+  static PropTypes = {
+    ...ProjectTeams.PropTypes,
+    // All teams in the organization
+    teams: PropTypes.array,
+  };
   getEndpoints() {
     const {orgId, projectId} = this.props.params;
     return [['projectTeams', `/projects/${orgId}/${projectId}/teams/`]];


### PR DESCRIPTION
**NOTE: this actually got fixed in another PR.**

Right now, we only grab the first 100 teams, which means that adding, the autocomplete for adding, and removing don't work if the team in question isn't one of those first 100 teams.