### PR TITLE
ref(symbolicator): Change metrics to be more usable in Datadog

### DIFF
--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -63,8 +63,9 @@ def run_symbolicator(stacktraces, modules, project, arch, signal, request_id_cac
                         signal=signal, stacktraces=stacktraces, modules=modules
                     )
 
-                metrics.incr('events.symbolicator.status.%s' % rv.status_code, tags={
-                    'project_id': project_id
+                metrics.incr('events.symbolicator.status_code', tags={
+                    'status_code': rv.status_code,
+                    'project_id': project_id,
                 })
 
                 if rv.status_code == 404 and request_id:
@@ -76,10 +77,10 @@ def run_symbolicator(stacktraces, modules, project, arch, signal, request_id_cac
 
                 rv.raise_for_status()
                 json = rv.json()
-                metrics.incr(
-                    'events.symbolicator.response.%s' % json['status'],
-                    tags={'project_id': project_id}
-                )
+                metrics.incr('events.symbolicator.response.%s', tags={
+                    'response': json['status'],
+                    'project_id': project_id,
+                })
 
                 if json['status'] == 'pending':
                     default_cache.set(

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -77,7 +77,7 @@ def run_symbolicator(stacktraces, modules, project, arch, signal, request_id_cac
 
                 rv.raise_for_status()
                 json = rv.json()
-                metrics.incr('events.symbolicator.response.%s', tags={
+                metrics.incr('events.symbolicator.response', tags={
                     'response': json['status'],
                     'project_id': project_id,
                 })


### PR DESCRIPTION
During review of our metrics it came up that they are not ideal for analysis in datadog right now. This changes status codes to be tags to make aggregation easier.