### PR TITLE
fix: Limit maximum offset for release files 

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -30,7 +30,7 @@ from sentry.utils import json
 
 
 from .authentication import ApiKeyAuthentication, TokenAuthentication
-from .paginator import Paginator
+from .paginator import BadPaginationError, Paginator
 from .permissions import NoPermission
 
 
@@ -239,10 +239,13 @@ class Endpoint(APIView):
         if not paginator:
             paginator = paginator_cls(**paginator_kwargs)
 
-        cursor_result = paginator.get_result(
-            limit=per_page,
-            cursor=input_cursor,
-        )
+        try:
+            cursor_result = paginator.get_result(
+                limit=per_page,
+                cursor=input_cursor,
+            )
+        except BadPaginationError as e:
+            return Response({'detail': e.message}, status=400)
 
         # map results based on callback
         if on_results:

--- a/src/sentry/api/endpoints/organization_release_files.py
+++ b/src/sentry/api/endpoints/organization_release_files.py
@@ -11,6 +11,7 @@ from sentry.api.content_negotiation import ConditionalContentNegotiation
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
+from sentry.constants import MAX_RELEASE_FILES_OFFSET
 from sentry.models import File, Release, ReleaseFile, Distribution
 
 ERR_FILE_EXISTS = 'A file matching this name already exists for the given release'
@@ -73,6 +74,7 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint):
             queryset=file_list,
             order_by='name',
             paginator_cls=OffsetPaginator,
+            max_offset=MAX_RELEASE_FILES_OFFSET,
             on_results=lambda r: serialize(load_dist(r), request.user),
         )
 

--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -13,6 +13,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.endpoints.organization_release_files import load_dist
+from sentry.constants import MAX_RELEASE_FILES_OFFSET
 from sentry.models import File, Release, ReleaseFile
 from sentry.utils.apidocs import scenario, attach_scenarios
 
@@ -88,6 +89,7 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint):
             queryset=file_list,
             order_by='name',
             paginator_cls=OffsetPaginator,
+            max_offset=MAX_RELEASE_FILES_OFFSET,
             on_results=lambda r: serialize(load_dist(r), request.user),
         )
 

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -229,6 +229,13 @@ KNOWN_DIF_FORMATS = {
 
 NATIVE_UNKNOWN_STRING = '<unknown>'
 
+# Maximum number of release files that can be "skipped" (i.e., maximum paginator offset)
+# inside release files API endpoints.
+# If this number is too large, it may cause problems because of inefficient
+# LIMIT-OFFSET database queries.
+# These problems should be solved after we implement artifact bundles workflow.
+MAX_RELEASE_FILES_OFFSET = 20000
+
 # to go from an integration id (in _platforms.json) to the platform
 # data, such as documentation url or humanized name.
 # example: java-logback -> {"type": "framework",

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 from unittest import TestCase as SimpleTestCase
 
 from sentry.api.paginator import (
+    BadPaginationError,
     Paginator,
     DateTimePaginator,
     OffsetPaginator,
@@ -141,6 +142,21 @@ class OffsetPaginatorTest(TestCase):
         assert result[0] == res1
         assert result.next
         assert result.prev
+
+    def test_max_offset(self):
+        self.create_user('foo@example.com')
+        self.create_user('bar@example.com')
+        self.create_user('baz@example.com')
+
+        queryset = User.objects.all()
+
+        paginator = OffsetPaginator(queryset, max_offset=10)
+        result1 = paginator.get_result(cursor=None)
+        assert len(result1) == 3, result1
+
+        paginator = OffsetPaginator(queryset, max_offset=0)
+        with self.assertRaises(BadPaginationError):
+            paginator.get_result()
 
 
 class DateTimePaginatorTest(TestCase):


### PR DESCRIPTION
More accurately, we limit the maximum offset that can be processed by OffsetPaginator for release files. 
Looking at the available data, 20000 should be a reasonable upper limit until artifact bundles are implemented. 