### PR TITLE
feat(discover): Fetch all tags for superusers

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -7,6 +7,7 @@ import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import {t} from 'app/locale';
 
 import {openModal} from 'app/actionCreators/modal';
+import ConfigStore from 'app/stores/configStore';
 
 import MissingProjectWarningModal from './missingProjectWarningModal';
 import {COLUMNS, PROMOTED_TAGS, SPECIAL_TAGS, HIDDEN_TAGS} from './data';
@@ -48,6 +49,11 @@ export default function createQueryBuilder(initial = {}, organization) {
   const defaultProjects = organization.projects
     .filter(projects => projects.isMember)
     .map(project => parseInt(project.id, 10));
+
+  const projectsToFetchTags = ConfigStore.get('user').isSuperuser
+    ? organization.projects
+    : defaultProjects;
+
   const columns = COLUMNS.map(col => ({...col, isTag: false}));
   let tags = [];
 
@@ -73,7 +79,7 @@ export default function createQueryBuilder(initial = {}, organization) {
    */
   function load() {
     return fetch({
-      projects: defaultProjects,
+      projects: projectsToFetchTags,
       fields: ['tags_key'],
       aggregations: [['count()', null, 'count']],
       orderby: '-count',


### PR DESCRIPTION
Make custom tags for all projects available to superusers.
Custom tags were not previously usable by superusers in Discover since
tags were fetched for all projects based on membership and superusers
are not members of any project.