### PR TITLE
fix(ui) Fix visuals on saved search items and pinning

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar.jsx
@@ -23,6 +23,7 @@ import SearchDropdown from 'app/views/stream/searchDropdown';
 import CreateSavedSearchButton from 'app/views/stream/createSavedSearchButton';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
+import Tooltip from 'app/components/tooltip';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 
@@ -674,14 +675,16 @@ class SmartSearchBar extends React.Component {
             {this.state.query !== '' && (
               <React.Fragment>
                 {this.props.hasPinnedSearch && (
-                  <PinButton
-                    type="button"
-                    borderless
-                    size="zero"
-                    onClick={this.onTogglePinnedSearch}
-                  >
-                    <PinIcon isPinned={!!this.props.pinnedSearch} src="icon-pin" />
-                  </PinButton>
+                  <Tooltip title={t('Pin this search')}>
+                    <PinButton
+                      type="button"
+                      borderless
+                      size="zero"
+                      onClick={this.onTogglePinnedSearch}
+                    >
+                      <PinIcon isPinned={!!this.props.pinnedSearch} src="icon-pin" />
+                    </PinButton>
+                  </Tooltip>
                 )}
                 <a className="search-clear-form" onClick={this.clearSearch}>
                   <span className="icon-circle-cross" />

--- a/src/sentry/static/sentry/app/views/stream/organizationSavedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/stream/organizationSavedSearchSelector.jsx
@@ -6,10 +6,8 @@ import {t} from 'app/locale';
 import Access from 'app/components/acl/access';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
-import MenuItem from 'app/components/menuItem';
 import DropdownButton from 'app/components/dropdownButton';
 import DropdownMenu from 'app/components/dropdownMenu';
-import InlineSvg from 'app/components/inlineSvg';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
@@ -50,11 +48,12 @@ export default class OrganizationSavedSearchSelector extends React.Component {
     }
 
     return savedSearchList.map(search => (
-      <StyledMenuItem onSelect={() => onSavedSearchSelect(search)} key={search.id}>
-        {search.isPinned && <InlineSvg src="icon-pin" />}
-        <SearchTitle>{search.name}</SearchTitle>
-        <SearchQuery>{search.query}</SearchQuery>
-        {search.isGlobal === false && (
+      <MenuItem key={search.id}>
+        <a tabIndex="-1" onClick={() => onSavedSearchSelect(search)}>
+          <SearchTitle>{search.name}</SearchTitle>
+          <SearchQuery>{search.query}</SearchQuery>
+        </a>
+        {search.isGlobal === false && search.isPinned === false && (
           <Access
             organization={organization}
             access={['org:write']}
@@ -74,7 +73,7 @@ export default class OrganizationSavedSearchSelector extends React.Component {
             </Confirm>
           </Access>
         )}
-      </StyledMenuItem>
+      </MenuItem>
     ));
   }
 
@@ -144,9 +143,6 @@ const SearchTitle = styled.strong`
 `;
 
 const SearchQuery = styled.code`
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
   color: ${p => p.theme.gray5};
   padding: 0;
   background: inherit;
@@ -154,40 +150,35 @@ const SearchQuery = styled.code`
 
 const DeleteButton = styled(Button)`
   color: ${p => p.theme.gray1};
-  background: ${p => p.theme.offWhite};
-  display: none;
-  position: absolute;
-
-  /* Rows are 20px tall */
-  top: 10px;
-  right: 10px;
+  background: transparent;
+  flex-shrink: 0;
+  padding: ${space(1)} ${space(1.5)} ${space(1)} 0;
 
   &:hover {
+    background: transparent;
     color: ${p => p.theme.blueLight};
   }
 `;
 
-const StyledMenuItem = styled(MenuItem)`
+const MenuItem = styled.li`
+  display: flex;
+
   position: relative;
   border-bottom: 1px solid ${p => p.theme.borderLight};
   font-size: ${p => p.theme.fontSizeMedium};
   padding: 0;
 
-  &:focus ${DeleteButton}, &:hover ${DeleteButton} {
-    display: block;
-  }
-
   &:last-child {
     border-bottom: 0;
+  }
+  & :hover {
+    background: ${p => p.theme.offWhite};
   }
 
   & a {
     display: block;
+    flex-grow: 1;
     padding: ${space(1)} ${space(1.5)};
-
-    & :hover {
-      background: ${p => p.theme.offWhite};
-    }
   }
 `;
 

--- a/tests/js/spec/views/stream/organizationSavedSearchSelector.spec.jsx
+++ b/tests/js/spec/views/stream/organizationSavedSearchSelector.spec.jsx
@@ -64,7 +64,7 @@ describe('OrganizationSavedSearchSelector', function() {
       wrapper.find('DropdownButton').simulate('click');
       await wrapper.update();
 
-      const item = wrapper.find('StyledMenuItem a').first();
+      const item = wrapper.find('MenuItem a').first();
       expect(item).toHaveLength(1);
 
       item.simulate('click');
@@ -79,7 +79,7 @@ describe('OrganizationSavedSearchSelector', function() {
 
       // Second item should have a delete button as it is not a global search
       const button = wrapper
-        .find('StyledMenuItem')
+        .find('MenuItem')
         .at(1)
         .find('Button[icon="icon-trash"]');
       expect(button).toHaveLength(1);
@@ -93,7 +93,7 @@ describe('OrganizationSavedSearchSelector', function() {
       await wrapper.update();
 
       const button = wrapper
-        .find('StyledMenuItem')
+        .find('MenuItem')
         .at(1)
         .find('Button[icon="icon-trash"]');
       expect(button).toHaveLength(0);
@@ -105,7 +105,7 @@ describe('OrganizationSavedSearchSelector', function() {
 
       // First item should not have a delete button as it is a global search
       const button = wrapper
-        .find('StyledMenuItem')
+        .find('MenuItem')
         .first()
         .find('Button[icon="icon-trash"]');
       expect(button).toHaveLength(0);
@@ -117,7 +117,7 @@ describe('OrganizationSavedSearchSelector', function() {
 
       // Second item should have a delete button as it is not a global search
       const button = wrapper
-        .find('StyledMenuItem')
+        .find('MenuItem')
         .at(1)
         .find('Button[icon="icon-trash"]');
       button.simulate('click');


### PR DESCRIPTION
* Add a tooltip on pin icon as per mockups.
* Don't display pin icon for pinned search in dropdown as it creates an awkward indent.
* Display trash cans all the time instead of on hover.
* Fix long text wrapping for saved-search items.

List items now look like:

![Screen Shot 2019-04-15 at 3 37 34 PM](https://user-images.githubusercontent.com/24086/56160539-6e7d9300-5f95-11e9-9bed-5b898c00a1b0.png)


