### PR TITLE
refs: Remove MySQL test run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,22 +152,6 @@ matrix:
         - psql -c 'create database sentry;' -U postgres
 
     - python: 2.7
-      name: 'Backend [MySQL]'
-      env: TEST_SUITE=mysql DB=mysql
-      services:
-        - memcached
-        - mysql
-        - redis-server
-      install:
-        - python setup.py install_egg_info
-        - pip install -e ".[dev,tests,optional]"
-        # 1.3.14 causes test failures. Pinning to 1.3.13 for now, hopefully
-        # a later release resolves this.
-        - pip install mysqlclient==1.3.13
-      before_script:
-        - mysql -u root -e 'create database sentry;'
-
-    - python: 2.7
       name: 'Acceptance'
       env: TEST_SUITE=acceptance USE_SNUBA=1
       services:


### PR DESCRIPTION
We no longer support MySQL or sqlite. We rely on the sqlite tests to handle riak, so leaving them in place for now.

![68747470733a2f2f692e696d6775722e636f6d2f565643744f47562e676966](https://user-images.githubusercontent.com/6288560/55517313-eb6b4d00-5624-11e9-883e-bd7dd73bfd55.gif)
