### PR TITLE
fix(dashboard): Fix multiple queries on dashboard

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDashboard/dashboard.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/dashboard.jsx
@@ -8,18 +8,20 @@ import space from 'app/styles/space';
 
 class Dashboard extends React.Component {
   static propTypes = {
+    busy: PropTypes.bool,
     releases: PropTypes.arrayOf(SentryTypes.Release),
     widgets: PropTypes.arrayOf(SentryTypes.Widget),
+    router: PropTypes.object,
   };
 
   render() {
-    const {releases, widgets} = this.props;
+    const {busy, router, releases, widgets} = this.props;
 
     return (
       <Widgets>
         {widgets.map((widget, i) => (
           <WidgetWrapper key={i}>
-            <Widget releases={releases} widget={widget} />
+            <Widget busy={busy} releases={releases} widget={widget} router={router} />
           </WidgetWrapper>
         ))}
       </Widgets>

--- a/src/sentry/static/sentry/app/views/organizationDashboard/dashboard.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/dashboard.jsx
@@ -8,20 +8,25 @@ import space from 'app/styles/space';
 
 class Dashboard extends React.Component {
   static propTypes = {
-    busy: PropTypes.bool,
+    releasesLoading: PropTypes.bool,
     releases: PropTypes.arrayOf(SentryTypes.Release),
     widgets: PropTypes.arrayOf(SentryTypes.Widget),
     router: PropTypes.object,
   };
 
   render() {
-    const {busy, router, releases, widgets} = this.props;
+    const {releasesLoading, router, releases, widgets} = this.props;
 
     return (
       <Widgets>
         {widgets.map((widget, i) => (
           <WidgetWrapper key={i}>
-            <Widget busy={busy} releases={releases} widget={widget} router={router} />
+            <Widget
+              releasesLoading={releasesLoading}
+              releases={releases}
+              widget={widget}
+              router={router}
+            />
           </WidgetWrapper>
         ))}
       </Widgets>

--- a/src/sentry/static/sentry/app/views/organizationDashboard/discoverQuery.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/discoverQuery.jsx
@@ -28,8 +28,9 @@ const createReleaseFieldCondition = releases => [
 
 class DiscoverQuery extends React.Component {
   static propTypes = {
-    // Busy means a parent component is busy and we should not perform any API requests yet
-    busy: PropTypes.bool,
+    // means a parent component is still loading releases
+    // and we should not perform any API requests yet (if we depend on releases)
+    releasesLoading: PropTypes.bool,
     compareToPeriod: PropTypes.shape({
       statsPeriodStart: PropTypes.string,
       statsPeriodEnd: PropTypes.string,
@@ -64,13 +65,16 @@ class DiscoverQuery extends React.Component {
     }
 
     // Allow component to update if queries are dependent on releases
-    // and if releases change, or busy prop changes
+    // and if releases change, or releasesLoading prop changes
     if (this.doesRequireReleases(nextProps.queries)) {
       if (!isEqual(this.props.releases, nextProps.releases)) {
         return true;
       }
 
-      if (!nextProps.busy && this.props.busy !== nextProps.busy) {
+      if (
+        !nextProps.releasesLoading &&
+        this.props.releasesLoading !== nextProps.releasesLoading
+      ) {
         return true;
       }
     }
@@ -88,11 +92,11 @@ class DiscoverQuery extends React.Component {
   componentDidUpdate(prevProps) {
     const keysToIgnore = ['children'];
 
-    // Ignore "busy" and "releases" props if we are not waiting for releases
-    // Otherwise we can potentially make an extra request if busy !== nextBusy and
+    // Ignore "releasesLoading" and "releases" props if we are not waiting for releases
+    // Otherwise we can potentially make an extra request if releasesLoading !== nextBusy and
     // globalSelection === nextGlobalSelection
     if (!this.doesRequireReleases(this.props.queries)) {
-      keysToIgnore.push('busy');
+      keysToIgnore.push('releasesLoading');
       keysToIgnore.push('releases');
     }
 
@@ -189,7 +193,7 @@ class DiscoverQuery extends React.Component {
     this.setState({reloading: true});
 
     // Do not fetch data if dependent on releases and parent component is busy fetching releases
-    if (this.doesRequireReleases(this.props.queries) && this.props.busy) {
+    if (this.doesRequireReleases(this.props.queries) && this.props.releasesLoading) {
       return;
     }
 

--- a/src/sentry/static/sentry/app/views/organizationDashboard/discoverQuery.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/discoverQuery.jsx
@@ -19,6 +19,8 @@ const createReleaseFieldCondition = releases => [
 
 class DiscoverQuery extends React.Component {
   static propTypes = {
+    // Busy means a parent component is busy and we should not perform any API requests yet
+    busy: PropTypes.bool,
     compareToPeriod: PropTypes.shape({
       statsPeriodStart: PropTypes.string,
       statsPeriodEnd: PropTypes.string,
@@ -52,7 +54,7 @@ class DiscoverQuery extends React.Component {
       return true;
     }
 
-    if (this.props.releases !== nextProps.releases) {
+    if (!isEqual(this.props.releases, nextProps.releases)) {
       return true;
     }
 
@@ -72,7 +74,7 @@ class DiscoverQuery extends React.Component {
       return;
     }
 
-    if (this.props.releases !== prevProps.releases) {
+    if (!isEqual(this.props.releases, prevProps.releases)) {
       this.createQueryBuilders();
     } else {
       this.fetchData();
@@ -85,6 +87,9 @@ class DiscoverQuery extends React.Component {
 
   createQueryBuilders() {
     const {organization, queries} = this.props;
+
+    this.queryBuilders = [];
+
     queries.forEach(({constraints, ...query}) => {
       if (constraints && constraints.includes('recentReleases')) {
         if (!this.props.releases) {
@@ -147,6 +152,11 @@ class DiscoverQuery extends React.Component {
   }
 
   async fetchData() {
+    // Do not fetch data when parent component is busy
+    if (this.props.busy) {
+      return;
+    }
+
     // Fetch
     this.setState({reloading: true});
     const promises = this.queryBuilders.map(builder => builder.fetchWithoutLimit());

--- a/src/sentry/static/sentry/app/views/organizationDashboard/discoverQuery.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/discoverQuery.jsx
@@ -9,7 +9,7 @@ import {parsePeriodToHours} from 'app/utils';
 import SentryTypes from 'app/sentryTypes';
 import createQueryBuilder from 'app/views/organizationDiscover/queryBuilder';
 
-// Note: We limit to the last 20 releases
+// Note: Limit max releases so that chart is still a bit readable
 const MAX_RECENT_RELEASES = 20;
 const createReleaseFieldCondition = releases => [
   [

--- a/src/sentry/static/sentry/app/views/organizationDashboard/organizationDashboardContainer.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/organizationDashboardContainer.jsx
@@ -1,4 +1,3 @@
-import {withRouter} from 'react-router';
 import React from 'react';
 
 import {PageContent, PageHeader} from 'app/styles/organization';
@@ -38,5 +37,5 @@ class OrganizationDashboardContainer extends React.Component {
     );
   }
 }
-export default withRouter(withOrganization(OrganizationDashboardContainer));
+export default withOrganization(OrganizationDashboardContainer);
 export {OrganizationDashboardContainer};

--- a/src/sentry/static/sentry/app/views/organizationDashboard/overviewDashboard.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/overviewDashboard.jsx
@@ -26,7 +26,7 @@ class OverviewDashboard extends AsyncView {
     return (
       <Dashboard
         releases={this.state.releases}
-        busy={this.state.loading}
+        releasesLoading={this.state.loading}
         router={router}
         {...overviewDashboard}
         {...props}

--- a/src/sentry/static/sentry/app/views/organizationDashboard/overviewDashboard.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/overviewDashboard.jsx
@@ -24,8 +24,8 @@ class OverviewDashboard extends AsyncView {
       <Dashboard
         releases={this.state.releases}
         busy={this.state.loading}
-        router={this.props.router}
         {...overviewDashboard}
+        {...this.props}
       />
     );
   }

--- a/src/sentry/static/sentry/app/views/organizationDashboard/overviewDashboard.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/overviewDashboard.jsx
@@ -20,12 +20,16 @@ class OverviewDashboard extends AsyncView {
   }
 
   renderBody() {
+    // Passing the rest of `this.props` to `<Dashboard>` for tests
+    const {router, ...props} = this.props;
+
     return (
       <Dashboard
         releases={this.state.releases}
         busy={this.state.loading}
+        router={router}
         {...overviewDashboard}
-        {...this.props}
+        {...props}
       />
     );
   }

--- a/src/sentry/static/sentry/app/views/organizationDashboard/overviewDashboard.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/overviewDashboard.jsx
@@ -20,7 +20,14 @@ class OverviewDashboard extends AsyncView {
   }
 
   renderBody() {
-    return <Dashboard releases={this.state.releases} {...overviewDashboard} />;
+    return (
+      <Dashboard
+        releases={this.state.releases}
+        busy={this.state.loading}
+        router={this.props.router}
+        {...overviewDashboard}
+      />
+    );
   }
 }
 export default OverviewDashboard;

--- a/src/sentry/static/sentry/app/views/organizationDashboard/utils/getChartDataFunc.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/utils/getChartDataFunc.jsx
@@ -14,6 +14,7 @@ export function getChartDataFunc({queries, type, fieldLabelMap}) {
       getChartDataByDay,
       [
         {
+          allSeries: true,
           fieldLabelMap,
         },
       ],

--- a/src/sentry/static/sentry/app/views/organizationDashboard/widget.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/widget.jsx
@@ -17,7 +17,7 @@ import WidgetChart from './widgetChart';
 
 class Widget extends React.Component {
   static propTypes = {
-    busy: PropTypes.bool,
+    releasesLoading: PropTypes.bool,
     releases: PropTypes.arrayOf(SentryTypes.Release),
     widget: SentryTypes.Widget,
     organization: SentryTypes.Organization,
@@ -26,13 +26,20 @@ class Widget extends React.Component {
   };
 
   render() {
-    const {organization, busy, router, widget, releases, selection} = this.props;
+    const {
+      organization,
+      releasesLoading,
+      router,
+      widget,
+      releases,
+      selection,
+    } = this.props;
     const {title, includePreviousPeriod, compareToPeriod} = widget;
 
     return (
       <ErrorBoundary customComponent={<ErrorCard>{t('Error loading widget')}</ErrorCard>}>
         <DiscoverQuery
-          busy={busy}
+          releasesLoading={releasesLoading}
           releases={releases}
           organization={organization}
           selection={selection}

--- a/src/sentry/static/sentry/app/views/organizationDashboard/widget.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDashboard/widget.jsx
@@ -1,4 +1,3 @@
-import {withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
@@ -18,6 +17,7 @@ import WidgetChart from './widgetChart';
 
 class Widget extends React.Component {
   static propTypes = {
+    busy: PropTypes.bool,
     releases: PropTypes.arrayOf(SentryTypes.Release),
     widget: SentryTypes.Widget,
     organization: SentryTypes.Organization,
@@ -26,12 +26,13 @@ class Widget extends React.Component {
   };
 
   render() {
-    const {organization, router, widget, releases, selection} = this.props;
+    const {organization, busy, router, widget, releases, selection} = this.props;
     const {title, includePreviousPeriod, compareToPeriod} = widget;
 
     return (
       <ErrorBoundary customComponent={<ErrorCard>{t('Error loading widget')}</ErrorCard>}>
         <DiscoverQuery
+          busy={busy}
           releases={releases}
           organization={organization}
           selection={selection}
@@ -77,7 +78,7 @@ class Widget extends React.Component {
   }
 }
 
-export default withRouter(withOrganization(withGlobalSelection(Widget)));
+export default withOrganization(withGlobalSelection(Widget));
 export {Widget};
 
 const StyledPanel = styled(Panel)`

--- a/tests/js/spec/views/organizationDashboard/dashboard.spec.jsx
+++ b/tests/js/spec/views/organizationDashboard/dashboard.spec.jsx
@@ -10,6 +10,9 @@ import OrganizationDashboardContainer from 'app/views/organizationDashboard';
 jest.mock('app/utils/withLatestContext');
 
 describe('OrganizationDashboard', function() {
+  let wrapper;
+  let discoverMock;
+
   const {organization, router, routerContext} = initializeOrg({
     projects: [{isMember: true}, {isMember: true, slug: 'new-project', id: 3}],
     organization: {
@@ -22,13 +25,20 @@ describe('OrganizationDashboard', function() {
       },
     },
   });
+
   const org = organization;
 
-  let discoverMock;
+  const createWrapper = props => {
+    wrapper = mount(
+      <OrganizationDashboardContainer>
+        <Dashboard {...props} />
+      </OrganizationDashboardContainer>,
+      routerContext
+    );
+    mockRouterPush(wrapper, router);
+  };
 
   beforeEach(function() {
-    router.push.mockRestore();
-    MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/environments/`,
       body: TestStubs.Environments(),
@@ -44,14 +54,17 @@ describe('OrganizationDashboard', function() {
     });
   });
 
+  afterEach(function() {
+    router.push.mockRestore();
+    MockApiClient.clearMockResponses();
+    if (wrapper) {
+      wrapper.unmount();
+    }
+    discoverMock.mockRestore();
+  });
+
   it('queries and renders discover-based widgets grouped by time', async function() {
-    const wrapper = mount(
-      <OrganizationDashboardContainer>
-        <Dashboard {...TestStubs.Dashboard()} />
-      </OrganizationDashboardContainer>,
-      routerContext
-    );
-    mockRouterPush(wrapper, router);
+    createWrapper(TestStubs.Dashboard());
 
     expect(discoverMock).toHaveBeenCalledTimes(2);
     expect(discoverMock).toHaveBeenCalledWith(
@@ -99,36 +112,30 @@ describe('OrganizationDashboard', function() {
   });
 
   it('queries and renders discover-based widgets not grouped by time', async function() {
-    const wrapper = mount(
-      <OrganizationDashboardContainer>
-        <Dashboard
-          {...TestStubs.Dashboard([
-            TestStubs.Widget(
+    createWrapper(
+      TestStubs.Dashboard([
+        TestStubs.Widget(
+          {
+            discover: [
               {
-                discover: [
-                  {
-                    name: 'Browsers',
-                    fields: ['browser.name'],
-                    conditions: [],
-                    aggregations: [['count()', null, 'count']],
-                    limit: 1000,
+                name: 'Browsers',
+                fields: ['browser.name'],
+                conditions: [],
+                aggregations: [['count()', null, 'count']],
+                limit: 1000,
 
-                    orderby: '-count',
-                    groupby: ['browser.name'],
-                  },
-                ],
+                orderby: '-count',
+                groupby: ['browser.name'],
               },
-              {
-                type: 'table',
-                title: 'Table',
-              }
-            ),
-          ])}
-        />
-      </OrganizationDashboardContainer>,
-      routerContext
+            ],
+          },
+          {
+            type: 'table',
+            title: 'Table',
+          }
+        ),
+      ])
     );
-    mockRouterPush(wrapper, router);
 
     expect(discoverMock).toHaveBeenCalledTimes(1);
     expect(discoverMock).toHaveBeenCalledWith(

--- a/tests/js/spec/views/organizationDashboard/discoverQuery.spec.jsx
+++ b/tests/js/spec/views/organizationDashboard/discoverQuery.spec.jsx
@@ -103,7 +103,9 @@ describe('DiscoverQuery', function() {
     wrapper.update();
     expect(renderMock).toHaveBeenCalledTimes(0);
 
-    wrapper.setProps({organization: TestStubs.Organization()});
+    wrapper.setProps({
+      organization: TestStubs.Organization({projects: [TestStubs.Project()]}),
+    });
     wrapper.update();
 
     // Called twice because of fetchData (state.reloading)

--- a/tests/js/spec/views/organizationDashboard/overviewDashboard.spec.jsx
+++ b/tests/js/spec/views/organizationDashboard/overviewDashboard.spec.jsx
@@ -1,0 +1,233 @@
+import React from 'react';
+
+import {initializeOrg} from 'app-test/helpers/initializeOrg';
+import {mockRouterPush} from 'app-test/helpers/mockRouterPush';
+import {mount} from 'enzyme';
+import OrganizationDashboardContainer from 'app/views/organizationDashboard';
+import OverviewDashboard from 'app/views/organizationDashboard/overviewDashboard';
+
+jest.mock('app/utils/withLatestContext');
+
+describe('OverviewDashboard', function() {
+  let wrapper;
+  let discoverMock;
+  let releasesMock;
+
+  const {organization, router, routerContext} = initializeOrg({
+    projects: [{isMember: true}, {isMember: true, slug: 'new-project', id: 3}],
+    organization: {
+      features: ['sentry10', 'discover', 'global-views'],
+    },
+    router: {
+      location: {
+        pathname: '/organizations/org-slug/dashboard/?statsPeriod=14d&utc=true',
+        query: {},
+      },
+    },
+  });
+
+  const org = organization;
+
+  const createWrapper = props => {
+    wrapper = mount(
+      <OrganizationDashboardContainer>
+        <OverviewDashboard params={{orgId: organization.slug}} {...props} />
+      </OrganizationDashboardContainer>,
+      routerContext
+    );
+    mockRouterPush(wrapper, router);
+  };
+
+  beforeEach(function() {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/environments/`,
+      body: TestStubs.Environments(),
+    });
+    releasesMock = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/releases/`,
+      body: [TestStubs.Release()],
+    });
+    discoverMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/discover/query/',
+      method: 'POST',
+      body: {
+        data: [],
+        meta: [],
+        timing: {},
+      },
+    });
+  });
+
+  afterEach(function() {
+    router.push.mockRestore();
+    MockApiClient.clearMockResponses();
+    if (wrapper) {
+      wrapper.unmount();
+    }
+    discoverMock.mockRestore();
+    releasesMock.mockRestore();
+  });
+
+  it('renders and updates "recentReleases" constraint ', async function() {
+    const eventsByReleaseWidget = TestStubs.Widget({
+      discover: [
+        {
+          name: 'Events by Release',
+          fields: ['release'],
+          constraints: ['recentReleases'],
+          conditions: [],
+          aggregations: [['count()', null, 'Events']],
+          limit: 5000,
+
+          orderby: '-time',
+          groupby: ['time', 'release'],
+          rollup: 86400,
+        },
+      ],
+    });
+    const dashboardData = TestStubs.Dashboard([
+      TestStubs.Widget(),
+      eventsByReleaseWidget,
+    ]);
+
+    createWrapper(dashboardData);
+
+    // TODO(billy): Figure out why releases gets called twice
+    expect(discoverMock).toHaveBeenCalledTimes(4);
+
+    expect(releasesMock).toHaveBeenCalledTimes(1);
+
+    // Known users
+    expect(discoverMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          environments: [],
+          projects: [2, 3],
+          range: '14d',
+
+          fields: [],
+          conditions: [['user.email', 'IS NOT NULL', null]],
+          aggregations: [['uniq', 'user.email', 'Known Users']],
+          limit: 1000,
+          orderby: '-time',
+          groupby: ['time'],
+          rollup: 86400,
+        }),
+      })
+    );
+
+    // Anonymous users
+    expect(discoverMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          environments: [],
+          projects: [2, 3],
+          range: '14d',
+
+          fields: [],
+          conditions: [['user.email', 'IS NULL', null]],
+          aggregations: [['count()', null, 'Anonymous Users']],
+          limit: 1000,
+          orderby: '-time',
+          groupby: ['time'],
+          rollup: 86400,
+        }),
+      })
+    );
+
+    // Events by Release
+    expect(discoverMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          environments: [],
+          projects: [2, 3],
+          range: '14d',
+
+          fields: [],
+          conditions: [],
+          aggregations: [['count()', null, 'Events']],
+          conditionFields: [
+            [
+              'if',
+              [
+                [
+                  'in',
+                  ['release', 'tuple', ["'92eccef279d966b2319f0802fa4b22b430a5f72b'"]],
+                ],
+                'release',
+                "'other'",
+              ],
+              'release',
+            ],
+          ],
+          limit: 5000,
+          orderby: '-time',
+          groupby: ['time', 'release'],
+          name: 'Events by Release',
+          rollup: 86400,
+        }),
+      })
+    );
+
+    await tick();
+    wrapper.update();
+
+    // Should have two LineCharts
+    expect(wrapper.find('LineChart')).toHaveLength(2);
+
+    discoverMock.mockRestore();
+    releasesMock.mockRestore();
+
+    // Change date time
+    wrapper.find('TimeRangeSelector HeaderItem').simulate('click');
+    wrapper.find('SelectorItem[value="7d"]').simulate('click');
+    wrapper.find('TimeRangeSelector HeaderItem').simulate('click');
+
+    await tick();
+    wrapper.update();
+
+    expect(discoverMock).toHaveBeenCalledTimes(4);
+
+    // Doesn't get called again because it doesn't use global selection header
+    // This request just fetches last 100 (paginated) releases
+    expect(releasesMock).toHaveBeenCalledTimes(0);
+
+    // requested with update date
+    expect(discoverMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          environments: [],
+          projects: [2, 3],
+          range: '7d',
+
+          fields: [],
+          conditions: [],
+          aggregations: [['count()', null, 'Events']],
+          conditionFields: [
+            [
+              'if',
+              [
+                [
+                  'in',
+                  ['release', 'tuple', ["'92eccef279d966b2319f0802fa4b22b430a5f72b'"]],
+                ],
+                'release',
+                "'other'",
+              ],
+              'release',
+            ],
+          ],
+          limit: 5000,
+          orderby: '-time',
+          groupby: ['time', 'release'],
+          name: 'Events by Release',
+          rollup: 86400,
+        }),
+      })
+    );
+  });
+});


### PR DESCRIPTION
There were a few race conditions when dashboards would get re-rendered
(e.g. changing date). Parent component would fetch releases, as well as
global state change, and a withRouter render as well. Also query builders
were not being re-built. Also adds an additional integration test.