### PR TITLE
fix(ui) Don't show save-org-search on event search

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar.jsx
@@ -667,10 +667,13 @@ class SmartSearchBar extends React.Component {
               disabled={disabled}
             />
             <span className="icon-search" />
-            <CreateSavedSearchButton
-              query={this.state.query}
-              organization={organization}
-            />
+
+            {this.props.hasPinnedSearch && (
+              <CreateSavedSearchButton
+                query={this.state.query}
+                organization={organization}
+              />
+            )}
             {this.state.query !== '' && (
               <React.Fragment>
                 {this.props.hasPinnedSearch && (


### PR DESCRIPTION
Use the `hasPinnedSearch` as a short term solution to hide the create saved search on the event search list. Very soon I'll be refactoring the input and button layouts.