### PR TITLE
feat(symbolicator): Path whitelist for MS symbol server

### DIFF
--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -29,7 +29,10 @@ BUILTIN_SOURCES = {
         'type': 'http',
         'id': 'sentry:microsoft',
         'layout': {'type': 'symstore'},
-        'filetypes': ['pdb', 'pe'],
+        'filters': {
+            'filetypes': ['pdb', 'pe'],
+            'path_prefixes': ['c:/windows']
+        },
         'url': 'https://msdl.microsoft.com/download/symbols/',
         'is_public': True,
     },

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -31,7 +31,7 @@ BUILTIN_SOURCES = {
         'layout': {'type': 'symstore'},
         'filters': {
             'filetypes': ['pdb', 'pe'],
-            'path_prefixes': ['c:/windows']
+            'path_patterns': ['?:/windows/**']
         },
         'url': 'https://msdl.microsoft.com/download/symbols/',
         'is_public': True,


### PR DESCRIPTION
See https://github.com/getsentry/symbolicator/pull/29 for rationale.

Currently we can just roll this out at roughly the same time. The worst that happens is that symbolicator treats `filters` as unknown key.