### PR TITLE
fix(tests) Fix the selectors used to wait on

### DIFF
--- a/src/sentry/static/sentry/app/components/actions/ignore.jsx
+++ b/src/sentry/static/sentry/app/components/actions/ignore.jsx
@@ -83,7 +83,11 @@ export default class IgnoreActions extends React.Component {
       return (
         <div className="btn-group">
           <Tooltip title={t('Change status to unresolved')}>
-            <a className={linkClassName} onClick={() => onUpdate({status: 'unresolved'})}>
+            <a
+              className={linkClassName}
+              data-test-id="button-unresolve"
+              onClick={() => onUpdate({status: 'unresolved'})}
+            >
               <span className="icon-ban" />
             </a>
           </Tooltip>

--- a/tests/acceptance/pages.py
+++ b/tests/acceptance/pages.py
@@ -41,13 +41,13 @@ class IssueDetailsPage(BasePage):
 
     def resolve_issue(self):
         self.browser.click('[data-test-id="action-link-resolve"]')
-        # Resolve should become active
-        self.browser.wait_until('.btn.active')
+        # Resolve should become unresolve
+        self.browser.wait_until('[data-test-id="button-unresolve"]')
 
     def ignore_issue(self):
         self.browser.click('[data-test-id="action-link-ignore"]')
-        # Ignore should become active
-        self.browser.wait_until('.btn.active')
+        # Ignore should become unresolve
+        self.browser.wait_until('[data-test-id="button-unresolve"]')
 
     def bookmark_issue(self):
         self.browser.click('.group-bookmark')

--- a/tests/acceptance/test_issue_details_workflow.py
+++ b/tests/acceptance/test_issue_details_workflow.py
@@ -48,7 +48,6 @@ class IssueDetailsWorkflowTest(AcceptanceTestCase, SnubaTestCase):
         )
         with self.feature('organizations:sentry10'):
             self.page.visit_issue(self.org.slug, event.group.id)
-            self.browser.save_screenshot('resolve.png')
             self.page.resolve_issue()
 
             res = self.page.api_issue_get(event.group.id)


### PR DESCRIPTION
While the ignore/resolve buttons do become `active` there are other buttons on the page that are already active. Using test-ids will reduce the window for races to occur.