### PR TITLE
fix(user-feedback): Fix "View Event" link

### DIFF
--- a/src/sentry/static/sentry/app/components/events/userFeedback.jsx
+++ b/src/sentry/static/sentry/app/components/events/userFeedback.jsx
@@ -20,8 +20,8 @@ class EventUserFeedback extends React.Component {
     const {report, orgId, projectId, issueId} = this.props;
 
     return projectId
-      ? `/${orgId}/${projectId}/issues/${issueId}/events/${report.event.id}/`
-      : `/organizations/${orgId}/issues/${issueId}/events/${report.event.id}/`;
+      ? `/${orgId}/${projectId}/issues/${issueId}/events/${report.event.eventID}/`
+      : `/organizations/${orgId}/issues/${issueId}/events/${report.event.eventID}/`;
   }
 
   render() {
@@ -39,8 +39,8 @@ class EventUserFeedback extends React.Component {
                   <div className="activity-author">
                     {report.name}
                     <small>{report.email}</small>
-                    {/* event_id might be undefined for legacy accounts */}
-                    {report.event.id && (
+                    {/* event.eventID might be undefined for legacy accounts */}
+                    {report.event.eventID && (
                       <small>
                         <Link to={this.getUrl()}>{t('View event')}</Link>
                       </small>

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -432,7 +432,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                             "/org-slug/project-slug/issues/1/activity/",
                           ],
                           Array [
-                            "/organizations/org-slug/issues/1/events/1/",
+                            "/organizations/org-slug/issues/1/events/12345678901234567890123456789012/",
                           ],
                         ],
                         "results": Array [
@@ -562,7 +562,7 @@ exports[`OrganizationUserFeedback renders 1`] = `
                               "/org-slug/project-slug/issues/1/activity/",
                             ],
                             Array [
-                              "/organizations/org-slug/issues/1/events/1/",
+                              "/organizations/org-slug/issues/1/events/12345678901234567890123456789012/",
                             ],
                           ],
                           "results": Array [
@@ -2626,12 +2626,12 @@ exports[`OrganizationUserFeedback renders 1`] = `
                                                             </small>
                                                             <small>
                                                               <Link
-                                                                to="/organizations/org-slug/issues/1/events/1/"
+                                                                to="/organizations/org-slug/issues/1/events/12345678901234567890123456789012/"
                                                               >
                                                                 <Link
                                                                   onlyActiveOnIndex={false}
                                                                   style={Object {}}
-                                                                  to="/organizations/org-slug/issues/1/events/1/"
+                                                                  to="/organizations/org-slug/issues/1/events/12345678901234567890123456789012/"
                                                                 >
                                                                   <a
                                                                     onClick={[Function]}


### PR DESCRIPTION
IDK when this change happened, but our reports have an `event.eventID`
instead of `event.id`. This has been broken for quite awhile.

![image](https://user-images.githubusercontent.com/79684/55921637-75ca2880-5bb2-11e9-8215-1347e748da25.png)
