### PR TITLE
fix(ui) Use more consistent language for resolve by commit

### DIFF
--- a/src/sentry/static/sentry/app/components/activity/item.jsx
+++ b/src/sentry/static/sentry/app/components/activity/item.jsx
@@ -129,7 +129,7 @@ class ActivityItem extends React.Component {
           issue: issueLink,
         });
       case 'set_resolved_in_commit':
-        return tct('[author] marked [issue] as fixed in [version]', {
+        return tct('[author] marked [issue] as resolved in [version]', {
           author,
           version: (
             <CommitLink
@@ -141,7 +141,7 @@ class ActivityItem extends React.Component {
           issue: issueLink,
         });
       case 'set_resolved_in_pull_request':
-        return tct('[author] marked [issue] as fixed in [version]', {
+        return tct('[author] marked [issue] as resolved in [version]', {
           author,
           version: (
             <PullRequestLink

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/groupActivity.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/groupActivity.jsx
@@ -63,7 +63,7 @@ class GroupActivityItem extends React.Component {
             })
           : t('%s marked this issue as resolved in the upcoming release', author);
       case 'set_resolved_in_commit':
-        return t('%(author)s marked this issue as fixed in %(version)s', {
+        return t('%(author)s marked this issue as resolved in %(version)s', {
           author,
           version: (
             <CommitLink
@@ -74,7 +74,7 @@ class GroupActivityItem extends React.Component {
           ),
         });
       case 'set_resolved_in_pull_request':
-        return t('%(author)s marked this issue as fixed in %(version)s', {
+        return t('%(author)s marked this issue as resolved in %(version)s', {
           author,
           version: (
             <PullRequestLink


### PR DESCRIPTION
In the issue details resolution info box we say 'resolved in commit', but on the activity stream for a group and organization we were using 'fixed in commit'. This makes the language consistent preferring 'resolved' as that is the status name we use everywhere else.

Fixes FEEDBACK-381