### PR TITLE
fix(ci) Only publish coverage when it exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,8 @@ script:
 
 after_success:
   - |
-      if [[ -f .artifacts/*coverage.xml || -f .artifacts/coverage/cobertura-coverage.xml ]]; then
+      coverage_files=$(ls .artifacts/*coverage.xml || true)
+      if [[ -n "$coverage_files" || -f .artifacts/coverage/cobertura-coverage.xml ]]; then
         pip install codecov
         codecov -e TEST_SUITE
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ env:
     # node's version is pinned by .nvmrc and is autodetected by `nvm install`.
     - NODE_DIR="${HOME}/.nvm/versions/node/v$(< .nvmrc)"
     - YARN_VERSION="1.13.0"
+
 script:
   # certain commands require sentry init to be run, but this is only true for
   # running things within Travis
@@ -43,16 +44,19 @@ script:
   - make travis-scan-$TEST_SUITE
   # installing dependencies for after_* steps here ensures they get cached
   # since those steps execute after travis runs `store build cache`
-  - pip install codecov
-  - npm install -g @zeus-ci/cli
 
 after_success:
-  - codecov -e TEST_SUITE
+  - |
+      if [[ -f .artifacts/*coverage.xml || -f .artifacts/coverage/cobertura-coverage.xml ]]; then
+        pip install codecov
+        codecov -e TEST_SUITE
+      fi
 
 after_failure:
   - dmesg | tail -n 100
 
 after_script:
+  - npm install -g @zeus-ci/cli
   - zeus upload -t "text/xml+xunit" .artifacts/*junit.xml
   - zeus upload -t "text/xml+coverage" .artifacts/*coverage.xml
   - zeus upload -t "text/xml+coverage" .artifacts/coverage/cobertura-coverage.xml


### PR DESCRIPTION
Don't try to publish coverage in builds that don't generate it. Shave a few seconds off of builds that don't generate coverage by not installing codecov and running it with no effect.