### PR TITLE
ref(api): Allow superusers to see permalink

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -340,7 +340,7 @@ class GroupSerializerBase(Serializer):
 
         # If user is not logged in and member of the organization,
         # do not return the permalink which contains private information i.e. org name.
-        if user.is_authenticated() and user.get_orgs().filter(id=obj.organization.id).exists():
+        if user.is_superuser or user.is_authenticated() and user.get_orgs().filter(id=obj.organization.id).exists():
             permalink = obj.get_absolute_url()
         else:
             permalink = None

--- a/tests/sentry/api/endpoints/test_shared_group_details.py
+++ b/tests/sentry/api/endpoints/test_shared_group_details.py
@@ -82,3 +82,10 @@ class SharedGroupDetailsTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert response.data['permalink']  # show permalink when logged in
+
+        superuser = self.create_user(email='foo@example.com', is_superuser=True)
+        self.login_as(user=superuser, superuser=True)
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert response.data['permalink']  # show permalink when superuser


### PR DESCRIPTION
`group.permalink` is used [here](https://github.com/getsentry/sentry/blob/master/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueForm.jsx#L104) and causes issues for superusers
