### PR TITLE
feat: Check global snuba.events-queries.enabled option instead of URL

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 from django.utils import timezone
 from rest_framework.response import Response
 
-from sentry import eventstream, tsdb, tagstore
+from sentry import eventstream, tsdb, tagstore, options
 from sentry.api import client
 from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases import GroupEndpoint
@@ -181,7 +181,8 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         # TODO(dcramer): handle unauthenticated/public response
 
         # TODO(jess): This can be removed when tagstore v2 is deprecated
-        use_snuba = request.GET.get('enable_snuba') == '1'
+        use_snuba = options.get('snuba.events-queries.enabled')
+
         environments = get_environments(request, group.project.organization)
         environment_ids = [e.id for e in environments]
 

--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -66,10 +66,7 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
         except (NoResults, ResourceDoesNotExist):
             return Response([])
 
-        use_snuba = (
-            request.GET.get('enable_snuba') == '1'
-            or options.get('snuba.events-queries.enabled')
-        )
+        use_snuba = options.get('snuba.events-queries.enabled')
         backend = self._get_events_snuba if use_snuba else self._get_events_legacy
         start, end = get_date_range_from_params(request.GET, optional=True)
         return backend(request, group, environments, query, tags, start, end)

--- a/src/sentry/api/endpoints/group_tags.py
+++ b/src/sentry/api/endpoints/group_tags.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
-from sentry import tagstore
+from sentry import tagstore, options
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.helpers.environments import get_environments
 from sentry.api.serializers import serialize
@@ -24,7 +24,7 @@ class GroupTagsEndpoint(GroupEndpoint):
         else:
             value_limit = 10
 
-        use_snuba = request.GET.get('enable_snuba') == '1'
+        use_snuba = use_snuba = options.get('snuba.events-queries.enabled')
 
         environment_ids = [e.id for e in get_environments(request, group.project.organization)]
 

--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -86,7 +86,6 @@ const GroupSidebar = createReactClass({
       query: pickBy({
         key: group.tags.map(data => data.key),
         environment: this.state.environments.map(env => env.name),
-        enable_snuba: this.getFeatures().has('sentry10') ? '1' : '0',
       }),
       success: data => {
         this.setState({

--- a/src/sentry/static/sentry/app/views/groupDetails/organization/index.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/organization/index.jsx
@@ -27,7 +27,6 @@ class OrganizationGroupDetails extends React.Component {
     return (
       <GroupDetails
         environments={selection.environments}
-        enableSnuba={true}
         showGlobalHeader={true}
         {...props}
       />

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/groupDetails.jsx
@@ -32,7 +32,6 @@ const GroupDetails = createReactClass({
 
     organization: SentryTypes.Organization,
     environments: PropTypes.arrayOf(PropTypes.string),
-    enableSnuba: PropTypes.bool,
     showGlobalHeader: PropTypes.bool,
   },
 
@@ -42,12 +41,6 @@ const GroupDetails = createReactClass({
   },
 
   mixins: [Reflux.listenTo(GroupStore, 'onGroupChange')],
-
-  getDefaultProps() {
-    return {
-      enableSnuba: false,
-    };
-  },
 
   getInitialState() {
     return {
@@ -93,10 +86,6 @@ const GroupDetails = createReactClass({
 
     if (this.props.environments) {
       query.environment = this.props.environments;
-    }
-
-    if (this.props.enableSnuba) {
-      query.enable_snuba = '1';
     }
 
     this.props.api.request(this.getGroupDetailsEndpoint(), {


### PR DESCRIPTION
Use the global `snuba.events-queries.enabled` option to determine
whether to use Snuba instead of relying on the UI passing an
`enable_snuba` param. This option will ALWAYS need to be on in order to
use Sentry 10.