### PR TITLE
ref: Refactor .travis.yml, add parallel builds 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,44 @@ after_script:
   - zeus upload -t "text/xml+checkstyle" .artifacts/*checkstyle.xml
   - zeus upload -t "application/webpack-stats+json" .artifacts/*webpack-stats.json
 
+base_postgres: &postgres_default
+  python: 2.7
+  services:
+    - memcached
+    - redis-server
+    - postgresql
+  install:
+    - python setup.py install_egg_info
+    - pip install -e ".[dev,tests,optional]"
+  before_script:
+    - psql -c 'create database sentry;' -U postgres
+
+base_acceptance: &acceptance_default
+  python: 2.7
+  services:
+    - docker
+    - memcached
+    - redis-server
+    - postgresql
+  before_install:
+    - find "$NODE_DIR" -type d -empty -delete
+    - nvm install
+    - npm install -g "yarn@${YARN_VERSION}"
+    - docker run -d --network host --name clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server:18.14.9
+    - docker run -d --network host --name snuba --env SNUBA_SETTINGS=test --env CLICKHOUSE_SERVER=localhost:9000 getsentry/snuba
+    - docker ps -a
+  install:
+    - yarn install --pure-lockfile
+    - python setup.py install_egg_info
+    - pip install -e ".[dev,tests,optional]"
+    - wget -N "https://chromedriver.storage.googleapis.com/2.45/chromedriver_linux64.zip" -P ~/
+    - unzip ~/chromedriver_linux64.zip -d ~/
+    - rm ~/chromedriver_linux64.zip
+    - sudo install -m755 ~/chromedriver /usr/local/bin/
+  before_script:
+    - psql -c 'create database sentry;' -U postgres
+
+
 # each job in the matrix inherits `env/global` and uses everything above,
 # but custom `services`, `before_install`, `install`, and `before_script` directives
 # may be defined to define and setup individual job environments with more precision.
@@ -83,46 +121,33 @@ matrix:
         - pip install -r requirements-dev.txt
         - yarn install --pure-lockfile
 
-    - python: 2.7
-      name: 'Backend [Postgres]'
-      env: TEST_SUITE=postgres DB=postgres
-      services:
-        - memcached
-        - redis-server
-        - postgresql
-      install:
-        - python setup.py install_egg_info
-        - pip install -e ".[dev,tests,optional]"
-      before_script:
-        - psql -c 'create database sentry;' -U postgres
+    - <<: *postgres_default
+      name: 'Backend [Postgres] (1/2)'
+      env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=0
+    - <<: *postgres_default
+      name: 'Backend [Postgres] (2/2)'
+      env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=1
 
     # django 1.8 compatibility
-    - python: 2.7
-      name: 'Backend [Postgres] (Django 1.8)'
-      env: TEST_SUITE=postgres DJANGO_VERSION=">=1.8,<1.9"
-      services:
-        - memcached
-        - redis-server
-        - postgresql
-      install:
-        - python setup.py install_egg_info
-        - pip install -e ".[dev,tests,optional]"
-      before_script:
-        - psql -c 'create database sentry;' -U postgres
+    - <<: *postgres_default
+      name: 'Backend [Postgres] (Django 1.8) (1/2)'
+      env: TEST_SUITE=postgres DB=postgres DJANGO_VERSION=">=1.8,<1.9" TOTAL_TEST_GROUPS=2 TEST_GROUP=0
+    - <<: *postgres_default
+      name: 'Backend [Postgres] (Django 1.8) (2/2)'
+      env: TEST_SUITE=postgres DB=postgres DJANGO_VERSION=">=1.8,<1.9" TOTAL_TEST_GROUPS=2 TEST_GROUP=1
 
     # django 1.8 compatibility with migrations
-    - python: 2.7
-      name: 'Backend [Postgres] (Django 1.8, No migrations)'
-      env: TEST_SUITE=postgres DJANGO_VERSION=">=1.8,<1.9" SOUTH_TESTS_MIGRATE=0
-      services:
-        - memcached
-        - redis-server
-        - postgresql
-      install:
-        - python setup.py install_egg_info
-        - pip install -e ".[dev,tests,optional]"
-      before_script:
-        - psql -c 'create database sentry;' -U postgres
+    - <<: *postgres_default
+      name: 'Backend [Postgres] (Django 1.8, No migrations) (1/2)'
+      env: TEST_SUITE=postgres DJANGO_VERSION=">=1.8,<1.9" SOUTH_TESTS_MIGRATE=0 TOTAL_TEST_GROUPS=2 TEST_GROUP=0
+    - <<: *postgres_default
+      name: 'Backend [Postgres] (Django 1.8, No migrations) (2/2)'
+      env: TEST_SUITE=postgres DJANGO_VERSION=">=1.8,<1.9" SOUTH_TESTS_MIGRATE=0 TOTAL_TEST_GROUPS=2 TEST_GROUP=1
+
+    # XXX(markus): Remove after rust interfaces are done
+    - <<: *postgres_default
+      name: 'Backend [Postgres] (Rust Interface Renormalization)'
+      env: TEST_SUITE=postgres DB=postgres SENTRY_TEST_USE_RUST_INTERFACE_RENORMALIZATION=1
 
     # only the sqlite suite runs riak tests
     - python: 2.7
@@ -136,73 +161,18 @@ matrix:
         - python setup.py install_egg_info
         - pip install -e ".[dev,tests,optional]"
 
+    - <<: *acceptance_default
+      name: 'Acceptance (1/2)'
+      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=0 PERCY_PARALLEL_NONCE=${TRAVIS_BUILD_ID} PERCY_PARALLEL_TOTAL=2
+    - <<: *acceptance_default
+      name: 'Acceptance (2/2)'
+      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=1 PERCY_PARALLEL_NONCE=${TRAVIS_BUILD_ID} PERCY_PARALLEL_TOTAL=2
 
     # XXX(markus): Remove after rust interfaces are done
-    - python: 2.7
-      name: 'Backend [Postgres] (Rust Interface Renormalization)'
-      env: TEST_SUITE=postgres DB=postgres SENTRY_TEST_USE_RUST_INTERFACE_RENORMALIZATION=1
-      services:
-        - memcached
-        - redis-server
-        - postgresql
-      install:
-        - python setup.py install_egg_info
-        - pip install -e ".[dev,tests,optional]"
-      before_script:
-        - psql -c 'create database sentry;' -U postgres
-
-    - python: 2.7
-      name: 'Acceptance'
-      env: TEST_SUITE=acceptance USE_SNUBA=1
-      services:
-        - docker
-        - memcached
-        - redis-server
-        - postgresql
-      before_install:
-        - find "$NODE_DIR" -type d -empty -delete
-        - nvm install
-        - npm install -g "yarn@${YARN_VERSION}"
-        - docker run -d --network host --name clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server:18.14.9
-        - docker run -d --network host --name snuba --env SNUBA_SETTINGS=test --env CLICKHOUSE_SERVER=localhost:9000 getsentry/snuba
-        - docker ps -a
-      install:
-        - yarn install --pure-lockfile
-        - python setup.py install_egg_info
-        - pip install -e ".[dev,tests,optional]"
-        - wget -N "https://chromedriver.storage.googleapis.com/2.45/chromedriver_linux64.zip" -P ~/
-        - unzip ~/chromedriver_linux64.zip -d ~/
-        - rm ~/chromedriver_linux64.zip
-        - sudo install -m755 ~/chromedriver /usr/local/bin/
-      before_script:
-        - psql -c 'create database sentry;' -U postgres
-
-    # XXX(markus): Remove after rust interfaces are done
-    - python: 2.7
+    - <<: *acceptance_default
+      python: 2.7
       name: 'Acceptance (Rust Interface Renormalization)'
       env: TEST_SUITE=acceptance USE_SNUBA=1 SENTRY_TEST_USE_RUST_INTERFACE_RENORMALIZATION=1 PERCY_ENABLE=0
-      services:
-        - docker
-        - memcached
-        - redis-server
-        - postgresql
-      before_install:
-        - find "$NODE_DIR" -type d -empty -delete
-        - nvm install
-        - npm install -g "yarn@${YARN_VERSION}"
-        - docker run -d --network host --name clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server:18.14.9
-        - docker run -d --network host --name snuba --env SNUBA_SETTINGS=test --env CLICKHOUSE_SERVER=localhost:9000 getsentry/snuba
-        - docker ps -a
-      install:
-        - yarn install --pure-lockfile
-        - python setup.py install_egg_info
-        - pip install -e ".[dev,tests,optional]"
-        - wget -N "https://chromedriver.storage.googleapis.com/2.45/chromedriver_linux64.zip" -P ~/
-        - unzip ~/chromedriver_linux64.zip -d ~/
-        - rm ~/chromedriver_linux64.zip
-        - sudo install -m755 ~/chromedriver /usr/local/bin/
-      before_script:
-        - psql -c 'create database sentry;' -U postgres
 
     - python: 2.7
       name: 'Frontend'

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,11 @@ test-python:
 	sentry init
 	make build-platform-assets
 	@echo "--> Running Python tests"
+ifndef TEST_GROUP
 	py.test tests/integration tests/sentry --cov . --cov-report="xml:.artifacts/python.coverage.xml" --junit-xml=".artifacts/python.junit.xml" || exit 1
+else
+	py.test tests/integration tests/sentry -m group_$(TEST_GROUP) --cov . --cov-report="xml:.artifacts/python.coverage.xml" --junit-xml=".artifacts/python.junit.xml" || exit 1
+endif
 	@echo ""
 
 test-snuba:
@@ -156,7 +160,12 @@ test-acceptance: node-version-check
 	@echo "--> Building static assets"
 	@$(WEBPACK) --display errors-only
 	@echo "--> Running acceptance tests"
+ifndef TEST_GROUP
 	py.test tests/acceptance --cov . --cov-report="xml:.artifacts/acceptance.coverage.xml" --junit-xml=".artifacts/acceptance.junit.xml" --html=".artifacts/acceptance.pytest.html"
+else
+	py.test tests/acceptance -m group_$(TEST_GROUP) --cov . --cov-report="xml:.artifacts/acceptance.coverage.xml" --junit-xml=".artifacts/acceptance.junit.xml" --html=".artifacts/acceptance.pytest.html"
+endif
+
 	@echo ""
 
 lint: lint-python lint-js

--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,9 @@ from __future__ import absolute_import
 
 import os
 import sys
+from hashlib import md5
+
+import pytest
 
 pytest_plugins = [
     'sentry.utils.pytest'
@@ -17,3 +20,10 @@ def pytest_configure(config):
     # XXX(dramer): Kombu throws a warning due to transaction.commit_manually
     # being used
     warnings.filterwarnings('error', '', Warning, r'^(?!(|kombu|raven|riak|sentry))')
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        total_groups = int(os.environ.get('TOTAL_TEST_GROUPS', 1))
+        group_num = int(md5(item.location[0]).hexdigest(), 16) % total_groups
+        item.add_marker(getattr(pytest.mark, 'group_%s' % group_num))

--- a/tests/sentry/api/endpoints/test_organization_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_searches.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import django
 from django.utils import timezone
 from exam import fixture
 
@@ -22,6 +23,11 @@ class OrganizationSearchesListTest(APITestCase):
         team = self.create_team(members=[self.user])
         project1 = self.create_project(teams=[team], name='foo')
         project2 = self.create_project(teams=[team], name='bar')
+
+        if django.VERSION[:2] >= (1, 8):
+            # Depending on test we run migrations in Django 1.8. This causes
+            # extra rows to be created, so remove them to keep this test working
+            SavedSearch.objects.filter(is_global=True).delete()
 
         SavedSearch.objects.create(
             project=project1,
@@ -76,6 +82,11 @@ class OrgLevelOrganizationSearchesListTest(APITestCase):
         )
 
     def create_base_data(self):
+        if django.VERSION[:2] >= (1, 8):
+            # Depending on test we run migrations in Django 1.8. This causes
+            # extra rows to be created, so remove them to keep this test working
+            SavedSearch.objects.filter(is_global=True).delete()
+
         team = self.create_team(members=[self.user])
         SavedSearch.objects.create(
             project=self.create_project(teams=[team], name='foo'),


### PR DESCRIPTION
Refactor .travis.yml to be DRYer. Add in parallel builds for the slowest builds. The slowest build
after these changes is Django 1.8 (with migrations). Not actually sure why we run the migrations for
1.8 when we don't run them for any of the other builds, potentially we can remove this test.