### PR TITLE
ref(tests): Use data-test-id attribute instead of classname for tests

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/searchDropdown.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchDropdown.jsx
@@ -44,7 +44,7 @@ class SearchDropdown extends React.PureComponent {
       <div className={classNames('search-dropdown', this.props.className)}>
         <ul className="search-helper search-autocomplete-list">
           {this.props.loading ? (
-            <li key="loading" className="search-autocomplete-item">
+            <li key="loading" data-test-id="search-autocomplete-item">
               <LoadingIndicator mini={true} />
             </li>
           ) : (
@@ -52,10 +52,8 @@ class SearchDropdown extends React.PureComponent {
               return (
                 <li
                   key={item.value || item.desc}
-                  className={classNames(
-                    'search-autocomplete-item',
-                    item.active && 'active'
-                  )}
+                  className={item.active ? 'active' : null}
+                  data-test-id="search-autocomplete-item"
                   onClick={this.props.onClick.bind(this, item.value, item)}
                 >
                   <span className={classNames('icon', item.className)} />

--- a/tests/js/spec/views/organizationEvents/searchBar.spec.jsx
+++ b/tests/js/spec/views/organizationEvents/searchBar.spec.jsx
@@ -8,7 +8,7 @@ const focusInput = el => el.find('input[name="query"]').simulate('focus');
 const selectFirstAutocompleteItem = el => {
   focusInput(el);
 
-  el.find('.search-autocomplete-item')
+  el.find('[data-test-id="search-autocomplete-item"]')
     .first()
     .simulate('click');
   const input = el.find('input');
@@ -129,8 +129,8 @@ describe('SearchBar', function() {
     await tick();
     wrapper.update();
 
-    expect(wrapper.find('.search-autocomplete-item')).toHaveLength(1);
-    expect(wrapper.find('.search-autocomplete-item').text()).toBe('gpu:');
+    expect(wrapper.find('[data-test-id="search-autocomplete-item"]')).toHaveLength(1);
+    expect(wrapper.find('[data-test-id="search-autocomplete-item"]').text()).toBe('gpu:');
   });
 
   it('ignores wildcard ("*") at the beginning of tag value query', async function() {


### PR DESCRIPTION
The `search-autocomplete-item` classname is only used for tests, not
styling.