### PR TITLE
fix: Fix unstable Monitor related tests

### DIFF
--- a/tests/sentry/api/endpoints/test_monitor_checkins.py
+++ b/tests/sentry/api/endpoints/test_monitor_checkins.py
@@ -2,11 +2,13 @@ from __future__ import absolute_import, print_function
 
 from datetime import timedelta
 from django.utils import timezone
+from freezegun import freeze_time
 
 from sentry.models import CheckInStatus, Monitor, MonitorCheckIn, MonitorStatus, MonitorType
 from sentry.testutils import APITestCase
 
 
+@freeze_time('2019-01-01')
 class CreateMonitorCheckInTest(APITestCase):
     def test_passing(self):
         user = self.create_user()


### PR DESCRIPTION
I've seen these tests fail randomly a few times, seems related to minute boundaries. Failures were
like `AssertionError: assert datetime.datetime(2019, 3, 13, 18, 35, tzinfo=<UTC>) ==
datetime.datetime(2019, 3, 13, 18, 34, tzinfo=<UTC>)`. Just freezing time around these tests so that we can hopefully avoid these issues.