### PR TITLE
fix(integrations) Don't log webhook payloads from jira-server

### DIFF
--- a/src/sentry/integrations/jira_server/webhooks.py
+++ b/src/sentry/integrations/jira_server/webhooks.py
@@ -66,12 +66,7 @@ class JiraIssueUpdatedWebhook(Endpoint):
         data = request.DATA
 
         if not data.get('changelog'):
-            logger.info(
-                'missing-changelog', extra={
-                    'integration_id': integration.id,
-                    'data': data,
-                }
-            )
+            logger.info('missing-changelog', extra={'integration_id': integration.id})
             return self.respond()
 
         handle_assignee_change(integration, data)


### PR DESCRIPTION
Jira payloads can be pretty hefty and are adding un-necessary load to our logging infrastructure.