### PR TITLE
feat(saml): Enable urn:federation:authentication:windows

### DIFF
--- a/src/sentry/auth/providers/saml2.py
+++ b/src/sentry/auth/providers/saml2.py
@@ -334,6 +334,10 @@ def build_saml_config(provider_config, org):
         'signatureAlgorithm': avd.get('signature_algorithm', OneLogin_Saml2_Constants.RSA_SHA256),
         'digestAlgorithm': avd.get('digest_algorithm', OneLogin_Saml2_Constants.SHA256),
         'wantNameId': False,
+        'requestedAuthnContext': [
+            'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
+            'urn:federation:authentication:windows',
+        ],
     }
 
     # TODO(epurkhiser): This is also available in the helper and should probably come from there.


### PR DESCRIPTION
Refs: ISSUE-275

This should allow users using Microsoft Azure-AD with Windows integrated authentication to authenticate with SAML to Sentry.

I've verified this doesn't affect normal SAML flows.