### PR TITLE
feat(discover): Increase requested results for by day queries

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -280,7 +280,7 @@ export default function createQueryBuilder(initial = {}, organization) {
         groupby: ['time'],
         rollup: 60 * 60 * 24,
         orderby: '-time',
-        limit: 1000,
+        limit: API_LIMIT,
       };
     }
 

--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -280,7 +280,7 @@ export default function createQueryBuilder(initial = {}, organization) {
         groupby: ['time'],
         rollup: 60 * 60 * 24,
         orderby: '-time',
-        limit: API_LIMIT,
+        limit: 5000,
       };
     }
 

--- a/src/sentry/static/sentry/app/views/organizationDiscover/resultManager.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/resultManager.jsx
@@ -66,7 +66,7 @@ export default function createResultManager(queryBuilder) {
 
     // If there are aggregations, get by-day data
     if (hasAggregations) {
-      promises.push(queryBuilder.fetch(byDayQuery));
+      promises.push(queryBuilder.fetchWithoutLimit(byDayQuery));
     }
 
     return Promise.all(promises).then(resp => {

--- a/tests/js/spec/views/organizationDiscover/discover.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/discover.spec.jsx
@@ -309,7 +309,7 @@ describe('Discover', function() {
         groupby: ['time'],
         rollup: 60 * 60 * 24,
         orderby: '-time',
-        limit: 10000,
+        limit: 5000,
       });
     });
   });

--- a/tests/js/spec/views/organizationDiscover/discover.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/discover.spec.jsx
@@ -242,6 +242,7 @@ describe('Discover', function() {
     let wrapper;
     beforeEach(function() {
       queryBuilder.fetch = jest.fn(() => Promise.resolve(mockResponse));
+      queryBuilder.fetchWithoutLimit = jest.fn(() => Promise.resolve(mockResponse));
 
       wrapper = mount(
         <Discover
@@ -302,13 +303,13 @@ describe('Discover', function() {
       wrapper.instance().updateField('aggregations', [['count()', null, 'count']]);
       wrapper.instance().runQuery();
       await tick();
-      expect(queryBuilder.fetch).toHaveBeenCalledTimes(2);
-      expect(queryBuilder.fetch).toHaveBeenNthCalledWith(1, queryBuilder.getExternal());
-      expect(queryBuilder.fetch).toHaveBeenNthCalledWith(2, {
+      expect(queryBuilder.fetch).toHaveBeenCalledWith(queryBuilder.getExternal());
+      expect(queryBuilder.fetchWithoutLimit).toHaveBeenCalledWith({
         ...queryBuilder.getExternal(),
         groupby: ['time'],
         rollup: 60 * 60 * 24,
         orderby: '-time',
+        limit: 10000,
       });
     });
   });
@@ -543,9 +544,9 @@ describe('Discover', function() {
         TestStubs.routerContext()
       );
 
-      queryBuilder.fetch = jest.fn(() =>
-        Promise.resolve({timing: {}, data: [], meta: []})
-      );
+      const mockResponse = Promise.resolve({timing: {}, data: [], meta: []});
+      queryBuilder.fetch = jest.fn(() => mockResponse);
+      queryBuilder.fetchWithoutLimit = jest.fn(() => mockResponse);
     });
 
     it('renders example queries', function() {
@@ -566,7 +567,8 @@ describe('Discover', function() {
       expect(query.fields).toEqual(['stack.filename']);
       expect(query.aggregations).toEqual([['count()', null, 'count']]);
       expect(query.conditions).toEqual([]);
-      expect(queryBuilder.fetch).toHaveBeenCalledTimes(2);
+      expect(queryBuilder.fetch).toHaveBeenCalled();
+      expect(queryBuilder.fetchWithoutLimit).toHaveBeenCalled();
     });
   });
 

--- a/tests/js/spec/views/organizationDiscover/resultManager.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/resultManager.spec.jsx
@@ -2,7 +2,7 @@ import createResultManager from 'app/views/organizationDiscover/resultManager';
 import createQueryBuilder from 'app/views/organizationDiscover/queryBuilder';
 
 describe('Result manager', function() {
-  let resultManager, queryBuilder, discoverMock;
+  let resultManager, queryBuilder, discoverMock, discoverByDayMock;
   beforeEach(function() {
     queryBuilder = createQueryBuilder(
       {},
@@ -13,6 +13,14 @@ describe('Result manager', function() {
 
     discoverMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/discover/query/?per_page=1000&cursor=0:0:1',
+      method: 'POST',
+      body: {
+        data: [],
+      },
+    });
+
+    discoverByDayMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/discover/query/',
       method: 'POST',
       body: {
         data: [],
@@ -48,7 +56,8 @@ describe('Result manager', function() {
     it('handles aggregations', async function() {
       queryBuilder.updateField('aggregations', [['count()', null, 'count']]);
       await resultManager.fetchAll();
-      expect(discoverMock).toHaveBeenCalledTimes(2);
+      expect(discoverMock).toHaveBeenCalledTimes(1);
+      expect(discoverByDayMock).toHaveBeenCalledTimes(1);
       expect(discoverMock).toHaveBeenCalledWith(
         '/organizations/org-slug/discover/query/?per_page=1000&cursor=0:0:1',
         expect.objectContaining({


### PR DESCRIPTION
Because of the way by day graphs are generated, we should request as
many results as possible to avoid truncating data. This increases the
requested limit from 1000 to 10000.

Closes SEN-409