### PR TITLE
ref(app-platform): Partially remove sentry-apps flag

### DIFF
--- a/src/sentry/api/endpoints/group_external_issue_details.py
+++ b/src/sentry/api/endpoints/group_external_issue_details.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.bases.group import GroupEndpoint
 from sentry.mediators import external_issues
 from sentry.models import PlatformExternalIssue
@@ -10,11 +9,6 @@ from sentry.models import PlatformExternalIssue
 
 class GroupExternalIssueDetailsEndpoint(GroupEndpoint):
     def delete(self, request, external_issue_id, group):
-        if not features.has('organizations:sentry-apps',
-                            group.organization,
-                            actor=request.user):
-            return Response(status=404)
-
         try:
             external_issue = PlatformExternalIssue.objects.get(
                 id=external_issue_id,

--- a/src/sentry/api/endpoints/group_external_issues.py
+++ b/src/sentry/api/endpoints/group_external_issues.py
@@ -1,8 +1,5 @@
 from __future__ import absolute_import
 
-from rest_framework.response import Response
-
-from sentry import features
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import PlatformExternalIssue
@@ -10,10 +7,6 @@ from sentry.models import PlatformExternalIssue
 
 class GroupExternalIssuesEndpoint(GroupEndpoint):
     def get(self, request, group):
-        if not features.has('organizations:sentry-apps',
-                            group.organization,
-                            actor=request.user):
-            return Response(status=404)
 
         external_issues = PlatformExternalIssue.objects.filter(
             group_id=group.id,

--- a/src/sentry/api/endpoints/organization_sentry_apps.py
+++ b/src/sentry/api/endpoints/organization_sentry_apps.py
@@ -3,12 +3,10 @@ from __future__ import absolute_import
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.features.helpers import requires_feature
 from sentry.models import SentryApp
 
 
 class OrganizationSentryAppsEndpoint(OrganizationEndpoint):
-    @requires_feature('organizations:sentry-apps')
     def get(self, request, organization):
         queryset = SentryApp.objects.filter(
             owner=organization,

--- a/src/sentry/api/endpoints/sentry_app_components.py
+++ b/src/sentry/api/endpoints/sentry_app_components.py
@@ -6,13 +6,11 @@ from sentry.api.bases import OrganizationEndpoint, SentryAppBaseEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.coreapi import APIError
-from sentry.features.helpers import requires_feature
 from sentry.mediators import sentry_app_components
 from sentry.models import Project, SentryAppComponent
 
 
 class SentryAppComponentsEndpoint(SentryAppBaseEndpoint):
-    @requires_feature('organizations:sentry-apps', any_org=True)
     def get(self, request, sentry_app):
         return self.paginate(
             request=request,
@@ -23,7 +21,6 @@ class SentryAppComponentsEndpoint(SentryAppBaseEndpoint):
 
 
 class OrganizationSentryAppComponentsEndpoint(OrganizationEndpoint):
-    @requires_feature('organizations:sentry-apps')
     def get(self, request, organization):
         try:
             project = Project.objects.get(

--- a/src/sentry/api/endpoints/sentry_app_installation_details.py
+++ b/src/sentry/api/endpoints/sentry_app_installation_details.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.bases import SentryAppInstallationBaseEndpoint
 from sentry.api.serializers import serialize
 from sentry.mediators.sentry_app_installations import Destroyer
@@ -10,19 +9,10 @@ from sentry.mediators.sentry_app_installations import Destroyer
 
 class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
     def get(self, request, installation):
-        if not features.has('organizations:sentry-apps',
-                            installation.organization,
-                            actor=request.user):
-            return Response(status=404)
 
         return Response(serialize(installation))
 
     def delete(self, request, installation):
-        if not features.has('organizations:sentry-apps',
-                            installation.organization,
-                            actor=request.user):
-            return Response(status=404)
-
         Destroyer.run(
             install=installation,
             user=request.user,

--- a/src/sentry/api/endpoints/sentry_app_installation_external_issues.py
+++ b/src/sentry/api/endpoints/sentry_app_installation_external_issues.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.bases import SentryAppInstallationBaseEndpoint
 from sentry.api.serializers import serialize
 from sentry.mediators.external_issues import IssueLinkCreator
@@ -11,11 +10,6 @@ from sentry.models import Group, Project
 
 class SentryAppInstallationExternalIssuesEndpoint(SentryAppInstallationBaseEndpoint):
     def post(self, request, installation):
-        if not features.has('organizations:sentry-apps',
-                            installation.organization,
-                            actor=request.user):
-            return Response(status=404)
-
         data = request.DATA.copy()
 
         if not set(['groupId', 'action', 'uri']).issubset(data.keys()):

--- a/src/sentry/api/endpoints/sentry_app_installation_external_requests.py
+++ b/src/sentry/api/endpoints/sentry_app_installation_external_requests.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.bases import SentryAppInstallationBaseEndpoint
 from sentry.mediators import external_requests
 from sentry.models import Project
@@ -10,11 +9,6 @@ from sentry.models import Project
 
 class SentryAppInstallationExternalRequestsEndpoint(SentryAppInstallationBaseEndpoint):
     def get(self, request, installation):
-        if not features.has('organizations:sentry-apps',
-                            installation.organization,
-                            actor=request.user):
-            return Response(status=404)
-
         try:
             project = Project.objects.get(
                 id=request.GET.get('projectId'),

--- a/src/sentry/api/endpoints/sentry_app_installations.py
+++ b/src/sentry/api/endpoints/sentry_app_installations.py
@@ -9,7 +9,6 @@ from sentry.api.bases import SentryAppInstallationsBaseEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.constants import SENTRY_APP_SLUG_MAX_LENGTH
-from sentry.features.helpers import requires_feature
 from sentry.mediators.sentry_app_installations import Creator
 from sentry.models import SentryAppInstallation
 
@@ -31,7 +30,6 @@ class SentryAppInstallationsSerializer(serializers.Serializer):
 
 
 class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
-    @requires_feature('organizations:sentry-apps')
     def get(self, request, organization):
         queryset = SentryAppInstallation.objects.filter(
             organization=organization,
@@ -45,7 +43,6 @@ class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
             on_results=lambda x: serialize(x, request.user),
         )
 
-    @requires_feature('organizations:sentry-apps')
     def post(self, request, organization):
         serializer = SentryAppInstallationsSerializer(data=request.DATA)
 

--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -12,7 +12,6 @@ from sentry.models import SentryApp
 
 
 class SentryAppsEndpoint(SentryAppsBaseEndpoint):
-    @requires_feature('organizations:sentry-apps', any_org=True)
     def get(self, request):
         return self.paginate(
             request=request,

--- a/src/sentry/static/sentry/app/components/group/externalIssuesList.jsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssuesList.jsx
@@ -82,12 +82,6 @@ class ExternalIssueList extends AsyncComponent {
     const {api, group, project, organization} = this.props;
 
     if (project && project.id && organization) {
-      const features = new Set(organization.features);
-
-      if (!features.has('sentry-apps')) {
-        return;
-      }
-
       api
         .requestPromise(`/groups/${group.id}/external-issues/`)
         .then(data => {

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/groupEventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/groupEventDetails.jsx
@@ -109,14 +109,8 @@ class GroupEventDetails extends React.Component {
         });
       });
 
-    if (organization) {
-      const features = new Set(organization.features);
-
-      if (features.has('sentry-apps')) {
-        fetchSentryAppInstallations(api, orgSlug);
-        fetchSentryAppComponents(api, orgSlug, projectId);
-      }
-    }
+    fetchSentryAppInstallations(api, orgSlug);
+    fetchSentryAppComponents(api, orgSlug, projectId);
   };
 
   render() {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
@@ -38,16 +38,10 @@ class OrganizationIntegrations extends AsyncComponent {
   getEndpoints() {
     const {orgId} = this.props.params;
     const query = {plugins: ['vsts', 'github', 'bitbucket']};
-    const endpoints = [
+    return [
       ['config', `/organizations/${orgId}/config/integrations/`],
       ['integrations', `/organizations/${orgId}/integrations/`],
       ['plugins', `/organizations/${orgId}/plugins/`, {query}],
-    ];
-    if (!this.props.organization.features.includes('sentry-apps')) {
-      return endpoints;
-    }
-    return [
-      ...endpoints,
       ['orgOwnedApps', `/organizations/${orgId}/sentry-apps/`],
       ['publishedApps', '/sentry-apps/'],
       ['appInstalls', `/organizations/${orgId}/sentry-app-installations/`],

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/index.jsx
@@ -47,6 +47,22 @@ class OrganizationDeveloperSettings extends AsyncView {
     );
 
     const isEmpty = this.state.applications.length === 0;
+    if (!organization.features.includes('sentry-apps')) {
+      return (
+        <div>
+          <SettingsPageHeader title={t('Developer Settings')} />
+          <Panel>
+            <PanelBody>
+              <EmptyMessage>
+                {t(
+                  "Want to build on top of the Sentry Integration Platform? We're working closely with early adopters. Please reach out to us by contacting partners@sentry.io"
+                )}
+              </EmptyMessage>
+            </PanelBody>
+          </Panel>
+        </div>
+      );
+    }
 
     return (
       <div>

--- a/tests/js/spec/views/groupDetails/groupEventDetails.spec.jsx
+++ b/tests/js/spec/views/groupDetails/groupEventDetails.spec.jsx
@@ -137,34 +137,12 @@ describe('groupEventDetails', () => {
     expect(browserHistory.replace).not.toHaveBeenCalled();
   });
 
-  it("doesn't load Sentry Apps without being flagged in", () => {
+  it('loads Sentry Apps', () => {
     const request = MockApiClient.addMockResponse({
       url: '/sentry-apps/',
       body: [],
     });
 
-    mount(
-      <GroupEventDetails
-        group={group}
-        project={project}
-        organization={org}
-        environments={[{id: '1', name: 'dev', displayName: 'Dev'}]}
-        params={{}}
-        location={{}}
-      />,
-      routerContext
-    );
-
-    expect(request).not.toHaveBeenCalled();
-  });
-
-  it('loads Sentry Apps when flagged in', () => {
-    const request = MockApiClient.addMockResponse({
-      url: '/sentry-apps/',
-      body: [],
-    });
-
-    org.features = ['sentry-apps'];
     project.organization = org;
 
     mount(
@@ -188,7 +166,6 @@ describe('groupEventDetails', () => {
       body: [],
     });
 
-    org.features = ['sentry-apps'];
     project.organization = org;
 
     mount(

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
@@ -16,7 +16,9 @@ exports[`Organization Developer Settings when no Apps exist displays empty state
         "team:write",
         "team:admin",
       ],
-      "features": Array [],
+      "features": Array [
+        "sentry-apps",
+      ],
       "id": "3",
       "name": "Organization Name",
       "onboardingTasks": Array [],
@@ -51,7 +53,9 @@ exports[`Organization Developer Settings when no Apps exist displays empty state
           "team:write",
           "team:admin",
         ],
-        "features": Array [],
+        "features": Array [
+          "sentry-apps",
+        ],
         "id": "3",
         "name": "Organization Name",
         "onboardingTasks": Array [],
@@ -330,7 +334,7 @@ exports[`Organization Developer Settings when no Apps exist displays empty state
 </WithOrganizationMockWrapper>
 `;
 
-exports[`Organization Developer Settings with published apps trash button is disabled 1`] = `
+exports[`Organization Developer Settings when not flagged in to sentry-apps displays contact us info 1`] = `
 <WithOrganizationMockWrapper
   organization={
     Object {
@@ -346,7 +350,9 @@ exports[`Organization Developer Settings with published apps trash button is dis
         "team:write",
         "team:admin",
       ],
-      "features": Array [],
+      "features": Array [
+        "sentry-apps",
+      ],
       "id": "3",
       "name": "Organization Name",
       "onboardingTasks": Array [],
@@ -381,7 +387,188 @@ exports[`Organization Developer Settings with published apps trash button is dis
           "team:write",
           "team:admin",
         ],
-        "features": Array [],
+        "features": Array [
+          "sentry-apps",
+        ],
+        "id": "3",
+        "name": "Organization Name",
+        "onboardingTasks": Array [],
+        "projects": Array [],
+        "scrapeJavaScript": true,
+        "slug": "org-slug",
+        "status": Object {
+          "id": "active",
+          "name": "active",
+        },
+        "teams": Array [],
+      }
+    }
+    params={
+      Object {
+        "orgId": "org-slug",
+      }
+    }
+  >
+    <SideEffect(DocumentTitle)
+      title="Sentry"
+    >
+      <DocumentTitle
+        title="Sentry"
+      >
+        <div>
+          <SettingsPageHeading
+            noTitleStyles={false}
+            title="Developer Settings"
+          >
+            <Wrapper>
+              <div
+                className="css-1r5ylk7-Wrapper e1kblvez2"
+              >
+                <Flex
+                  align="center"
+                >
+                  <Base
+                    align="center"
+                    className="css-5ipae5"
+                  >
+                    <div
+                      className="css-5ipae5"
+                      is={null}
+                    >
+                      <Title
+                        styled={false}
+                      >
+                        <Base
+                          className="css-1ky52ze-Title e1kblvez0"
+                        >
+                          <div
+                            className="css-1ky52ze-Title e1kblvez0"
+                            is={null}
+                          >
+                            <HeaderTitle>
+                              <h4
+                                className="css-1w8ttcn-HeaderTitle e6lvex72"
+                              >
+                                Developer Settings
+                              </h4>
+                            </HeaderTitle>
+                          </div>
+                        </Base>
+                      </Title>
+                    </div>
+                  </Base>
+                </Flex>
+              </div>
+            </Wrapper>
+          </SettingsPageHeading>
+          <Panel>
+            <Component
+              className="css-yahxlu-Panel e1laxa7d0"
+            >
+              <div
+                className="css-yahxlu-Panel e1laxa7d0"
+              >
+                <PanelBody
+                  direction="column"
+                  disablePadding={true}
+                  flex={false}
+                >
+                  <div
+                    className="css-9vq8an-textStyles"
+                  >
+                    <EmptyMessage>
+                      <Wrapper
+                        data-test-id="empty-message"
+                      >
+                        <div
+                          className="css-ev9qm0-Wrapper eh488yo0"
+                          data-test-id="empty-message"
+                        >
+                          <Description
+                            noMargin={true}
+                          >
+                            <Component
+                              className="css-pwn5v-TextBlock-Description-MarginStyles eh488yo1"
+                              noMargin={true}
+                            >
+                              <div
+                                className="css-pwn5v-TextBlock-Description-MarginStyles eh488yo1"
+                              >
+                                Want to build on top of the Sentry Integration Platform? We're working closely with early adopters. Please reach out to us by contacting partners@sentry.io
+                              </div>
+                            </Component>
+                          </Description>
+                        </div>
+                      </Wrapper>
+                    </EmptyMessage>
+                  </div>
+                </PanelBody>
+              </div>
+            </Component>
+          </Panel>
+        </div>
+      </DocumentTitle>
+    </SideEffect(DocumentTitle)>
+  </OrganizationDeveloperSettings>
+</WithOrganizationMockWrapper>
+`;
+
+exports[`Organization Developer Settings with published apps trash button is disabled 1`] = `
+<WithOrganizationMockWrapper
+  organization={
+    Object {
+      "access": Array [
+        "org:read",
+        "org:write",
+        "org:admin",
+        "org:integrations",
+        "project:read",
+        "project:write",
+        "project:admin",
+        "team:read",
+        "team:write",
+        "team:admin",
+      ],
+      "features": Array [
+        "sentry-apps",
+      ],
+      "id": "3",
+      "name": "Organization Name",
+      "onboardingTasks": Array [],
+      "projects": Array [],
+      "scrapeJavaScript": true,
+      "slug": "org-slug",
+      "status": Object {
+        "id": "active",
+        "name": "active",
+      },
+      "teams": Array [],
+    }
+  }
+  params={
+    Object {
+      "orgId": "org-slug",
+    }
+  }
+>
+  <OrganizationDeveloperSettings
+    organization={
+      Object {
+        "access": Array [
+          "org:read",
+          "org:write",
+          "org:admin",
+          "org:integrations",
+          "project:read",
+          "project:write",
+          "project:admin",
+          "team:read",
+          "team:write",
+          "team:admin",
+        ],
+        "features": Array [
+          "sentry-apps",
+        ],
         "id": "3",
         "name": "Organization Name",
         "onboardingTasks": Array [],
@@ -660,7 +847,9 @@ exports[`Organization Developer Settings with published apps trash button is dis
                             "team:write",
                             "team:admin",
                           ],
-                          "features": Array [],
+                          "features": Array [
+                            "sentry-apps",
+                          ],
                           "id": "3",
                           "name": "Organization Name",
                           "onboardingTasks": Array [],
@@ -991,7 +1180,9 @@ exports[`Organization Developer Settings with unpublished apps displays all Apps
         "team:write",
         "team:admin",
       ],
-      "features": Array [],
+      "features": Array [
+        "sentry-apps",
+      ],
       "id": "3",
       "name": "Organization Name",
       "onboardingTasks": Array [],
@@ -1026,7 +1217,9 @@ exports[`Organization Developer Settings with unpublished apps displays all Apps
           "team:write",
           "team:admin",
         ],
-        "features": Array [],
+        "features": Array [
+          "sentry-apps",
+        ],
         "id": "3",
         "name": "Organization Name",
         "onboardingTasks": Array [],
@@ -1305,7 +1498,9 @@ exports[`Organization Developer Settings with unpublished apps displays all Apps
                             "team:write",
                             "team:admin",
                           ],
-                          "features": Array [],
+                          "features": Array [
+                            "sentry-apps",
+                          ],
                           "id": "3",
                           "name": "Organization Name",
                           "onboardingTasks": Array [],
@@ -1827,7 +2022,9 @@ exports[`Organization Developer Settings without Owner permissions trash button 
       "access": Array [
         "org:read",
       ],
-      "features": Array [],
+      "features": Array [
+        "sentry-apps",
+      ],
       "id": "3",
       "name": "Organization Name",
       "onboardingTasks": Array [],
@@ -1853,7 +2050,9 @@ exports[`Organization Developer Settings without Owner permissions trash button 
         "access": Array [
           "org:read",
         ],
-        "features": Array [],
+        "features": Array [
+          "sentry-apps",
+        ],
         "id": "3",
         "name": "Organization Name",
         "onboardingTasks": Array [],
@@ -2123,7 +2322,9 @@ exports[`Organization Developer Settings without Owner permissions trash button 
                           "access": Array [
                             "org:read",
                           ],
-                          "features": Array [],
+                          "features": Array [
+                            "sentry-apps",
+                          ],
                           "id": "3",
                           "name": "Organization Name",
                           "onboardingTasks": Array [],
@@ -2391,7 +2592,9 @@ exports[`Organization Developer Settings without Owner permissions trash button 
                                                   "access": Array [
                                                     "org:read",
                                                   ],
-                                                  "features": Array [],
+                                                  "features": Array [
+                                                    "sentry-apps",
+                                                  ],
                                                   "id": "3",
                                                   "name": "Organization Name",
                                                   "onboardingTasks": Array [],

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
@@ -14,11 +14,31 @@ describe('Organization Developer Settings', function() {
     Client.clearMockResponses();
   });
 
+  describe('when not flagged in to sentry-apps', () => {
+    Client.addMockResponse({
+      url: `/organizations/${org.slug}/sentry-apps/`,
+      body: [],
+    });
+
+    const wrapper = mount(
+      <OrganizationDeveloperSettings params={{orgId: org.slug}} organization={org} />,
+      routerContext
+    );
+
+    it('displays contact us info', () => {
+      expect(wrapper).toMatchSnapshot();
+      expect(wrapper.find('[icon="icon-circle-add"]').exists()).toBe(false);
+      expect(wrapper.exists('EmptyMessage')).toBe(true);
+    });
+  });
+
   describe('when no Apps exist', () => {
     Client.addMockResponse({
       url: `/organizations/${org.slug}/sentry-apps/`,
       body: [],
     });
+
+    org.features = ['sentry-apps'];
 
     const wrapper = mount(
       <OrganizationDeveloperSettings params={{orgId: org.slug}} organization={org} />,
@@ -37,6 +57,8 @@ describe('Organization Developer Settings', function() {
       body: [sentryApp],
     });
 
+    org.features = ['sentry-apps'];
+
     const wrapper = mount(
       <OrganizationDeveloperSettings params={{orgId: org.slug}} organization={org} />,
       routerContext
@@ -54,6 +76,8 @@ describe('Organization Developer Settings', function() {
         method: 'DELETE',
         body: [],
       });
+      org.features = ['sentry-apps'];
+
       expect(wrapper.find('[icon="icon-trash"]').prop('disabled')).toEqual(false);
       wrapper.find('[icon="icon-trash"]').simulate('click');
       // confirm deletion by entering in app slug
@@ -74,6 +98,9 @@ describe('Organization Developer Settings', function() {
       url: `/organizations/${org.slug}/sentry-apps/`,
       body: [publishedSentryApp],
     });
+
+    org.features = ['sentry-apps'];
+
     const wrapper = mount(
       <OrganizationDeveloperSettings params={{orgId: org.slug}} organization={org} />,
       routerContext
@@ -91,6 +118,9 @@ describe('Organization Developer Settings', function() {
       url: `/organizations/${newOrg.slug}/sentry-apps/`,
       body: [sentryApp],
     });
+
+    newOrg.features = ['sentry-apps'];
+
     const wrapper = mount(
       <OrganizationDeveloperSettings
         params={{orgId: newOrg.slug}}

--- a/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
@@ -193,13 +193,11 @@ describe('OrganizationIntegrations', () => {
 
   describe('render()', () => {
     describe('without integrations', () => {
-      it('renders with sentry-apps', () => {
+      it('renders sentry apps', () => {
         orgOwnedSentryAppsRequest = Client.addMockResponse({
           url: `/organizations/${org.slug}/sentry-apps/`,
           body: [sentryApp],
         });
-
-        org = {...org, features: ['sentry-apps']};
 
         mount(
           <OrganizationIntegrations organization={org} params={params} />,
@@ -217,8 +215,6 @@ describe('OrganizationIntegrations', () => {
           body: [sentryApp],
         });
 
-        org = {...org, features: ['sentry-apps']};
-
         wrapper = mount(
           <OrganizationIntegrations organization={org} params={params} />,
           routerContext
@@ -232,12 +228,6 @@ describe('OrganizationIntegrations', () => {
           onInstall: expect.any(Function),
           organization: org,
         });
-      });
-
-      it('Does`t hit sentry apps endpoints when sentry-apps isn`t present', () => {
-        expect(orgOwnedSentryAppsRequest).not.toHaveBeenCalled();
-        expect(publishedSentryAppsRequest).not.toHaveBeenCalled();
-        expect(sentryInstallsRequest).not.toHaveBeenCalled();
       });
 
       it('Opens the integration dialog on install', function() {

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase
-from sentry.testutils.helpers import with_feature
 
 
 class SentryAppInstallationDetailsTest(APITestCase):
@@ -43,7 +42,6 @@ class SentryAppInstallationDetailsTest(APITestCase):
 
 
 class GetSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
-    @with_feature('organizations:sentry-apps')
     def test_access_within_installs_organization(self):
         self.login_as(user=self.user)
         response = self.client.get(self.url, format='json')
@@ -61,7 +59,6 @@ class GetSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
             'code': self.installation2.api_grant.code,
         }
 
-    @with_feature('organizations:sentry-apps')
     def test_no_access_outside_install_organization(self):
         self.login_as(user=self.user)
 
@@ -73,22 +70,14 @@ class GetSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
         response = self.client.get(url, format='json')
         assert response.status_code == 404
 
-    def test_no_access_without_internal_catchall(self):
-        self.login_as(user=self.user)
-
-        response = self.client.get(self.url, format='json')
-        assert response.status_code == 404
-
 
 class DeleteSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
-    @with_feature('organizations:sentry-apps')
     def test_delete_install(self):
         self.login_as(user=self.user)
         response = self.client.delete(self.url, format='json')
 
         assert response.status_code == 204
 
-    @with_feature('organizations:sentry-apps')
     def test_member_cannot_delete_install(self):
         user = self.create_user('bar@example.com')
         self.create_member(

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -5,7 +5,6 @@ import six
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase
-from sentry.testutils.helpers import with_feature
 
 
 class SentryAppInstallationsTest(APITestCase):
@@ -44,7 +43,6 @@ class SentryAppInstallationsTest(APITestCase):
 
 
 class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
-    @with_feature('organizations:sentry-apps')
     def test_superuser_sees_all_installs(self):
         self.login_as(user=self.superuser, superuser=True)
         response = self.client.get(self.url, format='json')
@@ -82,7 +80,6 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
             'code': self.installation.api_grant.code,
         }]
 
-    @with_feature('organizations:sentry-apps')
     def test_users_only_sees_installs_on_their_org(self):
         self.login_as(user=self.user)
         response = self.client.get(self.url, format='json')
@@ -109,15 +106,8 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
         response = self.client.get(url, format='json')
         assert response.status_code == 404
 
-    def test_no_access_without_internal_catchall(self):
-        self.login_as(user=self.user)
-
-        response = self.client.get(self.url, format='json')
-        assert response.status_code == 404
-
 
 class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
-    @with_feature('organizations:sentry-apps')
     def test_install_unpublished_app(self):
         self.login_as(user=self.user)
         app = self.create_sentry_app(
@@ -142,7 +132,6 @@ class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
         assert response.status_code == 200, response.content
         assert six.viewitems(expected) <= six.viewitems(response.data)
 
-    @with_feature('organizations:sentry-apps')
     def test_install_published_app(self):
         self.login_as(user=self.user)
         app = self.create_sentry_app(
@@ -168,7 +157,6 @@ class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
         assert response.status_code == 200, response.content
         assert six.viewitems(expected) <= six.viewitems(response.data)
 
-    @with_feature('organizations:sentry-apps')
     def test_members_cannot_install_apps(self):
         user = self.create_user('bar@example.com')
         self.create_member(
@@ -188,9 +176,3 @@ class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
             format='json',
         )
         assert response.status_code == 403
-
-    def test_no_access_without_internal_catchall(self):
-        self.login_as(user=self.user)
-
-        response = self.client.get(self.url, format='json')
-        assert response.status_code == 404

--- a/tests/sentry/api/endpoints/test_organization_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_apps.py
@@ -4,7 +4,6 @@ from django.core.urlresolvers import reverse
 
 from sentry.utils import json
 from sentry.testutils import APITestCase
-from sentry.testutils.helpers import with_feature
 
 
 def assert_response_json(response, data):
@@ -33,7 +32,6 @@ class OrganizationSentryAppsTest(APITestCase):
 
 
 class GetOrganizationSentryAppsTest(OrganizationSentryAppsTest):
-    @with_feature('organizations:sentry-apps')
     def test_gets_all_apps_in_own_org(self):
         self.login_as(user=self.user)
         response = self.client.get(self.url, format='json')
@@ -61,16 +59,9 @@ class GetOrganizationSentryAppsTest(OrganizationSentryAppsTest):
             }
         }])
 
-    @with_feature('organizations:sentry-apps')
     def test_cannot_see_apps_in_other_orgs(self):
         self.login_as(user=self.user)
         url = reverse('sentry-api-0-organization-sentry-apps', args=[self.super_org.slug])
         response = self.client.get(url, format='json')
 
         assert response.status_code == 403
-
-    def test_no_access_without_internal_catchall(self):
-        self.login_as(user=self.user)
-
-        response = self.client.get(self.url, format='json')
-        assert response.status_code == 404

--- a/tests/sentry/api/endpoints/test_sentry_app_components.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_components.py
@@ -7,7 +7,6 @@ from mock import patch, call
 
 from sentry.coreapi import APIError
 from sentry.testutils import APITestCase
-from sentry.testutils.helpers import with_feature
 
 
 class SentryAppComponentsTest(APITestCase):
@@ -34,7 +33,6 @@ class SentryAppComponentsTest(APITestCase):
 
         self.login_as(user=self.user)
 
-    @with_feature('organizations:sentry-apps')
     def test_retrieves_all_components(self):
         response = self.client.get(self.url, format='json')
 
@@ -99,7 +97,6 @@ class OrganizationSentryAppComponentsTest(APITestCase):
 
         self.login_as(user=self.user)
 
-    @with_feature('organizations:sentry-apps')
     @patch('sentry.mediators.sentry_app_components.Preparer.run')
     def test_retrieves_all_components_for_installed_apps(self, run):
         response = self.client.get(self.url, format='json')
@@ -129,7 +126,6 @@ class OrganizationSentryAppComponentsTest(APITestCase):
             },
         ]
 
-    @with_feature('organizations:sentry-apps')
     @patch('sentry.mediators.sentry_app_components.Preparer.run')
     def test_project_not_owned_by_org(self, run):
         org = self.create_organization(owner=self.create_user())
@@ -146,7 +142,6 @@ class OrganizationSentryAppComponentsTest(APITestCase):
         assert response.status_code == 404
         assert response.data == []
 
-    @with_feature('organizations:sentry-apps')
     @patch('sentry.mediators.sentry_app_components.Preparer.run')
     def test_filter_by_type(self, run):
         sentry_app = self.create_sentry_app(
@@ -180,7 +175,6 @@ class OrganizationSentryAppComponentsTest(APITestCase):
             }
         ]
 
-    @with_feature('organizations:sentry-apps')
     @patch('sentry.mediators.sentry_app_components.Preparer.run')
     def test_prepares_each_component(self, run):
         self.client.get(self.url, format='json')
@@ -200,7 +194,6 @@ class OrganizationSentryAppComponentsTest(APITestCase):
 
         run.assert_has_calls(calls, any_order=True)
 
-    @with_feature('organizations:sentry-apps')
     @patch('sentry.mediators.sentry_app_components.Preparer.run')
     def test_component_prep_errors_are_isolated(self, run):
         run.side_effect = [APIError(), self.component2]

--- a/tests/sentry/api/endpoints/test_sentry_app_installation_external_issues.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_installation_external_issues.py
@@ -6,7 +6,6 @@ import responses
 from django.core.urlresolvers import reverse
 from sentry.models import PlatformExternalIssue
 from sentry.testutils import APITestCase
-from sentry.testutils.helpers import with_feature
 
 
 class SentryAppInstallationExternalIssuesEndpointTest(APITestCase):
@@ -35,7 +34,6 @@ class SentryAppInstallationExternalIssuesEndpointTest(APITestCase):
         )
 
     @responses.activate
-    @with_feature('organizations:sentry-apps')
     def test_creates_external_issue(self):
         self.login_as(user=self.superuser, superuser=True)
         data = {
@@ -69,7 +67,6 @@ class SentryAppInstallationExternalIssuesEndpointTest(APITestCase):
         }
 
     @responses.activate
-    @with_feature('organizations:sentry-apps')
     def test_external_issue_doesnt_get_created(self):
         self.login_as(user=self.superuser, superuser=True)
         data = {

--- a/tests/sentry/api/endpoints/test_sentry_app_installation_external_requests.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_installation_external_requests.py
@@ -4,7 +4,6 @@ import responses
 
 from django.core.urlresolvers import reverse
 from sentry.testutils import APITestCase
-from sentry.testutils.helpers import with_feature
 
 
 class SentryAppInstallationExternalRequestsEndpointTest(APITestCase):
@@ -31,7 +30,6 @@ class SentryAppInstallationExternalRequestsEndpointTest(APITestCase):
         )
 
     @responses.activate
-    @with_feature('organizations:sentry-apps')
     def test_makes_external_request(self):
         self.login_as(user=self.user)
         options = [{
@@ -57,7 +55,6 @@ class SentryAppInstallationExternalRequestsEndpointTest(APITestCase):
         }
 
     @responses.activate
-    @with_feature('organizations:sentry-apps')
     def test_external_request_fails(self):
         self.login_as(user=self.user)
         responses.add(

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -38,7 +38,6 @@ class SentryAppsTest(APITestCase):
 
 
 class GetSentryAppsTest(SentryAppsTest):
-    @with_feature('organizations:sentry-apps')
     def test_superuser_sees_all_apps(self):
         self.login_as(user=self.superuser, superuser=True)
 
@@ -50,7 +49,6 @@ class GetSentryAppsTest(SentryAppsTest):
         assert self.unpublished_app.uuid in response_uuids
         assert self.unowned_unpublished_app.uuid in response_uuids
 
-    @with_feature('organizations:sentry-apps')
     def test_users_see_published_apps(self):
         self.login_as(user=self.user)
 
@@ -78,7 +76,6 @@ class GetSentryAppsTest(SentryAppsTest):
             }
         } in json.loads(response.content)
 
-    @with_feature('organizations:sentry-apps')
     def test_users_dont_see_unpublished_apps_their_org_owns(self):
         self.login_as(user=self.user)
 
@@ -89,7 +86,6 @@ class GetSentryAppsTest(SentryAppsTest):
             a['uuid'] for a in response.data
         ]
 
-    @with_feature('organizations:sentry-apps')
     def test_users_dont_see_unpublished_apps_outside_their_orgs(self):
         self.login_as(user=self.user)
 
@@ -99,12 +95,6 @@ class GetSentryAppsTest(SentryAppsTest):
         assert self.unowned_unpublished_app.uuid not in [
             a['uuid'] for a in response.data
         ]
-
-    def test_no_access_without_internal_catchall(self):
-        self.login_as(user=self.user)
-
-        response = self.client.get(self.url, format='json')
-        assert response.status_code == 404
 
 
 class PostSentryAppsTest(SentryAppsTest):


### PR DESCRIPTION
**What is the `sentry-apps` feature flag is still used for?**
* adding/updating/removing sentry apps
* keeping **Developer Settings** hidden from navigation bar

**What is this PR for?**
* removes `sentry-apps` feature flag for integrations page and all endpoints needed for published apps to be installed/used.
* adds messaging if people land on the **Developer Settings** page via manually plugging in the url
<img width="900" alt="Screen Shot 2019-04-22 at 9 30 21 AM" src="https://user-images.githubusercontent.com/15368179/56511406-594abc00-64e1-11e9-9cb8-b78af9602187.png">
