### PR TITLE
fix(globalheader): Fix TimeRangeSelector in Safari and improve error handling [SEN-472]

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
@@ -44,7 +44,7 @@ const getInternalDate = (date, utc) => {
     return getUtcToSystem(date);
   } else {
     return new Date(
-      moment.tz(moment.utc(date), getUserTimezone()).format('YYYY-MM-DD HH:mm:ss')
+      moment.tz(moment.utc(date), getUserTimezone()).format('YYYY/MM/DD HH:mm:ss')
     );
   }
 };

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/timePicker.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/timePicker.jsx
@@ -24,22 +24,24 @@ const TimePicker = styled(
           <div>
             <Input
               type="time"
+              key={start}
+              defaultValue={start}
               className="rdrDateDisplayItem"
               data-test-id="startTime"
               disabled={disabled}
-              value={start}
-              onChange={onChangeStart}
+              onBlur={onChangeStart}
             />
           </div>
 
           <div>
             <Input
               type="time"
+              defaultValue={end}
+              key={end}
               className="rdrDateDisplayItem"
               data-test-id="endTime"
               disabled={disabled}
-              value={end}
-              onChange={onChangeEnd}
+              onBlur={onChangeEnd}
             />
           </div>
         </div>

--- a/src/sentry/static/sentry/app/utils/dates.jsx
+++ b/src/sentry/static/sentry/app/utils/dates.jsx
@@ -5,10 +5,22 @@ import ConfigStore from 'app/stores/configStore';
 // TODO(billy): Move to TimeRangeSelector specific utils
 export const DEFAULT_DAY_START_TIME = '00:00:00';
 export const DEFAULT_DAY_END_TIME = '23:59:59';
-const DATE_FORMAT_NO_TIMEZONE = 'YYYY-MM-DD HH:mm:ss';
+const DATE_FORMAT_NO_TIMEZONE = 'YYYY/MM/DD HH:mm:ss';
 
 function getParser(local = false) {
   return local ? moment : moment.utc;
+}
+
+/**
+ * Checks if string is valid time. Only accepts 24 hour format.
+ *
+ * Chrome's time input will (at least for US locale), allow you to input 12
+ * hour format with AM/PM but the raw value is in 24 hour.
+ *
+ * Safari does not do any validation so you could get a value of > 24 hours
+ */
+export function isValidTime(str) {
+  return moment(str, 'HH:mm', true).isValid();
 }
 
 /**

--- a/tests/js/spec/components/organizations/timeRangeSelector/dateRange.spec.jsx
+++ b/tests/js/spec/components/organizations/timeRangeSelector/dateRange.spec.jsx
@@ -101,7 +101,7 @@ describe('DateRange', function() {
     it('changes start time for existing date', function() {
       wrapper
         .find('input[data-test-id="startTime"]')
-        .simulate('change', {target: {value: '11:00'}});
+        .simulate('blur', {target: {value: '11:00'}});
 
       expect(onChange).toHaveBeenLastCalledWith({
         start: new Date('2017-10-13T15:00:00.000Z'),
@@ -112,7 +112,7 @@ describe('DateRange', function() {
     it('changes end time for existing date', function() {
       wrapper
         .find('input[data-test-id="endTime"]')
-        .simulate('change', {target: {value: '12:00'}});
+        .simulate('blur', {target: {value: '12:00'}});
 
       expect(onChange).toHaveBeenLastCalledWith({
         start: new Date('2017-10-14T02:38:00.000Z'),
@@ -172,7 +172,7 @@ describe('DateRange', function() {
     it('changes utc start time for existing date', function() {
       wrapper
         .find('input[data-test-id="startTime"]')
-        .simulate('change', {target: {value: '11:00'}});
+        .simulate('blur', {target: {value: '11:00'}});
 
       // Initial start date  is 2017-10-13T22:38:00-0400
       expect(onChange).toHaveBeenLastCalledWith({
@@ -184,7 +184,7 @@ describe('DateRange', function() {
     it('changes end time for existing date', function() {
       wrapper
         .find('input[data-test-id="endTime"]')
-        .simulate('change', {target: {value: '12:00'}});
+        .simulate('blur', {target: {value: '12:00'}});
 
       // Initial end time is 2017-10-16T22:38:00-0400
       // Setting this to 12:00 means 2017-10-16T12:00-0400


### PR DESCRIPTION
* Fixes absolute dates for safari and includes better error handling for times (Safari does not follow standards for date parsing - it also does not enforce constraints in time input field)
* Change to propagate time changes on "blur" event

Fixes JAVASCRIPT-5YA