### PR TITLE
feat(api): Change workflow notification default to 'Only Issues I subscribe to' (SEN-434)

### DIFF
--- a/src/sentry/api/endpoints/user_notification_details.py
+++ b/src/sentry/api/endpoints/user_notification_details.py
@@ -36,7 +36,7 @@ USER_OPTION_SETTINGS = {
     },
     'workflowNotifications': {
         'key': 'workflow:notifications',
-        'default': UserOptionValue.all_conversations,  # '0'
+        'default': UserOptionValue.participating_only,  # '1'
         'type': int,
     }
 }

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -104,9 +104,9 @@ class GroupSerializerBase(Serializer):
         }
 
         # This is the user's default value for any projects that don't have
-        # the option value specifically recorded. (The default "all
-        # conversations" value is convention.)
-        global_default_workflow_option = options.get(None, UserOptionValue.all_conversations)
+        # the option value specifically recorded. (The default
+        # "participating_only" value is convention.)
+        global_default_workflow_option = options.get(None, UserOptionValue.participating_only)
 
         results = {}
         for project, groups in projects.items():

--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -177,7 +177,7 @@ class GroupSubscriptionManager(BaseManager):
             'workflow:notifications',
             users.keys(),
             group.project,
-            UserOptionValue.all_conversations,
+            UserOptionValue.participating_only,
         )
 
         for user_id, option in options.items():

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -691,7 +691,7 @@ class NotificationSettingsForm(forms.Form):
         self.fields['workflow_notifications'].initial = UserOption.objects.get_value(
             user=self.user,
             key='workflow:notifications',
-            default=UserOptionValue.all_conversations,
+            default=UserOptionValue.participating_only,
             project=None,
         )
 
@@ -787,7 +787,7 @@ class ProjectEmailOptionsForm(forms.Form):
                 user=self.user,
                 project=None,
                 key='workflow:notifications',
-                default=UserOptionValue.all_conversations,
+                default=UserOptionValue.participating_only,
             ),
         )
         self.fields['email'].initial = specified_email or alert_email or user.email

--- a/tests/sentry/api/endpoints/test_user_notification_details.py
+++ b/tests/sentry/api/endpoints/test_user_notification_details.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import
 
 from sentry.testutils import APITestCase
-from sentry.models import UserOption
+from sentry.models import (
+    UserOption,
+    UserOptionValue,
+)
 
 from django.core.urlresolvers import reverse
 
@@ -65,13 +68,14 @@ class UserNotificationDetailsTest(APITestCase):
             key="deploy-emails",
             value=1)
 
-        # default is 0
+        # default is UserOptionValue.participating_only
         UserOption.objects.create(
             user=user,
             project=None,
             organization=org,
             key="workflow:notifications",
-            value=1)
+            value=UserOptionValue.all_conversations,
+        )
 
         self.login_as(user=user)
 
@@ -86,7 +90,7 @@ class UserNotificationDetailsTest(APITestCase):
         assert resp.data.get('personalActivityNotifications') is False
         assert resp.data.get('selfAssignOnResolve') is False
         assert resp.data.get('subscribeByDefault') is True
-        assert resp.data.get('workflowNotifications') == 0
+        assert resp.data.get('workflowNotifications') == int(UserOptionValue.participating_only)
 
     def test_saves_and_returns_values(self):
         user = self.create_user(email='a@example.com')
@@ -110,7 +114,7 @@ class UserNotificationDetailsTest(APITestCase):
         assert resp.data.get('personalActivityNotifications') is True
         assert resp.data.get('selfAssignOnResolve') is True
         assert resp.data.get('subscribeByDefault') is True
-        assert resp.data.get('workflowNotifications') == 0
+        assert resp.data.get('workflowNotifications') == int(UserOptionValue.participating_only)
 
         assert UserOption.objects.get(user=user,
                                       project=None,

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -204,12 +204,12 @@ class GroupSerializerTest(TestCase):
 
         combinations = (
             # ((default, project), (subscribed, details))
-            ((None, None), (True, None)),
             ((UserOptionValue.all_conversations, None), (True, None)),
             ((UserOptionValue.all_conversations, UserOptionValue.all_conversations), (True, None)),
             ((UserOptionValue.all_conversations, UserOptionValue.participating_only), (False, None)),
             ((UserOptionValue.all_conversations, UserOptionValue.no_conversations),
              (False, {'disabled': True})),
+            ((None, None), (False, None)),
             ((UserOptionValue.participating_only, None), (False, None)),
             ((UserOptionValue.participating_only, UserOptionValue.all_conversations), (True, None)),
             ((UserOptionValue.participating_only, UserOptionValue.participating_only), (False, None)),

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -112,6 +112,12 @@ class GetParticipantsTest(TestCase):
         self.create_member(user=user, organization=org, teams=[team])
         self.create_member(user=user2, organization=org)
 
+        UserOption.objects.set_value(
+            user=user,
+            key='workflow:notifications',
+            value=UserOptionValue.all_conversations,
+        )
+
         # implicit membership
         users = GroupSubscription.objects.get_participants(group=group)
 
@@ -171,6 +177,11 @@ class GetParticipantsTest(TestCase):
         self.create_member(user=user, organization=org, teams=[team])
 
         user_option_sequence = itertools.count(300)  # prevent accidental overlap with user id
+        UserOption.objects.set_value(
+            user=user,
+            key='workflow:notifications',
+            value=UserOptionValue.all_conversations,
+        )
 
         def clear_workflow_options():
             UserOption.objects.filter(
@@ -290,6 +301,11 @@ class GetParticipantsTest(TestCase):
         group = self.create_group(project=project)
         user = self.create_user()
         self.create_member(user=user, organization=org, teams=[team])
+        UserOption.objects.set_value(
+            user=user,
+            key='workflow:notifications',
+            value=UserOptionValue.all_conversations,
+        )
 
         user_option_sequence = itertools.count(300)  # prevent accidental overlap with user id
 

--- a/tests/sentry/plugins/mail/tests.py
+++ b/tests/sentry/plugins/mail/tests.py
@@ -21,7 +21,8 @@ from sentry.api.serializers import (
 from sentry.digests.notifications import build_digest, event_to_record
 from sentry.models import (
     Activity, Event, Group, GroupSubscription, Organization, OrganizationMember,
-    OrganizationMemberTeam, ProjectOwnership, Rule, UserOption, UserReport
+    OrganizationMemberTeam, ProjectOwnership, Rule, UserOption, UserOptionValue,
+    UserReport
 )
 from sentry.ownership.grammar import Owner, Matcher, dump_schema
 from sentry.plugins import Notification
@@ -311,6 +312,11 @@ class MailPluginTest(TestCase):
         assert msg.subject.startswith('[Example prefix]')
 
     def test_assignment(self):
+        UserOption.objects.set_value(
+            user=self.user,
+            key='workflow:notifications',
+            value=UserOptionValue.all_conversations,
+        )
         activity = Activity.objects.create(
             project=self.project,
             group=self.group,
@@ -333,6 +339,12 @@ class MailPluginTest(TestCase):
         assert msg.to == [self.user.email]
 
     def test_assignment_team(self):
+        UserOption.objects.set_value(
+            user=self.user,
+            key='workflow:notifications',
+            value=UserOptionValue.all_conversations,
+        )
+
         activity = Activity.objects.create(
             project=self.project,
             group=self.group,
@@ -356,6 +368,11 @@ class MailPluginTest(TestCase):
 
     def test_note(self):
         user_foo = self.create_user('foo@example.com')
+        UserOption.objects.set_value(
+            user=self.user,
+            key='workflow:notifications',
+            value=UserOptionValue.all_conversations,
+        )
 
         activity = Activity.objects.create(
             project=self.project,
@@ -414,6 +431,11 @@ class MailPluginSignalsTest(TestCase):
 
     def test_user_feedback(self):
         report = self.create_report()
+        UserOption.objects.set_value(
+            user=self.user,
+            key='workflow:notifications',
+            value=UserOptionValue.all_conversations,
+        )
 
         with self.tasks():
             self.plugin.handle_signal(
@@ -439,6 +461,11 @@ class MailPluginSignalsTest(TestCase):
     def test_user_feedback__enhanced_privacy(self):
         self.organization.update(flags=F('flags').bitor(Organization.flags.enhanced_privacy))
         assert self.organization.flags.enhanced_privacy.is_set is True
+        UserOption.objects.set_value(
+            user=self.user,
+            key='workflow:notifications',
+            value=UserOptionValue.all_conversations,
+        )
 
         report = self.create_report()
 

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -199,12 +199,12 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
 
         combinations = (
             # ((default, project), (subscribed, details))
-            ((None, None), (True, None)),
             ((UserOptionValue.all_conversations, None), (True, None)),
             ((UserOptionValue.all_conversations, UserOptionValue.all_conversations), (True, None)),
             ((UserOptionValue.all_conversations, UserOptionValue.participating_only), (False, None)),
             ((UserOptionValue.all_conversations, UserOptionValue.no_conversations),
              (False, {'disabled': True})),
+            ((None, None), (False, None)),
             ((UserOptionValue.participating_only, None), (False, None)),
             ((UserOptionValue.participating_only, UserOptionValue.all_conversations), (True, None)),
             ((UserOptionValue.participating_only, UserOptionValue.participating_only), (False, None)),


### PR DESCRIPTION
Changing this from always to only subscribed issues. This should reduce email volume for users
significantly.