### PR TITLE
fix: Mark flaky tests as allowed failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -338,6 +338,8 @@ matrix:
     # XXX(markus): Remove after rust interfaces are done
     - env: TEST_SUITE=postgres DB=postgres SENTRY_TEST_USE_RUST_INTERFACE_RENORMALIZATION=1
 
+    - env: TEST_SUITE=symbolicator
+
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
The symbolicator seems to have connectivity issues left and right. Until we have retries implemented, just don't break master for now.

cc @jan-auer 