### PR TITLE
fix(ui) Don't render hidden DOM for guides and fix stacking

### DIFF
--- a/src/sentry/static/sentry/app/components/actions/ignore.jsx
+++ b/src/sentry/static/sentry/app/components/actions/ignore.jsx
@@ -119,13 +119,13 @@ export default class IgnoreActions extends React.Component {
           windowChoices={this.getIgnoreWindows()}
         />
         <div className="btn-group">
+          <GuideAnchor target="ignore_delete_discard" type="text" />
           <ActionLink
             {...actionLinkProps}
             className={linkClassName}
             onAction={() => onUpdate({status: 'ignored'})}
           >
             <span className="icon-ban hidden-xs" style={{marginRight: 5}} />
-            <GuideAnchor target="ignore_delete_discard" type="text" />
             {t('Ignore')}
           </ActionLink>
 

--- a/src/sentry/static/sentry/app/components/actions/resolve.jsx
+++ b/src/sentry/static/sentry/app/components/actions/resolve.jsx
@@ -126,6 +126,7 @@ export default class ResolveActions extends React.Component {
           projectId={projectId}
         />
         <div className="btn-group">
+          <GuideAnchor target="resolve" type="text" />
           <ActionLink
             {...actionLinkProps}
             title={'Resolve'}
@@ -133,7 +134,6 @@ export default class ResolveActions extends React.Component {
             onAction={() => onUpdate({status: 'resolved'})}
           >
             <span className="icon-checkmark hidden-xs" style={{marginRight: 5}} />
-            <GuideAnchor target="resolve" type="text" />
             {t('Resolve')}
           </ActionLink>
 

--- a/src/sentry/static/sentry/app/components/assistant/guideAnchor.jsx
+++ b/src/sentry/static/sentry/app/components/assistant/guideAnchor.jsx
@@ -64,6 +64,10 @@ const GuideAnchor = createReactClass({
 
   render() {
     const {target, type} = this.props;
+    const {active} = this.state;
+    if (!active) {
+      return this.props.children ? this.props.children : null;
+    }
 
     return (
       <GuideAnchorContainer innerRef={el => (this.anchorElement = el)} type={type}>

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/actions.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/actions.jsx
@@ -84,6 +84,7 @@ class DeleteActions extends React.Component {
   render() {
     return (
       <div className="btn-group">
+        <GuideAnchor type="text" target="ignore_delete_discard" />
         <LinkWithConfirmation
           className="group-remove btn btn-default btn-sm"
           title={t('Delete')}
@@ -93,7 +94,6 @@ class DeleteActions extends React.Component {
           onConfirm={this.props.onDelete}
         >
           <span className="icon-trash" />
-          <GuideAnchor type="text" target="ignore_delete_discard" />
         </LinkWithConfirmation>
         <DropdownLink caret={true} className="group-delete btn btn-default btn-sm">
           <MenuItem onClick={this.openDiscardModal}>

--- a/tests/js/spec/components/actions/__snapshots__/ignore.spec.jsx.snap
+++ b/tests/js/spec/components/actions/__snapshots__/ignore.spec.jsx.snap
@@ -233,6 +233,10 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
     <div
       className="btn-group"
     >
+      <GuideAnchor
+        target="ignore_delete_discard"
+        type="text"
+      />
       <ActionLink
         className="btn btn-default btn-sm"
         confirmLabel="Ignore"
@@ -265,35 +269,6 @@ exports[`IgnoreActions with confirmation step renders 1`] = `
                 }
               }
             />
-            <GuideAnchor
-              target="ignore_delete_discard"
-              type="text"
-            >
-              <GuideAnchorContainer
-                innerRef={[Function]}
-                type="text"
-              >
-                <div
-                  className="css-9u5for-GuideAnchorContainer e130o4350"
-                  type="text"
-                >
-                  <StyledGuideAnchor
-                    active={false}
-                    className="guide-anchor-ping ignore_delete_discard"
-                  >
-                    <div
-                      className="guide-anchor-ping ignore_delete_discard css-1yndvnf-StyledGuideAnchor e130o4351"
-                    >
-                      <StyledGuideAnchorRipples>
-                        <div
-                          className="css-3zj3g7-StyledGuideAnchorRipples e130o4352"
-                        />
-                      </StyledGuideAnchorRipples>
-                    </div>
-                  </StyledGuideAnchor>
-                </div>
-              </GuideAnchorContainer>
-            </GuideAnchor>
             Ignore
           </a>
           <Modal
@@ -6304,6 +6279,10 @@ exports[`IgnoreActions without confirmation renders 1`] = `
     <div
       className="btn-group"
     >
+      <GuideAnchor
+        target="ignore_delete_discard"
+        type="text"
+      />
       <ActionLink
         className="btn btn-default btn-sm"
         confirmLabel="Ignore"
@@ -6325,35 +6304,6 @@ exports[`IgnoreActions without confirmation renders 1`] = `
               }
             }
           />
-          <GuideAnchor
-            target="ignore_delete_discard"
-            type="text"
-          >
-            <GuideAnchorContainer
-              innerRef={[Function]}
-              type="text"
-            >
-              <div
-                className="css-9u5for-GuideAnchorContainer e130o4350"
-                type="text"
-              >
-                <StyledGuideAnchor
-                  active={false}
-                  className="guide-anchor-ping ignore_delete_discard"
-                >
-                  <div
-                    className="guide-anchor-ping ignore_delete_discard css-1yndvnf-StyledGuideAnchor e130o4351"
-                  >
-                    <StyledGuideAnchorRipples>
-                      <div
-                        className="css-3zj3g7-StyledGuideAnchorRipples e130o4352"
-                      />
-                    </StyledGuideAnchorRipples>
-                  </div>
-                </StyledGuideAnchor>
-              </div>
-            </GuideAnchorContainer>
-          </GuideAnchor>
           Ignore
         </a>
       </ActionLink>

--- a/tests/js/spec/components/actions/__snapshots__/resolve.spec.jsx.snap
+++ b/tests/js/spec/components/actions/__snapshots__/resolve.spec.jsx.snap
@@ -82,6 +82,10 @@ exports[`ResolveActions with confirmation step renders 1`] = `
     <div
       className="btn-group"
     >
+      <GuideAnchor
+        target="resolve"
+        type="text"
+      />
       <ActionLink
         className="btn btn-default btn-sm"
         confirmLabel="Resolve"
@@ -114,35 +118,6 @@ exports[`ResolveActions with confirmation step renders 1`] = `
                 }
               }
             />
-            <GuideAnchor
-              target="resolve"
-              type="text"
-            >
-              <GuideAnchorContainer
-                innerRef={[Function]}
-                type="text"
-              >
-                <div
-                  className="css-9u5for-GuideAnchorContainer e130o4350"
-                  type="text"
-                >
-                  <StyledGuideAnchor
-                    active={false}
-                    className="guide-anchor-ping resolve"
-                  >
-                    <div
-                      className="guide-anchor-ping resolve css-1yndvnf-StyledGuideAnchor e130o4351"
-                    >
-                      <StyledGuideAnchorRipples>
-                        <div
-                          className="css-3zj3g7-StyledGuideAnchorRipples e130o4352"
-                        />
-                      </StyledGuideAnchorRipples>
-                    </div>
-                  </StyledGuideAnchor>
-                </div>
-              </GuideAnchorContainer>
-            </GuideAnchor>
             Resolve
           </a>
           <Modal
@@ -545,6 +520,10 @@ exports[`ResolveActions without confirmation renders 1`] = `
     <div
       className="btn-group"
     >
+      <GuideAnchor
+        target="resolve"
+        type="text"
+      />
       <ActionLink
         className="btn btn-default btn-sm"
         confirmLabel="Resolve"
@@ -566,35 +545,6 @@ exports[`ResolveActions without confirmation renders 1`] = `
               }
             }
           />
-          <GuideAnchor
-            target="resolve"
-            type="text"
-          >
-            <GuideAnchorContainer
-              innerRef={[Function]}
-              type="text"
-            >
-              <div
-                className="css-9u5for-GuideAnchorContainer e130o4350"
-                type="text"
-              >
-                <StyledGuideAnchor
-                  active={false}
-                  className="guide-anchor-ping resolve"
-                >
-                  <div
-                    className="guide-anchor-ping resolve css-1yndvnf-StyledGuideAnchor e130o4351"
-                  >
-                    <StyledGuideAnchorRipples>
-                      <div
-                        className="css-3zj3g7-StyledGuideAnchorRipples e130o4352"
-                      />
-                    </StyledGuideAnchorRipples>
-                  </div>
-                </StyledGuideAnchor>
-              </div>
-            </GuideAnchorContainer>
-          </GuideAnchor>
           Resolve
         </a>
       </ActionLink>

--- a/tests/js/spec/components/assistant/__snapshots__/guideAnchor.spec.jsx.snap
+++ b/tests/js/spec/components/assistant/__snapshots__/guideAnchor.spec.jsx.snap
@@ -1,18 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GuideAnchor renders 1`] = `
-<GuideAnchorContainer
-  innerRef={[Function]}
-  type="text"
->
-  <StyledGuideAnchor
-    active={false}
-    className="guide-anchor-ping target 1"
-  >
-    <StyledGuideAnchorRipples />
-  </StyledGuideAnchor>
-</GuideAnchorContainer>
-`;
+exports[`GuideAnchor renders 1`] = `""`;
 
 exports[`GuideAnchor turns active when guide state changes 1`] = `
 <GuideAnchorContainer

--- a/tests/js/spec/components/assistant/guideAnchor.spec.jsx
+++ b/tests/js/spec/components/assistant/guideAnchor.spec.jsx
@@ -28,4 +28,16 @@ describe('GuideAnchor', function() {
     expect(component.state).toEqual({active: true});
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('renders no container when inactive', function() {
+    const wrapper = shallow(
+      <GuideAnchor target="target 1" type="text">
+        <span>A child</span>
+      </GuideAnchor>
+    );
+    const component = wrapper.instance();
+    wrapper.update();
+    expect(component.state).toEqual({active: false});
+    expect(wrapper.find('GuideAnchorContainer')).toHaveLength(0);
+  });
 });

--- a/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
@@ -915,43 +915,19 @@ exports[`projectAlertRules renders 1`] = `
                                     target="alert_conditions"
                                     type="text"
                                   >
-                                    <GuideAnchorContainer
-                                      innerRef={[Function]}
-                                      type="text"
+                                    <table
+                                      className="conditions-list table"
                                     >
-                                      <div
-                                        className="css-9u5for-GuideAnchorContainer e130o4350"
-                                        type="text"
-                                      >
-                                        <table
-                                          className="conditions-list table"
+                                      <tbody>
+                                        <tr
+                                          key="0"
                                         >
-                                          <tbody>
-                                            <tr
-                                              key="0"
-                                            >
-                                              <td>
-                                                An alert is first seen
-                                              </td>
-                                            </tr>
-                                          </tbody>
-                                        </table>
-                                        <StyledGuideAnchor
-                                          active={false}
-                                          className="guide-anchor-ping alert_conditions"
-                                        >
-                                          <div
-                                            className="guide-anchor-ping alert_conditions css-1yndvnf-StyledGuideAnchor e130o4351"
-                                          >
-                                            <StyledGuideAnchorRipples>
-                                              <div
-                                                className="css-3zj3g7-StyledGuideAnchorRipples e130o4352"
-                                              />
-                                            </StyledGuideAnchorRipples>
-                                          </div>
-                                        </StyledGuideAnchor>
-                                      </div>
-                                    </GuideAnchorContainer>
+                                          <td>
+                                            An alert is first seen
+                                          </td>
+                                        </tr>
+                                      </tbody>
+                                    </table>
                                   </GuideAnchor>
                                 </div>
                               </Condition>
@@ -985,43 +961,19 @@ exports[`projectAlertRules renders 1`] = `
                                     target="alert_actions"
                                     type="text"
                                   >
-                                    <GuideAnchorContainer
-                                      innerRef={[Function]}
-                                      type="text"
+                                    <table
+                                      className="actions-list table"
                                     >
-                                      <div
-                                        className="css-9u5for-GuideAnchorContainer e130o4350"
-                                        type="text"
-                                      >
-                                        <table
-                                          className="actions-list table"
+                                      <tbody>
+                                        <tr
+                                          key="0"
                                         >
-                                          <tbody>
-                                            <tr
-                                              key="0"
-                                            >
-                                              <td>
-                                                Send a notification to all services
-                                              </td>
-                                            </tr>
-                                          </tbody>
-                                        </table>
-                                        <StyledGuideAnchor
-                                          active={false}
-                                          className="guide-anchor-ping alert_actions"
-                                        >
-                                          <div
-                                            className="guide-anchor-ping alert_actions css-1yndvnf-StyledGuideAnchor e130o4351"
-                                          >
-                                            <StyledGuideAnchorRipples>
-                                              <div
-                                                className="css-3zj3g7-StyledGuideAnchorRipples e130o4352"
-                                              />
-                                            </StyledGuideAnchorRipples>
-                                          </div>
-                                        </StyledGuideAnchor>
-                                      </div>
-                                    </GuideAnchorContainer>
+                                          <td>
+                                            Send a notification to all services
+                                          </td>
+                                        </tr>
+                                      </tbody>
+                                    </table>
                                   </GuideAnchor>
                                 </div>
                               </Condition>


### PR DESCRIPTION
We don't need to emit any DOM for guide anchors when they are not active. This saves us a some DOM nodes and constantly running animations on invisible elements.

By shuffling the guide anchor locations around in the DOM the guides now correctly render on top of the split button dropdowns.

![Screen Shot 2019-04-08 at 12 32 57 PM](https://user-images.githubusercontent.com/24086/55741119-846ddf80-59fa-11e9-86c1-7d97b806385b.png)
