### PR TITLE
feat(superuser): Make non member projects clearer in dropdown

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
@@ -1,4 +1,4 @@
-import {pick, isEqual} from 'lodash';
+import {isEqual, pick, partition} from 'lodash';
 import {withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -301,14 +301,19 @@ class GlobalSelectionHeader extends React.Component {
   };
 
   getProjects = () => {
-    const {isSuperuser} = ConfigStore.get('user');
     const {projects} = this.props;
+    const {isSuperuser} = ConfigStore.get('user');
+
+    const [memberProjects, nonMemberProjects] = partition(
+      projects,
+      project => project.isMember
+    );
 
     if (isSuperuser) {
-      return projects;
+      return [...memberProjects, ...nonMemberProjects];
     }
 
-    return projects.filter(project => project.isMember);
+    return memberProjects;
   };
 
   getFirstProject = () => {

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -20,7 +20,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
   static propTypes = {
     organization: SentryTypes.Organization.isRequired,
     value: PropTypes.array,
-    projects: PropTypes.array,
+    projects: PropTypes.array.isRequired,
     onChange: PropTypes.func,
     onUpdate: PropTypes.func,
     multi: PropTypes.bool,

--- a/src/sentry/static/sentry/app/components/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectSelector.jsx
@@ -335,11 +335,13 @@ class ProjectSelectorItem extends React.PureComponent {
       <BadgeAndActionsWrapper
         bookmarkHasChanged={this.state.bookmarkHasChanged}
         onAnimationEnd={this.clearAnimation}
+        isProjectMember={project.isMember}
       >
         <GlobalSelectionHeaderRow
           checked={isChecked}
           onCheckClick={this.handleClick}
           multi={multi}
+          priority="secondary"
         >
           <BadgeWrapper multi={multi}>
             <IdBadge
@@ -427,13 +429,13 @@ const SettingsIcon = styled(InlineSvg)`
 `;
 
 const BadgeAndActionsWrapper = styled('div')`
+  background-color: ${p => (p.isProjectMember ? p.theme.white : p.theme.offWhite2)};
   animation: ${p => (p.bookmarkHasChanged ? `1s ${alertHighlight('info')}` : 'none')};
   z-index: ${p => (p.bookmarkHasChanged ? 1 : 'inherit')};
   position: relative;
   border-style: solid;
   border-width: 1px 0;
   border-color: transparent;
-
   &:hover ${StyledBookmarkStar}, &:hover ${SettingsIconLink} {
     opacity: 1;
   }

--- a/src/sentry/static/sentry/app/components/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectSelector.jsx
@@ -428,14 +428,21 @@ const SettingsIcon = styled(InlineSvg)`
   width: 16px;
 `;
 
+const getNonMemberStyles = p => {
+  return `
+    color: ${p.theme.gray2};
+    font-style: italic;
+  `;
+};
+
 const BadgeAndActionsWrapper = styled('div')`
-  background-color: ${p => (p.isProjectMember ? p.theme.white : p.theme.offWhite2)};
   animation: ${p => (p.bookmarkHasChanged ? `1s ${alertHighlight('info')}` : 'none')};
   z-index: ${p => (p.bookmarkHasChanged ? 1 : 'inherit')};
   position: relative;
   border-style: solid;
   border-width: 1px 0;
   border-color: transparent;
+  ${p => (p.isProjectMember ? null : getNonMemberStyles(p))}
   &:hover ${StyledBookmarkStar}, &:hover ${SettingsIconLink} {
     opacity: 1;
   }

--- a/src/sentry/static/sentry/app/components/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectSelector.jsx
@@ -431,7 +431,6 @@ const SettingsIcon = styled(InlineSvg)`
 const getNonMemberStyles = p => {
   return `
     color: ${p.theme.gray2};
-    font-style: italic;
   `;
 };
 

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -6,6 +6,7 @@ import GlobalSelectionHeader from 'app/components/organizations/globalSelectionH
 import GlobalSelectionStore from 'app/stores/globalSelectionStore';
 import * as globalActions from 'app/actionCreators/globalSelection';
 import ProjectsStore from 'app/stores/projectsStore';
+import ConfigStore from 'app/stores/configStore';
 
 const changeQuery = (routerContext, query) => ({
   ...routerContext,
@@ -305,6 +306,51 @@ describe('GlobalSelectionHeader', function() {
       const items = wrapper.find('MultipleEnvironmentSelector EnvironmentSelectorItem');
       expect(items.length).toEqual(1);
       expect(items.at(0).text()).toBe('staging');
+    });
+  });
+
+  describe('projects list', function() {
+    let wrapper, memberProject, nonMemberProject, initialData;
+    beforeEach(function() {
+      memberProject = TestStubs.Project({id: '3', isMember: true});
+      nonMemberProject = TestStubs.Project({id: '4', isMember: false});
+      const org = TestStubs.Organization({projects: [memberProject, nonMemberProject]});
+      ProjectsStore.loadInitialData(org.projects);
+
+      initialData = initializeOrg({
+        organization: org,
+        router: {
+          location: {query: {}},
+        },
+      });
+
+      wrapper = mount(
+        <GlobalSelectionHeader organization={initialData.organization} />,
+        initialData.routerContext
+      );
+    });
+    it('gets member projects', function() {
+      expect(wrapper.find('MultipleProjectSelector').prop('projects')).toEqual([
+        memberProject,
+      ]);
+    });
+
+    it('gets all projects if superuser', function() {
+      ConfigStore.config = {
+        user: {
+          isSuperuser: true,
+        },
+      };
+
+      wrapper = mount(
+        <GlobalSelectionHeader organization={initialData.organization} />,
+        initialData.routerContext
+      );
+
+      expect(wrapper.find('MultipleProjectSelector').prop('projects')).toEqual([
+        memberProject,
+        nonMemberProject,
+      ]);
     });
   });
 });


### PR DESCRIPTION
Moves projects without membership to the bottom of the project dropdown,
make them visually different with a grey background color. This change
currently only affects superusers.