### PR TITLE
[feat] Enable loader interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.0.0",
-    "@sentry/browser": "5.0.0-rc.3",
+    "@sentry/browser": "^5.0.5",
     "algoliasearch": "^3.32.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.0.0",
-    "@sentry/browser": "^5.0.5",
+    "@sentry/browser": "^5.0.6",
     "algoliasearch": "^3.32.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.0.0",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -835,8 +835,6 @@ SENTRY_FEATURES = {
     'organizations:sentry-apps': False,
 
     # DEPRECATED: pending removal.
-    'organizations:js-loader': False,
-    # DEPRECATED: pending removal.
     'organizations:new-teams': True,
     # Enable the relay functionality, for use with sentry semaphore. See
     # https://github.com/getsentry/semaphore.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -65,7 +65,6 @@ default_manager.add('organizations:integrations-issue-sync', OrganizationFeature
 default_manager.add('organizations:internal-catchall', OrganizationFeature)  # NOQA
 default_manager.add('organizations:sentry-apps', OrganizationFeature)  # NOQA
 default_manager.add('organizations:invite-members', OrganizationFeature)  # NOQA
-default_manager.add('organizations:js-loader', OrganizationFeature)  # NOQA
 default_manager.add('organizations:large-debug-files', OrganizationFeature)  # NOQA
 default_manager.add('organizations:legacy-event-id', OrganizationFeature)  # NOQA
 default_manager.add('organizations:monitors', OrganizationFeature)  # NOQA

--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -17,7 +17,7 @@ logger = logging.getLogger('sentry')
 
 _version_regexp = re.compile(r'^\d+\.\d+\.\d+$')  # We really only want stable releases
 LOADER_FOLDER = os.path.abspath(os.path.join(os.path.dirname(sentry.__file__), 'loader'))
-DEFAULT_VERSION = '4.x'  # DEFAULT_VERSION must exists, in case of 5.0 a new constant should be introduced
+DEFAULT_VERSION = '5.x'  # DEFAULT_VERSION must exists, in case of 5.0 a new constant should be introduced
 
 
 @lru_cache(maxsize=10)
@@ -39,7 +39,7 @@ def get_highest_browser_sdk_version(versions):
 
 
 def get_browser_sdk_version_versions():
-    return ['latest', DEFAULT_VERSION]
+    return ['latest', '4.x', DEFAULT_VERSION]
 
 
 def get_browser_sdk_version_choices():

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
@@ -386,44 +386,39 @@ const KeySettings = createReactClass({
               disabled={!hasAccess}
             />
 
-            <Feature features={['organizations:js-loader']}>
-              <Form
-                saveOnBlur
-                apiEndpoint={apiEndpoint}
-                apiMethod="PUT"
-                initialData={data}
-              >
-                <Panel>
-                  <PanelHeader>{t('JavaScript Loader')}</PanelHeader>
-                  <PanelBody>
-                    <Field
-                      help={tct(
-                        'Copy this script into your website to setup our JavaScript SDK without any additional configuration. [link]',
-                        {
-                          link: (
-                            <ExternalLink href="https://docs.sentry.io/platforms/javascript/browser/">
-                              What does the script provide?
-                            </ExternalLink>
-                          ),
-                        }
-                      )}
-                      inline={false}
-                      flexibleControlStateSize
-                    >
-                      <TextCopyInput>{`<script src='${loaderLink}' crossorigin="anonymous"></script>`}</TextCopyInput>
-                    </Field>
-                    <SelectField
-                      name="browserSdkVersion"
-                      choices={data.browserSdk ? data.browserSdk.choices : []}
-                      placeholder={t('4.x')}
-                      allowClear={false}
-                      enabled={!hasAccess}
-                      help={t('Select the version of the SDK that should be loaded')}
-                    />
-                  </PanelBody>
-                </Panel>
-              </Form>
-            </Feature>
+            <Form saveOnBlur apiEndpoint={apiEndpoint} apiMethod="PUT" initialData={data}>
+              <Panel>
+                <PanelHeader>{t('JavaScript Loader')}</PanelHeader>
+                <PanelBody>
+                  <Field
+                    help={tct(
+                      'Copy this script into your website to setup our JavaScript SDK without any additional configuration. [link]',
+                      {
+                        link: (
+                          <ExternalLink href="https://docs.sentry.io/platforms/javascript/browser/">
+                            What does the script provide?
+                          </ExternalLink>
+                        ),
+                      }
+                    )}
+                    inline={false}
+                    flexibleControlStateSize
+                  >
+                    <TextCopyInput>
+                      {`<script src='${loaderLink}' crossorigin="anonymous"></script>`}
+                    </TextCopyInput>
+                  </Field>
+                  <SelectField
+                    name="browserSdkVersion"
+                    choices={data.browserSdk ? data.browserSdk.choices : []}
+                    placeholder={t('4.x')}
+                    allowClear={false}
+                    enabled={!hasAccess}
+                    help={t('Select the version of the SDK that should be loaded')}
+                  />
+                </PanelBody>
+              </Panel>
+            </Form>
 
             <Panel>
               <PanelHeader>{t('Credentials')}</PanelHeader>

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
@@ -414,7 +414,9 @@ const KeySettings = createReactClass({
                     placeholder={t('4.x')}
                     allowClear={false}
                     enabled={!hasAccess}
-                    help={t('Select the version of the SDK that should be loaded')}
+                    help={t(
+                      'Select the version of the SDK that should be loaded. Note that it can take a few minutes until this change is live.'
+                    )}
                   />
                 </PanelBody>
               </Panel>

--- a/tests/sentry/web/frontend/test_js_sdk_loader.py
+++ b/tests/sentry/web/frontend/test_js_sdk_loader.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import TestCase
+from sentry.loader.browsersdkversion import DEFAULT_VERSION
 
 
 class JavaScriptSdkLoaderTest(TestCase):
@@ -58,7 +59,9 @@ class JavaScriptSdkLoaderTest(TestCase):
 
     @patch('sentry.loader.browsersdkversion.load_version_from_file')
     def test_headers(self, mock_load_version_from_file):
-        mocked_version = '4.9.9'
+        #  We want to always load the major version here since otherwise we fall back to
+        #  the default value which isn't correct.
+        mocked_version = '%s.9.9' % DEFAULT_VERSION[0]
         mock_load_version_from_file.return_value = [mocked_version]
 
         resp = self.client.get(self.path)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1200,56 +1200,56 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@sentry/browser@5.0.0-rc.3":
-  version "5.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.0.0-rc.3.tgz#4fdd46e160de6a86dd60c85161debbe9f742d7f1"
-  integrity sha512-VjwGAectausWvpRL8nr+4fm1xtlzDtnr/kYJFmN8LIA8Wsf1Ue3HhX7euGoG1ZMD52sp94WzOHtfzIgEwcEfaA==
+"@sentry/browser@^5.0.5":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.0.5.tgz#6ef7a9a53aa28081d3b7dcab211de317dac0072e"
+  integrity sha512-LZSuJZLxaNGdEXQ8wUYJuKVkbAJozWPA23k8msTr+GzJSgW94AR86zJjI4EE/BToyE+PpsQ90GeZ2qJMlxVQqg==
   dependencies:
-    "@sentry/core" "5.0.0-rc.3"
-    "@sentry/types" "5.0.0-rc.3"
-    "@sentry/utils" "5.0.0-rc.3"
+    "@sentry/core" "5.0.5"
+    "@sentry/types" "5.0.5"
+    "@sentry/utils" "5.0.5"
     tslib "^1.9.3"
 
-"@sentry/core@5.0.0-rc.3":
-  version "5.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.0.0-rc.3.tgz#16f581fe90f18bac823d331791955bb49236d861"
-  integrity sha512-CBp4ixw5LbuzMDFkJH1v4sQY8KLqWbD/VWezt3n6uCTHFjI5uJ4cMU9aFS91cBTshtmZ5ErpDdmpWhxOpkvNKA==
+"@sentry/core@5.0.5":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.0.5.tgz#415f61c2d0ef442e5cce1e1ab60321d115daea40"
+  integrity sha512-czr5pZwAxzArJJExysqM5oSFVHuRcf/268P+UCkUoBgATcvg95cQYk1FLWDYe+KRlkTj/e09+yp254SEGvkUSw==
   dependencies:
-    "@sentry/hub" "5.0.0-rc.3"
-    "@sentry/minimal" "5.0.0-rc.3"
-    "@sentry/types" "5.0.0-rc.3"
-    "@sentry/utils" "5.0.0-rc.3"
+    "@sentry/hub" "5.0.5"
+    "@sentry/minimal" "5.0.5"
+    "@sentry/types" "5.0.5"
+    "@sentry/utils" "5.0.5"
     tslib "^1.9.3"
 
-"@sentry/hub@5.0.0-rc.3":
-  version "5.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.0.0-rc.3.tgz#5ac368b37294e55e942f2084d8f8783bf5f34b4e"
-  integrity sha512-IySNLXtZLjRhtm0qU53wru/udd3tlSqm/dhCUBAZ5nH2SqdZMHo1YUuSDjWuIYkX/1jcJRMEVBp/XCUDuo8AZA==
+"@sentry/hub@5.0.5":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.0.5.tgz#a6697d0b303ee10908514d16b2930b22bd27f08e"
+  integrity sha512-xkYR1RVIfjjOxOI0zVq7cUMBhJlIpxPZC8XXQsrKQbwLnVUXmssPBGDoSWm6kUXsxXGztvxSYO8s3Y55LgxkvA==
   dependencies:
-    "@sentry/types" "5.0.0-rc.3"
-    "@sentry/utils" "5.0.0-rc.3"
+    "@sentry/types" "5.0.5"
+    "@sentry/utils" "5.0.5"
     tslib "^1.9.3"
 
-"@sentry/minimal@5.0.0-rc.3":
-  version "5.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.0.0-rc.3.tgz#bf4ac122a2ca34c846acd305bf0561deb040d84c"
-  integrity sha512-9/PBwG4qt7PP2bwyq5s1uB0Qg3edFafTspnIJLpIdpTz9dcFzir76xkf3Vj4FyDXkmvORWyAWxRfTfakO6DtXw==
+"@sentry/minimal@5.0.5":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.0.5.tgz#cf0141c92244daf1083122750fa10170b20c1ce1"
+  integrity sha512-zEaS3LlJSW53byhAVWsbCpmxLrQCnBFPYR/bDllPdgQub437FsF0iv2uAg916k6pEjLH6HudO8LSuBKWKtbnSA==
   dependencies:
-    "@sentry/hub" "5.0.0-rc.3"
-    "@sentry/types" "5.0.0-rc.3"
+    "@sentry/hub" "5.0.5"
+    "@sentry/types" "5.0.5"
     tslib "^1.9.3"
 
-"@sentry/types@5.0.0-rc.3":
-  version "5.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.0.0-rc.3.tgz#4f9349d52f9c0e0974b0da09a70705204471e489"
-  integrity sha512-RoTP3WtiOeMiCuXw3GB1GzjKo73XieCpDypqLDYQsrEMn2MaG6K+G+ETewpQUV7b9B9NOZb3yNVUMDs+uHojAg==
+"@sentry/types@5.0.5":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.0.5.tgz#03a7e2db3b187262433982174614e116dcc958c4"
+  integrity sha512-XolmufVfqlW9TPfRhqqLBZpCC5BlgEW2QrBrptsBOlmE3FNS3aHAX2WCgloBVZPK1OWqPi3Ef3A+1cVXx0PA2g==
 
-"@sentry/utils@5.0.0-rc.3":
-  version "5.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.0.0-rc.3.tgz#dc43a11fc4f677ef9ac21d01dd39a7022e5a8c98"
-  integrity sha512-brCwvQwwefep79CicHtx7T/d4SuXIfz4CDG5IZ3RMebX8TmsByIqTKO16B7kHSrTeNLHvQ5vc5htXS54aSfqeA==
+"@sentry/utils@5.0.5":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.0.5.tgz#0623b4df088e96c3d48fb0ec6cb8b44a89a22529"
+  integrity sha512-w8qz/QA+V7cNsguyKGIFRyfmOFKKlVuPzhfar/UKbSdN3BUEsgwu4eapH83c/5RGWrScM6NKiMxyXyEhoLGkFQ==
   dependencies:
-    "@sentry/types" "5.0.0-rc.3"
+    "@sentry/types" "5.0.5"
     tslib "^1.9.3"
 
 "@storybook/addon-a11y@^4.1.3":

--- a/yarn.lock
+++ b/yarn.lock
@@ -1200,56 +1200,56 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@sentry/browser@^5.0.5":
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.0.5.tgz#6ef7a9a53aa28081d3b7dcab211de317dac0072e"
-  integrity sha512-LZSuJZLxaNGdEXQ8wUYJuKVkbAJozWPA23k8msTr+GzJSgW94AR86zJjI4EE/BToyE+PpsQ90GeZ2qJMlxVQqg==
+"@sentry/browser@^5.0.6":
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.0.6.tgz#69add774de20d801942d71c836dd7295cbbb5af3"
+  integrity sha512-I0/3aRECsH0CYxdI9cdUKZdhGAJC5hZXRJjTMVZkShUCiVKFt5uLfZWqc3nnJCKksEeFvJHJ530f9nZ7d0I03Q==
   dependencies:
-    "@sentry/core" "5.0.5"
-    "@sentry/types" "5.0.5"
-    "@sentry/utils" "5.0.5"
+    "@sentry/core" "5.0.6"
+    "@sentry/types" "5.0.6"
+    "@sentry/utils" "5.0.6"
     tslib "^1.9.3"
 
-"@sentry/core@5.0.5":
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.0.5.tgz#415f61c2d0ef442e5cce1e1ab60321d115daea40"
-  integrity sha512-czr5pZwAxzArJJExysqM5oSFVHuRcf/268P+UCkUoBgATcvg95cQYk1FLWDYe+KRlkTj/e09+yp254SEGvkUSw==
+"@sentry/core@5.0.6":
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.0.6.tgz#e8c052d2db3fac50cd6e0bd58ff226233ee76068"
+  integrity sha512-+SOoxMAmi6yhu3ROuUj3qQIedvtpt2XVSoT8iYUwN1U2LZVYM2KFpJKqdpuQt3r1SvEGGEQKYVdGhCGhb6L88Q==
   dependencies:
-    "@sentry/hub" "5.0.5"
-    "@sentry/minimal" "5.0.5"
-    "@sentry/types" "5.0.5"
-    "@sentry/utils" "5.0.5"
+    "@sentry/hub" "5.0.6"
+    "@sentry/minimal" "5.0.6"
+    "@sentry/types" "5.0.6"
+    "@sentry/utils" "5.0.6"
     tslib "^1.9.3"
 
-"@sentry/hub@5.0.5":
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.0.5.tgz#a6697d0b303ee10908514d16b2930b22bd27f08e"
-  integrity sha512-xkYR1RVIfjjOxOI0zVq7cUMBhJlIpxPZC8XXQsrKQbwLnVUXmssPBGDoSWm6kUXsxXGztvxSYO8s3Y55LgxkvA==
+"@sentry/hub@5.0.6":
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.0.6.tgz#d8f71c0ca2f47676c06c1e98c26182e9c4c33e17"
+  integrity sha512-ku4rYu2Fy4VLCzPQGY+Oh6dOcDHC4q98hiMR7+adJ79vHjxAL0H+ig1WUGkuWsFZE87VZ+2NhR08l4rpmsEB9g==
   dependencies:
-    "@sentry/types" "5.0.5"
-    "@sentry/utils" "5.0.5"
+    "@sentry/types" "5.0.6"
+    "@sentry/utils" "5.0.6"
     tslib "^1.9.3"
 
-"@sentry/minimal@5.0.5":
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.0.5.tgz#cf0141c92244daf1083122750fa10170b20c1ce1"
-  integrity sha512-zEaS3LlJSW53byhAVWsbCpmxLrQCnBFPYR/bDllPdgQub437FsF0iv2uAg916k6pEjLH6HudO8LSuBKWKtbnSA==
+"@sentry/minimal@5.0.6":
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.0.6.tgz#7ba633d8d7057e56703124ff30b987021dfb4188"
+  integrity sha512-xPaokcBUlc6excZdfswnZceISpb43elhqHmW2BZ5SXemEOQ6OsUPQ1TosgsQQXqTJ6E0LIltBZoV+eA1FsKj3Q==
   dependencies:
-    "@sentry/hub" "5.0.5"
-    "@sentry/types" "5.0.5"
+    "@sentry/hub" "5.0.6"
+    "@sentry/types" "5.0.6"
     tslib "^1.9.3"
 
-"@sentry/types@5.0.5":
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.0.5.tgz#03a7e2db3b187262433982174614e116dcc958c4"
-  integrity sha512-XolmufVfqlW9TPfRhqqLBZpCC5BlgEW2QrBrptsBOlmE3FNS3aHAX2WCgloBVZPK1OWqPi3Ef3A+1cVXx0PA2g==
+"@sentry/types@5.0.6":
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.0.6.tgz#df1b318977e5308741049cc4f35986cf8255115f"
+  integrity sha512-EJYzjfnTfTQgqR3p6dSvIVZe0xe2Jz+tSmvuPABf7VoCmrFtEYkMCSf5IshMHeebmXUS5prrPSCAgVcIrJC+Bw==
 
-"@sentry/utils@5.0.5":
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.0.5.tgz#0623b4df088e96c3d48fb0ec6cb8b44a89a22529"
-  integrity sha512-w8qz/QA+V7cNsguyKGIFRyfmOFKKlVuPzhfar/UKbSdN3BUEsgwu4eapH83c/5RGWrScM6NKiMxyXyEhoLGkFQ==
+"@sentry/utils@5.0.6":
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.0.6.tgz#2c4371edc7660f395e6229c0fce234a6c0822802"
+  integrity sha512-JsDlCY3t5g+E1a34IqCpqvj8ZGv/t1nPpySxmlXuk4awnvgGTm+zsN+bauzYPTucqqJLHEILsQnasbJa2H15TA==
   dependencies:
-    "@sentry/types" "5.0.5"
+    "@sentry/types" "5.0.6"
     tslib "^1.9.3"
 
 "@storybook/addon-a11y@^4.1.3":


### PR DESCRIPTION
This PR does a few things:

1. It uses the stable release of `@sentry/browser` `5.0.5`
2. It removes the `organizations:js-loader` feature flag and with that enable this interface:

![image](https://user-images.githubusercontent.com/363802/55551759-d43b6680-56db-11e9-98bd-a3eb35943810.png)

This helps people to decide which version of the SDK they want to load when using the loader.

The logic of this was already in place and the way it works is that from now on if you create a new project by default you will get version `5.x` of the browser SDK.
All projects before that will stay on `4.x` and people need to opt-in / change the setting to receive the new SDK.

This is here to not break peoples sites when using the loader. As I said, the functionally was there since the loader existed we just hid the interface since there was no major bump before.

ref: https://github.com/getsentry/sentry-javascript/issues/1965

I've added @benvinegar since this is a new setting for people to concern, once this is ready to merge I will inform Support on this change.