### PR TITLE
fix(ui): Keep AWS icon consistent

### DIFF
--- a/src/sentry/static/sentry/app/components/platformIcon.jsx
+++ b/src/sentry/static/sentry/app/components/platformIcon.jsx
@@ -42,13 +42,15 @@ const PLATFORM_TO_ICON = {
   'python-pyramid': 'python',
   'python-rq': 'python',
   'python-tornado': 'python',
-  'python-awslambda': 'python',
+  'python-pythonawslambda': 'python',
   'react-native': 'apple',
   ruby: 'ruby',
   'ruby-rack': 'ruby',
   'ruby-rails': 'rails',
   rust: 'rust',
   swift: 'swift',
+  // TODO: AWS used to be python-awslambda but the displayed generic icon
+  // We need to figure out what is causing it to be python-pythonawslambda
 };
 
 export function getIcon(platform) {


### PR DESCRIPTION
The AWS icon showed a generic icon now to be consistent, the python icon will be there.
![Screen Shot 2019-04-18 at 3 36 00 PM](https://user-images.githubusercontent.com/25037561/56395901-5b66ff00-61f1-11e9-8313-5fd37223a4f1.png)
![Screen Shot 2019-04-18 at 3 36 24 PM](https://user-images.githubusercontent.com/25037561/56395908-63bf3a00-61f1-11e9-8b66-a70cbed5dbe3.png)
