### PR TITLE
ref(app-platform): Add ability to filter sentry apps based on status

### DIFF
--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -16,7 +16,6 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
     def get(self, request):
         status = request.GET.get('status')
 
-        queryset = []
         if status == 'published':
             queryset = SentryApp.objects.filter(status=SentryAppStatus.PUBLISHED)
 
@@ -33,8 +32,8 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
         else:
             if request.user.is_superuser:
                 queryset = SentryApp.objects.all()
-
-
+            else:
+                queryset = SentryApp.objects.filter(status=SentryAppStatus.PUBLISHED)
 
         return self.paginate(
             request=request,

--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
+from sentry.auth.superuser import is_active_superuser
 from sentry.api.bases import SentryAppsBaseEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
@@ -20,7 +21,7 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
             queryset = SentryApp.objects.filter(status=SentryAppStatus.PUBLISHED)
 
         elif status == 'unpublished':
-            if request.user.is_superuser:
+            if is_active_superuser(request):
                 queryset = SentryApp.objects.filter(
                     status=SentryAppStatus.UNPUBLISHED
                 )
@@ -30,7 +31,7 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
                     owner__in=request.user.get_orgs(),
                 )
         else:
-            if request.user.is_superuser:
+            if is_active_superuser(request):
                 queryset = SentryApp.objects.all()
             else:
                 queryset = SentryApp.objects.filter(status=SentryAppStatus.PUBLISHED)

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
@@ -43,7 +43,7 @@ class OrganizationIntegrations extends AsyncComponent {
       ['integrations', `/organizations/${orgId}/integrations/`],
       ['plugins', `/organizations/${orgId}/plugins/`, {query}],
       ['orgOwnedApps', `/organizations/${orgId}/sentry-apps/`],
-      ['publishedApps', '/sentry-apps/'],
+      ['publishedApps', `/sentry-apps/?status=${'published'}`],
       ['appInstalls', `/organizations/${orgId}/sentry-app-installations/`],
     ];
   }
@@ -168,7 +168,13 @@ class OrganizationIntegrations extends AsyncComponent {
 
   renderBody() {
     const {reloading, orgOwnedApps, publishedApps, appInstalls} = this.state;
-    const applications = (publishedApps || []).concat(orgOwnedApps || []);
+    const published = publishedApps || [];
+    // we dont want the app to render twice if its the org that created
+    // the published app.
+    const orgOwned = orgOwnedApps.filter(app => {
+      return !published.find(p => p.slug == app.slug);
+    });
+    const applications = published.concat(orgOwned);
 
     const installedProviders = this.providers
       .filter(p => p.isInstalled)

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
@@ -43,7 +43,7 @@ class OrganizationIntegrations extends AsyncComponent {
       ['integrations', `/organizations/${orgId}/integrations/`],
       ['plugins', `/organizations/${orgId}/plugins/`, {query}],
       ['orgOwnedApps', `/organizations/${orgId}/sentry-apps/`],
-      ['publishedApps', `/sentry-apps/?status=${'published'}`],
+      ['publishedApps', '/sentry-apps/', {status: 'published'}],
       ['appInstalls', `/organizations/${orgId}/sentry-app-installations/`],
     ];
   }

--- a/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
@@ -83,7 +83,7 @@ describe('OrganizationIntegrations', () => {
     });
 
     publishedSentryAppsRequest = Client.addMockResponse({
-      url: '/sentry-apps/',
+      url: `/sentry-apps/?status=${'published'}`,
       body: [],
     });
 
@@ -243,6 +243,25 @@ describe('OrganizationIntegrations', () => {
           .simulate('click');
 
         expect(openIntegrationDetails).toHaveBeenCalledWith(options);
+      });
+    });
+
+    describe('published and org-owned apps are consolidated', () => {
+      it('renders sentry app once', () => {
+        const publishedApp = {...sentryApp, status: 'published'};
+        Client.addMockResponse({
+          url: `/organizations/${org.slug}/sentry-apps/`,
+          body: [publishedApp],
+        });
+        Client.addMockResponse({
+          url: `/sentry-apps/?status=${'published'}`,
+          body: [publishedApp],
+        });
+        wrapper = mount(
+          <OrganizationIntegrations organization={org} params={params} />,
+          routerContext
+        );
+        expect(wrapper.find('SentryAppInstallations').length).toBe(1);
       });
     });
 

--- a/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
@@ -83,7 +83,7 @@ describe('OrganizationIntegrations', () => {
     });
 
     publishedSentryAppsRequest = Client.addMockResponse({
-      url: `/sentry-apps/?status=${'published'}`,
+      url: '/sentry-apps/',
       body: [],
     });
 
@@ -254,7 +254,7 @@ describe('OrganizationIntegrations', () => {
           body: [publishedApp],
         });
         Client.addMockResponse({
-          url: `/sentry-apps/?status=${'published'}`,
+          url: '/sentry-apps/',
           body: [publishedApp],
         });
         wrapper = mount(

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -75,7 +75,7 @@ class GetSentryAppsTest(SentryAppsTest):
             }
         } in json.loads(response.content)
 
-    def test_superuser_can_filter_apps_on_status(self):
+    def test_superuser_filter_on_published(self):
         self.login_as(user=self.superuser, superuser=True)
         url = u'{}?status=published'.format(self.url)
         response = self.client.get(url, format='json')
@@ -106,7 +106,18 @@ class GetSentryAppsTest(SentryAppsTest):
         assert self.unpublished_app.uuid not in response_uuids
         assert self.unowned_unpublished_app.uuid not in response_uuids
 
-    def test_user_can_filter_apps_on_status(self):
+    def test_superuser_filter_on_unpublished(self):
+        self.login_as(user=self.superuser, superuser=True)
+        url = u'{}?status=unpublished'.format(self.url)
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200
+        response_uuids = set(o['uuid'] for o in response.data)
+        assert self.unpublished_app.uuid in response_uuids
+        assert self.unowned_unpublished_app.uuid in response_uuids
+        assert self.published_app.uuid not in response_uuids
+
+    def test_user_filter_on_unpublished(self):
         self.login_as(user=self.user)
         url = u'{}?status=unpublished'.format(self.url)
         response = self.client.get(url, format='json')
@@ -136,6 +147,17 @@ class GetSentryAppsTest(SentryAppsTest):
         response_uuids = set(o['uuid'] for o in response.data)
         assert self.published_app.uuid not in response_uuids
         assert self.unowned_unpublished_app.uuid not in response_uuids
+
+        def test_user_filter_on_published(self):
+            self.login_as(user=self.user)
+            url = u'{}?status=published'.format(self.url)
+            response = self.client.get(url, format='json')
+
+            assert response.status_code == 200
+            response_uuids = set(o['uuid'] for o in response.data)
+            assert self.published_app.uuid in response_uuids
+            assert self.unpublished_app not in response_uuids
+            assert self.unowned_unpublished_app.uuid not in response_uuids
 
     def test_users_dont_see_unpublished_apps_their_org_owns(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -51,7 +51,6 @@ class GetSentryAppsTest(SentryAppsTest):
 
     def test_users_see_published_apps(self):
         self.login_as(user=self.user)
-
         response = self.client.get(self.url, format='json')
 
         assert response.status_code == 200
@@ -75,6 +74,37 @@ class GetSentryAppsTest(SentryAppsTest):
                 'slug': self.org.slug,
             }
         } in json.loads(response.content)
+
+    def test_superuser_can_filter_apps_on_status(self):
+        self.login_as(user=self.superuser, superuser=True)
+        url = u'{}?status=published'.format(self.url)
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200
+        assert {
+            'name': self.published_app.name,
+            'author': self.published_app.author,
+            'slug': self.published_app.slug,
+            'scopes': [],
+            'events': [],
+            'status': self.published_app.get_status_display(),
+            'uuid': self.published_app.uuid,
+            'webhookUrl': self.published_app.webhook_url,
+            'redirectUrl': self.published_app.redirect_url,
+            'isAlertable': self.published_app.is_alertable,
+            'clientId': self.published_app.application.client_id,
+            'clientSecret': self.published_app.application.client_secret,
+            'overview': self.published_app.overview,
+            'schema': {},
+            'owner': {
+                'id': self.org.id,
+                'slug': self.org.slug,
+            }
+        } in json.loads(response.content)
+
+        response_uuids = set(o['uuid'] for o in response.data)
+        assert self.unpublished_app.uuid not in response_uuids
+        assert self.unowned_unpublished_app.uuid not in response_uuids
 
     def test_users_dont_see_unpublished_apps_their_org_owns(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -106,6 +106,37 @@ class GetSentryAppsTest(SentryAppsTest):
         assert self.unpublished_app.uuid not in response_uuids
         assert self.unowned_unpublished_app.uuid not in response_uuids
 
+    def test_user_can_filter_apps_on_status(self):
+        self.login_as(user=self.user)
+        url = u'{}?status=unpublished'.format(self.url)
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200
+        assert {
+            'name': self.unpublished_app.name,
+            'author': self.unpublished_app.author,
+            'slug': self.unpublished_app.slug,
+            'scopes': [],
+            'events': [],
+            'status': self.unpublished_app.get_status_display(),
+            'uuid': self.unpublished_app.uuid,
+            'webhookUrl': self.unpublished_app.webhook_url,
+            'redirectUrl': self.unpublished_app.redirect_url,
+            'isAlertable': self.unpublished_app.is_alertable,
+            'clientId': self.unpublished_app.application.client_id,
+            'clientSecret': self.unpublished_app.application.client_secret,
+            'overview': self.unpublished_app.overview,
+            'schema': {},
+            'owner': {
+                'id': self.org.id,
+                'slug': self.org.slug,
+            }
+        } in json.loads(response.content)
+
+        response_uuids = set(o['uuid'] for o in response.data)
+        assert self.published_app.uuid not in response_uuids
+        assert self.unowned_unpublished_app.uuid not in response_uuids
+
     def test_users_dont_see_unpublished_apps_their_org_owns(self):
         self.login_as(user=self.user)
 


### PR DESCRIPTION
**Problem:**
The integration page will render an app twice if it is both published and owned by the org the user is in. Additionally superusers see apps that don't need to be rendered there at all (unpublished apps from different orgs) 

**Solution:**
Allow for filtering on `status`. When there is no status param, published apps will be returned for anyone that is not a superuser. If it is a superuser, we'll return everything. 