### PR TITLE
feat(ui) Update design for organization saved searches

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/organizationSavedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/stream/organizationSavedSearchSelector.jsx
@@ -8,7 +8,8 @@ import Access from 'app/components/acl/access';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
 import MenuItem from 'app/components/menuItem';
-import DropdownLink from 'app/components/dropdownLink';
+import DropdownButton from 'app/components/dropdownButton';
+import DropdownMenu from 'app/components/dropdownMenu';
 import InlineSvg from 'app/components/inlineSvg';
 import SentryTypes from 'app/sentryTypes';
 import {TextField} from 'app/components/forms';
@@ -16,6 +17,7 @@ import space from 'app/styles/space';
 import withApi from 'app/utils/withApi';
 import {addLoadingMessage, clearIndicators} from 'app/actionCreators/indicator';
 import {createSavedSearch} from 'app/actionCreators/savedSearches';
+import overflowEllipsis from 'app/styles/overflowEllipsis';
 
 export default class OrganizationSavedSearchSelector extends React.Component {
   static propTypes = {
@@ -55,7 +57,7 @@ export default class OrganizationSavedSearchSelector extends React.Component {
 
     return savedSearchList.map(search => (
       <StyledMenuItem onSelect={() => onSavedSearchSelect(search)} key={search.id}>
-        {search.isPinned && <InlineSvg src={'icon-pin'} />}
+        {search.isPinned && <InlineSvg src="icon-pin" />}
         <SearchTitle>{search.name}</SearchTitle>
         <SearchQuery>{search.query}</SearchQuery>
         {search.isGlobal === false && (
@@ -69,10 +71,11 @@ export default class OrganizationSavedSearchSelector extends React.Component {
               message={t('Are you sure you want to delete this saved search?')}
               stopPropagation
             >
-              <Button
+              <DeleteButton
+                borderless
                 title={t('Delete this saved search')}
                 icon="icon-trash"
-                size="xsmall"
+                size="zero"
               />
             </Confirm>
           </Access>
@@ -86,25 +89,34 @@ export default class OrganizationSavedSearchSelector extends React.Component {
 
     return (
       <Container>
-        <div className="stream-dropdown">
-          <DropdownLink btnGroup={true} title={this.getTitle()}>
-            {this.renderList()}
-            <Access
-              organization={organization}
-              access={['org:write']}
-              renderNoAccessMessage={false}
-            >
-              <StyledMenuItem divider={true} />
-              <ButtonBar>
-                <SaveSearchButton
-                  query={query}
-                  organization={organization}
-                  onSave={onSavedSearchCreate}
-                />
-              </ButtonBar>
-            </Access>
-          </DropdownLink>
-        </div>
+        <DropdownMenu alwaysRenderMenu={true}>
+          {({isOpen, getMenuProps, getActorProps}) => {
+            return (
+              <React.Fragment>
+                <StyledDropdownButton {...getActorProps()} isOpen={isOpen}>
+                  <ButtonTitle>{this.getTitle()}</ButtonTitle>
+                </StyledDropdownButton>
+                <MenuContainer {...getMenuProps({isStyled: true})} isOpen={isOpen}>
+                  {this.renderList()}
+                  <Access
+                    organization={organization}
+                    access={['org:write']}
+                    renderNoAccessMessage={false}
+                  >
+                    <StyledMenuItem divider={true} />
+                    <ButtonBar>
+                      <SaveSearchButton
+                        query={query}
+                        organization={organization}
+                        onSave={onSavedSearchCreate}
+                      />
+                    </ButtonBar>
+                  </Access>
+                </MenuContainer>
+              </React.Fragment>
+            );
+          }}
+        </DropdownMenu>
       </Container>
     );
   }
@@ -162,10 +174,14 @@ const SaveSearchButton = withApi(
         });
     };
 
-    onToggle = () => {
+    onToggle = event => {
       this.setState({
         isModalOpen: !this.state.isModalOpen,
       });
+
+      if (event) {
+        event.stopPropagation();
+      }
     };
 
     handleChangeName = val => {
@@ -240,15 +256,46 @@ const SaveSearchButton = withApi(
 );
 
 const Container = styled.div`
-  & .dropdown-menu {
-    max-width: 350px;
-    min-width: 275px;
+  position: relative;
+  display: block;
+`;
+
+const StyledDropdownButton = styled(DropdownButton)`
+  border-right: 0;
+  z-index: ${p => p.theme.zIndex.dropdownAutocomplete.actor};
+  border-radius: ${p =>
+    p.isOpen
+      ? `${p.theme.borderRadius} 0 0 0`
+      : `${p.theme.borderRadius} 0 0 ${p.theme.borderRadius}`};
+  white-space: nowrap;
+  max-width: 200px;
+
+  &:hover,
+  &:active {
+    border-right: 0;
+  }
+
+  /* Hack but search input, and sort dropdown are not standard size buttons */
+  & > span {
+    padding: 11px 16px;
   }
 `;
 
+const ButtonTitle = styled.span`
+  ${overflowEllipsis}
+`;
+
 const SearchTitle = styled.strong`
-  display: block;
-  max-width: 100%;
+  color: ${p => p.theme.gray5};
+  padding: 0;
+  background: inherit;
+
+  &:after {
+    content: ' \u2022 ';
+  }
+`;
+
+const SearchQuery = styled.code`
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
@@ -257,36 +304,63 @@ const SearchTitle = styled.strong`
   background: inherit;
 `;
 
-const SearchQuery = styled.code`
-  display: block;
-  max-width: 100%;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
-  color: ${p => p.theme.gray5};
-  padding: 0;
-  background: inherit;
+const DeleteButton = styled(Button)`
+  color: ${p => p.theme.gray1};
+  background: ${p => p.theme.offWhite};
+  display: none;
+  position: absolute;
+
+  /* Rows are 20px tall */
+  top: 10px;
+  right: 10px;
+
+  &:hover {
+    color: ${p => p.theme.blueLight};
+  }
 `;
 
 const StyledMenuItem = styled(MenuItem)`
   position: relative;
+  border-bottom: 1px solid ${p => p.theme.borderLight};
+  font-size: ${p => p.theme.fontSizeMedium};
+  padding: 0;
+
+  &:focus ${DeleteButton}, &:hover ${DeleteButton} {
+    display: block;
+  }
+
+  &:last-child {
+    border-bottom: 0;
+  }
 
   & a {
-    /* override shared-components.less */
-    padding: ${space(0.25)} ${space(1)} !important;
-  }
-
-  & button {
-    display: none;
-  }
-
-  &:focus,
-  &:hover button {
     display: block;
-    position: absolute;
-    top: ${space(0.5)};
-    right: ${space(1)};
+    padding: ${space(1)} ${space(1.5)};
+
+    & :hover {
+      background: ${p => p.theme.offWhite};
+    }
   }
+`;
+
+const MenuContainer = styled.ul`
+  list-style: none;
+  width: 375px;
+
+  position: absolute;
+  /* Buttons are 38px tall, this has to be -1 to get button overlapping the menu */
+  top: 37px;
+  padding: 0;
+  margin: 0;
+  z-index: ${p => p.theme.zIndex.dropdownAutocomplete.menu};
+
+  background: ${p => p.theme.background};
+  border-radius: 0 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius};
+  box-shadow: 0 1px 3px rgba(70, 82, 98, 0.25);
+  border: 1px solid ${p => p.theme.borderDark};
+  background-clip: padding-box;
+
+  display: ${p => (p.isOpen ? 'block' : 'none')};
 `;
 
 const EmptyItem = styled.li`

--- a/src/sentry/static/sentry/less/stream.less
+++ b/src/sentry/static/sentry/less/stream.less
@@ -870,7 +870,8 @@
     .btn-default;
     width: 176px;
     font-size: 14px;
-    border: 1px solid lighten(@gray-lighter, 7);
+    // Match colours with theme.jsx
+    border: 1px solid #d8d2de;
     padding: 6px 8px;
     border-radius: 3px;
 

--- a/tests/js/spec/views/stream/organizationSavedSearchSelector.spec.jsx
+++ b/tests/js/spec/views/stream/organizationSavedSearchSelector.spec.jsx
@@ -67,7 +67,7 @@ describe('OrganizationSavedSearchSelector', function() {
 
   describe('selecting an option', function() {
     it('calls onSelect when clicked', async function() {
-      wrapper.find('DropdownLink').simulate('click');
+      wrapper.find('DropdownButton').simulate('click');
       await wrapper.update();
 
       const item = wrapper.find('StyledMenuItem a').first();
@@ -80,7 +80,7 @@ describe('OrganizationSavedSearchSelector', function() {
 
   describe('removing a saved search', function() {
     it('shows a delete button with access', async function() {
-      wrapper.find('DropdownLink').simulate('click');
+      wrapper.find('DropdownButton').simulate('click');
       await wrapper.update();
 
       // Second item should have a delete button as it is not a global search
@@ -95,7 +95,7 @@ describe('OrganizationSavedSearchSelector', function() {
       organization.access = [];
       wrapper.setProps({organization});
 
-      wrapper.find('DropdownLink').simulate('click');
+      wrapper.find('DropdownButton').simulate('click');
       await wrapper.update();
 
       const button = wrapper
@@ -106,7 +106,7 @@ describe('OrganizationSavedSearchSelector', function() {
     });
 
     it('does not show a delete button for global search', async function() {
-      wrapper.find('DropdownLink').simulate('click');
+      wrapper.find('DropdownButton').simulate('click');
       await wrapper.update();
 
       // First item should not have a delete button as it is a global search
@@ -118,7 +118,7 @@ describe('OrganizationSavedSearchSelector', function() {
     });
 
     it('sends a request when delete button is clicked', async function() {
-      wrapper.find('DropdownLink').simulate('click');
+      wrapper.find('DropdownButton').simulate('click');
       await wrapper.update();
 
       // Second item should have a delete button as it is not a global search
@@ -136,14 +136,14 @@ describe('OrganizationSavedSearchSelector', function() {
 
   describe('saves a search', function() {
     it('clicking save search opens modal', function() {
-      wrapper.find('DropdownLink').simulate('click');
+      wrapper.find('DropdownButton').simulate('click');
       expect(wrapper.find('ModalDialog')).toHaveLength(0);
       wrapper.find('Button[data-test-id="save-current-search"]').simulate('click');
       expect(wrapper.find('ModalDialog')).toHaveLength(1);
     });
 
     it('saves a search', async function() {
-      wrapper.find('DropdownLink').simulate('click');
+      wrapper.find('DropdownButton').simulate('click');
       wrapper.find('Button[data-test-id="save-current-search"]').simulate('click');
       wrapper.find('#id-name').simulate('change', {target: {value: 'test'}});
       wrapper
@@ -161,7 +161,7 @@ describe('OrganizationSavedSearchSelector', function() {
 
       wrapper.setProps({organization: orgWithoutAccess});
 
-      const button = wrapper.find('button');
+      const button = wrapper.find('SaveSearchButton');
 
       expect(button).toHaveLength(0);
     });


### PR DESCRIPTION
Update organization saved search box to reflect the current design mockups. I've converted as much as I could into styled components which reduces dependencies on less styles a bit more.

I've left the 'create search' button in its former place for now. We have a separate task to move it later.

## Closed
<img width="587" alt="Screen Shot 2019-04-11 at 11 16 40 AM" src="https://user-images.githubusercontent.com/24086/55973359-618a3800-5c53-11e9-884c-ff461d2c99aa.png">

## Open with deletable row hover

<img width="586" alt="Screen Shot 2019-04-11 at 11 17 04 AM" src="https://user-images.githubusercontent.com/24086/55973373-6a7b0980-5c53-11e9-9221-7d12b2846f4c.png">


Fixes SEN-473