### PR TITLE
feat: Turn on global project access for org admins

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
@@ -301,15 +301,16 @@ class GlobalSelectionHeader extends React.Component {
   };
 
   getProjects = () => {
-    const {projects} = this.props;
+    const {organization, projects} = this.props;
     const {isSuperuser} = ConfigStore.get('user');
+    const isOrgAdmin = new Set(organization.access).has('org:admin');
 
     const [memberProjects, nonMemberProjects] = partition(
       projects,
       project => project.isMember
     );
 
-    if (isSuperuser) {
+    if (isSuperuser || isOrgAdmin) {
       return [memberProjects, nonMemberProjects];
     }
 

--- a/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/queryBuilder.jsx
@@ -50,8 +50,11 @@ export default function createQueryBuilder(initial = {}, organization) {
 
   const defaultProjectIds = getProjectIds(defaultProjects);
 
+  const hasGlobalProjectAccess =
+    ConfigStore.get('user').isSuperuser || organization.access.includes('org:admin');
+
   const projectsToFetchTags = getProjectIds(
-    ConfigStore.get('user').isSuperuser ? organization.projects : defaultProjects
+    hasGlobalProjectAccess ? organization.projects : defaultProjects
   );
 
   const columns = COLUMNS.map(col => ({...col, isTag: false}));


### PR DESCRIPTION
Org admins can now view all projects via the project selector. Projects
without membership are not selected by default and are listed under the
"Projects I don't belong to heading". This is the same behavior that
superusers currently have in Sentry. This brings the project selection
behavior closer to what it was previously in Sentry 9, where admins
could see all projects without explicitly joining a team.

Closes SEN-491