### PR TITLE
[WIP] fix(csp): Make {effective,violated}-directive interchangeable

### DIFF
--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -517,7 +517,10 @@ CSP_SCHEMA = {
                 'script-sample': {},
                 'disposition': {'type': 'string'},
             },
-            'required': ['effective-directive'],
+            'anyOf': [
+                {'required': ['effective-directive']},
+                {'required': ['violated-directive']},
+            ],
             # Allow additional keys as browser vendors are still changing CSP
             # implementations fairly frequently
             'additionalProperties': True,

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -510,7 +510,7 @@ CSP_SCHEMA = {
                 'original-policy': {'type': 'string'},
                 'referrer': {'type': 'string', 'default': ''},
                 'status-code': {'type': 'number'},
-                'violated-directive': {'type': 'string', 'default': ''},
+                'violated-directive': {'type': 'string', 'minLength': 1},
                 'source-file': {'type': 'string'},
                 'line-number': {'type': 'number'},
                 'column-number': {'type': 'number'},

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -518,8 +518,8 @@ CSP_SCHEMA = {
                 'disposition': {'type': 'string'},
             },
             'anyOf': [
-                {'required': ['effective-directive']},
                 {'required': ['violated-directive']},
+                {'required': ['effective-directive']},
             ],
             # Allow additional keys as browser vendors are still changing CSP
             # implementations fairly frequently

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -510,7 +510,7 @@ CSP_SCHEMA = {
                 'original-policy': {'type': 'string'},
                 'referrer': {'type': 'string', 'default': ''},
                 'status-code': {'type': 'number'},
-                'violated-directive': {'type': 'string', 'minLength': 1},
+                'violated-directive': {'type': 'string', 'default': ''},
                 'source-file': {'type': 'string'},
                 'line-number': {'type': 'number'},
                 'column-number': {'type': 'number'},

--- a/tests/sentry/event_manager/test_validate_csp.py
+++ b/tests/sentry/event_manager/test_validate_csp.py
@@ -78,14 +78,14 @@ def test_csp_validate(effective_directive, violated_directive, culprit_element):
         {},
         {"release": "abc123", "interface": 'csp', "report": {}},
         _build_test_report(effective_directive=None, violated_directive=None),
-        _build_test_report(effective_directive=None, violated_directive=""),
+        # _build_test_report(effective_directive=None, violated_directive=""),
         _build_test_report(effective_directive=None, violated_directive="blink-src"),
     ),
     ids=(
         'empty dict',
         'no csp-report',
         'no violated-directive to parse (expect KeyError)',
-        'unsplittable violated-directive (expect IndexError)',
+        # 'unsplittable violated-directive (expect IndexError)',
         'invalid violated-directive (not in schema enum)',
     )
 )

--- a/tests/sentry/event_manager/test_validate_csp.py
+++ b/tests/sentry/event_manager/test_validate_csp.py
@@ -78,14 +78,14 @@ def test_csp_validate(effective_directive, violated_directive, culprit_element):
         {},
         {"release": "abc123", "interface": 'csp', "report": {}},
         _build_test_report(effective_directive=None, violated_directive=None),
-        # _build_test_report(effective_directive=None, violated_directive=""),
+        _build_test_report(effective_directive=None, violated_directive=""),
         _build_test_report(effective_directive=None, violated_directive="blink-src"),
     ),
     ids=(
         'empty dict',
         'no csp-report',
         'no violated-directive to parse (expect KeyError)',
-        # 'unsplittable violated-directive (expect IndexError)',
+        'unsplittable violated-directive (expect IndexError)',
         'invalid violated-directive (not in schema enum)',
     )
 )


### PR DESCRIPTION
Firefox apparently omits 'effective-directive' in its CSP violation reports
and sends only 'violated-directive' instead.
This has already been (partially) addressed in #12272, but the JSON
Schema seems to be untouched.