### PR TITLE
fix: Ensure install wizard passes in common scenarios

### DIFF
--- a/src/sentry/static/sentry/app/views/installWizard.jsx
+++ b/src/sentry/static/sentry/app/views/installWizard.jsx
@@ -64,8 +64,10 @@ export default class InstallWizard extends AsyncView {
       // XXX(dcramer): we need the user to explicitly choose beacon.anonymous
       // vs using an implied default so effectively this is binding
       // all values to their server-defaults (as client-side defaults dont really work)
+      // TODO(dcramer): we need to rethink this logic as doing multiple "is this value actually set"
+      // is problematic
       if (
-        option.value !== undefined &&
+        option.value !== undefined && option.value !== "" && option.value !== null &&
         (option.field.isSet || optionName != 'beacon.anonymous')
       ) {
         data[optionName] = option.value;

--- a/src/sentry/static/sentry/app/views/installWizard.jsx
+++ b/src/sentry/static/sentry/app/views/installWizard.jsx
@@ -61,6 +61,9 @@ export default class InstallWizard extends AsyncView {
     const data = {};
     Object.keys(options).forEach(optionName => {
       const option = options[optionName];
+      if (option.field.disabled) {
+        return;
+      }
       // XXX(dcramer): we need the user to explicitly choose beacon.anonymous
       // vs using an implied default so effectively this is binding
       // all values to their server-defaults (as client-side defaults dont really work)

--- a/src/sentry/templatetags/sentry_react.py
+++ b/src/sentry/templatetags/sentry_react.py
@@ -47,6 +47,9 @@ def _needs_upgrade():
 
     # Check all required options to see if they've been set
     for key in options.filter(flag=options.FLAG_REQUIRED):
+        # ignore required flags which can be empty
+        if key.flags & options.FLAG_ALLOW_EMPTY:
+            continue
         # Ignore mail.* keys if smtp is disabled
         if smtp_disabled and key.name[:5] == 'mail.':
             continue


### PR DESCRIPTION
This patches around a few issues with how options are inferred in the frontend to trigger the setup wizard.

We likely need to do more work to make this correct, but this will at least solve the current state of the world.