### PR TITLE
fix(search) Don't use organization tag endpoints in sentry9 view

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/tags.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/tags.jsx
@@ -76,6 +76,23 @@ export function fetchProjectTags(orgId, projectId) {
 }
 
 /**
+ * Fetch tag values for a single project. Used for sentry9 views.
+ */
+export function fetchProjectTagValues(api, orgId, projectId, tagKey, search = null) {
+  const url = `/projects/${orgId}/${projectId}/tags/${tagKey}/values/`;
+
+  const query = {};
+  if (search) {
+    query.query = search;
+  }
+
+  return api.requestPromise(url, {
+    method: 'GET',
+    query,
+  });
+}
+
+/**
  * Fetch tags for an organization or a subset or projects.
  */
 export function fetchOrganizationTags(api, orgId, projectIds = null) {

--- a/src/sentry/static/sentry/app/views/stream/stream.jsx
+++ b/src/sentry/static/sentry/app/views/stream/stream.jsx
@@ -21,7 +21,7 @@ import ConfigStore from 'app/stores/configStore';
 import EnvironmentStore from 'app/stores/environmentStore';
 import ErrorRobot from 'app/components/errorRobot';
 import {fetchProjectSavedSearches} from 'app/actionCreators/savedSearches';
-import {fetchTagValues} from 'app/actionCreators/tags';
+import {fetchProjectTagValues} from 'app/actionCreators/tags';
 import GroupStore from 'app/stores/groupStore';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
@@ -662,7 +662,7 @@ const Stream = createReactClass({
   tagValueLoader(key, search) {
     const {orgId} = this.props.params;
     const project = this.getProject();
-    return fetchTagValues(this.api, orgId, key, search, project.id);
+    return fetchProjectTagValues(this.api, orgId, project.slug, key, search);
   },
 
   render() {


### PR DESCRIPTION
We were using the snuba backed organization tag value endpoint in the sentry9 view which doesn't work in on-premise 9.1 as there is no snuba there.

Fixes GH-12661
Fixes SEN-455