### PR TITLE
feat(api): Store last used label for project when creating a jira issue from sentry (SEN-440)

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -252,7 +252,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         return '%s/browse/%s' % (self.model.metadata['base_url'], key)
 
     def get_persisted_default_config_fields(self):
-        return ['project', 'issuetype', 'priority']
+        return ['project', 'issuetype', 'priority', 'labels']
 
     def get_group_description(self, group, event, **kwargs):
         output = [
@@ -530,6 +530,8 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                 field['default'] = defaults.get('priority', '')
             elif field['name'] == 'fixVersions':
                 field['choices'] = self.make_choices(client.get_versions(meta['key']))
+            elif field['name'] == 'labels':
+                field['default'] = defaults.get('labels', '')
 
         return fields
 


### PR DESCRIPTION
We want to remember the last used label for an issue and use it when creating other issues within
the same project.