### PR TITLE
fix(issues-search): Fix keyboard navigation into recent search

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
@@ -580,12 +580,18 @@ class SmartSearchBar extends React.Component {
           findSearchItemByIndex(searchItems, activeSearchItem) || [];
 
         if (typeof groupIndex !== 'undefined') {
-          // Move active selection up/down
-          delete searchItems[groupIndex].children[childrenIndex].active;
+          if (
+            searchItems[groupIndex] &&
+            searchItems[groupIndex].children &&
+            searchItems[groupIndex].children[childrenIndex]
+          ) {
+            delete searchItems[groupIndex].children[childrenIndex].active;
+          }
         }
 
         const totalItems = flatSearchItems.length;
 
+        // Move active selection up/down
         const nextActiveSearchItem =
           key === 'ArrowDown'
             ? (activeSearchItem + 1) % totalItems
@@ -968,7 +974,7 @@ function createSearchGroups(
 
   return {
     searchItems: [searchGroup, ...(recentSearchItems ? [recentSearchGroup] : [])],
-    flatSearchItems: [...searchItems, ...(recentSearchItems ? [recentSearchItems] : [])],
+    flatSearchItems: [...searchItems, ...(recentSearchItems ? recentSearchItems : [])],
     activeSearchItem,
   };
 }

--- a/tests/js/spec/views/stream/searchBar.spec.jsx
+++ b/tests/js/spec/views/stream/searchBar.spec.jsx
@@ -196,6 +196,41 @@ describe('SearchBar', function() {
         })
       );
     });
+
+    it('cycles through keyboard navigation for selection', async function() {
+      const props = {
+        orgId: '123',
+        query: 'timesSeen:',
+        tagValueLoader: () => {},
+        recentSearchType: 0,
+        displayRecentSearches: true,
+        supportedTags,
+      };
+      jest.useRealTimers();
+      const wrapper = mount(<SearchBar {...props} />, options);
+
+      wrapper.find('input').simulate('change', {target: {value: 'is:'}});
+      await tick();
+      wrapper.update();
+
+      expect(
+        wrapper
+          .find('SearchItem')
+          .at(0)
+          .find('li')
+          .prop('className')
+      ).toContain('active');
+
+      wrapper.find('input').simulate('keyDown', {key: 'ArrowUp'});
+
+      expect(
+        wrapper
+          .find('SearchItem')
+          .last()
+          .find('li')
+          .prop('className')
+      ).toContain('active');
+    });
   });
 
   describe('Pinned Searches', function() {


### PR DESCRIPTION
Issues search bar would crash when navigating into recent search items due to wrong data format.

Fixes JAVASCRIPT-B29