### PR TITLE
fix(app-platform): Better Sentry App errors

### DIFF
--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -42,14 +42,25 @@ class SchemaField(serializers.WritableField):
             raise ValidationError(e.message)
 
 
+class URLField(serializers.URLField):
+    def validate(self, url):
+        # The Django URLField doesn't distinguish between different types of
+        # invalid URLs, so do any manual checks here to give the User a better
+        # error message.
+        if not url.startswith('http'):
+            raise ValidationError('URL must start with http[s]://')
+
+        super(URLField, self).validate(url)
+
+
 class SentryAppSerializer(Serializer):
     name = serializers.CharField()
     author = serializers.CharField()
     scopes = ApiScopesField()
     events = EventListField(required=False)
     schema = SchemaField(required=False)
-    webhookUrl = serializers.URLField()
-    redirectUrl = serializers.URLField(required=False)
+    webhookUrl = URLField()
+    redirectUrl = URLField(required=False)
     isAlertable = serializers.BooleanField(required=False)
     overview = serializers.CharField(required=False)
 

--- a/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
+++ b/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
@@ -66,6 +66,14 @@ const forms = [
           }
           return schema;
         },
+        validate: ({id, form}) => {
+          try {
+            JSON.parse(form.schema);
+          } catch (e) {
+            return [[id, 'Invalid JSON']];
+          }
+          return [];
+        },
       },
       {
         name: 'overview',

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
@@ -22,7 +22,7 @@ describe('Sentry Application Details', function() {
     orgId = org.slug;
   });
 
-  describe('new sentry application', () => {
+  describe('Creating a new Sentry App', () => {
     beforeEach(() => {
       createAppRequest = Client.addMockResponse({
         url: '/sentry-apps/',
@@ -36,71 +36,77 @@ describe('Sentry Application Details', function() {
       );
     });
 
-    describe('renders()', () => {
-      it('it shows empty scopes and no credentials', function() {
-        // new app starts off with no scopes selected
-        expect(wrapper.find('PermissionsObserver').prop('scopes')).toEqual([]);
-        expect(
-          wrapper.find('PanelHeader').findWhere(h => h.text() == 'Permissions')
-        ).toBeDefined();
-      });
+    it('it shows empty scopes and no credentials', function() {
+      // new app starts off with no scopes selected
+      expect(wrapper.find('PermissionsObserver').prop('scopes')).toEqual([]);
+      expect(
+        wrapper.find('PanelHeader').findWhere(h => h.text() == 'Permissions')
+      ).toBeDefined();
     });
 
-    describe('saving new app', () => {
-      it('updates a SentryApp', function() {
-        wrapper
-          .find('Input[name="name"]')
-          .simulate('change', {target: {value: 'Test App'}});
-        wrapper
-          .find('Input[name="author"]')
-          .simulate('change', {target: {value: 'Sentry'}});
-        wrapper
-          .find('Input[name="webhookUrl"]')
-          .simulate('change', {target: {value: 'https://webhook.com'}});
-        wrapper
-          .find('Input[name="redirectUrl"]')
-          .simulate('change', {target: {value: 'https://webhook.com/setup'}});
-        wrapper.find('Switch[name="isAlertable"]').simulate('click');
-        selectByValue(wrapper, 'admin', {name: 'Member--permission'});
-        selectByValue(wrapper, 'admin', {name: 'Event--permission'});
-        wrapper
-          .find('Checkbox')
-          .first()
-          .simulate('change', {target: {checked: true}});
-        wrapper.find('form').simulate('submit');
+    it('saves', function() {
+      wrapper
+        .find('Input[name="name"]')
+        .simulate('change', {target: {value: 'Test App'}});
 
-        const data = {
-          name: 'Test App',
-          author: 'Sentry',
-          organization: org.slug,
-          redirectUrl: 'https://webhook.com/setup',
-          webhookUrl: 'https://webhook.com',
-          scopes: observable([
-            'member:read',
-            'member:admin',
-            'event:read',
-            'event:admin',
-          ]),
-          events: observable(['issue']),
-          isAlertable: true,
-          schema: {},
-        };
+      wrapper
+        .find('Input[name="author"]')
+        .simulate('change', {target: {value: 'Sentry'}});
 
-        expect(createAppRequest).toHaveBeenCalledWith(
-          '/sentry-apps/',
-          expect.objectContaining({
-            data,
-            method: 'POST',
-          })
-        );
-      });
+      wrapper
+        .find('Input[name="webhookUrl"]')
+        .simulate('change', {target: {value: 'https://webhook.com'}});
+
+      wrapper
+        .find('Input[name="redirectUrl"]')
+        .simulate('change', {target: {value: 'https://webhook.com/setup'}});
+
+      wrapper.find('TextArea[name="schema"]').simulate('change', {target: {value: '{}'}});
+
+      wrapper.find('Switch[name="isAlertable"]').simulate('click');
+
+      selectByValue(wrapper, 'admin', {name: 'Member--permission'});
+      selectByValue(wrapper, 'admin', {name: 'Event--permission'});
+
+      wrapper
+        .find('Checkbox')
+        .first()
+        .simulate('change', {target: {checked: true}});
+
+      wrapper.find('form').simulate('submit');
+
+      const data = {
+        name: 'Test App',
+        author: 'Sentry',
+        organization: org.slug,
+        redirectUrl: 'https://webhook.com/setup',
+        webhookUrl: 'https://webhook.com',
+        scopes: observable(['member:read', 'member:admin', 'event:read', 'event:admin']),
+        events: observable(['issue']),
+        isAlertable: true,
+        schema: {},
+      };
+
+      expect(createAppRequest).toHaveBeenCalledWith(
+        '/sentry-apps/',
+        expect.objectContaining({
+          data,
+          method: 'POST',
+        })
+      );
     });
   });
 
-  describe('edit existing application', () => {
+  describe('editing an existing Sentry App', () => {
     beforeEach(() => {
       sentryApp = TestStubs.SentryApp();
-      const appSlug = sentryApp.slug;
+      sentryApp.events = ['issue'];
+
+      editAppRequest = Client.addMockResponse({
+        url: `/sentry-apps/${sentryApp.slug}/`,
+        method: 'PUT',
+        body: [],
+      });
 
       Client.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/`,
@@ -108,78 +114,73 @@ describe('Sentry Application Details', function() {
       });
 
       wrapper = mount(
-        <SentryApplicationDetails params={{appSlug, orgId}} />,
+        <SentryApplicationDetails params={{appSlug: sentryApp.slug, orgId}} />,
         TestStubs.routerContext()
       );
     });
 
-    describe('renders()', () => {
-      it('it shows application data and credentials', function() {
-        // data should be filled out
-        expect(wrapper.find('PermissionsObserver').prop('scopes')).toEqual([
-          'project:read',
-        ]);
+    it('it shows application data and credentials', function() {
+      // data should be filled out
+      expect(wrapper.find('PermissionsObserver').prop('scopes')).toEqual([
+        'project:read',
+      ]);
 
-        // 'Credentials' should be last PanelHeader when editing an application.
-        expect(
-          wrapper
-            .find('PanelHeader')
-            .last()
-            .text()
-        ).toBe('Credentials');
-      });
+      // 'Credentials' should be last PanelHeader when editing an application.
+      expect(
+        wrapper
+          .find('PanelHeader')
+          .last()
+          .text()
+      ).toBe('Credentials');
     });
 
-    describe('saving edited app', () => {
-      beforeEach(() => {
-        sentryApp.events = ['issue'];
-        editAppRequest = Client.addMockResponse({
-          url: `/sentry-apps/${sentryApp.slug}/`,
+    it('it updates app with correct data', function() {
+      wrapper
+        .find('Input[name="redirectUrl"]')
+        .simulate('change', {target: {value: 'https://hello.com/'}});
+
+      wrapper.find('TextArea[name="schema"]').simulate('change', {target: {value: '{}'}});
+
+      wrapper
+        .find('Checkbox')
+        .first()
+        .simulate('change', {target: {checked: false}});
+
+      wrapper.find('form').simulate('submit');
+
+      expect(editAppRequest).toHaveBeenCalledWith(
+        `/sentry-apps/${sentryApp.slug}/`,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            redirectUrl: 'https://hello.com/',
+            events: observable.array([]),
+          }),
           method: 'PUT',
-          body: [],
-        });
-      });
+        })
+      );
+    });
 
-      it('it updates app with correct data', function() {
-        wrapper
-          .find('Input[name="redirectUrl"]')
-          .simulate('change', {target: {value: 'https://hello.com/'}});
+    it('submits with no-access for event subscription when permission is revoked', () => {
+      wrapper
+        .find('Checkbox')
+        .first()
+        .simulate('change', {target: {checked: true}});
 
-        wrapper
-          .find('Checkbox')
-          .first()
-          .simulate('change', {target: {checked: false}});
+      wrapper.find('TextArea[name="schema"]').simulate('change', {target: {value: '{}'}});
 
-        wrapper.find('form').simulate('submit');
+      selectByValue(wrapper, 'no-access', {name: 'Event--permission'});
 
-        expect(editAppRequest).toHaveBeenCalledWith(
-          `/sentry-apps/${sentryApp.slug}/`,
-          expect.objectContaining({
-            data: expect.objectContaining({
-              redirectUrl: 'https://hello.com/',
-              events: observable.array([]),
-            }),
-            method: 'PUT',
-          })
-        );
-      });
-      it('submits with no-access for event subscription when permission is revoked', () => {
-        wrapper
-          .find('Checkbox')
-          .first()
-          .simulate('change', {target: {checked: true}});
-        selectByValue(wrapper, 'no-access', {name: 'Event--permission'});
-        wrapper.find('form').simulate('submit');
-        expect(editAppRequest).toHaveBeenCalledWith(
-          `/sentry-apps/${sentryApp.slug}/`,
-          expect.objectContaining({
-            data: expect.objectContaining({
-              events: observable.array([]),
-            }),
-            method: 'PUT',
-          })
-        );
-      });
+      wrapper.find('form').simulate('submit');
+
+      expect(editAppRequest).toHaveBeenCalledWith(
+        `/sentry-apps/${sentryApp.slug}/`,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            events: observable.array([]),
+          }),
+          method: 'PUT',
+        })
+      );
     });
   });
 });

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -147,6 +147,16 @@ class PostSentryAppsTest(SentryAppsTest):
             {"name": ["Name Foo Bar is already taken, please use another."]}
 
     @with_feature('organizations:sentry-apps')
+    def test_invalid_with_missing_webhool_url_scheme(self):
+        self.login_as(user=self.user)
+        kwargs = {'webhookUrl': 'example.com'}
+        response = self._post(**kwargs)
+
+        assert response.status_code == 422
+        assert response.data == \
+            {'webhookUrl': ['URL must start with http[s]://']}
+
+    @with_feature('organizations:sentry-apps')
     def test_cannot_create_app_without_correct_permissions(self):
         self.login_as(user=self.user)
         kwargs = {'scopes': ('project:read',)}


### PR DESCRIPTION
Some of the errors you might receive when trying to create a Sentry App are pretty vague. This adds a couple more specific validations with better errors for:

- Invalid URL because of missing https://
- Invalid JSON in schema