### PR TITLE
ref(app-platform): Add sentry app stats and allow superusers to publish apps

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_details.py
+++ b/src/sentry/api/endpoints/sentry_app_details.py
@@ -41,6 +41,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
                 sentry_app=sentry_app,
                 name=result.get('name'),
                 author=result.get('author'),
+                status=result.get('status'),
                 webhook_url=result.get('webhookUrl'),
                 redirect_url=result.get('redirectUrl'),
                 is_alertable=result.get('isAlertable'),

--- a/src/sentry/api/endpoints/sentry_apps_stats.py
+++ b/src/sentry/api/endpoints/sentry_apps_stats.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
+from django.db.models import Count
 from sentry.api.bases import SentryAppsBaseEndpoint
 from sentry.models import SentryApp
 from sentry.api.permissions import SuperuserPermission
@@ -11,14 +12,16 @@ class SentryAppsStatsEndpoint(SentryAppsBaseEndpoint):
     permission_classes = (SuperuserPermission, )
 
     def get(self, request):
-        sentry_apps = SentryApp.objects.all().prefetch_related('installations')
+        sentry_apps = SentryApp.objects.filter(
+            installations__date_deleted=None).annotate(
+            Count('installations'))
         results = []
         for app in sentry_apps:
             results.append({
                 'id': app.id,
                 'slug': app.slug,
                 'name': app.name,
-                'installs': app.installations.count(),
+                'installs': app.installations__count,
             })
 
         return Response(results)

--- a/src/sentry/api/endpoints/sentry_apps_stats.py
+++ b/src/sentry/api/endpoints/sentry_apps_stats.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import
+
+from rest_framework.response import Response
+
+from sentry.api.bases import SentryAppsBaseEndpoint
+from sentry.models import SentryApp
+from sentry.api.permissions import SuperuserPermission
+
+
+class SentryAppsStatsEndpoint(SentryAppsBaseEndpoint):
+    permission_classes = (SuperuserPermission, )
+
+    def get(self, request):
+        sentry_apps = SentryApp.objects.all().prefetch_related('installations')
+        results = []
+        for app in sentry_apps:
+            results.append({
+                'id': app.id,
+                'slug': app.slug,
+                'name': app.name,
+                'installs': app.installations.count(),
+            })
+
+        return Response(results)

--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -32,6 +32,10 @@ class SentryAppSerializer(Serializer):
             data.update({
                 'clientId': obj.application.client_id,
                 'clientSecret': obj.application.client_secret,
+                'owner': {
+                    'id': obj.owner.id,
+                    'slug': obj.owner.slug,
+                },
             })
 
         return data

--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -57,6 +57,7 @@ class SentryAppSerializer(Serializer):
     name = serializers.CharField()
     author = serializers.CharField()
     scopes = ApiScopesField()
+    status = serializers.CharField(required=False)
     events = EventListField(required=False)
     schema = SchemaField(required=False)
     webhookUrl = URLField()

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -183,6 +183,7 @@ from .endpoints.release_deploys import ReleaseDeploysEndpoint
 from .endpoints.debug_files import DebugFilesEndpoint, DifAssembleEndpoint, \
     UnknownDebugFilesEndpoint, AssociateDSymFilesEndpoint
 from .endpoints.sentry_apps import SentryAppsEndpoint
+from .endpoints.sentry_apps_stats import SentryAppsStatsEndpoint
 from .endpoints.sentry_app_components import SentryAppComponentsEndpoint, \
     OrganizationSentryAppComponentsEndpoint
 from .endpoints.sentry_app_details import SentryAppDetailsEndpoint
@@ -1272,6 +1273,11 @@ urlpatterns = patterns(
         r'^sentry-apps/$',
         SentryAppsEndpoint.as_view(),
         name='sentry-api-0-sentry-apps'
+    ),
+    url(
+        r'^sentry-apps-stats/$',
+        SentryAppsStatsEndpoint.as_view(),
+        name='sentry-api-0-sentry-apps-stats'
     ),
     url(
         r'^sentry-apps/(?P<sentry_app_slug>[^\/]+)/$',

--- a/src/sentry/mediators/sentry_apps/updater.py
+++ b/src/sentry/mediators/sentry_apps/updater.py
@@ -17,6 +17,7 @@ from sentry.models.sentryapp import REQUIRED_EVENT_PERMISSIONS
 class Updater(Mediator):
     sentry_app = Param('sentry.models.SentryApp')
     name = Param(six.string_types, required=False)
+    status = Param(six.string_types, required=False)
     scopes = Param(Iterable, required=False)
     events = Param(Iterable, required=False)
     webhook_url = Param(six.string_types, required=False)
@@ -29,6 +30,7 @@ class Updater(Mediator):
     def call(self):
         self._update_name()
         self._update_author()
+        self._update_status()
         self._update_scopes()
         self._update_events()
         self._update_webhook_url()
@@ -46,6 +48,14 @@ class Updater(Mediator):
     @if_param('author')
     def _update_author(self):
         self.sentry_app.author = self.author
+
+    @if_param('status')
+    def _update_status(self):
+        if self.user.is_superuser:
+            if self.status == 'published':
+                self.sentry_app.status = SentryAppStatus.PUBLISHED
+            if self.status == 'unpublished':
+                self.sentry_app.status = SentryAppStatus.UNPUBLISHED
 
     @if_param('scopes')
     def _update_scopes(self):

--- a/tests/sentry/api/endpoints/test_organization_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_apps.py
@@ -55,6 +55,10 @@ class GetOrganizationSentryAppsTest(OrganizationSentryAppsTest):
             'clientSecret': self.unpublished_app.application.client_secret,
             'overview': self.unpublished_app.overview,
             'schema': {},
+            'owner': {
+                'id': self.org.id,
+                'slug': self.org.slug,
+            }
         }])
 
     @with_feature('organizations:sentry-apps')

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
+from sentry.constants import SentryAppStatus
+from sentry.models import SentryApp
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import with_feature
 from sentry.utils import json
@@ -124,6 +126,10 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             'clientSecret': self.published_app.application.client_secret,
             'overview': self.published_app.overview,
             'schema': {},
+            'owner': {
+                'id': self.org.id,
+                'slug': self.org.slug,
+            }
         }
 
     @with_feature('organizations:sentry-apps')
@@ -221,6 +227,42 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             format='json',
         )
         assert response.status_code == 404
+
+    @with_feature('organizations:sentry-apps')
+    def test_superusers_can_publish_apps(self):
+        self.login_as(user=self.superuser, superuser=True)
+        app = self.create_sentry_app(
+            name='SampleApp',
+            organization=self.org,
+        )
+        url = reverse('sentry-api-0-sentry-app-details', args=[app.slug])
+        response = self.client.put(
+            url,
+            data={
+                'status': 'published',
+            },
+            format='json',
+        )
+        assert response.status_code == 200
+        assert SentryApp.objects.get(id=app.id).status == SentryAppStatus.PUBLISHED
+
+    @with_feature('organizations:sentry-apps')
+    def test_nonsuperusers_cannot_publish_apps(self):
+        self.login_as(user=self.user)
+        app = self.create_sentry_app(
+            name='SampleApp',
+            organization=self.org,
+        )
+        url = reverse('sentry-api-0-sentry-app-details', args=[app.slug])
+        response = self.client.put(
+            url,
+            data={
+                'status': 'published',
+            },
+            format='json',
+        )
+        assert response.status_code == 200
+        assert SentryApp.objects.get(id=app.id).status == SentryAppStatus.UNPUBLISHED
 
 
 class DeleteSentryAppDetailsTest(SentryAppDetailsTest):

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -72,6 +72,10 @@ class GetSentryAppsTest(SentryAppsTest):
             'clientSecret': self.published_app.application.client_secret,
             'overview': self.published_app.overview,
             'schema': {},
+            'owner': {
+                'id': self.org.id,
+                'slug': self.org.slug,
+            }
         } in json.loads(response.content)
 
     @with_feature('organizations:sentry-apps')
@@ -96,6 +100,10 @@ class GetSentryAppsTest(SentryAppsTest):
             'clientSecret': self.unpublished_app.application.client_secret,
             'overview': self.unpublished_app.overview,
             'schema': {},
+            'owner': {
+                'id': self.org.id,
+                'slug': self.org.slug,
+            }
         } in json.loads(response.content)
 
     @with_feature('organizations:sentry-apps')

--- a/tests/sentry/api/endpoints/test_sentry_apps_stats.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps_stats.py
@@ -1,0 +1,59 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from sentry.utils import json
+from sentry.testutils import APITestCase
+from sentry.testutils.helpers import with_feature
+
+
+class SentryAppsStatsTest(APITestCase):
+    def setUp(self):
+        self.superuser = self.create_user(email='a@example.com', is_superuser=True)
+        self.user = self.create_user(email='boop@example.com')
+        self.org = self.create_organization(owner=self.user)
+        self.super_org = self.create_organization(owner=self.superuser)
+
+        self.app_1 = self.create_sentry_app(
+            name='Test',
+            organization=self.super_org,
+            published=True,
+        )
+
+        self.app_2 = self.create_sentry_app(
+            name='Testin',
+            organization=self.org,
+        )
+
+        self.create_sentry_app_installation(slug=self.app_1.slug, organization=self.org)
+        self.create_sentry_app_installation(slug=self.app_2.slug, organization=self.org)
+
+        self.url = reverse('sentry-api-0-sentry-apps-stats')
+
+    def test_superuser_has_access(self):
+        self.login_as(user=self.superuser, superuser=True)
+
+        response = self.client.get(self.url, format='json')
+
+        assert response.status_code == 200
+        assert json.loads(response.content) == \
+            [{
+                'id': self.app_1.id,
+                'slug': self.app_1.slug,
+                'name': self.app_1.name,
+                'installs': 1,
+            },
+            {
+                'id': self.app_2.id,
+                'slug': self.app_2.slug,
+                'name': self.app_2.name,
+                'installs': 1,
+            }]
+
+    @with_feature('organizations:sentry-apps')
+    def test_nonsuperusers_have_no_access(self):
+        self.login_as(user=self.user)
+
+        response = self.client.get(self.url, format='json')
+
+        assert response.status_code == 403

--- a/tests/sentry/mediators/sentry_apps/test_updater.py
+++ b/tests/sentry/mediators/sentry_apps/test_updater.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from sentry.coreapi import APIError
+from sentry.constants import SentryAppStatus
 from sentry.mediators.sentry_apps import Updater
 from sentry.mediators.service_hooks.creator import expand_events
 from sentry.models import SentryAppComponent, ServiceHook
@@ -102,4 +103,15 @@ class TestUpdater(TestCase):
     def test_updates_overview(self):
         self.updater.overview = 'Description of my very cool application'
         self.updater.call()
-        assert self.updater.overview == 'Description of my very cool application'
+        assert self.sentry_app.overview == 'Description of my very cool application'
+
+    def test_update_status_if_superuser(self):
+        self.updater.status = 'published'
+        self.user.is_superuser = True
+        self.updater.call()
+        assert self.sentry_app.status == SentryAppStatus.PUBLISHED
+
+    def test_doesnt_update_status_if_not_superuser(self):
+        self.updater.status = 'published'
+        self.updater.call()
+        assert self.sentry_app.status == SentryAppStatus.UNPUBLISHED


### PR DESCRIPTION
* Adds `sentry_apps_stats` endpoint to be used by `_admin`
* Adds the ability for superusers to update the `status` for an app (`published`/`unpublished`)
* Adds `owner` to sentry app serializer for superusers and those that own the app thats being serialized 

re: https://github.com/getsentry/getsentry/pull/2829