### PR TITLE
fix(ui) Fix zindex woes in hovercards.

### DIFF
--- a/src/sentry/static/sentry/app/components/hovercard.jsx
+++ b/src/sentry/static/sentry/app/components/hovercard.jsx
@@ -155,7 +155,8 @@ const StyledHovercard = styled('div')`
   text-align: left;
   padding: 0;
   line-height: 1;
-  z-index: 1000;
+  /* Some hovercards overlap the toplevel header, so we need the same zindex to appear on top */
+  z-index: ${p => p.theme.zIndex.globalSelectionHeader};
   white-space: initial;
   color: ${p => p.theme.gray5};
   border: 1px solid ${p => p.theme.borderLight};


### PR DESCRIPTION
Stack hovercards at the same height as the global selection header so that they appear on top of the global header should they intersect.

![Screen Shot 2019-04-23 at 3 47 33 PM](https://user-images.githubusercontent.com/24086/56611149-21c23980-65df-11e9-806a-a5f60c3f2cc4.png)

Fixes SEN-514