### PR TITLE
refs: Convert sqlite test run to just run riak tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,17 +147,19 @@ matrix:
       name: 'Backend [Postgres] (Rust Interface Renormalization)'
       env: TEST_SUITE=postgres DB=postgres SENTRY_TEST_USE_RUST_INTERFACE_RENORMALIZATION=1
 
-    # only the sqlite suite runs riak tests
     - python: 2.7
-      name: 'Backend [SQLite]'
-      env: TEST_SUITE=sqlite DB=sqlite
+      name: 'Backend [Riak]'
+      env: TEST_SUITE=riak DB=postgres
       services:
         - memcached
-        - riak
         - redis-server
+        - postgresql
+        - riak
       install:
         - python setup.py install_egg_info
         - pip install -e ".[dev,tests,optional]"
+      before_script:
+        - psql -c 'create database sentry;' -U postgres
 
     - <<: *acceptance_default
       name: 'Acceptance (1/2)'

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,12 @@ else
 endif
 	@echo ""
 
+test-riak:
+	sentry init
+	@echo "--> Running Riak tests"
+	py.test tests/sentry/nodestore/riak/backend --cov . --cov-report="xml:.artifacts/riak.coverage.xml" --junit-xml=".artifacts/riak.junit.xml" || exit 1
+	@echo ""
+
 test-snuba:
 	@echo "--> Running snuba tests"
 	py.test tests/snuba tests/sentry/eventstream/kafka -vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml" --junit-xml=".artifacts/snuba.junit.xml"
@@ -210,8 +216,7 @@ travis-noop:
 .PHONY: travis-test-lint
 travis-test-lint: lint-python lint-js
 
-.PHONY: travis-test-sqlite travis-test-postgres travis-test-mysql travis-test-acceptance travis-test-snuba travis-test-symbolicator travis-test-js travis-test-cli travis-test-dist
-travis-test-sqlite: test-python
+.PHONY: travis-test-postgres travis-test-mysql travis-test-acceptance travis-test-snuba travis-test-symbolicator travis-test-js travis-test-cli travis-test-dist travis-test-riak
 travis-test-postgres: test-python
 travis-test-mysql: test-python
 travis-test-acceptance: test-acceptance
@@ -226,15 +231,15 @@ travis-test-dist:
 	# See: https://github.com/travis-ci/travis-ci/issues/4704
 	SENTRY_BUILD=$(TRAVIS_COMMIT) SENTRY_LIGHT_BUILD=0 python setup.py -q sdist bdist_wheel
 	@ls -lh dist/
+travis-test-riak: test-riak
 
-.PHONY: scan-python travis-scan-sqlite travis-scan-postgres travis-scan-mysql travis-scan-acceptance travis-scan-snuba travis-scan-symbolicator travis-scan-js travis-scan-cli travis-scan-dist travis-scan-lint
+.PHONY: scan-python travis-scan-postgres travis-scan-mysql travis-scan-acceptance travis-scan-snuba travis-scan-symbolicator travis-scan-js travis-scan-cli travis-scan-dist travis-scan-lint travis-scan-riak
 scan-python:
 	@echo "--> Running Python vulnerability scanner"
 	$(PIP) install safety
 	bin/scan
 	@echo ""
 
-travis-scan-sqlite: scan-python
 travis-scan-postgres: scan-python
 travis-scan-mysql: scan-python
 travis-scan-acceptance: travis-noop
@@ -244,3 +249,4 @@ travis-scan-js: travis-noop
 travis-scan-cli: travis-noop
 travis-scan-dist: travis-noop
 travis-scan-lint: travis-noop
+travis-scan-riak: scan-python


### PR DESCRIPTION
We still want to run the Riak tests, but don't want to add it to every build. Converting the
sqlite test run to only test Riak, so that it's relatively fast and we can then remove sqlite related code.