### PR TITLE
feat: Use get_from_cache for event.group and event.project

### DIFF
--- a/src/sentry/api/endpoints/team_groups_new.py
+++ b/src/sentry/api/endpoints/team_groups_new.py
@@ -40,6 +40,8 @@ class TeamGroupsNewEndpoint(TeamEndpoint, EnvironmentMixin):
             ).order_by('-{}'.format(sort_value), '-first_seen')[:limit]
         )
 
+        # TODO(alex) I'm not sure this does anything. It seems to not be used
+        # anywhere in the Group model to return a cached value.
         for group in group_list:
             group._project_cache = project_dict.get(group.project_id)
 

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -166,7 +166,7 @@ class EventSerializer(Serializer):
         try:
             user_report = UserReport.objects.get(
                 event_id=event.event_id,
-                project=event.project,
+                project_id=event.project_id,
             )
         except UserReport.DoesNotExist:
             user_report = None

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -601,8 +601,7 @@ class EventManager(object):
         except Event.DoesNotExist:
             pass
         else:
-            # Make sure we cache on the project before returning
-            event._project_cache = project
+            event.project = project
             logger.info(
                 'duplicate.found',
                 exc_info=True,
@@ -639,7 +638,7 @@ class EventManager(object):
         event = self._get_event_instance(project_id=project_id)
         self._data = data = event.data.data
 
-        event._project_cache = project
+        event.project = project
 
         date = event.datetime
         platform = event.platform

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -340,14 +340,7 @@ def digest(request):
         ) for i in range(1, random.randint(2, 4))
     }
 
-    state = {
-        'project': project,
-        'groups': {},
-        'rules': rules,
-        'event_counts': {},
-        'user_counts': {},
-    }
-
+    groups = {}
     records = []
 
     event_sequence = itertools.count(1)
@@ -355,7 +348,9 @@ def digest(request):
 
     for i in range(random.randint(1, 30)):
         group = next(group_generator)
-        state['groups'][group.id] = group
+        group.event_count = random.randint(10, 1e4)
+        group.user_count = random.randint(10, 1e4)
+        groups[group.id] = group
 
         offset = timedelta(seconds=0)
         for i in range(random.randint(1, 10)):
@@ -380,16 +375,13 @@ def digest(request):
                     event.event_id,
                     Notification(
                         event,
-                        random.sample(state['rules'], random.randint(1, len(state['rules']))),
+                        random.sample(rules, random.randint(1, len(rules))),
                     ),
                     to_timestamp(event.datetime),
                 )
             )
 
-            state['event_counts'][group.id] = random.randint(10, 1e4)
-            state['user_counts'][group.id] = random.randint(10, 1e4)
-
-    digest = build_digest(project, records, state)
+    digest = build_digest(project, records, (groups, rules))
     start, end, counts = get_digest_metadata(digest)
 
     context = {

--- a/tests/sentry/models/test_event.py
+++ b/tests/sentry/models/test_event.py
@@ -129,6 +129,17 @@ class EventTest(TestCase):
         with self.assertNumQueries(0):
             event.get_environment() == environment
 
+    def test_project_cache(self):
+        event = self.store_event(
+            data={},
+            project_id=self.project.id
+        )
+
+        assert event.project == self.project
+
+        with self.assertNumQueries(0):
+            event.project == self.project
+
     def test_ip_address(self):
         event = self.create_event(data={
             'user': {'ip_address': '127.0.0.1'},

--- a/tests/sentry/plugins/mail/tests.py
+++ b/tests/sentry/plugins/mail/tests.py
@@ -118,6 +118,7 @@ class MailPluginTest(TestCase):
                 'metadata': event_type.get_metadata(event_data),
             }
         )
+        group.save()
 
         event = Event(
             group=group,
@@ -126,6 +127,7 @@ class MailPluginTest(TestCase):
             datetime=group.last_seen,
             data=event_data
         )
+        event.save()
 
         notification = Notification(event=event)
 
@@ -163,6 +165,7 @@ class MailPluginTest(TestCase):
                 'metadata': event_type.get_metadata(event_data),
             }
         )
+        group.save()
 
         event = Event(
             group=group,
@@ -171,6 +174,7 @@ class MailPluginTest(TestCase):
             datetime=group.last_seen,
             data=event_data,
         )
+        event.save()
 
         notification = Notification(event=event)
 

--- a/tests/snuba/models/test_event.py
+++ b/tests/snuba/models/test_event.py
@@ -73,7 +73,6 @@ class SnubaEventTest(TestCase, SnubaTestCase):
         assert event.event_id == self.event_id
         assert event.group.id == self.proj1group1.id
         assert event.project.id == self.proj1.id
-        assert event._project_cache == self.proj1
         # That shouldn't have triggered a nodestore load yet
         assert event.data._node_data is None
         # But after we ask for something that's not in snuba


### PR DESCRIPTION
Since the new grouping/hashing feature, serializing a list of events
requires looking up `event.project` for each one. Because the
`event._project_cache` was only at the instance level, a list of N
events form the same project would still fetch the same `Project` from
the DB N times.

This approach is also much cleaner in that it does not pollute the
model instance namespace with extra properties that have to be removed.