### PR TITLE
fix(discover): Drop inaccessible projects from saved query

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/missingProjectWarningModal.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/missingProjectWarningModal.jsx
@@ -8,7 +8,8 @@ import {t} from 'app/locale';
 export default class MissingProjectWarningModal extends React.Component {
   static propTypes = {
     organization: SentryTypes.Organization.isRequired,
-    projects: PropTypes.arrayOf(PropTypes.number).isRequired,
+    validProjects: PropTypes.arrayOf(PropTypes.number).isRequired,
+    invalidProjects: PropTypes.arrayOf(PropTypes.number).isRequired,
     closeModal: PropTypes.func,
   };
 
@@ -17,18 +18,22 @@ export default class MissingProjectWarningModal extends React.Component {
     return <li key={id}>{project ? project.slug : t(`Unknown project ${id}`)}</li>;
   }
   render() {
+    const {validProjects, invalidProjects} = this.props;
+
+    const text = validProjects.length
+      ? t(`You are not currently a member of all of the projects specified by
+          this query. As a result, data for the following projects will be
+          omitted from the displayed results:`)
+      : t(`You are not currently a member of any of the following projects specified
+           by this query. You may still run this query against other projects you
+           have access to.`);
+
     return (
       <Modal show={true}>
         <Header>{t('Project access')}</Header>
         <Body>
-          <p>
-            {t(
-              `You are not currently a member of all of the projects specified by
-            this query. As a result, data for the following projects will be
-            omitted from the displayed results:`
-            )}
-          </p>
-          <ul>{this.props.projects.map(id => this.renderProject(id))}</ul>
+          <p>{text}</p>
+          <ul>{invalidProjects.map(id => this.renderProject(id))}</ul>
         </Body>
         <Footer>
           <Button priority="primary" onClick={this.props.closeModal}>

--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -1,6 +1,6 @@
 /*eslint no-use-before-define: ["error", { "functions": false }]*/
 import React from 'react';
-import {uniq} from 'lodash';
+import {uniq, partition} from 'lodash';
 import moment from 'moment-timezone';
 
 import {Client} from 'app/api';
@@ -312,22 +312,26 @@ export default function createQueryBuilder(initial = {}, organization) {
    * Resets the query to defaults or the query provided
    * Displays a warning if user does not have access to any project in the query
    *
+   * @param {Object} [q] optional query to reset to
    * @returns {Void}
    */
   function reset(q = {}) {
-    const invalidProjects = (q.projects || []).filter(
-      project => !defaultProjects.includes(project)
+    const [validProjects, invalidProjects] = partition(q.projects || [], project =>
+      defaultProjects.includes(project)
     );
 
     if (invalidProjects.length) {
       openModal(deps => (
         <MissingProjectWarningModal
           organization={organization}
-          projects={invalidProjects}
+          validProjects={validProjects}
+          invalidProjects={invalidProjects}
           {...deps}
         />
       ));
     }
+
+    q.projects = validProjects;
 
     query = applyDefaults(q);
   }


### PR DESCRIPTION
Drop any projects a user does not have access to after displaying the
warning modal as this was causing the query to be unusable.

Also tweaks the warning message in the case of no projects to clarify
why no results will be seen.

Closes SEN-446