### PR TITLE
fix(app-platform): Allow empty Redirect URL

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_details.py
+++ b/src/sentry/api/endpoints/sentry_app_details.py
@@ -27,32 +27,39 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
 
             return Response(status=404)
 
+        data = {
+            'user': request.user,
+            'sentry_app': sentry_app,
+            'name': request.json_body.get('name'),
+            'status': request.json_body.get('status'),
+            'author': request.json_body.get('author'),
+            'webhookUrl': request.json_body.get('webhookUrl'),
+            'redirectUrl': request.json_body.get('redirectUrl'),
+            'isAlertable': request.json_body.get('isAlertable'),
+            'scopes': request.json_body.get('scopes'),
+            'events': request.json_body.get('events'),
+            'schema': request.json_body.get('schema'),
+            'overview': request.json_body.get('overview'),
+        }
+
         serializer = SentryAppSerializer(
             instance=sentry_app,
-            data=request.DATA,
+            data=data,
             partial=True,
         )
 
         if serializer.is_valid():
             result = serializer.object
 
-            updated_app = Updater.run(
-                user=request.user,
-                sentry_app=sentry_app,
-                name=result.get('name'),
-                author=result.get('author'),
-                status=result.get('status'),
-                webhook_url=result.get('webhookUrl'),
-                redirect_url=result.get('redirectUrl'),
-                is_alertable=result.get('isAlertable'),
-                scopes=result.get('scopes'),
-                events=result.get('events'),
-                schema=result.get('schema'),
-                overview=result.get('overview'),
-            )
+            data['redirect_url'] = data['redirectUrl']
+            data['webhook_url'] = data['webhookUrl']
+            data['is_alertable'] = data['isAlertable']
+            data['scopes'] = result.get('scopes')
+            data['events'] = result.get('events')
+
+            updated_app = Updater.run(**data)
 
             return Response(serialize(updated_app, request.user))
-
         return Response(serializer.errors, status=400)
 
     def delete(self, request, sentry_app):

--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -15,7 +15,7 @@ class ApiScopesField(serializers.WritableField):
     def validate(self, data):
         valid_scopes = ApiScopes()
 
-        if data is None:
+        if not data:
             return
 
         for scope in data:
@@ -25,6 +25,9 @@ class ApiScopesField(serializers.WritableField):
 
 class EventListField(serializers.WritableField):
     def validate(self, data):
+        if not data:
+            return
+
         if not set(data).issubset(VALID_EVENT_RESOURCES):
             raise ValidationError(u'Invalid event subscription: {}'.format(
                 ', '.join(set(data).difference(VALID_EVENT_RESOURCES))
@@ -33,7 +36,7 @@ class EventListField(serializers.WritableField):
 
 class SchemaField(serializers.WritableField):
     def validate(self, data):
-        if data == {}:
+        if not data or data == {}:
             return
 
         try:

--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -47,7 +47,7 @@ class URLField(serializers.URLField):
         # The Django URLField doesn't distinguish between different types of
         # invalid URLs, so do any manual checks here to give the User a better
         # error message.
-        if not url.startswith('http'):
+        if url and not url.startswith('http'):
             raise ValidationError('URL must start with http[s]://')
 
         super(URLField, self).validate(url)

--- a/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
+++ b/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
@@ -68,6 +68,10 @@ const forms = [
           return schema;
         },
         validate: ({id, form}) => {
+          if (!form.schema) {
+            return [];
+          }
+
           try {
             JSON.parse(form.schema);
           } catch (e) {

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
@@ -102,7 +102,13 @@ export default class SentryApplicationDetails extends AsyncView {
           apiMethod={method}
           apiEndpoint={endpoint}
           allowUndo
-          initialData={{organization: orgId, isAlertable: false, schema: {}, ...app}}
+          initialData={{
+            organization: orgId,
+            isAlertable: false,
+            schema: {},
+            scopes: [],
+            ...app,
+          }}
           model={this.form}
           onSubmitSuccess={this.onSubmitSuccess}
         >

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -256,6 +256,7 @@ class PostSentryAppsTest(SentryAppsTest):
             'scopes': ('project:read', 'event:read'),
             'events': ('issue',),
             'webhookUrl': 'https://example.com',
+            'redirectUrl': '',
             'isAlertable': False,
         }
 

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -150,7 +150,7 @@ class PostSentryAppsTest(SentryAppsTest):
         )
         sentry_apps.Destroyer.run(sentry_app=sentry_app, user=self.user)
         response = self._post(**{'name': sentry_app.name})
-        assert response.status_code == 422
+        assert response.status_code == 400
         assert response.data == \
             {"name": ["Name Foo Bar is already taken, please use another."]}
 
@@ -160,7 +160,7 @@ class PostSentryAppsTest(SentryAppsTest):
         kwargs = {'webhookUrl': 'example.com'}
         response = self._post(**kwargs)
 
-        assert response.status_code == 422
+        assert response.status_code == 400
         assert response.data == \
             {'webhookUrl': ['URL must start with http[s]://']}
 
@@ -170,7 +170,7 @@ class PostSentryAppsTest(SentryAppsTest):
         kwargs = {'scopes': ('project:read',)}
         response = self._post(**kwargs)
 
-        assert response.status_code == 422
+        assert response.status_code == 400
         assert response.data == \
             {'events': ['issue webhooks require the event:read permission.']}
 
@@ -197,7 +197,7 @@ class PostSentryAppsTest(SentryAppsTest):
             ],
         }}
         response = self._post(**kwargs)
-        assert response.status_code == 422
+        assert response.status_code == 400
         assert response.data == \
             {'schema': ["['#general'] is too short"]}
 
@@ -213,7 +213,7 @@ class PostSentryAppsTest(SentryAppsTest):
         self.login_as(self.user)
         response = self._post(name=None)
 
-        assert response.status_code == 422, response.content
+        assert response.status_code == 400, response.content
         assert 'name' in response.data
 
     @with_feature('organizations:sentry-apps')
@@ -221,7 +221,7 @@ class PostSentryAppsTest(SentryAppsTest):
         self.login_as(self.user)
         response = self._post(events=['project'])
 
-        assert response.status_code == 422, response.content
+        assert response.status_code == 400, response.content
         assert 'events' in response.data
 
     @with_feature('organizations:sentry-apps')
@@ -229,7 +229,7 @@ class PostSentryAppsTest(SentryAppsTest):
         self.login_as(self.user)
         response = self._post(scopes=('not:ascope', ))
 
-        assert response.status_code == 422, response.content
+        assert response.status_code == 400, response.content
         assert 'scopes' in response.data
 
     @with_feature('organizations:sentry-apps')
@@ -237,7 +237,7 @@ class PostSentryAppsTest(SentryAppsTest):
         self.login_as(self.user)
         response = self._post(webhookUrl=None)
 
-        assert response.status_code == 422, response.content
+        assert response.status_code == 400, response.content
         assert 'webhookUrl' in response.data
 
     @with_feature('organizations:sentry-apps')
@@ -253,6 +253,7 @@ class PostSentryAppsTest(SentryAppsTest):
             'name': 'MyApp',
             'organization': self.org.slug,
             'author': 'Sentry',
+            'schema': None,
             'scopes': ('project:read', 'event:read'),
             'events': ('issue',),
             'webhookUrl': 'https://example.com',


### PR DESCRIPTION
The validator was assuming there was a URL to validate, but sometimes it's an empty string.

This changes the validator to take that into account.