### PR TITLE
fix(ui) Fix stream dropdown positioning in firefox

### DIFF
--- a/src/sentry/static/sentry/less/stream.less
+++ b/src/sentry/static/sentry/less/stream.less
@@ -862,6 +862,10 @@
   margin-right: 5px;
   z-index: 1001;
 
+  .dropdown {
+    display: inline-block;
+  }
+
   .dropdown-toggle {
     .btn-default;
     width: 176px;
@@ -890,16 +894,14 @@
     overflow: hidden;
   }
 
+  // Hide the caret
   .dropdown-menu {
-    top: 0;
+    top: auto;
     left: 1px;
     width: 163px;
 
+    &:after,
     &:before {
-      display: none;
-    }
-
-    &:after {
       display: none;
     }
   }


### PR DESCRIPTION
The sort dropdown is mispositioned in Firefox, and entirely missing in beta/alpha firefox. These changes address those problems without disrupting display in chrome or safari.