### PR TITLE
fix(issue-details): Fix Events tab highlighting incorrectly

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
@@ -244,7 +244,7 @@ const GroupHeader = createReactClass({
           </ListLink>
           <ListLink
             to={`${baseUrl}${groupId}/events/?${searchTermWithoutQuery}`}
-            isActive={() => location.pathname.includes('/events/')}
+            isActive={() => location.pathname.endsWith('/events/')}
           >
             {t('Events')}
           </ListLink>


### PR DESCRIPTION
This is being highlighted when we are visiting URL to a specific event

Fixes SEN-498