### PR TITLE
fix(ui) Remove hover effect on searchbar buttons

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
@@ -804,6 +804,9 @@ const ButtonBar = styled.div`
 
   button {
     background: transparent;
+    &:hover {
+      background: transparent;
+    }
   }
 `;
 


### PR DESCRIPTION
When the search builder is active, the buttons should not have a background on hover as it is visually odd to have a white background on top of the grey box.

<img width="203" alt="Screen Shot 2019-04-18 at 12 07 17 PM" src="https://user-images.githubusercontent.com/24086/56375058-8b52da00-61d2-11e9-865a-5a8591cc938a.png">
