### PR TITLE
fix(tests) Inherit from unittest to save small amounts of time

### DIFF
--- a/tests/sentry/testutils/helpers/test_faux.py
+++ b/tests/sentry/testutils/helpers/test_faux.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from mock import patch
 
-from sentry.testutils import TestCase
+from unittest import TestCase
 from sentry.testutils.helpers.faux import faux
 
 

--- a/tests/sentry/tsdb/test_base.py
+++ b/tests/sentry/tsdb/test_base.py
@@ -6,7 +6,7 @@ import pytz
 
 from datetime import datetime, timedelta
 
-from sentry.testutils import TestCase
+from unittest import TestCase
 from sentry.tsdb.base import BaseTSDB, ONE_MINUTE, ONE_HOUR, ONE_DAY
 from sentry.utils.dates import to_timestamp
 from six.moves import xrange

--- a/tests/sentry/utils/hashlib/tests.py
+++ b/tests/sentry/utils/hashlib/tests.py
@@ -6,7 +6,7 @@ import pytest
 import six
 
 from sentry.utils.hashlib import md5_text, sha1_text, hash_values
-from sentry.testutils import TestCase
+from unittest import TestCase
 
 
 HASHLIB_VALUES_TESTS = (

--- a/tests/sentry/utils/http/tests.py
+++ b/tests/sentry/utils/http/tests.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import
 
 import mock
+import unittest
 
 from exam import fixture
 from django.http import HttpRequest
@@ -26,7 +27,7 @@ from sentry.utils.data_filters import (
 )
 
 
-class AbsoluteUriTest(TestCase):
+class AbsoluteUriTest(unittest.TestCase):
     def test_without_path(self):
         assert absolute_uri() == options.get('system.url-prefix')
 
@@ -34,7 +35,7 @@ class AbsoluteUriTest(TestCase):
         assert absolute_uri('/foo/bar') == '%s/foo/bar' % (options.get('system.url-prefix'), )
 
 
-class SameDomainTestCase(TestCase):
+class SameDomainTestCase(unittest.TestCase):
     def test_is_same_domain(self):
         url1 = 'http://example.com/foo/bar'
         url2 = 'http://example.com/biz/baz'
@@ -102,7 +103,7 @@ class GetOriginsTestCase(TestCase):
             self.assertEquals(result, frozenset([u'*']))
 
 
-class IsValidOriginTestCase(TestCase):
+class IsValidOriginTestCase(unittest.TestCase):
     @fixture
     def project(self):
         return mock.Mock()

--- a/tests/sentry/utils/json/tests.py
+++ b/tests/sentry/utils/json/tests.py
@@ -7,7 +7,7 @@ import uuid
 
 from enum import Enum
 
-from sentry.testutils import TestCase
+from unittest import TestCase
 from sentry.utils import json
 
 

--- a/tests/sentry/utils/locking/backends/test_redis.py
+++ b/tests/sentry/utils/locking/backends/test_redis.py
@@ -4,7 +4,7 @@ import pytest
 
 from exam import fixture
 
-from sentry.testutils import TestCase
+from unittest import TestCase
 from sentry.utils.locking.backends.redis import RedisLockBackend
 from sentry.utils.redis import clusters
 

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import unittest
+
 from datetime import timedelta
 from django.utils import timezone
 from mock import Mock
@@ -58,7 +60,7 @@ class CommitTestCase(TestCase):
         )
 
 
-class TokenizePathTestCase(TestCase):
+class TokenizePathTestCase(unittest.TestCase):
     def test_forward_slash(self):
         assert list(tokenize_path('foo/bar')) == ['bar', 'foo']
 
@@ -85,7 +87,7 @@ class TokenizePathTestCase(TestCase):
         assert list(tokenize_path('/')) == []
 
 
-class ScorePathMatchLengthTest(TestCase):
+class ScorePathMatchLengthTest(unittest.TestCase):
     def test_equal_paths(self):
         assert score_path_match_length('foo/bar/baz', 'foo/bar/baz') == 3
 
@@ -100,7 +102,7 @@ class ScorePathMatchLengthTest(TestCase):
         assert score_path_match_length('./foo/bar/baz', 'foo/bar/baz') == 3
 
 
-class GetFramePathsTestCase(TestCase):
+class GetFramePathsTestCase(unittest.TestCase):
     def setUp(self):
         self.event = Mock()
         self.event.data = {}

--- a/tests/sentry/utils/test_contexts_normalization.py
+++ b/tests/sentry/utils/test_contexts_normalization.py
@@ -4,7 +4,7 @@ from sentry.utils.contexts_normalization import (
     normalize_runtime,
     normalize_user_agent
 )
-from sentry.testutils import TestCase
+from unittest import TestCase
 
 
 class NormalizeRuntimeTests(TestCase):

--- a/tests/sentry/utils/test_data_scrubber.py
+++ b/tests/sentry/utils/test_data_scrubber.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 from sentry.constants import FILTER_MASK
-from sentry.testutils import TestCase
+from unittest import TestCase
 from sentry.utils.data_scrubber import SensitiveDataFilter
 
 VARS = {

--- a/tests/sentry/utils/test_encryption.py
+++ b/tests/sentry/utils/test_encryption.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from cryptography.fernet import Fernet
 
-from sentry.testutils import TestCase
+from unittest import TestCase
 from sentry.utils.encryption import EncryptionManager, MARKER
 
 

--- a/tests/sentry/utils/test_functional.py
+++ b/tests/sentry/utils/test_functional.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from sentry.utils.functional import compact
-from sentry.testutils import TestCase
+from unittest import TestCase
 
 
 class CompactTest(TestCase):

--- a/tests/sentry/utils/test_meta.py
+++ b/tests/sentry/utils/test_meta.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from copy import deepcopy
 
 from sentry.utils.meta import Meta
-from sentry.testutils import TestCase
+from unittest import TestCase
 
 
 input_meta = {'': {

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -6,7 +6,7 @@ import mock
 import pytest
 
 from sentry.exceptions import InvalidConfiguration
-from sentry.testutils.cases import TestCase
+from unittest import TestCase
 from sentry.utils.redis import (
     ClusterManager, _shared_pool, get_cluster_from_options, _RedisCluster, logger
 )

--- a/tests/sentry/utils/test_retries.py
+++ b/tests/sentry/utils/test_retries.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import mock
 
-from sentry.testutils import TestCase
+from unittest import TestCase
 from sentry.utils.retries import TimedRetryPolicy, RetryException
 
 

--- a/tests/sentry/utils/test_safe.py
+++ b/tests/sentry/utils/test_safe.py
@@ -5,7 +5,7 @@ from functools import partial
 import pytest
 
 from mock import patch, Mock
-from sentry.testutils import TestCase
+from unittest import TestCase
 from sentry.utils.canonical import CanonicalKeyDict
 from sentry.utils.safe import safe_execute, trim, trim_dict, get_path, set_path, \
     setdefault_path

--- a/tests/sentry/utils/test_safe.py
+++ b/tests/sentry/utils/test_safe.py
@@ -3,9 +3,10 @@ from __future__ import absolute_import
 from collections import OrderedDict
 from functools import partial
 import pytest
+import unittest
 
 from mock import patch, Mock
-from unittest import TestCase
+from sentry.testutils import TestCase
 from sentry.utils.canonical import CanonicalKeyDict
 from sentry.utils.safe import safe_execute, trim, trim_dict, get_path, set_path, \
     setdefault_path
@@ -13,7 +14,7 @@ from sentry.utils.safe import safe_execute, trim, trim_dict, get_path, set_path,
 a_very_long_string = 'a' * 1024
 
 
-class TrimTest(TestCase):
+class TrimTest(unittest.TestCase):
     def test_simple_string(self):
         assert trim(a_very_long_string) == a_very_long_string[:509] + '...'
 
@@ -58,7 +59,7 @@ class TrimTest(TestCase):
         assert trm(a) == {'a': {'b': {'c': '[]'}}}
 
 
-class TrimDictTest(TestCase):
+class TrimDictTest(unittest.TestCase):
     def test_large_dict(self):
         value = dict((k, k) for k in range(500))
         trim_dict(value)
@@ -107,7 +108,7 @@ class SafeExecuteTest(TestCase):
         assert mock_log.error.called is False
 
 
-class GetPathTest(TestCase):
+class GetPathTest(unittest.TestCase):
     def test_get_none(self):
         assert get_path(None, 'foo') is None
         assert get_path('foo', 'foo') is None
@@ -157,7 +158,7 @@ class GetPathTest(TestCase):
             get_path({}, 'foo', unknown=True)
 
 
-class SetPathTest(TestCase):
+class SetPathTest(unittest.TestCase):
     def test_set_none(self):
         assert not set_path(None, 'foo', value=42)
         assert not set_path('foo', 'foo', value=42)

--- a/tests/sentry/utils/test_session_store.py
+++ b/tests/sentry/utils/test_session_store.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.http import HttpRequest
 
-from sentry.testutils import TestCase
+from unittest import TestCase
 from sentry.utils.session_store import RedisSessionStore
 
 

--- a/tests/sentry/utils/test_types.py
+++ b/tests/sentry/utils/test_types.py
@@ -12,7 +12,7 @@ from sentry.utils.types import (
     Dict,
     Sequence,
 )
-from sentry.testutils import TestCase
+from unittest import TestCase
 
 
 class OptionsTypesTest(TestCase):


### PR DESCRIPTION
Inheriting from unittest.TestCase when we don't use the database lets us shave a few seconds off of the build duration.

Moves `pytest tests/sentry/utils` from ~18 seconds to ~16s