### PR TITLE
ci(codecov): Always send coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,18 +45,16 @@ script:
   # installing dependencies for after_* steps here ensures they get cached
   # since those steps execute after travis runs `store build cache`
 
-after_success:
+after_failure:
+  - dmesg | tail -n 100
+
+after_script:
   - |
       coverage_files=$(ls .artifacts/*coverage.xml || true)
       if [[ -n "$coverage_files" || -f .artifacts/coverage/cobertura-coverage.xml ]]; then
         pip install codecov
         codecov -e TEST_SUITE
       fi
-
-after_failure:
-  - dmesg | tail -n 100
-
-after_script:
   - npm install -g @zeus-ci/cli
   - zeus upload -t "text/xml+xunit" .artifacts/*junit.xml
   - zeus upload -t "text/xml+coverage" .artifacts/*coverage.xml


### PR DESCRIPTION
We were only sending coverage reports on success which meant that
when tests would fail our coverage numbers would drop by ~50%.