### PR TITLE
feat: Enabled grouping enhancements for old legacy strategies

### DIFF
--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -77,7 +77,7 @@ register_strategy_config(
     ],
     changelog='''
         * New grouping strategy optimized for native and javascript
-        * Supports grouping enhancements.
+        * Not compatible with the old legacy grouping
     '''
 )
 

--- a/src/sentry/grouping/strategies/legacy.py
+++ b/src/sentry/grouping/strategies/legacy.py
@@ -487,6 +487,7 @@ def stacktrace_legacy(stacktrace, config, variant, **meta):
 
     values = []
     prev_frame = None
+    frames_for_filtering = []
     for frame in frames:
         frame_component = config.get_grouping_component(frame, variant=variant, **meta)
         if variant == 'app' and not frame.in_app and not all_frames_considered_in_app:
@@ -504,7 +505,11 @@ def stacktrace_legacy(stacktrace, config, variant, **meta):
                 hint='frame considered in-app because no frame is in-app'
             )
         values.append(frame_component)
+        frames_for_filtering.append(frame.get_raw_data())
         prev_frame = frame
+
+    config.enhancements.update_frame_components_contributions(
+        values, frames_for_filtering, meta['event'].platform)
 
     return GroupingComponent(
         id='stacktrace',

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -340,7 +340,7 @@ def stacktrace_v1(stacktrace, config, variant, **meta):
                 hint='frame considered in-app because no frame is in-app'
             )
         values.append(frame_component)
-        frames_for_filtering.append(frame._data)
+        frames_for_filtering.append(frame.get_raw_data())
         prev_frame = frame
 
     config.enhancements.update_frame_components_contributions(

--- a/src/sentry/interfaces/base.py
+++ b/src/sentry/interfaces/base.py
@@ -148,6 +148,10 @@ class Interface(object):
         """
         return cls(**data) if data is not None else None
 
+    def get_raw_data(self):
+        """Returns the underlying raw data."""
+        return self._data
+
     def get_api_context(self, is_public=False):
         return self.to_json()
 

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy:2019_03_12/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy:2019_03_12/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-03T22:37:15.475204Z'
+created: '2019-04-09T07:38:26.537674Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -44,16 +44,16 @@ system:
           frame
             function (function name is used only if module or filename are available)
               u'_main'
-          frame
+          frame (marked out of app by grouping enhancement rule)
             function (function name is used only if module or filename are available)
               u'std::rt::lang_start_internal'
           frame
             function (function name is used only if module or filename are available)
               u'___rust_maybe_catch_panic'
-          frame
+          frame (marked out of app by grouping enhancement rule)
             function (function name is used only if module or filename are available)
               u'std::panicking::try::do_call'
-          frame
+          frame (marked out of app by grouping enhancement rule)
             function (function name is used only if module or filename are available)
               u'std::rt::lang_start::{{closure}}'
           frame

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy:2019_03_12/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy:2019_03_12/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-07T13:12:38.163514Z'
+created: '2019-04-09T07:38:26.571613Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -44,16 +44,16 @@ system:
           frame
             function (function name is used only if module or filename are available)
               u'_main'
-          frame
+          frame (marked out of app by grouping enhancement rule)
             function (function name is used only if module or filename are available)
               u'std::rt::lang_start_internal'
           frame
             function (function name is used only if module or filename are available)
               u'___rust_maybe_catch_panic'
-          frame
+          frame (marked out of app by grouping enhancement rule)
             function (function name is used only if module or filename are available)
               u'std::panicking::try::do_call'
-          frame
+          frame (marked out of app by grouping enhancement rule)
             function (function name is used only if module or filename are available)
               u'std::rt::lang_start::{{closure}}'
           frame


### PR DESCRIPTION
This pull request adds support for the grouping enhancements on the legacy config.
Now that the bases are separated there is no reason to not support it on the legacy
strategy as well.