### PR TITLE
feat(js): Better route strings from routes array

### DIFF
--- a/src/sentry/static/sentry/app/utils/getRouteStringFromRoutes.jsx
+++ b/src/sentry/static/sentry/app/utils/getRouteStringFromRoutes.jsx
@@ -1,7 +1,10 @@
+import {findLastIndex} from 'lodash';
+
 /**
  * Creates a route string from an array of `routes` from react-router
- * Note this is currently only used for error context logging. It does
- * not attempt to do anything smart (e.g. absolute vs relative paths in the list)
+ *
+ * It will look for the last route path that begins with a `/` and
+ * concatenate all of the following routes. Skips any routes without a path
  *
  * @param {Array<{}>} routes An array of route objects from react-router
  * @return String Returns a route path
@@ -11,13 +14,15 @@ export default function getRouteStringFromRoutes(routes) {
     return '';
   }
 
-  // Strip the first route (path: '/') since the subsequent children routes
-  // are all absolute paths
-  return (
-    '/' +
-    routes
-      .filter(r => r.path)
-      .map(r => r.path.replace(/^\//, ''))
-      .join('')
+  const routesWithPaths = routes.filter(({path}) => !!path);
+
+  const lastAbsolutePathIndex = findLastIndex(routesWithPaths, ({path}) =>
+    path.startsWith('/')
   );
+
+  return routesWithPaths
+    .slice(lastAbsolutePathIndex)
+    .filter(({path}) => !!path)
+    .map(({path}) => path)
+    .join('');
 }

--- a/tests/js/spec/utils/getRouteStringFromRoutes.spec.jsx
+++ b/tests/js/spec/utils/getRouteStringFromRoutes.spec.jsx
@@ -6,12 +6,12 @@ describe('getRouteStringFromRoutes', function() {
     {path: '/:orgId/'},
     {name: 'this should be skipped'},
     {path: '/organizations/:orgId/'},
+    {name: 'also skipped'},
     {path: 'api-keys/', name: 'API Key'},
   ];
+
   it('can get a route string from routes array and skips routes that do not have a path', function() {
-    expect(getRouteStringFromRoutes(routes)).toBe(
-      '/:orgId/organizations/:orgId/api-keys/'
-    );
+    expect(getRouteStringFromRoutes(routes)).toBe('/organizations/:orgId/api-keys/');
   });
 
   it('handles invalid `routes` values', function() {

--- a/tests/js/spec/views/routeError.spec.jsx
+++ b/tests/js/spec/views/routeError.spec.jsx
@@ -7,7 +7,10 @@ import {RouteError} from 'app/views/routeError';
 jest.mock('jquery');
 
 describe('RouteError', function() {
-  beforeEach(function() {});
+  afterEach(function() {
+    Sentry.captureException.mockClear();
+    Sentry.showReportDialog.mockClear();
+  });
 
   it('captures errors with raven', async function() {
     const error = new Error('Big Bad Error');
@@ -18,7 +21,7 @@ describe('RouteError', function() {
 
     expect(Sentry.captureException).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: 'Big Bad Error: /:orgId/organizations/:orgId/api-keys/',
+        message: 'Big Bad Error: /organizations/:orgId/api-keys/',
       })
     );
 

--- a/tests/js/spec/views/settings/components/settingsBreadcrumb/breadcrumbTitle.spec.jsx
+++ b/tests/js/spec/views/settings/components/settingsBreadcrumb/breadcrumbTitle.spec.jsx
@@ -51,6 +51,6 @@ describe('BreadcrumbTitle', function() {
     // Simulate navigating up a level, trimming the last title
     breadcrumbs.setProps({routes: upOneRoutes});
     await tick();
-    expect(SettingsBreadcrumbStore.pathMap).toEqual({'/one/two/': 'Second Title'});
+    expect(SettingsBreadcrumbStore.pathMap).toEqual({'/two/': 'Second Title'});
   });
 });


### PR DESCRIPTION
Previously, we were simply concatenating all route paths together. react-router supports nested routes that can specify either "absolute" or "relative" paths. Instead of concatenating all paths, only look at the most deeply nested route that has an "absolute" (begins with `/`) path and concatenate paths after that route.