### PR TITLE
fix(app-platform): Allow empty permissions

### DIFF
--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -32,8 +32,9 @@ class NameField(serializers.CharField):
 class ApiScopesField(serializers.WritableField):
     def validate(self, data):
         valid_scopes = ApiScopes()
+
         if data is None:
-            raise ValidationError('Must provide scopes')
+            return
 
         for scope in data:
             if scope not in valid_scopes:

--- a/src/sentry/mediators/sentry_apps/creator.py
+++ b/src/sentry/mediators/sentry_apps/creator.py
@@ -12,7 +12,7 @@ from sentry.models import (AuditLogEntryEvent, ApiApplication, SentryApp, Sentry
 class Creator(Mediator):
     name = Param(six.string_types)
     organization = Param('sentry.models.Organization')
-    scopes = Param(Iterable)
+    scopes = Param(Iterable, default=lambda self: [])
     events = Param(Iterable, default=lambda self: [])
     webhook_url = Param(six.string_types)
     redirect_url = Param(six.string_types, required=False)

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -182,20 +182,19 @@ class PostSentryAppsTest(SentryAppsTest):
             {'schema': ["['#general'] is too short"]}
 
     @with_feature('organizations:sentry-apps')
+    def test_allows_empty_schema(self):
+        self.login_as(self.user)
+        response = self._post(schema={})
+
+        assert response.status_code == 201, response.content
+
+    @with_feature('organizations:sentry-apps')
     def test_missing_name(self):
         self.login_as(self.user)
         response = self._post(name=None)
 
         assert response.status_code == 422, response.content
         assert 'name' in response.data
-
-    @with_feature('organizations:sentry-apps')
-    def test_missing_scopes(self):
-        self.login_as(self.user)
-        response = self._post(scopes=None)
-
-        assert response.status_code == 422, response.content
-        assert 'scopes' in response.data
 
     @with_feature('organizations:sentry-apps')
     def test_invalid_events(self):
@@ -220,6 +219,14 @@ class PostSentryAppsTest(SentryAppsTest):
 
         assert response.status_code == 422, response.content
         assert 'webhookUrl' in response.data
+
+    @with_feature('organizations:sentry-apps')
+    def test_allows_empty_permissions(self):
+        self.login_as(self.user)
+        response = self._post(scopes=None)
+
+        assert response.status_code == 201, response.content
+        assert response.data['scopes'] == []
 
     def _post(self, **kwargs):
         body = {


### PR DESCRIPTION
Previously we required a developer to choose _some_ permissions when creating an Integration. There's legit use-cases where they aren't necessary, though, so we're removing that constraint.