### PR TITLE
fix(saved-searches): Fix empty query string as valid search

### DIFF
--- a/src/sentry/static/sentry/app/utils/withSavedSearches.jsx
+++ b/src/sentry/static/sentry/app/utils/withSavedSearches.jsx
@@ -39,7 +39,13 @@ const withSavedSearches = WrappedComponent =>
 
               // If there's no direct saved search being requested (via URL route)
               // *AND* there's no query in URL, then check if there is pinned search
-              if (hasFeature && !savedSearch && !location.query.query) {
+              //
+              // Note: Don't use pinned searches when there is an empty query (query == empty string)
+              if (
+                hasFeature &&
+                !savedSearch &&
+                typeof location.query.query === 'undefined'
+              ) {
                 const pin = savedSearches.find(search => search.isPinned);
                 savedSearch = pin ? pin : null;
               }

--- a/tests/js/spec/views/organizationStream/overview.spec.jsx
+++ b/tests/js/spec/views/organizationStream/overview.spec.jsx
@@ -391,6 +391,39 @@ describe('OrganizationStream', function() {
       expect(getSavedSearchTitle(wrapper)).toBe('Custom Search');
     });
 
+    it('loads with an empty query in URL', async function() {
+      savedSearchesRequest = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/searches/',
+        body: [
+          TestStubs.Search({
+            id: '123',
+            name: 'My Pinned Search',
+            isPinned: true,
+            isGlobal: false,
+            isOrgCustom: false,
+            query: 'is:resolved',
+          }),
+        ],
+      });
+      createWrapper({location: {query: {query: ''}}});
+
+      await tick();
+      wrapper.update();
+
+      expect(issuesRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          // Should be called with empty query
+          data: expect.stringContaining(''),
+        })
+      );
+
+      expect(getSearchBarValue(wrapper)).toBe('');
+
+      // Organization saved search selector should have default saved search selected
+      expect(getSavedSearchTitle(wrapper)).toBe('Custom Search');
+    });
+
     it('selects a saved search and changes sort', async function() {
       const localSavedSearch = {...savedSearch, projectId: null};
       savedSearchesRequest = MockApiClient.addMockResponse({


### PR DESCRIPTION
This fixes the situation where you have a pinned query and you delete all search terms. Previously it would default to a pinned search.

Fixes SEN-531