### PR TITLE
fix(ui) Clear pinned/saved search on submit

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -379,7 +379,8 @@ const OrganizationStream = createReactClass({
       // if query is the same, just re-fetch data
       this.fetchData();
     } else {
-      this.transitionTo({query});
+      // Clear the saved search as the user wants something else.
+      this.transitionTo({query}, null);
     }
   },
 

--- a/tests/js/spec/views/organizationStream/overview.spec.jsx
+++ b/tests/js/spec/views/organizationStream/overview.spec.jsx
@@ -443,6 +443,45 @@ describe('OrganizationStream', function() {
       );
     });
 
+    it('clears a saved search when a custom one is entered', async function() {
+      savedSearchesRequest = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/searches/',
+        body: [
+          savedSearch,
+          TestStubs.Search({
+            id: '123',
+            name: 'Pinned search',
+            isPinned: true,
+            isGlobal: false,
+            isOrgCustom: true,
+            query: 'is:resolved',
+          }),
+        ],
+      });
+      createWrapper();
+      await tick();
+      await wrapper.update();
+
+      // Update the search input
+      wrapper
+        .find('StreamFilters SmartSearchBar StyledInput input')
+        .simulate('change', {target: {value: 'dogs'}});
+      // Submit the form
+      wrapper.find('StreamFilters SmartSearchBar form').simulate('submit');
+      await wrapper.update();
+
+      expect(browserHistory.push).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          pathname: '/organizations/org-slug/issues/',
+          query: {
+            environment: [],
+            project: [],
+            query: 'dogs',
+          },
+        })
+      );
+    });
+
     it.todo('pins and unpins a custom query');
 
     it.todo('pins and unpins a saved query');


### PR DESCRIPTION
When submitting a new search query we should clear any saved searches as the user wants to look at something else.

Fixes SEN-501