### PR TITLE
fix(ui) Improve tooltips and hover states for search bar icons

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
@@ -707,10 +707,13 @@ class SmartSearchBar extends React.Component {
       dropdownClassName,
       hasPinnedSearch,
       organization,
+      pinnedSearch,
       placeholder,
       disabled,
       onSidebarToggle,
     } = this.props;
+
+    const pinTooltip = !!pinnedSearch ? t('Unpin this search') : t('Pin this search');
 
     if (hasPinnedSearch) {
       return (
@@ -748,15 +751,15 @@ class SmartSearchBar extends React.Component {
               query={this.state.query}
               organization={organization}
             />
-            <Tooltip title={t('Pin this search')}>
+            <Tooltip title={pinTooltip}>
               <Button
                 type="button"
                 borderless
-                aria-label={t('Pin this search')}
+                aria-label={pinTooltip}
                 size="zero"
                 onClick={this.onTogglePinnedSearch}
               >
-                <PinIcon isPinned={!!this.props.pinnedSearch} src="icon-pin" />
+                <PinIcon isPinned={!!pinnedSearch} src="icon-pin" />
               </Button>
             </Tooltip>
             <SidebarButton
@@ -847,7 +850,7 @@ const SmartSearchBarContainer = withApi(
 const PinIcon = styled(InlineSvg)`
   fill: ${p => (p.isPinned ? p.theme.blueLight : p.theme.gray2)};
   &:hover {
-    fill: ${p => p.theme.blueLight};
+    fill: ${p => p.theme.gray3};
   }
 `;
 
@@ -916,6 +919,9 @@ const StyledInput = styled.input`
 const SidebarButton = styled(Button)`
   & svg {
     color: ${p => p.theme.gray2};
+  }
+  &:hover svg {
+    color: ${p => p.theme.gray3};
   }
   .show-sidebar & svg {
     color: ${p => p.theme.blueLight};

--- a/src/sentry/static/sentry/app/views/stream/createSavedSearchButton.jsx
+++ b/src/sentry/static/sentry/app/views/stream/createSavedSearchButton.jsx
@@ -154,7 +154,7 @@ class CreateSavedSearchButton extends React.Component {
 
 const StyledButton = styled(Button)`
   & svg {
-    color: ${p => p.theme.gray6};
+    color: ${p => p.theme.gray2};
   }
   &:hover svg {
     color: ${p => p.theme.gray3};

--- a/tests/js/spec/components/smartSearchBar.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar.spec.jsx
@@ -483,7 +483,7 @@ describe('SmartSearchBar', function() {
         options
       );
 
-      wrapper.find('button[aria-label="Pin this search"]').simulate('click');
+      wrapper.find('button[aria-label="Unpin this search"]').simulate('click');
       await wrapper.update();
 
       expect(pinRequest).not.toHaveBeenCalled();

--- a/tests/js/spec/views/stream/searchBar.spec.jsx
+++ b/tests/js/spec/views/stream/searchBar.spec.jsx
@@ -309,7 +309,7 @@ describe('SearchBar', function() {
         pinnedSearch: {id: '1', query: 'url:"fu"'},
       };
       const searchBar = mount(<SearchBar {...props} />, routerContext);
-      searchBar.find('button[aria-label="Pin this search"]').simulate('click');
+      searchBar.find('button[aria-label="Unpin this search"]').simulate('click');
 
       expect(unpinSearch).toHaveBeenLastCalledWith(
         expect.anything(),


### PR DESCRIPTION
Make the hover colour consistent across the search bar icons. Also update the tooltip to indicate the unpin action.

![search bar buttons](https://user-images.githubusercontent.com/24086/56678420-a8831f00-6690-11e9-8ef5-9274985bb633.gif)

Fixes SEN-533