### PR TITLE
feat: Add "sleep" queue

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -485,6 +485,7 @@ CELERY_QUEUES = [
     Queue('reports.deliver', routing_key='reports.deliver'),
     Queue('reports.prepare', routing_key='reports.prepare'),
     Queue('search', routing_key='search'),
+    Queue('sleep', routing_key='sleep'),
     Queue('stats', routing_key='stats'),
     Queue('unmerge', routing_key='unmerge'),
     Queue('update', routing_key='update'),

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -153,7 +153,7 @@ def preprocess_event_from_reprocessing(
 
 @instrumented_task(
     name='sentry.tasks.store.retry_process_event',
-    queue='events.process_event',  # XXX(markus): Change to new queue
+    queue='sleep',
     time_limit=(60 * 5) + 5,
     soft_time_limit=60 * 5,
 )


### PR DESCRIPTION
We'll be using this queue e.g. as part of symbolication pipeline. 