### PR TITLE
test(selenium): Scope selenium driver to the test session

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -165,6 +165,10 @@ matrix:
       name: 'Acceptance'
       env: TEST_SUITE=acceptance USE_SNUBA=1
 
+    - <<: *acceptance_default
+      name: 'Acceptance (Chromedriver session-bound)'
+      env: TEST_SUITE=acceptance USE_SNUBA=1 SENTRY_SELENIUM_USE_SESSION=1 PERCY_ENABLE=0
+
     # XXX(markus): Remove after rust interfaces are done
     - <<: *acceptance_default
       python: 2.7

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -772,6 +772,7 @@ class CliTestCase(TestCase):
         return self.runner.invoke(self.command, args, obj={})
 
 
+@pytest.mark.usefixtures('browser_setup')
 @pytest.mark.usefixtures('browser')
 class AcceptanceTestCase(TransactionTestCase):
     def setUp(self):

--- a/tests/acceptance/test_organization_events.py
+++ b/tests/acceptance/test_organization_events.py
@@ -34,5 +34,6 @@ class OrganizationEventsTest(AcceptanceTestCase):
     def test_events_empty(self):
         with self.feature(FEATURE_NAME):
             self.browser.get(self.path)
+            self.browser.wait_until_not('.loading-indicator')
             self.browser.wait_until_not('[data-test-id="events-request-loading"]')
             self.browser.snapshot('global events - empty')

--- a/tests/acceptance/test_organization_user_feedback.py
+++ b/tests/acceptance/test_organization_user_feedback.py
@@ -44,4 +44,5 @@ class OrganizationUserFeedbackTest(AcceptanceTestCase):
 
     def test_no_access(self):
         self.browser.get(self.path)
+        self.browser.wait_until_not('.loading-indicator')
         self.browser.snapshot('organization user feedback - no access')


### PR DESCRIPTION
Only start up one instance of the Selenium chrome webdriver per test session, instead of per each test function. This shaves off about 3-4 minutes from our acceptance tests.