### PR TITLE
fix(ui) Update store when saved searches are deleted

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/savedSearches.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/savedSearches.jsx
@@ -187,6 +187,7 @@ export function deleteSavedSearch(api, orgId, search) {
     .requestPromise(url, {
       method: 'DELETE',
     })
+    .then(() => SavedSearchesActions.deleteSavedSearchSuccess(search))
     .catch(handleXhrErrorResponse('Unable to delete a saved search'));
 
   return promise;

--- a/src/sentry/static/sentry/app/stores/savedSearchesStore.jsx
+++ b/src/sentry/static/sentry/app/stores/savedSearchesStore.jsx
@@ -129,6 +129,15 @@ const SavedSearchesStore = Reflux.createStore({
     this.trigger(this.state);
   },
 
+  onDeleteSavedSearchSuccess(search) {
+    this.state = {
+      ...this.state,
+      savedSearches: this.state.savedSearches.filter(item => item.id !== search.id),
+    };
+
+    this.trigger(this.state);
+  },
+
   onPinSearch(type, query, ...args) {
     const existingSearch = this.findByQuery(query);
 

--- a/tests/js/spec/stores/savedSearchesStore.spec.jsx
+++ b/tests/js/spec/stores/savedSearchesStore.spec.jsx
@@ -1,6 +1,7 @@
 import SavedSearchesStore from 'app/stores/savedSearchesStore';
 import {
   fetchSavedSearches,
+  deleteSavedSearch,
   pinSearch,
   unpinSearch,
 } from 'app/actionCreators/savedSearches';
@@ -258,5 +259,23 @@ describe('SavedSearchesStore', function() {
         query: 'is:unresolved',
       })
     );
+  });
+
+  it('removes deleted saved searches', async function() {
+    await fetchSavedSearches(api, 'org-1', {});
+    await tick();
+
+    const searches = SavedSearchesStore.get().savedSearches;
+    Client.addMockResponse({
+      url: `/organizations/org-1/searches/${searches[0].id}/`,
+      method: 'DELETE',
+      body: {},
+    });
+    await deleteSavedSearch(api, 'org-1', searches[0]);
+    await tick();
+
+    const newSearches = SavedSearchesStore.get().savedSearches;
+    expect(newSearches.length).toBeLessThan(searches.length);
+    expect(newSearches[0].id).not.toBe(searches[0].id);
   });
 });


### PR DESCRIPTION
When a saved search is deleted we need to update the store so that changes are reflected without a page reload.

Fixes SEN-530