### PR TITLE
ref(ui): Avoid full-page load indicator after project creation

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -96,7 +96,7 @@ const OrganizationContext = createReactClass({
     // If a new project was created, we need to re-fetch the
     // org details endpoint, which will propagate re-rendering
     // for the entire component tree
-    this.remountComponent();
+    this.fetchData();
   },
 
   getOrganizationSlug() {


### PR DESCRIPTION
Currently after project creation, the entire org context component would
remount. This *should be* unneeded, we should be able to just propegate
org context downThis is un-needed, instead we can just propegate org
context down.

Not positive 100% positive though, the old context API might be the reason we have to do this.