### PR TITLE
feat: Ignore extra arguments to a strategy configuration

### DIFF
--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -163,7 +163,7 @@ class StrategyConfiguration(object):
     delegates = {}
     changelog = None
 
-    def __init__(self, options=None):
+    def __init__(self, options=None, **extra):
         if options is None:
             options = {}
         self.options = options


### PR DESCRIPTION
Since different revisions of the workers will emit different values here
we need to make sure we ignore extra arguments to the strategy config.

Fixes SENTRY-AAV