### PR TITLE
fix(jira) Don't 500 when request token requests timeout

### DIFF
--- a/src/sentry/integrations/exceptions.py
+++ b/src/sentry/integrations/exceptions.py
@@ -43,7 +43,7 @@ class ApiHostError(ApiError):
 
     @classmethod
     def from_exception(cls, exception):
-        if hasattr(exception, 'request'):
+        if getattr(exception, 'request'):
             return cls.from_request(exception.request)
         return cls('Unable to reach host')
 
@@ -51,6 +51,21 @@ class ApiHostError(ApiError):
     def from_request(cls, request):
         host = urlparse(request.url).netloc
         return cls(u'Unable to reach host: {}'.format(host))
+
+
+class ApiTimeoutError(ApiError):
+    code = 504
+
+    @classmethod
+    def from_exception(cls, exception):
+        if getattr(exception, 'request'):
+            return cls.from_request(exception.request)
+        return cls('Timed out reaching host')
+
+    @classmethod
+    def from_request(cls, request):
+        host = urlparse(request.url).netloc
+        return cls(u'Timed out attempting to reach host: {}'.format(host))
 
 
 class ApiUnauthorized(ApiError):

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -762,7 +762,7 @@ class JiraIntegrationProvider(IntegrationProvider):
         return []
 
     def build_integration(self, state):
-        # Most information is not availabe during integration install time,
+        # Most information is not available during integration installation,
         # since the integration won't have been fully configired on JIRA's side
         # yet, we can't make API calls for more details like the server name or
         # Icon.

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -180,7 +180,7 @@ class OAuthLoginView(PipelineView):
             return self.redirect(authorize_url)
         except ApiError as error:
             logger.info('identity.jira-server.request-token', extra={'error': error})
-            return pipeline.error('Could not fetch a request token from Jira')
+            return pipeline.error('Could not fetch a request token from Jira. %s' % error)
 
 
 class OAuthCallbackView(PipelineView):


### PR DESCRIPTION
When a customer's jira-server times out while getting a request token we don't need to 500. Instead we should convert the timeout to an ApiError instance which all integrations should be handling correctly.

Fixes SEN-511
Fixes SENTRY-AG9