### PR TITLE
fix(discover): Results not updating after field change

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
@@ -209,6 +209,10 @@ class Result extends React.Component {
 
     const {view} = this.state;
 
+    if (!baseQuery.data && !byDayQuery.data) {
+      return null;
+    }
+
     const basicChartData = getChartData(baseQuery.data.data, baseQuery.query);
 
     const byDayChartData =

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
@@ -144,6 +144,7 @@ export function getVisualization(data, current = 'table') {
     return 'table';
   }
 
+  console.log(data);
   if (!baseQuery.query.aggregations.length && ['line', 'bar'].includes(current)) {
     return 'table';
   }

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
@@ -144,8 +144,11 @@ export function getVisualization(data, current = 'table') {
     return 'table';
   }
 
-  console.log(data);
-  if (!baseQuery.query.aggregations.length && ['line', 'bar'].includes(current)) {
+  if (
+    !baseQuery.query ||
+    !baseQuery.query.aggregations ||
+    (!baseQuery.query.aggregations.length && ['line', 'bar'].includes(current))
+  ) {
     return 'table';
   }
 

--- a/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/newQuery.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/sidebar/newQuery.jsx
@@ -68,6 +68,7 @@ export default class NewQuery extends React.Component {
                     onClick={onRunQuery}
                     priority="primary"
                     busy={isFetchingQuery}
+                    label={t('Run')}
                   >
                     {t('Run')}
                     {isFetchingQuery && <ButtonSpinner />}

--- a/tests/js/spec/views/organizationDiscover/discover.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/discover.spec.jsx
@@ -9,11 +9,29 @@ import createQueryBuilder from 'app/views/organizationDiscover/queryBuilder';
 
 describe('Discover', function() {
   let organization, project, queryBuilder;
+
   beforeEach(function() {
     project = TestStubs.Project();
     organization = TestStubs.Organization({projects: [project]});
     queryBuilder = createQueryBuilder({}, organization);
     GlobalSelectionStore.reset();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/discover/saved/',
+      body: {},
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/discover/query/?per_page=1000&cursor=0:0:1',
+      method: 'POST',
+      body: {
+        timing: {},
+        data: [{foo: 'bar', 'project.id': project.id}],
+        meta: [{name: 'foo'}],
+      },
+      headers: {
+        Link: '',
+      },
+    });
   });
 
   afterEach(function() {
@@ -65,6 +83,7 @@ describe('Discover', function() {
             search:
               'projects=%5B%5D&fields=%5B%22id%22%2C%22issue.id%22%2C%22project.name%22%2C%22platform%22%2C%22timestamp%22%5D&conditions=%5B%5D&aggregations=%5B%5D&range=%227d%22&orderby=%22-timestamp%22&limit=1000&start=null&end=null',
           }}
+          params={{}}
           queryBuilder={queryBuilder}
           organization={organization}
           updateSavedQueryData={jest.fn()}
@@ -78,6 +97,7 @@ describe('Discover', function() {
       expect(wrapper.state().data.baseQuery.data).toBe(null);
       wrapper.setProps({isLoading: false});
       await tick();
+      wrapper.update();
       expect(wrapper.state().data.baseQuery.query).toEqual(queryBuilder.getExternal());
       expect(wrapper.state().data.baseQuery.data).toEqual(
         expect.objectContaining({data: mockResponse.data})
@@ -91,6 +111,7 @@ describe('Discover', function() {
             query: {},
             search: '',
           }}
+          params={{}}
           queryBuilder={queryBuilder}
           organization={organization}
           updateSavedQueryData={jest.fn()}
@@ -246,6 +267,7 @@ describe('Discover', function() {
       wrapper = mount(
         <Discover
           location={{query: {}}}
+          params={{}}
           queryBuilder={queryBuilder}
           organization={organization}
           updateSavedQueryData={jest.fn()}
@@ -317,6 +339,7 @@ describe('Discover', function() {
       const wrapper = mount(
         <Discover
           location={{query: {}}}
+          params={{}}
           queryBuilder={queryBuilder}
           organization={organization}
           updateSavedQueryData={jest.fn()}
@@ -534,6 +557,7 @@ describe('Discover', function() {
             query: {},
             location: '?fields=something',
           }}
+          params={{}}
           updateSavedQueryData={jest.fn()}
           toggleEditMode={jest.fn()}
           isLoading={false}
@@ -588,6 +612,7 @@ describe('Discover', function() {
             query: {},
             location: '',
           }}
+          params={{}}
           updateSavedQueryData={jest.fn()}
           toggleEditMode={jest.fn()}
           isLoading={false}
@@ -632,6 +657,7 @@ describe('Discover', function() {
       wrapper = mount(
         <Discover
           location={{query: {}}}
+          params={{}}
           queryBuilder={queryBuilder}
           organization={organization}
           updateSavedQueryData={jest.fn()}

--- a/tests/js/spec/views/organizationDiscover/index.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/index.spec.jsx
@@ -1,13 +1,44 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import {mount} from 'enzyme';
 import {browserHistory} from 'react-router';
+import PropTypes from 'prop-types';
+import React from 'react';
 
+import {mount} from 'enzyme';
+import {selectByValue} from 'app-test/helpers/select';
 import GlobalSelectionStore from 'app/stores/globalSelectionStore';
 import OrganizationDiscoverContainerWithStore, {
   OrganizationDiscoverContainer,
 } from 'app/views/organizationDiscover';
 import ProjectsStore from 'app/stores/projectsStore';
+import Table from 'app/views/organizationDiscover/result/table';
+
+jest.mock('app/views/organizationDiscover/result/table', () => jest.fn(() => null));
+
+const results = {
+  timing: {
+    duration_ms: 29,
+    timestamp: 1553819742,
+    marks_ms: {
+      execute: 11,
+      rate_limit: 2,
+      prepare_query: 11,
+      get_configs: 0,
+      dedupe_wait: 0,
+      cache_get: 0,
+      validate_schema: 3,
+    },
+  },
+  meta: [{type: 'string', name: 'project.name'}, {type: 'string', name: 'title'}],
+  data: [
+    {
+      'project.name': 'heart',
+      title: "Blocked 'script' from 'example.com'",
+    },
+    {
+      'project.name': 'heart',
+      title: 'Exception: This is a test exception sent from the Raven CLI.',
+    },
+  ],
+};
 
 describe('OrganizationDiscoverContainer', function() {
   beforeEach(function() {
@@ -135,6 +166,152 @@ describe('OrganizationDiscoverContainer', function() {
         pathname: '/organizations/org-slug/discover/saved/1/',
         query: {editing: 'true'},
       });
+    });
+  });
+
+  describe.only('updates results', function() {
+    let wrapper, request;
+    const organization = TestStubs.Organization({
+      projects: [TestStubs.Project()],
+      features: ['discover'],
+    });
+    const routerContext = TestStubs.routerContext([{organization}]);
+
+    beforeAll(async function() {
+      wrapper = mount(
+        <OrganizationDiscoverContainerWithStore
+          location={{query: {}, search: ''}}
+          params={{}}
+        />,
+        routerContext
+      );
+      await tick();
+      wrapper.update();
+    });
+
+    it('clears summarize fields', function() {
+      wrapper
+        .find('SelectControl[name="fields"] .Select-clear-zone')
+        .simulate('mouseDown', {button: 0});
+
+      expect(wrapper.find('SelectControl[name="fields"]').prop('value')).toEqual([]);
+    });
+
+    it('adds fields summarize fields', function() {
+      selectByValue(wrapper, 'project.name', {name: 'fields', control: true});
+      selectByValue(wrapper, 'title', {name: 'fields', control: true});
+
+      expect(wrapper.find('SelectControl[name="fields"]').prop('value')).toEqual([
+        'project.name',
+        'title',
+      ]);
+    });
+
+    it('adds count aggregation', function() {
+      wrapper.find('Aggregations AddText Link').simulate('click');
+      const AggregationSelect = wrapper.find('Aggregations SelectControl').first();
+
+      AggregationSelect.find('input[role="combobox"]').simulate('focus');
+      AggregationSelect.find('.Select-control').simulate('mouseDown', {button: 0});
+      wrapper
+        .find('Option')
+        .findWhere(el => el.prop('option') && el.prop('option').value === 'count')
+        .simulate('mouseDown');
+
+      expect(
+        wrapper
+          .find('Aggregations SelectControl')
+          .first()
+          .prop('value')
+      ).toEqual('count');
+    });
+
+    it('runs initial query', async function() {
+      request = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/discover/query/?per_page=1000&cursor=0:0:1',
+        method: 'POST',
+        body: results,
+      });
+      wrapper.find('NewQuery button[aria-label="Run"]').simulate('click');
+      await tick();
+      wrapper.update();
+      expect(request).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            aggregations: [['count()', null, 'count']],
+            fields: ['project.name', 'title'],
+          }),
+        })
+      );
+      expect(Table).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            data: [
+              {'project.name': 'heart', title: "Blocked 'script' from 'example.com'"},
+              {
+                'project.name': 'heart',
+                title: 'Exception: This is a test exception sent from the Raven CLI.',
+              },
+            ],
+          }),
+        }),
+        expect.anything()
+      );
+    });
+
+    it('changes summarize fields', function() {
+      wrapper
+        .find('SelectControl[name="fields"] .Select-clear-zone')
+        .simulate('mouseDown', {button: 0});
+
+      selectByValue(wrapper, 'project.name', {name: 'fields', control: true});
+      selectByValue(wrapper, 'message', {name: 'fields', control: true});
+
+      expect(wrapper.find('SelectControl[name="fields"]').prop('value')).toEqual([
+        'project.name',
+        'message',
+      ]);
+    });
+
+    it('runs 2nd query', async function() {
+      request = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/discover/query/?per_page=1000&cursor=0:0:1',
+        method: 'POST',
+        body: {
+          ...results,
+          data: results.data.map(obj => ({
+            'project.name': obj['project.name'],
+            message: obj.title,
+          })),
+        },
+      });
+      wrapper.find('NewQuery button[aria-label="Run"]').simulate('click');
+      await tick();
+      wrapper.update();
+      expect(request).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            aggregations: [['count()', null, 'count']],
+            fields: ['project.name', 'message'],
+          }),
+        })
+      );
+      expect(Table).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            data: [
+              {'project.name': 'heart', message: "Blocked 'script' from 'example.com'"},
+              {
+                'project.name': 'heart',
+                message: 'Exception: This is a test exception sent from the Raven CLI.',
+              },
+            ],
+          }),
+        }),
+        expect.anything()
+      );
     });
   });
 

--- a/tests/js/spec/views/organizationDiscover/index.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/index.spec.jsx
@@ -169,7 +169,7 @@ describe('OrganizationDiscoverContainer', function() {
     });
   });
 
-  describe.only('updates results', function() {
+  describe('updates results', function() {
     let wrapper, request;
     const organization = TestStubs.Organization({
       projects: [TestStubs.Project()],


### PR DESCRIPTION
ResultManager was mutating its internal results object, which was being
passed as props to `<Results>` component, and so the previous and next
props were always the same in its lifecycle methods.