### PR TITLE
feat: No longer fix up the culprit for javascript

### DIFF
--- a/src/sentry/lang/javascript/plugin.py
+++ b/src/sentry/lang/javascript/plugin.py
@@ -12,7 +12,6 @@ from .errorlocale import translate_exception
 def preprocess_event(data):
     rewrite_exception(data)
     translate_exception(data)
-    fix_culprit(data)
     generate_modules(data)
     return data
 
@@ -28,14 +27,6 @@ def generate_modules(data):
             abs_path = frame.get('abs_path')
             if abs_path and abs_path.startswith(('http:', 'https:', 'webpack:', 'app:')):
                 frame['module'] = generate_module(abs_path)
-
-
-def fix_culprit(data):
-    if not get_path(data, 'exception', 'values', filter=True):
-        return
-
-    from sentry.event_manager import generate_culprit
-    data['culprit'] = generate_culprit(data)
 
 
 class JavascriptPlugin(Plugin2):

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -535,41 +535,6 @@ class TrimLineTest(TestCase):
 
 
 class GenerateModulesTest(TestCase):
-    def test_get_culprit_is_patched(self):
-        from sentry.lang.javascript.plugin import fix_culprit, generate_modules
-
-        data = {
-            'message': 'hello',
-            'platform': 'javascript',
-            'exception': {
-                'values': [
-                    {
-                        'type': 'Error',
-                        'stacktrace': {
-                            'frames': [
-                                {
-                                    'abs_path': 'http://example.com/foo.js',
-                                    'filename': 'foo.js',
-                                    'lineno': 4,
-                                    'colno': 0,
-                                    'function': 'thing',
-                                },
-                                {
-                                    'abs_path': 'http://example.com/bar.js',
-                                    'filename': 'bar.js',
-                                    'lineno': 1,
-                                    'colno': 0,
-                                    'function': 'oops',
-                                },
-                            ],
-                        },
-                    }
-                ],
-            }
-        }
-        generate_modules(data)
-        fix_culprit(data)
-        assert data['culprit'] == 'oops(bar)'
 
     def test_ensure_module_names(self):
         from sentry.lang.javascript.plugin import generate_modules
@@ -606,7 +571,7 @@ class GenerateModulesTest(TestCase):
         assert exc['stacktrace']['frames'][1]['module'] == 'foo/bar'
 
     def test_generate_modules_skips_none(self):
-        from sentry.lang.javascript.plugin import fix_culprit, generate_modules
+        from sentry.lang.javascript.plugin import generate_modules
 
         expected = {
             'culprit': '',
@@ -638,7 +603,6 @@ class GenerateModulesTest(TestCase):
 
         actual = deepcopy(expected)
         generate_modules(actual)
-        fix_culprit(actual)
         assert actual == expected
 
 


### PR DESCRIPTION
As a temporary fix we no longer require culprit in the javascript plugin.  This is necessary
beacuse a group does not know which transaction it belongs to for the overview page so the
culprit field was repurposed for this.  However since the javascript plugin fixes up the
culprit a transaction is lost in many cases.

This removes support for culprit rewriting so future group updates will retain the
transaction here.

Ideally we would know which transaction a group belongs to in other ways.