### PR TITLE
fix(minidump): Fix minidump links

### DIFF
--- a/src/sentry/static/sentry/app/components/eventsTable/eventsTable.jsx
+++ b/src/sentry/static/sentry/app/components/eventsTable/eventsTable.jsx
@@ -9,13 +9,15 @@ class EventsTable extends React.Component {
   static propTypes = {
     events: PropTypes.arrayOf(CustomPropTypes.Event),
     tagList: PropTypes.arrayOf(CustomPropTypes.Tag),
+    orgId: PropTypes.string.isRequired,
+    projectId: PropTypes.string.isRequired,
+    groupId: PropTypes.string.isRequired,
   };
 
   render() {
-    const {events, tagList} = this.props;
+    const {events, tagList, orgId, projectId, groupId} = this.props;
 
     const hasUser = !!events.find(event => event.user);
-    const {orgId, projectId, groupId} = this.props.params;
 
     return (
       <table className="table events-table">

--- a/src/sentry/static/sentry/app/views/groupDetails/organization/groupEvents.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/organization/groupEvents.jsx
@@ -118,14 +118,16 @@ const GroupEvents = createReactClass({
   },
 
   renderResults() {
-    const group = this.props.group;
+    const {group, params} = this.props;
     const tagList = group.tags.filter(tag => tag.key !== 'user') || [];
 
     return (
       <EventsTable
         tagList={tagList}
         events={this.state.eventList}
-        params={this.props.params}
+        orgId={params.orgId}
+        projectId={group.project.slug}
+        groupId={params.groupId}
       />
     );
   },

--- a/src/sentry/static/sentry/app/views/groupDetails/project/groupEvents.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/project/groupEvents.jsx
@@ -177,14 +177,16 @@ const GroupEvents = createReactClass({
   },
 
   renderResults() {
-    const group = this.props.group;
+    const {group, params} = this.props;
     const tagList = group.tags.filter(tag => tag.key !== 'user') || [];
 
     return (
       <EventsTable
         tagList={tagList}
         events={this.state.eventList}
-        params={this.props.params}
+        orgId={params.orgId}
+        projectId={params.projectId}
+        groupId={params.groupId}
       />
     );
   },

--- a/tests/js/spec/components/eventsTable/eventsTable.spec.jsx
+++ b/tests/js/spec/components/eventsTable/eventsTable.spec.jsx
@@ -13,7 +13,9 @@ describe('EventsTable', function() {
     const wrapper = shallow(
       <EventsTable
         tagList={[]}
-        params={{orgId: 'orgId', projectId: 'projectId', groupId: 'groupId'}}
+        orgId="orgId"
+        projectId="projectId"
+        groupId="groupId"
         events={events}
       />
     );

--- a/tests/js/spec/views/groupDetails/__snapshots__/organizationGroupEvents.spec.jsx.snap
+++ b/tests/js/spec/views/groupDetails/__snapshots__/organizationGroupEvents.spec.jsx.snap
@@ -41,13 +41,9 @@ exports[`groupEvents renders 1`] = `
             },
           ]
         }
-        params={
-          Object {
-            "groupId": "1",
-            "orgId": "orgId",
-            "projectId": "projectId",
-          }
-        }
+        groupId="1"
+        orgId="orgId"
+        projectId="project-slug"
         tagList={Array []}
       />
     </PanelBody>

--- a/tests/js/spec/views/groupDetails/__snapshots__/projectGroupEvents.spec.jsx.snap
+++ b/tests/js/spec/views/groupDetails/__snapshots__/projectGroupEvents.spec.jsx.snap
@@ -41,13 +41,9 @@ exports[`groupEvents renders 1`] = `
             },
           ]
         }
-        params={
-          Object {
-            "groupId": "1",
-            "orgId": "orgId",
-            "projectId": "projectId",
-          }
-        }
+        groupId="1"
+        orgId="orgId"
+        projectId="projectId"
         tagList={Array []}
       />
     </PanelBody>


### PR DESCRIPTION
Fixes a broken link to minidumps in the event table. Since project is no
longer in the URL it's likely this has never worked in Sentry 10.