### PR TITLE
ref: Add safety parameter to `db.delete_column`.

### DIFF
--- a/src/sentry/south_migrations/0002_auto__del_field_groupedmessage_url__chg_field_groupedmessage_view__chg.py
+++ b/src/sentry/south_migrations/0002_auto__del_field_groupedmessage_url__chg_field_groupedmessage_view__chg.py
@@ -9,7 +9,7 @@ class Migration(SchemaMigration):
     def forwards(self, orm):
 
         # Deleting field 'GroupedMessage.url'
-        db.delete_column('sentry_groupedmessage', 'url')
+        db.delete_column('sentry_groupedmessage', 'url', safety_lock=False)
 
         # Changing field 'GroupedMessage.view'
         db.alter_column(

--- a/src/sentry/south_migrations/0003_auto__add_field_message_group__del_field_groupedmessage_server_name.py
+++ b/src/sentry/south_migrations/0003_auto__add_field_message_group__del_field_groupedmessage_server_name.py
@@ -19,12 +19,12 @@ class Migration(SchemaMigration):
         )
 
         # Deleting field 'GroupedMessage.server_name'
-        db.delete_column('sentry_groupedmessage', 'server_name')
+        db.delete_column('sentry_groupedmessage', 'server_name', safety_lock=False)
 
     def backwards(self, orm):
 
         # Deleting field 'Message.group'
-        db.delete_column('sentry_message', 'group_id')
+        db.delete_column('sentry_message', 'group_id', safety_lock=False)
 
         # Adding field 'GroupedMessage.server_name'
         db.add_column(

--- a/src/sentry/south_migrations/0007_auto__add_field_message_site.py
+++ b/src/sentry/south_migrations/0007_auto__add_field_message_site.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
     def backwards(self, orm):
 
         # Deleting field 'Message.site'
-        db.delete_column('sentry_message', 'site')
+        db.delete_column('sentry_message', 'site', safety_lock=False)
 
     models = {
         'sentry.filtervalue': {

--- a/src/sentry/south_migrations/0008_auto__chg_field_message_view__add_field_groupedmessage_data__chg_field.py
+++ b/src/sentry/south_migrations/0008_auto__chg_field_message_view__add_field_groupedmessage_data__chg_field.py
@@ -44,7 +44,7 @@ class Migration(SchemaMigration):
         )
 
         # Deleting field 'GroupedMessage.data'
-        db.delete_column('sentry_groupedmessage', 'data')
+        db.delete_column('sentry_groupedmessage', 'data', safety_lock=False)
 
         # Changing field 'GroupedMessage.view'
         db.alter_column(

--- a/src/sentry/south_migrations/0009_auto__add_field_message_message_id.py
+++ b/src/sentry/south_migrations/0009_auto__add_field_message_message_id.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
     def backwards(self, orm):
 
         # Deleting field 'Message.message_id'
-        db.delete_column('sentry_message', 'message_id')
+        db.delete_column('sentry_message', 'message_id', safety_lock=False)
 
     models = {
         'sentry.filtervalue': {

--- a/src/sentry/south_migrations/0011_auto__add_field_groupedmessage_score.py
+++ b/src/sentry/south_migrations/0011_auto__add_field_groupedmessage_score.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
     def backwards(self, orm):
 
         # Deleting field 'GroupedMessage.score'
-        db.delete_column('sentry_groupedmessage', 'score')
+        db.delete_column('sentry_groupedmessage', 'score', safety_lock=False)
 
     models = {
         'sentry.filtervalue': {

--- a/src/sentry/south_migrations/0015_auto__add_field_message_project__add_field_messagecountbyminute_projec.py
+++ b/src/sentry/south_migrations/0015_auto__add_field_message_project__add_field_messagecountbyminute_projec.py
@@ -66,7 +66,8 @@ class Migration(SchemaMigration):
             keep_default=False
         )
 
-        # Adding unique constraint on 'MessageFilterValue', fields ['project', 'group', 'value', 'key']
+        # Adding unique constraint on 'MessageFilterValue', fields ['project',
+        # 'group', 'value', 'key']
         db.create_unique('sentry_messagefiltervalue', ['project_id', 'group_id', 'value', 'key'])
 
         # Adding field 'GroupedMessage.project'
@@ -79,15 +80,18 @@ class Migration(SchemaMigration):
             keep_default=False
         )
 
-        # Adding unique constraint on 'GroupedMessage', fields ['project', 'checksum', 'logger', 'view']
+        # Adding unique constraint on 'GroupedMessage', fields ['project',
+        # 'checksum', 'logger', 'view']
         db.create_unique('sentry_groupedmessage', ['project_id', 'checksum', 'logger', 'view'])
 
     def backwards(self, orm):
 
-        # Removing unique constraint on 'GroupedMessage', fields ['project', 'checksum', 'logger', 'view']
+        # Removing unique constraint on 'GroupedMessage', fields ['project',
+        # 'checksum', 'logger', 'view']
         db.delete_unique('sentry_groupedmessage', ['project_id', 'checksum', 'logger', 'view'])
 
-        # Removing unique constraint on 'MessageFilterValue', fields ['project', 'group', 'value', 'key']
+        # Removing unique constraint on 'MessageFilterValue', fields ['project',
+        # 'group', 'value', 'key']
         db.delete_unique('sentry_messagefiltervalue', ['project_id', 'group_id', 'value', 'key'])
 
         # Removing unique constraint on 'FilterValue', fields ['project', 'value', 'key']
@@ -97,28 +101,28 @@ class Migration(SchemaMigration):
         db.delete_unique('sentry_messagecountbyminute', ['project_id', 'date', 'group_id'])
 
         # Deleting field 'Message.project'
-        db.delete_column('sentry_message', 'project_id')
+        db.delete_column('sentry_message', 'project_id', safety_lock=False)
 
         # Deleting field 'MessageCountByMinute.project'
-        db.delete_column('sentry_messagecountbyminute', 'project_id')
+        db.delete_column('sentry_messagecountbyminute', 'project_id', safety_lock=False)
 
         # Adding unique constraint on 'MessageCountByMinute', fields ['date', 'group']
         db.create_unique('sentry_messagecountbyminute', ['date', 'group_id'])
 
         # Deleting field 'FilterValue.project'
-        db.delete_column('sentry_filtervalue', 'project_id')
+        db.delete_column('sentry_filtervalue', 'project_id', safety_lock=False)
 
         # Adding unique constraint on 'FilterValue', fields ['key', 'value']
         db.create_unique('sentry_filtervalue', ['key', 'value'])
 
         # Deleting field 'MessageFilterValue.project'
-        db.delete_column('sentry_messagefiltervalue', 'project_id')
+        db.delete_column('sentry_messagefiltervalue', 'project_id', safety_lock=False)
 
         # Adding unique constraint on 'MessageFilterValue', fields ['group', 'value', 'key']
         db.create_unique('sentry_messagefiltervalue', ['group_id', 'value', 'key'])
 
         # Deleting field 'GroupedMessage.project'
-        db.delete_column('sentry_groupedmessage', 'project_id')
+        db.delete_column('sentry_groupedmessage', 'project_id', safety_lock=False)
 
         # Adding unique constraint on 'GroupedMessage', fields ['checksum', 'logger', 'view']
         db.create_unique('sentry_groupedmessage', ['checksum', 'logger', 'view'])

--- a/src/sentry/south_migrations/0016_auto__add_field_projectmember_is_superuser.py
+++ b/src/sentry/south_migrations/0016_auto__add_field_projectmember_is_superuser.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
     def backwards(self, orm):
 
         # Deleting field 'ProjectMember.is_superuser'
-        db.delete_column('sentry_projectmember', 'is_superuser')
+        db.delete_column('sentry_projectmember', 'is_superuser', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0017_auto__add_field_projectmember_api_key.py
+++ b/src/sentry/south_migrations/0017_auto__add_field_projectmember_api_key.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
     def backwards(self, orm):
 
         # Deleting field 'ProjectMember.api_key'
-        db.delete_column('sentry_projectmember', 'api_key')
+        db.delete_column('sentry_projectmember', 'api_key', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0019_auto__del_field_projectmember_api_key__add_field_projectmember_public_.py
+++ b/src/sentry/south_migrations/0019_auto__del_field_projectmember_api_key__add_field_projectmember_public_.py
@@ -9,7 +9,7 @@ class Migration(SchemaMigration):
     def forwards(self, orm):
 
         # Deleting field 'ProjectMember.api_key'
-        db.delete_column('sentry_projectmember', 'api_key')
+        db.delete_column('sentry_projectmember', 'api_key', safety_lock=False)
 
         # Adding field 'ProjectMember.public_key'
         db.add_column(
@@ -38,10 +38,10 @@ class Migration(SchemaMigration):
         )
 
         # Deleting field 'ProjectMember.public_key'
-        db.delete_column('sentry_projectmember', 'public_key')
+        db.delete_column('sentry_projectmember', 'public_key', safety_lock=False)
 
         # Deleting field 'ProjectMember.secret_key'
-        db.delete_column('sentry_projectmember', 'secret_key')
+        db.delete_column('sentry_projectmember', 'secret_key', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0022_auto__del_field_group_class_name__del_field_group_traceback__del_field.py
+++ b/src/sentry/south_migrations/0022_auto__del_field_group_class_name__del_field_group_traceback__del_field.py
@@ -9,19 +9,19 @@ class Migration(SchemaMigration):
     def forwards(self, orm):
 
         # Deleting field 'Group.class_name'
-        db.delete_column('sentry_groupedmessage', 'class_name')
+        db.delete_column('sentry_groupedmessage', 'class_name', safety_lock=False)
 
         # Deleting field 'Group.traceback'
-        db.delete_column('sentry_groupedmessage', 'traceback')
+        db.delete_column('sentry_groupedmessage', 'traceback', safety_lock=False)
 
         # Deleting field 'Event.class_name'
-        db.delete_column('sentry_message', 'class_name')
+        db.delete_column('sentry_message', 'class_name', safety_lock=False)
 
         # Deleting field 'Event.traceback'
-        db.delete_column('sentry_message', 'traceback')
+        db.delete_column('sentry_message', 'traceback', safety_lock=False)
 
         # Deleting field 'Event.url'
-        db.delete_column('sentry_message', 'url')
+        db.delete_column('sentry_message', 'url', safety_lock=False)
 
     def backwards(self, orm):
 

--- a/src/sentry/south_migrations/0023_auto__add_field_event_time_spent.py
+++ b/src/sentry/south_migrations/0023_auto__add_field_event_time_spent.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
     def backwards(self, orm):
 
         # Deleting field 'Event.time_spent'
-        db.delete_column('sentry_message', 'time_spent')
+        db.delete_column('sentry_message', 'time_spent', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0024_auto__add_field_group_time_spent_total__add_field_group_time_spent_cou.py
+++ b/src/sentry/south_migrations/0024_auto__add_field_group_time_spent_total__add_field_group_time_spent_cou.py
@@ -27,10 +27,10 @@ class Migration(SchemaMigration):
     def backwards(self, orm):
 
         # Deleting field 'Group.time_spent_total'
-        db.delete_column('sentry_groupedmessage', 'time_spent_total')
+        db.delete_column('sentry_groupedmessage', 'time_spent_total', safety_lock=False)
 
         # Deleting field 'Group.time_spent_count'
-        db.delete_column('sentry_groupedmessage', 'time_spent_count')
+        db.delete_column('sentry_groupedmessage', 'time_spent_count', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0025_auto__add_field_messagecountbyminute_time_spent_total__add_field_messa.py
+++ b/src/sentry/south_migrations/0025_auto__add_field_messagecountbyminute_time_spent_total__add_field_messa.py
@@ -27,10 +27,10 @@ class Migration(SchemaMigration):
     def backwards(self, orm):
 
         # Deleting field 'MessageCountByMinute.time_spent_total'
-        db.delete_column('sentry_messagecountbyminute', 'time_spent_total')
+        db.delete_column('sentry_messagecountbyminute', 'time_spent_total', safety_lock=False)
 
         # Deleting field 'MessageCountByMinute.time_spent_count'
-        db.delete_column('sentry_messagecountbyminute', 'time_spent_count')
+        db.delete_column('sentry_messagecountbyminute', 'time_spent_count', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0026_auto__add_field_project_status.py
+++ b/src/sentry/south_migrations/0026_auto__add_field_project_status.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
     def backwards(self, orm):
 
         # Deleting field 'Project.status'
-        db.delete_column('sentry_project', 'status')
+        db.delete_column('sentry_project', 'status', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0029_auto__del_field_projectmember_is_superuser__del_field_projectmember_pe.py
+++ b/src/sentry/south_migrations/0029_auto__del_field_projectmember_is_superuser__del_field_projectmember_pe.py
@@ -9,10 +9,10 @@ class Migration(SchemaMigration):
     def forwards(self, orm):
 
         # Deleting field 'ProjectMember.is_superuser'
-        db.delete_column('sentry_projectmember', 'is_superuser')
+        db.delete_column('sentry_projectmember', 'is_superuser', safety_lock=False)
 
         # Deleting field 'ProjectMember.permissions'
-        db.delete_column('sentry_projectmember', 'permissions')
+        db.delete_column('sentry_projectmember', 'permissions', safety_lock=False)
 
         # Adding field 'ProjectMember.type'
         db.add_column(
@@ -38,7 +38,7 @@ class Migration(SchemaMigration):
         )
 
         # Deleting field 'ProjectMember.type'
-        db.delete_column('sentry_projectmember', 'type')
+        db.delete_column('sentry_projectmember', 'type', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0031_auto__add_field_view_verbose_name__add_field_view_verbose_name_plural_.py
+++ b/src/sentry/south_migrations/0031_auto__add_field_view_verbose_name__add_field_view_verbose_name_plural_.py
@@ -27,10 +27,10 @@ class Migration(SchemaMigration):
     def backwards(self, orm):
 
         # Deleting field 'View.verbose_name'
-        db.delete_column('sentry_view', 'verbose_name')
+        db.delete_column('sentry_view', 'verbose_name', safety_lock=False)
 
         # Deleting field 'View.verbose_name_plural'
-        db.delete_column('sentry_view', 'verbose_name_plural')
+        db.delete_column('sentry_view', 'verbose_name_plural', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0039_auto__add_field_searchdocument_status.py
+++ b/src/sentry/south_migrations/0039_auto__add_field_searchdocument_status.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
     def backwards(self, orm):
 
         # Deleting field 'SearchDocument.status'
-        db.delete_column('sentry_searchdocument', 'status')
+        db.delete_column('sentry_searchdocument', 'status', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0041_auto__add_field_messagefiltervalue_last_seen__add_field_messagefilterv.py
+++ b/src/sentry/south_migrations/0041_auto__add_field_messagefiltervalue_last_seen__add_field_messagefilterv.py
@@ -31,10 +31,10 @@ class Migration(SchemaMigration):
     def backwards(self, orm):
 
         # Deleting field 'MessageFilterValue.last_seen'
-        db.delete_column('sentry_messagefiltervalue', 'last_seen')
+        db.delete_column('sentry_messagefiltervalue', 'last_seen', safety_lock=False)
 
         # Deleting field 'MessageFilterValue.first_seen'
-        db.delete_column('sentry_messagefiltervalue', 'first_seen')
+        db.delete_column('sentry_messagefiltervalue', 'first_seen', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0044_auto__add_field_projectmember_is_active.py
+++ b/src/sentry/south_migrations/0044_auto__add_field_projectmember_is_active.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
     def backwards(self, orm):
 
         # Deleting field 'ProjectMember.is_active'
-        db.delete_column('sentry_projectmember', 'is_active')
+        db.delete_column('sentry_projectmember', 'is_active', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0046_auto__add_teammember__add_unique_teammember_team_user__add_team__add_p.py
+++ b/src/sentry/south_migrations/0046_auto__add_teammember__add_unique_teammember_team_user__add_team__add_p.py
@@ -113,10 +113,10 @@ class Migration(SchemaMigration):
         db.delete_table('sentry_projectkey')
 
         # Deleting field 'Project.slug'
-        db.delete_column('sentry_project', 'slug')
+        db.delete_column('sentry_project', 'slug', safety_lock=False)
 
         # Deleting field 'Project.team'
-        db.delete_column('sentry_project', 'team_id')
+        db.delete_column('sentry_project', 'team_id', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0050_remove_project_keys_from_members.py
+++ b/src/sentry/south_migrations/0050_remove_project_keys_from_members.py
@@ -9,10 +9,10 @@ class Migration(SchemaMigration):
     def forwards(self, orm):
 
         # Deleting field 'ProjectMember.public_key'
-        db.delete_column('sentry_projectmember', 'public_key')
+        db.delete_column('sentry_projectmember', 'public_key', safety_lock=False)
 
         # Deleting field 'ProjectMember.secret_key'
-        db.delete_column('sentry_projectmember', 'secret_key')
+        db.delete_column('sentry_projectmember', 'secret_key', safety_lock=False)
 
     def backwards(self, orm):
 

--- a/src/sentry/south_migrations/0056_auto__add_field_group_resolved_at.py
+++ b/src/sentry/south_migrations/0056_auto__add_field_group_resolved_at.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
     def backwards(self, orm):
 
         # Deleting field 'Group.resolved_at'
-        db.delete_column('sentry_groupedmessage', 'resolved_at')
+        db.delete_column('sentry_groupedmessage', 'resolved_at', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0057_auto__add_field_group_active_at.py
+++ b/src/sentry/south_migrations/0057_auto__add_field_group_active_at.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
     def backwards(self, orm):
 
         # Deleting field 'Group.active_at'
-        db.delete_column('sentry_groupedmessage', 'active_at')
+        db.delete_column('sentry_groupedmessage', 'active_at', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0061_auto__add_field_group_group_id__add_field_group_is_public.py
+++ b/src/sentry/south_migrations/0061_auto__add_field_group_group_id__add_field_group_is_public.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Group.is_public'
-        db.delete_column('sentry_groupedmessage', 'is_public')
+        db.delete_column('sentry_groupedmessage', 'is_public', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0067_auto__add_field_group_platform__add_field_event_platform.py
+++ b/src/sentry/south_migrations/0067_auto__add_field_group_platform__add_field_event_platform.py
@@ -21,10 +21,10 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Group.platform'
-        db.delete_column('sentry_groupedmessage', 'platform')
+        db.delete_column('sentry_groupedmessage', 'platform', safety_lock=False)
 
         # Deleting field 'Event.platform'
-        db.delete_column('sentry_message', 'platform')
+        db.delete_column('sentry_message', 'platform', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0068_auto__add_field_projectkey_user_added__add_field_projectkey_date_added.py
+++ b/src/sentry/south_migrations/0068_auto__add_field_projectkey_user_added__add_field_projectkey_date_added.py
@@ -25,10 +25,10 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'ProjectKey.user_added'
-        db.delete_column('sentry_projectkey', 'user_added_id')
+        db.delete_column('sentry_projectkey', 'user_added_id', safety_lock=False)
 
         # Deleting field 'ProjectKey.date_added'
-        db.delete_column('sentry_projectkey', 'date_added')
+        db.delete_column('sentry_projectkey', 'date_added', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0071_auto__add_field_group_users_seen.py
+++ b/src/sentry/south_migrations/0071_auto__add_field_group_users_seen.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Group.users_seen'
-        db.delete_column('sentry_groupedmessage', 'users_seen')
+        db.delete_column('sentry_groupedmessage', 'users_seen', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0073_auto__add_field_project_platform.py
+++ b/src/sentry/south_migrations/0073_auto__add_field_project_platform.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Project.platform'
-        db.delete_column('sentry_project', 'platform')
+        db.delete_column('sentry_project', 'platform', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0078_auto__add_field_affecteduserbygroup_tuser.py
+++ b/src/sentry/south_migrations/0078_auto__add_field_affecteduserbygroup_tuser.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'AffectedUserByGroup.tuser'
-        db.delete_column('sentry_affecteduserbygroup', 'tuser_id')
+        db.delete_column('sentry_affecteduserbygroup', 'tuser_id', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0079_auto__del_unique_affecteduserbygroup_project_ident_group__add_unique_a.py
+++ b/src/sentry/south_migrations/0079_auto__del_unique_affecteduserbygroup_project_ident_group__add_unique_a.py
@@ -29,7 +29,7 @@ class Migration(SchemaMigration):
         db.create_unique('sentry_affecteduserbygroup', ['project_id', 'ident', 'group_id'])
 
         # Deleting field 'TrackedUser.num_events'
-        db.delete_column('sentry_trackeduser', 'num_events')
+        db.delete_column('sentry_trackeduser', 'num_events', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0082_auto__add_activity__add_field_group_num_comments__add_field_event_num_.py
+++ b/src/sentry/south_migrations/0082_auto__add_activity__add_field_group_num_comments__add_field_event_num_.py
@@ -59,10 +59,10 @@ class Migration(SchemaMigration):
         db.delete_table('sentry_activity')
 
         # Deleting field 'Group.num_comments'
-        db.delete_column('sentry_groupedmessage', 'num_comments')
+        db.delete_column('sentry_groupedmessage', 'num_comments', safety_lock=False)
 
         # Deleting field 'Event.num_comments'
-        db.delete_column('sentry_message', 'num_comments')
+        db.delete_column('sentry_message', 'num_comments', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0086_auto__add_field_team_date_added.py
+++ b/src/sentry/south_migrations/0086_auto__add_field_team_date_added.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Team.date_added'
-        db.delete_column('sentry_team', 'date_added')
+        db.delete_column('sentry_team', 'date_added', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0090_auto__add_grouptagkey__add_unique_grouptagkey_project_group_key__add_f.py
+++ b/src/sentry/south_migrations/0090_auto__add_grouptagkey__add_unique_grouptagkey_project_group_key__add_f.py
@@ -74,16 +74,16 @@ class Migration(SchemaMigration):
         db.delete_table('sentry_grouptagkey')
 
         # Deleting field 'FilterValue.times_seen'
-        db.delete_column('sentry_filtervalue', 'times_seen')
+        db.delete_column('sentry_filtervalue', 'times_seen', safety_lock=False)
 
         # Deleting field 'FilterValue.last_seen'
-        db.delete_column('sentry_filtervalue', 'last_seen')
+        db.delete_column('sentry_filtervalue', 'last_seen', safety_lock=False)
 
         # Deleting field 'FilterValue.first_seen'
-        db.delete_column('sentry_filtervalue', 'first_seen')
+        db.delete_column('sentry_filtervalue', 'first_seen', safety_lock=False)
 
         # Deleting field 'FilterKey.values_seen'
-        db.delete_column('sentry_filterkey', 'values_seen')
+        db.delete_column('sentry_filterkey', 'values_seen', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0093_auto__add_field_alert_status.py
+++ b/src/sentry/south_migrations/0093_auto__add_field_alert_status.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Alert.status'
-        db.delete_column('sentry_alert', 'status')
+        db.delete_column('sentry_alert', 'status', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0096_auto__add_field_tagvalue_data.py
+++ b/src/sentry/south_migrations/0096_auto__add_field_tagvalue_data.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'TagValue.data'
-        db.delete_column('sentry_filtervalue', 'data')
+        db.delete_column('sentry_filtervalue', 'data', safety_lock=False)
 
     models = {
         'sentry.user': {

--- a/src/sentry/south_migrations/0097_auto__del_affecteduserbygroup__del_unique_affecteduserbygroup_project_.py
+++ b/src/sentry/south_migrations/0097_auto__del_affecteduserbygroup__del_unique_affecteduserbygroup_project_.py
@@ -20,7 +20,7 @@ class Migration(SchemaMigration):
         db.delete_table('sentry_trackeduser')
 
         # Deleting field 'Group.users_seen'
-        db.delete_column('sentry_groupedmessage', 'users_seen')
+        db.delete_column('sentry_groupedmessage', 'users_seen', safety_lock=False)
 
     def backwards(self, orm):
         raise NotImplementedError("This is no time machine bro")

--- a/src/sentry/south_migrations/0099_auto__del_field_teammember_is_active.py
+++ b/src/sentry/south_migrations/0099_auto__del_field_teammember_is_active.py
@@ -8,7 +8,7 @@ from django.db import models
 class Migration(SchemaMigration):
     def forwards(self, orm):
         # Deleting field 'TeamMember.is_active'
-        db.delete_column(u'sentry_teammember', 'is_active')
+        db.delete_column(u'sentry_teammember', 'is_active', safety_lock=False)
 
     def backwards(self, orm):
         # Adding field 'TeamMember.is_active'

--- a/src/sentry/south_migrations/0100_auto__add_field_tagkey_label.py
+++ b/src/sentry/south_migrations/0100_auto__add_field_tagkey_label.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'TagKey.label'
-        db.delete_column('sentry_filterkey', 'label')
+        db.delete_column('sentry_filterkey', 'label', safety_lock=False)
 
     models = {
         u'auth.group': {

--- a/src/sentry/south_migrations/0113_auto__add_field_team_status.py
+++ b/src/sentry/south_migrations/0113_auto__add_field_team_status.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Team.status'
-        db.delete_column('sentry_team', 'status')
+        db.delete_column('sentry_team', 'status', safety_lock=False)
 
     models = {
         'sentry.accessgroup': {

--- a/src/sentry/south_migrations/0114_auto__add_field_projectkey_roles.py
+++ b/src/sentry/south_migrations/0114_auto__add_field_projectkey_roles.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'ProjectKey.roles'
-        db.delete_column('sentry_projectkey', 'roles')
+        db.delete_column('sentry_projectkey', 'roles', safety_lock=False)
 
     models = {
         'sentry.accessgroup': {

--- a/src/sentry/south_migrations/0116_auto__del_field_event_server_name__del_field_event_culprit__del_field_.py
+++ b/src/sentry/south_migrations/0116_auto__del_field_event_server_name__del_field_event_culprit__del_field_.py
@@ -8,19 +8,19 @@ from django.db import models
 class Migration(SchemaMigration):
     def forwards(self, orm):
         # Deleting field 'Event.server_name'
-        db.delete_column('sentry_message', 'server_name')
+        db.delete_column('sentry_message', 'server_name', safety_lock=False)
 
         # Deleting field 'Event.culprit'
-        db.delete_column('sentry_message', 'view')
+        db.delete_column('sentry_message', 'view', safety_lock=False)
 
         # Deleting field 'Event.level'
-        db.delete_column('sentry_message', 'level')
+        db.delete_column('sentry_message', 'level', safety_lock=False)
 
         # Deleting field 'Event.site'
-        db.delete_column('sentry_message', 'site')
+        db.delete_column('sentry_message', 'site', safety_lock=False)
 
         # Deleting field 'Event.logger'
-        db.delete_column('sentry_message', 'logger')
+        db.delete_column('sentry_message', 'logger', safety_lock=False)
 
     def backwards(self, orm):
         # Adding field 'Event.server_name'

--- a/src/sentry/south_migrations/0119_auto__add_field_projectkey_label.py
+++ b/src/sentry/south_migrations/0119_auto__add_field_projectkey_label.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'ProjectKey.label'
-        db.delete_column('sentry_projectkey', 'label')
+        db.delete_column('sentry_projectkey', 'label', safety_lock=False)
 
     models = {
         'sentry.accessgroup': {

--- a/src/sentry/south_migrations/0125_auto__add_field_user_is_managed.py
+++ b/src/sentry/south_migrations/0125_auto__add_field_user_is_managed.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'User.is_managed'
-        db.delete_column('auth_user', 'is_managed')
+        db.delete_column('auth_user', 'is_managed', safety_lock=False)
 
     models = {
         'sentry.accessgroup': {

--- a/src/sentry/south_migrations/0126_auto__add_field_option_last_updated.py
+++ b/src/sentry/south_migrations/0126_auto__add_field_option_last_updated.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Option.last_updated'
-        db.delete_column('sentry_option', 'last_updated')
+        db.delete_column('sentry_option', 'last_updated', safety_lock=False)
 
     models = {
         'sentry.accessgroup': {

--- a/src/sentry/south_migrations/0130_auto__del_field_project_owner.py
+++ b/src/sentry/south_migrations/0130_auto__del_field_project_owner.py
@@ -8,7 +8,7 @@ from django.db import models
 class Migration(SchemaMigration):
     def forwards(self, orm):
         # Deleting field 'Project.owner'
-        db.delete_column(u'sentry_project', 'owner_id')
+        db.delete_column(u'sentry_project', 'owner_id', safety_lock=False)
 
     def backwards(self, orm):
         # Adding field 'Project.owner'

--- a/src/sentry/south_migrations/0131_auto__add_organizationmember__add_unique_organizationmember_organizati.py
+++ b/src/sentry/south_migrations/0131_auto__add_organizationmember__add_unique_organizationmember_organizati.py
@@ -65,7 +65,7 @@ class Migration(SchemaMigration):
         db.delete_table('sentry_organization')
 
         # Deleting field 'Team.organization'
-        db.delete_column('sentry_team', 'organization_id')
+        db.delete_column('sentry_team', 'organization_id', safety_lock=False)
 
     models = {
         'sentry.accessgroup': {

--- a/src/sentry/south_migrations/0137_auto__add_field_organizationmember_has_global_access.py
+++ b/src/sentry/south_migrations/0137_auto__add_field_organizationmember_has_global_access.py
@@ -34,7 +34,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'OrganizationMember.has_global_access'
-        db.delete_column('sentry_organizationmember', 'has_global_access')
+        db.delete_column('sentry_organizationmember', 'has_global_access', safety_lock=False)
 
         # Removing M2M table for field teams on 'OrganizationMember'
         db.delete_table(db.shorten_name('sentry_organizationmember_teams'))

--- a/src/sentry/south_migrations/0140_auto__add_field_organization_slug.py
+++ b/src/sentry/south_migrations/0140_auto__add_field_organization_slug.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Organization.slug'
-        db.delete_column('sentry_organization', 'slug')
+        db.delete_column('sentry_organization', 'slug', safety_lock=False)
 
     models = {
         'sentry.accessgroup': {

--- a/src/sentry/south_migrations/0142_auto__add_field_project_organization__add_unique_project_organization_.py
+++ b/src/sentry/south_migrations/0142_auto__add_field_project_organization__add_unique_project_organization_.py
@@ -25,7 +25,7 @@ class Migration(SchemaMigration):
         db.delete_unique('sentry_project', ['organization_id', 'slug'])
 
         # Deleting field 'Project.organization'
-        db.delete_column('sentry_project', 'organization_id')
+        db.delete_column('sentry_project', 'organization_id', safety_lock=False)
 
     models = {
         'sentry.accessgroup': {

--- a/src/sentry/south_migrations/0146_auto__add_field_auditlogentry_ip_address.py
+++ b/src/sentry/south_migrations/0146_auto__add_field_auditlogentry_ip_address.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'AuditLogEntry.ip_address'
-        db.delete_column('sentry_auditlogentry', 'ip_address')
+        db.delete_column('sentry_auditlogentry', 'ip_address', safety_lock=False)
 
     models = {
         'sentry.accessgroup': {

--- a/src/sentry/south_migrations/0152_auto__add_field_file_checksum__chg_field_file_name__add_unique_file_na.py
+++ b/src/sentry/south_migrations/0152_auto__add_field_file_checksum__chg_field_file_name__add_unique_file_na.py
@@ -27,7 +27,7 @@ class Migration(SchemaMigration):
         db.delete_unique('sentry_file', ['name', 'checksum'])
 
         # Deleting field 'File.checksum'
-        db.delete_column('sentry_file', 'checksum')
+        db.delete_column('sentry_file', 'checksum', safety_lock=False)
 
         # Changing field 'File.name'
         db.alter_column(

--- a/src/sentry/south_migrations/0153_auto__add_field_grouprulestatus_last_active.py
+++ b/src/sentry/south_migrations/0153_auto__add_field_grouprulestatus_last_active.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'GroupRuleStatus.last_active'
-        db.delete_column('sentry_grouprulestatus', 'last_active')
+        db.delete_column('sentry_grouprulestatus', 'last_active', safety_lock=False)
 
     models = {
         'sentry.accessgroup': {

--- a/src/sentry/south_migrations/0154_auto__add_field_tagkey_status.py
+++ b/src/sentry/south_migrations/0154_auto__add_field_tagkey_status.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'TagKey.status'
-        db.delete_column('sentry_filterkey', 'status')
+        db.delete_column('sentry_filterkey', 'status', safety_lock=False)
 
     models = {
         'sentry.accessgroup': {

--- a/src/sentry/south_migrations/0155_auto__add_field_projectkey_status.py
+++ b/src/sentry/south_migrations/0155_auto__add_field_projectkey_status.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'ProjectKey.status'
-        db.delete_column('sentry_projectkey', 'status')
+        db.delete_column('sentry_projectkey', 'status', safety_lock=False)
 
     models = {
         'sentry.accessgroup': {

--- a/src/sentry/south_migrations/0159_auto__add_field_authidentity_last_verified__add_field_organizationmemb.py
+++ b/src/sentry/south_migrations/0159_auto__add_field_authidentity_last_verified__add_field_organizationmemb.py
@@ -25,10 +25,10 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'AuthIdentity.last_verified'
-        db.delete_column('sentry_authidentity', 'last_verified')
+        db.delete_column('sentry_authidentity', 'last_verified', safety_lock=False)
 
         # Deleting field 'OrganizationMember.flags'
-        db.delete_column('sentry_organizationmember', 'flags')
+        db.delete_column('sentry_organizationmember', 'flags', safety_lock=False)
 
     models = {
         'sentry.accessgroup': {

--- a/src/sentry/south_migrations/0160_auto__add_field_authprovider_default_global_access.py
+++ b/src/sentry/south_migrations/0160_auto__add_field_authprovider_default_global_access.py
@@ -29,7 +29,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'AuthProvider.default_global_access'
-        db.delete_column('sentry_authprovider', 'default_global_access')
+        db.delete_column('sentry_authprovider', 'default_global_access', safety_lock=False)
 
         # Removing M2M table for field default_teams on 'AuthProvider'
         db.delete_table(db.shorten_name('sentry_authprovider_default_teams'))

--- a/src/sentry/south_migrations/0163_auto__add_field_authidentity_last_synced.py
+++ b/src/sentry/south_migrations/0163_auto__add_field_authidentity_last_synced.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'AuthIdentity.last_synced'
-        db.delete_column('sentry_authidentity', 'last_synced')
+        db.delete_column('sentry_authidentity', 'last_synced', safety_lock=False)
 
     models = {
         'sentry.accessgroup': {

--- a/src/sentry/south_migrations/0164_auto__add_releasefile__add_unique_releasefile_release_ident__add_field.py
+++ b/src/sentry/south_migrations/0164_auto__add_releasefile__add_unique_releasefile_release_ident__add_field.py
@@ -60,7 +60,7 @@ class Migration(SchemaMigration):
         db.delete_table('sentry_releasefile')
 
         # Deleting field 'File.headers'
-        db.delete_column('sentry_file', 'headers')
+        db.delete_column('sentry_file', 'headers', safety_lock=False)
 
         # Changing field 'File.storage_options'
         db.alter_column(

--- a/src/sentry/south_migrations/0166_auto__chg_field_user_id__add_field_apikey_allowed_origins.py
+++ b/src/sentry/south_migrations/0166_auto__chg_field_user_id__add_field_apikey_allowed_origins.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'ApiKey.allowed_origins'
-        db.delete_column('sentry_apikey', 'allowed_origins')
+        db.delete_column('sentry_apikey', 'allowed_origins', safety_lock=False)
 
     models = {
         'sentry.accessgroup': {

--- a/src/sentry/south_migrations/0167_auto__add_field_authprovider_flags.py
+++ b/src/sentry/south_migrations/0167_auto__add_field_authprovider_flags.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'AuthProvider.flags'
-        db.delete_column('sentry_authprovider', 'flags')
+        db.delete_column('sentry_authprovider', 'flags', safety_lock=False)
 
     models = {
         'sentry.accessgroup': {

--- a/src/sentry/south_migrations/0169_auto__del_field_projectkey_user.py
+++ b/src/sentry/south_migrations/0169_auto__del_field_projectkey_user.py
@@ -8,7 +8,7 @@ from django.db import models
 class Migration(SchemaMigration):
     def forwards(self, orm):
         # Deleting field 'ProjectKey.user'
-        db.delete_column(u'sentry_projectkey', 'user_id')
+        db.delete_column(u'sentry_projectkey', 'user_id', safety_lock=False)
 
     def backwards(self, orm):
         # Adding field 'ProjectKey.user'

--- a/src/sentry/south_migrations/0170_auto__add_organizationmemberteam__add_unique_organizationmemberteam_te.py
+++ b/src/sentry/south_migrations/0170_auto__add_organizationmemberteam__add_unique_organizationmemberteam_te.py
@@ -49,10 +49,10 @@ class Migration(SchemaMigration):
         db.create_unique('sentry_organizationaccessrequest', ['team_id', 'member_id'])
 
     def backwards(self, orm):
-        db.delete_column('sentry_organizationmember_teams', 'is_active')
+        db.delete_column('sentry_organizationmember_teams', 'is_active', safety_lock=False)
 
         # Deleting field 'Organization.flags'
-        db.delete_column('sentry_organization', 'flags')
+        db.delete_column('sentry_organization', 'flags', safety_lock=False)
 
         # Removing unique constraint on 'OrganizationAccessRequest', fields ['team', 'member']
         db.delete_unique('sentry_organizationaccessrequest', ['team_id', 'member_id'])

--- a/src/sentry/south_migrations/0172_auto__del_field_team_owner.py
+++ b/src/sentry/south_migrations/0172_auto__del_field_team_owner.py
@@ -8,7 +8,7 @@ from django.db import models
 class Migration(SchemaMigration):
     def forwards(self, orm):
         # Deleting field 'Team.owner'
-        db.delete_column(u'sentry_team', 'owner_id')
+        db.delete_column(u'sentry_team', 'owner_id', safety_lock=False)
 
     def backwards(self, orm):
         # Adding field 'Team.owner'

--- a/src/sentry/south_migrations/0174_auto__del_field_projectkey_user_added.py
+++ b/src/sentry/south_migrations/0174_auto__del_field_projectkey_user_added.py
@@ -8,7 +8,7 @@ from django.db import models
 class Migration(SchemaMigration):
     def forwards(self, orm):
         # Deleting field 'ProjectKey.user_added'
-        db.delete_column(u'sentry_projectkey', 'user_added_id')
+        db.delete_column(u'sentry_projectkey', 'user_added_id', safety_lock=False)
 
     def backwards(self, orm):
         # Adding field 'ProjectKey.user_added'

--- a/src/sentry/south_migrations/0176_auto__add_field_organizationmember_counter__add_unique_organizationmem.py
+++ b/src/sentry/south_migrations/0176_auto__add_field_organizationmember_counter__add_unique_organizationmem.py
@@ -25,7 +25,7 @@ class Migration(SchemaMigration):
         db.delete_unique('sentry_organizationmember', ['organization_id', 'counter'])
 
         # Deleting field 'OrganizationMember.counter'
-        db.delete_column('sentry_organizationmember', 'counter')
+        db.delete_column('sentry_organizationmember', 'counter', safety_lock=False)
 
     models = {
         'sentry.accessgroup': {

--- a/src/sentry/south_migrations/0179_auto__add_field_release_date_released.py
+++ b/src/sentry/south_migrations/0179_auto__add_field_release_date_released.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Release.date_released'
-        db.delete_column('sentry_release', 'date_released')
+        db.delete_column('sentry_release', 'date_released', safety_lock=False)
 
     models = {
         'sentry.accessgroup': {

--- a/src/sentry/south_migrations/0180_auto__add_field_release_environment__add_field_release_ref__add_field_.py
+++ b/src/sentry/south_migrations/0180_auto__add_field_release_environment__add_field_release_ref__add_field_.py
@@ -58,19 +58,19 @@ class Migration(SchemaMigration):
         db.delete_unique('sentry_release', ['project_id', 'version', 'environment'])
 
         # Deleting field 'Release.environment'
-        db.delete_column('sentry_release', 'environment')
+        db.delete_column('sentry_release', 'environment', safety_lock=False)
 
         # Deleting field 'Release.ref'
-        db.delete_column('sentry_release', 'ref')
+        db.delete_column('sentry_release', 'ref', safety_lock=False)
 
         # Deleting field 'Release.url'
-        db.delete_column('sentry_release', 'url')
+        db.delete_column('sentry_release', 'url', safety_lock=False)
 
         # Deleting field 'Release.date_started'
-        db.delete_column('sentry_release', 'date_started')
+        db.delete_column('sentry_release', 'date_started', safety_lock=False)
 
         # Deleting field 'Release.data'
-        db.delete_column('sentry_release', 'data')
+        db.delete_column('sentry_release', 'data', safety_lock=False)
 
         # Adding unique constraint on 'Release', fields ['project', 'version']
         db.create_unique(u'sentry_release', ['project_id', 'version'])

--- a/src/sentry/south_migrations/0181_auto__del_field_release_environment__del_unique_release_project_versio.py
+++ b/src/sentry/south_migrations/0181_auto__del_field_release_environment__del_unique_release_project_versio.py
@@ -11,7 +11,7 @@ class Migration(SchemaMigration):
         db.delete_unique(u'sentry_release', ['project_id', 'version', 'environment'])
 
         # Deleting field 'Release.environment'
-        db.delete_column(u'sentry_release', 'environment')
+        db.delete_column(u'sentry_release', 'environment', safety_lock=False)
 
         # Adding unique constraint on 'Release', fields ['project', 'version']
         db.create_unique('sentry_release', ['project_id', 'version'])

--- a/src/sentry/south_migrations/0182_auto__add_field_auditlogentry_actor_label__add_field_auditlogentry_act.py
+++ b/src/sentry/south_migrations/0182_auto__add_field_auditlogentry_actor_label__add_field_auditlogentry_act.py
@@ -35,10 +35,10 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'AuditLogEntry.actor_label'
-        db.delete_column('sentry_auditlogentry', 'actor_label')
+        db.delete_column('sentry_auditlogentry', 'actor_label', safety_lock=False)
 
         # Deleting field 'AuditLogEntry.actor_key'
-        db.delete_column('sentry_auditlogentry', 'actor_key_id')
+        db.delete_column('sentry_auditlogentry', 'actor_key_id', safety_lock=False)
 
         # User chose to not deal with backwards NULL issues for 'AuditLogEntry.actor'
         raise RuntimeError(

--- a/src/sentry/south_migrations/0184_auto__del_field_group_checksum__del_unique_group_project_checksum__del.py
+++ b/src/sentry/south_migrations/0184_auto__del_field_group_checksum__del_unique_group_project_checksum__del.py
@@ -11,10 +11,10 @@ class Migration(SchemaMigration):
         db.delete_unique('sentry_groupedmessage', ['project_id', 'checksum'])
 
         # Deleting field 'Group.checksum'
-        db.delete_column('sentry_groupedmessage', 'checksum')
+        db.delete_column('sentry_groupedmessage', 'checksum', safety_lock=False)
 
         # Deleting field 'Event.checksum'
-        db.delete_column('sentry_message', 'checksum')
+        db.delete_column('sentry_message', 'checksum', safety_lock=False)
 
     def backwards(self, orm):
 
@@ -23,7 +23,8 @@ class Migration(SchemaMigration):
             "Cannot reverse this migration. 'Group.checksum' and its values cannot be restored."
         )
 
-        # The following code is provided here to aid in writing a correct migration        # Adding field 'Group.checksum'
+        # The following code is provided here to aid in writing a correct
+        # migration        # Adding field 'Group.checksum'
         db.add_column(
             'sentry_groupedmessage',
             'checksum',
@@ -39,7 +40,8 @@ class Migration(SchemaMigration):
             "Cannot reverse this migration. 'Event.checksum' and its values cannot be restored."
         )
 
-        # The following code is provided here to aid in writing a correct migration        # Adding field 'Event.checksum'
+        # The following code is provided here to aid in writing a correct
+        # migration        # Adding field 'Event.checksum'
         db.add_column(
             'sentry_message',
             'checksum',

--- a/src/sentry/south_migrations/0186_auto__add_field_group_first_release.py
+++ b/src/sentry/south_migrations/0186_auto__add_field_group_first_release.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Group.first_release'
-        db.delete_column('sentry_groupedmessage', 'first_release_id')
+        db.delete_column('sentry_groupedmessage', 'first_release_id', safety_lock=False)
 
     models = {
         'sentry.accessgroup': {

--- a/src/sentry/south_migrations/0190_auto__add_field_release_new_groups.py
+++ b/src/sentry/south_migrations/0190_auto__add_field_release_new_groups.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Release.new_groups'
-        db.delete_column('sentry_release', 'new_groups')
+        db.delete_column('sentry_release', 'new_groups', safety_lock=False)
 
     models = {
         'sentry.accessgroup': {

--- a/src/sentry/south_migrations/0194_auto__del_field_project_platform.py
+++ b/src/sentry/south_migrations/0194_auto__del_field_project_platform.py
@@ -8,7 +8,7 @@ from django.db import models
 class Migration(SchemaMigration):
     def forwards(self, orm):
         # Deleting field 'Project.platform'
-        db.delete_column(u'sentry_project', 'platform')
+        db.delete_column(u'sentry_project', 'platform', safety_lock=False)
 
     def backwards(self, orm):
         # Adding field 'Project.platform'

--- a/src/sentry/south_migrations/0196_auto__del_field_organization_owner.py
+++ b/src/sentry/south_migrations/0196_auto__del_field_organization_owner.py
@@ -8,7 +8,7 @@ from django.db import models
 class Migration(SchemaMigration):
     def forwards(self, orm):
         # Deleting field 'Organization.owner'
-        db.delete_column(u'sentry_organization', 'owner_id')
+        db.delete_column(u'sentry_organization', 'owner_id', safety_lock=False)
 
     def backwards(self, orm):
         # Adding field 'Organization.owner'

--- a/src/sentry/south_migrations/0198_auto__add_field_release_primary_owner.py
+++ b/src/sentry/south_migrations/0198_auto__add_field_release_primary_owner.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Release.owner'
-        db.delete_column('sentry_release', 'owner_id')
+        db.delete_column('sentry_release', 'owner_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0199_auto__add_field_project_first_event.py
+++ b/src/sentry/south_migrations/0199_auto__add_field_project_first_event.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Project.first_event'
-        db.delete_column('sentry_project', 'first_event')
+        db.delete_column('sentry_project', 'first_event', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0205_auto__add_field_organizationmember_role.py
+++ b/src/sentry/south_migrations/0205_auto__add_field_organizationmember_role.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'OrganizationMember.role'
-        db.delete_column('sentry_organizationmember', 'role')
+        db.delete_column('sentry_organizationmember', 'role', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0207_auto__add_field_organization_default_role.py
+++ b/src/sentry/south_migrations/0207_auto__add_field_organization_default_role.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Organization.default_role'
-        db.delete_column('sentry_organization', 'default_role')
+        db.delete_column('sentry_organization', 'default_role', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0210_auto__del_field_broadcast_badge.py
+++ b/src/sentry/south_migrations/0210_auto__del_field_broadcast_badge.py
@@ -8,7 +8,7 @@ from django.db import models
 class Migration(SchemaMigration):
     def forwards(self, orm):
         # Deleting field 'Broadcast.badge'
-        db.delete_column(u'sentry_broadcast', 'badge')
+        db.delete_column(u'sentry_broadcast', 'badge', safety_lock=False)
 
     def backwards(self, orm):
         # Adding field 'Broadcast.badge'

--- a/src/sentry/south_migrations/0211_auto__add_field_broadcast_title.py
+++ b/src/sentry/south_migrations/0211_auto__add_field_broadcast_title.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Broadcast.title'
-        db.delete_column('sentry_broadcast', 'title')
+        db.delete_column('sentry_broadcast', 'title', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0212_auto__add_fileblob__add_field_file_blob.py
+++ b/src/sentry/south_migrations/0212_auto__add_fileblob__add_field_file_blob.py
@@ -47,7 +47,7 @@ class Migration(SchemaMigration):
         db.delete_table('sentry_fileblob')
 
         # Deleting field 'File.blob'
-        db.delete_column('sentry_file', 'blob_id')
+        db.delete_column('sentry_file', 'blob_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0214_auto__add_field_broadcast_upstream_id.py
+++ b/src/sentry/south_migrations/0214_auto__add_field_broadcast_upstream_id.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Broadcast.upstream_id'
-        db.delete_column('sentry_broadcast', 'upstream_id')
+        db.delete_column('sentry_broadcast', 'upstream_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0215_auto__add_field_broadcast_date_expires.py
+++ b/src/sentry/south_migrations/0215_auto__add_field_broadcast_date_expires.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Broadcast.date_expires'
-        db.delete_column('sentry_broadcast', 'date_expires')
+        db.delete_column('sentry_broadcast', 'date_expires', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0218_auto__add_field_groupresolution_status.py
+++ b/src/sentry/south_migrations/0218_auto__add_field_groupresolution_status.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'GroupResolution.status'
-        db.delete_column('sentry_groupresolution', 'status')
+        db.delete_column('sentry_groupresolution', 'status', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0219_auto__add_field_groupbookmark_date_added.py
+++ b/src/sentry/south_migrations/0219_auto__add_field_groupbookmark_date_added.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'GroupBookmark.date_added'
-        db.delete_column('sentry_groupbookmark', 'date_added')
+        db.delete_column('sentry_groupbookmark', 'date_added', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0220_auto__del_field_fileblob_storage_options__del_field_fileblob_storage__.py
+++ b/src/sentry/south_migrations/0220_auto__del_field_fileblob_storage_options__del_field_fileblob_storage__.py
@@ -8,16 +8,16 @@ from django.db import models
 class Migration(SchemaMigration):
     def forwards(self, orm):
         # Deleting field 'FileBlob.storage_options'
-        db.delete_column(u'sentry_fileblob', 'storage_options')
+        db.delete_column(u'sentry_fileblob', 'storage_options', safety_lock=False)
 
         # Deleting field 'FileBlob.storage'
-        db.delete_column(u'sentry_fileblob', 'storage')
+        db.delete_column(u'sentry_fileblob', 'storage', safety_lock=False)
 
         # Deleting field 'File.storage_options'
-        db.delete_column(u'sentry_file', 'storage_options')
+        db.delete_column(u'sentry_file', 'storage_options', safety_lock=False)
 
         # Deleting field 'File.storage'
-        db.delete_column(u'sentry_file', 'storage')
+        db.delete_column(u'sentry_file', 'storage', safety_lock=False)
 
     def backwards(self, orm):
         raise RuntimeError(

--- a/src/sentry/south_migrations/0222_auto__del_field_user_last_name__del_field_user_first_name__add_field_u.py
+++ b/src/sentry/south_migrations/0222_auto__del_field_user_last_name__del_field_user_first_name__add_field_u.py
@@ -7,7 +7,7 @@ from django.db import models
 
 class Migration(SchemaMigration):
     def forwards(self, orm):
-        db.delete_column('auth_user', 'last_name')
+        db.delete_column('auth_user', 'last_name', safety_lock=False)
 
     def backwards(self, orm):
         # Adding field 'User.last_name'

--- a/src/sentry/south_migrations/0227_auto__del_field_activity_event.py
+++ b/src/sentry/south_migrations/0227_auto__del_field_activity_event.py
@@ -8,7 +8,7 @@ from django.db import models
 class Migration(SchemaMigration):
     def forwards(self, orm):
         # Deleting field 'Activity.event'
-        db.delete_column(u'sentry_activity', 'event_id')
+        db.delete_column(u'sentry_activity', 'event_id', safety_lock=False)
 
     def backwards(self, orm):
         # Adding field 'Activity.event'

--- a/src/sentry/south_migrations/0228_auto__del_field_event_num_comments.py
+++ b/src/sentry/south_migrations/0228_auto__del_field_event_num_comments.py
@@ -8,7 +8,7 @@ from django.db import models
 class Migration(SchemaMigration):
     def forwards(self, orm):
         # Deleting field 'Event.num_comments'
-        db.delete_column('sentry_message', 'num_comments')
+        db.delete_column('sentry_message', 'num_comments', safety_lock=False)
 
     def backwards(self, orm):
         # Adding field 'Event.num_comments'

--- a/src/sentry/south_migrations/0231_auto__add_field_savedsearch_is_default.py
+++ b/src/sentry/south_migrations/0231_auto__add_field_savedsearch_is_default.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'SavedSearch.is_default'
-        db.delete_column('sentry_savedsearch', 'is_default')
+        db.delete_column('sentry_savedsearch', 'is_default', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0241_auto__add_counter__add_unique_counter_project_ident__add_field_group_s.py
+++ b/src/sentry/south_migrations/0241_auto__add_counter__add_unique_counter_project_ident__add_field_group_s.py
@@ -42,7 +42,7 @@ class Migration(SchemaMigration):
         db.delete_table('sentry_projectcounter')
 
         # Deleting field 'Group.short_id'
-        db.delete_column('sentry_groupedmessage', 'short_id')
+        db.delete_column('sentry_groupedmessage', 'short_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0242_auto__add_field_project_forced_color.py
+++ b/src/sentry/south_migrations/0242_auto__add_field_project_forced_color.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Project.forced_color'
-        db.delete_column('sentry_project', 'forced_color')
+        db.delete_column('sentry_project', 'forced_color', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0253_auto__add_field_eventtag_group_id.py
+++ b/src/sentry/south_migrations/0253_auto__add_field_eventtag_group_id.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'EventTag.group_id'
-        db.delete_column('sentry_eventtag', 'group_id')
+        db.delete_column('sentry_eventtag', 'group_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0258_auto__add_field_user_is_password_expired__add_field_user_last_password.py
+++ b/src/sentry/south_migrations/0258_auto__add_field_user_is_password_expired__add_field_user_last_password.py
@@ -25,10 +25,10 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'User.is_password_expired'
-        db.delete_column('auth_user', 'is_password_expired')
+        db.delete_column('auth_user', 'is_password_expired', safety_lock=False)
 
         # Deleting field 'User.last_password_change'
-        db.delete_column('auth_user', 'last_password_change')
+        db.delete_column('auth_user', 'last_password_change', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0265_auto__add_field_rule_status.py
+++ b/src/sentry/south_migrations/0265_auto__add_field_rule_status.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Rule.status'
-        db.delete_column('sentry_rule', 'status')
+        db.delete_column('sentry_rule', 'status', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0270_auto__add_field_organizationmember_token.py
+++ b/src/sentry/south_migrations/0270_auto__add_field_organizationmember_token.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'OrganizationMember.token'
-        db.delete_column('sentry_organizationmember', 'token')
+        db.delete_column('sentry_organizationmember', 'token', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0271_auto__del_field_organizationmember_counter.py
+++ b/src/sentry/south_migrations/0271_auto__del_field_organizationmember_counter.py
@@ -8,7 +8,7 @@ from django.db import models
 class Migration(SchemaMigration):
     def forwards(self, orm):
         # Deleting field 'OrganizationMember.counter'
-        db.delete_column(u'sentry_organizationmember', 'counter')
+        db.delete_column(u'sentry_organizationmember', 'counter', safety_lock=False)
 
     def backwards(self, orm):
         # Adding field 'OrganizationMember.counter'

--- a/src/sentry/south_migrations/0276_auto__add_field_user_session_nonce.py
+++ b/src/sentry/south_migrations/0276_auto__add_field_user_session_nonce.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'User.session_nonce'
-        db.delete_column('auth_user', 'session_nonce')
+        db.delete_column('auth_user', 'session_nonce', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0277_auto__add_commitfilechange__add_unique_commitfilechange_commit_filenam.py
+++ b/src/sentry/south_migrations/0277_auto__add_commitfilechange__add_unique_commitfilechange_commit_filenam.py
@@ -74,11 +74,13 @@ class Migration(SchemaMigration):
             keep_default=False
         )
 
-        # Adding unique constraint on 'Repository', fields ['organization_id', 'provider', 'external_id']
+        # Adding unique constraint on 'Repository', fields ['organization_id',
+        # 'provider', 'external_id']
         db.create_unique('sentry_repository', ['organization_id', 'provider', 'external_id'])
 
     def backwards(self, orm):
-        # Removing unique constraint on 'Repository', fields ['organization_id', 'provider', 'external_id']
+        # Removing unique constraint on 'Repository', fields ['organization_id',
+        # 'provider', 'external_id']
         db.delete_unique('sentry_repository', ['organization_id', 'provider', 'external_id'])
 
         # Removing unique constraint on 'CommitFileChange', fields ['commit', 'filename']
@@ -88,19 +90,19 @@ class Migration(SchemaMigration):
         db.delete_table('sentry_commitfilechange')
 
         # Deleting field 'Repository.url'
-        db.delete_column('sentry_repository', 'url')
+        db.delete_column('sentry_repository', 'url', safety_lock=False)
 
         # Deleting field 'Repository.provider'
-        db.delete_column('sentry_repository', 'provider')
+        db.delete_column('sentry_repository', 'provider', safety_lock=False)
 
         # Deleting field 'Repository.external_id'
-        db.delete_column('sentry_repository', 'external_id')
+        db.delete_column('sentry_repository', 'external_id', safety_lock=False)
 
         # Deleting field 'Repository.config'
-        db.delete_column('sentry_repository', 'config')
+        db.delete_column('sentry_repository', 'config', safety_lock=False)
 
         # Deleting field 'Repository.status'
-        db.delete_column('sentry_repository', 'status')
+        db.delete_column('sentry_repository', 'status', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0278_auto__add_releaseproject__add_unique_releaseproject_project_release__a.py
+++ b/src/sentry/south_migrations/0278_auto__add_releaseproject__add_unique_releaseproject_project_release__a.py
@@ -48,7 +48,7 @@ class Migration(SchemaMigration):
         db.delete_table('sentry_release_project')
 
         # Deleting field 'Release.organization'
-        db.delete_column('sentry_release', 'organization_id')
+        db.delete_column('sentry_release', 'organization_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0280_auto__add_field_releasecommit_organization_id.py
+++ b/src/sentry/south_migrations/0280_auto__add_field_releasecommit_organization_id.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'ReleaseCommit.organization_id'
-        db.delete_column('sentry_releasecommit', 'organization_id')
+        db.delete_column('sentry_releasecommit', 'organization_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0282_auto__add_field_releasefile_organization__add_field_releaseenvironment.py
+++ b/src/sentry/south_migrations/0282_auto__add_field_releasefile_organization__add_field_releaseenvironment.py
@@ -29,10 +29,10 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'ReleaseFile.organization'
-        db.delete_column('sentry_releasefile', 'organization_id')
+        db.delete_column('sentry_releasefile', 'organization_id', safety_lock=False)
 
         # Deleting field 'ReleaseEnvironment.organization_id'
-        db.delete_column('sentry_environmentrelease', 'organization_id')
+        db.delete_column('sentry_environmentrelease', 'organization_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0287_auto__add_field_releaseproject_new_groups.py
+++ b/src/sentry/south_migrations/0287_auto__add_field_releaseproject_new_groups.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'ReleaseProject.new_groups'
-        db.delete_column('sentry_release_project', 'new_groups')
+        db.delete_column('sentry_release_project', 'new_groups', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0295_auto__add_environmentproject__add_unique_environmentproject_project_en.py
+++ b/src/sentry/south_migrations/0295_auto__add_environmentproject__add_unique_environmentproject_project_en.py
@@ -46,7 +46,7 @@ class Migration(SchemaMigration):
         db.delete_table('sentry_environmentproject')
 
         # Deleting field 'Environment.organization_id'
-        db.delete_column('sentry_environment', 'organization_id')
+        db.delete_column('sentry_environment', 'organization_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0297_auto__add_field_project_flags.py
+++ b/src/sentry/south_migrations/0297_auto__add_field_project_flags.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Project.flags'
-        db.delete_column('sentry_project', 'flags')
+        db.delete_column('sentry_project', 'flags', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0306_auto__add_apigrant__add_apiauthorization__add_unique_apiauthorization_.py
+++ b/src/sentry/south_migrations/0306_auto__add_apigrant__add_apiauthorization__add_unique_apiauthorization_.py
@@ -102,7 +102,7 @@ class Migration(SchemaMigration):
         db.send_create_signal('sentry', ['ApiApplication'])
 
         # Deleting field 'ApiToken.key'
-        db.delete_column(u'sentry_apitoken', 'key_id')
+        db.delete_column(u'sentry_apitoken', 'key_id', safety_lock=False)
 
         # Adding field 'ApiToken.application'
         db.add_column(
@@ -154,13 +154,13 @@ class Migration(SchemaMigration):
         )
 
         # Deleting field 'ApiToken.application'
-        db.delete_column('sentry_apitoken', 'application_id')
+        db.delete_column('sentry_apitoken', 'application_id', safety_lock=False)
 
         # Deleting field 'ApiToken.refresh_token'
-        db.delete_column('sentry_apitoken', 'refresh_token')
+        db.delete_column('sentry_apitoken', 'refresh_token', safety_lock=False)
 
         # Deleting field 'ApiToken.expires_at'
-        db.delete_column('sentry_apitoken', 'expires_at')
+        db.delete_column('sentry_apitoken', 'expires_at', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0307_auto__add_field_apigrant_scope_list__add_field_apitoken_scope_list__ad.py
+++ b/src/sentry/south_migrations/0307_auto__add_field_apigrant_scope_list__add_field_apitoken_scope_list__ad.py
@@ -49,16 +49,16 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'ApiGrant.scope_list'
-        db.delete_column('sentry_apigrant', 'scope_list')
+        db.delete_column('sentry_apigrant', 'scope_list', safety_lock=False)
 
         # Deleting field 'ApiToken.scope_list'
-        db.delete_column('sentry_apitoken', 'scope_list')
+        db.delete_column('sentry_apitoken', 'scope_list', safety_lock=False)
 
         # Deleting field 'ApiAuthorization.scope_list'
-        db.delete_column('sentry_apiauthorization', 'scope_list')
+        db.delete_column('sentry_apiauthorization', 'scope_list', safety_lock=False)
 
         # Deleting field 'ApiKey.scope_list'
-        db.delete_column('sentry_apikey', 'scope_list')
+        db.delete_column('sentry_apikey', 'scope_list', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0310_auto__add_field_savedsearch_owner.py
+++ b/src/sentry/south_migrations/0310_auto__add_field_savedsearch_owner.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'SavedSearch.owner'
-        db.delete_column('sentry_savedsearch', 'owner_id')
+        db.delete_column('sentry_savedsearch', 'owner_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0313_auto__add_field_commitauthor_external_id__add_unique_commitauthor_orga.py
+++ b/src/sentry/south_migrations/0313_auto__add_field_commitauthor_external_id__add_unique_commitauthor_orga.py
@@ -23,7 +23,7 @@ class Migration(SchemaMigration):
         db.delete_unique('sentry_commitauthor', ['organization_id', 'external_id'])
 
         # Deleting field 'CommitAuthor.external_id'
-        db.delete_column('sentry_commitauthor', 'external_id')
+        db.delete_column('sentry_commitauthor', 'external_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0314_auto__add_distribution__add_unique_distribution_release_name__add_fiel.py
+++ b/src/sentry/south_migrations/0314_auto__add_distribution__add_unique_distribution_release_name__add_fiel.py
@@ -52,7 +52,7 @@ class Migration(SchemaMigration):
         db.delete_table('sentry_distribution')
 
         # Deleting field 'ReleaseFile.dist'
-        db.delete_column('sentry_releasefile', 'dist_id')
+        db.delete_column('sentry_releasefile', 'dist_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0315_auto__add_field_useroption_organization__add_unique_useroption_user_or.py
+++ b/src/sentry/south_migrations/0315_auto__add_field_useroption_organization__add_unique_useroption_user_or.py
@@ -25,7 +25,7 @@ class Migration(SchemaMigration):
         db.delete_unique('sentry_useroption', ['user_id', 'organization_id', 'key'])
 
         # Deleting field 'UserOption.organization'
-        db.delete_column('sentry_useroption', 'organization_id')
+        db.delete_column('sentry_useroption', 'organization_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0318_auto__add_field_deploy_notified.py
+++ b/src/sentry/south_migrations/0318_auto__add_field_deploy_notified.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Deploy.notified'
-        db.delete_column('sentry_deploy', 'notified')
+        db.delete_column('sentry_deploy', 'notified', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0321_auto__add_field_projectkey_rate_limit_count__add_field_projectkey_rate.py
+++ b/src/sentry/south_migrations/0321_auto__add_field_projectkey_rate_limit_count__add_field_projectkey_rate.py
@@ -25,10 +25,10 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'ProjectKey.rate_limit_count'
-        db.delete_column('sentry_projectkey', 'rate_limit_count')
+        db.delete_column('sentry_projectkey', 'rate_limit_count', safety_lock=False)
 
         # Deleting field 'ProjectKey.rate_limit_window'
-        db.delete_column('sentry_projectkey', 'rate_limit_window')
+        db.delete_column('sentry_projectkey', 'rate_limit_window', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0324_auto__add_field_eventuser_name__add_field_userreport_event_user_id.py
+++ b/src/sentry/south_migrations/0324_auto__add_field_eventuser_name__add_field_userreport_event_user_id.py
@@ -25,10 +25,10 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'EventUser.name'
-        db.delete_column('sentry_eventuser', 'name')
+        db.delete_column('sentry_eventuser', 'name', safety_lock=False)
 
         # Deleting field 'UserReport.event_user_id'
-        db.delete_column('sentry_userreport', 'event_user_id')
+        db.delete_column('sentry_userreport', 'event_user_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0327_auto__add_field_release_commit_count__add_field_release_last_commit_id.py
+++ b/src/sentry/south_migrations/0327_auto__add_field_release_commit_count__add_field_release_last_commit_id.py
@@ -51,19 +51,19 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Release.commit_count'
-        db.delete_column('sentry_release', 'commit_count')
+        db.delete_column('sentry_release', 'commit_count', safety_lock=False)
 
         # Deleting field 'Release.last_commit_id'
-        db.delete_column('sentry_release', 'last_commit_id')
+        db.delete_column('sentry_release', 'last_commit_id', safety_lock=False)
 
         # Deleting field 'Release.authors'
-        db.delete_column('sentry_release', 'authors')
+        db.delete_column('sentry_release', 'authors', safety_lock=False)
 
         # Deleting field 'Release.total_deploys'
-        db.delete_column('sentry_release', 'total_deploys')
+        db.delete_column('sentry_release', 'total_deploys', safety_lock=False)
 
         # Deleting field 'Release.last_deploy_id'
-        db.delete_column('sentry_release', 'last_deploy_id')
+        db.delete_column('sentry_release', 'last_deploy_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0330_auto__add_field_grouphash_state.py
+++ b/src/sentry/south_migrations/0330_auto__add_field_grouphash_state.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'GroupHash.state'
-        db.delete_column('sentry_grouphash', 'state')
+        db.delete_column('sentry_grouphash', 'state', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0333_auto__add_field_groupresolution_type__add_field_groupresolution_actor_.py
+++ b/src/sentry/south_migrations/0333_auto__add_field_groupresolution_type__add_field_groupresolution_actor_.py
@@ -25,10 +25,10 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'GroupResolution.type'
-        db.delete_column('sentry_groupresolution', 'type')
+        db.delete_column('sentry_groupresolution', 'type', safety_lock=False)
 
         # Deleting field 'GroupResolution.actor_id'
-        db.delete_column('sentry_groupresolution', 'actor_id')
+        db.delete_column('sentry_groupresolution', 'actor_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0334_auto__add_field_project_platform.py
+++ b/src/sentry/south_migrations/0334_auto__add_field_project_platform.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Project.platform'
-        db.delete_column('sentry_project', 'platform')
+        db.delete_column('sentry_project', 'platform', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0335_auto__add_field_groupsnooze_actor_id.py
+++ b/src/sentry/south_migrations/0335_auto__add_field_groupsnooze_actor_id.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'GroupSnooze.actor_id'
-        db.delete_column('sentry_groupsnooze', 'actor_id')
+        db.delete_column('sentry_groupsnooze', 'actor_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0336_auto__add_field_user_last_active.py
+++ b/src/sentry/south_migrations/0336_auto__add_field_user_last_active.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'User.last_active'
-        db.delete_column('auth_user', 'last_active')
+        db.delete_column('auth_user', 'last_active', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0340_auto__add_grouptombstone__add_field_grouphash_group_tombstone_id.py
+++ b/src/sentry/south_migrations/0340_auto__add_grouptombstone__add_field_grouphash_group_tombstone_id.py
@@ -60,7 +60,7 @@ class Migration(SchemaMigration):
         db.delete_table('sentry_grouptombstone')
 
         # Deleting field 'GroupHash.group_tombstone_id'
-        db.delete_column('sentry_grouphash', 'group_tombstone_id')
+        db.delete_column('sentry_grouphash', 'group_tombstone_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0341_auto__add_organizationintegration__add_unique_organizationintegration_.py
+++ b/src/sentry/south_migrations/0341_auto__add_organizationintegration__add_unique_organizationintegration_.py
@@ -127,7 +127,7 @@ class Migration(SchemaMigration):
         db.delete_table('sentry_projectintegration')
 
         # Deleting field 'Repository.integration_id'
-        db.delete_column('sentry_repository', 'integration_id')
+        db.delete_column('sentry_repository', 'integration_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0355_auto__add_field_organizationintegration_config__add_field_organization.py
+++ b/src/sentry/south_migrations/0355_auto__add_field_organizationintegration_config__add_field_organization.py
@@ -24,10 +24,10 @@ class Migration(SchemaMigration):
                       keep_default=False)
 
         # Deleting field 'Integration.default_auth_id'
-        db.delete_column(u'sentry_integration', 'default_auth_id')
+        db.delete_column(u'sentry_integration', 'default_auth_id', safety_lock=False)
 
         # Deleting field 'Integration.config'
-        db.delete_column(u'sentry_integration', 'config')
+        db.delete_column(u'sentry_integration', 'config', safety_lock=False)
 
         # Adding field 'Integration.metadata'
         db.add_column('sentry_integration', 'metadata',
@@ -40,10 +40,10 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'OrganizationIntegration.config'
-        db.delete_column('sentry_organizationintegration', 'config')
+        db.delete_column('sentry_organizationintegration', 'config', safety_lock=False)
 
         # Deleting field 'OrganizationIntegration.default_auth_id'
-        db.delete_column('sentry_organizationintegration', 'default_auth_id')
+        db.delete_column('sentry_organizationintegration', 'default_auth_id', safety_lock=False)
 
         # Adding field 'Integration.default_auth_id'
         db.add_column(u'sentry_integration', 'default_auth_id',
@@ -57,7 +57,7 @@ class Migration(SchemaMigration):
                       keep_default=False)
 
         # Deleting field 'Integration.metadata'
-        db.delete_column('sentry_integration', 'metadata')
+        db.delete_column('sentry_integration', 'metadata', safety_lock=False)
 
         # Changing field 'ProjectIntegration.config'
         db.alter_column('sentry_projectintegration', 'config',

--- a/src/sentry/south_migrations/0381_auto__del_field_deletedproject_team_name__del_field_deletedproject_tea.py
+++ b/src/sentry/south_migrations/0381_auto__del_field_deletedproject_team_name__del_field_deletedproject_tea.py
@@ -13,13 +13,13 @@ class Migration(SchemaMigration):
 
     def forwards(self, orm):
         # Deleting field 'DeletedProject.team_name'
-        db.delete_column(u'sentry_deletedproject', 'team_name')
+        db.delete_column(u'sentry_deletedproject', 'team_name', safety_lock=False)
 
         # Deleting field 'DeletedProject.team_slug'
-        db.delete_column(u'sentry_deletedproject', 'team_slug')
+        db.delete_column(u'sentry_deletedproject', 'team_slug', safety_lock=False)
 
         # Deleting field 'DeletedProject.team_id'
-        db.delete_column(u'sentry_deletedproject', 'team_id')
+        db.delete_column(u'sentry_deletedproject', 'team_id', safety_lock=False)
 
     def backwards(self, orm):
         # Adding field 'DeletedProject.team_name'

--- a/src/sentry/south_migrations/0385_auto__add_field_rule_environment_id.py
+++ b/src/sentry/south_migrations/0385_auto__add_field_rule_environment_id.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Rule.environment_id'
-        db.delete_column('sentry_rule', 'environment_id')
+        db.delete_column('sentry_rule', 'environment_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0387_auto__add_field_groupassignee_team__chg_field_groupassignee_user.py
+++ b/src/sentry/south_migrations/0387_auto__add_field_groupassignee_team__chg_field_groupassignee_user.py
@@ -40,7 +40,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'GroupAssignee.team'
-        db.delete_column('sentry_groupasignee', 'team_id')
+        db.delete_column('sentry_groupasignee', 'team_id', safety_lock=False)
 
         # User chose to not deal with backwards NULL issues for 'GroupAssignee.user'
         raise RuntimeError(

--- a/src/sentry/south_migrations/0388_auto__add_field_environmentproject_is_hidden.py
+++ b/src/sentry/south_migrations/0388_auto__add_field_environmentproject_is_hidden.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'EnvironmentProject.is_hidden'
-        db.delete_column('sentry_environmentproject', 'is_hidden')
+        db.delete_column('sentry_environmentproject', 'is_hidden', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0389_auto__add_field_groupenvironment_first_release_id__add_index_groupenvi.py
+++ b/src/sentry/south_migrations/0389_auto__add_field_groupenvironment_first_release_id__add_index_groupenvi.py
@@ -40,7 +40,7 @@ class Migration(SchemaMigration):
         db.delete_index('sentry_groupenvironment', ['environment_id', 'first_release_id'])
 
         # Deleting field 'GroupEnvironment.first_release_id'
-        db.delete_column('sentry_groupenvironment', 'first_release_id')
+        db.delete_column('sentry_groupenvironment', 'first_release_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0390_auto__add_field_userreport_environment.py
+++ b/src/sentry/south_migrations/0390_auto__add_field_userreport_environment.py
@@ -20,7 +20,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'UserReport.environment'
-        db.delete_column('sentry_userreport', 'environment_id')
+        db.delete_column('sentry_userreport', 'environment_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0396_auto__del_field_project_team.py
+++ b/src/sentry/south_migrations/0396_auto__del_field_project_team.py
@@ -13,7 +13,7 @@ class Migration(SchemaMigration):
 
     def forwards(self, orm):
         # Deleting field 'Project.team'
-        db.delete_column(u'sentry_project', 'team_id')
+        db.delete_column(u'sentry_project', 'team_id', safety_lock=False)
 
     def backwards(self, orm):
         # Adding field 'Project.team'

--- a/src/sentry/south_migrations/0402_auto__add_field_organizationintegration_date_added__add_field_identity.py
+++ b/src/sentry/south_migrations/0402_auto__add_field_organizationintegration_date_added__add_field_identity.py
@@ -29,13 +29,13 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'OrganizationIntegration.date_added'
-        db.delete_column('sentry_organizationintegration', 'date_added')
+        db.delete_column('sentry_organizationintegration', 'date_added', safety_lock=False)
 
         # Deleting field 'IdentityProvider.date_added'
-        db.delete_column('sentry_identityprovider', 'date_added')
+        db.delete_column('sentry_identityprovider', 'date_added', safety_lock=False)
 
         # Deleting field 'Integration.date_added'
-        db.delete_column('sentry_integration', 'date_added')
+        db.delete_column('sentry_integration', 'date_added', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0405_auto__add_field_user_flags.py
+++ b/src/sentry/south_migrations/0405_auto__add_field_user_flags.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'User.flags'
-        db.delete_column('auth_user', 'flags')
+        db.delete_column('auth_user', 'flags', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0407_auto__add_field_identityprovider_external_id__add_unique_identityprovi.py
+++ b/src/sentry/south_migrations/0407_auto__add_field_identityprovider_external_id__add_unique_identityprovi.py
@@ -17,15 +17,17 @@ class Migration(SchemaMigration):
                       self.gf('django.db.models.fields.CharField')(max_length=64, null=True),
                       keep_default=False)
 
-        # Adding unique constraint on 'IdentityProvider', fields ['type', 'organization', 'external_id']
+        # Adding unique constraint on 'IdentityProvider', fields ['type',
+        # 'organization', 'external_id']
         db.create_unique('sentry_identityprovider', ['type', 'organization_id', 'external_id'])
 
     def backwards(self, orm):
-        # Removing unique constraint on 'IdentityProvider', fields ['type', 'organization', 'external_id']
+        # Removing unique constraint on 'IdentityProvider', fields ['type',
+        # 'organization', 'external_id']
         db.delete_unique('sentry_identityprovider', ['type', 'organization_id', 'external_id'])
 
         # Deleting field 'IdentityProvider.external_id'
-        db.delete_column('sentry_identityprovider', 'external_id')
+        db.delete_column('sentry_identityprovider', 'external_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0409_auto__add_field_releaseprojectenvironment_last_deploy_id.py
+++ b/src/sentry/south_migrations/0409_auto__add_field_releaseprojectenvironment_last_deploy_id.py
@@ -20,7 +20,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'ReleaseProjectEnvironment.last_deploy_id'
-        db.delete_column('sentry_releaseprojectenvironment', 'last_deploy_id')
+        db.delete_column('sentry_releaseprojectenvironment', 'last_deploy_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0411_auto__add_field_projectkey_data.py
+++ b/src/sentry/south_migrations/0411_auto__add_field_projectkey_data.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'ProjectKey.data'
-        db.delete_column('sentry_projectkey', 'data')
+        db.delete_column('sentry_projectkey', 'data', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0421_auto__del_field_identityprovider_organization_id__del_unique_identityp.py
+++ b/src/sentry/south_migrations/0421_auto__del_field_identityprovider_organization_id__del_unique_identityp.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
         db.delete_unique(u'sentry_identityprovider', ['type', 'organization_id', 'external_id'])
 
         # Deleting field 'IdentityProvider.organization_id'
-        db.delete_column(u'sentry_identityprovider', 'organization_id')
+        db.delete_column(u'sentry_identityprovider', 'organization_id', safety_lock=False)
 
     def backwards(self, orm):
         # Adding field 'IdentityProvider.organization_id'

--- a/src/sentry/south_migrations/0424_auto__add_field_integration_status.py
+++ b/src/sentry/south_migrations/0424_auto__add_field_integration_status.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Integration.status'
-        db.delete_column('sentry_integration', 'status')
+        db.delete_column('sentry_integration', 'status', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0426_auto__add_sentryappinstallation__add_sentryapp__add_field_user_is_sent.py
+++ b/src/sentry/south_migrations/0426_auto__add_sentryappinstallation__add_sentryapp__add_field_user_is_sent.py
@@ -16,11 +16,26 @@ class Migration(SchemaMigration):
         db.create_table('sentry_sentryappinstallation', (
             ('id', self.gf('sentry.db.models.fields.bounded.BoundedBigAutoField')(primary_key=True)),
             ('date_deleted', self.gf('django.db.models.fields.DateTimeField')(null=True, blank=True)),
-            ('sentry_app', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(related_name='installations', to=orm['sentry.SentryApp'])),
-            ('organization', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(related_name='sentry_app_installations', to=orm['sentry.Organization'])),
-            ('authorization', self.gf('django.db.models.fields.related.OneToOneField')(related_name='sentry_app_installation', unique=True, null=True, on_delete=models.SET_NULL, to=orm['sentry.ApiAuthorization'])),
-            ('api_grant', self.gf('django.db.models.fields.related.OneToOneField')(related_name='sentry_app_installation', unique=True, null=True, on_delete=models.SET_NULL, to=orm['sentry.ApiGrant'])),
-            ('uuid', self.gf('django.db.models.fields.CharField')(default='b0d8118e-f1fa-4224-a090-28c812ef94e4', max_length=64)),
+            ('sentry_app', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(
+                related_name='installations', to=orm['sentry.SentryApp'])),
+            ('organization', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(
+                related_name='sentry_app_installations', to=orm['sentry.Organization'])),
+            ('authorization',
+             self.gf('django.db.models.fields.related.OneToOneField')(related_name='sentry_app_installation',
+                                                                      unique=True,
+                                                                      null=True,
+                                                                      on_delete=models.SET_NULL,
+                                                                      to=orm['sentry.ApiAuthorization'])),
+            (
+                'api_grant',
+                self.gf('django.db.models.fields.related.OneToOneField')(
+                    related_name='sentry_app_installation',
+                    unique=True,
+                    null=True,
+                    on_delete=models.SET_NULL,
+                    to=orm['sentry.ApiGrant'])),
+            ('uuid', self.gf('django.db.models.fields.CharField')
+             (default='b0d8118e-f1fa-4224-a090-28c812ef94e4', max_length=64)),
             ('date_added', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
             ('date_updated', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
         ))
@@ -30,14 +45,19 @@ class Migration(SchemaMigration):
         db.create_table('sentry_sentryapp', (
             ('id', self.gf('sentry.db.models.fields.bounded.BoundedBigAutoField')(primary_key=True)),
             ('date_deleted', self.gf('django.db.models.fields.DateTimeField')(null=True, blank=True)),
-            ('application', self.gf('django.db.models.fields.related.OneToOneField')(related_name='sentry_app', unique=True, to=orm['sentry.ApiApplication'])),
-            ('proxy_user', self.gf('django.db.models.fields.related.OneToOneField')(related_name='sentry_app', unique=True, to=orm['sentry.User'])),
-            ('owner', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(related_name='owned_sentry_apps', to=orm['sentry.User'])),
+            ('application', self.gf('django.db.models.fields.related.OneToOneField')
+             (related_name='sentry_app', unique=True, to=orm['sentry.ApiApplication'])),
+            ('proxy_user', self.gf('django.db.models.fields.related.OneToOneField')(
+                related_name='sentry_app', unique=True, to=orm['sentry.User'])),
+            ('owner', self.gf('sentry.db.models.fields.foreignkey.FlexibleForeignKey')(
+                related_name='owned_sentry_apps', to=orm['sentry.User'])),
             ('scopes', self.gf('django.db.models.fields.BigIntegerField')(default=None)),
-            ('scope_list', self.gf('sentry.db.models.fields.array.ArrayField')(of=('django.db.models.fields.TextField', [], {}))),
+            ('scope_list', self.gf('sentry.db.models.fields.array.ArrayField')(
+                of=('django.db.models.fields.TextField', [], {}))),
             ('name', self.gf('django.db.models.fields.TextField')()),
             ('slug', self.gf('django.db.models.fields.CharField')(unique=True, max_length=64)),
-            ('uuid', self.gf('django.db.models.fields.CharField')(default='45ab4e12-5a17-461b-8665-bca3fbe00836', max_length=64)),
+            ('uuid', self.gf('django.db.models.fields.CharField')
+             (default='45ab4e12-5a17-461b-8665-bca3fbe00836', max_length=64)),
             ('webhook_url', self.gf('django.db.models.fields.TextField')()),
             ('date_added', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
             ('date_updated', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
@@ -46,7 +66,8 @@ class Migration(SchemaMigration):
 
         # Adding field 'User.is_sentry_app'
         db.add_column('auth_user', 'is_sentry_app',
-                      self.gf('django.db.models.fields.NullBooleanField')(default=None, null=True, blank=True),
+                      self.gf('django.db.models.fields.NullBooleanField')(
+                          default=None, null=True, blank=True),
                       keep_default=False)
 
     def backwards(self, orm):
@@ -57,7 +78,7 @@ class Migration(SchemaMigration):
         db.delete_table('sentry_sentryapp')
 
         # Deleting field 'User.is_sentry_app'
-        db.delete_column('auth_user', 'is_sentry_app')
+        db.delete_column('auth_user', 'is_sentry_app', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0430_auto__add_field_organizationintegration_status.py
+++ b/src/sentry/south_migrations/0430_auto__add_field_organizationintegration_status.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'OrganizationIntegration.status'
-        db.delete_column('sentry_organizationintegration', 'status')
+        db.delete_column('sentry_organizationintegration', 'status', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0431_auto__add_field_externalissue_metadata.py
+++ b/src/sentry/south_migrations/0431_auto__add_field_externalissue_metadata.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'ExternalIssue.metadata'
-        db.delete_column('sentry_externalissue', 'metadata')
+        db.delete_column('sentry_externalissue', 'metadata', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0432_auto__add_field_relay_is_internal.py
+++ b/src/sentry/south_migrations/0432_auto__add_field_relay_is_internal.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'Relay.is_internal'
-        db.delete_column('sentry_relay', 'is_internal')
+        db.delete_column('sentry_relay', 'is_internal', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0433_auto__add_field_relay_is_internal__add_field_userip_country_code__add_.py
+++ b/src/sentry/south_migrations/0433_auto__add_field_relay_is_internal__add_field_userip_country_code__add_.py
@@ -24,10 +24,10 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'UserIP.country_code'
-        db.delete_column('sentry_userip', 'country_code')
+        db.delete_column('sentry_userip', 'country_code', safety_lock=False)
 
         # Deleting field 'UserIP.region_code'
-        db.delete_column('sentry_userip', 'region_code')
+        db.delete_column('sentry_userip', 'region_code', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0435_auto__add_field_discoversavedquery_created_by.py
+++ b/src/sentry/south_migrations/0435_auto__add_field_discoversavedquery_created_by.py
@@ -20,7 +20,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'DiscoverSavedQuery.created_by'
-        db.delete_column('sentry_discoversavedquery', 'created_by_id')
+        db.delete_column('sentry_discoversavedquery', 'created_by_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0437_auto__add_field_sentryapp_status.py
+++ b/src/sentry/south_migrations/0437_auto__add_field_sentryapp_status.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'SentryApp.status'
-        db.delete_column('sentry_sentryapp', 'status')
+        db.delete_column('sentry_sentryapp', 'status', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0441_auto__add_field_projectdebugfile_data.py
+++ b/src/sentry/south_migrations/0441_auto__add_field_projectdebugfile_data.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'ProjectDebugFile.data'
-        db.delete_column('sentry_projectdsymfile', 'data')
+        db.delete_column('sentry_projectdsymfile', 'data', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0443_auto__add_field_organizationmember_token_expires_at.py
+++ b/src/sentry/south_migrations/0443_auto__add_field_organizationmember_token_expires_at.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'OrganizationMember.token_expires_at'
-        db.delete_column('sentry_organizationmember', 'token_expires_at')
+        db.delete_column('sentry_organizationmember', 'token_expires_at', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0444_auto__add_sentryappavatar__add_field_sentryapp_redirect_url__add_field.py
+++ b/src/sentry/south_migrations/0444_auto__add_sentryappavatar__add_field_sentryapp_redirect_url__add_field.py
@@ -44,10 +44,10 @@ class Migration(SchemaMigration):
         db.delete_table('sentry_sentryappavatar')
 
         # Deleting field 'SentryApp.redirect_url'
-        db.delete_column('sentry_sentryapp', 'redirect_url')
+        db.delete_column('sentry_sentryapp', 'redirect_url', safety_lock=False)
 
         # Deleting field 'SentryApp.overview'
-        db.delete_column('sentry_sentryapp', 'overview')
+        db.delete_column('sentry_sentryapp', 'overview', safety_lock=False)
 
         # Changing field 'SentryApp.webhook_url'
         db.alter_column(

--- a/src/sentry/south_migrations/0447_auto__del_field_promptsactivity_organization__add_field_promptsactivit.py
+++ b/src/sentry/south_migrations/0447_auto__del_field_promptsactivity_organization__add_field_promptsactivit.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
                 'user_id', 'feature', 'organization_id', 'project_id'])
 
         # Deleting field 'PromptsActivity.organization'
-        db.delete_column(u'sentry_promptsactivity', 'organization_id')
+        db.delete_column(u'sentry_promptsactivity', 'organization_id', safety_lock=False)
 
         # Adding field 'PromptsActivity.organization_id'
         db.add_column('sentry_promptsactivity', 'organization_id',
@@ -50,7 +50,7 @@ class Migration(SchemaMigration):
                       keep_default=False)
 
         # Deleting field 'PromptsActivity.organization_id'
-        db.delete_column('sentry_promptsactivity', 'organization_id')
+        db.delete_column('sentry_promptsactivity', 'organization_id', safety_lock=False)
 
         # Changing field 'PromptsActivity.project_id'
         db.alter_column('sentry_promptsactivity', 'project_id', self.gf(

--- a/src/sentry/south_migrations/0448_auto__add_field_sentryapp_is_alertable.py
+++ b/src/sentry/south_migrations/0448_auto__add_field_sentryapp_is_alertable.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'SentryApp.is_alertable'
-        db.delete_column('sentry_sentryapp', 'is_alertable')
+        db.delete_column('sentry_sentryapp', 'is_alertable', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0452_auto__add_field_sentryapp_events.py
+++ b/src/sentry/south_migrations/0452_auto__add_field_sentryapp_events.py
@@ -20,7 +20,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'SentryApp.events'
-        db.delete_column('sentry_sentryapp', 'events')
+        db.delete_column('sentry_sentryapp', 'events', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0455_auto__add_field_groupenvironment_first_seen.py
+++ b/src/sentry/south_migrations/0455_auto__add_field_groupenvironment_first_seen.py
@@ -33,7 +33,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'GroupEnvironment.first_seen'
-        db.delete_column('sentry_groupenvironment', 'first_seen')
+        db.delete_column('sentry_groupenvironment', 'first_seen', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0457_auto__add_field_savedsearch_is_global__chg_field_savedsearch_project__.py
+++ b/src/sentry/south_migrations/0457_auto__add_field_savedsearch_is_global__chg_field_savedsearch_project__.py
@@ -48,7 +48,7 @@ class Migration(SchemaMigration):
         # Removing index on 'SavedSearch', fields ['is_global']
         db.delete_index('sentry_savedsearch', ['is_global'])
         # Deleting field 'SavedSearch.is_global'
-        db.delete_column('sentry_savedsearch', 'is_global')
+        db.delete_column('sentry_savedsearch', 'is_global', safety_lock=False)
 
         # Changing field 'SavedSearch.project'
         # We can make this not null without a default here since we've removed any

--- a/src/sentry/south_migrations/0460_auto__add_field_servicehook_organization_id.py
+++ b/src/sentry/south_migrations/0460_auto__add_field_servicehook_organization_id.py
@@ -20,7 +20,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'ServiceHook.organization_id'
-        db.delete_column('sentry_servicehook', 'organization_id')
+        db.delete_column('sentry_servicehook', 'organization_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0464_auto__add_sentryappcomponent__add_field_sentryapp_schema.py
+++ b/src/sentry/south_migrations/0464_auto__add_sentryappcomponent__add_field_sentryapp_schema.py
@@ -34,7 +34,7 @@ class Migration(SchemaMigration):
         db.delete_table('sentry_sentryappcomponent')
 
         # Deleting field 'SentryApp.schema'
-        db.delete_column('sentry_sentryapp', 'schema')
+        db.delete_column('sentry_sentryapp', 'schema', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0468_auto__add_field_projectdebugfile_code_id__add_index_projectdebugfile_p.py
+++ b/src/sentry/south_migrations/0468_auto__add_field_projectdebugfile_code_id__add_index_projectdebugfile_p.py
@@ -35,7 +35,7 @@ class Migration(SchemaMigration):
         db.delete_index('sentry_projectdsymfile', ['project_id', 'code_id'])
 
         # Deleting field 'ProjectDebugFile.code_id'
-        db.delete_column('sentry_projectdsymfile', 'code_id')
+        db.delete_column('sentry_projectdsymfile', 'code_id', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0470_org_saved_search.py
+++ b/src/sentry/south_migrations/0470_org_saved_search.py
@@ -40,10 +40,10 @@ class Migration(SchemaMigration):
         db.delete_unique('sentry_savedsearch', ['organization_id', 'owner_id', 'type'])
 
         # Deleting field 'SavedSearch.organization'
-        db.delete_column('sentry_savedsearch', 'organization_id')
+        db.delete_column('sentry_savedsearch', 'organization_id', safety_lock=False)
 
         # Deleting field 'SavedSearch.type'
-        db.delete_column('sentry_savedsearch', 'type')
+        db.delete_column('sentry_savedsearch', 'type', safety_lock=False)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0472_auto__add_field_sentryapp_author.py
+++ b/src/sentry/south_migrations/0472_auto__add_field_sentryapp_author.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'SentryApp.author'
-        db.delete_column('sentry_sentryapp', 'author')
+        db.delete_column('sentry_sentryapp', 'author', safety_lock=True)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0473_auto__add_field_projectownership_auto_assignment.py
+++ b/src/sentry/south_migrations/0473_auto__add_field_projectownership_auto_assignment.py
@@ -19,7 +19,7 @@ class Migration(SchemaMigration):
 
     def backwards(self, orm):
         # Deleting field 'ProjectOwnership.auto_assignment'
-        db.delete_column('sentry_projectownership', 'auto_assignment')
+        db.delete_column('sentry_projectownership', 'auto_assignment', safety_lock=True)
 
     models = {
         'sentry.activity': {

--- a/src/sentry/south_migrations/0474_auto__del_field_sentryappinstallation_authorization.py
+++ b/src/sentry/south_migrations/0474_auto__del_field_sentryappinstallation_authorization.py
@@ -13,7 +13,7 @@ class Migration(SchemaMigration):
 
     def forwards(self, orm):
         # Deleting field 'SentryAppInstallation.authorization'
-        db.delete_column(u'sentry_sentryappinstallation', 'authorization_id')
+        db.delete_column(u'sentry_sentryappinstallation', 'authorization_id', safety_lock=False)
 
     def backwards(self, orm):
         # Adding field 'SentryAppInstallation.authorization'

--- a/src/south/db/generic.py
+++ b/src/south/db/generic.py
@@ -939,10 +939,21 @@ class DatabaseOperations(object):
     drop_index = alias('delete_index')
 
     @delete_column_constraints
-    def delete_column(self, table_name, name):
+    def delete_column(self, table_name, name, safety_lock=True):
         """
         Deletes the column 'column_name' from the table 'table_name'.
         """
+        if safety_lock:
+            raise Exception(
+                'Deleting columns is dangerous. You need to do this in two '
+                'separate commits that must be deployed separately:\n'
+                ' - Remove the column from the django model, and make it '
+                'nullable in the table if it currently is not.\n'
+                ' - After the previous step has deployed, write the migration '
+                'to remove the column from the table itself, and set '
+                '`safety_lock` to False.\n'
+                'If unsure, ask in #engineering.',
+            )
         params = (self.quote_name(table_name), self.quote_name(name))
         self.execute(self.delete_column_string % params, [])
 


### PR DESCRIPTION
Deleting columns in production is dangerous. Since we do a rolling deploy, once the column is
deleted we have some percent of servers running code that expects the column to still exist in the
database, which causes everything to error. Our pattern for working around this is to remove the column from the model and make the column nullable if not currently. Then once this has deployed successfully, it's safe to remove the column from the table.

This is currently enforced by making sure the right person checks it, but is easy to miss. So this
PR adds a safety lock parameter to remind anyone who is deleting a column to go through this
procedure. Produces an error message like:

```
 > sentry:0474_auto__del_field_sentryappinstallation_authorization
Error in migration: sentry:0474_auto__del_field_sentryappinstallation_authorization
Traceback (most recent call last):
  File "/Users/dfuller/.virtualenvs/sentry/bin/sentry", line 11, in <module>
    load_entry_point('sentry', 'console_scripts', 'sentry')()
  File "/Users/dfuller/code/sentry/src/sentry/runner/__init__.py", line 162, in main
    cli(prog_name=get_prog(), obj={}, max_content_width=100)
  File "/Users/dfuller/.virtualenvs/sentry/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/dfuller/.virtualenvs/sentry/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/dfuller/.virtualenvs/sentry/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/dfuller/.virtualenvs/sentry/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/dfuller/.virtualenvs/sentry/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/dfuller/.virtualenvs/sentry/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/dfuller/code/sentry/src/sentry/runner/decorators.py", line 36, in inner
    return ctx.invoke(f, *args, **kwargs)
  File "/Users/dfuller/.virtualenvs/sentry/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/dfuller/.virtualenvs/sentry/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/dfuller/code/sentry/src/sentry/runner/commands/upgrade.py", line 75, in upgrade
    _upgrade(not noinput, traceback, verbosity, not no_repair)
  File "/Users/dfuller/code/sentry/src/sentry/runner/commands/upgrade.py", line 30, in _upgrade
    ignore_ghost_migrations=True,
  File "/Users/dfuller/.virtualenvs/sentry/lib/python2.7/site-packages/django/core/management/__init__.py", line 159, in call_command
    return klass.execute(*args, **defaults)
  File "/Users/dfuller/.virtualenvs/sentry/lib/python2.7/site-packages/django/core/management/base.py", line 285, in execute
    output = self.handle(*args, **options)
  File "/Users/dfuller/.virtualenvs/sentry/lib/python2.7/site-packages/django/core/management/base.py", line 415, in handle
    return self.handle_noargs(**options)
  File "/Users/dfuller/code/sentry/src/south/management/commands/syncdb.py", line 125, in handle_noargs
    management.call_command('south_migrate', **options)
  File "/Users/dfuller/.virtualenvs/sentry/lib/python2.7/site-packages/django/core/management/__init__.py", line 159, in call_command
    return klass.execute(*args, **defaults)
  File "/Users/dfuller/.virtualenvs/sentry/lib/python2.7/site-packages/django/core/management/base.py", line 285, in execute
    output = self.handle(*args, **options)
  File "/Users/dfuller/code/sentry/src/south/management/commands/south_migrate.py", line 105, in handle
    ignore_ghosts=ignore_ghosts,
  File "/Users/dfuller/code/sentry/src/south/migration/__init__.py", line 231, in migrate_app
    success = migrator.migrate_many(target, workplan, database)
  File "/Users/dfuller/code/sentry/src/south/migration/migrators.py", line 290, in migrate_many
    result = self.migrate(migration, database)
  File "/Users/dfuller/code/sentry/src/south/migration/migrators.py", line 131, in migrate
    result = self.run(migration, database)
  File "/Users/dfuller/code/sentry/src/south/migration/migrators.py", line 240, in run
    return super(Forwards, self).run(migration, database)
  File "/Users/dfuller/code/sentry/src/south/migration/migrators.py", line 113, in run
    return self.run_migration(migration, database)
  File "/Users/dfuller/code/sentry/src/south/migration/migrators.py", line 85, in run_migration
    migration_function()
  File "/Users/dfuller/code/sentry/src/south/migration/migrators.py", line 61, in <lambda>
    return (lambda: direction(orm))
  File "/Users/dfuller/code/sentry/src/sentry/south_migrations/0474_auto__del_field_sentryappinstallation_authorization.py", line 16, in forwards
    db.delete_column(u'sentry_sentryappinstallation', 'authorization_id')
  File "/Users/dfuller/code/sentry/src/south/db/generic.py", line 60, in _column_rm
    return func(self, table, column, *args, **opts)
  File "/Users/dfuller/code/sentry/src/south/db/generic.py", line 948, in delete_column
    'Deleting columns is dangerous. You need to do this in two '
Exception: Deleting columns is dangerous. You need to do this in two separate commits that must be deployed separately:
 - Remove the column from the django model, and make it nullable in the table if it currently is not.
 - After the previous step has deployed, write the migration to remove the column from the table itself, and set `safety_lock` to False.
If unsure, ask in #engineering.
```