### PR TITLE
ref(app-platform): Include stacktrace information in issue.description 

### DIFF
--- a/src/sentry/static/sentry/app/components/group/externalIssuesList.jsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssuesList.jsx
@@ -22,6 +22,7 @@ class ExternalIssueList extends AsyncComponent {
     group: SentryTypes.Group.isRequired,
     project: SentryTypes.Project.isRequired,
     organization: SentryTypes.Organization.isRequired,
+    event: SentryTypes.Event,
     orgId: PropTypes.string,
   };
 
@@ -138,6 +139,7 @@ class ExternalIssueList extends AsyncComponent {
         <SentryAppExternalIssueActions
           key={sentryApp.slug}
           group={group}
+          event={this.props.event}
           sentryAppComponent={component}
           sentryAppInstallation={installation}
           externalIssue={issue}

--- a/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueActions.jsx
+++ b/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueActions.jsx
@@ -22,7 +22,7 @@ class SentryAppExternalIssueActions extends React.Component {
     sentryAppComponent: PropTypes.object.isRequired,
     sentryAppInstallation: PropTypes.object,
     externalIssue: PropTypes.object,
-    event: SentryTypes.object.Event,
+    event: SentryTypes.Event,
   };
 
   constructor(props) {

--- a/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueActions.jsx
+++ b/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueActions.jsx
@@ -11,6 +11,7 @@ import SentryAppIcon from 'app/components/sentryAppIcon';
 import SentryAppExternalIssueForm from 'app/components/group/sentryAppExternalIssueForm';
 import NavTabs from 'app/components/navTabs';
 import {t, tct} from 'app/locale';
+import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import {deleteExternalIssue} from 'app/actionCreators/platformExternalIssues';
 
@@ -21,6 +22,7 @@ class SentryAppExternalIssueActions extends React.Component {
     sentryAppComponent: PropTypes.object.isRequired,
     sentryAppInstallation: PropTypes.object,
     externalIssue: PropTypes.object,
+    event: SentryTypes.object.Event,
   };
 
   constructor(props) {
@@ -144,6 +146,7 @@ class SentryAppExternalIssueActions extends React.Component {
             config={sentryAppComponent.schema}
             action={action}
             onSubmitSuccess={this.onSubmitSuccess}
+            event={this.props.event}
           />
         </Modal.Body>
       </Modal>

--- a/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueForm.jsx
+++ b/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueForm.jsx
@@ -18,6 +18,7 @@ class SentryAppExternalIssueForm extends React.Component {
     sentryAppInstallation: PropTypes.object,
     config: PropTypes.object.isRequired,
     action: PropTypes.oneOf(['link', 'create']),
+    event: SentryTypes.object.Event,
     onSubmitSuccess: PropTypes.func,
   };
 

--- a/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueForm.jsx
+++ b/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueForm.jsx
@@ -9,6 +9,7 @@ import Form from 'app/views/settings/components/forms/form';
 import SentryTypes from 'app/sentryTypes';
 import {t} from 'app/locale';
 import ExternalIssueStore from 'app/stores/externalIssueStore';
+import rawStacktraceContent from 'app/components/events/interfaces/rawStacktraceContent';
 import withApi from 'app/utils/withApi';
 
 class SentryAppExternalIssueForm extends React.Component {
@@ -18,7 +19,7 @@ class SentryAppExternalIssueForm extends React.Component {
     sentryAppInstallation: PropTypes.object,
     config: PropTypes.object.isRequired,
     action: PropTypes.oneOf(['link', 'create']),
-    event: SentryTypes.object.Event,
+    event: SentryTypes.Event,
     onSubmitSuccess: PropTypes.func,
   };
 
@@ -77,6 +78,42 @@ class SentryAppExternalIssueForm extends React.Component {
       : {};
   };
 
+  getStacktrace() {
+    const evt = this.props.event;
+    if (!evt || !evt.entries) {
+      return '';
+    }
+
+    const exc = evt.entries.find(({type}) => type === 'exception');
+
+    if (!exc) {
+      // Look for a message if not an exception
+      const msg = evt.entries.find(({type}) => type === 'message');
+      if (!msg) {
+        return '';
+      }
+
+      return msg.data && msg.data.message && [msg.data.message];
+    }
+
+    if (!exc.data) {
+      return '';
+    }
+
+    const contentArr = exc.data.values
+      .filter(value => !!value.stacktrace)
+      .map(value => rawStacktraceContent(value.stacktrace, evt.platform, value))
+      .reduce((acc, value) => {
+        return acc.concat(value);
+      }, []);
+
+    if (contentArr[0]) {
+      return '```\n' + contentArr[0] + '\n```';
+    } else {
+      return '';
+    }
+  }
+
   getFieldDefault(field) {
     const {group} = this.props;
     if (field.type == 'textarea') {
@@ -87,10 +124,11 @@ class SentryAppExternalIssueForm extends React.Component {
       case 'issue.title':
         return group.title;
       case 'issue.description':
+        const stacktrace = this.getStacktrace();
         const queryParams = {referrer: this.props.sentryAppInstallation.sentryApp.name};
         const url = addQueryParamsToExistingUrl(group.permalink, queryParams);
         const shortId = group.shortId;
-        return t('Sentry Issue: [%s](%s)', shortId, url);
+        return t('Sentry Issue: [%s](%s) \n \n %s', shortId, url, stacktrace);
       default:
         return '';
     }

--- a/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueForm.jsx
+++ b/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueForm.jsx
@@ -9,7 +9,7 @@ import Form from 'app/views/settings/components/forms/form';
 import SentryTypes from 'app/sentryTypes';
 import {t} from 'app/locale';
 import ExternalIssueStore from 'app/stores/externalIssueStore';
-import rawStacktraceContent from 'app/components/events/interfaces/rawStacktraceContent';
+import getStacktraceBody from 'app/utils/getStacktraceBody';
 import withApi from 'app/utils/withApi';
 
 class SentryAppExternalIssueForm extends React.Component {
@@ -80,35 +80,10 @@ class SentryAppExternalIssueForm extends React.Component {
 
   getStacktrace() {
     const evt = this.props.event;
-    if (!evt || !evt.entries) {
-      return '';
-    }
-
-    const exc = evt.entries.find(({type}) => type === 'exception');
-
-    if (!exc) {
-      // Look for a message if not an exception
-      const msg = evt.entries.find(({type}) => type === 'message');
-      if (!msg) {
-        return '';
-      }
-
-      return msg.data && msg.data.message && [msg.data.message];
-    }
-
-    if (!exc.data) {
-      return '';
-    }
-
-    const contentArr = exc.data.values
-      .filter(value => !!value.stacktrace)
-      .map(value => rawStacktraceContent(value.stacktrace, evt.platform, value))
-      .reduce((acc, value) => {
-        return acc.concat(value);
-      }, []);
+    const contentArr = getStacktraceBody(evt);
 
     if (contentArr[0]) {
-      return '```\n' + contentArr[0] + '\n```';
+      return '\n\n```\n' + contentArr[0] + '\n```';
     } else {
       return '';
     }
@@ -128,7 +103,7 @@ class SentryAppExternalIssueForm extends React.Component {
         const queryParams = {referrer: this.props.sentryAppInstallation.sentryApp.name};
         const url = addQueryParamsToExistingUrl(group.permalink, queryParams);
         const shortId = group.shortId;
-        return t('Sentry Issue: [%s](%s) \n \n %s', shortId, url, stacktrace);
+        return t('Sentry Issue: [%s](%s)%s', shortId, url, stacktrace);
       default:
         return '';
     }

--- a/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueForm.jsx
+++ b/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueForm.jsx
@@ -82,7 +82,7 @@ class SentryAppExternalIssueForm extends React.Component {
     const evt = this.props.event;
     const contentArr = getStacktraceBody(evt);
 
-    if (contentArr[0]) {
+    if (contentArr && contentArr.length > 0) {
       return '\n\n```\n' + contentArr[0] + '\n```';
     } else {
       return '';

--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -251,6 +251,7 @@ const GroupSidebar = createReactClass({
           allEnvironments={this.state.allEnvironmentsGroupData}
         />
         <ExternalIssueList
+          event={this.props.event}
           group={this.props.group}
           project={project}
           orgId={organization.slug}

--- a/src/sentry/static/sentry/app/utils/getStacktraceBody.jsx
+++ b/src/sentry/static/sentry/app/utils/getStacktraceBody.jsx
@@ -1,0 +1,34 @@
+import rawStacktraceContent from 'app/components/events/interfaces/rawStacktraceContent';
+
+export default function getException(event) {
+  if (!event || !event.entries) {
+    return [];
+  }
+
+  // TODO(billyvg): This only accounts for the first exception, will need navigation to be able to
+  // diff multiple exceptions
+  //
+  // See: https://github.com/getsentry/sentry/issues/6055
+  const exc = event.entries.find(({type}) => type === 'exception');
+
+  if (!exc) {
+    // Look for a message if not an exception
+    const msg = event.entries.find(({type}) => type === 'message');
+    if (!msg) {
+      return [];
+    }
+
+    return msg.data && msg.data.message && [msg.data.message];
+  }
+
+  if (!exc.data) {
+    return [];
+  }
+
+  return exc.data.values
+    .filter(value => !!value.stacktrace)
+    .map(value => rawStacktraceContent(value.stacktrace, event.platform, value))
+    .reduce((acc, value) => {
+      return acc.concat(value);
+    }, []);
+}

--- a/src/sentry/static/sentry/app/utils/getStacktraceBody.jsx
+++ b/src/sentry/static/sentry/app/utils/getStacktraceBody.jsx
@@ -1,6 +1,6 @@
 import rawStacktraceContent from 'app/components/events/interfaces/rawStacktraceContent';
 
-export default function getException(event) {
+export default function getStacktraceBody(event) {
   if (!event || !event.entries) {
     return [];
   }
@@ -17,8 +17,7 @@ export default function getException(event) {
     if (!msg) {
       return [];
     }
-
-    return msg.data && msg.data.message && [msg.data.message];
+    return msg.data && msg.data.formatted && [msg.data.formatted];
   }
 
   if (!exc.data) {

--- a/tests/js/fixtures/eventStacktraceException.js
+++ b/tests/js/fixtures/eventStacktraceException.js
@@ -1,0 +1,45 @@
+import {Event} from './event';
+
+const exception = {
+  type: 'exception',
+  data: {
+    values: [
+      {
+        module: 'example.application',
+        type: 'Error',
+        value: 'an error occurred',
+        stacktrace: {
+          frames: [
+            {
+              function: 'main',
+              module: 'example.application',
+              lineNo: 1,
+              filename: 'application',
+            },
+            {
+              function: 'doThing',
+              module: 'example.application',
+              lineNo: 2,
+              filename: 'application',
+            },
+          ],
+        },
+      },
+    ],
+  },
+};
+
+const message = {
+  type: 'message',
+  data: {
+    formatted: 'Something is broken',
+  },
+};
+
+export function EventStacktraceException(params = []) {
+  return Event({entries: [{...exception}], ...params});
+}
+
+export function EventStacktraceMessage(params = []) {
+  return Event({entries: [{...message}], ...params});
+}

--- a/tests/js/spec/components/issueDiff.spec.jsx
+++ b/tests/js/spec/components/issueDiff.spec.jsx
@@ -61,14 +61,14 @@ describe('IssueDiff', function() {
     Client.addMockResponse({
       url: '/issues/target/events/latest/',
       body: {
-        entries: [{type: 'message', data: {message: 'Hello World'}}],
+        entries: [{type: 'message', data: {formatted: 'Hello World'}}],
       },
     });
     Client.addMockResponse({
       url: '/issues/base/events/latest/',
       body: {
         platform: 'javascript',
-        entries: [{type: 'message', data: {message: 'Foo World'}}],
+        entries: [{type: 'message', data: {formatted: 'Foo World'}}],
       },
     });
 

--- a/tests/js/spec/utils/getStacktraceBody.spec.jsx
+++ b/tests/js/spec/utils/getStacktraceBody.spec.jsx
@@ -1,0 +1,25 @@
+import getStacktraceBody from 'app/utils/getStacktraceBody';
+
+describe('getStacktraceBody', function() {
+  const eventException = TestStubs.EventStacktraceException({platform: 'python'});
+  const eventMessage = TestStubs.EventStacktraceMessage({platform: 'python'});
+
+  it('formats with an exception', function() {
+    const result = getStacktraceBody(eventException);
+    expect(result).toEqual([
+      `Error: an error occurred
+  File "application", line 1, in main
+  File "application", line 2, in doThing`,
+    ]);
+  });
+
+  it('formats with a message', function() {
+    const result = getStacktraceBody(eventMessage);
+    expect(result).toEqual(['Something is broken']);
+  });
+
+  it('returns empty array for empty event entries', function() {
+    const result = getStacktraceBody({});
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
Adds in the stacktrace/message information to be consistent with the other integrations. This information will only be populated if the default `issue.description` is listed in the sentry app `schema`. 
> <img width="476" alt="Screen Shot 2019-04-15 at 12 55 59 PM" src="https://user-images.githubusercontent.com/15368179/56161272-fd7eb100-5f7d-11e9-99c7-d9d9a6535585.png">
