### PR TITLE
ref(tests) Extract lint into a separate build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ matrix:
         - nvm install
         - npm install -g "yarn@${YARN_VERSION}"
         - pip install -r requirements-dev.txt
+        - yarn install --pure-lockfile
 
     # only the sqlite suite runs riak tests
     - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ env:
 script:
   # certain commands require sentry init to be run, but this is only true for
   # running things within Travis
-  - make travis-lint-$TEST_SUITE
   - make travis-test-$TEST_SUITE
   - make travis-scan-$TEST_SUITE
   # installing dependencies for after_* steps here ensures they get cached
@@ -68,6 +67,15 @@ after_script:
 matrix:
   fast_finish: true
   include:
+    # Lint python and javascript together
+    - python: 2.7
+      env: TEST_SUITE=lint
+      install:
+        - find "$NODE_DIR" -type d -empty -delete
+        - nvm install
+        - npm install -g "yarn@${YARN_VERSION}"
+        - pip install -r requirements-dev.txt
+
     # only the sqlite suite runs riak tests
     - python: 2.7
       env: TEST_SUITE=sqlite DB=sqlite

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ travis-test-dist:
 	SENTRY_BUILD=$(TRAVIS_COMMIT) SENTRY_LIGHT_BUILD=0 python setup.py -q sdist bdist_wheel
 	@ls -lh dist/
 
-.PHONY: scan-python travis-scan-sqlite travis-scan-postgres travis-scan-mysql travis-scan-acceptance travis-scan-snuba travis-scan-js travis-scan-cli travis-scan-dist
+.PHONY: scan-python travis-scan-sqlite travis-scan-postgres travis-scan-mysql travis-scan-acceptance travis-scan-snuba travis-scan-js travis-scan-cli travis-scan-dist travis-scan-lint
 scan-python:
 	@echo "--> Running Python vulnerability scanner"
 	$(PIP) install safety
@@ -217,3 +217,4 @@ travis-scan-snuba: scan-python
 travis-scan-js: travis-noop
 travis-scan-cli: travis-noop
 travis-scan-dist: travis-noop
+travis-scan-lint: travis-noop

--- a/Makefile
+++ b/Makefile
@@ -183,15 +183,8 @@ publish:
 travis-noop:
 	@echo "nothing to do here."
 
-.PHONY: travis-lint-sqlite travis-lint-postgres travis-lint-mysql travis-lint-acceptance travis-lint-snuba travis-lint-js travis-lint-cli travis-lint-dist
-travis-lint-sqlite: lint-python
-travis-lint-postgres: lint-python
-travis-lint-mysql: lint-python
-travis-lint-acceptance: travis-noop
-travis-lint-snuba: lint-python
-travis-lint-js: lint-js
-travis-lint-cli: travis-noop
-travis-lint-dist: travis-noop
+.PHONY: travis-test-lint
+travis-test-lint: lint-python lint-js
 
 .PHONY: travis-test-sqlite travis-test-postgres travis-test-mysql travis-test-acceptance travis-test-snuba travis-test-js travis-test-cli travis-test-dist
 travis-test-sqlite: test-python


### PR DESCRIPTION
We currently run lint on *every* build which takes 50s-90s. By pulling all of that into a separate build we can consolidate that time.