### PR TITLE
Add Docker to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -7,3 +7,4 @@ brew 'postgresql@9.6', link: true
 
 tap 'caskroom/cask'
 cask 'chromedriver'
+cask 'docker'


### PR DESCRIPTION
So that this paragraph in [Running the Development Server](https://docs.sentry.io/development/contribute/environment/) is true:

> Next, we need to start up our development services. This includes running services like Postgres, Redis, etc. `sentry devservices` depends on Docker, which should have gotten installed during `make develop`...