### PR TITLE
feat(dropdown autocomplete): support label heights in virtualized version

### DIFF
--- a/docs-ui/components/dropdownAutoComplete.stories.js
+++ b/docs-ui/components/dropdownAutoComplete.stories.js
@@ -80,7 +80,12 @@ const addTo = name =>
     .add(
       'grouped',
       withInfo('Group labels can receive a component too')(() => (
-        <DropdownAutoComplete items={groupedItems} alignMenu="left">
+        <DropdownAutoComplete
+          items={groupedItems}
+          alignMenu="left"
+          virtualizedHeight={44}
+          virtualizedLabelHeight={28}
+        >
           {({isOpen, selectedItem}) => (selectedItem ? selectedItem.label : 'Click me!')}
         </DropdownAutoComplete>
       ))

--- a/docs-ui/components/dropdownAutoComplete.stories.js
+++ b/docs-ui/components/dropdownAutoComplete.stories.js
@@ -23,6 +23,20 @@ const items = [
 
 const groupedItems = [
   {
+    value: 'defaults',
+    hideGroupLabel: true,
+    items: [
+      {
+        value: 'recent thing',
+        label: 'recent thing',
+      },
+      {
+        value: 'other recent thing',
+        label: 'other recent thing',
+      },
+    ],
+  },
+  {
     value: 'countries',
     label: (
       <div>

--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -286,7 +286,7 @@ class DropdownAutoCompleteMenu extends React.Component {
     const {index} = item;
 
     return item.groupLabel ? (
-      <LabelWithBorder style={style} key={item.label || item.id}>
+      <LabelWithBorder style={style} key={key}>
         {item.label && <GroupLabel>{item.label}</GroupLabel>}
       </LabelWithBorder>
     ) : (

--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -286,7 +286,7 @@ class DropdownAutoCompleteMenu extends React.Component {
     const {index} = item;
 
     return item.groupLabel ? (
-      <LabelWithBorder style={style} key={key}>
+      <LabelWithBorder style={style} key={item.value}>
         {item.label && <GroupLabel>{item.label}</GroupLabel>}
       </LabelWithBorder>
     ) : (

--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -121,6 +121,11 @@ class DropdownAutoCompleteMenu extends React.Component {
     virtualizedHeight: PropTypes.number,
 
     /**
+     * If you use grouping with virtualizedHeight, the labels will be that height unless specified here
+     */
+    virtualizedLabelHeight: PropTypes.number,
+
+    /**
      * Search input's placeholder text
      */
     searchPlaceholder: PropTypes.string,
@@ -217,8 +222,19 @@ class DropdownAutoCompleteMenu extends React.Component {
     return this.filterItems(items, inputValue).map((item, index) => ({...item, index}));
   };
 
+  getHeight = items => {
+    const {maxHeight, virtualizedHeight, virtualizedLabelHeight} = this.props;
+    const minHeight = virtualizedLabelHeight
+      ? items.reduce(
+          (a, r) => a + (r.groupLabel ? virtualizedLabelHeight : virtualizedHeight),
+          0
+        )
+      : items.length * virtualizedHeight;
+    return Math.min(minHeight, maxHeight);
+  };
+
   renderList = ({items, ...otherProps}) => {
-    const {maxHeight, virtualizedHeight} = this.props;
+    const {virtualizedHeight, virtualizedLabelHeight} = this.props;
 
     // If `virtualizedHeight` is defined, use a virtualized list
     if (typeof virtualizedHeight !== 'undefined') {
@@ -228,9 +244,13 @@ class DropdownAutoCompleteMenu extends React.Component {
             <List
               width={width}
               style={{outline: 'none'}}
-              height={Math.min(items.length * virtualizedHeight, maxHeight)}
+              height={this.getHeight(items)}
               rowCount={items.length}
-              rowHeight={virtualizedHeight}
+              rowHeight={({index}) => {
+                return items[index].groupLabel && virtualizedLabelHeight
+                  ? virtualizedLabelHeight
+                  : virtualizedHeight;
+              }}
               rowRenderer={({key, index, style}) => {
                 const item = items[index];
                 return this.renderRow({
@@ -581,8 +601,10 @@ const AutoCompleteItem = styled('div')`
 
 const LabelWithBorder = styled('div')`
   background-color: ${p => p.theme.offWhite};
-  border: 1px solid ${p => p.theme.borderLight};
+  border-bottom: 1px solid ${p => p.theme.borderLight};
   border-width: 1px 0;
+  color: ${p => p.theme.gray3};
+  font-size: ${p => p.theme.fontSizeMedium};
 
   &:first-child {
     border-top: none;

--- a/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
@@ -125,7 +125,7 @@ exports[`DropdownAutoCompleteMenu renders with a group 1`] = `
                         key="countries"
                       >
                         <div
-                          className="css-o8s6pc-LabelWithBorder ejumqxq5"
+                          className="css-1lqzols-LabelWithBorder ejumqxq5"
                         >
                           <GroupLabel>
                             <div

--- a/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
@@ -122,7 +122,7 @@ exports[`DropdownAutoCompleteMenu renders with a group 1`] = `
                       data-test-id="autocomplete-list"
                     >
                       <LabelWithBorder
-                        key="countries-undefined"
+                        key="countries"
                       >
                         <div
                           className="css-1lqzols-LabelWithBorder ejumqxq5"

--- a/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
@@ -122,7 +122,7 @@ exports[`DropdownAutoCompleteMenu renders with a group 1`] = `
                       data-test-id="autocomplete-list"
                     >
                       <LabelWithBorder
-                        key="countries"
+                        key="countries-undefined"
                       >
                         <div
                           className="css-1lqzols-LabelWithBorder ejumqxq5"


### PR DESCRIPTION
This adds a prop called `virtualizedLabelHeight` which can be factored into item and menu virtualized heights.