### PR TITLE
feat(app-platform): Expose SentryApp author

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_details.py
+++ b/src/sentry/api/endpoints/sentry_app_details.py
@@ -27,7 +27,11 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
 
             return Response(status=404)
 
-        serializer = SentryAppSerializer(data=request.DATA, partial=True)
+        serializer = SentryAppSerializer(
+            instance=sentry_app,
+            data=request.DATA,
+            partial=True,
+        )
 
         if serializer.is_valid():
             result = serializer.object
@@ -35,6 +39,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
             updated_app = Updater.run(
                 sentry_app=sentry_app,
                 name=result.get('name'),
+                author=result.get('author'),
                 webhook_url=result.get('webhookUrl'),
                 redirect_url=result.get('redirectUrl'),
                 is_alertable=result.get('isAlertable'),

--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -31,6 +31,7 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
 
             sentry_app = Creator.run(
                 name=result.get('name'),
+                author=result.get('author'),
                 organization=self._get_user_org(request),
                 scopes=result.get('scopes'),
                 events=result.get('events'),

--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -14,6 +14,7 @@ class SentryAppSerializer(Serializer):
         data = {
             'name': obj.name,
             'slug': obj.slug,
+            'author': obj.author,
             'scopes': obj.get_scopes(),
             'events': consolidate_events(obj.events),
             'status': obj.get_status_display(),

--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -11,24 +11,6 @@ from sentry.models import ApiScopes, SentryApp
 from sentry.models.sentryapp import VALID_EVENT_RESOURCES, REQUIRED_EVENT_PERMISSIONS
 
 
-class NameField(serializers.CharField):
-    def from_native(self, data):
-        rv = super(NameField, self).from_native(data)
-        if not rv:
-            return
-        if not self.is_valid_slug(rv):
-            raise ValidationError(u'Name {} is already taken, please use another.'.format(data))
-        return rv
-
-    def is_valid_slug(self, value):
-        slug = slugify(value)
-
-        if SentryApp.with_deleted.filter(slug=slug).exists():
-            return False
-
-        return True
-
-
 class ApiScopesField(serializers.WritableField):
     def validate(self, data):
         valid_scopes = ApiScopes()
@@ -60,7 +42,8 @@ class SchemaField(serializers.WritableField):
 
 
 class SentryAppSerializer(Serializer):
-    name = NameField()
+    name = serializers.CharField()
+    author = serializers.CharField()
     scopes = ApiScopesField()
     events = EventListField(required=False)
     schema = SchemaField(required=False)
@@ -68,6 +51,25 @@ class SentryAppSerializer(Serializer):
     redirectUrl = serializers.URLField(required=False)
     isAlertable = serializers.BooleanField(required=False)
     overview = serializers.CharField(required=False)
+
+    def __init__(self, instance=None, *args, **kwargs):
+        self.instance = instance
+        super(SentryAppSerializer, self).__init__(*args, **kwargs)
+
+    def validate_name(self, attrs, source):
+        if not attrs.get('name'):
+            return attrs
+
+        queryset = SentryApp.with_deleted.filter(slug=slugify(attrs['name']))
+
+        if self.instance:
+            queryset = queryset.exclude(id=self.instance.id)
+
+        if queryset.exists():
+            raise ValidationError(
+                u'Name {} is already taken, please use another.'.format(attrs['name'])
+            )
+        return attrs
 
     def validate_events(self, attrs, source):
         if not attrs.get('scopes'):

--- a/src/sentry/mediators/sentry_apps/creator.py
+++ b/src/sentry/mediators/sentry_apps/creator.py
@@ -11,6 +11,7 @@ from sentry.models import (AuditLogEntryEvent, ApiApplication, SentryApp, Sentry
 
 class Creator(Mediator):
     name = Param(six.string_types)
+    author = Param(six.string_types)
     organization = Param('sentry.models.Organization')
     scopes = Param(Iterable)
     events = Param(Iterable, default=lambda self: [])
@@ -44,6 +45,7 @@ class Creator(Mediator):
 
         return SentryApp.objects.create(
             name=self.name,
+            author=self.author,
             application_id=self.api_app.id,
             owner_id=self.organization.id,
             proxy_user_id=self.proxy.id,

--- a/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
+++ b/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
@@ -15,6 +15,14 @@ const forms = [
         help: 'Human readable name of your application.',
       },
       {
+        name: 'author',
+        type: 'string',
+        required: true,
+        placeholder: 'Acme Software',
+        label: 'Author',
+        help: 'The company or person who built and maintains this Integration.',
+      },
+      {
         name: 'webhookUrl',
         type: 'string',
         required: true,

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -672,7 +672,7 @@ class Factories(object):
         UserPermission.objects.create(user=user, permission=permission)
 
     @staticmethod
-    def create_sentry_app(name=None, organization=None, published=False, scopes=(),
+    def create_sentry_app(name=None, author='Sentry', organization=None, published=False, scopes=(),
                           webhook_url=None, **kwargs):
         if not name:
             name = petname.Generate(2, ' ', letters=10).title()
@@ -684,6 +684,7 @@ class Factories(object):
         _kwargs = {
             'name': name,
             'organization': organization,
+            'author': author,
             'scopes': scopes,
             'webhook_url': webhook_url,
             'events': [],

--- a/tests/js/fixtures/sentryApp.js
+++ b/tests/js/fixtures/sentryApp.js
@@ -1,6 +1,7 @@
 export function SentryApp(params = {}) {
   return {
     name: 'Sample App',
+    author: 'Sentry',
     slug: 'sample-app',
     scopes: ['project:read'],
     events: [],

--- a/tests/js/spec/components/modals/__snapshots__/sentryAppPermissionsModal.spec.jsx.snap
+++ b/tests/js/spec/components/modals/__snapshots__/sentryAppPermissionsModal.spec.jsx.snap
@@ -6,6 +6,7 @@ exports[`SentryAppPermissionsModal installs the application 1`] = `
   Header={[Function]}
   app={
     Object {
+      "author": "Sentry",
       "clientId": "client-id",
       "clientSecret": "client-secret",
       "events": Array [],
@@ -229,6 +230,7 @@ exports[`SentryAppPermissionsModal renders permissions modal 1`] = `
   Header={[Function]}
   app={
     Object {
+      "author": "Sentry",
       "clientId": "client-id",
       "clientSecret": "client-secret",
       "events": Array [],

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
@@ -492,6 +492,7 @@ exports[`Organization Developer Settings with published apps trash button is dis
                   <SentryApplicationRow
                     app={
                       Object {
+                        "author": "Sentry",
                         "clientId": "client-id",
                         "clientSecret": "client-secret",
                         "events": Array [],
@@ -533,6 +534,7 @@ exports[`Organization Developer Settings with published apps trash button is dis
                                 <SentryAppAvatar
                                   sentryApp={
                                     Object {
+                                      "author": "Sentry",
                                       "clientId": "client-id",
                                       "clientSecret": "client-secret",
                                       "events": Array [],
@@ -1070,6 +1072,7 @@ exports[`Organization Developer Settings with unpublished apps displays all Apps
                   <SentryApplicationRow
                     app={
                       Object {
+                        "author": "Sentry",
                         "clientId": "client-id",
                         "clientSecret": "client-secret",
                         "events": Array [],
@@ -1111,6 +1114,7 @@ exports[`Organization Developer Settings with unpublished apps displays all Apps
                                 <SentryAppAvatar
                                   sentryApp={
                                     Object {
+                                      "author": "Sentry",
                                       "clientId": "client-id",
                                       "clientSecret": "client-secret",
                                       "events": Array [],
@@ -1848,6 +1852,7 @@ exports[`Organization Developer Settings without Owner permissions trash button 
                   <SentryApplicationRow
                     app={
                       Object {
+                        "author": "Sentry",
                         "clientId": "client-id",
                         "clientSecret": "client-secret",
                         "events": Array [],
@@ -1889,6 +1894,7 @@ exports[`Organization Developer Settings without Owner permissions trash button 
                                 <SentryAppAvatar
                                   sentryApp={
                                     Object {
+                                      "author": "Sentry",
                                       "clientId": "client-id",
                                       "clientSecret": "client-secret",
                                       "events": Array [],

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/sentryApplicationDetails.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/sentryApplicationDetails.spec.jsx.snap
@@ -69,6 +69,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
           className="form-stacked"
           initialData={
             Object {
+              "author": "Sentry",
               "clientId": "client-id",
               "clientSecret": "client-secret",
               "events": Array [],
@@ -106,6 +107,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                   "label": "Name",
                   "name": "name",
                   "placeholder": "e.g. My Application",
+                  "required": true,
+                  "type": "text",
+                },
+                "author" => Object {
+                  "access": undefined,
+                  "children": [Function],
+                  "className": undefined,
+                  "disabled": undefined,
+                  "features": undefined,
+                  "field": [Function],
+                  "flexibleControlStateSize": false,
+                  "help": "The company or person who built and maintains this Integration.",
+                  "hideErrorMessage": false,
+                  "highlighted": false,
+                  "label": "Author",
+                  "name": "author",
+                  "placeholder": "Acme Software",
                   "required": true,
                   "type": "text",
                 },
@@ -450,6 +468,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                 "Project--permission": "read",
                 "Release--permission": "no-access",
                 "Team--permission": "no-access",
+                "author": "Sentry",
                 "clientId": "client-id",
                 "clientSecret": "client-secret",
                 "events": Array [],
@@ -475,6 +494,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                 "Project--permission": "read",
                 "Release--permission": "no-access",
                 "Team--permission": "no-access",
+                "author": "Sentry",
                 "clientId": "client-id",
                 "clientSecret": "client-secret",
                 "events": Array [],
@@ -508,6 +528,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                   "isAlertable" => false,
                   "schema" => Object {},
                   "name" => "Sample App",
+                  "author" => "Sentry",
                   "slug" => "sample-app",
                   "scopes" => Array [
                     "project:read",
@@ -548,6 +569,14 @@ exports[`Sentry Application Details edit existing application renders() it shows
                           "label": "Name",
                           "name": "name",
                           "placeholder": "e.g. My Application",
+                          "required": true,
+                          "type": "string",
+                        },
+                        Object {
+                          "help": "The company or person who built and maintains this Integration.",
+                          "label": "Author",
+                          "name": "author",
+                          "placeholder": "Acme Software",
                           "required": true,
                           "type": "string",
                         },
@@ -625,6 +654,14 @@ exports[`Sentry Application Details edit existing application renders() it shows
                               "label": "Name",
                               "name": "name",
                               "placeholder": "e.g. My Application",
+                              "required": true,
+                              "type": "string",
+                            },
+                            Object {
+                              "help": "The company or person who built and maintains this Integration.",
+                              "label": "Author",
+                              "name": "author",
+                              "placeholder": "Acme Software",
                               "required": true,
                               "type": "string",
                             },
@@ -871,6 +908,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "required": true,
                                                                     "type": "text",
                                                                   },
+                                                                  "author" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "The company or person who built and maintains this Integration.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Author",
+                                                                    "name": "author",
+                                                                    "placeholder": "Acme Software",
+                                                                    "required": true,
+                                                                    "type": "text",
+                                                                  },
                                                                   "webhookUrl" => Object {
                                                                     "access": undefined,
                                                                     "children": [Function],
@@ -1212,6 +1266,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                   "Project--permission": "read",
                                                                   "Release--permission": "no-access",
                                                                   "Team--permission": "no-access",
+                                                                  "author": "Sentry",
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
                                                                   "events": Array [],
@@ -1237,6 +1292,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                   "Project--permission": "read",
                                                                   "Release--permission": "no-access",
                                                                   "Team--permission": "no-access",
+                                                                  "author": "Sentry",
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
                                                                   "events": Array [],
@@ -1270,6 +1326,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "isAlertable" => false,
                                                                     "schema" => Object {},
                                                                     "name" => "Sample App",
+                                                                    "author" => "Sentry",
                                                                     "slug" => "sample-app",
                                                                     "scopes" => Array [
                                                                       "project:read",
@@ -1362,6 +1419,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -1449,6 +1507,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "label": "Name",
                                                                                                 "name": "name",
                                                                                                 "placeholder": "e.g. My Application",
+                                                                                                "required": true,
+                                                                                                "type": "text",
+                                                                                              },
+                                                                                              "author" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "The company or person who built and maintains this Integration.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Author",
+                                                                                                "name": "author",
+                                                                                                "placeholder": "Acme Software",
                                                                                                 "required": true,
                                                                                                 "type": "text",
                                                                                               },
@@ -1793,6 +1868,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -1818,6 +1894,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -1851,6 +1928,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "isAlertable" => false,
                                                                                                 "schema" => Object {},
                                                                                                 "name" => "Sample App",
+                                                                                                "author" => "Sentry",
                                                                                                 "slug" => "sample-app",
                                                                                                 "scopes" => Array [
                                                                                                   "project:read",
@@ -1868,6 +1946,1218 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                           }
                                                                                         }
                                                                                         name="name"
+                                                                                      >
+                                                                                        <Observer />
+                                                                                        <Observer />
+                                                                                      </ControlState>
+                                                                                    </div>
+                                                                                  </Base>
+                                                                                </Flex>
+                                                                              </Component>
+                                                                            </FieldControlState>
+                                                                          </div>
+                                                                        </Base>
+                                                                      </Flex>
+                                                                    </Component>
+                                                                  </FieldControlWrapper>
+                                                                  <Observer />
+                                                                </div>
+                                                              </Base>
+                                                            </Box>
+                                                          </Component>
+                                                        </FieldControlErrorWrapper>
+                                                      </FieldControl>
+                                                    </div>
+                                                  </Base>
+                                                </Flex>
+                                              </Component>
+                                            </FieldWrapper>
+                                          </Field>
+                                        </FormField>
+                                      </InputField>
+                                    </TextField>
+                                  </FieldFromConfig>
+                                  <FieldFromConfig
+                                    field={
+                                      Object {
+                                        "help": "The company or person who built and maintains this Integration.",
+                                        "label": "Author",
+                                        "name": "author",
+                                        "placeholder": "Acme Software",
+                                        "required": true,
+                                        "type": "string",
+                                      }
+                                    }
+                                    highlighted={false}
+                                    key="author"
+                                  >
+                                    <TextField
+                                      help="The company or person who built and maintains this Integration."
+                                      highlighted={false}
+                                      label="Author"
+                                      name="author"
+                                      placeholder="Acme Software"
+                                      required={true}
+                                      type="string"
+                                    >
+                                      <InputField
+                                        field={[Function]}
+                                        help="The company or person who built and maintains this Integration."
+                                        highlighted={false}
+                                        label="Author"
+                                        name="author"
+                                        placeholder="Acme Software"
+                                        required={true}
+                                        type="text"
+                                      >
+                                        <FormField
+                                          field={[Function]}
+                                          flexibleControlStateSize={false}
+                                          help="The company or person who built and maintains this Integration."
+                                          hideErrorMessage={false}
+                                          highlighted={false}
+                                          label="Author"
+                                          name="author"
+                                          placeholder="Acme Software"
+                                          required={true}
+                                          type="text"
+                                        >
+                                          <Field
+                                            alignRight={false}
+                                            disabled={false}
+                                            field={[Function]}
+                                            flexibleControlStateSize={false}
+                                            help="The company or person who built and maintains this Integration."
+                                            highlighted={false}
+                                            id="author"
+                                            inline={true}
+                                            label="Author"
+                                            name="author"
+                                            placeholder="Acme Software"
+                                            required={true}
+                                            type="text"
+                                            visible={true}
+                                          >
+                                            <FieldWrapper
+                                              hasControlState={true}
+                                              highlighted={false}
+                                              inline={true}
+                                            >
+                                              <Component
+                                                className="css-gf4a1r-FieldWrapper-getPadding-borderStyle-inlineStyle etqqcs20"
+                                              >
+                                                <Flex
+                                                  className="css-gf4a1r-FieldWrapper-getPadding-borderStyle-inlineStyle etqqcs20"
+                                                >
+                                                  <Base
+                                                    className="etqqcs20 css-12j1xki-FieldWrapper-getPadding-borderStyle-inlineStyle"
+                                                  >
+                                                    <div
+                                                      className="etqqcs20 css-12j1xki-FieldWrapper-getPadding-borderStyle-inlineStyle"
+                                                      is={null}
+                                                    >
+                                                      <FieldDescription
+                                                        htmlFor="author"
+                                                        inline={true}
+                                                      >
+                                                        <Component
+                                                          className="css-gxpq9u-FieldDescription-inlineStyle e12jefmo0"
+                                                          htmlFor="author"
+                                                          inline={true}
+                                                        >
+                                                          <label
+                                                            className="css-gxpq9u-FieldDescription-inlineStyle e12jefmo0"
+                                                            htmlFor="author"
+                                                          >
+                                                            <FieldLabel
+                                                              disabled={false}
+                                                            >
+                                                              <div
+                                                                className="css-qzvhly-FieldLabel ejkuyjq0"
+                                                              >
+                                                                Author
+                                                                 
+                                                                <FieldRequiredBadge>
+                                                                  <div
+                                                                    className="css-x360nj-FieldRequiredBadge e1u93u900"
+                                                                  />
+                                                                </FieldRequiredBadge>
+                                                              </div>
+                                                            </FieldLabel>
+                                                            <FieldHelp>
+                                                              <div
+                                                                className="css-aqmwwj-FieldHelp e19g0xdp0"
+                                                              >
+                                                                The company or person who built and maintains this Integration.
+                                                              </div>
+                                                            </FieldHelp>
+                                                          </label>
+                                                        </Component>
+                                                      </FieldDescription>
+                                                      <FieldControl
+                                                        alignRight={false}
+                                                        controlState={
+                                                          <ControlState
+                                                            model={
+                                                              SentryAppFormModel {
+                                                                "api": Client {},
+                                                                "errors": Object {},
+                                                                "fieldDescriptor": Map {
+                                                                  "name" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "Human readable name of your application.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Name",
+                                                                    "name": "name",
+                                                                    "placeholder": "e.g. My Application",
+                                                                    "required": true,
+                                                                    "type": "text",
+                                                                  },
+                                                                  "author" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "The company or person who built and maintains this Integration.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Author",
+                                                                    "name": "author",
+                                                                    "placeholder": "Acme Software",
+                                                                    "required": true,
+                                                                    "type": "text",
+                                                                  },
+                                                                  "webhookUrl" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "The URL Sentry will send requests to on installation changes.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Webhook URL",
+                                                                    "name": "webhookUrl",
+                                                                    "placeholder": "e.g. https://example.com/sentry/webhook/",
+                                                                    "required": true,
+                                                                    "type": "text",
+                                                                  },
+                                                                  "redirectUrl" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "The URL Sentry will redirect users to after installation.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Redirect URL",
+                                                                    "name": "redirectUrl",
+                                                                    "placeholder": "e.g. https://example.com/sentry/setup/",
+                                                                    "type": "text",
+                                                                  },
+                                                                  "isAlertable" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": <span>
+                                                                      <span>
+                                                                        If enabled, this application will be an action under alert rules in Sentry. The notification destination is the Webhook URL specified above. More on actions 
+                                                                      </span>
+                                                                      <a
+                                                                        href="https://docs.sentry.io/product/notifications/#actions"
+                                                                      >
+                                                                        <span>
+                                                                          Here
+                                                                        </span>
+                                                                      </a>
+                                                                      <span>
+                                                                        .
+                                                                      </span>
+                                                                    </span>,
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Alert Rule Action",
+                                                                    "name": "isAlertable",
+                                                                    "resetOnError": true,
+                                                                    "type": "boolean",
+                                                                  },
+                                                                  "schema" => Object {
+                                                                    "access": undefined,
+                                                                    "autosize": true,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "getValue": [Function],
+                                                                    "help": "Schema for your UI components",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Schema",
+                                                                    "name": "schema",
+                                                                    "setValue": [Function],
+                                                                    "type": "textarea",
+                                                                  },
+                                                                  "overview" => Object {
+                                                                    "access": undefined,
+                                                                    "autosize": true,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "Description of your application and its functionality.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Overview",
+                                                                    "name": "overview",
+                                                                    "type": "textarea",
+                                                                  },
+                                                                  "Project--permission" => Object {
+                                                                    "alignRight": false,
+                                                                    "allowEmpty": false,
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "no-access",
+                                                                        "No Access",
+                                                                      ],
+                                                                      Array [
+                                                                        "read",
+                                                                        "Read",
+                                                                      ],
+                                                                      Array [
+                                                                        "write",
+                                                                        "Read & Write",
+                                                                      ],
+                                                                      Array [
+                                                                        "admin",
+                                                                        "Admin",
+                                                                      ],
+                                                                    ],
+                                                                    "className": undefined,
+                                                                    "defaultValue": "read",
+                                                                    "escapeMarkup": true,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "formatMessageValue": [Function],
+                                                                    "help": "Projects, Tags, Debug Files, and Feedback",
+                                                                    "hideErrorMessage": false,
+                                                                    "label": "Project",
+                                                                    "name": "Project--permission",
+                                                                    "onChange": [Function],
+                                                                    "placeholder": "--",
+                                                                    "small": false,
+                                                                    "value": "read",
+                                                                  },
+                                                                  "Team--permission" => Object {
+                                                                    "alignRight": false,
+                                                                    "allowEmpty": false,
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "no-access",
+                                                                        "No Access",
+                                                                      ],
+                                                                      Array [
+                                                                        "read",
+                                                                        "Read",
+                                                                      ],
+                                                                      Array [
+                                                                        "write",
+                                                                        "Read & Write",
+                                                                      ],
+                                                                      Array [
+                                                                        "admin",
+                                                                        "Admin",
+                                                                      ],
+                                                                    ],
+                                                                    "className": undefined,
+                                                                    "defaultValue": "no-access",
+                                                                    "escapeMarkup": true,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "formatMessageValue": [Function],
+                                                                    "help": "Teams of members",
+                                                                    "hideErrorMessage": false,
+                                                                    "label": "Team",
+                                                                    "name": "Team--permission",
+                                                                    "onChange": [Function],
+                                                                    "placeholder": "--",
+                                                                    "small": false,
+                                                                    "value": "no-access",
+                                                                  },
+                                                                  "Release--permission" => Object {
+                                                                    "alignRight": false,
+                                                                    "allowEmpty": false,
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "no-access",
+                                                                        "No Access",
+                                                                      ],
+                                                                      Array [
+                                                                        "admin",
+                                                                        "Admin",
+                                                                      ],
+                                                                    ],
+                                                                    "className": undefined,
+                                                                    "defaultValue": "no-access",
+                                                                    "escapeMarkup": true,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "formatMessageValue": [Function],
+                                                                    "help": "Releases, Commits, and related Files",
+                                                                    "hideErrorMessage": false,
+                                                                    "label": "Release",
+                                                                    "name": "Release--permission",
+                                                                    "onChange": [Function],
+                                                                    "placeholder": "--",
+                                                                    "small": false,
+                                                                    "value": "no-access",
+                                                                  },
+                                                                  "Event--permission" => Object {
+                                                                    "alignRight": false,
+                                                                    "allowEmpty": false,
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "no-access",
+                                                                        "No Access",
+                                                                      ],
+                                                                      Array [
+                                                                        "read",
+                                                                        "Read",
+                                                                      ],
+                                                                      Array [
+                                                                        "write",
+                                                                        "Read & Write",
+                                                                      ],
+                                                                      Array [
+                                                                        "admin",
+                                                                        "Admin",
+                                                                      ],
+                                                                    ],
+                                                                    "className": undefined,
+                                                                    "defaultValue": "no-access",
+                                                                    "escapeMarkup": true,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "formatMessageValue": [Function],
+                                                                    "help": "Issues, Events, and workflow statuses",
+                                                                    "hideErrorMessage": false,
+                                                                    "label": "Issue & Event",
+                                                                    "name": "Event--permission",
+                                                                    "onChange": [Function],
+                                                                    "placeholder": "--",
+                                                                    "small": false,
+                                                                    "value": "no-access",
+                                                                  },
+                                                                  "Organization--permission" => Object {
+                                                                    "alignRight": false,
+                                                                    "allowEmpty": false,
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "no-access",
+                                                                        "No Access",
+                                                                      ],
+                                                                      Array [
+                                                                        "read",
+                                                                        "Read",
+                                                                      ],
+                                                                      Array [
+                                                                        "write",
+                                                                        "Read & Write",
+                                                                      ],
+                                                                      Array [
+                                                                        "admin",
+                                                                        "Admin",
+                                                                      ],
+                                                                    ],
+                                                                    "className": undefined,
+                                                                    "defaultValue": "no-access",
+                                                                    "escapeMarkup": true,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "formatMessageValue": [Function],
+                                                                    "help": "Manage Organizations, resolve IDs, retrieve Repositories and Commits",
+                                                                    "hideErrorMessage": false,
+                                                                    "label": "Organization",
+                                                                    "name": "Organization--permission",
+                                                                    "onChange": [Function],
+                                                                    "placeholder": "--",
+                                                                    "small": false,
+                                                                    "value": "no-access",
+                                                                  },
+                                                                  "Member--permission" => Object {
+                                                                    "alignRight": false,
+                                                                    "allowEmpty": false,
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "no-access",
+                                                                        "No Access",
+                                                                      ],
+                                                                      Array [
+                                                                        "read",
+                                                                        "Read",
+                                                                      ],
+                                                                      Array [
+                                                                        "write",
+                                                                        "Read & Write",
+                                                                      ],
+                                                                      Array [
+                                                                        "admin",
+                                                                        "Admin",
+                                                                      ],
+                                                                    ],
+                                                                    "className": undefined,
+                                                                    "defaultValue": "no-access",
+                                                                    "escapeMarkup": true,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "formatMessageValue": [Function],
+                                                                    "help": "Manage Members within Teams",
+                                                                    "hideErrorMessage": false,
+                                                                    "label": "Member",
+                                                                    "name": "Member--permission",
+                                                                    "onChange": [Function],
+                                                                    "placeholder": "--",
+                                                                    "small": false,
+                                                                    "value": "no-access",
+                                                                  },
+                                                                  "clientId" => Object {
+                                                                    "children": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "hideErrorMessage": false,
+                                                                    "label": "Client ID",
+                                                                    "name": "clientId",
+                                                                    "overflow": true,
+                                                                  },
+                                                                  "clientSecret" => Object {
+                                                                    "children": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "hideErrorMessage": false,
+                                                                    "label": "Client Secret",
+                                                                    "name": "clientSecret",
+                                                                    "overflow": true,
+                                                                  },
+                                                                },
+                                                                "fieldState": Object {
+                                                                  "events": Object {
+                                                                    "Saving": false,
+                                                                    "showSave": true,
+                                                                  },
+                                                                },
+                                                                "fields": Object {
+                                                                  "Event--permission": "no-access",
+                                                                  "Member--permission": "no-access",
+                                                                  "Organization--permission": "no-access",
+                                                                  "Project--permission": "read",
+                                                                  "Release--permission": "no-access",
+                                                                  "Team--permission": "no-access",
+                                                                  "author": "Sentry",
+                                                                  "clientId": "client-id",
+                                                                  "clientSecret": "client-secret",
+                                                                  "events": Array [],
+                                                                  "isAlertable": false,
+                                                                  "name": "Sample App",
+                                                                  "organization": "org-slug",
+                                                                  "overview": "This is an app.",
+                                                                  "redirectUrl": "https://example/com/setup",
+                                                                  "schema": "",
+                                                                  "scopes": Array [
+                                                                    "project:read",
+                                                                  ],
+                                                                  "slug": "sample-app",
+                                                                  "status": "unpublished",
+                                                                  "uuid": "123456123456123456123456",
+                                                                  "webhookUrl": "https://example.com/webhook",
+                                                                },
+                                                                "formState": "Ready",
+                                                                "initialData": Object {
+                                                                  "Event--permission": "no-access",
+                                                                  "Member--permission": "no-access",
+                                                                  "Organization--permission": "no-access",
+                                                                  "Project--permission": "read",
+                                                                  "Release--permission": "no-access",
+                                                                  "Team--permission": "no-access",
+                                                                  "author": "Sentry",
+                                                                  "clientId": "client-id",
+                                                                  "clientSecret": "client-secret",
+                                                                  "events": Array [],
+                                                                  "isAlertable": false,
+                                                                  "name": "Sample App",
+                                                                  "organization": "org-slug",
+                                                                  "overview": "This is an app.",
+                                                                  "redirectUrl": "https://example/com/setup",
+                                                                  "schema": "",
+                                                                  "scopes": Array [
+                                                                    "project:read",
+                                                                  ],
+                                                                  "slug": "sample-app",
+                                                                  "status": "unpublished",
+                                                                  "uuid": "123456123456123456123456",
+                                                                  "webhookUrl": "https://example.com/webhook",
+                                                                },
+                                                                "options": Object {
+                                                                  "allowUndo": true,
+                                                                  "apiEndpoint": "/sentry-apps/sample-app/",
+                                                                  "apiMethod": "PUT",
+                                                                  "onFieldChange": undefined,
+                                                                  "onSubmitError": [Function],
+                                                                  "onSubmitSuccess": [Function],
+                                                                  "resetOnError": undefined,
+                                                                  "saveOnBlur": false,
+                                                                },
+                                                                "snapshots": Array [
+                                                                  Map {
+                                                                    "organization" => "org-slug",
+                                                                    "isAlertable" => false,
+                                                                    "schema" => Object {},
+                                                                    "name" => "Sample App",
+                                                                    "author" => "Sentry",
+                                                                    "slug" => "sample-app",
+                                                                    "scopes" => Array [
+                                                                      "project:read",
+                                                                    ],
+                                                                    "events" => Array [],
+                                                                    "status" => "unpublished",
+                                                                    "uuid" => "123456123456123456123456",
+                                                                    "webhookUrl" => "https://example.com/webhook",
+                                                                    "redirectUrl" => "https://example/com/setup",
+                                                                    "clientId" => "client-id",
+                                                                    "clientSecret" => "client-secret",
+                                                                    "overview" => "This is an app.",
+                                                                  },
+                                                                ],
+                                                              }
+                                                            }
+                                                            name="author"
+                                                          />
+                                                        }
+                                                        disabled={false}
+                                                        errorState={
+                                                          <Observer>
+                                                            [Function]
+                                                          </Observer>
+                                                        }
+                                                        flexibleControlStateSize={false}
+                                                        inline={true}
+                                                      >
+                                                        <FieldControlErrorWrapper
+                                                          inline={true}
+                                                        >
+                                                          <Component
+                                                            className="css-1xbxyck-FieldControlErrorWrapper e78b1iv0"
+                                                            inline={true}
+                                                          >
+                                                            <Box
+                                                              className="css-1xbxyck-FieldControlErrorWrapper e78b1iv0"
+                                                            >
+                                                              <Base
+                                                                className="e78b1iv0 css-1kkovz0-FieldControlErrorWrapper"
+                                                              >
+                                                                <div
+                                                                  className="e78b1iv0 css-1kkovz0-FieldControlErrorWrapper"
+                                                                  is={null}
+                                                                >
+                                                                  <FieldControlWrapper>
+                                                                    <Component
+                                                                      className="css-1ke1xob-FieldControlWrapper e78b1iv2"
+                                                                    >
+                                                                      <Flex
+                                                                        className="css-1ke1xob-FieldControlWrapper e78b1iv2"
+                                                                      >
+                                                                        <Base
+                                                                          className="e78b1iv2 css-w4o1g8-FieldControlWrapper"
+                                                                        >
+                                                                          <div
+                                                                            className="e78b1iv2 css-w4o1g8-FieldControlWrapper"
+                                                                            is={null}
+                                                                          >
+                                                                            <FieldControlStyled
+                                                                              alignRight={false}
+                                                                            >
+                                                                              <Component
+                                                                                alignRight={false}
+                                                                                className="css-1pkvhmy-FieldControlStyled e78b1iv1"
+                                                                              >
+                                                                                <Box
+                                                                                  className="css-1pkvhmy-FieldControlStyled e78b1iv1"
+                                                                                >
+                                                                                  <Base
+                                                                                    className="e78b1iv1 css-wkkbba-FieldControlStyled"
+                                                                                  >
+                                                                                    <div
+                                                                                      className="e78b1iv1 css-wkkbba-FieldControlStyled"
+                                                                                      is={null}
+                                                                                    >
+                                                                                      <Observer>
+                                                                                        <Input
+                                                                                          disabled={false}
+                                                                                          error={false}
+                                                                                          field={[Function]}
+                                                                                          help="The company or person who built and maintains this Integration."
+                                                                                          highlighted={false}
+                                                                                          id="author"
+                                                                                          initialData={
+                                                                                            Object {
+                                                                                              "Event--permission": "no-access",
+                                                                                              "Member--permission": "no-access",
+                                                                                              "Organization--permission": "no-access",
+                                                                                              "Project--permission": "read",
+                                                                                              "Release--permission": "no-access",
+                                                                                              "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
+                                                                                              "clientId": "client-id",
+                                                                                              "clientSecret": "client-secret",
+                                                                                              "events": Array [],
+                                                                                              "isAlertable": false,
+                                                                                              "name": "Sample App",
+                                                                                              "organization": "org-slug",
+                                                                                              "overview": "This is an app.",
+                                                                                              "redirectUrl": "https://example/com/setup",
+                                                                                              "schema": "",
+                                                                                              "scopes": Array [
+                                                                                                "project:read",
+                                                                                              ],
+                                                                                              "slug": "sample-app",
+                                                                                              "status": "unpublished",
+                                                                                              "uuid": "123456123456123456123456",
+                                                                                              "webhookUrl": "https://example.com/webhook",
+                                                                                            }
+                                                                                          }
+                                                                                          innerRef={[Function]}
+                                                                                          label="Author"
+                                                                                          name="author"
+                                                                                          onBlur={[Function]}
+                                                                                          onChange={[Function]}
+                                                                                          onKeyDown={[Function]}
+                                                                                          placeholder="Acme Software"
+                                                                                          required={true}
+                                                                                          type="text"
+                                                                                          value="Sentry"
+                                                                                        >
+                                                                                          <input
+                                                                                            className="css-pzg7em-Input-inputStyles e1xej46s0"
+                                                                                            disabled={false}
+                                                                                            id="author"
+                                                                                            label="Author"
+                                                                                            name="author"
+                                                                                            onBlur={[Function]}
+                                                                                            onChange={[Function]}
+                                                                                            onKeyDown={[Function]}
+                                                                                            placeholder="Acme Software"
+                                                                                            required={true}
+                                                                                            type="text"
+                                                                                            value="Sentry"
+                                                                                          />
+                                                                                        </Input>
+                                                                                      </Observer>
+                                                                                    </div>
+                                                                                  </Base>
+                                                                                </Box>
+                                                                              </Component>
+                                                                            </FieldControlStyled>
+                                                                            <FieldControlState
+                                                                              flexibleControlStateSize={false}
+                                                                            >
+                                                                              <Component
+                                                                                className="css-1j6hng-FieldControlState e1rziqw00"
+                                                                                flexibleControlStateSize={false}
+                                                                              >
+                                                                                <Flex
+                                                                                  className="css-1j6hng-FieldControlState e1rziqw00"
+                                                                                >
+                                                                                  <Base
+                                                                                    className="e1rziqw00 css-1fqbh7r-FieldControlState"
+                                                                                  >
+                                                                                    <div
+                                                                                      className="e1rziqw00 css-1fqbh7r-FieldControlState"
+                                                                                      is={null}
+                                                                                    >
+                                                                                      <ControlState
+                                                                                        model={
+                                                                                          SentryAppFormModel {
+                                                                                            "api": Client {},
+                                                                                            "errors": Object {},
+                                                                                            "fieldDescriptor": Map {
+                                                                                              "name" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "Human readable name of your application.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Name",
+                                                                                                "name": "name",
+                                                                                                "placeholder": "e.g. My Application",
+                                                                                                "required": true,
+                                                                                                "type": "text",
+                                                                                              },
+                                                                                              "author" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "The company or person who built and maintains this Integration.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Author",
+                                                                                                "name": "author",
+                                                                                                "placeholder": "Acme Software",
+                                                                                                "required": true,
+                                                                                                "type": "text",
+                                                                                              },
+                                                                                              "webhookUrl" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "The URL Sentry will send requests to on installation changes.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Webhook URL",
+                                                                                                "name": "webhookUrl",
+                                                                                                "placeholder": "e.g. https://example.com/sentry/webhook/",
+                                                                                                "required": true,
+                                                                                                "type": "text",
+                                                                                              },
+                                                                                              "redirectUrl" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "The URL Sentry will redirect users to after installation.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Redirect URL",
+                                                                                                "name": "redirectUrl",
+                                                                                                "placeholder": "e.g. https://example.com/sentry/setup/",
+                                                                                                "type": "text",
+                                                                                              },
+                                                                                              "isAlertable" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": <span>
+                                                                                                  <span>
+                                                                                                    If enabled, this application will be an action under alert rules in Sentry. The notification destination is the Webhook URL specified above. More on actions 
+                                                                                                  </span>
+                                                                                                  <a
+                                                                                                    href="https://docs.sentry.io/product/notifications/#actions"
+                                                                                                  >
+                                                                                                    <span>
+                                                                                                      Here
+                                                                                                    </span>
+                                                                                                  </a>
+                                                                                                  <span>
+                                                                                                    .
+                                                                                                  </span>
+                                                                                                </span>,
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Alert Rule Action",
+                                                                                                "name": "isAlertable",
+                                                                                                "resetOnError": true,
+                                                                                                "type": "boolean",
+                                                                                              },
+                                                                                              "schema" => Object {
+                                                                                                "access": undefined,
+                                                                                                "autosize": true,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "getValue": [Function],
+                                                                                                "help": "Schema for your UI components",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Schema",
+                                                                                                "name": "schema",
+                                                                                                "setValue": [Function],
+                                                                                                "type": "textarea",
+                                                                                              },
+                                                                                              "overview" => Object {
+                                                                                                "access": undefined,
+                                                                                                "autosize": true,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "Description of your application and its functionality.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Overview",
+                                                                                                "name": "overview",
+                                                                                                "type": "textarea",
+                                                                                              },
+                                                                                              "Project--permission" => Object {
+                                                                                                "alignRight": false,
+                                                                                                "allowEmpty": false,
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "no-access",
+                                                                                                    "No Access",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "read",
+                                                                                                    "Read",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "write",
+                                                                                                    "Read & Write",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "admin",
+                                                                                                    "Admin",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "className": undefined,
+                                                                                                "defaultValue": "read",
+                                                                                                "escapeMarkup": true,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "formatMessageValue": [Function],
+                                                                                                "help": "Projects, Tags, Debug Files, and Feedback",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "label": "Project",
+                                                                                                "name": "Project--permission",
+                                                                                                "onChange": [Function],
+                                                                                                "placeholder": "--",
+                                                                                                "small": false,
+                                                                                                "value": "read",
+                                                                                              },
+                                                                                              "Team--permission" => Object {
+                                                                                                "alignRight": false,
+                                                                                                "allowEmpty": false,
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "no-access",
+                                                                                                    "No Access",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "read",
+                                                                                                    "Read",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "write",
+                                                                                                    "Read & Write",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "admin",
+                                                                                                    "Admin",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "className": undefined,
+                                                                                                "defaultValue": "no-access",
+                                                                                                "escapeMarkup": true,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "formatMessageValue": [Function],
+                                                                                                "help": "Teams of members",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "label": "Team",
+                                                                                                "name": "Team--permission",
+                                                                                                "onChange": [Function],
+                                                                                                "placeholder": "--",
+                                                                                                "small": false,
+                                                                                                "value": "no-access",
+                                                                                              },
+                                                                                              "Release--permission" => Object {
+                                                                                                "alignRight": false,
+                                                                                                "allowEmpty": false,
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "no-access",
+                                                                                                    "No Access",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "admin",
+                                                                                                    "Admin",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "className": undefined,
+                                                                                                "defaultValue": "no-access",
+                                                                                                "escapeMarkup": true,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "formatMessageValue": [Function],
+                                                                                                "help": "Releases, Commits, and related Files",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "label": "Release",
+                                                                                                "name": "Release--permission",
+                                                                                                "onChange": [Function],
+                                                                                                "placeholder": "--",
+                                                                                                "small": false,
+                                                                                                "value": "no-access",
+                                                                                              },
+                                                                                              "Event--permission" => Object {
+                                                                                                "alignRight": false,
+                                                                                                "allowEmpty": false,
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "no-access",
+                                                                                                    "No Access",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "read",
+                                                                                                    "Read",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "write",
+                                                                                                    "Read & Write",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "admin",
+                                                                                                    "Admin",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "className": undefined,
+                                                                                                "defaultValue": "no-access",
+                                                                                                "escapeMarkup": true,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "formatMessageValue": [Function],
+                                                                                                "help": "Issues, Events, and workflow statuses",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "label": "Issue & Event",
+                                                                                                "name": "Event--permission",
+                                                                                                "onChange": [Function],
+                                                                                                "placeholder": "--",
+                                                                                                "small": false,
+                                                                                                "value": "no-access",
+                                                                                              },
+                                                                                              "Organization--permission" => Object {
+                                                                                                "alignRight": false,
+                                                                                                "allowEmpty": false,
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "no-access",
+                                                                                                    "No Access",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "read",
+                                                                                                    "Read",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "write",
+                                                                                                    "Read & Write",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "admin",
+                                                                                                    "Admin",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "className": undefined,
+                                                                                                "defaultValue": "no-access",
+                                                                                                "escapeMarkup": true,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "formatMessageValue": [Function],
+                                                                                                "help": "Manage Organizations, resolve IDs, retrieve Repositories and Commits",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "label": "Organization",
+                                                                                                "name": "Organization--permission",
+                                                                                                "onChange": [Function],
+                                                                                                "placeholder": "--",
+                                                                                                "small": false,
+                                                                                                "value": "no-access",
+                                                                                              },
+                                                                                              "Member--permission" => Object {
+                                                                                                "alignRight": false,
+                                                                                                "allowEmpty": false,
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "no-access",
+                                                                                                    "No Access",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "read",
+                                                                                                    "Read",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "write",
+                                                                                                    "Read & Write",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "admin",
+                                                                                                    "Admin",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "className": undefined,
+                                                                                                "defaultValue": "no-access",
+                                                                                                "escapeMarkup": true,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "formatMessageValue": [Function],
+                                                                                                "help": "Manage Members within Teams",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "label": "Member",
+                                                                                                "name": "Member--permission",
+                                                                                                "onChange": [Function],
+                                                                                                "placeholder": "--",
+                                                                                                "small": false,
+                                                                                                "value": "no-access",
+                                                                                              },
+                                                                                              "clientId" => Object {
+                                                                                                "children": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "hideErrorMessage": false,
+                                                                                                "label": "Client ID",
+                                                                                                "name": "clientId",
+                                                                                                "overflow": true,
+                                                                                              },
+                                                                                              "clientSecret" => Object {
+                                                                                                "children": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "hideErrorMessage": false,
+                                                                                                "label": "Client Secret",
+                                                                                                "name": "clientSecret",
+                                                                                                "overflow": true,
+                                                                                              },
+                                                                                            },
+                                                                                            "fieldState": Object {
+                                                                                              "events": Object {
+                                                                                                "Saving": false,
+                                                                                                "showSave": true,
+                                                                                              },
+                                                                                            },
+                                                                                            "fields": Object {
+                                                                                              "Event--permission": "no-access",
+                                                                                              "Member--permission": "no-access",
+                                                                                              "Organization--permission": "no-access",
+                                                                                              "Project--permission": "read",
+                                                                                              "Release--permission": "no-access",
+                                                                                              "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
+                                                                                              "clientId": "client-id",
+                                                                                              "clientSecret": "client-secret",
+                                                                                              "events": Array [],
+                                                                                              "isAlertable": false,
+                                                                                              "name": "Sample App",
+                                                                                              "organization": "org-slug",
+                                                                                              "overview": "This is an app.",
+                                                                                              "redirectUrl": "https://example/com/setup",
+                                                                                              "schema": "",
+                                                                                              "scopes": Array [
+                                                                                                "project:read",
+                                                                                              ],
+                                                                                              "slug": "sample-app",
+                                                                                              "status": "unpublished",
+                                                                                              "uuid": "123456123456123456123456",
+                                                                                              "webhookUrl": "https://example.com/webhook",
+                                                                                            },
+                                                                                            "formState": "Ready",
+                                                                                            "initialData": Object {
+                                                                                              "Event--permission": "no-access",
+                                                                                              "Member--permission": "no-access",
+                                                                                              "Organization--permission": "no-access",
+                                                                                              "Project--permission": "read",
+                                                                                              "Release--permission": "no-access",
+                                                                                              "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
+                                                                                              "clientId": "client-id",
+                                                                                              "clientSecret": "client-secret",
+                                                                                              "events": Array [],
+                                                                                              "isAlertable": false,
+                                                                                              "name": "Sample App",
+                                                                                              "organization": "org-slug",
+                                                                                              "overview": "This is an app.",
+                                                                                              "redirectUrl": "https://example/com/setup",
+                                                                                              "schema": "",
+                                                                                              "scopes": Array [
+                                                                                                "project:read",
+                                                                                              ],
+                                                                                              "slug": "sample-app",
+                                                                                              "status": "unpublished",
+                                                                                              "uuid": "123456123456123456123456",
+                                                                                              "webhookUrl": "https://example.com/webhook",
+                                                                                            },
+                                                                                            "options": Object {
+                                                                                              "allowUndo": true,
+                                                                                              "apiEndpoint": "/sentry-apps/sample-app/",
+                                                                                              "apiMethod": "PUT",
+                                                                                              "onFieldChange": undefined,
+                                                                                              "onSubmitError": [Function],
+                                                                                              "onSubmitSuccess": [Function],
+                                                                                              "resetOnError": undefined,
+                                                                                              "saveOnBlur": false,
+                                                                                            },
+                                                                                            "snapshots": Array [
+                                                                                              Map {
+                                                                                                "organization" => "org-slug",
+                                                                                                "isAlertable" => false,
+                                                                                                "schema" => Object {},
+                                                                                                "name" => "Sample App",
+                                                                                                "author" => "Sentry",
+                                                                                                "slug" => "sample-app",
+                                                                                                "scopes" => Array [
+                                                                                                  "project:read",
+                                                                                                ],
+                                                                                                "events" => Array [],
+                                                                                                "status" => "unpublished",
+                                                                                                "uuid" => "123456123456123456123456",
+                                                                                                "webhookUrl" => "https://example.com/webhook",
+                                                                                                "redirectUrl" => "https://example/com/setup",
+                                                                                                "clientId" => "client-id",
+                                                                                                "clientSecret" => "client-secret",
+                                                                                                "overview" => "This is an app.",
+                                                                                              },
+                                                                                            ],
+                                                                                          }
+                                                                                        }
+                                                                                        name="author"
                                                                                       >
                                                                                         <Observer />
                                                                                         <Observer />
@@ -2042,6 +3332,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "required": true,
                                                                     "type": "text",
                                                                   },
+                                                                  "author" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "The company or person who built and maintains this Integration.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Author",
+                                                                    "name": "author",
+                                                                    "placeholder": "Acme Software",
+                                                                    "required": true,
+                                                                    "type": "text",
+                                                                  },
                                                                   "webhookUrl" => Object {
                                                                     "access": undefined,
                                                                     "children": [Function],
@@ -2383,6 +3690,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                   "Project--permission": "read",
                                                                   "Release--permission": "no-access",
                                                                   "Team--permission": "no-access",
+                                                                  "author": "Sentry",
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
                                                                   "events": Array [],
@@ -2408,6 +3716,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                   "Project--permission": "read",
                                                                   "Release--permission": "no-access",
                                                                   "Team--permission": "no-access",
+                                                                  "author": "Sentry",
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
                                                                   "events": Array [],
@@ -2441,6 +3750,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "isAlertable" => false,
                                                                     "schema" => Object {},
                                                                     "name" => "Sample App",
+                                                                    "author" => "Sentry",
                                                                     "slug" => "sample-app",
                                                                     "scopes" => Array [
                                                                       "project:read",
@@ -2533,6 +3843,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -2620,6 +3931,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "label": "Name",
                                                                                                 "name": "name",
                                                                                                 "placeholder": "e.g. My Application",
+                                                                                                "required": true,
+                                                                                                "type": "text",
+                                                                                              },
+                                                                                              "author" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "The company or person who built and maintains this Integration.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Author",
+                                                                                                "name": "author",
+                                                                                                "placeholder": "Acme Software",
                                                                                                 "required": true,
                                                                                                 "type": "text",
                                                                                               },
@@ -2964,6 +4292,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -2989,6 +4318,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -3022,6 +4352,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "isAlertable" => false,
                                                                                                 "schema" => Object {},
                                                                                                 "name" => "Sample App",
+                                                                                                "author" => "Sentry",
                                                                                                 "slug" => "sample-app",
                                                                                                 "scopes" => Array [
                                                                                                   "project:read",
@@ -3204,6 +4535,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "required": true,
                                                                     "type": "text",
                                                                   },
+                                                                  "author" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "The company or person who built and maintains this Integration.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Author",
+                                                                    "name": "author",
+                                                                    "placeholder": "Acme Software",
+                                                                    "required": true,
+                                                                    "type": "text",
+                                                                  },
                                                                   "webhookUrl" => Object {
                                                                     "access": undefined,
                                                                     "children": [Function],
@@ -3545,6 +4893,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                   "Project--permission": "read",
                                                                   "Release--permission": "no-access",
                                                                   "Team--permission": "no-access",
+                                                                  "author": "Sentry",
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
                                                                   "events": Array [],
@@ -3570,6 +4919,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                   "Project--permission": "read",
                                                                   "Release--permission": "no-access",
                                                                   "Team--permission": "no-access",
+                                                                  "author": "Sentry",
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
                                                                   "events": Array [],
@@ -3603,6 +4953,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "isAlertable" => false,
                                                                     "schema" => Object {},
                                                                     "name" => "Sample App",
+                                                                    "author" => "Sentry",
                                                                     "slug" => "sample-app",
                                                                     "scopes" => Array [
                                                                       "project:read",
@@ -3695,6 +5046,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -3780,6 +5132,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "label": "Name",
                                                                                                 "name": "name",
                                                                                                 "placeholder": "e.g. My Application",
+                                                                                                "required": true,
+                                                                                                "type": "text",
+                                                                                              },
+                                                                                              "author" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "The company or person who built and maintains this Integration.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Author",
+                                                                                                "name": "author",
+                                                                                                "placeholder": "Acme Software",
                                                                                                 "required": true,
                                                                                                 "type": "text",
                                                                                               },
@@ -4124,6 +5493,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -4149,6 +5519,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -4182,6 +5553,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "isAlertable" => false,
                                                                                                 "schema" => Object {},
                                                                                                 "name" => "Sample App",
+                                                                                                "author" => "Sentry",
                                                                                                 "slug" => "sample-app",
                                                                                                 "scopes" => Array [
                                                                                                   "project:read",
@@ -4464,6 +5836,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "required": true,
                                                                     "type": "text",
                                                                   },
+                                                                  "author" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "The company or person who built and maintains this Integration.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Author",
+                                                                    "name": "author",
+                                                                    "placeholder": "Acme Software",
+                                                                    "required": true,
+                                                                    "type": "text",
+                                                                  },
                                                                   "webhookUrl" => Object {
                                                                     "access": undefined,
                                                                     "children": [Function],
@@ -4805,6 +6194,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                   "Project--permission": "read",
                                                                   "Release--permission": "no-access",
                                                                   "Team--permission": "no-access",
+                                                                  "author": "Sentry",
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
                                                                   "events": Array [],
@@ -4830,6 +6220,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                   "Project--permission": "read",
                                                                   "Release--permission": "no-access",
                                                                   "Team--permission": "no-access",
+                                                                  "author": "Sentry",
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
                                                                   "events": Array [],
@@ -4863,6 +6254,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "isAlertable" => false,
                                                                     "schema" => Object {},
                                                                     "name" => "Sample App",
+                                                                    "author" => "Sentry",
                                                                     "slug" => "sample-app",
                                                                     "scopes" => Array [
                                                                       "project:read",
@@ -4970,6 +6362,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -5074,6 +6467,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "label": "Name",
                                                                                                 "name": "name",
                                                                                                 "placeholder": "e.g. My Application",
+                                                                                                "required": true,
+                                                                                                "type": "text",
+                                                                                              },
+                                                                                              "author" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "The company or person who built and maintains this Integration.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Author",
+                                                                                                "name": "author",
+                                                                                                "placeholder": "Acme Software",
                                                                                                 "required": true,
                                                                                                 "type": "text",
                                                                                               },
@@ -5418,6 +6828,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -5443,6 +6854,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -5476,6 +6888,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "isAlertable" => false,
                                                                                                 "schema" => Object {},
                                                                                                 "name" => "Sample App",
+                                                                                                "author" => "Sentry",
                                                                                                 "slug" => "sample-app",
                                                                                                 "scopes" => Array [
                                                                                                   "project:read",
@@ -5668,6 +7081,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "required": true,
                                                                     "type": "text",
                                                                   },
+                                                                  "author" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "The company or person who built and maintains this Integration.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Author",
+                                                                    "name": "author",
+                                                                    "placeholder": "Acme Software",
+                                                                    "required": true,
+                                                                    "type": "text",
+                                                                  },
                                                                   "webhookUrl" => Object {
                                                                     "access": undefined,
                                                                     "children": [Function],
@@ -6009,6 +7439,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                   "Project--permission": "read",
                                                                   "Release--permission": "no-access",
                                                                   "Team--permission": "no-access",
+                                                                  "author": "Sentry",
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
                                                                   "events": Array [],
@@ -6034,6 +7465,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                   "Project--permission": "read",
                                                                   "Release--permission": "no-access",
                                                                   "Team--permission": "no-access",
+                                                                  "author": "Sentry",
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
                                                                   "events": Array [],
@@ -6067,6 +7499,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "isAlertable" => false,
                                                                     "schema" => Object {},
                                                                     "name" => "Sample App",
+                                                                    "author" => "Sentry",
                                                                     "slug" => "sample-app",
                                                                     "scopes" => Array [
                                                                       "project:read",
@@ -6161,6 +7594,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -6273,6 +7707,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "label": "Name",
                                                                                                 "name": "name",
                                                                                                 "placeholder": "e.g. My Application",
+                                                                                                "required": true,
+                                                                                                "type": "text",
+                                                                                              },
+                                                                                              "author" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "The company or person who built and maintains this Integration.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Author",
+                                                                                                "name": "author",
+                                                                                                "placeholder": "Acme Software",
                                                                                                 "required": true,
                                                                                                 "type": "text",
                                                                                               },
@@ -6617,6 +8068,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -6642,6 +8094,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -6675,6 +8128,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "isAlertable" => false,
                                                                                                 "schema" => Object {},
                                                                                                 "name" => "Sample App",
+                                                                                                "author" => "Sentry",
                                                                                                 "slug" => "sample-app",
                                                                                                 "scopes" => Array [
                                                                                                   "project:read",
@@ -6857,6 +8311,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "required": true,
                                                                     "type": "text",
                                                                   },
+                                                                  "author" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "The company or person who built and maintains this Integration.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Author",
+                                                                    "name": "author",
+                                                                    "placeholder": "Acme Software",
+                                                                    "required": true,
+                                                                    "type": "text",
+                                                                  },
                                                                   "webhookUrl" => Object {
                                                                     "access": undefined,
                                                                     "children": [Function],
@@ -7198,6 +8669,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                   "Project--permission": "read",
                                                                   "Release--permission": "no-access",
                                                                   "Team--permission": "no-access",
+                                                                  "author": "Sentry",
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
                                                                   "events": Array [],
@@ -7223,6 +8695,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                   "Project--permission": "read",
                                                                   "Release--permission": "no-access",
                                                                   "Team--permission": "no-access",
+                                                                  "author": "Sentry",
                                                                   "clientId": "client-id",
                                                                   "clientSecret": "client-secret",
                                                                   "events": Array [],
@@ -7256,6 +8729,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                     "isAlertable" => false,
                                                                     "schema" => Object {},
                                                                     "name" => "Sample App",
+                                                                    "author" => "Sentry",
                                                                     "slug" => "sample-app",
                                                                     "scopes" => Array [
                                                                       "project:read",
@@ -7349,6 +8823,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -7460,6 +8935,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "label": "Name",
                                                                                                 "name": "name",
                                                                                                 "placeholder": "e.g. My Application",
+                                                                                                "required": true,
+                                                                                                "type": "text",
+                                                                                              },
+                                                                                              "author" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "The company or person who built and maintains this Integration.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Author",
+                                                                                                "name": "author",
+                                                                                                "placeholder": "Acme Software",
                                                                                                 "required": true,
                                                                                                 "type": "text",
                                                                                               },
@@ -7804,6 +9296,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -7829,6 +9322,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -7862,6 +9356,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                                 "isAlertable" => false,
                                                                                                 "schema" => Object {},
                                                                                                 "name" => "Sample App",
+                                                                                                "author" => "Sentry",
                                                                                                 "slug" => "sample-app",
                                                                                                 "scopes" => Array [
                                                                                                   "project:read",
@@ -8205,6 +9700,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                             "required": true,
                                                             "type": "text",
                                                           },
+                                                          "author" => Object {
+                                                            "access": undefined,
+                                                            "children": [Function],
+                                                            "className": undefined,
+                                                            "disabled": undefined,
+                                                            "features": undefined,
+                                                            "field": [Function],
+                                                            "flexibleControlStateSize": false,
+                                                            "help": "The company or person who built and maintains this Integration.",
+                                                            "hideErrorMessage": false,
+                                                            "highlighted": false,
+                                                            "label": "Author",
+                                                            "name": "author",
+                                                            "placeholder": "Acme Software",
+                                                            "required": true,
+                                                            "type": "text",
+                                                          },
                                                           "webhookUrl" => Object {
                                                             "access": undefined,
                                                             "children": [Function],
@@ -8546,6 +10058,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                           "Project--permission": "read",
                                                           "Release--permission": "no-access",
                                                           "Team--permission": "no-access",
+                                                          "author": "Sentry",
                                                           "clientId": "client-id",
                                                           "clientSecret": "client-secret",
                                                           "events": Array [],
@@ -8571,6 +10084,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                           "Project--permission": "read",
                                                           "Release--permission": "no-access",
                                                           "Team--permission": "no-access",
+                                                          "author": "Sentry",
                                                           "clientId": "client-id",
                                                           "clientSecret": "client-secret",
                                                           "events": Array [],
@@ -8604,6 +10118,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                             "isAlertable" => false,
                                                             "schema" => Object {},
                                                             "name" => "Sample App",
+                                                            "author" => "Sentry",
                                                             "slug" => "sample-app",
                                                             "scopes" => Array [
                                                               "project:read",
@@ -8721,6 +10236,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "Project--permission": "read",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "author": "Sentry",
                                                                                       "clientId": "client-id",
                                                                                       "clientSecret": "client-secret",
                                                                                       "events": Array [],
@@ -8792,6 +10308,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "Project--permission": "read",
                                                                                         "Release--permission": "no-access",
                                                                                         "Team--permission": "no-access",
+                                                                                        "author": "Sentry",
                                                                                         "clientId": "client-id",
                                                                                         "clientSecret": "client-secret",
                                                                                         "events": Array [],
@@ -8864,6 +10381,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                           "Project--permission": "read",
                                                                                           "Release--permission": "no-access",
                                                                                           "Team--permission": "no-access",
+                                                                                          "author": "Sentry",
                                                                                           "clientId": "client-id",
                                                                                           "clientSecret": "client-secret",
                                                                                           "events": Array [],
@@ -8936,6 +10454,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "Project--permission": "read",
                                                                                             "Release--permission": "no-access",
                                                                                             "Team--permission": "no-access",
+                                                                                            "author": "Sentry",
                                                                                             "clientId": "client-id",
                                                                                             "clientSecret": "client-secret",
                                                                                             "events": Array [],
@@ -9018,6 +10537,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -9256,6 +10776,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "label": "Name",
                                                                                         "name": "name",
                                                                                         "placeholder": "e.g. My Application",
+                                                                                        "required": true,
+                                                                                        "type": "text",
+                                                                                      },
+                                                                                      "author" => Object {
+                                                                                        "access": undefined,
+                                                                                        "children": [Function],
+                                                                                        "className": undefined,
+                                                                                        "disabled": undefined,
+                                                                                        "features": undefined,
+                                                                                        "field": [Function],
+                                                                                        "flexibleControlStateSize": false,
+                                                                                        "help": "The company or person who built and maintains this Integration.",
+                                                                                        "hideErrorMessage": false,
+                                                                                        "highlighted": false,
+                                                                                        "label": "Author",
+                                                                                        "name": "author",
+                                                                                        "placeholder": "Acme Software",
                                                                                         "required": true,
                                                                                         "type": "text",
                                                                                       },
@@ -9600,6 +11137,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "Project--permission": "read",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "author": "Sentry",
                                                                                       "clientId": "client-id",
                                                                                       "clientSecret": "client-secret",
                                                                                       "events": Array [],
@@ -9625,6 +11163,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "Project--permission": "read",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "author": "Sentry",
                                                                                       "clientId": "client-id",
                                                                                       "clientSecret": "client-secret",
                                                                                       "events": Array [],
@@ -9658,6 +11197,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "isAlertable" => false,
                                                                                         "schema" => Object {},
                                                                                         "name" => "Sample App",
+                                                                                        "author" => "Sentry",
                                                                                         "slug" => "sample-app",
                                                                                         "scopes" => Array [
                                                                                           "project:read",
@@ -9930,6 +11470,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                             "required": true,
                                                             "type": "text",
                                                           },
+                                                          "author" => Object {
+                                                            "access": undefined,
+                                                            "children": [Function],
+                                                            "className": undefined,
+                                                            "disabled": undefined,
+                                                            "features": undefined,
+                                                            "field": [Function],
+                                                            "flexibleControlStateSize": false,
+                                                            "help": "The company or person who built and maintains this Integration.",
+                                                            "hideErrorMessage": false,
+                                                            "highlighted": false,
+                                                            "label": "Author",
+                                                            "name": "author",
+                                                            "placeholder": "Acme Software",
+                                                            "required": true,
+                                                            "type": "text",
+                                                          },
                                                           "webhookUrl" => Object {
                                                             "access": undefined,
                                                             "children": [Function],
@@ -10271,6 +11828,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                           "Project--permission": "read",
                                                           "Release--permission": "no-access",
                                                           "Team--permission": "no-access",
+                                                          "author": "Sentry",
                                                           "clientId": "client-id",
                                                           "clientSecret": "client-secret",
                                                           "events": Array [],
@@ -10296,6 +11854,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                           "Project--permission": "read",
                                                           "Release--permission": "no-access",
                                                           "Team--permission": "no-access",
+                                                          "author": "Sentry",
                                                           "clientId": "client-id",
                                                           "clientSecret": "client-secret",
                                                           "events": Array [],
@@ -10329,6 +11888,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                             "isAlertable" => false,
                                                             "schema" => Object {},
                                                             "name" => "Sample App",
+                                                            "author" => "Sentry",
                                                             "slug" => "sample-app",
                                                             "scopes" => Array [
                                                               "project:read",
@@ -10446,6 +12006,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "Project--permission": "read",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "author": "Sentry",
                                                                                       "clientId": "client-id",
                                                                                       "clientSecret": "client-secret",
                                                                                       "events": Array [],
@@ -10517,6 +12078,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "Project--permission": "read",
                                                                                         "Release--permission": "no-access",
                                                                                         "Team--permission": "no-access",
+                                                                                        "author": "Sentry",
                                                                                         "clientId": "client-id",
                                                                                         "clientSecret": "client-secret",
                                                                                         "events": Array [],
@@ -10589,6 +12151,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                           "Project--permission": "read",
                                                                                           "Release--permission": "no-access",
                                                                                           "Team--permission": "no-access",
+                                                                                          "author": "Sentry",
                                                                                           "clientId": "client-id",
                                                                                           "clientSecret": "client-secret",
                                                                                           "events": Array [],
@@ -10661,6 +12224,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "Project--permission": "read",
                                                                                             "Release--permission": "no-access",
                                                                                             "Team--permission": "no-access",
+                                                                                            "author": "Sentry",
                                                                                             "clientId": "client-id",
                                                                                             "clientSecret": "client-secret",
                                                                                             "events": Array [],
@@ -10743,6 +12307,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -10984,6 +12549,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "required": true,
                                                                                         "type": "text",
                                                                                       },
+                                                                                      "author" => Object {
+                                                                                        "access": undefined,
+                                                                                        "children": [Function],
+                                                                                        "className": undefined,
+                                                                                        "disabled": undefined,
+                                                                                        "features": undefined,
+                                                                                        "field": [Function],
+                                                                                        "flexibleControlStateSize": false,
+                                                                                        "help": "The company or person who built and maintains this Integration.",
+                                                                                        "hideErrorMessage": false,
+                                                                                        "highlighted": false,
+                                                                                        "label": "Author",
+                                                                                        "name": "author",
+                                                                                        "placeholder": "Acme Software",
+                                                                                        "required": true,
+                                                                                        "type": "text",
+                                                                                      },
                                                                                       "webhookUrl" => Object {
                                                                                         "access": undefined,
                                                                                         "children": [Function],
@@ -11325,6 +12907,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "Project--permission": "read",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "author": "Sentry",
                                                                                       "clientId": "client-id",
                                                                                       "clientSecret": "client-secret",
                                                                                       "events": Array [],
@@ -11350,6 +12933,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "Project--permission": "read",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "author": "Sentry",
                                                                                       "clientId": "client-id",
                                                                                       "clientSecret": "client-secret",
                                                                                       "events": Array [],
@@ -11383,6 +12967,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "isAlertable" => false,
                                                                                         "schema" => Object {},
                                                                                         "name" => "Sample App",
+                                                                                        "author" => "Sentry",
                                                                                         "slug" => "sample-app",
                                                                                         "scopes" => Array [
                                                                                           "project:read",
@@ -11620,6 +13205,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                             "label": "Name",
                                                             "name": "name",
                                                             "placeholder": "e.g. My Application",
+                                                            "required": true,
+                                                            "type": "text",
+                                                          },
+                                                          "author" => Object {
+                                                            "access": undefined,
+                                                            "children": [Function],
+                                                            "className": undefined,
+                                                            "disabled": undefined,
+                                                            "features": undefined,
+                                                            "field": [Function],
+                                                            "flexibleControlStateSize": false,
+                                                            "help": "The company or person who built and maintains this Integration.",
+                                                            "hideErrorMessage": false,
+                                                            "highlighted": false,
+                                                            "label": "Author",
+                                                            "name": "author",
+                                                            "placeholder": "Acme Software",
                                                             "required": true,
                                                             "type": "text",
                                                           },
@@ -11964,6 +13566,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                           "Project--permission": "read",
                                                           "Release--permission": "no-access",
                                                           "Team--permission": "no-access",
+                                                          "author": "Sentry",
                                                           "clientId": "client-id",
                                                           "clientSecret": "client-secret",
                                                           "events": Array [],
@@ -11989,6 +13592,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                           "Project--permission": "read",
                                                           "Release--permission": "no-access",
                                                           "Team--permission": "no-access",
+                                                          "author": "Sentry",
                                                           "clientId": "client-id",
                                                           "clientSecret": "client-secret",
                                                           "events": Array [],
@@ -12022,6 +13626,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                             "isAlertable" => false,
                                                             "schema" => Object {},
                                                             "name" => "Sample App",
+                                                            "author" => "Sentry",
                                                             "slug" => "sample-app",
                                                             "scopes" => Array [
                                                               "project:read",
@@ -12131,6 +13736,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "Project--permission": "read",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "author": "Sentry",
                                                                                       "clientId": "client-id",
                                                                                       "clientSecret": "client-secret",
                                                                                       "events": Array [],
@@ -12194,6 +13800,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "Project--permission": "read",
                                                                                         "Release--permission": "no-access",
                                                                                         "Team--permission": "no-access",
+                                                                                        "author": "Sentry",
                                                                                         "clientId": "client-id",
                                                                                         "clientSecret": "client-secret",
                                                                                         "events": Array [],
@@ -12258,6 +13865,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                           "Project--permission": "read",
                                                                                           "Release--permission": "no-access",
                                                                                           "Team--permission": "no-access",
+                                                                                          "author": "Sentry",
                                                                                           "clientId": "client-id",
                                                                                           "clientSecret": "client-secret",
                                                                                           "events": Array [],
@@ -12322,6 +13930,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "Project--permission": "read",
                                                                                             "Release--permission": "no-access",
                                                                                             "Team--permission": "no-access",
+                                                                                            "author": "Sentry",
                                                                                             "clientId": "client-id",
                                                                                             "clientSecret": "client-secret",
                                                                                             "events": Array [],
@@ -12396,6 +14005,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -12626,6 +14236,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "label": "Name",
                                                                                         "name": "name",
                                                                                         "placeholder": "e.g. My Application",
+                                                                                        "required": true,
+                                                                                        "type": "text",
+                                                                                      },
+                                                                                      "author" => Object {
+                                                                                        "access": undefined,
+                                                                                        "children": [Function],
+                                                                                        "className": undefined,
+                                                                                        "disabled": undefined,
+                                                                                        "features": undefined,
+                                                                                        "field": [Function],
+                                                                                        "flexibleControlStateSize": false,
+                                                                                        "help": "The company or person who built and maintains this Integration.",
+                                                                                        "hideErrorMessage": false,
+                                                                                        "highlighted": false,
+                                                                                        "label": "Author",
+                                                                                        "name": "author",
+                                                                                        "placeholder": "Acme Software",
                                                                                         "required": true,
                                                                                         "type": "text",
                                                                                       },
@@ -12970,6 +14597,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "Project--permission": "read",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "author": "Sentry",
                                                                                       "clientId": "client-id",
                                                                                       "clientSecret": "client-secret",
                                                                                       "events": Array [],
@@ -12995,6 +14623,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "Project--permission": "read",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "author": "Sentry",
                                                                                       "clientId": "client-id",
                                                                                       "clientSecret": "client-secret",
                                                                                       "events": Array [],
@@ -13028,6 +14657,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "isAlertable" => false,
                                                                                         "schema" => Object {},
                                                                                         "name" => "Sample App",
+                                                                                        "author" => "Sentry",
                                                                                         "slug" => "sample-app",
                                                                                         "scopes" => Array [
                                                                                           "project:read",
@@ -13300,6 +14930,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                             "required": true,
                                                             "type": "text",
                                                           },
+                                                          "author" => Object {
+                                                            "access": undefined,
+                                                            "children": [Function],
+                                                            "className": undefined,
+                                                            "disabled": undefined,
+                                                            "features": undefined,
+                                                            "field": [Function],
+                                                            "flexibleControlStateSize": false,
+                                                            "help": "The company or person who built and maintains this Integration.",
+                                                            "hideErrorMessage": false,
+                                                            "highlighted": false,
+                                                            "label": "Author",
+                                                            "name": "author",
+                                                            "placeholder": "Acme Software",
+                                                            "required": true,
+                                                            "type": "text",
+                                                          },
                                                           "webhookUrl" => Object {
                                                             "access": undefined,
                                                             "children": [Function],
@@ -13641,6 +15288,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                           "Project--permission": "read",
                                                           "Release--permission": "no-access",
                                                           "Team--permission": "no-access",
+                                                          "author": "Sentry",
                                                           "clientId": "client-id",
                                                           "clientSecret": "client-secret",
                                                           "events": Array [],
@@ -13666,6 +15314,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                           "Project--permission": "read",
                                                           "Release--permission": "no-access",
                                                           "Team--permission": "no-access",
+                                                          "author": "Sentry",
                                                           "clientId": "client-id",
                                                           "clientSecret": "client-secret",
                                                           "events": Array [],
@@ -13699,6 +15348,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                             "isAlertable" => false,
                                                             "schema" => Object {},
                                                             "name" => "Sample App",
+                                                            "author" => "Sentry",
                                                             "slug" => "sample-app",
                                                             "scopes" => Array [
                                                               "project:read",
@@ -13816,6 +15466,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "Project--permission": "read",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "author": "Sentry",
                                                                                       "clientId": "client-id",
                                                                                       "clientSecret": "client-secret",
                                                                                       "events": Array [],
@@ -13887,6 +15538,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "Project--permission": "read",
                                                                                         "Release--permission": "no-access",
                                                                                         "Team--permission": "no-access",
+                                                                                        "author": "Sentry",
                                                                                         "clientId": "client-id",
                                                                                         "clientSecret": "client-secret",
                                                                                         "events": Array [],
@@ -13959,6 +15611,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                           "Project--permission": "read",
                                                                                           "Release--permission": "no-access",
                                                                                           "Team--permission": "no-access",
+                                                                                          "author": "Sentry",
                                                                                           "clientId": "client-id",
                                                                                           "clientSecret": "client-secret",
                                                                                           "events": Array [],
@@ -14031,6 +15684,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "Project--permission": "read",
                                                                                             "Release--permission": "no-access",
                                                                                             "Team--permission": "no-access",
+                                                                                            "author": "Sentry",
                                                                                             "clientId": "client-id",
                                                                                             "clientSecret": "client-secret",
                                                                                             "events": Array [],
@@ -14113,6 +15767,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -14351,6 +16006,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "label": "Name",
                                                                                         "name": "name",
                                                                                         "placeholder": "e.g. My Application",
+                                                                                        "required": true,
+                                                                                        "type": "text",
+                                                                                      },
+                                                                                      "author" => Object {
+                                                                                        "access": undefined,
+                                                                                        "children": [Function],
+                                                                                        "className": undefined,
+                                                                                        "disabled": undefined,
+                                                                                        "features": undefined,
+                                                                                        "field": [Function],
+                                                                                        "flexibleControlStateSize": false,
+                                                                                        "help": "The company or person who built and maintains this Integration.",
+                                                                                        "hideErrorMessage": false,
+                                                                                        "highlighted": false,
+                                                                                        "label": "Author",
+                                                                                        "name": "author",
+                                                                                        "placeholder": "Acme Software",
                                                                                         "required": true,
                                                                                         "type": "text",
                                                                                       },
@@ -14695,6 +16367,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "Project--permission": "read",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "author": "Sentry",
                                                                                       "clientId": "client-id",
                                                                                       "clientSecret": "client-secret",
                                                                                       "events": Array [],
@@ -14720,6 +16393,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "Project--permission": "read",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "author": "Sentry",
                                                                                       "clientId": "client-id",
                                                                                       "clientSecret": "client-secret",
                                                                                       "events": Array [],
@@ -14753,6 +16427,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "isAlertable" => false,
                                                                                         "schema" => Object {},
                                                                                         "name" => "Sample App",
+                                                                                        "author" => "Sentry",
                                                                                         "slug" => "sample-app",
                                                                                         "scopes" => Array [
                                                                                           "project:read",
@@ -15025,6 +16700,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                             "required": true,
                                                             "type": "text",
                                                           },
+                                                          "author" => Object {
+                                                            "access": undefined,
+                                                            "children": [Function],
+                                                            "className": undefined,
+                                                            "disabled": undefined,
+                                                            "features": undefined,
+                                                            "field": [Function],
+                                                            "flexibleControlStateSize": false,
+                                                            "help": "The company or person who built and maintains this Integration.",
+                                                            "hideErrorMessage": false,
+                                                            "highlighted": false,
+                                                            "label": "Author",
+                                                            "name": "author",
+                                                            "placeholder": "Acme Software",
+                                                            "required": true,
+                                                            "type": "text",
+                                                          },
                                                           "webhookUrl" => Object {
                                                             "access": undefined,
                                                             "children": [Function],
@@ -15366,6 +17058,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                           "Project--permission": "read",
                                                           "Release--permission": "no-access",
                                                           "Team--permission": "no-access",
+                                                          "author": "Sentry",
                                                           "clientId": "client-id",
                                                           "clientSecret": "client-secret",
                                                           "events": Array [],
@@ -15391,6 +17084,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                           "Project--permission": "read",
                                                           "Release--permission": "no-access",
                                                           "Team--permission": "no-access",
+                                                          "author": "Sentry",
                                                           "clientId": "client-id",
                                                           "clientSecret": "client-secret",
                                                           "events": Array [],
@@ -15424,6 +17118,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                             "isAlertable" => false,
                                                             "schema" => Object {},
                                                             "name" => "Sample App",
+                                                            "author" => "Sentry",
                                                             "slug" => "sample-app",
                                                             "scopes" => Array [
                                                               "project:read",
@@ -15541,6 +17236,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "Project--permission": "read",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "author": "Sentry",
                                                                                       "clientId": "client-id",
                                                                                       "clientSecret": "client-secret",
                                                                                       "events": Array [],
@@ -15612,6 +17308,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "Project--permission": "read",
                                                                                         "Release--permission": "no-access",
                                                                                         "Team--permission": "no-access",
+                                                                                        "author": "Sentry",
                                                                                         "clientId": "client-id",
                                                                                         "clientSecret": "client-secret",
                                                                                         "events": Array [],
@@ -15684,6 +17381,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                           "Project--permission": "read",
                                                                                           "Release--permission": "no-access",
                                                                                           "Team--permission": "no-access",
+                                                                                          "author": "Sentry",
                                                                                           "clientId": "client-id",
                                                                                           "clientSecret": "client-secret",
                                                                                           "events": Array [],
@@ -15756,6 +17454,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "Project--permission": "read",
                                                                                             "Release--permission": "no-access",
                                                                                             "Team--permission": "no-access",
+                                                                                            "author": "Sentry",
                                                                                             "clientId": "client-id",
                                                                                             "clientSecret": "client-secret",
                                                                                             "events": Array [],
@@ -15838,6 +17537,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -16076,6 +17776,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "label": "Name",
                                                                                         "name": "name",
                                                                                         "placeholder": "e.g. My Application",
+                                                                                        "required": true,
+                                                                                        "type": "text",
+                                                                                      },
+                                                                                      "author" => Object {
+                                                                                        "access": undefined,
+                                                                                        "children": [Function],
+                                                                                        "className": undefined,
+                                                                                        "disabled": undefined,
+                                                                                        "features": undefined,
+                                                                                        "field": [Function],
+                                                                                        "flexibleControlStateSize": false,
+                                                                                        "help": "The company or person who built and maintains this Integration.",
+                                                                                        "hideErrorMessage": false,
+                                                                                        "highlighted": false,
+                                                                                        "label": "Author",
+                                                                                        "name": "author",
+                                                                                        "placeholder": "Acme Software",
                                                                                         "required": true,
                                                                                         "type": "text",
                                                                                       },
@@ -16420,6 +18137,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "Project--permission": "read",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "author": "Sentry",
                                                                                       "clientId": "client-id",
                                                                                       "clientSecret": "client-secret",
                                                                                       "events": Array [],
@@ -16445,6 +18163,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "Project--permission": "read",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "author": "Sentry",
                                                                                       "clientId": "client-id",
                                                                                       "clientSecret": "client-secret",
                                                                                       "events": Array [],
@@ -16478,6 +18197,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "isAlertable" => false,
                                                                                         "schema" => Object {},
                                                                                         "name" => "Sample App",
+                                                                                        "author" => "Sentry",
                                                                                         "slug" => "sample-app",
                                                                                         "scopes" => Array [
                                                                                           "project:read",
@@ -16750,6 +18470,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                             "required": true,
                                                             "type": "text",
                                                           },
+                                                          "author" => Object {
+                                                            "access": undefined,
+                                                            "children": [Function],
+                                                            "className": undefined,
+                                                            "disabled": undefined,
+                                                            "features": undefined,
+                                                            "field": [Function],
+                                                            "flexibleControlStateSize": false,
+                                                            "help": "The company or person who built and maintains this Integration.",
+                                                            "hideErrorMessage": false,
+                                                            "highlighted": false,
+                                                            "label": "Author",
+                                                            "name": "author",
+                                                            "placeholder": "Acme Software",
+                                                            "required": true,
+                                                            "type": "text",
+                                                          },
                                                           "webhookUrl" => Object {
                                                             "access": undefined,
                                                             "children": [Function],
@@ -17091,6 +18828,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                           "Project--permission": "read",
                                                           "Release--permission": "no-access",
                                                           "Team--permission": "no-access",
+                                                          "author": "Sentry",
                                                           "clientId": "client-id",
                                                           "clientSecret": "client-secret",
                                                           "events": Array [],
@@ -17116,6 +18854,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                           "Project--permission": "read",
                                                           "Release--permission": "no-access",
                                                           "Team--permission": "no-access",
+                                                          "author": "Sentry",
                                                           "clientId": "client-id",
                                                           "clientSecret": "client-secret",
                                                           "events": Array [],
@@ -17149,6 +18888,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                             "isAlertable" => false,
                                                             "schema" => Object {},
                                                             "name" => "Sample App",
+                                                            "author" => "Sentry",
                                                             "slug" => "sample-app",
                                                             "scopes" => Array [
                                                               "project:read",
@@ -17266,6 +19006,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "Project--permission": "read",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "author": "Sentry",
                                                                                       "clientId": "client-id",
                                                                                       "clientSecret": "client-secret",
                                                                                       "events": Array [],
@@ -17337,6 +19078,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "Project--permission": "read",
                                                                                         "Release--permission": "no-access",
                                                                                         "Team--permission": "no-access",
+                                                                                        "author": "Sentry",
                                                                                         "clientId": "client-id",
                                                                                         "clientSecret": "client-secret",
                                                                                         "events": Array [],
@@ -17409,6 +19151,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                           "Project--permission": "read",
                                                                                           "Release--permission": "no-access",
                                                                                           "Team--permission": "no-access",
+                                                                                          "author": "Sentry",
                                                                                           "clientId": "client-id",
                                                                                           "clientSecret": "client-secret",
                                                                                           "events": Array [],
@@ -17481,6 +19224,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                             "Project--permission": "read",
                                                                                             "Release--permission": "no-access",
                                                                                             "Team--permission": "no-access",
+                                                                                            "author": "Sentry",
                                                                                             "clientId": "client-id",
                                                                                             "clientSecret": "client-secret",
                                                                                             "events": Array [],
@@ -17563,6 +19307,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                               "Project--permission": "read",
                                                                                               "Release--permission": "no-access",
                                                                                               "Team--permission": "no-access",
+                                                                                              "author": "Sentry",
                                                                                               "clientId": "client-id",
                                                                                               "clientSecret": "client-secret",
                                                                                               "events": Array [],
@@ -17801,6 +19546,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "label": "Name",
                                                                                         "name": "name",
                                                                                         "placeholder": "e.g. My Application",
+                                                                                        "required": true,
+                                                                                        "type": "text",
+                                                                                      },
+                                                                                      "author" => Object {
+                                                                                        "access": undefined,
+                                                                                        "children": [Function],
+                                                                                        "className": undefined,
+                                                                                        "disabled": undefined,
+                                                                                        "features": undefined,
+                                                                                        "field": [Function],
+                                                                                        "flexibleControlStateSize": false,
+                                                                                        "help": "The company or person who built and maintains this Integration.",
+                                                                                        "hideErrorMessage": false,
+                                                                                        "highlighted": false,
+                                                                                        "label": "Author",
+                                                                                        "name": "author",
+                                                                                        "placeholder": "Acme Software",
                                                                                         "required": true,
                                                                                         "type": "text",
                                                                                       },
@@ -18145,6 +19907,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "Project--permission": "read",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "author": "Sentry",
                                                                                       "clientId": "client-id",
                                                                                       "clientSecret": "client-secret",
                                                                                       "events": Array [],
@@ -18170,6 +19933,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                       "Project--permission": "read",
                                                                                       "Release--permission": "no-access",
                                                                                       "Team--permission": "no-access",
+                                                                                      "author": "Sentry",
                                                                                       "clientId": "client-id",
                                                                                       "clientSecret": "client-secret",
                                                                                       "events": Array [],
@@ -18203,6 +19967,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                         "isAlertable" => false,
                                                                                         "schema" => Object {},
                                                                                         "name" => "Sample App",
+                                                                                        "author" => "Sentry",
                                                                                         "slug" => "sample-app",
                                                                                         "scopes" => Array [
                                                                                           "project:read",
@@ -18525,6 +20290,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                     "required": true,
                                                     "type": "text",
                                                   },
+                                                  "author" => Object {
+                                                    "access": undefined,
+                                                    "children": [Function],
+                                                    "className": undefined,
+                                                    "disabled": undefined,
+                                                    "features": undefined,
+                                                    "field": [Function],
+                                                    "flexibleControlStateSize": false,
+                                                    "help": "The company or person who built and maintains this Integration.",
+                                                    "hideErrorMessage": false,
+                                                    "highlighted": false,
+                                                    "label": "Author",
+                                                    "name": "author",
+                                                    "placeholder": "Acme Software",
+                                                    "required": true,
+                                                    "type": "text",
+                                                  },
                                                   "webhookUrl" => Object {
                                                     "access": undefined,
                                                     "children": [Function],
@@ -18866,6 +20648,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                   "Project--permission": "read",
                                                   "Release--permission": "no-access",
                                                   "Team--permission": "no-access",
+                                                  "author": "Sentry",
                                                   "clientId": "client-id",
                                                   "clientSecret": "client-secret",
                                                   "events": Array [],
@@ -18891,6 +20674,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                   "Project--permission": "read",
                                                   "Release--permission": "no-access",
                                                   "Team--permission": "no-access",
+                                                  "author": "Sentry",
                                                   "clientId": "client-id",
                                                   "clientSecret": "client-secret",
                                                   "events": Array [],
@@ -18924,6 +20708,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                     "isAlertable" => false,
                                                     "schema" => Object {},
                                                     "name" => "Sample App",
+                                                    "author" => "Sentry",
                                                     "slug" => "sample-app",
                                                     "scopes" => Array [
                                                       "project:read",
@@ -19095,6 +20880,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                 "required": true,
                                                                                 "type": "text",
                                                                               },
+                                                                              "author" => Object {
+                                                                                "access": undefined,
+                                                                                "children": [Function],
+                                                                                "className": undefined,
+                                                                                "disabled": undefined,
+                                                                                "features": undefined,
+                                                                                "field": [Function],
+                                                                                "flexibleControlStateSize": false,
+                                                                                "help": "The company or person who built and maintains this Integration.",
+                                                                                "hideErrorMessage": false,
+                                                                                "highlighted": false,
+                                                                                "label": "Author",
+                                                                                "name": "author",
+                                                                                "placeholder": "Acme Software",
+                                                                                "required": true,
+                                                                                "type": "text",
+                                                                              },
                                                                               "webhookUrl" => Object {
                                                                                 "access": undefined,
                                                                                 "children": [Function],
@@ -19436,6 +21238,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                               "Project--permission": "read",
                                                                               "Release--permission": "no-access",
                                                                               "Team--permission": "no-access",
+                                                                              "author": "Sentry",
                                                                               "clientId": "client-id",
                                                                               "clientSecret": "client-secret",
                                                                               "events": Array [],
@@ -19461,6 +21264,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                               "Project--permission": "read",
                                                                               "Release--permission": "no-access",
                                                                               "Team--permission": "no-access",
+                                                                              "author": "Sentry",
                                                                               "clientId": "client-id",
                                                                               "clientSecret": "client-secret",
                                                                               "events": Array [],
@@ -19494,6 +21298,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                 "isAlertable" => false,
                                                                                 "schema" => Object {},
                                                                                 "name" => "Sample App",
+                                                                                "author" => "Sentry",
                                                                                 "slug" => "sample-app",
                                                                                 "scopes" => Array [
                                                                                   "project:read",
@@ -19624,6 +21429,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                     "label": "Name",
                                                     "name": "name",
                                                     "placeholder": "e.g. My Application",
+                                                    "required": true,
+                                                    "type": "text",
+                                                  },
+                                                  "author" => Object {
+                                                    "access": undefined,
+                                                    "children": [Function],
+                                                    "className": undefined,
+                                                    "disabled": undefined,
+                                                    "features": undefined,
+                                                    "field": [Function],
+                                                    "flexibleControlStateSize": false,
+                                                    "help": "The company or person who built and maintains this Integration.",
+                                                    "hideErrorMessage": false,
+                                                    "highlighted": false,
+                                                    "label": "Author",
+                                                    "name": "author",
+                                                    "placeholder": "Acme Software",
                                                     "required": true,
                                                     "type": "text",
                                                   },
@@ -19968,6 +21790,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                   "Project--permission": "read",
                                                   "Release--permission": "no-access",
                                                   "Team--permission": "no-access",
+                                                  "author": "Sentry",
                                                   "clientId": "client-id",
                                                   "clientSecret": "client-secret",
                                                   "events": Array [],
@@ -19993,6 +21816,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                   "Project--permission": "read",
                                                   "Release--permission": "no-access",
                                                   "Team--permission": "no-access",
+                                                  "author": "Sentry",
                                                   "clientId": "client-id",
                                                   "clientSecret": "client-secret",
                                                   "events": Array [],
@@ -20026,6 +21850,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                     "isAlertable" => false,
                                                     "schema" => Object {},
                                                     "name" => "Sample App",
+                                                    "author" => "Sentry",
                                                     "slug" => "sample-app",
                                                     "scopes" => Array [
                                                       "project:read",
@@ -20194,6 +22019,23 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                 "label": "Name",
                                                                                 "name": "name",
                                                                                 "placeholder": "e.g. My Application",
+                                                                                "required": true,
+                                                                                "type": "text",
+                                                                              },
+                                                                              "author" => Object {
+                                                                                "access": undefined,
+                                                                                "children": [Function],
+                                                                                "className": undefined,
+                                                                                "disabled": undefined,
+                                                                                "features": undefined,
+                                                                                "field": [Function],
+                                                                                "flexibleControlStateSize": false,
+                                                                                "help": "The company or person who built and maintains this Integration.",
+                                                                                "hideErrorMessage": false,
+                                                                                "highlighted": false,
+                                                                                "label": "Author",
+                                                                                "name": "author",
+                                                                                "placeholder": "Acme Software",
                                                                                 "required": true,
                                                                                 "type": "text",
                                                                               },
@@ -20538,6 +22380,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                               "Project--permission": "read",
                                                                               "Release--permission": "no-access",
                                                                               "Team--permission": "no-access",
+                                                                              "author": "Sentry",
                                                                               "clientId": "client-id",
                                                                               "clientSecret": "client-secret",
                                                                               "events": Array [],
@@ -20563,6 +22406,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                               "Project--permission": "read",
                                                                               "Release--permission": "no-access",
                                                                               "Team--permission": "no-access",
+                                                                              "author": "Sentry",
                                                                               "clientId": "client-id",
                                                                               "clientSecret": "client-secret",
                                                                               "events": Array [],
@@ -20596,6 +22440,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                                                                                 "isAlertable" => false,
                                                                                 "schema" => Object {},
                                                                                 "name" => "Sample App",
+                                                                                "author" => "Sentry",
                                                                                 "slug" => "sample-app",
                                                                                 "scopes" => Array [
                                                                                   "project:read",
@@ -20807,6 +22652,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                   "label": "Name",
                   "name": "name",
                   "placeholder": "e.g. My Application",
+                  "required": true,
+                  "type": "text",
+                },
+                "author" => Object {
+                  "access": undefined,
+                  "children": [Function],
+                  "className": undefined,
+                  "disabled": undefined,
+                  "features": undefined,
+                  "field": [Function],
+                  "flexibleControlStateSize": false,
+                  "help": "The company or person who built and maintains this Integration.",
+                  "hideErrorMessage": false,
+                  "highlighted": false,
+                  "label": "Author",
+                  "name": "author",
+                  "placeholder": "Acme Software",
                   "required": true,
                   "type": "text",
                 },
@@ -21199,6 +23061,14 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                           "type": "string",
                         },
                         Object {
+                          "help": "The company or person who built and maintains this Integration.",
+                          "label": "Author",
+                          "name": "author",
+                          "placeholder": "Acme Software",
+                          "required": true,
+                          "type": "string",
+                        },
+                        Object {
                           "help": "The URL Sentry will send requests to on installation changes.",
                           "label": "Webhook URL",
                           "name": "webhookUrl",
@@ -21272,6 +23142,14 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                               "label": "Name",
                               "name": "name",
                               "placeholder": "e.g. My Application",
+                              "required": true,
+                              "type": "string",
+                            },
+                            Object {
+                              "help": "The company or person who built and maintains this Integration.",
+                              "label": "Author",
+                              "name": "author",
+                              "placeholder": "Acme Software",
                               "required": true,
                               "type": "string",
                             },
@@ -21515,6 +23393,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                     "label": "Name",
                                                                     "name": "name",
                                                                     "placeholder": "e.g. My Application",
+                                                                    "required": true,
+                                                                    "type": "text",
+                                                                  },
+                                                                  "author" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "The company or person who built and maintains this Integration.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Author",
+                                                                    "name": "author",
+                                                                    "placeholder": "Acme Software",
                                                                     "required": true,
                                                                     "type": "text",
                                                                   },
@@ -22032,6 +23927,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                                 "required": true,
                                                                                                 "type": "text",
                                                                                               },
+                                                                                              "author" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "The company or person who built and maintains this Integration.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Author",
+                                                                                                "name": "author",
+                                                                                                "placeholder": "Acme Software",
+                                                                                                "required": true,
+                                                                                                "type": "text",
+                                                                                              },
                                                                                               "webhookUrl" => Object {
                                                                                                 "access": undefined,
                                                                                                 "children": [Function],
@@ -22428,6 +24340,1090 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                   <FieldFromConfig
                                     field={
                                       Object {
+                                        "help": "The company or person who built and maintains this Integration.",
+                                        "label": "Author",
+                                        "name": "author",
+                                        "placeholder": "Acme Software",
+                                        "required": true,
+                                        "type": "string",
+                                      }
+                                    }
+                                    highlighted={false}
+                                    key="author"
+                                  >
+                                    <TextField
+                                      help="The company or person who built and maintains this Integration."
+                                      highlighted={false}
+                                      label="Author"
+                                      name="author"
+                                      placeholder="Acme Software"
+                                      required={true}
+                                      type="string"
+                                    >
+                                      <InputField
+                                        field={[Function]}
+                                        help="The company or person who built and maintains this Integration."
+                                        highlighted={false}
+                                        label="Author"
+                                        name="author"
+                                        placeholder="Acme Software"
+                                        required={true}
+                                        type="text"
+                                      >
+                                        <FormField
+                                          field={[Function]}
+                                          flexibleControlStateSize={false}
+                                          help="The company or person who built and maintains this Integration."
+                                          hideErrorMessage={false}
+                                          highlighted={false}
+                                          label="Author"
+                                          name="author"
+                                          placeholder="Acme Software"
+                                          required={true}
+                                          type="text"
+                                        >
+                                          <Field
+                                            alignRight={false}
+                                            disabled={false}
+                                            field={[Function]}
+                                            flexibleControlStateSize={false}
+                                            help="The company or person who built and maintains this Integration."
+                                            highlighted={false}
+                                            id="author"
+                                            inline={true}
+                                            label="Author"
+                                            name="author"
+                                            placeholder="Acme Software"
+                                            required={true}
+                                            type="text"
+                                            visible={true}
+                                          >
+                                            <FieldWrapper
+                                              hasControlState={true}
+                                              highlighted={false}
+                                              inline={true}
+                                            >
+                                              <Component
+                                                className="css-gf4a1r-FieldWrapper-getPadding-borderStyle-inlineStyle etqqcs20"
+                                              >
+                                                <Flex
+                                                  className="css-gf4a1r-FieldWrapper-getPadding-borderStyle-inlineStyle etqqcs20"
+                                                >
+                                                  <Base
+                                                    className="etqqcs20 css-12j1xki-FieldWrapper-getPadding-borderStyle-inlineStyle"
+                                                  >
+                                                    <div
+                                                      className="etqqcs20 css-12j1xki-FieldWrapper-getPadding-borderStyle-inlineStyle"
+                                                      is={null}
+                                                    >
+                                                      <FieldDescription
+                                                        htmlFor="author"
+                                                        inline={true}
+                                                      >
+                                                        <Component
+                                                          className="css-gxpq9u-FieldDescription-inlineStyle e12jefmo0"
+                                                          htmlFor="author"
+                                                          inline={true}
+                                                        >
+                                                          <label
+                                                            className="css-gxpq9u-FieldDescription-inlineStyle e12jefmo0"
+                                                            htmlFor="author"
+                                                          >
+                                                            <FieldLabel
+                                                              disabled={false}
+                                                            >
+                                                              <div
+                                                                className="css-qzvhly-FieldLabel ejkuyjq0"
+                                                              >
+                                                                Author
+                                                                 
+                                                                <FieldRequiredBadge>
+                                                                  <div
+                                                                    className="css-x360nj-FieldRequiredBadge e1u93u900"
+                                                                  />
+                                                                </FieldRequiredBadge>
+                                                              </div>
+                                                            </FieldLabel>
+                                                            <FieldHelp>
+                                                              <div
+                                                                className="css-aqmwwj-FieldHelp e19g0xdp0"
+                                                              >
+                                                                The company or person who built and maintains this Integration.
+                                                              </div>
+                                                            </FieldHelp>
+                                                          </label>
+                                                        </Component>
+                                                      </FieldDescription>
+                                                      <FieldControl
+                                                        alignRight={false}
+                                                        controlState={
+                                                          <ControlState
+                                                            model={
+                                                              SentryAppFormModel {
+                                                                "api": Client {},
+                                                                "errors": Object {},
+                                                                "fieldDescriptor": Map {
+                                                                  "name" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "Human readable name of your application.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Name",
+                                                                    "name": "name",
+                                                                    "placeholder": "e.g. My Application",
+                                                                    "required": true,
+                                                                    "type": "text",
+                                                                  },
+                                                                  "author" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "The company or person who built and maintains this Integration.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Author",
+                                                                    "name": "author",
+                                                                    "placeholder": "Acme Software",
+                                                                    "required": true,
+                                                                    "type": "text",
+                                                                  },
+                                                                  "webhookUrl" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "The URL Sentry will send requests to on installation changes.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Webhook URL",
+                                                                    "name": "webhookUrl",
+                                                                    "placeholder": "e.g. https://example.com/sentry/webhook/",
+                                                                    "required": true,
+                                                                    "type": "text",
+                                                                  },
+                                                                  "redirectUrl" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "The URL Sentry will redirect users to after installation.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Redirect URL",
+                                                                    "name": "redirectUrl",
+                                                                    "placeholder": "e.g. https://example.com/sentry/setup/",
+                                                                    "type": "text",
+                                                                  },
+                                                                  "isAlertable" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": <span>
+                                                                      <span>
+                                                                        If enabled, this application will be an action under alert rules in Sentry. The notification destination is the Webhook URL specified above. More on actions 
+                                                                      </span>
+                                                                      <a
+                                                                        href="https://docs.sentry.io/product/notifications/#actions"
+                                                                      >
+                                                                        <span>
+                                                                          Here
+                                                                        </span>
+                                                                      </a>
+                                                                      <span>
+                                                                        .
+                                                                      </span>
+                                                                    </span>,
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Alert Rule Action",
+                                                                    "name": "isAlertable",
+                                                                    "resetOnError": true,
+                                                                    "type": "boolean",
+                                                                  },
+                                                                  "schema" => Object {
+                                                                    "access": undefined,
+                                                                    "autosize": true,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "getValue": [Function],
+                                                                    "help": "Schema for your UI components",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Schema",
+                                                                    "name": "schema",
+                                                                    "setValue": [Function],
+                                                                    "type": "textarea",
+                                                                  },
+                                                                  "overview" => Object {
+                                                                    "access": undefined,
+                                                                    "autosize": true,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "Description of your application and its functionality.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Overview",
+                                                                    "name": "overview",
+                                                                    "type": "textarea",
+                                                                  },
+                                                                  "Project--permission" => Object {
+                                                                    "alignRight": false,
+                                                                    "allowEmpty": false,
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "no-access",
+                                                                        "No Access",
+                                                                      ],
+                                                                      Array [
+                                                                        "read",
+                                                                        "Read",
+                                                                      ],
+                                                                      Array [
+                                                                        "write",
+                                                                        "Read & Write",
+                                                                      ],
+                                                                      Array [
+                                                                        "admin",
+                                                                        "Admin",
+                                                                      ],
+                                                                    ],
+                                                                    "className": undefined,
+                                                                    "defaultValue": "no-access",
+                                                                    "escapeMarkup": true,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "formatMessageValue": [Function],
+                                                                    "help": "Projects, Tags, Debug Files, and Feedback",
+                                                                    "hideErrorMessage": false,
+                                                                    "label": "Project",
+                                                                    "name": "Project--permission",
+                                                                    "onChange": [Function],
+                                                                    "placeholder": "--",
+                                                                    "small": false,
+                                                                    "value": "no-access",
+                                                                  },
+                                                                  "Team--permission" => Object {
+                                                                    "alignRight": false,
+                                                                    "allowEmpty": false,
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "no-access",
+                                                                        "No Access",
+                                                                      ],
+                                                                      Array [
+                                                                        "read",
+                                                                        "Read",
+                                                                      ],
+                                                                      Array [
+                                                                        "write",
+                                                                        "Read & Write",
+                                                                      ],
+                                                                      Array [
+                                                                        "admin",
+                                                                        "Admin",
+                                                                      ],
+                                                                    ],
+                                                                    "className": undefined,
+                                                                    "defaultValue": "no-access",
+                                                                    "escapeMarkup": true,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "formatMessageValue": [Function],
+                                                                    "help": "Teams of members",
+                                                                    "hideErrorMessage": false,
+                                                                    "label": "Team",
+                                                                    "name": "Team--permission",
+                                                                    "onChange": [Function],
+                                                                    "placeholder": "--",
+                                                                    "small": false,
+                                                                    "value": "no-access",
+                                                                  },
+                                                                  "Release--permission" => Object {
+                                                                    "alignRight": false,
+                                                                    "allowEmpty": false,
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "no-access",
+                                                                        "No Access",
+                                                                      ],
+                                                                      Array [
+                                                                        "admin",
+                                                                        "Admin",
+                                                                      ],
+                                                                    ],
+                                                                    "className": undefined,
+                                                                    "defaultValue": "no-access",
+                                                                    "escapeMarkup": true,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "formatMessageValue": [Function],
+                                                                    "help": "Releases, Commits, and related Files",
+                                                                    "hideErrorMessage": false,
+                                                                    "label": "Release",
+                                                                    "name": "Release--permission",
+                                                                    "onChange": [Function],
+                                                                    "placeholder": "--",
+                                                                    "small": false,
+                                                                    "value": "no-access",
+                                                                  },
+                                                                  "Event--permission" => Object {
+                                                                    "alignRight": false,
+                                                                    "allowEmpty": false,
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "no-access",
+                                                                        "No Access",
+                                                                      ],
+                                                                      Array [
+                                                                        "read",
+                                                                        "Read",
+                                                                      ],
+                                                                      Array [
+                                                                        "write",
+                                                                        "Read & Write",
+                                                                      ],
+                                                                      Array [
+                                                                        "admin",
+                                                                        "Admin",
+                                                                      ],
+                                                                    ],
+                                                                    "className": undefined,
+                                                                    "defaultValue": "no-access",
+                                                                    "escapeMarkup": true,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "formatMessageValue": [Function],
+                                                                    "help": "Issues, Events, and workflow statuses",
+                                                                    "hideErrorMessage": false,
+                                                                    "label": "Issue & Event",
+                                                                    "name": "Event--permission",
+                                                                    "onChange": [Function],
+                                                                    "placeholder": "--",
+                                                                    "small": false,
+                                                                    "value": "no-access",
+                                                                  },
+                                                                  "Organization--permission" => Object {
+                                                                    "alignRight": false,
+                                                                    "allowEmpty": false,
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "no-access",
+                                                                        "No Access",
+                                                                      ],
+                                                                      Array [
+                                                                        "read",
+                                                                        "Read",
+                                                                      ],
+                                                                      Array [
+                                                                        "write",
+                                                                        "Read & Write",
+                                                                      ],
+                                                                      Array [
+                                                                        "admin",
+                                                                        "Admin",
+                                                                      ],
+                                                                    ],
+                                                                    "className": undefined,
+                                                                    "defaultValue": "no-access",
+                                                                    "escapeMarkup": true,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "formatMessageValue": [Function],
+                                                                    "help": "Manage Organizations, resolve IDs, retrieve Repositories and Commits",
+                                                                    "hideErrorMessage": false,
+                                                                    "label": "Organization",
+                                                                    "name": "Organization--permission",
+                                                                    "onChange": [Function],
+                                                                    "placeholder": "--",
+                                                                    "small": false,
+                                                                    "value": "no-access",
+                                                                  },
+                                                                  "Member--permission" => Object {
+                                                                    "alignRight": false,
+                                                                    "allowEmpty": false,
+                                                                    "children": [Function],
+                                                                    "choices": Array [
+                                                                      Array [
+                                                                        "no-access",
+                                                                        "No Access",
+                                                                      ],
+                                                                      Array [
+                                                                        "read",
+                                                                        "Read",
+                                                                      ],
+                                                                      Array [
+                                                                        "write",
+                                                                        "Read & Write",
+                                                                      ],
+                                                                      Array [
+                                                                        "admin",
+                                                                        "Admin",
+                                                                      ],
+                                                                    ],
+                                                                    "className": undefined,
+                                                                    "defaultValue": "no-access",
+                                                                    "escapeMarkup": true,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "formatMessageValue": [Function],
+                                                                    "help": "Manage Members within Teams",
+                                                                    "hideErrorMessage": false,
+                                                                    "label": "Member",
+                                                                    "name": "Member--permission",
+                                                                    "onChange": [Function],
+                                                                    "placeholder": "--",
+                                                                    "small": false,
+                                                                    "value": "no-access",
+                                                                  },
+                                                                },
+                                                                "fieldState": Object {
+                                                                  "events": Object {
+                                                                    "Saving": false,
+                                                                    "showSave": true,
+                                                                  },
+                                                                },
+                                                                "fields": Object {
+                                                                  "Event--permission": "no-access",
+                                                                  "Member--permission": "no-access",
+                                                                  "Organization--permission": "no-access",
+                                                                  "Project--permission": "no-access",
+                                                                  "Release--permission": "no-access",
+                                                                  "Team--permission": "no-access",
+                                                                  "events": Array [],
+                                                                  "isAlertable": false,
+                                                                  "organization": "org-slug",
+                                                                  "schema": "",
+                                                                },
+                                                                "formState": "Ready",
+                                                                "initialData": Object {
+                                                                  "Event--permission": "no-access",
+                                                                  "Member--permission": "no-access",
+                                                                  "Organization--permission": "no-access",
+                                                                  "Project--permission": "no-access",
+                                                                  "Release--permission": "no-access",
+                                                                  "Team--permission": "no-access",
+                                                                  "isAlertable": false,
+                                                                  "organization": "org-slug",
+                                                                  "schema": "",
+                                                                },
+                                                                "options": Object {
+                                                                  "allowUndo": true,
+                                                                  "apiEndpoint": "/sentry-apps/",
+                                                                  "apiMethod": "POST",
+                                                                  "onFieldChange": undefined,
+                                                                  "onSubmitError": [Function],
+                                                                  "onSubmitSuccess": [Function],
+                                                                  "resetOnError": undefined,
+                                                                  "saveOnBlur": false,
+                                                                },
+                                                                "snapshots": Array [
+                                                                  Map {
+                                                                    "organization" => "org-slug",
+                                                                    "isAlertable" => false,
+                                                                    "schema" => Object {},
+                                                                  },
+                                                                ],
+                                                              }
+                                                            }
+                                                            name="author"
+                                                          />
+                                                        }
+                                                        disabled={false}
+                                                        errorState={
+                                                          <Observer>
+                                                            [Function]
+                                                          </Observer>
+                                                        }
+                                                        flexibleControlStateSize={false}
+                                                        inline={true}
+                                                      >
+                                                        <FieldControlErrorWrapper
+                                                          inline={true}
+                                                        >
+                                                          <Component
+                                                            className="css-1xbxyck-FieldControlErrorWrapper e78b1iv0"
+                                                            inline={true}
+                                                          >
+                                                            <Box
+                                                              className="css-1xbxyck-FieldControlErrorWrapper e78b1iv0"
+                                                            >
+                                                              <Base
+                                                                className="e78b1iv0 css-1kkovz0-FieldControlErrorWrapper"
+                                                              >
+                                                                <div
+                                                                  className="e78b1iv0 css-1kkovz0-FieldControlErrorWrapper"
+                                                                  is={null}
+                                                                >
+                                                                  <FieldControlWrapper>
+                                                                    <Component
+                                                                      className="css-1ke1xob-FieldControlWrapper e78b1iv2"
+                                                                    >
+                                                                      <Flex
+                                                                        className="css-1ke1xob-FieldControlWrapper e78b1iv2"
+                                                                      >
+                                                                        <Base
+                                                                          className="e78b1iv2 css-w4o1g8-FieldControlWrapper"
+                                                                        >
+                                                                          <div
+                                                                            className="e78b1iv2 css-w4o1g8-FieldControlWrapper"
+                                                                            is={null}
+                                                                          >
+                                                                            <FieldControlStyled
+                                                                              alignRight={false}
+                                                                            >
+                                                                              <Component
+                                                                                alignRight={false}
+                                                                                className="css-1pkvhmy-FieldControlStyled e78b1iv1"
+                                                                              >
+                                                                                <Box
+                                                                                  className="css-1pkvhmy-FieldControlStyled e78b1iv1"
+                                                                                >
+                                                                                  <Base
+                                                                                    className="e78b1iv1 css-wkkbba-FieldControlStyled"
+                                                                                  >
+                                                                                    <div
+                                                                                      className="e78b1iv1 css-wkkbba-FieldControlStyled"
+                                                                                      is={null}
+                                                                                    >
+                                                                                      <Observer>
+                                                                                        <Input
+                                                                                          disabled={false}
+                                                                                          error={false}
+                                                                                          field={[Function]}
+                                                                                          help="The company or person who built and maintains this Integration."
+                                                                                          highlighted={false}
+                                                                                          id="author"
+                                                                                          initialData={
+                                                                                            Object {
+                                                                                              "Event--permission": "no-access",
+                                                                                              "Member--permission": "no-access",
+                                                                                              "Organization--permission": "no-access",
+                                                                                              "Project--permission": "no-access",
+                                                                                              "Release--permission": "no-access",
+                                                                                              "Team--permission": "no-access",
+                                                                                              "isAlertable": false,
+                                                                                              "organization": "org-slug",
+                                                                                              "schema": "",
+                                                                                            }
+                                                                                          }
+                                                                                          innerRef={[Function]}
+                                                                                          label="Author"
+                                                                                          name="author"
+                                                                                          onBlur={[Function]}
+                                                                                          onChange={[Function]}
+                                                                                          onKeyDown={[Function]}
+                                                                                          placeholder="Acme Software"
+                                                                                          required={true}
+                                                                                          type="text"
+                                                                                          value=""
+                                                                                        >
+                                                                                          <input
+                                                                                            className="css-pzg7em-Input-inputStyles e1xej46s0"
+                                                                                            disabled={false}
+                                                                                            id="author"
+                                                                                            label="Author"
+                                                                                            name="author"
+                                                                                            onBlur={[Function]}
+                                                                                            onChange={[Function]}
+                                                                                            onKeyDown={[Function]}
+                                                                                            placeholder="Acme Software"
+                                                                                            required={true}
+                                                                                            type="text"
+                                                                                            value=""
+                                                                                          />
+                                                                                        </Input>
+                                                                                      </Observer>
+                                                                                    </div>
+                                                                                  </Base>
+                                                                                </Box>
+                                                                              </Component>
+                                                                            </FieldControlStyled>
+                                                                            <FieldControlState
+                                                                              flexibleControlStateSize={false}
+                                                                            >
+                                                                              <Component
+                                                                                className="css-1j6hng-FieldControlState e1rziqw00"
+                                                                                flexibleControlStateSize={false}
+                                                                              >
+                                                                                <Flex
+                                                                                  className="css-1j6hng-FieldControlState e1rziqw00"
+                                                                                >
+                                                                                  <Base
+                                                                                    className="e1rziqw00 css-1fqbh7r-FieldControlState"
+                                                                                  >
+                                                                                    <div
+                                                                                      className="e1rziqw00 css-1fqbh7r-FieldControlState"
+                                                                                      is={null}
+                                                                                    >
+                                                                                      <ControlState
+                                                                                        model={
+                                                                                          SentryAppFormModel {
+                                                                                            "api": Client {},
+                                                                                            "errors": Object {},
+                                                                                            "fieldDescriptor": Map {
+                                                                                              "name" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "Human readable name of your application.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Name",
+                                                                                                "name": "name",
+                                                                                                "placeholder": "e.g. My Application",
+                                                                                                "required": true,
+                                                                                                "type": "text",
+                                                                                              },
+                                                                                              "author" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "The company or person who built and maintains this Integration.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Author",
+                                                                                                "name": "author",
+                                                                                                "placeholder": "Acme Software",
+                                                                                                "required": true,
+                                                                                                "type": "text",
+                                                                                              },
+                                                                                              "webhookUrl" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "The URL Sentry will send requests to on installation changes.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Webhook URL",
+                                                                                                "name": "webhookUrl",
+                                                                                                "placeholder": "e.g. https://example.com/sentry/webhook/",
+                                                                                                "required": true,
+                                                                                                "type": "text",
+                                                                                              },
+                                                                                              "redirectUrl" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "The URL Sentry will redirect users to after installation.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Redirect URL",
+                                                                                                "name": "redirectUrl",
+                                                                                                "placeholder": "e.g. https://example.com/sentry/setup/",
+                                                                                                "type": "text",
+                                                                                              },
+                                                                                              "isAlertable" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": <span>
+                                                                                                  <span>
+                                                                                                    If enabled, this application will be an action under alert rules in Sentry. The notification destination is the Webhook URL specified above. More on actions 
+                                                                                                  </span>
+                                                                                                  <a
+                                                                                                    href="https://docs.sentry.io/product/notifications/#actions"
+                                                                                                  >
+                                                                                                    <span>
+                                                                                                      Here
+                                                                                                    </span>
+                                                                                                  </a>
+                                                                                                  <span>
+                                                                                                    .
+                                                                                                  </span>
+                                                                                                </span>,
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Alert Rule Action",
+                                                                                                "name": "isAlertable",
+                                                                                                "resetOnError": true,
+                                                                                                "type": "boolean",
+                                                                                              },
+                                                                                              "schema" => Object {
+                                                                                                "access": undefined,
+                                                                                                "autosize": true,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "getValue": [Function],
+                                                                                                "help": "Schema for your UI components",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Schema",
+                                                                                                "name": "schema",
+                                                                                                "setValue": [Function],
+                                                                                                "type": "textarea",
+                                                                                              },
+                                                                                              "overview" => Object {
+                                                                                                "access": undefined,
+                                                                                                "autosize": true,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "Description of your application and its functionality.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Overview",
+                                                                                                "name": "overview",
+                                                                                                "type": "textarea",
+                                                                                              },
+                                                                                              "Project--permission" => Object {
+                                                                                                "alignRight": false,
+                                                                                                "allowEmpty": false,
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "no-access",
+                                                                                                    "No Access",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "read",
+                                                                                                    "Read",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "write",
+                                                                                                    "Read & Write",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "admin",
+                                                                                                    "Admin",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "className": undefined,
+                                                                                                "defaultValue": "no-access",
+                                                                                                "escapeMarkup": true,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "formatMessageValue": [Function],
+                                                                                                "help": "Projects, Tags, Debug Files, and Feedback",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "label": "Project",
+                                                                                                "name": "Project--permission",
+                                                                                                "onChange": [Function],
+                                                                                                "placeholder": "--",
+                                                                                                "small": false,
+                                                                                                "value": "no-access",
+                                                                                              },
+                                                                                              "Team--permission" => Object {
+                                                                                                "alignRight": false,
+                                                                                                "allowEmpty": false,
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "no-access",
+                                                                                                    "No Access",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "read",
+                                                                                                    "Read",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "write",
+                                                                                                    "Read & Write",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "admin",
+                                                                                                    "Admin",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "className": undefined,
+                                                                                                "defaultValue": "no-access",
+                                                                                                "escapeMarkup": true,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "formatMessageValue": [Function],
+                                                                                                "help": "Teams of members",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "label": "Team",
+                                                                                                "name": "Team--permission",
+                                                                                                "onChange": [Function],
+                                                                                                "placeholder": "--",
+                                                                                                "small": false,
+                                                                                                "value": "no-access",
+                                                                                              },
+                                                                                              "Release--permission" => Object {
+                                                                                                "alignRight": false,
+                                                                                                "allowEmpty": false,
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "no-access",
+                                                                                                    "No Access",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "admin",
+                                                                                                    "Admin",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "className": undefined,
+                                                                                                "defaultValue": "no-access",
+                                                                                                "escapeMarkup": true,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "formatMessageValue": [Function],
+                                                                                                "help": "Releases, Commits, and related Files",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "label": "Release",
+                                                                                                "name": "Release--permission",
+                                                                                                "onChange": [Function],
+                                                                                                "placeholder": "--",
+                                                                                                "small": false,
+                                                                                                "value": "no-access",
+                                                                                              },
+                                                                                              "Event--permission" => Object {
+                                                                                                "alignRight": false,
+                                                                                                "allowEmpty": false,
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "no-access",
+                                                                                                    "No Access",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "read",
+                                                                                                    "Read",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "write",
+                                                                                                    "Read & Write",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "admin",
+                                                                                                    "Admin",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "className": undefined,
+                                                                                                "defaultValue": "no-access",
+                                                                                                "escapeMarkup": true,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "formatMessageValue": [Function],
+                                                                                                "help": "Issues, Events, and workflow statuses",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "label": "Issue & Event",
+                                                                                                "name": "Event--permission",
+                                                                                                "onChange": [Function],
+                                                                                                "placeholder": "--",
+                                                                                                "small": false,
+                                                                                                "value": "no-access",
+                                                                                              },
+                                                                                              "Organization--permission" => Object {
+                                                                                                "alignRight": false,
+                                                                                                "allowEmpty": false,
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "no-access",
+                                                                                                    "No Access",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "read",
+                                                                                                    "Read",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "write",
+                                                                                                    "Read & Write",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "admin",
+                                                                                                    "Admin",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "className": undefined,
+                                                                                                "defaultValue": "no-access",
+                                                                                                "escapeMarkup": true,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "formatMessageValue": [Function],
+                                                                                                "help": "Manage Organizations, resolve IDs, retrieve Repositories and Commits",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "label": "Organization",
+                                                                                                "name": "Organization--permission",
+                                                                                                "onChange": [Function],
+                                                                                                "placeholder": "--",
+                                                                                                "small": false,
+                                                                                                "value": "no-access",
+                                                                                              },
+                                                                                              "Member--permission" => Object {
+                                                                                                "alignRight": false,
+                                                                                                "allowEmpty": false,
+                                                                                                "children": [Function],
+                                                                                                "choices": Array [
+                                                                                                  Array [
+                                                                                                    "no-access",
+                                                                                                    "No Access",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "read",
+                                                                                                    "Read",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "write",
+                                                                                                    "Read & Write",
+                                                                                                  ],
+                                                                                                  Array [
+                                                                                                    "admin",
+                                                                                                    "Admin",
+                                                                                                  ],
+                                                                                                ],
+                                                                                                "className": undefined,
+                                                                                                "defaultValue": "no-access",
+                                                                                                "escapeMarkup": true,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "formatMessageValue": [Function],
+                                                                                                "help": "Manage Members within Teams",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "label": "Member",
+                                                                                                "name": "Member--permission",
+                                                                                                "onChange": [Function],
+                                                                                                "placeholder": "--",
+                                                                                                "small": false,
+                                                                                                "value": "no-access",
+                                                                                              },
+                                                                                            },
+                                                                                            "fieldState": Object {
+                                                                                              "events": Object {
+                                                                                                "Saving": false,
+                                                                                                "showSave": true,
+                                                                                              },
+                                                                                            },
+                                                                                            "fields": Object {
+                                                                                              "Event--permission": "no-access",
+                                                                                              "Member--permission": "no-access",
+                                                                                              "Organization--permission": "no-access",
+                                                                                              "Project--permission": "no-access",
+                                                                                              "Release--permission": "no-access",
+                                                                                              "Team--permission": "no-access",
+                                                                                              "events": Array [],
+                                                                                              "isAlertable": false,
+                                                                                              "organization": "org-slug",
+                                                                                              "schema": "",
+                                                                                            },
+                                                                                            "formState": "Ready",
+                                                                                            "initialData": Object {
+                                                                                              "Event--permission": "no-access",
+                                                                                              "Member--permission": "no-access",
+                                                                                              "Organization--permission": "no-access",
+                                                                                              "Project--permission": "no-access",
+                                                                                              "Release--permission": "no-access",
+                                                                                              "Team--permission": "no-access",
+                                                                                              "isAlertable": false,
+                                                                                              "organization": "org-slug",
+                                                                                              "schema": "",
+                                                                                            },
+                                                                                            "options": Object {
+                                                                                              "allowUndo": true,
+                                                                                              "apiEndpoint": "/sentry-apps/",
+                                                                                              "apiMethod": "POST",
+                                                                                              "onFieldChange": undefined,
+                                                                                              "onSubmitError": [Function],
+                                                                                              "onSubmitSuccess": [Function],
+                                                                                              "resetOnError": undefined,
+                                                                                              "saveOnBlur": false,
+                                                                                            },
+                                                                                            "snapshots": Array [
+                                                                                              Map {
+                                                                                                "organization" => "org-slug",
+                                                                                                "isAlertable" => false,
+                                                                                                "schema" => Object {},
+                                                                                              },
+                                                                                            ],
+                                                                                          }
+                                                                                        }
+                                                                                        name="author"
+                                                                                      >
+                                                                                        <Observer />
+                                                                                        <Observer />
+                                                                                      </ControlState>
+                                                                                    </div>
+                                                                                  </Base>
+                                                                                </Flex>
+                                                                              </Component>
+                                                                            </FieldControlState>
+                                                                          </div>
+                                                                        </Base>
+                                                                      </Flex>
+                                                                    </Component>
+                                                                  </FieldControlWrapper>
+                                                                  <Observer />
+                                                                </div>
+                                                              </Base>
+                                                            </Box>
+                                                          </Component>
+                                                        </FieldControlErrorWrapper>
+                                                      </FieldControl>
+                                                    </div>
+                                                  </Base>
+                                                </Flex>
+                                              </Component>
+                                            </FieldWrapper>
+                                          </Field>
+                                        </FormField>
+                                      </InputField>
+                                    </TextField>
+                                  </FieldFromConfig>
+                                  <FieldFromConfig
+                                    field={
+                                      Object {
                                         "help": "The URL Sentry will send requests to on installation changes.",
                                         "label": "Webhook URL",
                                         "name": "webhookUrl",
@@ -22565,6 +25561,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                     "label": "Name",
                                                                     "name": "name",
                                                                     "placeholder": "e.g. My Application",
+                                                                    "required": true,
+                                                                    "type": "text",
+                                                                  },
+                                                                  "author" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "The company or person who built and maintains this Integration.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Author",
+                                                                    "name": "author",
+                                                                    "placeholder": "Acme Software",
                                                                     "required": true,
                                                                     "type": "text",
                                                                   },
@@ -23079,6 +26092,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                                 "label": "Name",
                                                                                                 "name": "name",
                                                                                                 "placeholder": "e.g. My Application",
+                                                                                                "required": true,
+                                                                                                "type": "text",
+                                                                                              },
+                                                                                              "author" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "The company or person who built and maintains this Integration.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Author",
+                                                                                                "name": "author",
+                                                                                                "placeholder": "Acme Software",
                                                                                                 "required": true,
                                                                                                 "type": "text",
                                                                                               },
@@ -23609,6 +26639,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                     "required": true,
                                                                     "type": "text",
                                                                   },
+                                                                  "author" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "The company or person who built and maintains this Integration.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Author",
+                                                                    "name": "author",
+                                                                    "placeholder": "Acme Software",
+                                                                    "required": true,
+                                                                    "type": "text",
+                                                                  },
                                                                   "webhookUrl" => Object {
                                                                     "access": undefined,
                                                                     "children": [Function],
@@ -24118,6 +27165,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                                 "label": "Name",
                                                                                                 "name": "name",
                                                                                                 "placeholder": "e.g. My Application",
+                                                                                                "required": true,
+                                                                                                "type": "text",
+                                                                                              },
+                                                                                              "author" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "The company or person who built and maintains this Integration.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Author",
+                                                                                                "name": "author",
+                                                                                                "placeholder": "Acme Software",
                                                                                                 "required": true,
                                                                                                 "type": "text",
                                                                                               },
@@ -24748,6 +27812,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                     "required": true,
                                                                     "type": "text",
                                                                   },
+                                                                  "author" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "The company or person who built and maintains this Integration.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Author",
+                                                                    "name": "author",
+                                                                    "placeholder": "Acme Software",
+                                                                    "required": true,
+                                                                    "type": "text",
+                                                                  },
                                                                   "webhookUrl" => Object {
                                                                     "access": undefined,
                                                                     "children": [Function],
@@ -25294,6 +28375,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                                 "required": true,
                                                                                                 "type": "text",
                                                                                               },
+                                                                                              "author" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "The company or person who built and maintains this Integration.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Author",
+                                                                                                "name": "author",
+                                                                                                "placeholder": "Acme Software",
+                                                                                                "required": true,
+                                                                                                "type": "text",
+                                                                                              },
                                                                                               "webhookUrl" => Object {
                                                                                                 "access": undefined,
                                                                                                 "children": [Function],
@@ -25828,6 +28926,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                     "label": "Name",
                                                                     "name": "name",
                                                                     "placeholder": "e.g. My Application",
+                                                                    "required": true,
+                                                                    "type": "text",
+                                                                  },
+                                                                  "author" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "The company or person who built and maintains this Integration.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Author",
+                                                                    "name": "author",
+                                                                    "placeholder": "Acme Software",
                                                                     "required": true,
                                                                     "type": "text",
                                                                   },
@@ -26372,6 +29487,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                                 "required": true,
                                                                                                 "type": "text",
                                                                                               },
+                                                                                              "author" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "The company or person who built and maintains this Integration.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Author",
+                                                                                                "name": "author",
+                                                                                                "placeholder": "Acme Software",
+                                                                                                "required": true,
+                                                                                                "type": "text",
+                                                                                              },
                                                                                               "webhookUrl" => Object {
                                                                                                 "access": undefined,
                                                                                                 "children": [Function],
@@ -26896,6 +30028,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                     "label": "Name",
                                                                     "name": "name",
                                                                     "placeholder": "e.g. My Application",
+                                                                    "required": true,
+                                                                    "type": "text",
+                                                                  },
+                                                                  "author" => Object {
+                                                                    "access": undefined,
+                                                                    "children": [Function],
+                                                                    "className": undefined,
+                                                                    "disabled": undefined,
+                                                                    "features": undefined,
+                                                                    "field": [Function],
+                                                                    "flexibleControlStateSize": false,
+                                                                    "help": "The company or person who built and maintains this Integration.",
+                                                                    "hideErrorMessage": false,
+                                                                    "highlighted": false,
+                                                                    "label": "Author",
+                                                                    "name": "author",
+                                                                    "placeholder": "Acme Software",
                                                                     "required": true,
                                                                     "type": "text",
                                                                   },
@@ -27435,6 +30584,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                                 "label": "Name",
                                                                                                 "name": "name",
                                                                                                 "placeholder": "e.g. My Application",
+                                                                                                "required": true,
+                                                                                                "type": "text",
+                                                                                              },
+                                                                                              "author" => Object {
+                                                                                                "access": undefined,
+                                                                                                "children": [Function],
+                                                                                                "className": undefined,
+                                                                                                "disabled": undefined,
+                                                                                                "features": undefined,
+                                                                                                "field": [Function],
+                                                                                                "flexibleControlStateSize": false,
+                                                                                                "help": "The company or person who built and maintains this Integration.",
+                                                                                                "hideErrorMessage": false,
+                                                                                                "highlighted": false,
+                                                                                                "label": "Author",
+                                                                                                "name": "author",
+                                                                                                "placeholder": "Acme Software",
                                                                                                 "required": true,
                                                                                                 "type": "text",
                                                                                               },
@@ -28119,6 +31285,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                             "label": "Name",
                                                             "name": "name",
                                                             "placeholder": "e.g. My Application",
+                                                            "required": true,
+                                                            "type": "text",
+                                                          },
+                                                          "author" => Object {
+                                                            "access": undefined,
+                                                            "children": [Function],
+                                                            "className": undefined,
+                                                            "disabled": undefined,
+                                                            "features": undefined,
+                                                            "field": [Function],
+                                                            "flexibleControlStateSize": false,
+                                                            "help": "The company or person who built and maintains this Integration.",
+                                                            "hideErrorMessage": false,
+                                                            "highlighted": false,
+                                                            "label": "Author",
+                                                            "name": "author",
+                                                            "placeholder": "Acme Software",
                                                             "required": true,
                                                             "type": "text",
                                                           },
@@ -29057,6 +32240,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                         "required": true,
                                                                                         "type": "text",
                                                                                       },
+                                                                                      "author" => Object {
+                                                                                        "access": undefined,
+                                                                                        "children": [Function],
+                                                                                        "className": undefined,
+                                                                                        "disabled": undefined,
+                                                                                        "features": undefined,
+                                                                                        "field": [Function],
+                                                                                        "flexibleControlStateSize": false,
+                                                                                        "help": "The company or person who built and maintains this Integration.",
+                                                                                        "hideErrorMessage": false,
+                                                                                        "highlighted": false,
+                                                                                        "label": "Author",
+                                                                                        "name": "author",
+                                                                                        "placeholder": "Acme Software",
+                                                                                        "required": true,
+                                                                                        "type": "text",
+                                                                                      },
                                                                                       "webhookUrl" => Object {
                                                                                         "access": undefined,
                                                                                         "children": [Function],
@@ -29671,6 +32871,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                             "label": "Name",
                                                             "name": "name",
                                                             "placeholder": "e.g. My Application",
+                                                            "required": true,
+                                                            "type": "text",
+                                                          },
+                                                          "author" => Object {
+                                                            "access": undefined,
+                                                            "children": [Function],
+                                                            "className": undefined,
+                                                            "disabled": undefined,
+                                                            "features": undefined,
+                                                            "field": [Function],
+                                                            "flexibleControlStateSize": false,
+                                                            "help": "The company or person who built and maintains this Integration.",
+                                                            "hideErrorMessage": false,
+                                                            "highlighted": false,
+                                                            "label": "Author",
+                                                            "name": "author",
+                                                            "placeholder": "Acme Software",
                                                             "required": true,
                                                             "type": "text",
                                                           },
@@ -30609,6 +33826,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                         "required": true,
                                                                                         "type": "text",
                                                                                       },
+                                                                                      "author" => Object {
+                                                                                        "access": undefined,
+                                                                                        "children": [Function],
+                                                                                        "className": undefined,
+                                                                                        "disabled": undefined,
+                                                                                        "features": undefined,
+                                                                                        "field": [Function],
+                                                                                        "flexibleControlStateSize": false,
+                                                                                        "help": "The company or person who built and maintains this Integration.",
+                                                                                        "hideErrorMessage": false,
+                                                                                        "highlighted": false,
+                                                                                        "label": "Author",
+                                                                                        "name": "author",
+                                                                                        "placeholder": "Acme Software",
+                                                                                        "required": true,
+                                                                                        "type": "text",
+                                                                                      },
                                                                                       "webhookUrl" => Object {
                                                                                         "access": undefined,
                                                                                         "children": [Function],
@@ -31191,6 +34425,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                             "label": "Name",
                                                             "name": "name",
                                                             "placeholder": "e.g. My Application",
+                                                            "required": true,
+                                                            "type": "text",
+                                                          },
+                                                          "author" => Object {
+                                                            "access": undefined,
+                                                            "children": [Function],
+                                                            "className": undefined,
+                                                            "disabled": undefined,
+                                                            "features": undefined,
+                                                            "field": [Function],
+                                                            "flexibleControlStateSize": false,
+                                                            "help": "The company or person who built and maintains this Integration.",
+                                                            "hideErrorMessage": false,
+                                                            "highlighted": false,
+                                                            "label": "Author",
+                                                            "name": "author",
+                                                            "placeholder": "Acme Software",
                                                             "required": true,
                                                             "type": "text",
                                                           },
@@ -32081,6 +35332,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                         "required": true,
                                                                                         "type": "text",
                                                                                       },
+                                                                                      "author" => Object {
+                                                                                        "access": undefined,
+                                                                                        "children": [Function],
+                                                                                        "className": undefined,
+                                                                                        "disabled": undefined,
+                                                                                        "features": undefined,
+                                                                                        "field": [Function],
+                                                                                        "flexibleControlStateSize": false,
+                                                                                        "help": "The company or person who built and maintains this Integration.",
+                                                                                        "hideErrorMessage": false,
+                                                                                        "highlighted": false,
+                                                                                        "label": "Author",
+                                                                                        "name": "author",
+                                                                                        "placeholder": "Acme Software",
+                                                                                        "required": true,
+                                                                                        "type": "text",
+                                                                                      },
                                                                                       "webhookUrl" => Object {
                                                                                         "access": undefined,
                                                                                         "children": [Function],
@@ -32695,6 +35963,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                             "label": "Name",
                                                             "name": "name",
                                                             "placeholder": "e.g. My Application",
+                                                            "required": true,
+                                                            "type": "text",
+                                                          },
+                                                          "author" => Object {
+                                                            "access": undefined,
+                                                            "children": [Function],
+                                                            "className": undefined,
+                                                            "disabled": undefined,
+                                                            "features": undefined,
+                                                            "field": [Function],
+                                                            "flexibleControlStateSize": false,
+                                                            "help": "The company or person who built and maintains this Integration.",
+                                                            "hideErrorMessage": false,
+                                                            "highlighted": false,
+                                                            "label": "Author",
+                                                            "name": "author",
+                                                            "placeholder": "Acme Software",
                                                             "required": true,
                                                             "type": "text",
                                                           },
@@ -33633,6 +36918,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                         "required": true,
                                                                                         "type": "text",
                                                                                       },
+                                                                                      "author" => Object {
+                                                                                        "access": undefined,
+                                                                                        "children": [Function],
+                                                                                        "className": undefined,
+                                                                                        "disabled": undefined,
+                                                                                        "features": undefined,
+                                                                                        "field": [Function],
+                                                                                        "flexibleControlStateSize": false,
+                                                                                        "help": "The company or person who built and maintains this Integration.",
+                                                                                        "hideErrorMessage": false,
+                                                                                        "highlighted": false,
+                                                                                        "label": "Author",
+                                                                                        "name": "author",
+                                                                                        "placeholder": "Acme Software",
+                                                                                        "required": true,
+                                                                                        "type": "text",
+                                                                                      },
                                                                                       "webhookUrl" => Object {
                                                                                         "access": undefined,
                                                                                         "children": [Function],
@@ -34247,6 +37549,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                             "label": "Name",
                                                             "name": "name",
                                                             "placeholder": "e.g. My Application",
+                                                            "required": true,
+                                                            "type": "text",
+                                                          },
+                                                          "author" => Object {
+                                                            "access": undefined,
+                                                            "children": [Function],
+                                                            "className": undefined,
+                                                            "disabled": undefined,
+                                                            "features": undefined,
+                                                            "field": [Function],
+                                                            "flexibleControlStateSize": false,
+                                                            "help": "The company or person who built and maintains this Integration.",
+                                                            "hideErrorMessage": false,
+                                                            "highlighted": false,
+                                                            "label": "Author",
+                                                            "name": "author",
+                                                            "placeholder": "Acme Software",
                                                             "required": true,
                                                             "type": "text",
                                                           },
@@ -35185,6 +38504,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                         "required": true,
                                                                                         "type": "text",
                                                                                       },
+                                                                                      "author" => Object {
+                                                                                        "access": undefined,
+                                                                                        "children": [Function],
+                                                                                        "className": undefined,
+                                                                                        "disabled": undefined,
+                                                                                        "features": undefined,
+                                                                                        "field": [Function],
+                                                                                        "flexibleControlStateSize": false,
+                                                                                        "help": "The company or person who built and maintains this Integration.",
+                                                                                        "hideErrorMessage": false,
+                                                                                        "highlighted": false,
+                                                                                        "label": "Author",
+                                                                                        "name": "author",
+                                                                                        "placeholder": "Acme Software",
+                                                                                        "required": true,
+                                                                                        "type": "text",
+                                                                                      },
                                                                                       "webhookUrl" => Object {
                                                                                         "access": undefined,
                                                                                         "children": [Function],
@@ -35799,6 +39135,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                             "label": "Name",
                                                             "name": "name",
                                                             "placeholder": "e.g. My Application",
+                                                            "required": true,
+                                                            "type": "text",
+                                                          },
+                                                          "author" => Object {
+                                                            "access": undefined,
+                                                            "children": [Function],
+                                                            "className": undefined,
+                                                            "disabled": undefined,
+                                                            "features": undefined,
+                                                            "field": [Function],
+                                                            "flexibleControlStateSize": false,
+                                                            "help": "The company or person who built and maintains this Integration.",
+                                                            "hideErrorMessage": false,
+                                                            "highlighted": false,
+                                                            "label": "Author",
+                                                            "name": "author",
+                                                            "placeholder": "Acme Software",
                                                             "required": true,
                                                             "type": "text",
                                                           },
@@ -36734,6 +40087,23 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                                                                                         "label": "Name",
                                                                                         "name": "name",
                                                                                         "placeholder": "e.g. My Application",
+                                                                                        "required": true,
+                                                                                        "type": "text",
+                                                                                      },
+                                                                                      "author" => Object {
+                                                                                        "access": undefined,
+                                                                                        "children": [Function],
+                                                                                        "className": undefined,
+                                                                                        "disabled": undefined,
+                                                                                        "features": undefined,
+                                                                                        "field": [Function],
+                                                                                        "flexibleControlStateSize": false,
+                                                                                        "help": "The company or person who built and maintains this Integration.",
+                                                                                        "hideErrorMessage": false,
+                                                                                        "highlighted": false,
+                                                                                        "label": "Author",
+                                                                                        "name": "author",
+                                                                                        "placeholder": "Acme Software",
                                                                                         "required": true,
                                                                                         "type": "text",
                                                                                       },

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
@@ -53,6 +53,9 @@ describe('Sentry Application Details', function() {
           .find('Input[name="name"]')
           .simulate('change', {target: {value: 'Test App'}});
         wrapper
+          .find('Input[name="author"]')
+          .simulate('change', {target: {value: 'Sentry'}});
+        wrapper
           .find('Input[name="webhookUrl"]')
           .simulate('change', {target: {value: 'https://webhook.com'}});
         wrapper
@@ -69,6 +72,7 @@ describe('Sentry Application Details', function() {
 
         const data = {
           name: 'Test App',
+          author: 'Sentry',
           organization: org.slug,
           redirectUrl: 'https://webhook.com/setup',
           webhookUrl: 'https://webhook.com',

--- a/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/sentryAppInstallations.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/sentryAppInstallations.spec.jsx.snap
@@ -6,6 +6,7 @@ exports[`Sentry App Installations when Apps exist displays all Apps owned by the
   applications={
     Array [
       Object {
+        "author": "Sentry",
         "clientId": "client-id",
         "clientSecret": "client-secret",
         "events": Array [],
@@ -30,6 +31,7 @@ exports[`Sentry App Installations when Apps exist displays all Apps owned by the
   <SentryApplicationRow
     app={
       Object {
+        "author": "Sentry",
         "clientId": "client-id",
         "clientSecret": "client-secret",
         "events": Array [],
@@ -72,6 +74,7 @@ exports[`Sentry App Installations when Apps exist displays all Apps owned by the
                 <SentryAppAvatar
                   sentryApp={
                     Object {
+                      "author": "Sentry",
                       "clientId": "client-id",
                       "clientSecret": "client-secret",
                       "events": Array [],

--- a/tests/sentry/api/endpoints/test_organization_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_apps.py
@@ -42,6 +42,7 @@ class GetOrganizationSentryAppsTest(OrganizationSentryAppsTest):
 
         assert_response_json(response, [{
             'name': self.unpublished_app.name,
+            'author': self.unpublished_app.author,
             'slug': self.unpublished_app.slug,
             'scopes': [],
             'events': [],

--- a/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta
 from django.core.urlresolvers import reverse
 from django.utils import timezone
 
-from sentry.mediators import sentry_apps
 from sentry.models import ApiApplication, ApiToken
 from sentry.testutils import APITestCase
 
@@ -17,14 +16,14 @@ class TestSentryAppAuthorizations(APITestCase):
         self.user = self.create_user()
         self.org = self.create_organization()
 
-        self.sentry_app = sentry_apps.Creator.run(
+        self.sentry_app = self.create_sentry_app(
             name='nulldb',
             organization=self.create_organization(),
             scopes=('org:read', ),
             webhook_url='http://example.com',
         )
 
-        self.other_sentry_app = sentry_apps.Creator.run(
+        self.other_sentry_app = self.create_sentry_app(
             name='slowdb',
             organization=self.create_organization(),
             scopes=(),

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -101,7 +101,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         response = self.client.put(
             self.url,
             data={
-                'name': 'NewName',
+                'name': self.published_app.name,
                 'webhookUrl': 'https://newurl.com',
                 'redirectUrl': 'https://newredirecturl.com',
                 'isAlertable': True,
@@ -109,7 +109,8 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             format='json',
         )
         assert json.loads(response.content) == {
-            'name': 'NewName',
+            'name': self.published_app.name,
+            'author': self.published_app.author,
             'slug': self.published_app.slug,
             'scopes': [],
             'events': [],
@@ -155,7 +156,9 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             name='Foo Bar',
             organization=self.org,
         )
+
         sentry_apps.Destroyer.run(sentry_app=sentry_app)
+
         response = self.client.put(
             self.url,
             data={'name': sentry_app.name},

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -59,6 +59,7 @@ class GetSentryAppsTest(SentryAppsTest):
         assert response.status_code == 200
         assert {
             'name': self.published_app.name,
+            'author': self.published_app.author,
             'slug': self.published_app.slug,
             'scopes': [],
             'events': [],
@@ -82,6 +83,7 @@ class GetSentryAppsTest(SentryAppsTest):
         assert response.status_code == 200
         assert {
             'name': self.unpublished_app.name,
+            'author': self.unpublished_app.author,
             'slug': self.unpublished_app.slug,
             'scopes': [],
             'events': [],
@@ -225,6 +227,7 @@ class PostSentryAppsTest(SentryAppsTest):
         body = {
             'name': 'MyApp',
             'organization': self.org.slug,
+            'author': 'Sentry',
             'scopes': ('project:read', 'event:read'),
             'events': ('issue',),
             'webhookUrl': 'https://example.com',

--- a/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from mock import patch
 
 from sentry.coreapi import APIUnauthorized
-from sentry.mediators import sentry_apps
 from sentry.mediators.sentry_app_installations import InstallationNotifier
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.faux import faux
@@ -25,7 +24,7 @@ class TestInstallationNotifier(TestCase):
         self.user = self.create_user(name='foo')
         self.org = self.create_organization(owner=self.user)
 
-        self.sentry_app = sentry_apps.Creator.run(
+        self.sentry_app = self.create_sentry_app(
             name='foo',
             organization=self.org,
             webhook_url='https://example.com',

--- a/tests/sentry/mediators/sentry_apps/test_creator.py
+++ b/tests/sentry/mediators/sentry_apps/test_creator.py
@@ -11,6 +11,7 @@ class TestCreator(TestCase):
         self.org = self.create_organization(owner=self.user)
         self.creator = Creator(
             name='nulldb',
+            author='Sentry',
             organization=self.org,
             scopes=('project:read',),
             webhook_url='http://example.com',
@@ -79,6 +80,7 @@ class TestCreator(TestCase):
         request = self.make_request(user=self.user, method='GET')
         Creator.run(
             name='nulldb',
+            author='Sentry',
             organization=self.org,
             scopes=('project:read',),
             webhook_url='http://example.com',


### PR DESCRIPTION
Developers need to be able to specify who created and maintains Sentry Apps. This change allows them to input them and exposes them thoughout the API where necessary.

Also fixes a bug where you could not update a Sentry App without changing it's name. The uniqueness validation wasn't taking into consideration the app being updated when checking if the slug is unique.