### PR TITLE
feat(app-platform): Add actor to issue create/link payload

### DIFF
--- a/src/sentry/api/endpoints/organization_user_details.py
+++ b/src/sentry/api/endpoints/organization_user_details.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import
+
+from rest_framework.response import Response
+
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.serializers import serialize
+from sentry.models import OrganizationMember
+
+
+class OrganizationUserDetailsEndpoint(OrganizationEndpoint):
+    def get(self, request, organization, user_id):
+        try:
+            org_member = OrganizationMember.objects.get(
+                user__id=user_id,
+                organization=organization,
+            )
+        except OrganizationMember.DoesNotExist:
+            return Response(status=404)
+
+        return Response(serialize(org_member, request.user))

--- a/src/sentry/api/endpoints/organization_user_details.py
+++ b/src/sentry/api/endpoints/organization_user_details.py
@@ -5,9 +5,12 @@ from rest_framework.response import Response
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import OrganizationMember
+from sentry.api.endpoints.organization_member_index import MemberPermission
 
 
 class OrganizationUserDetailsEndpoint(OrganizationEndpoint):
+    permission_classes = (MemberPermission, )
+
     def get(self, request, organization, user_id):
         try:
             org_member = OrganizationMember.objects.get(

--- a/src/sentry/api/endpoints/organization_user_details.py
+++ b/src/sentry/api/endpoints/organization_user_details.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import OrganizationMember
+from sentry.models import User
 from sentry.api.endpoints.organization_member_index import MemberPermission
 
 
@@ -13,11 +13,11 @@ class OrganizationUserDetailsEndpoint(OrganizationEndpoint):
 
     def get(self, request, organization, user_id):
         try:
-            org_member = OrganizationMember.objects.get(
-                user__id=user_id,
-                organization=organization,
+            user = User.objects.get(
+                id=user_id,
+                sentry_orgmember_set__organization_id=organization.id,
             )
-        except OrganizationMember.DoesNotExist:
+        except User.DoesNotExist:
             return Response(status=404)
 
-        return Response(serialize(org_member, request.user))
+        return Response(serialize(user, request.user))

--- a/src/sentry/api/endpoints/sentry_app_installation_external_issues.py
+++ b/src/sentry/api/endpoints/sentry_app_installation_external_issues.py
@@ -47,6 +47,7 @@ class SentryAppInstallationExternalIssuesEndpoint(SentryAppInstallationBaseEndpo
                 action=action,
                 fields=data,
                 uri=uri,
+                user=request.user,
             )
         except Exception:
             return Response({'error': 'Error communicating with Sentry App service'}, status=400)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -116,6 +116,7 @@ from .endpoints.organization_tagkey_values import OrganizationTagKeyValuesEndpoi
 from .endpoints.organization_tags import OrganizationTagsEndpoint
 from .endpoints.organization_user_reports import OrganizationUserReportsEndpoint
 from .endpoints.organization_users import OrganizationUsersEndpoint
+from .endpoints.organization_user_details import OrganizationUserDetailsEndpoint
 from .endpoints.sentry_app_installations import SentryAppInstallationsEndpoint
 from .endpoints.sentry_app_installation_details import SentryAppInstallationDetailsEndpoint
 from .endpoints.sentry_app_installation_external_requests import SentryAppInstallationExternalRequestsEndpoint
@@ -730,6 +731,11 @@ urlpatterns = patterns(
         r'^organizations/(?P<organization_slug>[^\/]+)/users/$',
         OrganizationUsersEndpoint.as_view(),
         name='sentry-api-0-organization-users'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/users/(?P<user_id>[^\/]+)/$',
+        OrganizationUserDetailsEndpoint.as_view(),
+        name='sentry-api-0-organization-user-details'
     ),
     url(
         r'^organizations/(?P<organization_slug>[^\/]+)/sentry-app-installations/$',

--- a/src/sentry/mediators/external_issues/issue_link_creator.py
+++ b/src/sentry/mediators/external_issues/issue_link_creator.py
@@ -14,6 +14,7 @@ class IssueLinkCreator(Mediator):
     action = Param(six.string_types)
     fields = Param(object)
     uri = Param(six.string_types)
+    user = Param('sentry.models.User')
 
     def call(self):
         self._verify_action()
@@ -31,6 +32,7 @@ class IssueLinkCreator(Mediator):
             uri=self.uri,
             group=self.group,
             fields=self.fields,
+            user=self.user,
         )
 
     def _format_response_data(self):

--- a/src/sentry/mediators/external_requests/issue_link_requester.py
+++ b/src/sentry/mediators/external_requests/issue_link_requester.py
@@ -49,6 +49,7 @@ class IssueLinkRequester(Mediator):
     uri = Param(six.string_types)
     group = Param('sentry.models.Group')
     fields = Param(object)
+    user = Param('sentry.models.User')
 
     def call(self):
         return self._make_request()
@@ -111,6 +112,11 @@ class IssueLinkRequester(Mediator):
         body['project'] = {
             'slug': project.slug,
             'id': project.id,
+        }
+        body['actor'] = {
+            'type': 'user',
+            'id': self.user.id,
+            'name': self.user.name,
         }
         return json.dumps(body)
 

--- a/tests/sentry/api/endpoints/test_organization_user_details.py
+++ b/tests/sentry/api/endpoints/test_organization_user_details.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import
+
+import six
+
+from django.core.urlresolvers import reverse
+from sentry.testutils import APITestCase
+
+
+class OrganizationUserDetailsTest(APITestCase):
+    def setUp(self):
+        self.owner_user = self.create_user('foo@localhost', username='foo')
+        self.user = self.create_user('bar@localhost', username='bar')
+
+        self.org = self.create_organization(owner=self.owner_user)
+        self.member = self.create_member(organization=self.org, user=self.user)
+        self.url = reverse(
+            'sentry-api-0-organization-user-details',
+            args=[
+                self.org.slug,
+                self.user.id])
+
+    def test_gets_info_for_user_in_org(self):
+        self.login_as(user=self.owner_user)
+        response = self.client.get(self.url)
+        assert response.data['user']['id'] == six.text_type(self.user.id)
+        assert response.data['email'] == self.user.email
+
+    def test_cannot_access_info_if_user_not_in_org(self):
+        self.login_as(user=self.owner_user)
+        user = self.create_user('meep@localhost', username='meep')
+        url = reverse('sentry-api-0-organization-user-details',
+                      args=[self.org.slug, user.id],
+                      )
+        response = self.client.get(url)
+
+        assert response.status_code == 404

--- a/tests/sentry/api/endpoints/test_organization_user_details.py
+++ b/tests/sentry/api/endpoints/test_organization_user_details.py
@@ -22,7 +22,7 @@ class OrganizationUserDetailsTest(APITestCase):
     def test_gets_info_for_user_in_org(self):
         self.login_as(user=self.owner_user)
         response = self.client.get(self.url)
-        assert response.data['user']['id'] == six.text_type(self.user.id)
+        assert response.data['id'] == six.text_type(self.user.id)
         assert response.data['email'] == self.user.email
 
     def test_cannot_access_info_if_user_not_in_org(self):

--- a/tests/sentry/mediators/external_issues/test_issue_link_creator.py
+++ b/tests/sentry/mediators/external_issues/test_issue_link_creator.py
@@ -56,6 +56,7 @@ class TestIssueLinkCreator(TestCase):
             action='create',
             uri='/link-issue',
             fields=fields,
+            user=self.user,
         )
 
         external_issue = PlatformExternalIssue.objects.all()[0]
@@ -72,4 +73,5 @@ class TestIssueLinkCreator(TestCase):
                 action='doop',
                 uri='/link-issue',
                 fields={},
+                user=self.user,
             )

--- a/tests/sentry/mediators/external_requests/test_issue_link_requester.py
+++ b/tests/sentry/mediators/external_requests/test_issue_link_requester.py
@@ -56,6 +56,7 @@ class TestIssueLinkRequester(TestCase):
             group=self.group,
             uri='/link-issue',
             fields=fields,
+            user=self.user,
         )
         assert result == {
             'project': 'ProjectName',
@@ -77,6 +78,11 @@ class TestIssueLinkRequester(TestCase):
             'project': {
                 'id': self.project.id,
                 'slug': self.project.slug,
+            },
+            'actor': {
+                'type': 'user',
+                'id': self.user.id,
+                'name': self.user.name,
             }
         }
         payload = json.loads(request.body)
@@ -103,6 +109,7 @@ class TestIssueLinkRequester(TestCase):
                 group=self.group,
                 uri='/link-issue',
                 fields={},
+                user=self.user,
             )
 
     @responses.activate
@@ -121,4 +128,5 @@ class TestIssueLinkRequester(TestCase):
                 group=self.group,
                 uri='/link-issue',
                 fields={},
+                user=self.user,
             )


### PR DESCRIPTION
* Adds actor payload on `create` and `link` requests so that sentry app services know who created or linked the issue. The `actor['id']` can be used to look up the corresponding information about that user so as to link (attempt to) the sentry user to the user in the other service.
* Adds the `organizations/<org_slug>/users/:id` endpoint to be used for the look up described above.

**Why not use `users/:id` ?**
Requests made by sentry apps cannot use the `users/:id` endpoint that exists today because of the `UserPermissions` which requires `user == request.user` to be true. Ideally we can modify this but for now we're keeping the user detail to be scoped under the organization. 