### PR TITLE
fix: Use default version for SDK 4.x

### DIFF
--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -17,7 +17,7 @@ logger = logging.getLogger('sentry')
 
 _version_regexp = re.compile(r'^\d+\.\d+\.\d+$')  # We really only want stable releases
 LOADER_FOLDER = os.path.abspath(os.path.join(os.path.dirname(sentry.__file__), 'loader'))
-DEFAULT_VERSION = '5.x'  # DEFAULT_VERSION must exists, in case of 5.0 a new constant should be introduced
+DEFAULT_VERSION = '4.x'  # DEFAULT_VERSION must exists, in case of 5.0 a new constant should be introduced
 
 
 @lru_cache(maxsize=10)
@@ -39,7 +39,7 @@ def get_highest_browser_sdk_version(versions):
 
 
 def get_browser_sdk_version_versions():
-    return ['latest', '4.x', DEFAULT_VERSION]
+    return ['latest', '5.x', DEFAULT_VERSION]
 
 
 def get_browser_sdk_version_choices():


### PR DESCRIPTION
By default we want to use `4.x`