### PR TITLE
fix(sidebar): Fix using wrong pathname

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -175,7 +175,7 @@ class Sidebar extends React.Component {
     ].map(route => `/organizations/${this.props.organization.slug}/${route}/`);
 
     // Only keep the querystring if the current route matches one of the above
-    if (globalSelectionRoutes.includes(this.props.location.pathname)) {
+    if (globalSelectionRoutes.includes(pathname)) {
       const query = extractSelectionParameters(this.props.location.query);
 
       // Handle cmd-click (mac) and meta-click (linux)


### PR DESCRIPTION
This method checks if the current pathname is part of the "global selection routes". This means if you were on issue details page it would fail because it was not apart of the routes that use global selection header. Instead, what we want is to check the target pathname