### PR TITLE
fix(slack): Use event message/type when available

### DIFF
--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -85,8 +85,11 @@ def build_attachment_title(group, event=None):
 
 
 def build_attachment_text(group, event=None):
-    ev_metadata = group.get_event_metadata()
-    ev_type = group.get_event_type()
+    # Group and Event both implement get_event_{type,metadata}
+    obj = event if event is not None else group
+    ev_metadata = obj.get_event_metadata()
+    ev_type = obj.get_event_type()
+
     if ev_type == 'error':
         return ev_metadata.get('value') or ev_metadata.get('function')
     else:


### PR DESCRIPTION
Fixes ISSUE-416

Pulls the text for the slack notification message/type from the event when available.