### PR TITLE
(fix) Fix issue_page.viewed analytics event

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/organization/index.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/organization/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import SentryTypes from 'app/sentryTypes';
+import {analytics} from 'app/utils/analytics';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 
@@ -9,7 +10,15 @@ import GroupDetails from '../shared/groupDetails';
 class OrganizationGroupDetails extends React.Component {
   static propTypes = {
     selection: SentryTypes.GlobalSelection.isRequired,
+    organization: SentryTypes.Organization.isRequired,
   };
+
+  componentDidMount() {
+    analytics('issue_page.viewed', {
+      group_id: parseInt(this.props.params.groupId, 10),
+      org_id: parseInt(this.props.organization.id, 10),
+    });
+  }
 
   render() {
     // eslint-disable-next-line no-unused-vars

--- a/src/sentry/static/sentry/app/views/groupDetails/project/index.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/project/index.jsx
@@ -38,7 +38,6 @@ class ProjectGroupDetails extends React.Component {
     analytics('issue_page.viewed', {
       group_id: parseInt(this.props.params.groupId, 10),
       org_id: parseInt(this.context.organization.id, 10),
-      project_id: parseInt(this.context.project.id, 10),
     });
   }
 

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/groupDetails.jsx
@@ -17,6 +17,7 @@ import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import ProjectsStore from 'app/stores/projectsStore';
 import SentryTypes from 'app/sentryTypes';
+import {analytics} from 'app/utils/analytics';
 
 import {ERROR_TYPES} from '../shared/constants';
 import GroupHeader from '../shared/header';
@@ -32,6 +33,10 @@ const GroupDetails = createReactClass({
     environments: PropTypes.arrayOf(PropTypes.string),
     enableSnuba: PropTypes.bool,
     showGlobalHeader: PropTypes.bool,
+  },
+
+  contextTypes: {
+    organization: SentryTypes.Organization,
   },
 
   childContextTypes: {
@@ -135,6 +140,16 @@ const GroupDetails = createReactClass({
         });
 
         GroupStore.loadInitialData([data]);
+
+        const organization = this.props.organization || this.context.organization;
+        const payload = {
+          group_id: parseInt(data.id, 10),
+          org_id: parseInt(organization.id, 10),
+        };
+        if (project) {
+          payload.project_id = parseInt(project.id, 10);
+        }
+        analytics('issue_page.viewed', payload);
       },
       error: (_, _textStatus, errorThrown) => {
         let errorType = null;

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/groupDetails.jsx
@@ -17,7 +17,6 @@ import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import ProjectsStore from 'app/stores/projectsStore';
 import SentryTypes from 'app/sentryTypes';
-import {analytics} from 'app/utils/analytics';
 
 import {ERROR_TYPES} from '../shared/constants';
 import GroupHeader from '../shared/header';
@@ -33,10 +32,6 @@ const GroupDetails = createReactClass({
     environments: PropTypes.arrayOf(PropTypes.string),
     enableSnuba: PropTypes.bool,
     showGlobalHeader: PropTypes.bool,
-  },
-
-  contextTypes: {
-    organization: SentryTypes.Organization,
   },
 
   childContextTypes: {
@@ -140,16 +135,6 @@ const GroupDetails = createReactClass({
         });
 
         GroupStore.loadInitialData([data]);
-
-        const organization = this.props.organization || this.context.organization;
-        const payload = {
-          group_id: parseInt(data.id, 10),
-          org_id: parseInt(organization.id, 10),
-        };
-        if (project) {
-          payload.project_id = parseInt(project.id, 10);
-        }
-        analytics('issue_page.viewed', payload);
       },
       error: (_, _textStatus, errorThrown) => {
         let errorType = null;


### PR DESCRIPTION
Seems to have broken in https://github.com/getsentry/sentry/pull/11422 with Sentry 10 changes.

Tried putting it in various places like componentDidMount or onGroupChange, but they either don't have the data yet, or are called multiple times. Putting it right after the API call seems to come closest to logging it once.