### PR TITLE
ref: Unpin symbolicator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -257,7 +257,7 @@ matrix:
         - redis-server
         - postgresql
       before_install:
-        - docker run -d --network host --name symbolicator us.gcr.io/sentryio/symbolicator:088c09f8b1c00bdb8e0009a985f6a0d4abd9b372 run
+        - docker run -d --network host --name symbolicator us.gcr.io/sentryio/symbolicator:latest run
         - docker ps -a
       install:
         - python setup.py install_egg_info


### PR DESCRIPTION
For as long as it's an allowed failure it's actually not necessary to make sure the build is stable.