### PR TITLE
fix: Fix paginating through events of an issue

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/shared/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/eventToolbar.jsx
@@ -43,9 +43,10 @@ const GroupEventToolbar = createReactClass({
     projectId: PropTypes.string.isRequired,
     group: SentryTypes.Group.isRequired,
     event: SentryTypes.Event.isRequired,
+    location: PropTypes.object.isRequired,
   },
 
-  shouldComponentUpdate(nextProps, nextState) {
+  shouldComponentUpdate(nextProps) {
     return this.props.event.id !== nextProps.event.id;
   },
 
@@ -83,7 +84,7 @@ const GroupEventToolbar = createReactClass({
   render() {
     const evt = this.props.event;
 
-    const {organization, orgId, projectId} = this.props;
+    const {organization, orgId, projectId, location} = this.props;
     const groupId = this.props.group.id;
 
     const hasSentry10 = new Set(organization.features).has('sentry10');
@@ -95,7 +96,7 @@ const GroupEventToolbar = createReactClass({
       evt.previousEventID ? (
         <Link
           key="oldest"
-          to={`${baseEventsPath}oldest/`}
+          to={{pathname: `${baseEventsPath}oldest/`, query: location.query}}
           className="btn btn-default"
           title={t('Oldest')}
         >
@@ -109,7 +110,10 @@ const GroupEventToolbar = createReactClass({
       evt.previousEventID ? (
         <Link
           key="prev"
-          to={`${baseEventsPath}${evt.previousEventID}/`}
+          to={{
+            pathname: `${baseEventsPath}${evt.previousEventID}/`,
+            query: location.query,
+          }}
           className="btn btn-default"
         >
           {t('Older')}
@@ -122,7 +126,7 @@ const GroupEventToolbar = createReactClass({
       evt.nextEventID ? (
         <Link
           key="next"
-          to={`${baseEventsPath}${evt.nextEventID}/`}
+          to={{pathname: `${baseEventsPath}${evt.nextEventID}/`, query: location.query}}
           className="btn btn-default"
         >
           {t('Newer')}
@@ -135,7 +139,7 @@ const GroupEventToolbar = createReactClass({
       evt.nextEventID ? (
         <Link
           key="latest"
-          to={`${baseEventsPath}latest/`}
+          to={{pathname: `${baseEventsPath}latest/`, query: location.query}}
           className="btn btn-default"
           title={t('Newest')}
         >

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/groupEventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/groupEventDetails.jsx
@@ -114,7 +114,7 @@ class GroupEventDetails extends React.Component {
   };
 
   render() {
-    const {group, project, organization, environments} = this.props;
+    const {group, project, organization, environments, location} = this.props;
     const evt = withMeta(this.state.event);
 
     return (
@@ -128,6 +128,7 @@ class GroupEventDetails extends React.Component {
                 event={evt}
                 orgId={organization.slug}
                 projectId={project.slug}
+                location={location}
               />
             )}
             {group.status != 'unresolved' && (

--- a/tests/js/spec/views/groupDetails/groupEventDetails.spec.jsx
+++ b/tests/js/spec/views/groupDetails/groupEventDetails.spec.jsx
@@ -137,6 +137,61 @@ describe('groupEventDetails', () => {
     expect(browserHistory.replace).not.toHaveBeenCalled();
   });
 
+  it('next/prev links', async function() {
+    event = TestStubs.Event({
+      size: 1,
+      dateCreated: '2019-03-20T00:00:00.000Z',
+      errors: [],
+      entries: [],
+      tags: [{key: 'environment', value: 'dev'}],
+      previousEventID: 'prev-event-id',
+      nextEventID: 'next-event-id',
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/events/1/`,
+      body: event,
+    });
+
+    const wrapper = mount(
+      <GroupEventDetails
+        group={group}
+        project={project}
+        organization={org}
+        environments={[{id: '1', name: 'dev', displayName: 'Dev'}]}
+        params={{orgId: org.slug, groupId: group.id, eventId: '1'}}
+        location={{query: {environment: 'dev'}}}
+      />,
+      routerContext
+    );
+    await tick();
+
+    wrapper.update();
+
+    const buttons = wrapper
+      .find('.event-toolbar')
+      .find('.btn-group')
+      .find('Link');
+
+    expect(buttons.at(0).prop('to')).toEqual({
+      pathname: '/org-slug/project-slug/issues/1/events/oldest/',
+      query: {environment: 'dev'},
+    });
+
+    expect(buttons.at(1).prop('to')).toEqual({
+      pathname: '/org-slug/project-slug/issues/1/events/prev-event-id/',
+      query: {environment: 'dev'},
+    });
+    expect(buttons.at(2).prop('to')).toEqual({
+      pathname: '/org-slug/project-slug/issues/1/events/next-event-id/',
+      query: {environment: 'dev'},
+    });
+    expect(buttons.at(3).prop('to')).toEqual({
+      pathname: '/org-slug/project-slug/issues/1/events/latest/',
+      query: {environment: 'dev'},
+    });
+  });
+
   it('loads Sentry Apps', () => {
     const request = MockApiClient.addMockResponse({
       url: '/sentry-apps/',


### PR DESCRIPTION
Ensures that URL params are preserved when paginating through the events
of an issue. This fixes a bug that caused global selection values to be
dropped upon paginating.

Fixes SEN-506