### PR TITLE
feat(unreal): Adds custom event payload files to unreal

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -65,7 +65,7 @@ sqlparse>=0.1.16,<0.2.0
 statsd>=3.1.0,<3.2.0
 strict-rfc3339>=0.7
 structlog==16.1.0
-symbolic>=6.0.4,<7.0.0
+symbolic>=6.0.6,<7.0.0
 toronado>=0.0.11,<0.1.0
 ua-parser>=0.6.1,<0.8.0
 # for bitbucket client


### PR DESCRIPTION
This un-featuregates the custom event payload attachment files and adds support
for them to the unreal endpoint.

Depends on https://github.com/getsentry/symbolic/pull/135