### PR TITLE
fix(emails): Add troubleshooting/references links

### DIFF
--- a/src/sentry/templates/sentry/emails/unable-to-fetch-commits.html
+++ b/src/sentry/templates/sentry/emails/unable-to-fetch-commits.html
@@ -4,6 +4,11 @@
   <h3>Unable to Fetch Commits</h3>
   <p>We were unable to fetch the commit log for your release (<em>{{ release.version }}</em>) due to the following error:</p>
   <p>{{ error_message }}</p>
+  <p><strong>Troubleshooting & References</strong></p>
+  <ul>
+    <li><a href="https://help.sentry.io/hc/en-us/articles/360019866834-Why-am-I-receiving-the-email-Unable-to-Fetch-Commits-">Why am I receiving the email "Unable to Fetch Commits"?</a></li>
+    <li><a href="https://docs.sentry.io/workflow/releases/?platform=php#associate-commits-with-a-release">Associate Commits with a Release</a></li>
+  </ul>
 {% endblock %}
 
 {% block footer %}{% endblock %}

--- a/src/sentry/templates/sentry/emails/unable-to-fetch-commits.html
+++ b/src/sentry/templates/sentry/emails/unable-to-fetch-commits.html
@@ -4,7 +4,7 @@
   <h3>Unable to Fetch Commits</h3>
   <p>We were unable to fetch the commit log for your release (<em>{{ release.version }}</em>) due to the following error:</p>
   <p>{{ error_message }}</p>
-  <p><strong>Troubleshooting & References</strong></p>
+  <p><strong>Troubleshooting &amp; References</strong></p>
   <ul>
     <li><a href="https://help.sentry.io/hc/en-us/articles/360019866834-Why-am-I-receiving-the-email-Unable-to-Fetch-Commits-">Why am I receiving the email "Unable to Fetch Commits"?</a></li>
     <li><a href="https://docs.sentry.io/workflow/releases/?platform=php#associate-commits-with-a-release">Associate Commits with a Release</a></li>

--- a/src/sentry/templates/sentry/emails/unable-to-fetch-commits.txt
+++ b/src/sentry/templates/sentry/emails/unable-to-fetch-commits.txt
@@ -4,3 +4,8 @@ Unable to Fetch Commits
 We were unable to fetch the commit log for your release ({{ release.version }}) due to the following error:
 
 {{ error_message }}
+
+Troubleshooting & References
+
+https://help.sentry.io/hc/en-us/articles/360019866834-Why-am-I-receiving-the-email-Unable-to-Fetch-Commits-
+https://docs.sentry.io/workflow/releases/?platform=php#associate-commits-with-a-release

--- a/src/sentry/templates/sentry/emails/unable-to-fetch-commits.txt
+++ b/src/sentry/templates/sentry/emails/unable-to-fetch-commits.txt
@@ -5,7 +5,7 @@ We were unable to fetch the commit log for your release ({{ release.version }}) 
 
 {{ error_message }}
 
-Troubleshooting & References
+Troubleshooting &amp; References
 
 https://help.sentry.io/hc/en-us/articles/360019866834-Why-am-I-receiving-the-email-Unable-to-Fetch-Commits-
 https://docs.sentry.io/workflow/releases/?platform=php#associate-commits-with-a-release

--- a/tests/fixtures/emails/unable_to_fetch_commits.txt
+++ b/tests/fixtures/emails/unable_to_fetch_commits.txt
@@ -4,3 +4,8 @@ Unable to Fetch Commits
 We were unable to fetch the commit log for your release (abcdef) due to the following error:
 
 An internal server error occurred
+
+Troubleshooting &amp; References
+
+https://help.sentry.io/hc/en-us/articles/360019866834-Why-am-I-receiving-the-email-Unable-to-Fetch-Commits-
+https://docs.sentry.io/workflow/releases/?platform=php#associate-commits-with-a-release


### PR DESCRIPTION
Add Troubleshooting/References links to Unable to Fetch Commits email.

**Links**:
- [Why am I receiving the email "Unable to Fetch Commits"?](https://help.sentry.io/hc/en-us/articles/360019866834-Why-am-I-receiving-the-email-Unable-to-Fetch-Commits-)
- [Associate Commits with a Release](https://docs.sentry.io/workflow/releases/?platform=php#associate-commits-with-a-release)

**HTML**
<img width="692" alt="Screen Shot 2019-04-01 at 5 06 33 PM" src="https://user-images.githubusercontent.com/20312973/55368005-90125100-54a4-11e9-91e4-6ff44adb463d.png">

**Plaintext**
<img width="860" alt="Screen Shot 2019-04-01 at 5 06 49 PM" src="https://user-images.githubusercontent.com/20312973/55368009-94d70500-54a4-11e9-9a85-005db4f507c6.png">