### PR TITLE
feat: `full` parameter for event list APIs

### DIFF
--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -16,7 +16,7 @@ from sentry.api.event_search import get_snuba_query_args
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.environments import get_environments
 from sentry.api.helpers.events import get_direct_hit_response
-from sentry.api.serializers import serialize, SimpleEventSerializer
+from sentry.api.serializers import EventSerializer, serialize, SimpleEventSerializer
 from sentry.api.paginator import DateTimePaginator, GenericOffsetPaginator
 from sentry.api.utils import get_date_range_from_params
 from sentry.models import Event, Group, SnubaEvent
@@ -101,7 +101,8 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
             **snuba_args
         )
 
-        serializer = SimpleEventSerializer()
+        full = request.GET.get('full', False)
+        serializer = EventSerializer() if full else SimpleEventSerializer()
         return self.paginate(
             request=request,
             on_results=lambda results: serialize(

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError, NoProjects
 from sentry.api.helpers.events import get_direct_hit_response
 from sentry.api.paginator import GenericOffsetPaginator
-from sentry.api.serializers import serialize, SimpleEventSerializer
+from sentry.api.serializers import EventSerializer, serialize, SimpleEventSerializer
 from sentry.api.serializers.snuba import SnubaTSResultSerializer
 from sentry.models import SnubaEvent
 from sentry.utils.dates import parse_stats_period
@@ -55,7 +55,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                 **snuba_args
             )
 
-        serializer = SimpleEventSerializer()
+        full = request.GET.get('full', False)
+        serializer = EventSerializer() if full else SimpleEventSerializer()
         return self.paginate(
             request=request,
             on_results=lambda results: serialize(

--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -7,7 +7,7 @@ from functools import partial
 from sentry import options
 from sentry.api.base import DocSection
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.api.serializers import serialize
+from sentry.api.serializers import EventSerializer, serialize, SimpleEventSerializer
 from sentry.utils.apidocs import scenario, attach_scenarios
 
 
@@ -76,10 +76,12 @@ class ProjectEventsEndpoint(ProjectEndpoint):
             referrer='api.project-events',
         )
 
+        full = request.GET.get('full', False)
+        serializer = EventSerializer() if full else SimpleEventSerializer()
         return self.paginate(
             request=request,
             on_results=lambda results: serialize(
-                [SnubaEvent(row) for row in results], request.user),
+                [SnubaEvent(row) for row in results], request.user, serializer),
             paginator=GenericOffsetPaginator(data_fn=data_fn)
         )
 

--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -63,6 +63,8 @@ class ProjectEventsEndpoint(ProjectEndpoint):
             conditions.append(
                 [['positionCaseInsensitive', ['message', "'%s'" % (query,)]], '!=', 0])
 
+        full = request.GET.get('full', False)
+        snuba_cols = SnubaEvent.minimal_columns if full else SnubaEvent.selected_columns
         now = timezone.now()
         data_fn = partial(
             # extract 'data' from raw_query result
@@ -71,12 +73,11 @@ class ProjectEventsEndpoint(ProjectEndpoint):
             end=now,
             conditions=conditions,
             filter_keys={'project_id': [project.id]},
-            selected_columns=SnubaEvent.minimal_columns,
+            selected_columns=snuba_cols,
             orderby='-timestamp',
             referrer='api.project-events',
         )
 
-        full = request.GET.get('full', False)
         serializer = EventSerializer() if full else SimpleEventSerializer()
         return self.paginate(
             request=request,


### PR DESCRIPTION
For (org/project/group) event list apis, add the option of a 'full'
parameter that serializes the complete event (with stacktraces etc)
but defaults to False, meaning these event lists will render with the
SimpleEventSerializer by default. the Simple version is faster/better
for cases where we don't need all details of every event, just enough
info to render a table/list view.

Changes in behavior:
Currently the org-events and group-events lists are already set to
render the Simple version so the default behavior doesn't change,
but the project-events is set to render the full one, this PR changes 
that so that all of them render the Simple version by default.