### PR TITLE
fix(ui) Allow Feature to have no children

### DIFF
--- a/src/sentry/static/sentry/app/components/acl/feature.jsx
+++ b/src/sentry/static/sentry/app/components/acl/feature.jsx
@@ -185,7 +185,7 @@ class Feature extends React.Component {
       return children(renderProps);
     }
 
-    return hasFeature ? children : null;
+    return hasFeature && children ? children : null;
   }
 }
 

--- a/tests/js/spec/components/acl/feature.spec.jsx
+++ b/tests/js/spec/components/acl/feature.spec.jsx
@@ -178,6 +178,24 @@ describe('Feature', function() {
     });
   });
 
+  describe('no children', function() {
+    it('should display renderDisabled with no feature', function() {
+      const wrapper = mount(
+        <Feature features={['nope']} renderDisabled={() => <span>disabled</span>} />,
+        routerContext
+      );
+      expect(wrapper.find('Feature span').text()).toBe('disabled');
+    });
+
+    it('should display be empty when on', function() {
+      const wrapper = mount(
+        <Feature features={['org-bar']} renderDisabled={() => <span>disabled</span>} />,
+        routerContext
+      );
+      expect(wrapper.find('Feature').text()).toBeNull();
+    });
+  });
+
   describe('as React node', function() {
     it('has features', function() {
       const wrapper = mount(


### PR DESCRIPTION
I have a use case where I'm using Feature to only render contents when the named feature is not present. When the feature is on for the user I want the Feature element to emit no DOM, and now it can.