### PR TITLE
fix(ui): Fix duplicate fetchData call in Organization Stream

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -121,6 +121,11 @@ const OrganizationStream = createReactClass({
     const prevQuery = prevProps.location.query;
     const newQuery = this.props.location.query;
 
+    // Wait for saved searches to load before we attempt to fetch stream data
+    if (this.state.savedSearchLoading) {
+      return;
+    }
+
     // If any important url parameter changed or saved search changed
     // reload data.
     if (


### PR DESCRIPTION
On initial mount, fetchData gets called twice and 1 request gets cancelled because of savedSearch request. Make it wait for saved searches request to complete first.

Fixes JAVASCRIPT-630