### PR TITLE
travis: Benchmark without runInBand

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
   "scripts": {
     "test": "node scripts/test.js",
     "test-precommit": "yarn test --bail --findRelatedTests -u",
-    "test-ci": "JEST_JUNIT_OUTPUT=.artifacts/jest.junit.xml yarn test --runInBand --ci --coverage --testResultsProcessor=jest-junit",
+    "test-ci": "JEST_JUNIT_OUTPUT=.artifacts/jest.junit.xml yarn test --ci --coverage --testResultsProcessor=jest-junit",
     "test-debug": "node --inspect-brk scripts/test.js --runInBand",
     "test-staged": "yarn test --findRelatedTests $(git diff --name-only --cached)",
     "lint": "node_modules/.bin/eslint tests/js src/sentry/static/sentry/app --ext .js,.jsx",


### PR DESCRIPTION
without runInBand: 370s, 361s, 357s
with runInBand: 420s, 377s, 371s