### PR TITLE
fix(ui): Remove `isRequired` for SavedSearch.id

### DIFF
--- a/src/sentry/static/sentry/app/sentryTypes.jsx
+++ b/src/sentry/static/sentry/app/sentryTypes.jsx
@@ -381,7 +381,7 @@ export const SentryApplication = PropTypes.shape({
 });
 
 export const SavedSearch = PropTypes.shape({
-  id: PropTypes.string.isRequired,
+  id: PropTypes.string,
   dateCreated: PropTypes.string,
   isDefault: PropTypes.bool,
   isGlobal: PropTypes.bool,


### PR DESCRIPTION
Reason is we optimistically update and the object doesn't have an id yet after pinning