### PR TITLE
fix(github) Fix github:enterprise issue search not working 

### DIFF
--- a/src/sentry/integrations/github/search.py
+++ b/src/sentry/integrations/github/search.py
@@ -32,7 +32,7 @@ class GitHubSearchEndpoint(IntegrationEndpoint):
                 return Response({'detail': 'repo is a required parameter'}, status=400)
 
             try:
-                response = installation.get_client().search_issues(
+                response = installation.search_issues(
                     query=(u'repo:%s %s' % (repo, query)).encode('utf-8'),
                 )
             except ApiError as err:

--- a/src/sentry/integrations/github/search.py
+++ b/src/sentry/integrations/github/search.py
@@ -32,7 +32,7 @@ class GitHubSearchEndpoint(IntegrationEndpoint):
                 return Response({'detail': 'repo is a required parameter'}, status=400)
 
             try:
-                response = installation.search_issues(
+                response = installation.get_client().search_issues(
                     query=(u'repo:%s %s' % (repo, query)).encode('utf-8'),
                 )
             except ApiError as err:

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -111,6 +111,9 @@ class GitHubEnterpriseIntegration(IntegrationInstallation, GitHubIssueBasic, Rep
             data.append({'name': repo['name'], 'identifier': repo['full_name']})
         return data
 
+    def search_issues(self, query):
+        return self.get_client().search_issues(query)
+
     def reinstall(self):
         installation_id = self.model.external_id.split(':')[1]
         metadata = self.model.metadata

--- a/tests/sentry/integrations/github_enterprise/test_search.py
+++ b/tests/sentry/integrations/github_enterprise/test_search.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import
+
+from datetime import datetime, timedelta
+from sentry.models import Integration
+from ..github.test_search import GithubSearchTest
+
+
+class GithubEnterpriseSearchTest(GithubSearchTest):
+    # Inherit test methods/scenarios from GithubSearchTest
+    # and fill out the slots that customize it to use github:enterprise
+    provider = 'github_enterprise'
+    base_url = 'https://github.example.org/api/v3'
+
+    def create_integration(self):
+        future = datetime.now() + timedelta(hours=1)
+        return Integration.objects.create(
+            provider=self.provider,
+            name='test',
+            external_id=9999,
+            metadata={
+                'domain_name': 'github.example.org',
+                'account_type': 'Organization',
+                'access_token': '123456789',
+                'expires_at': future.replace(microsecond=0).isoformat(),
+                'installation': {
+                    'private_key': 'some private key',
+                    'id': 123456,
+                    'verify_ssl': True
+                }
+            }
+        )


### PR DESCRIPTION
Adapting the changes from #12882 to not require abstraction piercing and also add tests for github:enterprise issue search as there were none before.