### PR TITLE
ref: Allow loading of SnubaEvents with minimal properties.

### DIFF
--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -71,7 +71,7 @@ class ProjectEventsEndpoint(ProjectEndpoint):
             end=now,
             conditions=conditions,
             filter_keys={'project_id': [project.id]},
-            selected_columns=SnubaEvent.selected_columns,
+            selected_columns=SnubaEvent.minimal_columns,
             orderby='-timestamp',
             referrer='api.project-events',
         )

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -508,7 +508,7 @@ class SnubaEvent(EventCommon):
     def __getattr__(self, name):
         """
         Depending on what snuba data this event was initialized with, we may
-        have the data availablle to return, or we may have to look in the
+        have the data available to return, or we may have to look in the
         `data` dict (which would force a nodestore load). All unresolved
         self.foo type accesses will come through here.
         """

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -426,40 +426,35 @@ class SnubaEvent(EventCommon):
         as a regular Event.
     """
 
-    # The list of columns that we should request from snuba to be able to fill
-    # out the object.
-    selected_columns = [
-        'event_id',
-        'project_id',
-        'message',
-        'title',
-        'type',
-        'location',
-        'culprit',
-        'timestamp',
-        'group_id',
-        'platform',
-
-        # Required to provide snuba-only tags
-        'tags.key',
-        'tags.value',
-
-        # Required to provide snuba-only 'user' interface
-        'user_id',
-        'username',
-        'ip_address',
-        'email',
-    ]
-
     # The minimal list of columns we need to get from snuba to bootstrap an
     # event. If the client is planning on loading the entire event body from
     # nodestore anyway, we may as well only fetch the minimum from snuba to
     # avoid duplicated work.
     minimal_columns = [
         'event_id',
+        'group_id',
         'project_id',
         'timestamp',
-        'group_id',
+    ]
+
+    # A list of all useful columns we can get from snuba.
+    selected_columns = minimal_columns + [
+        'culprit',
+        'location',
+        'message',
+        'platform',
+        'title',
+        'type',
+
+        # Required to provide snuba-only tags
+        'tags.key',
+        'tags.value',
+
+        # Required to provide snuba-only 'user' interface
+        'email',
+        'ip_address',
+        'user_id',
+        'username',
     ]
 
     objects = SnubaEventManager()

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -228,7 +228,7 @@ class SnubaEventSerializerTest(TestCase):
 
         # Make sure we didn't have to call out to Nodestore to get the data
         # required to serialize this event and the NodeData is still empty.
-        assert event.data._node_data is None, "Node data was populated"
+        assert event.data._node_data is None, "SimpleEventSerializer should not load Nodestore data."
 
         assert result['eventID'] == event.event_id
         assert result['projectID'] == six.text_type(event.project_id)

--- a/tests/snuba/models/test_event.py
+++ b/tests/snuba/models/test_event.py
@@ -72,7 +72,6 @@ class SnubaEventTest(TestCase, SnubaTestCase):
         # Make sure we get back event properties from snuba
         assert event.event_id == self.event_id
         assert event.group.id == self.proj1group1.id
-        assert event._project_cache is None
         assert event.project.id == self.proj1.id
         assert event._project_cache == self.proj1
         # That shouldn't have triggered a nodestore load yet

--- a/tests/snuba/models/test_event.py
+++ b/tests/snuba/models/test_event.py
@@ -72,8 +72,16 @@ class SnubaEventTest(TestCase, SnubaTestCase):
         # Make sure we get back event properties from snuba
         assert event.event_id == self.event_id
         assert event.group.id == self.proj1group1.id
+        assert event._project_cache is None
         assert event.project.id == self.proj1.id
-        # And the event data payload from nodestore
+        assert event._project_cache == self.proj1
+        # That shouldn't have triggered a nodestore load yet
+        assert event.data._node_data is None
+        # But after we ask for something that's not in snuba
+        event.get_hashes()
+        # We should have populated the NodeData
+        assert event.data._node_data is not None
+        # And the full user should be in there.
         assert event.data['user']['id'] == u'user1'
 
     def test_same(self):
@@ -92,3 +100,31 @@ class SnubaEventTest(TestCase, SnubaTestCase):
         del django_serialized['id']
         del snuba_serialized['id']
         assert django_serialized == snuba_serialized
+
+    def test_minimal(self):
+        """
+        Test that a SnubaEvent that only loads minimal data from snuba
+        can still be serialized completely by falling back to nodestore data.
+        """
+        django_event = Event.objects.get(project_id=self.proj1.id, event_id=self.event_id)
+        snuba_event = SnubaEvent.get_event(
+            self.proj1.id,
+            self.event_id,
+            snuba_cols=SnubaEvent.minimal_columns)
+
+        django_serialized = serialize(django_event)
+        snuba_serialized = serialize(snuba_event)
+        del django_serialized['id']
+        del snuba_serialized['id']
+        assert django_serialized == snuba_serialized
+
+    def test_bind_nodes(self):
+        """
+        Test that bind_nodes works on snubaevents to populate their
+        NodeDatas.
+        """
+        event = SnubaEvent.get_event(self.proj1.id, self.event_id)
+        assert event.data._node_data is None
+        Event.objects.bind_nodes([event], 'data')
+        assert event.data._node_data is not None
+        assert event.data['user']['id'] == u'user1'


### PR DESCRIPTION
In order to cut down on duplicated work. Practicallly speaking there
will be 2 scenarios:

1. You only need a lightweight version of the event (you are using
`SimpleEventSerializer`) so you can find/load the events from snuba
using `SnubaEvent.selected_columns` and serialize it using
`SimpleEventSerializer` and nodestore is never touched. This is the fast
path.

2. You know you are going to need to output the entire event body (you
are using the default `EventSerializer`) so only load the minimal set of
columns from snuba needed to resolve the node id, and fetch everything
else from nodestore.