### PR TITLE
fix(dropdown-autocomplete): resolve arrow-key regression caused by addition of react-virtualized

### DIFF
--- a/docs-ui/components/dropdownAutoComplete.stories.js
+++ b/docs-ui/components/dropdownAutoComplete.stories.js
@@ -34,6 +34,10 @@ const groupedItems = [
         value: 'other recent thing',
         label: 'other recent thing',
       },
+      {
+        value: 'yet another recent thing',
+        label: 'yet another recent thing',
+      },
     ],
   },
   {

--- a/src/sentry/static/sentry/app/components/autoComplete.jsx
+++ b/src/sentry/static/sentry/app/components/autoComplete.jsx
@@ -221,11 +221,10 @@ class AutoComplete extends React.Component {
   };
 
   moveHighlightedIndex = (step, e) => {
-    const listSize = this.items.size - 1;
     let newIndex = this.state.highlightedIndex + step;
 
     // Make sure new index is within bounds
-    newIndex = Math.max(0, Math.min(newIndex, listSize));
+    newIndex = Math.max(0, Math.min(newIndex, this.itemCount - 1));
 
     this.setState({
       highlightedIndex: newIndex,
@@ -298,10 +297,14 @@ class AutoComplete extends React.Component {
     };
   };
 
-  getMenuProps = menuProps => ({
-    ...menuProps,
-    onMouseDown: this.handleMenuMouseDown.bind(this, menuProps),
-  });
+  getMenuProps = menuProps => {
+    this.itemCount = menuProps.itemCount;
+
+    return {
+      ...menuProps,
+      onMouseDown: this.handleMenuMouseDown.bind(this, menuProps),
+    };
+  };
 
   render() {
     const {children, onMenuOpen} = this.props;

--- a/src/sentry/static/sentry/app/components/autoComplete.jsx
+++ b/src/sentry/static/sentry/app/components/autoComplete.jsx
@@ -222,9 +222,10 @@ class AutoComplete extends React.Component {
 
   moveHighlightedIndex = (step, e) => {
     let newIndex = this.state.highlightedIndex + step;
+    const listSize = this.itemCount || this.items.size;
 
     // Make sure new index is within bounds
-    newIndex = Math.max(0, Math.min(newIndex, this.itemCount - 1));
+    newIndex = Math.max(0, Math.min(newIndex, listSize - 1));
 
     this.setState({
       highlightedIndex: newIndex,
@@ -298,7 +299,9 @@ class AutoComplete extends React.Component {
   };
 
   getMenuProps = menuProps => {
-    this.itemCount = menuProps.itemCount;
+    this.seState({
+      itemCount: menuProps.itemCount
+    });
 
     return {
       ...menuProps,

--- a/src/sentry/static/sentry/app/components/autoComplete.jsx
+++ b/src/sentry/static/sentry/app/components/autoComplete.jsx
@@ -299,9 +299,7 @@ class AutoComplete extends React.Component {
   };
 
   getMenuProps = menuProps => {
-    this.seState({
-      itemCount: menuProps.itemCount
-    });
+    this.itemCount = menuProps.itemCount;
 
     return {
       ...menuProps,

--- a/src/sentry/static/sentry/app/components/autoComplete.jsx
+++ b/src/sentry/static/sentry/app/components/autoComplete.jsx
@@ -222,6 +222,9 @@ class AutoComplete extends React.Component {
 
   moveHighlightedIndex = (step, e) => {
     let newIndex = this.state.highlightedIndex + step;
+
+    // when this component is in virtualized mode, only a subset of items will be passed
+    // down, making the array length inaccurate. instead we manually pass the length as itemCount
     const listSize = this.itemCount || this.items.size;
 
     // Make sure new index is within bounds

--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -278,7 +278,6 @@ class DropdownAutoCompleteMenu extends React.Component {
     item,
     style,
     itemSize,
-    itemCount,
     key,
     highlightedIndex,
     inputValue,
@@ -296,7 +295,7 @@ class DropdownAutoCompleteMenu extends React.Component {
         key={key}
         index={index}
         highlightedIndex={highlightedIndex}
-        {...getItemProps({item, index, style, itemCount})}
+        {...getItemProps({item, index, style})}
       >
         {typeof item.label === 'function' ? item.label({inputValue}) : item.label}
       </AutoCompleteItem>
@@ -397,7 +396,6 @@ class DropdownAutoCompleteMenu extends React.Component {
                 getActorProps,
                 actions,
                 isOpen,
-                itemCount,
                 selectedItem,
               })}
 

--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -278,6 +278,7 @@ class DropdownAutoCompleteMenu extends React.Component {
     item,
     style,
     itemSize,
+    itemCount,
     key,
     highlightedIndex,
     inputValue,
@@ -295,7 +296,7 @@ class DropdownAutoCompleteMenu extends React.Component {
         key={key}
         index={index}
         highlightedIndex={highlightedIndex}
-        {...getItemProps({item, index, style})}
+        {...getItemProps({item, index, style, itemCount})}
       >
         {typeof item.label === 'function' ? item.label({inputValue}) : item.label}
       </AutoCompleteItem>
@@ -359,6 +360,7 @@ class DropdownAutoCompleteMenu extends React.Component {
           const filterValueOrInput =
             typeof filterValue !== 'undefined' ? filterValue : inputValue;
           // Only filter results if menu is open and there are items
+
           const autoCompleteResults =
             (isOpen &&
               items &&
@@ -380,6 +382,8 @@ class DropdownAutoCompleteMenu extends React.Component {
           // emptyHidesInput is set to true.
           const showInput = !hideInput && (hasItems || !emptyHidesInput);
 
+          const itemCount = autoCompleteResults.filter(i => !i.groupLabel).length;
+
           const renderedFooter =
             typeof menuFooter === 'function' ? menuFooter({actions}) : menuFooter;
 
@@ -393,6 +397,7 @@ class DropdownAutoCompleteMenu extends React.Component {
                 getActorProps,
                 actions,
                 isOpen,
+                itemCount,
                 selectedItem,
               })}
 
@@ -404,6 +409,7 @@ class DropdownAutoCompleteMenu extends React.Component {
                     style,
                     isStyled: true,
                     css: this.props.css,
+                    itemCount,
                     blendCorner,
                     alignMenu,
                     menuWithArrow,

--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -359,7 +359,6 @@ class DropdownAutoCompleteMenu extends React.Component {
           const filterValueOrInput =
             typeof filterValue !== 'undefined' ? filterValue : inputValue;
           // Only filter results if menu is open and there are items
-
           const autoCompleteResults =
             (isOpen &&
               items &&

--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -380,7 +380,11 @@ class DropdownAutoCompleteMenu extends React.Component {
           // emptyHidesInput is set to true.
           const showInput = !hideInput && (hasItems || !emptyHidesInput);
 
-          const itemCount = autoCompleteResults.filter(i => !i.groupLabel).length;
+          // When virtualization is turned on, we need to pass in the number of
+          // selecteable items for arrow-key limits
+          const itemCount =
+            this.props.virtualizedHeight &&
+            autoCompleteResults.filter(i => !i.groupLabel).length;
 
           const renderedFooter =
             typeof menuFooter === 'function' ? menuFooter({actions}) : menuFooter;

--- a/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
@@ -60,6 +60,7 @@ exports[`DropdownAutoCompleteMenu renders with a group 1`] = `
             <StyledMenu
               blendCorner={true}
               innerRef={[Function]}
+              itemCount={2}
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseEnter={[Function]}
@@ -239,6 +240,7 @@ exports[`DropdownAutoCompleteMenu renders without a group 1`] = `
             <StyledMenu
               blendCorner={true}
               innerRef={[Function]}
+              itemCount={3}
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseEnter={[Function]}

--- a/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
@@ -60,7 +60,6 @@ exports[`DropdownAutoCompleteMenu renders with a group 1`] = `
             <StyledMenu
               blendCorner={true}
               innerRef={[Function]}
-              itemCount={2}
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseEnter={[Function]}
@@ -240,7 +239,6 @@ exports[`DropdownAutoCompleteMenu renders without a group 1`] = `
             <StyledMenu
               blendCorner={true}
               innerRef={[Function]}
-              itemCount={3}
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseEnter={[Function]}


### PR DESCRIPTION
![down-key](https://user-images.githubusercontent.com/435981/56521903-c0c13580-64fa-11e9-91ef-215b302bdcc9.gif)

tldr;

* autocomplete counts the number of child items and uses this to determine the limit of the index when arrowing around
* react-virtualized will change the order and number of children fed into autocomplete
* this is generally ok because we keep track of things by an index that is assigned from _above_ virtualized, so virtualized can do it's job in ignorant bliss
* except for the arrow key limit, which is not fed in from above but is instead determined at the autocomplete level, so therefore the limit will more or less cap out at 10. 

here is a diagram:

<pre>
dropdownAutocomplete (100 items)
|-react-virtualized(10/100 items)
  |-autocomplete(10 items)
</pre>

to fix this we feed in the results count from the top (omitting labels):

![down-key-fixed](https://user-images.githubusercontent.com/435981/56526418-1993cc80-6501-11e9-8950-db287e964bba.gif)



