### PR TITLE
fix(sidebar): scroll at small viewport heights

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -235,7 +235,7 @@ class Sidebar extends React.Component {
 
     return (
       <StyledSidebar innerRef={this.sidebarRef} collapsed={collapsed}>
-        <SidebarSectionGroup>
+        <SidebarSectionGroupPrimary>
           <SidebarSection>
             <SidebarDropdown
               onClick={this.hidePanel}
@@ -247,90 +247,123 @@ class Sidebar extends React.Component {
             />
           </SidebarSection>
 
-          {hasOrganization && (
-            <React.Fragment>
-              <SidebarSection>
-                <SidebarItem
-                  {...sidebarItemProps}
-                  index
-                  onClick={this.hidePanel}
-                  icon={<InlineSvg src="icon-projects" />}
-                  label={t('Projects')}
-                  to={
-                    hasSentry10
-                      ? `/organizations/${organization.slug}/projects/`
-                      : `/${organization.slug}/`
-                  }
-                />
-                <Feature features={['sentry10']} organization={organization}>
+          <PrimaryItems>
+            {hasOrganization && (
+              <React.Fragment>
+                <SidebarSection>
                   <SidebarItem
                     {...sidebarItemProps}
-                    onClick={(_id, evt) =>
-                      this.navigateWithGlobalSelection(
-                        `/organizations/${organization.slug}/issues/`,
-                        evt
-                      )
+                    index
+                    onClick={this.hidePanel}
+                    icon={<InlineSvg src="icon-projects" />}
+                    label={t('Projects')}
+                    to={
+                      hasSentry10
+                        ? `/organizations/${organization.slug}/projects/`
+                        : `/${organization.slug}/`
                     }
-                    icon={<InlineSvg src="icon-issues" />}
-                    label={t('Issues')}
-                    to={`/organizations/${organization.slug}/issues/`}
-                    id="issues"
                   />
-                </Feature>
-
-                <Feature
-                  features={['events']}
-                  hookName="events-sidebar-item"
-                  organization={organization}
-                >
-                  <SidebarItem
-                    {...sidebarItemProps}
-                    onClick={(_id, evt) =>
-                      this.navigateWithGlobalSelection(
-                        `/organizations/${organization.slug}/events/`,
-                        evt
-                      )
-                    }
-                    icon={<InlineSvg src="icon-stack" />}
-                    label={t('Events')}
-                    to={`/organizations/${organization.slug}/events/`}
-                    id="events"
-                  />
-                </Feature>
-
-                {hasSentry10 && (
-                  <React.Fragment>
+                  <Feature features={['sentry10']} organization={organization}>
                     <SidebarItem
                       {...sidebarItemProps}
                       onClick={(_id, evt) =>
                         this.navigateWithGlobalSelection(
-                          `/organizations/${organization.slug}/releases/`,
+                          `/organizations/${organization.slug}/issues/`,
                           evt
                         )
                       }
-                      icon={<InlineSvg src="icon-releases" />}
-                      label={t('Releases')}
-                      to={`/organizations/${organization.slug}/releases/`}
-                      id="releases"
+                      icon={<InlineSvg src="icon-issues" />}
+                      label={t('Issues')}
+                      to={`/organizations/${organization.slug}/issues/`}
+                      id="issues"
                     />
+                  </Feature>
+
+                  <Feature
+                    features={['events']}
+                    hookName="events-sidebar-item"
+                    organization={organization}
+                  >
                     <SidebarItem
                       {...sidebarItemProps}
                       onClick={(_id, evt) =>
                         this.navigateWithGlobalSelection(
-                          `/organizations/${organization.slug}/user-feedback/`,
+                          `/organizations/${organization.slug}/events/`,
                           evt
                         )
                       }
-                      icon={<InlineSvg src="icon-support" />}
-                      label={t('User Feedback')}
-                      to={`/organizations/${organization.slug}/user-feedback/`}
-                      id="user-feedback"
+                      icon={<InlineSvg src="icon-stack" />}
+                      label={t('Events')}
+                      to={`/organizations/${organization.slug}/events/`}
+                      id="events"
                     />
-                  </React.Fragment>
-                )}
+                  </Feature>
 
-                {!hasSentry10 && (
-                  <Feature features={['discover']} organization={organization}>
+                  {hasSentry10 && (
+                    <React.Fragment>
+                      <SidebarItem
+                        {...sidebarItemProps}
+                        onClick={(_id, evt) =>
+                          this.navigateWithGlobalSelection(
+                            `/organizations/${organization.slug}/releases/`,
+                            evt
+                          )
+                        }
+                        icon={<InlineSvg src="icon-releases" />}
+                        label={t('Releases')}
+                        to={`/organizations/${organization.slug}/releases/`}
+                        id="releases"
+                      />
+                      <SidebarItem
+                        {...sidebarItemProps}
+                        onClick={(_id, evt) =>
+                          this.navigateWithGlobalSelection(
+                            `/organizations/${organization.slug}/user-feedback/`,
+                            evt
+                          )
+                        }
+                        icon={<InlineSvg src="icon-support" />}
+                        label={t('User Feedback')}
+                        to={`/organizations/${organization.slug}/user-feedback/`}
+                        id="user-feedback"
+                      />
+                    </React.Fragment>
+                  )}
+
+                  {!hasSentry10 && (
+                    <Feature features={['discover']} organization={organization}>
+                      <SidebarItem
+                        {...sidebarItemProps}
+                        onClick={this.hidePanel}
+                        icon={<InlineSvg src="icon-discover" />}
+                        label={t('Discover')}
+                        to={`/organizations/${organization.slug}/discover/`}
+                        id="discover"
+                      />
+                    </Feature>
+                  )}
+                </SidebarSection>
+
+                <SidebarSection>
+                  <Feature
+                    features={['sentry10', 'discover']}
+                    organization={organization}
+                  >
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      index
+                      onClick={this.hidePanel}
+                      icon={<InlineSvg src="icon-health" />}
+                      label={t('Dashboards')}
+                      to={`/organizations/${organization.slug}/dashboards/`}
+                      id="customizable-dashboards"
+                    />
+                  </Feature>
+                  <Feature
+                    features={['sentry10', 'discover']}
+                    hookName="discover-sidebar-item"
+                    organization={organization}
+                  >
                     <SidebarItem
                       {...sidebarItemProps}
                       onClick={this.hidePanel}
@@ -340,113 +373,85 @@ class Sidebar extends React.Component {
                       id="discover"
                     />
                   </Feature>
+                  <Feature features={['monitors']} organization={organization}>
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      onClick={(_id, evt) =>
+                        this.navigateWithGlobalSelection(
+                          `/organizations/${organization.slug}/monitors/`,
+                          evt
+                        )
+                      }
+                      icon={<InlineSvg src="icon-labs" />}
+                      label={t('Monitors')}
+                      to={`/organizations/${organization.slug}/monitors/`}
+                      id="monitors"
+                    />
+                  </Feature>
+                </SidebarSection>
+
+                {!hasSentry10 && (
+                  <SidebarSection>
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      onClick={this.hidePanel}
+                      icon={<InlineSvg src="icon-user" />}
+                      label={t('Assigned to me')}
+                      to={`/organizations/${organization.slug}/issues/assigned/`}
+                      id="assigned"
+                    />
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      onClick={this.hidePanel}
+                      icon={<InlineSvg src="icon-star" />}
+                      label={t('Bookmarked issues')}
+                      to={`/organizations/${organization.slug}/issues/bookmarks/`}
+                      id="bookmarks"
+                    />
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      onClick={this.hidePanel}
+                      icon={<InlineSvg src="icon-history" />}
+                      label={t('Recently viewed')}
+                      to={`/organizations/${organization.slug}/issues/history/`}
+                      id="history"
+                    />
+                  </SidebarSection>
                 )}
-              </SidebarSection>
 
-              <SidebarSection>
-                <Feature features={['sentry10', 'discover']} organization={organization}>
-                  <SidebarItem
-                    {...sidebarItemProps}
-                    index
-                    onClick={this.hidePanel}
-                    icon={<InlineSvg src="icon-health" />}
-                    label={t('Dashboards')}
-                    to={`/organizations/${organization.slug}/dashboards/`}
-                    id="customizable-dashboards"
-                  />
-                </Feature>
-                <Feature
-                  features={['sentry10', 'discover']}
-                  hookName="discover-sidebar-item"
-                  organization={organization}
-                >
-                  <SidebarItem
-                    {...sidebarItemProps}
-                    onClick={this.hidePanel}
-                    icon={<InlineSvg src="icon-discover" />}
-                    label={t('Discover')}
-                    to={`/organizations/${organization.slug}/discover/`}
-                    id="discover"
-                  />
-                </Feature>
-                <Feature features={['monitors']} organization={organization}>
-                  <SidebarItem
-                    {...sidebarItemProps}
-                    onClick={(_id, evt) =>
-                      this.navigateWithGlobalSelection(
-                        `/organizations/${organization.slug}/monitors/`,
-                        evt
-                      )
-                    }
-                    icon={<InlineSvg src="icon-labs" />}
-                    label={t('Monitors')}
-                    to={`/organizations/${organization.slug}/monitors/`}
-                    id="monitors"
-                  />
-                </Feature>
-              </SidebarSection>
-
-              {!hasSentry10 && (
                 <SidebarSection>
                   <SidebarItem
                     {...sidebarItemProps}
                     onClick={this.hidePanel}
-                    icon={<InlineSvg src="icon-user" />}
-                    label={t('Assigned to me')}
-                    to={`/organizations/${organization.slug}/issues/assigned/`}
-                    id="assigned"
+                    icon={<InlineSvg src="icon-activity" size="22px" />}
+                    label={t('Activity')}
+                    to={`/organizations/${organization.slug}/activity/`}
+                    id="activity"
                   />
                   <SidebarItem
                     {...sidebarItemProps}
                     onClick={this.hidePanel}
-                    icon={<InlineSvg src="icon-star" />}
-                    label={t('Bookmarked issues')}
-                    to={`/organizations/${organization.slug}/issues/bookmarks/`}
-                    id="bookmarks"
-                  />
-                  <SidebarItem
-                    {...sidebarItemProps}
-                    onClick={this.hidePanel}
-                    icon={<InlineSvg src="icon-history" />}
-                    label={t('Recently viewed')}
-                    to={`/organizations/${organization.slug}/issues/history/`}
-                    id="history"
+                    icon={<InlineSvg src="icon-stats" />}
+                    label={t('Stats')}
+                    to={`/organizations/${organization.slug}/stats/`}
+                    id="stats"
                   />
                 </SidebarSection>
-              )}
 
-              <SidebarSection>
-                <SidebarItem
-                  {...sidebarItemProps}
-                  onClick={this.hidePanel}
-                  icon={<InlineSvg src="icon-activity" size="22px" />}
-                  label={t('Activity')}
-                  to={`/organizations/${organization.slug}/activity/`}
-                  id="activity"
-                />
-                <SidebarItem
-                  {...sidebarItemProps}
-                  onClick={this.hidePanel}
-                  icon={<InlineSvg src="icon-stats" />}
-                  label={t('Stats')}
-                  to={`/organizations/${organization.slug}/stats/`}
-                  id="stats"
-                />
-              </SidebarSection>
-
-              <SidebarSection>
-                <SidebarItem
-                  {...sidebarItemProps}
-                  onClick={this.hidePanel}
-                  icon={<InlineSvg src="icon-settings" />}
-                  label={t('Settings')}
-                  to={`/settings/${organization.slug}/`}
-                  id="settings"
-                />
-              </SidebarSection>
-            </React.Fragment>
-          )}
-        </SidebarSectionGroup>
+                <SidebarSection>
+                  <SidebarItem
+                    {...sidebarItemProps}
+                    onClick={this.hidePanel}
+                    icon={<InlineSvg src="icon-settings" />}
+                    label={t('Settings')}
+                    to={`/settings/${organization.slug}/`}
+                    id="settings"
+                  />
+                </SidebarSection>
+              </React.Fragment>
+            )}
+          </PrimaryItems>
+        </SidebarSectionGroupPrimary>
 
         {hasOrganization && (
           <SidebarSectionGroup>
@@ -558,13 +563,12 @@ const StyledSidebar = styled('div')`
   background: linear-gradient(${p => p.theme.gray4}, ${p => p.theme.gray5});
   color: ${p => p.theme.sidebar.color};
   line-height: 1;
-  padding: 12px 19px 2px; /* Allows for 32px avatars  */
+  padding: 12px 0 2px; /* Allows for 32px avatars  */
   width: ${p => p.theme.sidebar.expandedWidth};
   position: fixed;
   top: 0;
   left: 0;
   bottom: 0;
-  overflow: auto;
   justify-content: space-between;
   z-index: ${p => p.theme.zIndex.sidebar};
   ${responsiveFlex};
@@ -584,11 +588,40 @@ const StyledSidebar = styled('div')`
 
 const SidebarSectionGroup = styled('div')`
   ${responsiveFlex};
-  flex-shrink: 0;
+`;
+
+const SidebarSectionGroupPrimary = styled(SidebarSectionGroup)`
+  /* necessary for child flexing on msedge and ff */
+  min-height: 0;
+`;
+
+const PrimaryItems = styled('div')`
+  overflow: auto;
+  flex: 1;
+  -ms-autohiding-scrollbar: -ms-autohiding-scrollbar;
+
+  &::-webkit-scrollbar {
+    background-color: transparent;
+    width: 8px;
+    margin: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: ${p => p.theme.gray3};
+    border-radius: 8px;
+  }
+
+  @media (max-height: 600px) {
+    border-bottom: 1px solid ${p => p.theme.gray3};
+    padding-bottom: 1em;
+    box-shadow: rgba(0, 0, 0, 0.25) 0px -10px 20px inset;
+  }
 `;
 
 const SidebarSection = styled(SidebarSectionGroup)`
   ${p => !p.noMargin && `margin: ${space(1)} 0`};
+  padding: 0 19px;
+
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     margin: 0 ${space(1)};
   }

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -606,6 +606,8 @@ const SidebarSectionGroupPrimary = styled(SidebarSectionGroup)`
 const PrimaryItems = styled('div')`
   overflow: auto;
   flex: 1;
+  display: flex;
+  flex-direction: column;
 
   @media (max-height: 600px) and (min-width: ${p => p.theme.breakpoints[0]}) {
     border-bottom: 1px solid ${p => p.theme.gray3};
@@ -624,8 +626,8 @@ const PrimaryItems = styled('div')`
   }
 
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
-    display: flex;
     overflow-y: visible;
+    flex-direction: row;
     height: 100%;
     align-items: center;
     border-right: 1px solid ${p => p.theme.gray3};

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -598,23 +598,26 @@ const SidebarSectionGroupPrimary = styled(SidebarSectionGroup)`
 const PrimaryItems = styled('div')`
   overflow: auto;
   flex: 1;
-  -ms-autohiding-scrollbar: -ms-autohiding-scrollbar;
 
-  &::-webkit-scrollbar {
-    background-color: transparent;
-    width: 8px;
-    margin: 4px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: ${p => p.theme.gray3};
-    border-radius: 8px;
-  }
-
-  @media (max-height: 600px) {
+  @media (max-height: 600px) and (min-width: ${p => p.theme.breakpoints[0]}) {
     border-bottom: 1px solid ${p => p.theme.gray3};
     padding-bottom: 1em;
     box-shadow: rgba(0, 0, 0, 0.25) 0px -10px 20px inset;
+
+    &::-webkit-scrollbar {
+      background-color: transparent;
+      width: 8px;
+      margin: 4px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: ${p => p.theme.gray3};
+      border-radius: 8px;
+    }
+  }
+
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    display: flex;
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -581,7 +581,7 @@ const StyledSidebar = styled('div')`
     height: ${p => p.theme.sidebar.mobileHeight};
     bottom: auto;
     width: auto;
-    padding: 0;
+    padding: 0 ${space(1)};
     align-items: center;
   }
 `;
@@ -593,6 +593,13 @@ const SidebarSectionGroup = styled('div')`
 const SidebarSectionGroupPrimary = styled(SidebarSectionGroup)`
   /* necessary for child flexing on msedge and ff */
   min-height: 0;
+  min-width: 0;
+
+  /* expand to fill the entire height on mobile */
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    height: 100%;
+    align-items: center;
+  }
 `;
 
 const PrimaryItems = styled('div')`
@@ -601,8 +608,8 @@ const PrimaryItems = styled('div')`
 
   @media (max-height: 600px) and (min-width: ${p => p.theme.breakpoints[0]}) {
     border-bottom: 1px solid ${p => p.theme.gray3};
-    padding-bottom: 1em;
-    box-shadow: rgba(0, 0, 0, 0.25) 0px -10px 20px inset;
+    padding-bottom: ${p => space(1)};
+    box-shadow: rgba(0, 0, 0, 0.15) 0px -10px 10px inset;
 
     &::-webkit-scrollbar {
       background-color: transparent;
@@ -618,6 +625,16 @@ const PrimaryItems = styled('div')`
 
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     display: flex;
+    overflow-y: visible;
+    height: 100%;
+    align-items: center;
+    border-right: 1px solid ${p => p.theme.gray3};
+    padding-right: ${p => space(1)};
+    box-shadow: rgba(0, 0, 0, 0.15) -10px 0px 10px inset;
+
+    ::-webkit-scrollbar {
+      display: none;
+    }
   }
 `;
 
@@ -626,7 +643,8 @@ const SidebarSection = styled(SidebarSectionGroup)`
   padding: 0 19px;
 
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
-    margin: 0 ${space(1)};
+    margin: 0;
+    padding: 0;
   }
 
   &:empty {

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -608,6 +608,7 @@ const PrimaryItems = styled('div')`
   flex: 1;
   display: flex;
   flex-direction: column;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
 
   @media (max-height: 600px) and (min-width: ${p => p.theme.breakpoints[0]}) {
     border-bottom: 1px solid ${p => p.theme.gray3};

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -564,6 +564,7 @@ const StyledSidebar = styled('div')`
   top: 0;
   left: 0;
   bottom: 0;
+  overflow: auto;
   justify-content: space-between;
   z-index: ${p => p.theme.zIndex.sidebar};
   ${responsiveFlex};

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -594,6 +594,7 @@ const SidebarSectionGroupPrimary = styled(SidebarSectionGroup)`
   /* necessary for child flexing on msedge and ff */
   min-height: 0;
   min-width: 0;
+  flex: 1;
 
   /* expand to fill the entire height on mobile */
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
@@ -614,7 +615,6 @@ const PrimaryItems = styled('div')`
     &::-webkit-scrollbar {
       background-color: transparent;
       width: 8px;
-      margin: 4px;
     }
 
     &::-webkit-scrollbar-thumb {
@@ -630,6 +630,7 @@ const PrimaryItems = styled('div')`
     align-items: center;
     border-right: 1px solid ${p => p.theme.gray3};
     padding-right: ${p => space(1)};
+    margin-right: ${p => space(0.5)};
     box-shadow: rgba(0, 0, 0, 0.15) -10px 0px 10px inset;
 
     ::-webkit-scrollbar {

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
@@ -97,7 +97,7 @@ class SidebarItem extends React.Component {
         >
           <SidebarItemWrapper>
             <SidebarItemIcon>{icon}</SidebarItemIcon>
-            {!collapsed && !isTop && (
+            {!(collapsed || isTop) && (
               <SidebarItemLabel>
                 <LabelHook id={this.props.id}>
                   <TextOverflow>{label}</TextOverflow>

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
@@ -97,7 +97,7 @@ class SidebarItem extends React.Component {
         >
           <SidebarItemWrapper>
             <SidebarItemIcon>{icon}</SidebarItemIcon>
-            {!(collapsed || isTop) && (
+            {!collapsed && !isTop && (
               <SidebarItemLabel>
                 <LabelHook id={this.props.id}>
                   <TextOverflow>{label}</TextOverflow>


### PR DESCRIPTION
Creates a scrollable area at smaller viewports when there are too many elements to fit in the main navigation container:

![scrollerolors](https://user-images.githubusercontent.com/435981/55848040-87eb8e80-5b00-11e9-84c3-bce19f1e9478.gif)

The scrollbar will:
* only appear when the containing element is shorter than the navigation items
* have a standardized look on all versions of chrome and safari

The sidebar shadow and border:
* will appear whenever the browser is shorter than 600px regardless of # of nav elements
* do not look too bad even when no scrollbar is active

Browsers:

* OSX Chrome: Like in the screenshot
* OSX Safari: Like in the screenshot
* OSX Firefox: Classic OSX thin transparent bar
* Win Chrome: Like in the screenshot
* Win Firefox: Big gray bar (see below)
* Win Edge: Autohiding Big gray bar (see below)
* Mobile browsers: See screenshot at bottom

The worst case scenario is Firefox on Windows:

![image](https://user-images.githubusercontent.com/435981/55848304-50c9ad00-5b01-11e9-84f4-be7602b51389.png)

But if you ask me, this is still better than not being able to see all of the items! and (again) it will not appear unless the nav items are taller than the containing box. So we are looking at a small subsection of users who: have small screens, have many navigation items, use unpopular browsers, and are on Windows.

This pull also resolves the same issue on mobile:

![image](https://user-images.githubusercontent.com/435981/55850232-668ea080-5b08-11e9-8cfd-be484c8cbeb9.png)

![image](https://user-images.githubusercontent.com/435981/55850599-d2253d80-5b09-11e9-9125-99bc1bf088c1.png)

