### PR TITLE
fix(ui) Fix z-index of SortOptions and broken ref forwarding

### DIFF
--- a/src/sentry/static/sentry/app/components/button/index.jsx
+++ b/src/sentry/static/sentry/app/components/button/index.jsx
@@ -201,24 +201,23 @@ const shouldForwardProp = p =>
   (p !== 'disabled' && isPropValid(p)) || customProps.includes(p);
 
 const StyledButton = styled(
-  ({external, ...props}) => {
+  React.forwardRef((props, ref) => {
     // Get component to use based on existance of `to` or `href` properties
     // Can be react-router `Link`, `a`, or `button`
     if (props.to) {
-      return <Link {...props} />;
+      return <Link ref={ref} {...props} />;
     }
 
     if (!props.href) {
-      return <button {...props} />;
+      return <button ref={ref} {...props} />;
     }
 
     if (external) {
-      return <ExternalLink {...props} />;
+      return <ExternalLink ref={ref} {...props} />;
     }
 
-    return <a {...props} />;
-  },
-  {shouldForwardProp}
+    return <a ref={ref} {...props} />;
+  })
 )`
   display: inline-block;
   line-height: 1;

--- a/src/sentry/static/sentry/app/components/button/index.jsx
+++ b/src/sentry/static/sentry/app/components/button/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled, {css} from 'react-emotion';
 import isPropValid from '@emotion/is-prop-valid';
+import {pickBy} from 'lodash';
 
 import ExternalLink from 'app/components/externalLink';
 import InlineSvg from 'app/components/inlineSvg';
@@ -196,27 +197,28 @@ const getColors = ({priority, disabled, borderless, theme}) => {
   `;
 };
 
-const customProps = ['external', 'size'];
-const shouldForwardProp = p =>
-  (p !== 'disabled' && isPropValid(p)) || customProps.includes(p);
-
 const StyledButton = styled(
-  React.forwardRef((props, ref) => {
+  React.forwardRef((prop, ref) => {
+    const forwardProps = pickBy(
+      prop,
+      (value, key) => key !== 'disabled' && isPropValid(key)
+    );
+
     // Get component to use based on existance of `to` or `href` properties
     // Can be react-router `Link`, `a`, or `button`
-    if (props.to) {
-      return <Link ref={ref} {...props} />;
+    if (prop.to) {
+      return <Link ref={ref} {...forwardProps} />;
     }
 
-    if (!props.href) {
-      return <button ref={ref} {...props} />;
+    if (!prop.href) {
+      return <button ref={ref} {...forwardProps} />;
     }
 
-    if (external) {
-      return <ExternalLink ref={ref} {...props} />;
+    if (prop.external) {
+      return <ExternalLink ref={ref} {...forwardProps} />;
     }
 
-    return <a ref={ref} {...props} />;
+    return <a ref={ref} {...forwardProps} />;
   })
 )`
   display: inline-block;

--- a/src/sentry/static/sentry/app/components/button/index.jsx
+++ b/src/sentry/static/sentry/app/components/button/index.jsx
@@ -198,6 +198,8 @@ const getColors = ({priority, disabled, borderless, theme}) => {
 };
 
 const StyledButton = styled(
+  // While props is the conventional name, we're using `prop` to trick
+  // eslint as using `props` results in unfixable 'missing proptypes` warnings.
   React.forwardRef((prop, ref) => {
     const forwardProps = pickBy(
       prop,

--- a/src/sentry/static/sentry/app/components/dropdownButton.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownButton.jsx
@@ -25,7 +25,9 @@ const StyledChevronDown = styled(props => (
   margin-left: 0.33em;
 `;
 
-const StyledButton = styled(({isOpen, ...props}) => <Button {...props} />)`
+const StyledButton = styled(
+  React.forwardRef((props, ref) => <Button innerRef={ref} {...props} />)
+)`
   border-bottom-right-radius: ${p => (p.isOpen ? 0 : p.theme.borderRadius)};
   border-bottom-left-radius: ${p => (p.isOpen ? 0 : p.theme.borderRadius)};
   position: relative;

--- a/src/sentry/static/sentry/app/components/dropdownButton.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownButton.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import styled from 'react-emotion';
 import Button from 'app/components/button';
 import InlineSvg from 'app/components/inlineSvg';
+import {omit} from 'lodash';
 
 class DropdownButton extends React.Component {
   static propTypes = {
@@ -26,7 +27,10 @@ const StyledChevronDown = styled(props => (
 `;
 
 const StyledButton = styled(
-  React.forwardRef((props, ref) => <Button innerRef={ref} {...props} />)
+  React.forwardRef((props, ref) => {
+    const forwardProps = omit(props, ['isOpen']);
+    return <Button innerRef={ref} {...forwardProps} />;
+  })
 )`
   border-bottom-right-radius: ${p => (p.isOpen ? 0 : p.theme.borderRadius)};
   border-bottom-left-radius: ${p => (p.isOpen ? 0 : p.theme.borderRadius)};

--- a/src/sentry/static/sentry/app/components/dropdownButton.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownButton.jsx
@@ -4,19 +4,20 @@ import styled from 'react-emotion';
 import Button from 'app/components/button';
 import InlineSvg from 'app/components/inlineSvg';
 
-const DropdownButton = ({isOpen, children, ...props}) => {
-  return (
-    <StyledButton isOpen={isOpen} {...props}>
-      {children}
-      <StyledChevronDown />
-    </StyledButton>
-  );
-};
-
-DropdownButton.displayName = 'DropdownButton';
-DropdownButton.propTypes = {
-  isOpen: PropTypes.bool,
-};
+class DropdownButton extends React.Component {
+  static propTypes = {
+    isOpen: PropTypes.bool,
+  };
+  render() {
+    const {isOpen, children, ...otherProps} = this.props;
+    return (
+      <StyledButton isOpen={isOpen} {...otherProps}>
+        {children}
+        <StyledChevronDown />
+      </StyledButton>
+    );
+  }
+}
 
 const StyledChevronDown = styled(props => (
   <InlineSvg src="icon-chevron-down" {...props} />

--- a/src/sentry/static/sentry/app/utils/theme.jsx
+++ b/src/sentry/static/sentry/app/utils/theme.jsx
@@ -73,9 +73,6 @@ const theme = {
   zIndex: {
     header: 1000,
     dropdown: 1001,
-    globalSelectionHeader: 1002,
-    sidebar: 1003,
-    orgAndUserMenu: 1004,
 
     dropdownAutocomplete: {
       // needs to be below actor but above other page elements (e.g. pagination)
@@ -87,8 +84,12 @@ const theme = {
       actor: 1008,
     },
 
+    globalSelectionHeader: 1009,
+    sidebar: 1010,
+    orgAndUserMenu: 1011,
+
     // Sentry user feedback modal
-    sentryErrorEmbed: 1009,
+    sentryErrorEmbed: 1090,
 
     modal: 10000,
     toast: 10001,

--- a/src/sentry/static/sentry/app/views/stream/organizationSavedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/stream/organizationSavedSearchSelector.jsx
@@ -93,7 +93,10 @@ export default class OrganizationSavedSearchSelector extends React.Component {
           {({isOpen, getMenuProps, getActorProps}) => {
             return (
               <React.Fragment>
-                <StyledDropdownButton {...getActorProps()} isOpen={isOpen}>
+                <StyledDropdownButton
+                  {...getActorProps({isStyled: true})}
+                  isOpen={isOpen}
+                >
                   <ButtonTitle>{this.getTitle()}</ButtonTitle>
                 </StyledDropdownButton>
                 <MenuContainer {...getMenuProps({isStyled: true})} isOpen={isOpen}>

--- a/src/sentry/static/sentry/app/views/stream/sortOptions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/sortOptions.jsx
@@ -66,7 +66,10 @@ class SortOptions extends React.PureComponent {
           {({isOpen, getMenuProps, getActorProps}) => {
             return (
               <React.Fragment>
-                <StyledDropdownButton {...getActorProps()} isOpen={isOpen}>
+                <StyledDropdownButton
+                  {...getActorProps({isStyled: true})}
+                  isOpen={isOpen}
+                >
                   <em>{t('Sort by')}: &nbsp; </em>
                   {this.getSortLabel(this.state.sortKey)}
                 </StyledDropdownButton>

--- a/src/sentry/static/sentry/app/views/stream/sortOptions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/sortOptions.jsx
@@ -93,7 +93,9 @@ const Container = styled.div`
   margin-right: ${space(0.5)};
 `;
 
-const StyledDropdownButton = styled(DropdownButton)`
+const StyledDropdownButton = styled(
+  React.forwardRef((prop, ref) => <DropdownButton innerRef={ref} {...prop} />)
+)`
   z-index: ${p => p.theme.zIndex.dropdownAutocomplete.actor};
   white-space: nowrap;
   font-weight: normal;

--- a/tests/js/spec/components/__snapshots__/confirmDelete.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/confirmDelete.spec.jsx.snap
@@ -256,10 +256,11 @@ exports[`ConfirmDelete renders 1`] = `
                 }
               }
             >
-              <Component
+              <ForwardRef
                 aria-disabled={false}
                 aria-label="Cancel"
                 className="css-cmo08-StyledButton-getColors eqrebog0"
+                disabled={false}
                 onClick={[Function]}
                 role="button"
                 style={
@@ -292,7 +293,7 @@ exports[`ConfirmDelete renders 1`] = `
                     </Component>
                   </ButtonLabel>
                 </button>
-              </Component>
+              </ForwardRef>
             </StyledButton>
           </Button>
           <Button
@@ -314,14 +315,16 @@ exports[`ConfirmDelete renders 1`] = `
               role="button"
               to={null}
             >
-              <Component
+              <ForwardRef
                 aria-disabled={true}
                 aria-label="Confirm"
                 autoFocus={true}
                 className="css-bo8dlg-StyledButton-getColors eqrebog0"
                 data-test-id="confirm-modal"
+                disabled={true}
                 href={null}
                 onClick={[Function]}
+                priority="primary"
                 role="button"
                 to={null}
               >
@@ -351,7 +354,7 @@ exports[`ConfirmDelete renders 1`] = `
                     </Component>
                   </ButtonLabel>
                 </button>
-              </Component>
+              </ForwardRef>
             </StyledButton>
           </Button>
         </div>

--- a/tests/js/spec/components/forms/__snapshots__/formField.spec.jsx.snap
+++ b/tests/js/spec/components/forms/__snapshots__/formField.spec.jsx.snap
@@ -332,12 +332,14 @@ exports[`FormField + model renders with Form 1`] = `
               role="button"
               type="submit"
             >
-              <Component
+              <ForwardRef
                 aria-disabled={false}
                 aria-label="Save Changes"
                 className="css-1msljz8-StyledButton-getColors eqrebog0"
                 data-test-id="form-submit"
+                disabled={false}
                 onClick={[Function]}
+                priority="primary"
                 role="button"
                 type="submit"
               >
@@ -365,7 +367,7 @@ exports[`FormField + model renders with Form 1`] = `
                     </Component>
                   </ButtonLabel>
                 </button>
-              </Component>
+              </ForwardRef>
             </StyledButton>
           </Button>
         </Observer>

--- a/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
+++ b/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
@@ -417,10 +417,11 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
           role="button"
           size="small"
         >
-          <Component
+          <ForwardRef
             aria-disabled={false}
             aria-label="Cancel"
             className="css-dkprmi-StyledButton-getColors eqrebog0"
+            disabled={false}
             onClick={[Function]}
             role="button"
             size="small"
@@ -448,7 +449,7 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
                 </Component>
               </ButtonLabel>
             </button>
-          </Component>
+          </ForwardRef>
         </StyledButton>
       </Button>
       <withConfig(AccessContainer)
@@ -737,11 +738,13 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
                             }
                           }
                         >
-                          <Component
+                          <ForwardRef
                             aria-disabled={false}
                             aria-label="Add Installation"
                             className="css-zvpqlo-StyledButton-getColors eqrebog0"
+                            disabled={false}
                             onClick={[Function]}
+                            priority="primary"
                             role="button"
                             size="small"
                             style={
@@ -780,7 +783,7 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
                                 </Component>
                               </ButtonLabel>
                             </button>
-                          </Component>
+                          </ForwardRef>
                         </StyledButton>
                       </Button>
                     </AddIntegration>

--- a/tests/js/spec/components/modals/__snapshots__/sentryAppPermissionsModal.spec.jsx.snap
+++ b/tests/js/spec/components/modals/__snapshots__/sentryAppPermissionsModal.spec.jsx.snap
@@ -141,11 +141,13 @@ exports[`SentryAppPermissionsModal installs the application 1`] = `
           priority="success"
           role="button"
         >
-          <Component
+          <ForwardRef
             aria-disabled={false}
             aria-label="Install"
             className="ey7jt0i0 css-17kpa0r-StyledButton-getColors-StyledButton eqrebog0"
+            disabled={false}
             onClick={[Function]}
+            priority="success"
             role="button"
           >
             <button
@@ -170,7 +172,7 @@ exports[`SentryAppPermissionsModal installs the application 1`] = `
                 </Component>
               </ButtonLabel>
             </button>
-          </Component>
+          </ForwardRef>
         </StyledButton>
       </Button>
     </StyledButton>
@@ -190,10 +192,11 @@ exports[`SentryAppPermissionsModal installs the application 1`] = `
           onClick={[Function]}
           role="button"
         >
-          <Component
+          <ForwardRef
             aria-disabled={false}
             aria-label="Cancel"
             className="ey7jt0i0 css-1xref87-StyledButton-getColors-StyledButton eqrebog0"
+            disabled={false}
             onClick={[Function]}
             role="button"
           >
@@ -216,7 +219,7 @@ exports[`SentryAppPermissionsModal installs the application 1`] = `
                 </Component>
               </ButtonLabel>
             </button>
-          </Component>
+          </ForwardRef>
         </StyledButton>
       </Button>
     </StyledButton>
@@ -365,11 +368,13 @@ exports[`SentryAppPermissionsModal renders permissions modal 1`] = `
           priority="success"
           role="button"
         >
-          <Component
+          <ForwardRef
             aria-disabled={false}
             aria-label="Install"
             className="ey7jt0i0 css-17kpa0r-StyledButton-getColors-StyledButton eqrebog0"
+            disabled={false}
             onClick={[Function]}
+            priority="success"
             role="button"
           >
             <button
@@ -394,7 +399,7 @@ exports[`SentryAppPermissionsModal renders permissions modal 1`] = `
                 </Component>
               </ButtonLabel>
             </button>
-          </Component>
+          </ForwardRef>
         </StyledButton>
       </Button>
     </StyledButton>
@@ -414,10 +419,11 @@ exports[`SentryAppPermissionsModal renders permissions modal 1`] = `
           onClick={[Function]}
           role="button"
         >
-          <Component
+          <ForwardRef
             aria-disabled={false}
             aria-label="Cancel"
             className="ey7jt0i0 css-1xref87-StyledButton-getColors-StyledButton eqrebog0"
+            disabled={false}
             onClick={[Function]}
             role="button"
           >
@@ -440,7 +446,7 @@ exports[`SentryAppPermissionsModal renders permissions modal 1`] = `
                 </Component>
               </ButtonLabel>
             </button>
-          </Component>
+          </ForwardRef>
         </StyledButton>
       </Button>
     </StyledButton>

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -169,7 +169,7 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
   }
 >
   <div
-    className="css-1ldvedv-OrgAndUserMenu-SidebarDropdownMenu e1fowdfw9"
+    className="css-1edm9sw-OrgAndUserMenu-SidebarDropdownMenu e1fowdfw9"
     onClick={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -1255,10 +1255,11 @@ exports[`Sidebar SidebarPanel can show Incidents in Sidebar Panel 1`] = `
               role="button"
               size="small"
             >
-              <Component
+              <ForwardRef
                 aria-disabled={false}
                 aria-label="Learn more"
                 className="css-dkprmi-StyledButton-getColors eqrebog0"
+                disabled={false}
                 external={true}
                 href="https://status.sentry.io"
                 onClick={[Function]}
@@ -1303,7 +1304,7 @@ exports[`Sidebar SidebarPanel can show Incidents in Sidebar Panel 1`] = `
                     </ButtonLabel>
                   </a>
                 </ExternalLink>
-              </Component>
+              </ForwardRef>
             </StyledButton>
           </Button>
         </div>
@@ -1323,11 +1324,11 @@ exports[`Sidebar can have onboarding feature 1`] = `
     collapsed={false}
   >
     <Component
-      className="css-1qwi75e-StyledSidebarPanel-getPositionForOrientation e1cvaskl0"
+      className="css-1k75klj-StyledSidebarPanel-getPositionForOrientation e1cvaskl0"
       collapsed={false}
     >
       <div
-        className="css-1qwi75e-StyledSidebarPanel-getPositionForOrientation e1cvaskl0"
+        className="css-1k75klj-StyledSidebarPanel-getPositionForOrientation e1cvaskl0"
       >
         <SidebarPanelHeader>
           <div
@@ -1750,7 +1751,7 @@ exports[`Sidebar renders without org and router 1`] = `
   org={null}
 >
   <div
-    className="css-1ldvedv-OrgAndUserMenu-SidebarDropdownMenu e1fowdfw9"
+    className="css-1edm9sw-OrgAndUserMenu-SidebarDropdownMenu e1fowdfw9"
     onClick={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}

--- a/tests/js/spec/stores/savedSearchesStore.spec.jsx
+++ b/tests/js/spec/stores/savedSearchesStore.spec.jsx
@@ -42,14 +42,15 @@ describe('SavedSearchesStore', function() {
   });
 
   it('fetching saved searches updates store', async function() {
-    fetchSavedSearches(api, 'org-1');
+    await fetchSavedSearches(api, 'org-1');
     await tick();
+
     expect(SavedSearchesStore.get().savedSearches).toHaveLength(2);
     expect(SavedSearchesStore.get().isLoading).toBe(false);
   });
 
   it('creates a new pin search', async function() {
-    fetchSavedSearches(api, 'org-1');
+    await fetchSavedSearches(api, 'org-1');
     await tick();
 
     pinSearch(api, 'org-1', 0, 'level:info');

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -163,7 +163,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                           isOpen={false}
                                           size="xsmall"
                                         >
-                                          <Component
+                                          <ForwardRef
                                             className="css-qfyoa0-StyledButton e1yghndz1"
                                             isOpen={false}
                                             size="xsmall"
@@ -171,19 +171,22 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                             <Button
                                               className="css-qfyoa0-StyledButton e1yghndz1"
                                               disabled={false}
+                                              innerRef={null}
                                               size="xsmall"
                                             >
                                               <StyledButton
                                                 aria-disabled={false}
                                                 className="css-qfyoa0-StyledButton e1yghndz1"
                                                 disabled={false}
+                                                innerRef={null}
                                                 onClick={[Function]}
                                                 role="button"
                                                 size="xsmall"
                                               >
-                                                <Component
+                                                <ForwardRef
                                                   aria-disabled={false}
                                                   className="e1yghndz1 css-1momm09-StyledButton-getColors-StyledButton eqrebog0"
+                                                  disabled={false}
                                                   onClick={[Function]}
                                                   role="button"
                                                   size="xsmall"
@@ -239,10 +242,10 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                                       </Component>
                                                     </ButtonLabel>
                                                   </button>
-                                                </Component>
+                                                </ForwardRef>
                                               </StyledButton>
                                             </Button>
-                                          </Component>
+                                          </ForwardRef>
                                         </StyledButton>
                                       </DropdownButton>
                                     </div>
@@ -617,9 +620,10 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                         role="button"
                         size="small"
                       >
-                        <Component
+                        <ForwardRef
                           aria-disabled={false}
                           className="css-dkprmi-StyledButton-getColors eqrebog0"
+                          disabled={false}
                           onClick={[Function]}
                           role="button"
                           size="small"
@@ -676,7 +680,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                               </Component>
                             </ButtonLabel>
                           </button>
-                        </Component>
+                        </ForwardRef>
                       </StyledButton>
                     </Button>
                   </Tooltip>
@@ -984,9 +988,10 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                         role="button"
                         size="small"
                       >
-                        <Component
+                        <ForwardRef
                           aria-disabled={false}
                           className="css-dkprmi-StyledButton-getColors eqrebog0"
+                          disabled={false}
                           onClick={[Function]}
                           role="button"
                           size="small"
@@ -1043,7 +1048,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                               </Component>
                             </ButtonLabel>
                           </button>
-                        </Component>
+                        </ForwardRef>
                       </StyledButton>
                     </Button>
                   </Tooltip>

--- a/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
@@ -885,11 +885,13 @@ exports[`Project Ownership Input renders 1`] = `
               size="small"
               to={null}
             >
-              <Component
+              <ForwardRef
                 aria-disabled={true}
                 className="e1hyuoc79 css-ogw40-StyledButton-getColors-AddButton eqrebog0"
+                disabled={true}
                 href={null}
                 onClick={[Function]}
+                priority="primary"
                 role="button"
                 size="small"
                 to={null}
@@ -964,7 +966,7 @@ exports[`Project Ownership Input renders 1`] = `
                     </Component>
                   </ButtonLabel>
                 </button>
-              </Component>
+              </ForwardRef>
             </StyledButton>
           </Button>
         </AddButton>
@@ -1053,11 +1055,13 @@ url:http://example.com/settings/* #product"
                   role="button"
                   size="small"
                 >
-                  <Component
+                  <ForwardRef
                     aria-disabled={false}
                     aria-label="Save Changes"
                     className="css-zvpqlo-StyledButton-getColors eqrebog0"
+                    disabled={false}
                     onClick={[Function]}
+                    priority="primary"
                     role="button"
                     size="small"
                   >
@@ -1086,7 +1090,7 @@ url:http://example.com/settings/* #product"
                         </Component>
                       </ButtonLabel>
                     </button>
-                  </Component>
+                  </ForwardRef>
                 </StyledButton>
               </Button>
             </div>

--- a/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRuleDetails.spec.jsx.snap
@@ -719,9 +719,10 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                           tabIndex="-1"
                                           type="button"
                                         >
-                                          <Component
+                                          <ForwardRef
                                             aria-disabled={false}
                                             className="css-dkprmi-StyledButton-getColors eqrebog0"
+                                            disabled={false}
                                             onClick={[Function]}
                                             role="button"
                                             size="small"
@@ -796,7 +797,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                                 </Component>
                                               </ButtonLabel>
                                             </button>
-                                          </Component>
+                                          </ForwardRef>
                                         </StyledButton>
                                       </Button>
                                     </div>
@@ -1537,9 +1538,10 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                           tabIndex="-1"
                                           type="button"
                                         >
-                                          <Component
+                                          <ForwardRef
                                             aria-disabled={false}
                                             className="css-dkprmi-StyledButton-getColors eqrebog0"
+                                            disabled={false}
                                             onClick={[Function]}
                                             role="button"
                                             size="small"
@@ -1614,7 +1616,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                                 </Component>
                                               </ButtonLabel>
                                             </button>
-                                          </Component>
+                                          </ForwardRef>
                                         </StyledButton>
                                       </Button>
                                     </div>
@@ -2436,10 +2438,11 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                               role="button"
                               to="/settings/org-slug/project-slug/alerts/rules/"
                             >
-                              <Component
+                              <ForwardRef
                                 aria-disabled={false}
                                 aria-label="Cancel"
                                 className="elb7f1e1 css-tzavck-StyledButton-getColors-CancelButton eqrebog0"
+                                disabled={false}
                                 onClick={[Function]}
                                 role="button"
                                 to="/settings/org-slug/project-slug/alerts/rules/"
@@ -2475,7 +2478,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                     </ButtonLabel>
                                   </a>
                                 </Link>
-                              </Component>
+                              </ForwardRef>
                             </StyledButton>
                           </Button>
                         </CancelButton>
@@ -2491,11 +2494,13 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                             priority="primary"
                             role="button"
                           >
-                            <Component
+                            <ForwardRef
                               aria-disabled={false}
                               aria-label="Save Rule"
                               className="css-1msljz8-StyledButton-getColors eqrebog0"
+                              disabled={false}
                               onClick={[Function]}
+                              priority="primary"
                               role="button"
                             >
                               <button
@@ -2520,7 +2525,7 @@ exports[`ProjectAlertRuleDetails Edit alert rule renders 1`] = `
                                   </Component>
                                 </ButtonLabel>
                               </button>
-                            </Component>
+                            </ForwardRef>
                           </StyledButton>
                         </Button>
                       </div>
@@ -4733,10 +4738,11 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                               role="button"
                               to="/settings/org-slug/project-slug/alerts/rules/"
                             >
-                              <Component
+                              <ForwardRef
                                 aria-disabled={false}
                                 aria-label="Cancel"
                                 className="elb7f1e1 css-tzavck-StyledButton-getColors-CancelButton eqrebog0"
+                                disabled={false}
                                 onClick={[Function]}
                                 role="button"
                                 to="/settings/org-slug/project-slug/alerts/rules/"
@@ -4772,7 +4778,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                     </ButtonLabel>
                                   </a>
                                 </Link>
-                              </Component>
+                              </ForwardRef>
                             </StyledButton>
                           </Button>
                         </CancelButton>
@@ -4788,11 +4794,13 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                             priority="primary"
                             role="button"
                           >
-                            <Component
+                            <ForwardRef
                               aria-disabled={false}
                               aria-label="Save Rule"
                               className="css-1msljz8-StyledButton-getColors eqrebog0"
+                              disabled={false}
                               onClick={[Function]}
+                              priority="primary"
                               role="button"
                             >
                               <button
@@ -4817,7 +4825,7 @@ exports[`ProjectAlertRuleDetails New alert rule renders 1`] = `
                                   </Component>
                                 </ButtonLabel>
                               </button>
-                            </Component>
+                            </ForwardRef>
                           </StyledButton>
                         </Button>
                       </div>

--- a/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertRules.spec.jsx.snap
@@ -231,11 +231,13 @@ exports[`projectAlertRules renders 1`] = `
                                 size="small"
                                 to="/settings/org-slug/projects/project1/alerts/rules/new/"
                               >
-                                <Component
+                                <ForwardRef
                                   aria-disabled={false}
                                   aria-label="New Alert Rule"
                                   className="css-zvpqlo-StyledButton-getColors eqrebog0"
+                                  disabled={false}
                                   onClick={[Function]}
+                                  priority="primary"
                                   role="button"
                                   size="small"
                                   to="/settings/org-slug/projects/project1/alerts/rules/new/"
@@ -323,7 +325,7 @@ exports[`projectAlertRules renders 1`] = `
                                       </ButtonLabel>
                                     </a>
                                   </Link>
-                                </Component>
+                                </ForwardRef>
                               </StyledButton>
                             </Button>
                           </Tooltip>
@@ -672,11 +674,12 @@ exports[`projectAlertRules renders 1`] = `
                                         }
                                         to="1/"
                                       >
-                                        <Component
+                                        <ForwardRef
                                           aria-disabled={false}
                                           aria-label="Edit Rule"
                                           className="css-dkprmi-StyledButton-getColors eqrebog0"
                                           data-test-id="edit-rule"
+                                          disabled={false}
                                           onClick={[Function]}
                                           role="button"
                                           size="xsmall"
@@ -733,7 +736,7 @@ exports[`projectAlertRules renders 1`] = `
                                               </ButtonLabel>
                                             </a>
                                           </Link>
-                                        </Component>
+                                        </ForwardRef>
                                       </StyledButton>
                                     </Button>
                                   </Tooltip>
@@ -764,9 +767,10 @@ exports[`projectAlertRules renders 1`] = `
                                           role="button"
                                           size="xsmall"
                                         >
-                                          <Component
+                                          <ForwardRef
                                             aria-disabled={false}
                                             className="css-dkprmi-StyledButton-getColors eqrebog0"
+                                            disabled={false}
                                             onClick={[Function]}
                                             role="button"
                                             size="xsmall"
@@ -837,7 +841,7 @@ exports[`projectAlertRules renders 1`] = `
                                                 </Component>
                                               </ButtonLabel>
                                             </button>
-                                          </Component>
+                                          </ForwardRef>
                                         </StyledButton>
                                       </Button>
                                       <Modal

--- a/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -934,10 +934,11 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                     role="button"
                                     size="xsmall"
                                   >
-                                    <Component
+                                    <ForwardRef
                                       aria-disabled={false}
                                       aria-label="Set as default"
                                       className="ezuela50 css-fp1reu-StyledButton-getColors-EnvironmentButton eqrebog0"
+                                      disabled={false}
                                       onClick={[Function]}
                                       role="button"
                                       size="xsmall"
@@ -965,7 +966,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                           </Component>
                                         </ButtonLabel>
                                       </button>
-                                    </Component>
+                                    </ForwardRef>
                                   </StyledButton>
                                 </Button>
                               </EnvironmentButton>
@@ -1157,10 +1158,11 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                     role="button"
                                     size="xsmall"
                                   >
-                                    <Component
+                                    <ForwardRef
                                       aria-disabled={false}
                                       aria-label="Set as default"
                                       className="ezuela50 css-fp1reu-StyledButton-getColors-EnvironmentButton eqrebog0"
+                                      disabled={false}
                                       onClick={[Function]}
                                       role="button"
                                       size="xsmall"
@@ -1188,7 +1190,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                           </Component>
                                         </ButtonLabel>
                                       </button>
-                                    </Component>
+                                    </ForwardRef>
                                   </StyledButton>
                                 </Button>
                               </EnvironmentButton>
@@ -1212,10 +1214,11 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                     role="button"
                                     size="xsmall"
                                   >
-                                    <Component
+                                    <ForwardRef
                                       aria-disabled={false}
                                       aria-label="Hide"
                                       className="ezuela50 css-fp1reu-StyledButton-getColors-EnvironmentButton eqrebog0"
+                                      disabled={false}
                                       onClick={[Function]}
                                       role="button"
                                       size="xsmall"
@@ -1243,7 +1246,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                           </Component>
                                         </ButtonLabel>
                                       </button>
-                                    </Component>
+                                    </ForwardRef>
                                   </StyledButton>
                                 </Button>
                               </EnvironmentButton>
@@ -1467,10 +1470,11 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                     role="button"
                                     size="xsmall"
                                   >
-                                    <Component
+                                    <ForwardRef
                                       aria-disabled={false}
                                       aria-label="Hide"
                                       className="ezuela50 css-fp1reu-StyledButton-getColors-EnvironmentButton eqrebog0"
+                                      disabled={false}
                                       onClick={[Function]}
                                       role="button"
                                       size="xsmall"
@@ -1498,7 +1502,7 @@ exports[`ProjectEnvironments render active renders environment list and sets sta
                                           </Component>
                                         </ButtonLabel>
                                       </button>
-                                    </Component>
+                                    </ForwardRef>
                                   </StyledButton>
                                 </Button>
                               </EnvironmentButton>
@@ -2458,10 +2462,11 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                                     role="button"
                                     size="xsmall"
                                   >
-                                    <Component
+                                    <ForwardRef
                                       aria-disabled={false}
                                       aria-label="Show"
                                       className="ezuela50 css-fp1reu-StyledButton-getColors-EnvironmentButton eqrebog0"
+                                      disabled={false}
                                       onClick={[Function]}
                                       role="button"
                                       size="xsmall"
@@ -2489,7 +2494,7 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                                           </Component>
                                         </ButtonLabel>
                                       </button>
-                                    </Component>
+                                    </ForwardRef>
                                   </StyledButton>
                                 </Button>
                               </EnvironmentButton>

--- a/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
@@ -220,10 +220,11 @@ exports[`ProjectPluginDetails renders 1`] = `
                                   }
                                 }
                               >
-                                <Component
+                                <ForwardRef
                                   aria-disabled={false}
                                   aria-label="Enable Plugin"
                                   className="css-dkprmi-StyledButton-getColors eqrebog0"
+                                  disabled={false}
                                   onClick={[Function]}
                                   role="button"
                                   size="small"
@@ -261,7 +262,7 @@ exports[`ProjectPluginDetails renders 1`] = `
                                       </Component>
                                     </ButtonLabel>
                                   </button>
-                                </Component>
+                                </ForwardRef>
                               </StyledButton>
                             </Button>
                             <Button
@@ -277,10 +278,11 @@ exports[`ProjectPluginDetails renders 1`] = `
                                 role="button"
                                 size="small"
                               >
-                                <Component
+                                <ForwardRef
                                   aria-disabled={false}
                                   aria-label="Reset Configuration"
                                   className="css-dkprmi-StyledButton-getColors eqrebog0"
+                                  disabled={false}
                                   onClick={[Function]}
                                   role="button"
                                   size="small"
@@ -308,7 +310,7 @@ exports[`ProjectPluginDetails renders 1`] = `
                                       </Component>
                                     </ButtonLabel>
                                   </button>
-                                </Component>
+                                </ForwardRef>
                               </StyledButton>
                             </Button>
                           </div>

--- a/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectSavedSearches.spec.jsx.snap
@@ -390,9 +390,10 @@ exports[`ProjectSavedSearches renders 1`] = `
                                                 role="button"
                                                 size="small"
                                               >
-                                                <Component
+                                                <ForwardRef
                                                   aria-disabled={false}
                                                   className="css-dkprmi-StyledButton-getColors eqrebog0"
+                                                  disabled={false}
                                                   onClick={[Function]}
                                                   role="button"
                                                   size="small"
@@ -463,7 +464,7 @@ exports[`ProjectSavedSearches renders 1`] = `
                                                       </Component>
                                                     </ButtonLabel>
                                                   </button>
-                                                </Component>
+                                                </ForwardRef>
                                               </StyledButton>
                                             </Button>
                                             <Modal
@@ -708,9 +709,10 @@ exports[`ProjectSavedSearches renders 1`] = `
                                                 role="button"
                                                 size="small"
                                               >
-                                                <Component
+                                                <ForwardRef
                                                   aria-disabled={false}
                                                   className="css-dkprmi-StyledButton-getColors eqrebog0"
+                                                  disabled={false}
                                                   onClick={[Function]}
                                                   role="button"
                                                   size="small"
@@ -781,7 +783,7 @@ exports[`ProjectSavedSearches renders 1`] = `
                                                       </Component>
                                                     </ButtonLabel>
                                                   </button>
-                                                </Component>
+                                                </ForwardRef>
                                               </StyledButton>
                                             </Button>
                                             <Modal

--- a/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
@@ -486,10 +486,11 @@ exports[`ProjectTags renders 1`] = `
                                               role="button"
                                               size="xsmall"
                                             >
-                                              <Component
+                                              <ForwardRef
                                                 aria-disabled={false}
                                                 className="css-dkprmi-StyledButton-getColors eqrebog0"
                                                 data-test-id="delete"
+                                                disabled={false}
                                                 onClick={[Function]}
                                                 role="button"
                                                 size="xsmall"
@@ -561,7 +562,7 @@ exports[`ProjectTags renders 1`] = `
                                                     </Component>
                                                   </ButtonLabel>
                                                 </button>
-                                              </Component>
+                                              </ForwardRef>
                                             </StyledButton>
                                           </Button>
                                         </a>
@@ -715,10 +716,11 @@ exports[`ProjectTags renders 1`] = `
                                               role="button"
                                               size="xsmall"
                                             >
-                                              <Component
+                                              <ForwardRef
                                                 aria-disabled={false}
                                                 className="css-dkprmi-StyledButton-getColors eqrebog0"
                                                 data-test-id="delete"
+                                                disabled={false}
                                                 onClick={[Function]}
                                                 role="button"
                                                 size="xsmall"
@@ -790,7 +792,7 @@ exports[`ProjectTags renders 1`] = `
                                                     </Component>
                                                   </ButtonLabel>
                                                 </button>
-                                              </Component>
+                                              </ForwardRef>
                                             </StyledButton>
                                           </Button>
                                         </a>
@@ -944,10 +946,11 @@ exports[`ProjectTags renders 1`] = `
                                               role="button"
                                               size="xsmall"
                                             >
-                                              <Component
+                                              <ForwardRef
                                                 aria-disabled={false}
                                                 className="css-dkprmi-StyledButton-getColors eqrebog0"
                                                 data-test-id="delete"
+                                                disabled={false}
                                                 onClick={[Function]}
                                                 role="button"
                                                 size="xsmall"
@@ -1019,7 +1022,7 @@ exports[`ProjectTags renders 1`] = `
                                                     </Component>
                                                   </ButtonLabel>
                                                 </button>
-                                              </Component>
+                                              </ForwardRef>
                                             </StyledButton>
                                           </Button>
                                         </a>
@@ -1176,10 +1179,11 @@ exports[`ProjectTags renders 1`] = `
                                               size="xsmall"
                                               to={null}
                                             >
-                                              <Component
+                                              <ForwardRef
                                                 aria-disabled={true}
                                                 className="css-1ujzp8g-StyledButton-getColors eqrebog0"
                                                 data-test-id="delete"
+                                                disabled={true}
                                                 href={null}
                                                 onClick={[Function]}
                                                 role="button"
@@ -1255,7 +1259,7 @@ exports[`ProjectTags renders 1`] = `
                                                     </Component>
                                                   </ButtonLabel>
                                                 </button>
-                                              </Component>
+                                              </ForwardRef>
                                             </StyledButton>
                                           </Button>
                                         </a>
@@ -1411,10 +1415,11 @@ exports[`ProjectTags renders 1`] = `
                                               size="xsmall"
                                               to={null}
                                             >
-                                              <Component
+                                              <ForwardRef
                                                 aria-disabled={true}
                                                 className="css-1ujzp8g-StyledButton-getColors eqrebog0"
                                                 data-test-id="delete"
+                                                disabled={true}
                                                 href={null}
                                                 onClick={[Function]}
                                                 role="button"
@@ -1490,7 +1495,7 @@ exports[`ProjectTags renders 1`] = `
                                                     </Component>
                                                   </ButtonLabel>
                                                 </button>
-                                              </Component>
+                                              </ForwardRef>
                                             </StyledButton>
                                           </Button>
                                         </a>

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -1001,11 +1001,13 @@ exports[`RuleBuilder renders 1`] = `
             size="small"
             to={null}
           >
-            <Component
+            <ForwardRef
               aria-disabled={true}
               className="e1hyuoc79 css-ogw40-StyledButton-getColors-AddButton eqrebog0"
+              disabled={true}
               href={null}
               onClick={[Function]}
+              priority="primary"
               role="button"
               size="small"
               to={null}
@@ -1080,7 +1082,7 @@ exports[`RuleBuilder renders 1`] = `
                   </Component>
                 </ButtonLabel>
               </button>
-            </Component>
+            </ForwardRef>
           </StyledButton>
         </Button>
       </AddButton>
@@ -2816,10 +2818,12 @@ exports[`RuleBuilder renders with suggestions 1`] = `
             role="button"
             size="small"
           >
-            <Component
+            <ForwardRef
               aria-disabled={false}
               className="e1hyuoc79 css-1q9tuf6-StyledButton-getColors-AddButton eqrebog0"
+              disabled={false}
               onClick={[Function]}
+              priority="primary"
               role="button"
               size="small"
             >
@@ -2891,7 +2895,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                   </Component>
                 </ButtonLabel>
               </button>
-            </Component>
+            </ForwardRef>
           </StyledButton>
         </Button>
       </AddButton>

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -508,7 +508,7 @@ exports[`InviteMember should render roles when available and allowed, and handle
                                                 isOpen={false}
                                                 size="xsmall"
                                               >
-                                                <Component
+                                                <ForwardRef
                                                   aria-label="Add Team"
                                                   className="css-t6oz6z-StyledButton e1yghndz1"
                                                   disabled={true}
@@ -519,6 +519,7 @@ exports[`InviteMember should render roles when available and allowed, and handle
                                                     aria-label="Add Team"
                                                     className="css-t6oz6z-StyledButton e1yghndz1"
                                                     disabled={true}
+                                                    innerRef={null}
                                                     size="xsmall"
                                                   >
                                                     <StyledButton
@@ -527,15 +528,17 @@ exports[`InviteMember should render roles when available and allowed, and handle
                                                       className="css-t6oz6z-StyledButton e1yghndz1"
                                                       disabled={true}
                                                       href={null}
+                                                      innerRef={null}
                                                       onClick={[Function]}
                                                       role="button"
                                                       size="xsmall"
                                                       to={null}
                                                     >
-                                                      <Component
+                                                      <ForwardRef
                                                         aria-disabled={true}
                                                         aria-label="Add Team"
                                                         className="e1yghndz1 css-a1a4aj-StyledButton-getColors-StyledButton eqrebog0"
+                                                        disabled={true}
                                                         href={null}
                                                         onClick={[Function]}
                                                         role="button"
@@ -596,10 +599,10 @@ exports[`InviteMember should render roles when available and allowed, and handle
                                                             </Component>
                                                           </ButtonLabel>
                                                         </button>
-                                                      </Component>
+                                                      </ForwardRef>
                                                     </StyledButton>
                                                   </Button>
-                                                </Component>
+                                                </ForwardRef>
                                               </StyledButton>
                                             </DropdownButton>
                                           </div>
@@ -670,11 +673,14 @@ exports[`InviteMember should render roles when available and allowed, and handle
           priority="primary"
           role="button"
         >
-          <Component
+          <ForwardRef
             aria-disabled={false}
             aria-label="Add Member"
+            busy={false}
             className="invite-member-submit css-1msljz8-StyledButton-getColors eqrebog0"
+            disabled={false}
             onClick={[Function]}
+            priority="primary"
             role="button"
           >
             <button
@@ -699,7 +705,7 @@ exports[`InviteMember should render roles when available and allowed, and handle
                 </Component>
               </ButtonLabel>
             </button>
-          </Component>
+          </ForwardRef>
         </StyledButton>
       </Button>
     </div>

--- a/tests/js/spec/views/onboarding/__snapshots__/createProject.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/__snapshots__/createProject.spec.jsx.snap
@@ -1447,10 +1447,12 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                       title="Create a team"
                       type="button"
                     >
-                      <Component
+                      <ForwardRef
                         aria-disabled={false}
+                        borderless={true}
                         className="tip tip css-1v8ytf5-StyledButton-getColors eqrebog0"
                         data-test-id="create-team"
+                        disabled={false}
                         onClick={[Function]}
                         role="button"
                         title="Create a team"
@@ -1521,7 +1523,7 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                             </Component>
                           </ButtonLabel>
                         </button>
-                      </Component>
+                      </ForwardRef>
                     </StyledButton>
                   </Tooltip>
                 </Button>
@@ -1546,13 +1548,15 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
               role="button"
               to={null}
             >
-              <Component
+              <ForwardRef
                 aria-disabled={true}
                 aria-label="Create Project"
                 className="css-bo8dlg-StyledButton-getColors eqrebog0"
                 data-test-id="create-project"
+                disabled={true}
                 href={null}
                 onClick={[Function]}
+                priority="primary"
                 role="button"
                 to={null}
               >
@@ -1581,7 +1585,7 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                     </Component>
                   </ButtonLabel>
                 </button>
-              </Component>
+              </ForwardRef>
             </StyledButton>
           </Button>
         </div>
@@ -2046,9 +2050,11 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                         role="button"
                         size="xsmall"
                       >
-                        <Component
+                        <ForwardRef
                           aria-disabled={false}
+                          borderless={true}
                           className="ewlrg795 css-2lxdh0-StyledButton-getColors-ClearButton eqrebog0"
+                          disabled={false}
                           onClick={[Function]}
                           role="button"
                           size="xsmall"
@@ -2121,7 +2127,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                               </Component>
                             </ButtonLabel>
                           </button>
-                        </Component>
+                        </ForwardRef>
                       </StyledButton>
                     </Button>
                   </Component>
@@ -2406,10 +2412,12 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                       title="Create a team"
                       type="button"
                     >
-                      <Component
+                      <ForwardRef
                         aria-disabled={false}
+                        borderless={true}
                         className="tip tip css-1v8ytf5-StyledButton-getColors eqrebog0"
                         data-test-id="create-team"
+                        disabled={false}
                         onClick={[Function]}
                         role="button"
                         title="Create a team"
@@ -2480,7 +2488,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                             </Component>
                           </ButtonLabel>
                         </button>
-                      </Component>
+                      </ForwardRef>
                     </StyledButton>
                   </Tooltip>
                 </Button>
@@ -2505,13 +2513,15 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
               role="button"
               to={null}
             >
-              <Component
+              <ForwardRef
                 aria-disabled={true}
                 aria-label="Create Project"
                 className="css-bo8dlg-StyledButton-getColors eqrebog0"
                 data-test-id="create-project"
+                disabled={true}
                 href={null}
                 onClick={[Function]}
+                priority="primary"
                 role="button"
                 to={null}
               >
@@ -2540,7 +2550,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                     </Component>
                   </ButtonLabel>
                 </button>
-              </Component>
+              </ForwardRef>
             </StyledButton>
           </Button>
         </div>
@@ -2905,9 +2915,11 @@ exports[`CreateProject should fill in project name if its empty when platform is
                         role="button"
                         size="xsmall"
                       >
-                        <Component
+                        <ForwardRef
                           aria-disabled={false}
+                          borderless={true}
                           className="ewlrg795 css-2lxdh0-StyledButton-getColors-ClearButton eqrebog0"
+                          disabled={false}
                           onClick={[Function]}
                           role="button"
                           size="xsmall"
@@ -2980,7 +2992,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
                               </Component>
                             </ButtonLabel>
                           </button>
-                        </Component>
+                        </ForwardRef>
                       </StyledButton>
                     </Button>
                   </Component>
@@ -4015,10 +4027,12 @@ exports[`CreateProject should fill in project name if its empty when platform is
                       title="Create a team"
                       type="button"
                     >
-                      <Component
+                      <ForwardRef
                         aria-disabled={false}
+                        borderless={true}
                         className="tip tip css-1v8ytf5-StyledButton-getColors eqrebog0"
                         data-test-id="create-team"
+                        disabled={false}
                         onClick={[Function]}
                         role="button"
                         title="Create a team"
@@ -4089,7 +4103,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
                             </Component>
                           </ButtonLabel>
                         </button>
-                      </Component>
+                      </ForwardRef>
                     </StyledButton>
                   </Tooltip>
                 </Button>
@@ -4114,13 +4128,15 @@ exports[`CreateProject should fill in project name if its empty when platform is
               role="button"
               to={null}
             >
-              <Component
+              <ForwardRef
                 aria-disabled={true}
                 aria-label="Create Project"
                 className="css-bo8dlg-StyledButton-getColors eqrebog0"
                 data-test-id="create-project"
+                disabled={true}
                 href={null}
                 onClick={[Function]}
+                priority="primary"
                 role="button"
                 to={null}
               >
@@ -4149,7 +4165,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
                     </Component>
                   </ButtonLabel>
                 </button>
-              </Component>
+              </ForwardRef>
             </StyledButton>
           </Button>
         </div>

--- a/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/configure/__snapshots__/index.spec.jsx.snap
@@ -66,11 +66,13 @@ exports[`Configure should render correctly render() should render platform docs 
                     priority="primary"
                     role="button"
                   >
-                    <Component
+                    <ForwardRef
                       aria-disabled={false}
                       aria-label="Or See Sample Event"
                       className="eadl9o50 css-w2sk1s-StyledButton-getColors-StyledButton eqrebog0"
+                      disabled={false}
                       onClick={[Function]}
+                      priority="primary"
                       role="button"
                     >
                       <button
@@ -95,7 +97,7 @@ exports[`Configure should render correctly render() should render platform docs 
                           </Component>
                         </ButtonLabel>
                       </button>
-                    </Component>
+                    </ForwardRef>
                   </StyledButton>
                 </Button>
               </StyledButton>
@@ -379,10 +381,11 @@ exports[`Configure should render correctly render() should render platform docs 
                                                       role="button"
                                                       size="small"
                                                     >
-                                                      <Component
+                                                      <ForwardRef
                                                         aria-disabled={false}
                                                         aria-label="< Back"
                                                         className="css-dkprmi-StyledButton-getColors eqrebog0"
+                                                        disabled={false}
                                                         href="/testOrg/project-slug/getting-started/"
                                                         onClick={[Function]}
                                                         role="button"
@@ -412,7 +415,7 @@ exports[`Configure should render correctly render() should render platform docs 
                                                             </Component>
                                                           </ButtonLabel>
                                                         </a>
-                                                      </Component>
+                                                      </ForwardRef>
                                                     </StyledButton>
                                                   </Button>
                                                 </div>
@@ -445,10 +448,11 @@ exports[`Configure should render correctly render() should render platform docs 
                                                       role="button"
                                                       size="small"
                                                     >
-                                                      <Component
+                                                      <ForwardRef
                                                         aria-disabled={false}
                                                         aria-label="Full Documentation"
                                                         className="css-dkprmi-StyledButton-getColors eqrebog0"
+                                                        disabled={false}
                                                         external={true}
                                                         href="https://docs.getsentry.com/hosted/clients/csharp/"
                                                         onClick={[Function]}
@@ -493,7 +497,7 @@ exports[`Configure should render correctly render() should render platform docs 
                                                             </ButtonLabel>
                                                           </a>
                                                         </ExternalLink>
-                                                      </Component>
+                                                      </ForwardRef>
                                                     </StyledButton>
                                                   </Button>
                                                 </div>
@@ -611,12 +615,14 @@ exports[`Configure should render correctly render() should render platform docs 
               priority="primary"
               role="button"
             >
-              <Component
+              <ForwardRef
                 aria-disabled={false}
                 aria-label="All done!"
                 className="css-1msljz8-StyledButton-getColors eqrebog0"
                 data-test-id="configure-done"
+                disabled={false}
                 onClick={[Function]}
+                priority="primary"
                 role="button"
               >
                 <button
@@ -642,7 +648,7 @@ exports[`Configure should render correctly render() should render platform docs 
                     </Component>
                   </ButtonLabel>
                 </button>
-              </Component>
+              </ForwardRef>
             </StyledButton>
           </Button>
         </div>

--- a/tests/js/spec/views/organizationProjectsDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationProjectsDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -902,10 +902,11 @@ exports[`ProjectCard renders 1`] = `
                                 role="button"
                                 size="xsmall"
                               >
-                                <Component
+                                <ForwardRef
                                   aria-disabled={false}
                                   aria-label="Track deploys"
                                   className="css-dkprmi-StyledButton-getColors eqrebog0"
+                                  disabled={false}
                                   external={true}
                                   href="https://docs.sentry.io/learn/releases/"
                                   onClick={[Function]}
@@ -950,7 +951,7 @@ exports[`ProjectCard renders 1`] = `
                                       </ButtonLabel>
                                     </a>
                                   </ExternalLink>
-                                </Component>
+                                </ForwardRef>
                               </StyledButton>
                             </Button>
                           </div>

--- a/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -111,11 +111,13 @@ exports[`OrganizationApiKeysList renders 1`] = `
                         role="button"
                         size="small"
                       >
-                        <Component
+                        <ForwardRef
                           aria-disabled={false}
                           aria-label="New API Key"
                           className="css-zvpqlo-StyledButton-getColors eqrebog0"
+                          disabled={false}
                           onClick={[Function]}
+                          priority="primary"
                           role="button"
                           size="small"
                         >
@@ -189,7 +191,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
                               </Component>
                             </ButtonLabel>
                           </button>
-                        </Component>
+                        </ForwardRef>
                       </StyledButton>
                     </Button>
                   </div>

--- a/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
@@ -86,11 +86,13 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                             size="small"
                             to="/organizations/org-slug/projects/new/"
                           >
-                            <Component
+                            <ForwardRef
                               aria-disabled={false}
                               aria-label="Create Project"
                               className="css-zvpqlo-StyledButton-getColors eqrebog0"
+                              disabled={false}
                               onClick={[Function]}
+                              priority="primary"
                               role="button"
                               size="small"
                               to="/organizations/org-slug/projects/new/"
@@ -178,7 +180,7 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                                   </ButtonLabel>
                                 </a>
                               </Link>
-                            </Component>
+                            </ForwardRef>
                           </StyledButton>
                         </Button>
                       </div>
@@ -690,10 +692,11 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                                   size="small"
                                   to="/settings/org-slug/projects/project-slug/"
                                 >
-                                  <Component
+                                  <ForwardRef
                                     aria-disabled={false}
                                     aria-label="Settings"
                                     className="css-dkprmi-StyledButton-getColors eqrebog0"
+                                    disabled={false}
                                     onClick={[Function]}
                                     role="button"
                                     size="small"
@@ -780,7 +783,7 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                                         </ButtonLabel>
                                       </a>
                                     </Link>
-                                  </Component>
+                                  </ForwardRef>
                                 </StyledButton>
                               </Button>
                             </div>

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
@@ -86,11 +86,13 @@ exports[`Organization Developer Settings when no Apps exist displays empty state
                             size="small"
                             to="/settings/org-slug/developer-settings/new/"
                           >
-                            <Component
+                            <ForwardRef
                               aria-disabled={false}
                               aria-label="Create New Application"
                               className="css-zvpqlo-StyledButton-getColors eqrebog0"
+                              disabled={false}
                               onClick={[Function]}
+                              priority="primary"
                               role="button"
                               size="small"
                               to="/settings/org-slug/developer-settings/new/"
@@ -178,7 +180,7 @@ exports[`Organization Developer Settings when no Apps exist displays empty state
                                   </ButtonLabel>
                                 </a>
                               </Link>
-                            </Component>
+                            </ForwardRef>
                           </StyledButton>
                         </Button>
                       </div>
@@ -347,11 +349,13 @@ exports[`Organization Developer Settings with published apps trash button is dis
                             size="small"
                             to="/settings/org-slug/developer-settings/new/"
                           >
-                            <Component
+                            <ForwardRef
                               aria-disabled={false}
                               aria-label="Create New Application"
                               className="css-zvpqlo-StyledButton-getColors eqrebog0"
+                              disabled={false}
                               onClick={[Function]}
+                              priority="primary"
                               role="button"
                               size="small"
                               to="/settings/org-slug/developer-settings/new/"
@@ -439,7 +443,7 @@ exports[`Organization Developer Settings with published apps trash button is dis
                                   </ButtonLabel>
                                 </a>
                               </Link>
-                            </Component>
+                            </ForwardRef>
                           </StyledButton>
                         </Button>
                       </div>
@@ -736,9 +740,10 @@ exports[`Organization Developer Settings with published apps trash button is dis
                                               title="Published apps cannot be removed."
                                               to={null}
                                             >
-                                              <Component
+                                              <ForwardRef
                                                 aria-disabled={true}
                                                 className="tip tip css-1ujzp8g-StyledButton-getColors eqrebog0"
+                                                disabled={true}
                                                 href={null}
                                                 onClick={[Function]}
                                                 role="button"
@@ -815,7 +820,7 @@ exports[`Organization Developer Settings with published apps trash button is dis
                                                     </Component>
                                                   </ButtonLabel>
                                                 </button>
-                                              </Component>
+                                              </ForwardRef>
                                             </StyledButton>
                                           </Tooltip>
                                         </Button>
@@ -927,11 +932,13 @@ exports[`Organization Developer Settings with unpublished apps displays all Apps
                             size="small"
                             to="/settings/org-slug/developer-settings/new/"
                           >
-                            <Component
+                            <ForwardRef
                               aria-disabled={false}
                               aria-label="Create New Application"
                               className="css-zvpqlo-StyledButton-getColors eqrebog0"
+                              disabled={false}
                               onClick={[Function]}
+                              priority="primary"
                               role="button"
                               size="small"
                               to="/settings/org-slug/developer-settings/new/"
@@ -1019,7 +1026,7 @@ exports[`Organization Developer Settings with unpublished apps displays all Apps
                                   </ButtonLabel>
                                 </a>
                               </Link>
-                            </Component>
+                            </ForwardRef>
                           </StyledButton>
                         </Button>
                       </div>
@@ -1467,9 +1474,10 @@ exports[`Organization Developer Settings with unpublished apps displays all Apps
                                                     role="button"
                                                     size="small"
                                                   >
-                                                    <Component
+                                                    <ForwardRef
                                                       aria-disabled={false}
                                                       className="css-dkprmi-StyledButton-getColors eqrebog0"
+                                                      disabled={false}
                                                       onClick={[Function]}
                                                       role="button"
                                                       size="small"
@@ -1540,7 +1548,7 @@ exports[`Organization Developer Settings with unpublished apps displays all Apps
                                                           </Component>
                                                         </ButtonLabel>
                                                       </button>
-                                                    </Component>
+                                                    </ForwardRef>
                                                   </StyledButton>
                                                 </Button>
                                                 <Modal
@@ -1707,11 +1715,13 @@ exports[`Organization Developer Settings without Owner permissions trash button 
                             size="small"
                             to="/settings/org-slug/developer-settings/new/"
                           >
-                            <Component
+                            <ForwardRef
                               aria-disabled={false}
                               aria-label="Create New Application"
                               className="css-zvpqlo-StyledButton-getColors eqrebog0"
+                              disabled={false}
                               onClick={[Function]}
+                              priority="primary"
                               role="button"
                               size="small"
                               to="/settings/org-slug/developer-settings/new/"
@@ -1799,7 +1809,7 @@ exports[`Organization Developer Settings without Owner permissions trash button 
                                   </ButtonLabel>
                                 </a>
                               </Link>
-                            </Component>
+                            </ForwardRef>
                           </StyledButton>
                         </Button>
                       </div>
@@ -2197,9 +2207,10 @@ exports[`Organization Developer Settings without Owner permissions trash button 
                                                     title="Owner permissions are required for this action."
                                                     to={null}
                                                   >
-                                                    <Component
+                                                    <ForwardRef
                                                       aria-disabled={true}
                                                       className="tip tip css-1ujzp8g-StyledButton-getColors eqrebog0"
+                                                      disabled={true}
                                                       href={null}
                                                       onClick={[Function]}
                                                       role="button"
@@ -2276,7 +2287,7 @@ exports[`Organization Developer Settings without Owner permissions trash button 
                                                           </Component>
                                                         </ButtonLabel>
                                                       </button>
-                                                    </Component>
+                                                    </ForwardRef>
                                                   </StyledButton>
                                                 </Tooltip>
                                               </Button>

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/sentryApplicationDetails.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/sentryApplicationDetails.spec.jsx.snap
@@ -22513,12 +22513,14 @@ exports[`Sentry Application Details edit existing application renders() it shows
                       role="button"
                       type="submit"
                     >
-                      <Component
+                      <ForwardRef
                         aria-disabled={false}
                         aria-label="Save Changes"
                         className="css-1msljz8-StyledButton-getColors eqrebog0"
                         data-test-id="form-submit"
+                        disabled={false}
                         onClick={[Function]}
+                        priority="primary"
                         role="button"
                         type="submit"
                       >
@@ -22546,7 +22548,7 @@ exports[`Sentry Application Details edit existing application renders() it shows
                             </Component>
                           </ButtonLabel>
                         </button>
-                      </Component>
+                      </ForwardRef>
                     </StyledButton>
                   </Button>
                 </Observer>
@@ -40669,12 +40671,14 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                       role="button"
                       type="submit"
                     >
-                      <Component
+                      <ForwardRef
                         aria-disabled={false}
                         aria-label="Save Changes"
                         className="css-1msljz8-StyledButton-getColors eqrebog0"
                         data-test-id="form-submit"
+                        disabled={false}
                         onClick={[Function]}
+                        priority="primary"
                         role="button"
                         type="submit"
                       >
@@ -40702,7 +40706,7 @@ exports[`Sentry Application Details new sentry application renders() it shows em
                             </Component>
                           </ButtonLabel>
                         </button>
-                      </Component>
+                      </ForwardRef>
                     </StyledButton>
                   </Button>
                 </Observer>

--- a/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/index.spec.jsx.snap
@@ -749,12 +749,12 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                                     "actor": 1008,
                                                     "menu": 1007,
                                                   },
-                                                  "globalSelectionHeader": 1002,
+                                                  "globalSelectionHeader": 1009,
                                                   "header": 1000,
                                                   "modal": 10000,
-                                                  "orgAndUserMenu": 1004,
-                                                  "sentryErrorEmbed": 1009,
-                                                  "sidebar": 1003,
+                                                  "orgAndUserMenu": 1011,
+                                                  "sentryErrorEmbed": 1090,
+                                                  "sidebar": 1010,
                                                   "toast": 10001,
                                                 },
                                               }
@@ -1018,12 +1018,12 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                                             "actor": 1008,
                                                             "menu": 1007,
                                                           },
-                                                          "globalSelectionHeader": 1002,
+                                                          "globalSelectionHeader": 1009,
                                                           "header": 1000,
                                                           "modal": 10000,
-                                                          "orgAndUserMenu": 1004,
-                                                          "sentryErrorEmbed": 1009,
-                                                          "sidebar": 1003,
+                                                          "orgAndUserMenu": 1011,
+                                                          "sentryErrorEmbed": 1090,
+                                                          "sidebar": 1010,
                                                           "toast": 10001,
                                                         },
                                                       }
@@ -1080,10 +1080,11 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                     role="button"
                                     size="small"
                                   >
-                                    <Component
+                                    <ForwardRef
                                       aria-disabled={false}
                                       aria-label="Add Another"
                                       className="css-dkprmi-StyledButton-getColors eqrebog0"
+                                      disabled={false}
                                       onClick={[Function]}
                                       role="button"
                                       size="small"
@@ -1156,7 +1157,7 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                           </Component>
                                         </ButtonLabel>
                                       </button>
-                                    </Component>
+                                    </ForwardRef>
                                   </StyledButton>
                                 </Button>
                               </div>
@@ -1692,10 +1693,12 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                                     onClick={[Function]}
                                                     role="button"
                                                   >
-                                                    <Component
+                                                    <ForwardRef
                                                       aria-disabled={false}
                                                       aria-label="Remove"
+                                                      borderless={true}
                                                       className="ejqw4f70 css-1rs3lxn-StyledButton-getColors-StyledButton eqrebog0"
+                                                      disabled={false}
                                                       onClick={[Function]}
                                                       role="button"
                                                     >
@@ -1763,7 +1766,7 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                                           </Component>
                                                         </ButtonLabel>
                                                       </button>
-                                                    </Component>
+                                                    </ForwardRef>
                                                   </StyledButton>
                                                 </Button>
                                               </StyledButton>
@@ -2216,12 +2219,12 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                                     "actor": 1008,
                                                     "menu": 1007,
                                                   },
-                                                  "globalSelectionHeader": 1002,
+                                                  "globalSelectionHeader": 1009,
                                                   "header": 1000,
                                                   "modal": 10000,
-                                                  "orgAndUserMenu": 1004,
-                                                  "sentryErrorEmbed": 1009,
-                                                  "sidebar": 1003,
+                                                  "orgAndUserMenu": 1011,
+                                                  "sentryErrorEmbed": 1090,
+                                                  "sidebar": 1010,
                                                   "toast": 10001,
                                                 },
                                               }
@@ -2485,12 +2488,12 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                                             "actor": 1008,
                                                             "menu": 1007,
                                                           },
-                                                          "globalSelectionHeader": 1002,
+                                                          "globalSelectionHeader": 1009,
                                                           "header": 1000,
                                                           "modal": 10000,
-                                                          "orgAndUserMenu": 1004,
-                                                          "sentryErrorEmbed": 1009,
-                                                          "sidebar": 1003,
+                                                          "orgAndUserMenu": 1011,
+                                                          "sentryErrorEmbed": 1090,
+                                                          "sidebar": 1010,
                                                           "toast": 10001,
                                                         },
                                                       }
@@ -2547,10 +2550,11 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                     role="button"
                                     size="small"
                                   >
-                                    <Component
+                                    <ForwardRef
                                       aria-disabled={false}
                                       aria-label="Add Another"
                                       className="css-dkprmi-StyledButton-getColors eqrebog0"
+                                      disabled={false}
                                       onClick={[Function]}
                                       role="button"
                                       size="small"
@@ -2623,7 +2627,7 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                           </Component>
                                         </ButtonLabel>
                                       </button>
-                                    </Component>
+                                    </ForwardRef>
                                   </StyledButton>
                                 </Button>
                               </div>
@@ -3138,10 +3142,12 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                                     onClick={[Function]}
                                                     role="button"
                                                   >
-                                                    <Component
+                                                    <ForwardRef
                                                       aria-disabled={false}
                                                       aria-label="Remove"
+                                                      borderless={true}
                                                       className="ejqw4f70 css-1rs3lxn-StyledButton-getColors-StyledButton eqrebog0"
+                                                      disabled={false}
                                                       onClick={[Function]}
                                                       role="button"
                                                     >
@@ -3209,7 +3215,7 @@ exports[`OrganizationIntegrations render() with installed integrations Displays 
                                                           </Component>
                                                         </ButtonLabel>
                                                       </button>
-                                                    </Component>
+                                                    </ForwardRef>
                                                   </StyledButton>
                                                 </Button>
                                               </StyledButton>
@@ -3973,12 +3979,12 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                                     "actor": 1008,
                                                     "menu": 1007,
                                                   },
-                                                  "globalSelectionHeader": 1002,
+                                                  "globalSelectionHeader": 1009,
                                                   "header": 1000,
                                                   "modal": 10000,
-                                                  "orgAndUserMenu": 1004,
-                                                  "sentryErrorEmbed": 1009,
-                                                  "sidebar": 1003,
+                                                  "orgAndUserMenu": 1011,
+                                                  "sentryErrorEmbed": 1090,
+                                                  "sidebar": 1010,
                                                   "toast": 10001,
                                                 },
                                               }
@@ -4242,12 +4248,12 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                                             "actor": 1008,
                                                             "menu": 1007,
                                                           },
-                                                          "globalSelectionHeader": 1002,
+                                                          "globalSelectionHeader": 1009,
                                                           "header": 1000,
                                                           "modal": 10000,
-                                                          "orgAndUserMenu": 1004,
-                                                          "sentryErrorEmbed": 1009,
-                                                          "sidebar": 1003,
+                                                          "orgAndUserMenu": 1011,
+                                                          "sentryErrorEmbed": 1090,
+                                                          "sidebar": 1010,
                                                           "toast": 10001,
                                                         },
                                                       }
@@ -4304,10 +4310,11 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                     role="button"
                                     size="small"
                                   >
-                                    <Component
+                                    <ForwardRef
                                       aria-disabled={false}
                                       aria-label="Install"
                                       className="css-dkprmi-StyledButton-getColors eqrebog0"
+                                      disabled={false}
                                       onClick={[Function]}
                                       role="button"
                                       size="small"
@@ -4380,7 +4387,7 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                           </Component>
                                         </ButtonLabel>
                                       </button>
-                                    </Component>
+                                    </ForwardRef>
                                   </StyledButton>
                                 </Button>
                               </div>
@@ -4739,12 +4746,12 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                                     "actor": 1008,
                                                     "menu": 1007,
                                                   },
-                                                  "globalSelectionHeader": 1002,
+                                                  "globalSelectionHeader": 1009,
                                                   "header": 1000,
                                                   "modal": 10000,
-                                                  "orgAndUserMenu": 1004,
-                                                  "sentryErrorEmbed": 1009,
-                                                  "sidebar": 1003,
+                                                  "orgAndUserMenu": 1011,
+                                                  "sentryErrorEmbed": 1090,
+                                                  "sidebar": 1010,
                                                   "toast": 10001,
                                                 },
                                               }
@@ -5008,12 +5015,12 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                                             "actor": 1008,
                                                             "menu": 1007,
                                                           },
-                                                          "globalSelectionHeader": 1002,
+                                                          "globalSelectionHeader": 1009,
                                                           "header": 1000,
                                                           "modal": 10000,
-                                                          "orgAndUserMenu": 1004,
-                                                          "sentryErrorEmbed": 1009,
-                                                          "sidebar": 1003,
+                                                          "orgAndUserMenu": 1011,
+                                                          "sentryErrorEmbed": 1090,
+                                                          "sidebar": 1010,
                                                           "toast": 10001,
                                                         },
                                                       }
@@ -5070,10 +5077,11 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                     role="button"
                                     size="small"
                                   >
-                                    <Component
+                                    <ForwardRef
                                       aria-disabled={false}
                                       aria-label="Install"
                                       className="css-dkprmi-StyledButton-getColors eqrebog0"
+                                      disabled={false}
                                       onClick={[Function]}
                                       role="button"
                                       size="small"
@@ -5146,7 +5154,7 @@ exports[`OrganizationIntegrations render() without integrations Displays integra
                                           </Component>
                                         </ButtonLabel>
                                       </button>
-                                    </Component>
+                                    </ForwardRef>
                                   </StyledButton>
                                 </Button>
                               </div>

--- a/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/sentryAppInstallations.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/sentryAppInstallations.spec.jsx.snap
@@ -427,12 +427,12 @@ exports[`Sentry App Installations when Apps exist displays all Apps owned by the
                                           "actor": 1008,
                                           "menu": 1007,
                                         },
-                                        "globalSelectionHeader": 1002,
+                                        "globalSelectionHeader": 1009,
                                         "header": 1000,
                                         "modal": 10000,
-                                        "orgAndUserMenu": 1004,
-                                        "sentryErrorEmbed": 1009,
-                                        "sidebar": 1003,
+                                        "orgAndUserMenu": 1011,
+                                        "sentryErrorEmbed": 1090,
+                                        "sidebar": 1010,
                                         "toast": 10001,
                                       },
                                     }
@@ -696,12 +696,12 @@ exports[`Sentry App Installations when Apps exist displays all Apps owned by the
                                                   "actor": 1008,
                                                   "menu": 1007,
                                                 },
-                                                "globalSelectionHeader": 1002,
+                                                "globalSelectionHeader": 1009,
                                                 "header": 1000,
                                                 "modal": 10000,
-                                                "orgAndUserMenu": 1004,
-                                                "sentryErrorEmbed": 1009,
-                                                "sidebar": 1003,
+                                                "orgAndUserMenu": 1011,
+                                                "sentryErrorEmbed": 1090,
+                                                "sidebar": 1010,
                                                 "toast": 10001,
                                               },
                                             }
@@ -763,10 +763,11 @@ exports[`Sentry App Installations when Apps exist displays all Apps owned by the
                           role="button"
                           size="small"
                         >
-                          <Component
+                          <ForwardRef
                             aria-disabled={false}
                             aria-label="Install"
                             className="btn btn-default css-dkprmi-StyledButton-getColors eqrebog0"
+                            disabled={false}
                             onClick={[Function]}
                             role="button"
                             size="small"
@@ -839,7 +840,7 @@ exports[`Sentry App Installations when Apps exist displays all Apps owned by the
                                 </Component>
                               </ButtonLabel>
                             </button>
-                          </Component>
+                          </ForwardRef>
                         </StyledButton>
                       </Button>
                     </div>

--- a/tests/js/spec/views/stream/__snapshots__/actions.spec.jsx.snap
+++ b/tests/js/spec/views/stream/__snapshots__/actions.spec.jsx.snap
@@ -164,10 +164,11 @@ exports[`StreamActions Bulk Total results < bulk limit bulk resolves 1`] = `
                 }
               }
             >
-              <Component
+              <ForwardRef
                 aria-disabled={false}
                 aria-label="Cancel"
                 className="css-cmo08-StyledButton-getColors eqrebog0"
+                disabled={false}
                 onClick={[Function]}
                 role="button"
                 style={
@@ -200,7 +201,7 @@ exports[`StreamActions Bulk Total results < bulk limit bulk resolves 1`] = `
                     </Component>
                   </ButtonLabel>
                 </button>
-              </Component>
+              </ForwardRef>
             </StyledButton>
           </Button>
           <Button
@@ -220,13 +221,15 @@ exports[`StreamActions Bulk Total results < bulk limit bulk resolves 1`] = `
               priority="primary"
               role="button"
             >
-              <Component
+              <ForwardRef
                 aria-disabled={false}
                 aria-label="Bulk resolve issues"
                 autoFocus={true}
                 className="css-1msljz8-StyledButton-getColors eqrebog0"
                 data-test-id="confirm-modal"
+                disabled={false}
                 onClick={[Function]}
+                priority="primary"
                 role="button"
               >
                 <button
@@ -253,7 +256,7 @@ exports[`StreamActions Bulk Total results < bulk limit bulk resolves 1`] = `
                     </Component>
                   </ButtonLabel>
                 </button>
-              </Component>
+              </ForwardRef>
             </StyledButton>
           </Button>
         </div>
@@ -459,10 +462,11 @@ exports[`StreamActions Bulk Total results > bulk limit bulk resolves 1`] = `
                 }
               }
             >
-              <Component
+              <ForwardRef
                 aria-disabled={false}
                 aria-label="Cancel"
                 className="css-cmo08-StyledButton-getColors eqrebog0"
+                disabled={false}
                 onClick={[Function]}
                 role="button"
                 style={
@@ -495,7 +499,7 @@ exports[`StreamActions Bulk Total results > bulk limit bulk resolves 1`] = `
                     </Component>
                   </ButtonLabel>
                 </button>
-              </Component>
+              </ForwardRef>
             </StyledButton>
           </Button>
           <Button
@@ -515,13 +519,15 @@ exports[`StreamActions Bulk Total results > bulk limit bulk resolves 1`] = `
               priority="primary"
               role="button"
             >
-              <Component
+              <ForwardRef
                 aria-disabled={false}
                 aria-label="Bulk resolve issues"
                 autoFocus={true}
                 className="css-1msljz8-StyledButton-getColors eqrebog0"
                 data-test-id="confirm-modal"
+                disabled={false}
                 onClick={[Function]}
+                priority="primary"
                 role="button"
               >
                 <button
@@ -548,7 +554,7 @@ exports[`StreamActions Bulk Total results > bulk limit bulk resolves 1`] = `
                     </Component>
                   </ButtonLabel>
                 </button>
-              </Component>
+              </ForwardRef>
             </StyledButton>
           </Button>
         </div>

--- a/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/organizationUserFeedback.spec.jsx.snap
@@ -625,10 +625,10 @@ exports[`OrganizationUserFeedback renders 1`] = `
                   >
                     <Header>
                       <Base
-                        className="css-14hw0r3-Header e10yv9i90"
+                        className="css-tp5q3x-Header e10yv9i90"
                       >
                         <div
-                          className="css-14hw0r3-Header e10yv9i90"
+                          className="css-tp5q3x-Header e10yv9i90"
                           is={null}
                         >
                           <HeaderItemPosition>


### PR DESCRIPTION
:clap: for @billyvg on the assistance with getting ref-forwarding working. This fixes the warnings we were seeing about missing dropdownActor by forwarding refs down to the actual HTML buttons.

I've also fixed the z-index issues where in page dropdowns would stack higher than the global bar.

Fixes JAVASCRIPT-9E1