### PR TITLE
fix(commands): Delete old ApiTokens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ base_acceptance: &acceptance_default
     - yarn install --pure-lockfile
     - python setup.py install_egg_info
     - pip install -e ".[dev,tests,optional]"
-    - wget -N "https://chromedriver.storage.googleapis.com/2.45/chromedriver_linux64.zip" -P ~/
+    - wget -N "https://chromedriver.storage.googleapis.com/$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_74)/chromedriver_linux64.zip" -P ~/
     - unzip ~/chromedriver_linux64.zip -d ~/
     - rm ~/chromedriver_linux64.zip
     - sudo install -m755 ~/chromedriver /usr/local/bin/

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -221,7 +221,9 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
             if not silent:
                 click.echo(u'>> Skipping {}'.format(model.__name__))
         else:
-            model.objects.filter(expires_at__lt=timezone.now()).delete()
+            model.objects.filter(
+                expires_at__lt=(timezone.now() - timedelta(days=days)),
+            ).delete()
 
     project_id = None
     if project:


### PR DESCRIPTION
The ApiToken cleanup was deleting tokens immediately, instead of honoring the --days argument to the script.

This was causing integrations to not be able to refresh tokens since they didn't exist when they tried to.