### PR TITLE
ref: Pull out serializer class selection logic

### DIFF
--- a/src/sentry/api/endpoints/broadcast_details.py
+++ b/src/sentry/api/endpoints/broadcast_details.py
@@ -39,11 +39,13 @@ class BroadcastDetailsEndpoint(Endpoint):
             return AdminBroadcastValidator
         return BroadcastValidator
 
-    def _serialize_response(self, request, broadcast):
+    def _get_serializer(self, request):
         if is_active_superuser(request):
-            serializer_cls = AdminBroadcastSerializer
-        else:
-            serializer_cls = BroadcastSerializer
+            return AdminBroadcastSerializer
+        return BroadcastSerializer
+
+    def _serialize_response(self, request, broadcast):
+        serializer_cls = self._get_serializer(request)
         return self.respond(serialize(broadcast, request.user, serializer=serializer_cls()))
 
     def get(self, request, broadcast_id):

--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -24,12 +24,15 @@ logger = logging.getLogger('sentry')
 class BroadcastIndexEndpoint(Endpoint):
     permission_classes = (IsAuthenticated, )
 
-    def _serialize_objects(self, items, request):
+    def _get_serializer(self, request):
         if is_active_superuser(request):
             serializer_cls = AdminBroadcastSerializer
         else:
             serializer_cls = BroadcastSerializer
+        return serializer_cls
 
+    def _serialize_objects(self, items, request):
+        serializer_cls = self._get_serializer(request)
         return serialize(items, request.user, serializer=serializer_cls())
 
     def get(self, request):

--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -26,10 +26,8 @@ class BroadcastIndexEndpoint(Endpoint):
 
     def _get_serializer(self, request):
         if is_active_superuser(request):
-            serializer_cls = AdminBroadcastSerializer
-        else:
-            serializer_cls = BroadcastSerializer
-        return serializer_cls
+            return AdminBroadcastSerializer
+        return BroadcastSerializer
 
     def _serialize_objects(self, items, request):
         serializer_cls = self._get_serializer(request)


### PR DESCRIPTION
This refactors the serializer class selection into its own helper function. Will be useful when subclassing.