### PR TITLE
fix: Match sqlparse in test to getsentrys version

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -12,4 +12,4 @@ pytest-cov>=2.5.1,<2.6.0
 pytest-timeout==1.2.1
 pytest-xdist>=1.18.0,<1.19.0
 responses>=0.8.1,<0.9.0
-sqlparse==0.2.4
+sqlparse==0.1.19


### PR DESCRIPTION
This version was even out of the range of the sentry requirements-base