### PR TITLE
fix(discover): Fix bar chart rendering

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {browserHistory} from 'react-router';
 import PropTypes from 'prop-types';
-import {throttle, isEqual} from 'lodash';
+import {throttle} from 'lodash';
 
 import SentryTypes from 'app/sentryTypes';
 import {t} from 'app/locale';
@@ -76,15 +76,6 @@ class Result extends React.Component {
         search,
       });
     }
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return (
-      (nextProps.location.state === 'fetching' &&
-        nextProps.location.state !== this.props.location.state) ||
-      !isEqual(nextProps, this.props) ||
-      !isEqual(nextState, this.state)
-    );
   }
 
   componentWillUnmount() {
@@ -261,6 +252,7 @@ class Result extends React.Component {
                 legend={{data: [baseQuery.query.aggregations[0][2]], truncate: 80}}
                 xAxis={{truncate: 80}}
                 renderer="canvas"
+                options={{animation: false}}
               />
             </ChartWrapper>
           )}
@@ -289,6 +281,7 @@ class Result extends React.Component {
                 renderer="canvas"
                 isGroupedByDate={true}
                 utc={utc}
+                options={{animation: false}}
               />
               {this.renderNote()}
             </ChartWrapper>

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/utils.jsx
@@ -22,6 +22,7 @@ export function getChartData(data, query) {
   return query.aggregations.map(aggregation => {
     return {
       seriesName: aggregation[2],
+      animation: false,
       data: data.map(res => {
         return {
           value: res[aggregation[2]],

--- a/tests/js/spec/views/organizationDiscover/result/utils.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/result/utils.spec.jsx
@@ -32,6 +32,7 @@ describe('Utils', function() {
             {value: 2, name: 'project.id 5 environment alpha'},
             {value: 6, name: 'project.id 5 environment production'},
           ],
+          animation: false,
         },
         {
           seriesName: 'uniq_id',
@@ -41,6 +42,7 @@ describe('Utils', function() {
             {value: 4, name: 'project.id 5 environment alpha'},
             {value: 10, name: 'project.id 5 environment production'},
           ],
+          animation: false,
         },
       ];
 


### PR DESCRIPTION
This prevents bar charts being re-animated every time some field in the
query builder is updated. The previous solution (shouldComponentUpdate)
had a side effect of not rerendering the chart when it actually needed
to be updated since the result is not stored in props or state.