### PR TITLE
fix(app-platform): Save Author on update

### DIFF
--- a/src/sentry/mediators/sentry_apps/updater.py
+++ b/src/sentry/mediators/sentry_apps/updater.py
@@ -26,6 +26,7 @@ class Updater(Mediator):
 
     def call(self):
         self._update_name()
+        self._update_author()
         self._update_scopes()
         self._update_events()
         self._update_webhook_url()
@@ -39,6 +40,10 @@ class Updater(Mediator):
     @if_param('name')
     def _update_name(self):
         self.sentry_app.name = self.name
+
+    @if_param('author')
+    def _update_author(self):
+        self.sentry_app.author = self.author
 
     @if_param('scopes')
     def _update_scopes(self):

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -102,6 +102,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             self.url,
             data={
                 'name': self.published_app.name,
+                'author': 'A Company',
                 'webhookUrl': 'https://newurl.com',
                 'redirectUrl': 'https://newredirecturl.com',
                 'isAlertable': True,
@@ -110,7 +111,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         )
         assert json.loads(response.content) == {
             'name': self.published_app.name,
-            'author': self.published_app.author,
+            'author': 'A Company',
             'slug': self.published_app.slug,
             'scopes': [],
             'events': [],


### PR DESCRIPTION
The `author` field wasn't being saved when updating a Sentry App. This fixes that.