### PR TITLE
fix(app-platform): Remove order dependence

### DIFF
--- a/tests/sentry/api/endpoints/test_sentry_apps_stats.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps_stats.py
@@ -36,19 +36,19 @@ class SentryAppsStatsTest(APITestCase):
         response = self.client.get(self.url, format='json')
 
         assert response.status_code == 200
-        assert json.loads(response.content) == \
-            [{
-                'id': self.app_1.id,
-                'slug': self.app_1.slug,
-                'name': self.app_1.name,
-                'installs': 1,
-            },
-            {
-                'id': self.app_2.id,
-                'slug': self.app_2.slug,
-                'name': self.app_2.name,
-                'installs': 1,
-            }]
+        assert {
+            'id': self.app_2.id,
+            'slug': self.app_2.slug,
+            'name': self.app_2.name,
+            'installs': 1,
+        } in json.loads(response.content)
+
+        assert {
+            'id': self.app_1.id,
+            'slug': self.app_1.slug,
+            'name': self.app_1.name,
+            'installs': 1,
+        } in json.loads(response.content)
 
     @with_feature('organizations:sentry-apps')
     def test_nonsuperusers_have_no_access(self):


### PR DESCRIPTION
The previous test failed due to the order of the response body not
matching the order the test specified them in.

Instead, just ensure the response body contains each object we expect,
removing any reliance on ordering.