### PR TITLE
fix(api): Fix bug where serialization fails for a pull request that is related to a removed repo (SEN-516)

### DIFF
--- a/src/sentry/api/serializers/models/pullrequest.py
+++ b/src/sentry/api/serializers/models/pullrequest.py
@@ -36,9 +36,12 @@ class PullRequestSerializer(Serializer):
         result = {}
         for item in item_list:
             repository_id = six.text_type(item.repository_id)
+            external_url = ''
+            if item.repository_id in repository_map:
+                external_url = self._external_url(repository_map[item.repository_id], item)
             result[item] = {
                 'repository': serialized_repos.get(repository_id, {}),
-                'external_url': self._external_url(repository_map[item.repository_id], item),
+                'external_url': external_url,
                 'user': users_by_author.get(six.text_type(item.author_id), {})
                 if item.author_id else {},
             }

--- a/tests/sentry/api/serializers/test_pull_request.py
+++ b/tests/sentry/api/serializers/test_pull_request.py
@@ -110,3 +110,25 @@ class PullRequestSerializerTest(TestCase):
         assert result['title'] == 'cool pr'
         assert result['repository']['name'] == 'test/test'
         assert result['author'] == {'name': 'stebe', 'email': 'stebe@sentry.io'}
+
+    def test_deleted_repository(self):
+        commit_author = CommitAuthor.objects.create(
+            name='stebe',
+            email='stebe@sentry.io',
+            organization_id=self.project.organization_id,
+        )
+        pull_request = PullRequest.objects.create(
+            organization_id=self.project.organization_id,
+            repository_id=12345,
+            key='9',
+            author=commit_author,
+            message='waddap',
+            title="cool pr"
+        )
+        result = serialize(pull_request, self.user)
+
+        assert result['message'] == pull_request.message
+        assert result['title'] == pull_request.title
+        assert result['repository'] == {}
+        assert result['author'] == {'name': commit_author.name, 'email': commit_author.email}
+        assert result['externalUrl'] == ''


### PR DESCRIPTION
We have an issue that has a pr associated with it, but the repository associated with the pr has
been deleted. This causes an issue with serialization, so just have the externalUrl be blank if the
repository doesn't exist.

Fixes SENTRY-AE5