### PR TITLE
feat: Only show location for native events

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -371,6 +371,7 @@ class GroupSerializerBase(Serializer):
             'status': status_label,
             'statusDetails': status_details,
             'isPublic': share_id is not None,
+            'platform': obj.platform,
             'project': {
                 'id': six.text_type(obj.project.id),
                 'name': obj.project.name,

--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
@@ -9,6 +9,7 @@ import ProjectLink from 'app/components/projectLink';
 import {Metadata} from 'app/sentryTypes';
 import EventOrGroupTitle from 'app/components/eventOrGroupTitle';
 import Tooltip from 'app/components/tooltip';
+import {isNativePlatform} from 'app/utils/platform';
 
 /**
  * Displays an event or group/issue title (i.e. in Stream)
@@ -63,7 +64,7 @@ class EventOrGroupHeader extends React.Component {
 
   getLocation() {
     const {data} = this.props;
-    if (data.type === 'error') {
+    if (data.type === 'error' && isNativePlatform(data.platform)) {
       const {metadata} = data || {};
       return metadata.filename || null;
     }

--- a/src/sentry/static/sentry/app/utils/platform.jsx
+++ b/src/sentry/static/sentry/app/utils/platform.jsx
@@ -1,0 +1,12 @@
+export function isNativePlatform(platform) {
+  switch (platform) {
+    case 'cocoa':
+    case 'objc':
+    case 'native':
+    case 'swift':
+    case 'c':
+      return true;
+    default:
+      return false;
+  }
+}


### PR DESCRIPTION
This only renders the location information for events that are considered native. This uses the same platform mapping as we have for the grouping on the backend. This required platform to be exposed from the group serializer.

Before:

![image](https://user-images.githubusercontent.com/7396/56056241-eeb8b400-5d5b-11e9-892a-c175a8f18bde.png)

After:

![image](https://user-images.githubusercontent.com/7396/56056097-84a00f00-5d5b-11e9-9390-e3863e81e168.png)