### PR TITLE
ref(symbolicator): Updates for newer symbolicator

### DIFF
--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -265,6 +265,8 @@ class NativeStacktraceProcessor(StacktraceProcessor):
                 error = SymbolicationFailed(type=EventError.NATIVE_BAD_DSYM)
             elif status == 'too_large':
                 error = SymbolicationFailed(type=EventError.FETCH_TOO_LARGE)
+            elif status == 'fetching_failed':
+                error = SymbolicationFailed(type=EventError.FETCH_GENERIC_ERROR)
             elif status == 'other':
                 error = SymbolicationFailed(type=EventError.UNKNOWN_ERROR)
             else:

--- a/src/sentry/stacktraces.py
+++ b/src/sentry/stacktraces.py
@@ -5,7 +5,7 @@ import logging
 from datetime import datetime
 from django.utils import timezone
 
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 
 from sentry.models import Project, Release
 from sentry.utils.cache import cache
@@ -33,7 +33,11 @@ class ProcessableFrame(object):
         self.processable_frames = processable_frames
 
     def __repr__(self):
-        return '<ProcessableFrame %r #%r>' % (self.frame.get('function') or 'unknown', self.idx, )
+        return '<ProcessableFrame %r #%r at %r>' % (
+            self.frame.get('function') or 'unknown',
+            self.idx,
+            self.frame.get('instruction_addr'),
+        )
 
     def __contains__(self, key):
         return key in self.frame
@@ -319,7 +323,7 @@ def get_stacktrace_processing_task(infos, processors):
     processors that seem to not handle any frames.
     """
     by_processor = {}
-    by_stacktrace_info = {}
+    by_stacktrace_info = OrderedDict()
     to_lookup = {}
 
     for info in infos:

--- a/src/sentry/stacktraces.py
+++ b/src/sentry/stacktraces.py
@@ -323,8 +323,12 @@ def get_stacktrace_processing_task(infos, processors):
     processors that seem to not handle any frames.
     """
     by_processor = {}
-    by_stacktrace_info = OrderedDict()
     to_lookup = {}
+
+    # by_stacktrace_info requires stable sorting as it is used in
+    # StacktraceProcessingTask.iter_processable_stacktraces. This is important
+    # to guarantee reproducible symbolicator requests.
+    by_stacktrace_info = OrderedDict()
 
     for info in infos:
         processable_frames = get_processable_frames(info, processors)


### PR DESCRIPTION
Ensures that stacktraces have a stable order to be able to retry symbolication requests and handles a previously unhandled debug file status.