### PR TITLE
fix(discover): Fix loading tags for superusers in Discover

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -46,13 +46,13 @@ export default function createQueryBuilder(initial = {}, organization) {
     query.range = DEFAULT_STATS_PERIOD;
   }
 
-  const defaultProjects = organization.projects
-    .filter(projects => projects.isMember)
-    .map(project => parseInt(project.id, 10));
+  const defaultProjects = organization.projects.filter(projects => projects.isMember);
 
-  const projectsToFetchTags = ConfigStore.get('user').isSuperuser
-    ? organization.projects
-    : defaultProjects;
+  const defaultProjectIds = getProjectIds(defaultProjects);
+
+  const projectsToFetchTags = getProjectIds(
+    ConfigStore.get('user').isSuperuser ? organization.projects : defaultProjects
+  );
 
   const columns = COLUMNS.map(col => ({...col, isTag: false}));
   let tags = [];
@@ -120,7 +120,7 @@ export default function createQueryBuilder(initial = {}, organization) {
    */
   function getExternal() {
     // Default to all projects if none is selected
-    const projects = query.projects.length ? query.projects : defaultProjects;
+    const projects = query.projects.length ? query.projects : defaultProjectIds;
 
     // Default to DEFAULT_STATS_PERIOD when no date range selected (either relative or absolute)
     const {range, start, end} = query;
@@ -322,7 +322,7 @@ export default function createQueryBuilder(initial = {}, organization) {
    */
   function reset(q = {}) {
     const [validProjects, invalidProjects] = partition(q.projects || [], project =>
-      defaultProjects.includes(project)
+      defaultProjectIds.includes(project)
     );
 
     if (invalidProjects.length) {
@@ -340,4 +340,8 @@ export default function createQueryBuilder(initial = {}, organization) {
 
     query = applyDefaults(q);
   }
+}
+
+function getProjectIds(projects) {
+  return projects.map(project => parseInt(project.id, 10));
 }

--- a/tests/js/spec/views/organizationDiscover/queryBuilder.spec.jsx
+++ b/tests/js/spec/views/organizationDiscover/queryBuilder.spec.jsx
@@ -1,5 +1,6 @@
 import createQueryBuilder from 'app/views/organizationDiscover/queryBuilder';
 import {openModal} from 'app/actionCreators/modal';
+import ConfigStore from 'app/stores/configStore';
 
 jest.mock('app/actionCreators/modal');
 
@@ -27,22 +28,32 @@ describe('Query Builder', function() {
   });
 
   describe('loads()', function() {
-    afterEach(function() {
-      MockApiClient.clearMockResponses();
-    });
-
-    it('loads tags', async function() {
-      const discoverMock = MockApiClient.addMockResponse({
+    let discoverMock;
+    beforeEach(function() {
+      discoverMock = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/discover/query/?per_page=1000&cursor=0:0:1',
         method: 'POST',
         body: {
           data: [{tags_key: 'tag1', count: 5}, {tags_key: 'tag2', count: 1}],
         },
       });
+    });
+
+    afterEach(function() {
+      MockApiClient.clearMockResponses();
+    });
+
+    it('loads tags for projects with membership', async function() {
       const queryBuilder = createQueryBuilder(
         {},
-        TestStubs.Organization({projects: [TestStubs.Project()]})
+        TestStubs.Organization({
+          projects: [
+            TestStubs.Project({id: 1, isMember: false}),
+            TestStubs.Project({id: 2}),
+          ],
+        })
       );
+
       await queryBuilder.load();
 
       expect(discoverMock).toHaveBeenCalledWith(
@@ -75,8 +86,52 @@ describe('Query Builder', function() {
       });
     });
 
+    it("loads all project's tags for superuser", async function() {
+      ConfigStore.set('user', TestStubs.User({isSuperuser: true}));
+      const queryBuilder = createQueryBuilder(
+        {},
+        TestStubs.Organization({
+          projects: [
+            TestStubs.Project({id: 1, isMember: false}),
+            TestStubs.Project({id: 2}),
+          ],
+        })
+      );
+
+      await queryBuilder.load();
+
+      expect(discoverMock).toHaveBeenCalledWith(
+        '/organizations/org-slug/discover/query/?per_page=1000&cursor=0:0:1',
+        expect.objectContaining({
+          data: expect.objectContaining({
+            fields: ['tags_key'],
+            aggregations: [['count()', null, 'count']],
+            orderby: '-count',
+            projects: [1, 2],
+            range: '90d',
+          }),
+        })
+      );
+
+      expect(queryBuilder.getColumns()).toContainEqual({
+        name: 'tag1',
+        type: 'string',
+        isTag: true,
+      });
+      expect(queryBuilder.getColumns()).toContainEqual({
+        name: 'tag2',
+        type: 'string',
+        isTag: true,
+      });
+      expect(queryBuilder.getColumns()).not.toContainEqual({
+        name: 'environment',
+        type: 'string',
+        isTag: true,
+      });
+    });
+
     it('loads hardcoded tags when API request fails', async function() {
-      const discoverMock = MockApiClient.addMockResponse({
+      discoverMock = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/discover/query/?per_page=1000&cursor=0:0:1',
         method: 'POST',
       });


### PR DESCRIPTION
Fixes a bug that caused tags to not be loaded correctly for superusers in
Discover. The querybuilder was incorrectly posting a list of project
objects in the request instead of a list of project ids.

Fixes SENTRY-AFQ