### PR TITLE
fix(percy) Dismiss assistant in project releases visual test

### DIFF
--- a/tests/acceptance/test_project_releases.py
+++ b/tests/acceptance/test_project_releases.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+import json
+
+from django.conf import settings
 from django.utils import timezone
 
 from sentry.testutils import AcceptanceTestCase
@@ -39,10 +42,21 @@ class ProjectReleasesTest(AcceptanceTestCase):
         self.browser.snapshot('project releases with releases')
 
     def test_with_no_releases(self):
+        self.dismiss_assistant()
         self.browser.get(self.path)
         self.browser.wait_until_not('.loading')
         self.browser.wait_until('.ref-project-releases')
         self.browser.snapshot('project releases without releases')
+
+    def dismiss_assistant(self):
+        # Forward session cookie to django client.
+        self.client.cookies[settings.SESSION_COOKIE_NAME] = self.session.session_key
+
+        res = self.client.put(
+            '/api/0/assistant/',
+            content_type='application/json',
+            data=json.dumps({'guide_id': 2, 'status': 'viewed', 'useful': True}))
+        assert res.status_code == 201
 
 
 class ProjectReleaseDetailsTest(AcceptanceTestCase):


### PR DESCRIPTION
I've been noticing an assistant cue appearing inconsistently on the project without releases visual test. We can get more stable results by ensuring the assistant has been dismissed first.