### PR TITLE
fix(issues-stream): Reset saved searches store when unmounting Stream

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/savedSearches.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/savedSearches.jsx
@@ -4,6 +4,10 @@ import {t} from 'app/locale';
 import SavedSearchesActions from 'app/actions/savedSearchesActions';
 import handleXhrErrorResponse from 'app/utils/handleXhrErrorResponse';
 
+export function resetSavedSearches() {
+  SavedSearchesActions.resetSavedSearches();
+}
+
 export function fetchSavedSearches(api, orgId, projectMap, useOrgSavedSearches = false) {
   const url = `/organizations/${orgId}/searches/`;
 

--- a/src/sentry/static/sentry/app/actions/savedSearchesActions.jsx
+++ b/src/sentry/static/sentry/app/actions/savedSearchesActions.jsx
@@ -1,6 +1,7 @@
 import Reflux from 'reflux';
 
 export default Reflux.createActions([
+  'resetSavedSearches',
   'startFetchSavedSearches',
   'fetchSavedSearchesSuccess',
   'fetchSavedSearchesError',

--- a/src/sentry/static/sentry/app/stores/savedSearchesStore.jsx
+++ b/src/sentry/static/sentry/app/stores/savedSearchesStore.jsx
@@ -13,12 +13,14 @@ const SavedSearchesStore = Reflux.createStore({
       deleteSavedSearchSuccess,
       pinSearch,
       pinSearchSuccess,
+      resetSavedSearches,
       unpinSearch,
     } = SavedSearchesActions;
 
     this.listenTo(startFetchSavedSearches, this.onStartFetchSavedSearches);
     this.listenTo(fetchSavedSearchesSuccess, this.onFetchSavedSearchesSuccess);
     this.listenTo(fetchSavedSearchesError, this.onFetchSavedSearchesError);
+    this.listenTo(resetSavedSearches, this.onReset);
     this.listenTo(createSavedSearchSuccess, this.onCreateSavedSearchSuccess);
     this.listenTo(deleteSavedSearchSuccess, this.onDeleteSavedSearchSuccess);
     this.listenTo(pinSearch, this.onPinSearch);
@@ -93,6 +95,14 @@ const SavedSearchesStore = Reflux.createStore({
    */
   findByQuery(query) {
     return this.state.savedSearches.find(savedSearch => query === savedSearch.query);
+  },
+
+  /**
+   * Reset store to initial state
+   */
+  onReset() {
+    this.reset();
+    this.trigger(this.state);
   },
 
   onStartFetchSavedSearches() {

--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -11,10 +11,14 @@ import qs from 'query-string';
 import {Client} from 'app/api';
 import {Panel, PanelBody} from 'app/components/panels';
 import {analytics} from 'app/utils/analytics';
+import {
+  deleteSavedSearch,
+  fetchSavedSearches,
+  resetSavedSearches,
+} from 'app/actionCreators/savedSearches';
 import {extractSelectionParameters} from 'app/components/organizations/globalSelectionHeader/utils';
 import {fetchOrgMembers, indexMembersByProject} from 'app/actionCreators/members';
 import {fetchOrganizationTags, fetchTagValues} from 'app/actionCreators/tags';
-import {fetchSavedSearches, deleteSavedSearch} from 'app/actionCreators/savedSearches';
 import {getUtcDateString} from 'app/utils/dates';
 import {t} from 'app/locale';
 import ConfigStore from 'app/stores/configStore';
@@ -160,6 +164,18 @@ const OrganizationStream = createReactClass({
     this.projectCache = {};
     GroupStore.reset();
     this.api.clear();
+
+    // Reset store when unmounting because we always fetch on mount
+    // This means if you navigate away from stream and then back to stream,
+    // this component will go from:
+    // "ready" ->
+    // "loading" (because fetching saved searches) ->
+    // "ready"
+    //
+    // We don't render anything until saved searches is ready, so this can
+    // cause weird side effects (e.g. ProcessingIssueList mounting and making
+    // a request, but immediately unmounting when fetching saved searches)
+    resetSavedSearches();
   },
 
   // Memoize projects fetched as selections are made


### PR DESCRIPTION
This fixes a bug where the Stream goes from "ready" -> "loading" -> "ready" causing components to be unmounted and re-mounted due to the loading caused by fetching saved searches.

We may want to revisit how we load since there are two loaders waiting for 1) saved searches and 2) issues stream. We could reduce down to 1 loader if we had a disabled+loading state for the org saved searches and search input.

Although this content is unlikely to change often, we don't do any cacheing elsewhere in the app, so I opted to just clear the store on unmount.


Fixes SEN-535