### PR TITLE
fix: Increase max-age for loader

### DIFF
--- a/src/sentry/web/frontend/js_sdk_loader.py
+++ b/src/sentry/web/frontend/js_sdk_loader.py
@@ -12,7 +12,7 @@ from sentry.web.helpers import render_to_response
 from sentry.loader.browsersdkversion import get_browser_sdk_version
 
 
-CACHE_CONTROL = 'public, max-age=30, s-maxage=60, stale-while-revalidate=315360000, stale-if-error=315360000'
+CACHE_CONTROL = 'public, max-age=600, s-maxage=60, stale-while-revalidate=315360000, stale-if-error=315360000'
 
 
 class JavaScriptSdkLoader(BaseView):


### PR DESCRIPTION
We increase `max-age` timeout from 30s to 10min.
10min is still a reasonable time to react and the loader.