### PR TITLE
fix(ui): Create project when switching selected team

### DIFF
--- a/src/sentry/static/sentry/app/views/onboarding/createProject.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/createProject.jsx
@@ -172,7 +172,7 @@ class CreateProject extends React.Component {
                   clearable={false}
                   value={team}
                   placeholder={t('Select a Team')}
-                  onChange={val => this.setState({team: val})}
+                  onChange={choice => this.setState({team: choice.value})}
                   options={teams.map(({slug}) => ({
                     label: `#${slug}`,
                     value: slug,


### PR DESCRIPTION
Will add an associated test after. But wanted to get this in first.

Fixes: [JAVASCRIPT-28Z](https://sentry.io/organizations/sentry/issues/318436033/?environment=prod&project=11276&query=is%3Aunresolved&statsPeriod=14d&utc=false)