### PR TITLE
feat(discover): Improve validation messages

### DIFF
--- a/src/sentry/api/endpoints/organization_discover_query.py
+++ b/src/sentry/api/endpoints/organization_discover_query.py
@@ -40,6 +40,7 @@ class DiscoverQuerySerializer(serializers.Serializer):
         child=serializers.CharField(),
         required=False,
         allow_null=True,
+        default=[],
     )
     limit = serializers.IntegerField(min_value=0, max_value=10000, required=False)
     rollup = serializers.IntegerField(required=False)
@@ -90,6 +91,9 @@ class DiscoverQuerySerializer(serializers.Serializer):
             raise serializers.ValidationError('You must specify a date filter')
         elif date_fields_provided > 1:
             raise serializers.ValidationError('Conflicting date filters supplied')
+
+        if not data.get('fields') and not data.get('aggregations'):
+            raise serializers.ValidationError('Specify at least one field or aggregation')
 
         try:
             start, end = get_date_range_from_params({


### PR DESCRIPTION
Return a proper validation message if no fields or aggregations are
supplied by the user. Whilst this won't ever happen using the Discover
UI some users are now accessing the Discover API directly, so this will
help provide more useful feedback.