### PR TITLE
fix(ui): PlatformPicker filter input line-height

### DIFF
--- a/src/sentry/static/sentry/app/components/platformPicker.jsx
+++ b/src/sentry/static/sentry/app/components/platformPicker.jsx
@@ -171,6 +171,8 @@ const SearchBar = styled('div')`
     background: none;
     padding: 2px 4px;
     width: 100%;
+    /* Ensure a consistent line height to keep the input the desired height */
+    line-height: 24px;
 
     &:focus {
       outline: none;

--- a/tests/js/spec/components/__snapshots__/createProject.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/createProject.spec.jsx.snap
@@ -333,7 +333,7 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
           </CategoryNav>
           <SearchBar>
             <div
-              className="css-otjzwm-SearchBar-inputStyles exv4dm81"
+              className="css-1tdbwvk-SearchBar-inputStyles exv4dm81"
             >
               <InlineSvg
                 src="icon-search"
@@ -1893,7 +1893,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
           </CategoryNav>
           <SearchBar>
             <div
-              className="css-otjzwm-SearchBar-inputStyles exv4dm81"
+              className="css-1tdbwvk-SearchBar-inputStyles exv4dm81"
             >
               <InlineSvg
                 src="icon-search"
@@ -2859,7 +2859,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
           </CategoryNav>
           <SearchBar>
             <div
-              className="css-otjzwm-SearchBar-inputStyles exv4dm81"
+              className="css-1tdbwvk-SearchBar-inputStyles exv4dm81"
             >
               <InlineSvg
                 src="icon-search"


### PR DESCRIPTION
Specifically in the settings page this causes problems, since we set the line-height to 1