### PR TITLE
feat(incidents): Add "Create New Incident" modal

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/modal.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/modal.jsx
@@ -69,7 +69,7 @@ export function openCreateIncidentModal(options = {}) {
     .then(mod => mod.default)
     .then(Modal => {
       openModal(deps => <Modal {...deps} {...options} />, {
-        modalClassName: 'create-team-modal',
+        modalClassName: 'create-incident-modal',
       });
     });
 }

--- a/src/sentry/static/sentry/app/actionCreators/modal.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/modal.jsx
@@ -63,6 +63,20 @@ export function openDiffModal(options) {
 /**
  * @param Object options
  * @param Object options.organization The organization to create a team for
+ */
+export function openCreateIncidentModal(options = {}) {
+  import(/* webpackChunkName: "CreateIncidentModal" */ '../components/modals/createIncidentModal')
+    .then(mod => mod.default)
+    .then(Modal => {
+      openModal(deps => <Modal {...deps} {...options} />, {
+        modalClassName: 'create-team-modal',
+      });
+    });
+}
+
+/**
+ * @param Object options
+ * @param Object options.organization The organization to create a team for
  * @param Object options.project (optional) An initial project to add the team to. This may be deprecated soon as
  * we may add a project selection inside of the modal flow
  */

--- a/src/sentry/static/sentry/app/actionCreators/modal.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/modal.jsx
@@ -65,7 +65,7 @@ export function openDiffModal(options) {
  * @param Object options.organization The organization to create a team for
  */
 export function openCreateIncidentModal(options = {}) {
-  import(/* webpackChunkName: "CreateIncidentModal" */ '../components/modals/createIncidentModal')
+  import(/* webpackChunkName: "CreateIncidentModal" */ 'app/components/modals/createIncidentModal')
     .then(mod => mod.default)
     .then(Modal => {
       openModal(deps => <Modal {...deps} {...options} />, {

--- a/src/sentry/static/sentry/app/components/modals/createIncidentModal.jsx
+++ b/src/sentry/static/sentry/app/components/modals/createIncidentModal.jsx
@@ -1,0 +1,62 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import {t} from 'app/locale';
+import Form from 'app/views/settings/components/forms/form';
+// import SentryTypes from 'app/sentryTypes';
+import TextField from 'app/views/settings/components/forms/textField';
+
+class CreateIncidentModal extends React.Component {
+  static propTypes = {
+    closeModal: PropTypes.func,
+    onClose: PropTypes.func,
+    Body: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
+    Header: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
+    // organization: SentryTypes.Organization.isRequired,
+  };
+
+  handleSubmit = (data, onSuccess, onError) => {
+    // TODO(billy): Actually create incident and handle success follow up
+  };
+
+  handleSuccess = data => {
+    if (this.props.onClose) {
+      this.props.onClose(data);
+    }
+
+    this.props.closeModal();
+  };
+
+  render() {
+    const {Body, Header, closeModal} = this.props;
+
+    return (
+      <React.Fragment>
+        <Header closeButton onHide={closeModal}>
+          {t('Create New Incident')}
+        </Header>
+        <Body>
+          <Form
+            submitLabel={t('Create Incident')}
+            onSubmit={this.handleSubmit}
+            onSubmitSuccess={this.handleSuccess}
+            requireChanges
+          >
+            <TextField
+              name="name"
+              label={t('Incident Name')}
+              placeholder={t('Incident Name')}
+              help={t('Give a name to help identify the incident')}
+              required
+              stacked
+              inline={false}
+              flexibleControlStateSize
+            />
+          </Form>
+        </Body>
+      </React.Fragment>
+    );
+  }
+}
+
+export default CreateIncidentModal;

--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -681,6 +681,7 @@ const OrganizationStream = createReactClass({
 
           <Panel>
             <StreamActions
+              organization={organization}
               orgId={organization.slug}
               projectId={projectId}
               selection={this.props.selection}

--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -6,20 +6,23 @@ import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
 
+import {openCreateIncidentModal} from 'app/actionCreators/modal';
 import {t, tct, tn} from 'app/locale';
 import ActionLink from 'app/components/actions/actionLink';
-import withApi from 'app/utils/withApi';
 import Checkbox from 'app/components/checkbox';
 import DropdownLink from 'app/components/dropdownLink';
 import ExternalLink from 'app/components/externalLink';
+import Feature from 'app/components/acl/feature';
 import IgnoreActions from 'app/components/actions/ignore';
 import IndicatorStore from 'app/stores/indicatorStore';
+import InlineSvg from 'app/components/inlineSvg';
 import MenuItem from 'app/components/menuItem';
 import ResolveActions from 'app/components/actions/resolve';
 import SelectedGroupStore from 'app/stores/selectedGroupStore';
 import SentryTypes from 'app/sentryTypes';
 import ToolbarHeader from 'app/components/toolbarHeader';
 import Tooltip from 'app/components/tooltip';
+import withApi from 'app/utils/withApi';
 
 const BULK_LIMIT = 1000;
 const BULK_LIMIT_STR = BULK_LIMIT.toLocaleString();
@@ -152,6 +155,7 @@ const StreamActions = createReactClass({
     queryCount: PropTypes.number,
     hasReleases: PropTypes.bool,
     latestRelease: PropTypes.object,
+    organization: SentryTypes.Organization,
   },
 
   mixins: [Reflux.listenTo(SelectedGroupStore, 'onSelectedGroupChange')],
@@ -320,6 +324,7 @@ const StreamActions = createReactClass({
       query,
       realtimeActive,
       statsPeriod,
+      organization,
     } = this.props;
     const issues = this.state.selectedIds;
     const numIssues = issues.size;
@@ -385,6 +390,20 @@ const StreamActions = createReactClass({
                 <i aria-hidden="true" className="icon-star-solid" />
               </ActionLink>
             </div>
+
+            <Feature features={['incidents']}>
+              <div className="btn-group hidden-xs">
+                <ActionLink
+                  className="btn btn-default btn-sm hidden-sm hidden-xs"
+                  title={t('Create new incident')}
+                  disabled={!anySelected}
+                  onAction={() => openCreateIncidentModal({organization})}
+                >
+                  <InlineSvg src="icon-circle-add" />
+                </ActionLink>
+              </div>
+            </Feature>
+
             <div className="btn-group">
               <DropdownLink
                 key="actions"

--- a/tests/js/spec/views/organizationStream/overview.spec.jsx
+++ b/tests/js/spec/views/organizationStream/overview.spec.jsx
@@ -1193,4 +1193,8 @@ describe('OrganizationStream', function() {
       expect(wrapper.find(ErrorRobot)).toHaveLength(0);
     });
   });
+
+  describe('Incidents', function() {
+    it.todo('creates an incident by selecting issues from stream');
+  });
 });


### PR DESCRIPTION
When one or more issues are selected in stream, allow button to open a create new incident modal that asks for incident name.

Note this is currently not hooked up to the API.

Closes SEN-523