### PR TITLE
fix: Fix some unstable tests

### DIFF
--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -108,7 +108,9 @@ class SlackIntegrationTest(IntegrationTestCase):
         self.assert_setup_flow()
         self.assert_setup_flow(team_id='TXXXXXXX2', authorizing_user_id='UXXXXXXX2')
 
-        integrations = Integration.objects.filter(provider=self.provider.key)
+        integrations = Integration.objects.filter(
+            provider=self.provider.key,
+        ).order_by('external_id')
 
         assert integrations.count() == 2
         assert integrations[0].external_id == 'TXXXXXXX1'

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -4,6 +4,7 @@ import pytest
 import six
 
 from django.utils import timezone
+from freezegun import freeze_time
 from mock import patch
 
 from sentry.api.exceptions import InvalidRepository
@@ -322,6 +323,7 @@ class SetCommitsTestCase(TestCase):
         assert release.authors == [six.text_type(author.id)]
         assert release.last_commit_id == latest_commit.id
 
+    @freeze_time()
     def test_using_saved_data(self):
         org = self.create_organization()
         project = self.create_project(organization=org, name='foo')


### PR DESCRIPTION
`test_using_saved_data`: Failed due to a second boundary issue. Just freezing time to resolve
`test_multiple_integrations`: Database query not using an order, so sometimes we'll fetch in a
different order and fail. Specified order to resolve.