### PR TITLE
fix(ui): Remove thin transparent line atop PanelAlert's

### DIFF
--- a/src/sentry/static/sentry/app/components/panels/panelAlert.jsx
+++ b/src/sentry/static/sentry/app/components/panels/panelAlert.jsx
@@ -15,7 +15,7 @@ const DEFAULT_ICONS = {
 const PanelAlert = styled(({type, icon, ...props}) => (
   <Alert {...props} icon={icon || DEFAULT_ICONS[type]} type={type} system={true} />
 ))`
-  margin: 1px 0;
+  margin: 0 0 1px 0;
   border-radius: 0;
 `;
 


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/1421724/56630513-7b8a2a00-6606-11e9-8c2a-626099063083.png)

After
![image](https://user-images.githubusercontent.com/1421724/56630483-61e8e280-6606-11e9-9c5f-50e1a3eb0469.png)
