### PR TITLE
fix(ui): Handle ProjectsStore updates in ProjectContext

### DIFF
--- a/src/sentry/static/sentry/app/views/projects/projectContext.jsx
+++ b/src/sentry/static/sentry/app/views/projects/projectContext.jsx
@@ -99,7 +99,7 @@ const ProjectContext = createReactClass({
     // added. Re-fetch project details in case that the new project is the active
     // project.
     //
-    // For now, only compare lengths. It is possible that proeject slugs within
+    // For now, only compare lengths. It is possible that project slugs within
     // the list could change, but it doesn't seem to be broken anywhere else at
     // the moment that would require deeper checks.
     if (prevProps.projects.length !== this.props.projects.length) {

--- a/src/sentry/static/sentry/app/views/projects/projectContext.jsx
+++ b/src/sentry/static/sentry/app/views/projects/projectContext.jsx
@@ -95,6 +95,17 @@ const ProjectContext = createReactClass({
       this.fetchData();
     }
 
+    // Project list has changed. Likely indicating that a new project has been
+    // added. Re-fetch project details in case that the new project is the active
+    // project.
+    //
+    // For now, only compare lengths. It is possible that proeject slugs within
+    // the list could change, but it doesn't seem to be broken anywhere else at
+    // the moment that would require deeper checks.
+    if (prevProps.projects.length !== this.props.projects.length) {
+      this.fetchData();
+    }
+
     // Call forceUpdate() on <DocumentTitle/> if either project or organization
     // state has changed. This is because <DocumentTitle/>'s shouldComponentUpdate()
     // returns false unless props differ; meaning context changes for project/org
@@ -148,7 +159,7 @@ const ProjectContext = createReactClass({
     return projects.find(({slug}) => slug === projectSlug) || null;
   },
 
-  fetchData() {
+  async fetchData() {
     const {orgId, projectId, location, skipReload} = this.props;
     // we fetch core access/information from the global organization data
     const activeProject = this.identifyProject();
@@ -168,61 +179,63 @@ const ProjectContext = createReactClass({
       );
 
       const environmentRequest = this.props.api.requestPromise(
-        this.getEnvironmentListEndpoint()
+        `/projects/${orgId}/${projectId}/environments/`
       );
 
-      Promise.all([projectRequest, environmentRequest]).then(
-        ([project, envs]) => {
-          this.setState({
-            loading: false,
-            project,
-            error: false,
-            errorType: null,
-          });
+      try {
+        const [project, envs] = await Promise.all([projectRequest, environmentRequest]);
+        this.setState({
+          loading: false,
+          project,
+          error: false,
+          errorType: null,
+        });
 
-          // assuming here that this means the project is considered the active project
-          setActiveProject(project);
+        // assuming here that this means the project is considered the active project
+        setActiveProject(project);
 
-          // If an environment is specified in the query string, load it instead of default
-          const queryEnv = location.query.environment;
-          // The default environment cannot be "" (No Environment)
-          const {defaultEnvironment} = project;
-          const envName = typeof queryEnv === 'undefined' ? defaultEnvironment : queryEnv;
-          loadEnvironments(envs, envName);
-        },
-        () => {
-          this.setState({
-            loading: false,
-            error: false,
-            errorType: ERROR_TYPES.UNKNOWN,
-          });
-        }
-      );
+        // If an environment is specified in the query string, load it instead of default
+        const queryEnv = location.query.environment;
+        // The default environment cannot be "" (No Environment)
+        const {defaultEnvironment} = project;
+        const envName = typeof queryEnv === 'undefined' ? defaultEnvironment : queryEnv;
+        loadEnvironments(envs, envName);
+      } catch (error) {
+        this.setState({
+          loading: false,
+          error: false,
+          errorType: ERROR_TYPES.UNKNOWN,
+        });
+      }
 
       fetchOrgMembers(this.props.api, orgId, activeProject.id);
-    } else if (activeProject && !activeProject.isMember) {
+
+      return;
+    }
+
+    // User is not a memberof the active project
+    if (activeProject && !activeProject.isMember) {
       this.setState({
         loading: false,
         error: true,
         errorType: ERROR_TYPES.MISSING_MEMBERSHIP,
       });
-    } else {
-      // The request is a 404 or other error
-      this.props.api.request(`/projects/${orgId}/${projectId}/`, {
-        error: () => {
-          this.setState({
-            loading: false,
-            error: true,
-            errorType: ERROR_TYPES.PROJECT_NOT_FOUND,
-          });
-        },
+
+      return;
+    }
+
+    // There is no active project. This likely indicates either the project
+    // *does not exist* or the project has not yet been added to the store.
+    // Either way, make a request to check for existence of the project.
+    try {
+      await this.props.api.requestPromise(`/projects/${orgId}/${projectId}/`);
+    } catch (error) {
+      this.setState({
+        loading: false,
+        error: true,
+        errorType: ERROR_TYPES.PROJECT_NOT_FOUND,
       });
     }
-  },
-
-  getEnvironmentListEndpoint() {
-    const {orgId, projectId} = this.props;
-    return `/projects/${orgId}/${projectId}/environments/`;
   },
 
   setProjectNavSection(section) {

--- a/tests/js/spec/views/projects/projectContext.spec.jsx
+++ b/tests/js/spec/views/projects/projectContext.spec.jsx
@@ -118,4 +118,47 @@ describe('projectContext component', function() {
 
     expect(fetchMock).toHaveBeenCalled();
   });
+
+  it('fetches data again if projects list changes', function() {
+    const router = TestStubs.router();
+    const fetchMock = MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/`,
+      method: 'GET',
+      statusCode: 200,
+      body: project,
+    });
+
+    const projectContext = (
+      <ProjectContext
+        api={new MockApiClient()}
+        params={{orgId: org.slug, projectId: project.slug}}
+        projects={[]}
+        routes={routes}
+        router={router}
+        location={location}
+        orgId={org.slug}
+        projectId={project.slug}
+      />
+    );
+
+    const wrapper = mount(projectContext, {
+      context: {organization: org},
+      childContextTypes: {organization: SentryTypes.Organization},
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // The project will become active, thus requesting org members
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/users/`,
+      method: 'GET',
+      statusCode: 200,
+      body: [],
+    });
+
+    wrapper.setProps({projects: [project]});
+    wrapper.update();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
In the case where the list of projects is updated in the ProjectsStore, the ProjectContext component will never handle that list changing, thus if the projectId was not in the list at fetchData time, but does exist, it will never complete loading as there is never a setState call that clears the loading indicator. The project state will also never be correctly set.

This fixes this issue by calling fetchData again if the projects list changes.

This currently doesn't handle deep equals (if the project slugs change) but I believe that to not be an issue, since this problem has not appeared anywhere else outside of onboarding project creation