### PR TITLE
fix(filters): Filter out google spiders explicitly

### DIFF
--- a/src/sentry/filters/web_crawlers.py
+++ b/src/sentry/filters/web_crawlers.py
@@ -14,10 +14,10 @@ CRAWLERS = re.compile(
         (
             # Google spiders (Adsense and others)
             # https://support.google.com/webmasters/answer/1061943?hl=en
-            r'Mediapartners-Google',
-            r'AdsBot-Google',
+            r'Mediapartners\-Google',
+            r'AdsBot\-Google',
             r'Googlebot',
-            r'FeedFetcher-Google',
+            r'FeedFetcher\-Google',
             # Bing search
             r'BingBot',
             r'BingPreview',

--- a/src/sentry/filters/web_crawlers.py
+++ b/src/sentry/filters/web_crawlers.py
@@ -12,12 +12,12 @@ from sentry.utils.safe import get_path
 CRAWLERS = re.compile(
     r'|'.join(
         (
-            # various Google services
-            r'AdsBot',
-            # Google Adsense
-            r'Mediapartners',
-            # Google+ and Google web search, but not apis-google
-            r'(?<!APIs-)Google',
+            # Google spiders (Adsense and others)
+            # https://support.google.com/webmasters/answer/1061943?hl=en
+            r'Mediapartners-Google',
+            r'AdsBot-Google',
+            r'Googlebot',
+            r'FeedFetcher-Google',
             # Bing search
             r'BingBot',
             r'BingPreview',

--- a/tests/sentry/filters/test_web_crawlers.py
+++ b/tests/sentry/filters/test_web_crawlers.py
@@ -23,9 +23,27 @@ class WebCrawlersFilterTest(TestCase):
             }
         }
 
-    def test_filters_googlebot(self):
-        data = self.get_mock_data('Googlebot')
+    def test_filters_google_adsense(self):
+        data = self.get_mock_data('Mediapartners-Google')
         assert self.apply_filter(data)
+
+    def test_filters_google_adsbot(self):
+        data = self.get_mock_data('AdsBot-Google (+http://www.google.com/adsbot.html)')
+        assert self.apply_filter(data)
+
+    def test_filters_google_bot(self):
+        data = self.get_mock_data(
+            'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)')
+        assert self.apply_filter(data)
+
+    def test_filters_google_feedfetcher(self):
+        data = self.get_mock_data('FeedFetcher-Google; (+http://www.google.com/feedfetcher.html)')
+        assert self.apply_filter(data)
+
+    def test_does_not_filter_google_pubsub(self):
+        data = self.get_mock_data(
+            'APIs-Google (+https://developers.google.com/webmasters/APIs-Google.html)')
+        assert not self.apply_filter(data)
 
     def test_does_not_filter_chrome(self):
         data = self.get_mock_data(


### PR DESCRIPTION
The current filter ("nothing that says `google` unless it starts `APIs-`") doesn’t work, because the `APIs-Google` user agent string is actually (in its full form) `APIs-Google; (+https://developers.google.com/webmasters/APIs-Google.html)`... meaning it gets blocked anyway, because of the `google` in the domain. Also, the lookbehind is computationally expensive.

This replaces the regex with an explicit list of google spiders per https://support.google.com/webmasters/answer/1061943?hl=en.