### PR TITLE
fix(saved-search) Fix stale state being used when saving searches

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/createSavedSearchButton.jsx
+++ b/src/sentry/static/sentry/app/views/stream/createSavedSearchButton.jsx
@@ -22,19 +22,17 @@ class CreateSavedSearchButton extends React.Component {
     organization: SentryTypes.Organization.isRequired,
   };
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      isModalOpen: false,
-      isSaving: false,
-      query: props.query,
-      name: '',
-      error: null,
-    };
-  }
+  state = {
+    isModalOpen: false,
+    isSaving: false,
+    name: '',
+    error: null,
+    query: null,
+  };
 
   onSubmit = e => {
     const {api, organization} = this.props;
+    const query = this.state.query || this.props.query;
 
     e.preventDefault();
 
@@ -42,7 +40,7 @@ class CreateSavedSearchButton extends React.Component {
 
     addLoadingMessage(t('Saving Changes'));
 
-    createSavedSearch(api, organization.slug, this.state.name, this.state.query)
+    createSavedSearch(api, organization.slug, this.state.name, query)
       .then(data => {
         this.onToggle();
         this.setState({

--- a/src/sentry/static/sentry/app/views/stream/createSavedSearchButton.jsx
+++ b/src/sentry/static/sentry/app/views/stream/createSavedSearchButton.jsx
@@ -63,9 +63,15 @@ class CreateSavedSearchButton extends React.Component {
   };
 
   onToggle = event => {
-    this.setState({
+    const newState = {
       isModalOpen: !this.state.isModalOpen,
-    });
+    };
+    if (newState.isModalOpen === false) {
+      newState.name = '';
+      newState.error = null;
+      newState.query = null;
+    }
+    this.setState(newState);
 
     if (event) {
       event.preventDefault();

--- a/tests/js/spec/views/stream/createSavedSearchButton.spec.jsx
+++ b/tests/js/spec/views/stream/createSavedSearchButton.spec.jsx
@@ -37,7 +37,7 @@ describe('CreateSavedSearchButton', function() {
       expect(wrapper.find('ModalDialog')).toHaveLength(1);
     });
 
-    it('saves a search', async function() {
+    it('saves a search when query is not changed', async function() {
       wrapper.find('button[data-test-id="save-current-search"]').simulate('click');
       wrapper.find('#id-name').simulate('change', {target: {value: 'new search name'}});
       wrapper
@@ -52,6 +52,28 @@ describe('CreateSavedSearchButton', function() {
           data: {
             name: 'new search name',
             query: 'is:unresolved assigned:lyn@sentry.io',
+            type: 0,
+          },
+        })
+      );
+    });
+
+    it('saves a search when query is changed', async function() {
+      wrapper.find('button[data-test-id="save-current-search"]').simulate('click');
+      wrapper.find('#id-name').simulate('change', {target: {value: 'new search name'}});
+      wrapper.find('#id-query').simulate('change', {target: {value: 'is:resolved'}});
+      wrapper
+        .find('ModalDialog')
+        .find('Button[priority="primary"]')
+        .simulate('submit');
+
+      await tick();
+      expect(createMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: {
+            name: 'new search name',
+            query: 'is:resolved',
             type: 0,
           },
         })


### PR DESCRIPTION
Don't duplicate state from props into state. Instead prefer state over props when saving.

Fixes SEN-534