### PR TITLE
feat(app-platform): Add beta tag to Integrations

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow.jsx
@@ -3,6 +3,7 @@ import {Box, Flex} from 'grid-emotion';
 import {Link} from 'react-router';
 
 import Access from 'app/components/acl/access';
+import BetaTag from 'app/components/betaTag';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
 import ConfirmDelete from 'app/components/confirmDelete';
@@ -102,6 +103,7 @@ export default class SentryApplicationRow extends React.PureComponent {
               ) : (
                 app.name
               )}
+              <BetaTag />
             </SentryAppName>
             <SentryAppDetails>
               {showPublishStatus ? (

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
@@ -736,6 +736,62 @@ exports[`Organization Developer Settings with published apps trash button is dis
                                                 </a>
                                               </Link>
                                             </SentryAppLink>
+                                            <BetaTag>
+                                              <Tooltip
+                                                title="This feature is in beta and may change in the future."
+                                                tooltipOptions={
+                                                  Object {
+                                                    "placement": "right",
+                                                  }
+                                                }
+                                              >
+                                                <StyledTag
+                                                  className="tip"
+                                                  priority="beta"
+                                                  size="small"
+                                                  title="This feature is in beta and may change in the future."
+                                                >
+                                                  <Tag
+                                                    className="tip css-f9iwbc-StyledTag e1xs0x250"
+                                                    priority="beta"
+                                                    size="small"
+                                                    title="This feature is in beta and may change in the future."
+                                                  >
+                                                    <TagTextStyled
+                                                      className="tip css-f9iwbc-StyledTag e1xs0x250"
+                                                      priority="beta"
+                                                      size="small"
+                                                      title="This feature is in beta and may change in the future."
+                                                    >
+                                                      <Component
+                                                        className="tip e1xs0x250 css-4og6iv-TagTextStyled-StyledTag e6q9yfr0"
+                                                        priority="beta"
+                                                        size="small"
+                                                        title="This feature is in beta and may change in the future."
+                                                      >
+                                                        <Box
+                                                          className="tip e1xs0x250 css-4og6iv-TagTextStyled-StyledTag e6q9yfr0"
+                                                          title="This feature is in beta and may change in the future."
+                                                        >
+                                                          <Base
+                                                            className="tip e1xs0x250 e6q9yfr0 css-1r8ewb4-TagTextStyled-StyledTag"
+                                                            title="This feature is in beta and may change in the future."
+                                                          >
+                                                            <div
+                                                              className="tip e1xs0x250 e6q9yfr0 css-1r8ewb4-TagTextStyled-StyledTag"
+                                                              is={null}
+                                                              title="This feature is in beta and may change in the future."
+                                                            >
+                                                              beta
+                                                            </div>
+                                                          </Base>
+                                                        </Box>
+                                                      </Component>
+                                                    </TagTextStyled>
+                                                  </Tag>
+                                                </StyledTag>
+                                              </Tooltip>
+                                            </BetaTag>
                                           </div>
                                         </SentryAppName>
                                         <SentryAppDetails>
@@ -1325,6 +1381,62 @@ exports[`Organization Developer Settings with unpublished apps displays all Apps
                                                 </a>
                                               </Link>
                                             </SentryAppLink>
+                                            <BetaTag>
+                                              <Tooltip
+                                                title="This feature is in beta and may change in the future."
+                                                tooltipOptions={
+                                                  Object {
+                                                    "placement": "right",
+                                                  }
+                                                }
+                                              >
+                                                <StyledTag
+                                                  className="tip"
+                                                  priority="beta"
+                                                  size="small"
+                                                  title="This feature is in beta and may change in the future."
+                                                >
+                                                  <Tag
+                                                    className="tip css-f9iwbc-StyledTag e1xs0x250"
+                                                    priority="beta"
+                                                    size="small"
+                                                    title="This feature is in beta and may change in the future."
+                                                  >
+                                                    <TagTextStyled
+                                                      className="tip css-f9iwbc-StyledTag e1xs0x250"
+                                                      priority="beta"
+                                                      size="small"
+                                                      title="This feature is in beta and may change in the future."
+                                                    >
+                                                      <Component
+                                                        className="tip e1xs0x250 css-4og6iv-TagTextStyled-StyledTag e6q9yfr0"
+                                                        priority="beta"
+                                                        size="small"
+                                                        title="This feature is in beta and may change in the future."
+                                                      >
+                                                        <Box
+                                                          className="tip e1xs0x250 css-4og6iv-TagTextStyled-StyledTag e6q9yfr0"
+                                                          title="This feature is in beta and may change in the future."
+                                                        >
+                                                          <Base
+                                                            className="tip e1xs0x250 e6q9yfr0 css-1r8ewb4-TagTextStyled-StyledTag"
+                                                            title="This feature is in beta and may change in the future."
+                                                          >
+                                                            <div
+                                                              className="tip e1xs0x250 e6q9yfr0 css-1r8ewb4-TagTextStyled-StyledTag"
+                                                              is={null}
+                                                              title="This feature is in beta and may change in the future."
+                                                            >
+                                                              beta
+                                                            </div>
+                                                          </Base>
+                                                        </Box>
+                                                      </Component>
+                                                    </TagTextStyled>
+                                                  </Tag>
+                                                </StyledTag>
+                                              </Tooltip>
+                                            </BetaTag>
                                           </div>
                                         </SentryAppName>
                                         <SentryAppDetails>
@@ -2087,6 +2199,62 @@ exports[`Organization Developer Settings without Owner permissions trash button 
                                                 </a>
                                               </Link>
                                             </SentryAppLink>
+                                            <BetaTag>
+                                              <Tooltip
+                                                title="This feature is in beta and may change in the future."
+                                                tooltipOptions={
+                                                  Object {
+                                                    "placement": "right",
+                                                  }
+                                                }
+                                              >
+                                                <StyledTag
+                                                  className="tip"
+                                                  priority="beta"
+                                                  size="small"
+                                                  title="This feature is in beta and may change in the future."
+                                                >
+                                                  <Tag
+                                                    className="tip css-f9iwbc-StyledTag e1xs0x250"
+                                                    priority="beta"
+                                                    size="small"
+                                                    title="This feature is in beta and may change in the future."
+                                                  >
+                                                    <TagTextStyled
+                                                      className="tip css-f9iwbc-StyledTag e1xs0x250"
+                                                      priority="beta"
+                                                      size="small"
+                                                      title="This feature is in beta and may change in the future."
+                                                    >
+                                                      <Component
+                                                        className="tip e1xs0x250 css-4og6iv-TagTextStyled-StyledTag e6q9yfr0"
+                                                        priority="beta"
+                                                        size="small"
+                                                        title="This feature is in beta and may change in the future."
+                                                      >
+                                                        <Box
+                                                          className="tip e1xs0x250 css-4og6iv-TagTextStyled-StyledTag e6q9yfr0"
+                                                          title="This feature is in beta and may change in the future."
+                                                        >
+                                                          <Base
+                                                            className="tip e1xs0x250 e6q9yfr0 css-1r8ewb4-TagTextStyled-StyledTag"
+                                                            title="This feature is in beta and may change in the future."
+                                                          >
+                                                            <div
+                                                              className="tip e1xs0x250 e6q9yfr0 css-1r8ewb4-TagTextStyled-StyledTag"
+                                                              is={null}
+                                                              title="This feature is in beta and may change in the future."
+                                                            >
+                                                              beta
+                                                            </div>
+                                                          </Base>
+                                                        </Box>
+                                                      </Component>
+                                                    </TagTextStyled>
+                                                  </Tag>
+                                                </StyledTag>
+                                              </Tooltip>
+                                            </BetaTag>
                                           </div>
                                         </SentryAppName>
                                         <SentryAppDetails>

--- a/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/sentryAppInstallations.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/sentryAppInstallations.spec.jsx.snap
@@ -152,6 +152,62 @@ exports[`Sentry App Installations when Apps exist displays all Apps owned by the
                           className="css-uiwo8x-SentryAppName eac2pqx4"
                         >
                           Sample App
+                          <BetaTag>
+                            <Tooltip
+                              title="This feature is in beta and may change in the future."
+                              tooltipOptions={
+                                Object {
+                                  "placement": "right",
+                                }
+                              }
+                            >
+                              <StyledTag
+                                className="tip"
+                                priority="beta"
+                                size="small"
+                                title="This feature is in beta and may change in the future."
+                              >
+                                <Tag
+                                  className="tip css-f9iwbc-StyledTag e1xs0x250"
+                                  priority="beta"
+                                  size="small"
+                                  title="This feature is in beta and may change in the future."
+                                >
+                                  <TagTextStyled
+                                    className="tip css-f9iwbc-StyledTag e1xs0x250"
+                                    priority="beta"
+                                    size="small"
+                                    title="This feature is in beta and may change in the future."
+                                  >
+                                    <Component
+                                      className="tip e1xs0x250 css-4og6iv-TagTextStyled-StyledTag e6q9yfr0"
+                                      priority="beta"
+                                      size="small"
+                                      title="This feature is in beta and may change in the future."
+                                    >
+                                      <Box
+                                        className="tip e1xs0x250 css-4og6iv-TagTextStyled-StyledTag e6q9yfr0"
+                                        title="This feature is in beta and may change in the future."
+                                      >
+                                        <Base
+                                          className="tip e1xs0x250 e6q9yfr0 css-1r8ewb4-TagTextStyled-StyledTag"
+                                          title="This feature is in beta and may change in the future."
+                                        >
+                                          <div
+                                            className="tip e1xs0x250 e6q9yfr0 css-1r8ewb4-TagTextStyled-StyledTag"
+                                            is={null}
+                                            title="This feature is in beta and may change in the future."
+                                          >
+                                            beta
+                                          </div>
+                                        </Base>
+                                      </Box>
+                                    </Component>
+                                  </TagTextStyled>
+                                </Tag>
+                              </StyledTag>
+                            </Tooltip>
+                          </BetaTag>
                         </div>
                       </SentryAppName>
                       <SentryAppDetails>


### PR DESCRIPTION
For new Integrations that are launched on the Integration Platform, display a "beta" tag next to them.

![image](https://user-images.githubusercontent.com/36059/56323849-f2fd1c80-6121-11e9-9786-e4402aad24d4.png)