### PR TITLE
refs: Split up acceptance tests again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -198,8 +198,11 @@ matrix:
       env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=1 MIGRATIONS_TEST_MIGRATE=1
 
     - <<: *acceptance_default
-      name: 'Acceptance'
-      env: TEST_SUITE=acceptance USE_SNUBA=1
+      name: 'Acceptance (1/2)'
+      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=0 PERCY_PARALLEL_NONCE=${TRAVIS_BUILD_ID} PERCY_PARALLEL_TOTAL=2
+    - <<: *acceptance_default
+      name: 'Acceptance (2/2)'
+      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=1 PERCY_PARALLEL_NONCE=${TRAVIS_BUILD_ID} PERCY_PARALLEL_TOTAL=2
 
     - <<: *acceptance_default
       name: 'Plugins'

--- a/.travis.yml
+++ b/.travis.yml
@@ -198,11 +198,14 @@ matrix:
       env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=1 MIGRATIONS_TEST_MIGRATE=1
 
     - <<: *acceptance_default
-      name: 'Acceptance (1/2)'
-      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=0 PERCY_PARALLEL_NONCE=${TRAVIS_BUILD_ID} PERCY_PARALLEL_TOTAL=2
+      name: 'Acceptance (1/3)'
+      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=3 TEST_GROUP=0
     - <<: *acceptance_default
-      name: 'Acceptance (2/2)'
-      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=1 PERCY_PARALLEL_NONCE=${TRAVIS_BUILD_ID} PERCY_PARALLEL_TOTAL=2
+      name: 'Acceptance (2/3)'
+      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=3 TEST_GROUP=1
+    - <<: *acceptance_default
+      name: 'Acceptance (3/3)'
+      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=3 TEST_GROUP=2
 
     - <<: *acceptance_default
       name: 'Plugins'

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -445,7 +445,7 @@ def percy(request):
     percy = percy.Runner(loader=loader, config=percy_config)
     percy.initialize_build()
 
-    request.addfinalizer(percy.finalize_build)
+    request.session._percy = percy
     return percy
 
 

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -445,7 +445,7 @@ def percy(request):
     percy = percy.Runner(loader=loader, config=percy_config)
     percy.initialize_build()
 
-    request.session._percy = percy
+    request.addfinalizer(percy.finalize_build)
     return percy
 
 


### PR DESCRIPTION
We had a problem where failed builds couldn't be retried, since percy considered the build
finalized. This changes the percy build to only finalize if the test run was successful. This change
probably means we don't get screenshots on failed tests, not sure if that's something people care
about?

We also use build id + build run so that if someone re-runs all builds then they'll successfully get
new snapshots.