### PR TITLE
feat(group-events): Drop query when navigating to issue events

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
@@ -4,6 +4,8 @@ import styled from 'react-emotion';
 import createReactClass from 'create-react-class';
 import {Link} from 'react-router';
 import withApi from 'app/utils/withApi';
+import {omit} from 'lodash';
+import qs from 'query-string';
 import {fetchOrgMembers} from 'app/actionCreators/members';
 import AssigneeSelector from 'app/components/assigneeSelector';
 import Count from 'app/components/count';
@@ -119,6 +121,8 @@ const GroupHeader = createReactClass({
     const baseUrl = params.projectId
       ? `/${orgId}/${params.projectId}/issues/`
       : `/organizations/${orgId}/issues/`;
+
+    const searchTermWithoutQuery = qs.stringify(omit(location.query, 'query'));
 
     return (
       <div className={className}>
@@ -239,7 +243,7 @@ const GroupHeader = createReactClass({
             {t('Tags')}
           </ListLink>
           <ListLink
-            to={`${baseUrl}${groupId}/events/${location.search}`}
+            to={`${baseUrl}${groupId}/events/${searchTermWithoutQuery}`}
             isActive={() => location.pathname.includes('/events/')}
           >
             {t('Events')}


### PR DESCRIPTION
Drop the query value from the URL when navigating to issue events. Since
event queries are quite different from issue queries it doesn't make
sense to preserve the issue list query when navigating from the issue to the events
tab. Previously issue specific terms (like is:unresolved) were silently
ignored but will return a 4xx error with the new Snuba backed events search.