### PR TITLE
fix(apidocs) Update the api-docs to use postgres

### DIFF
--- a/api-docs/generator.py
+++ b/api-docs/generator.py
@@ -88,15 +88,13 @@ def drop_db():
     report('db', 'Dropping database')
     config = settings.DATABASES['default']
     drop = Popen(
-        ['psql', '-U', config['USER'], '-h', config['HOST'],
-            '-c', 'DROP DATABASE {}'.format(config['NAME'])],
+        ['dropdb', '-U', config['USER'], '-h', config['HOST'], config['NAME']],
         stdin=PIPE,
         stdout=open(os.devnull, 'r+'))
     drop.communicate()
 
     create = Popen(
-        ['psql', '-U', config['USER'], '-h', config['HOST'],
-            '-c', 'CREATE DATABASE {}'.format(config['NAME'])],
+        ['createdb', '-U', config['USER'], '-h', config['HOST'], config['NAME']],
         stdin=PIPE,
         stdout=open(os.devnull, 'r+'))
     create.communicate()

--- a/api-docs/generator.py
+++ b/api-docs/generator.py
@@ -8,7 +8,7 @@ import logging
 import six
 
 from datetime import datetime
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, check_output
 from six.moves.urllib.parse import urlparse
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -87,17 +87,12 @@ def init_db():
 def drop_db():
     report('db', 'Dropping database')
     config = settings.DATABASES['default']
-    drop = Popen(
-        ['dropdb', '-U', config['USER'], '-h', config['HOST'], config['NAME']],
-        stdin=PIPE,
-        stdout=open(os.devnull, 'r+'))
-    drop.communicate()
-
-    create = Popen(
-        ['createdb', '-U', config['USER'], '-h', config['HOST'], config['NAME']],
-        stdin=PIPE,
-        stdout=open(os.devnull, 'r+'))
-    create.communicate()
+    check_output([
+        'dropdb', '-U', config['USER'], '-h', config['HOST'], config['NAME']
+    ])
+    check_output([
+        'createdb', '-U', config['USER'], '-h', config['HOST'], config['NAME']
+    ])
 
 
 class SentryBox(object):
@@ -122,7 +117,6 @@ class SentryBox(object):
             report('redis', 'Stopping redis server')
             self.redis.kill()
             self.redis.wait()
-        drop_db()
 
 
 def run_scenario(vars, scenario_ident, func):

--- a/api-docs/sentry.conf.py
+++ b/api-docs/sentry.conf.py
@@ -19,8 +19,11 @@ CONF_ROOT = os.path.dirname(__file__)
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': '/tmp/sentry_apidocs.db',
+        'ENGINE': 'sentry.db.postgres',
+        'NAME': 'sentry_api_docs',
+        'USER': 'postgres',
+        'PASSWORD': '',
+        'HOST': '127.0.0.1',
     }
 }
 SENTRY_USE_BIG_INTS = True


### PR DESCRIPTION
With the removal of SQLite from our supported database types we need to update the apidocs generation tool to not use sqlite.