### PR TITLE
fix(plugins) Don't log errors when plugins fail with expected problems

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -16,6 +16,7 @@ from django.conf import settings
 from sentry import features
 from sentry.utils import snuba
 from sentry.utils.cache import cache
+from sentry.exceptions import PluginError
 from sentry.plugins import plugins
 from sentry.signals import event_processed
 from sentry.tasks.sentry_apps import process_resource_change_bound
@@ -201,7 +202,12 @@ def plugin_post_process_group(plugin_slug, event, **kwargs):
         scope.set_tag("project", event.project_id)
 
     plugin = plugins.get(plugin_slug)
-    safe_execute(plugin.post_process, event=event, group=event.group, **kwargs)
+    safe_execute(
+        plugin.post_process,
+        event=event,
+        group=event.group,
+        expected_errors=(PluginError,),
+        **kwargs)
 
 
 @instrumented_task(

--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -23,6 +23,7 @@ def safe_execute(func, *args, **kwargs):
     # TODO: we should make smart savepoints (only executing the savepoint server
     # side if we execute a query)
     _with_transaction = kwargs.pop('_with_transaction', True)
+    expected_errors = kwargs.pop('expected_errors', None)
     try:
         if _with_transaction:
             with transaction.atomic():
@@ -37,8 +38,11 @@ def safe_execute(func, *args, **kwargs):
 
         func_name = getattr(func, '__name__', six.text_type(func))
         cls_name = cls.__name__
-
         logger = logging.getLogger('sentry.safe.%s' % (cls_name.lower(), ))
+
+        if expected_errors and isinstance(e, expected_errors):
+            logger.info('%s.process_error_ignored', func_name, extra={'exception': e})
+            return
         logger.error('%s.process_error', func_name, exc_info=True, extra={'exception': e})
     else:
         return result


### PR DESCRIPTION
When plugin post processing fails with known exception types we shouldn't log errors. There is nothing we can do with these problems as they come from known & expected situations in plugin code.

Fixes SENTRY-40X