### PR TITLE
fix(project-dashboard): Fix grouping projects by teams

### DIFF
--- a/src/sentry/static/sentry/app/utils/getProjectsByTeams.jsx
+++ b/src/sentry/static/sentry/app/utils/getProjectsByTeams.jsx
@@ -15,7 +15,7 @@ export default function getProjectsByTeams(teams, projects, isSuperuser = false)
         if (!usersTeams.has(team.slug)) {
           return;
         }
-        if (!projectsByTeam[team.slug]) {
+        if (!projectsByTeam.hasOwnProperty(team.slug)) {
           projectsByTeam[team.slug] = [];
         }
         projectsByTeam[team.slug].push(project);


### PR DESCRIPTION
Fixes a bug where a team named "constructor" will cause this function
to break since it is also a property on a JavaScript object.

Fixes JAVASCRIPT-AP4