### PR TITLE
fix(jira) Don't 500 when oauth tokens are revoked

### DIFF
--- a/src/sentry/integrations/exceptions.py
+++ b/src/sentry/integrations/exceptions.py
@@ -43,7 +43,7 @@ class ApiHostError(ApiError):
 
     @classmethod
     def from_exception(cls, exception):
-        if hasattr(exception, 'request'):
+        if getattr(exception, 'request'):
             return cls.from_request(exception.request)
         return cls('Unable to reach host')
 

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -179,7 +179,10 @@ class OAuthLoginView(PipelineView):
 
             return self.redirect(authorize_url)
         except ApiError as error:
-            logger.info('identity.jira-server.request-token', extra={'error': error})
+            logger.info('identity.jira-server.request-token', extra={
+                'url': config.get('url'),
+                'error': error
+            })
             return pipeline.error('Could not fetch a request token from Jira')
 
 


### PR DESCRIPTION
If an oauth token is revoked or expired we shouldn't 500 when handling jira & jira server webhooks. Instead we can reply with a 400 and hope that one day the user deletes the webhook.

Fixes SENTRY-9PF
Fixes SENTRY-AA2