### PR TITLE
build(storybook): Rename babel config back to ".babelrc"

### DIFF
--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -1,0 +1,24 @@
+/* storybook@4.x.x does not seem to support any other babel config filename */
+{
+  "presets": ["@babel/react", "@babel/env"],
+  "plugins": [
+    "emotion",
+    "lodash",
+    "react-hot-loader/babel",
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-proposal-object-rest-spread",
+    "@babel/plugin-proposal-optional-chaining",
+    "@babel/plugin-transform-runtime",
+    ["@babel/plugin-proposal-decorators", {"legacy": true}],
+    ["@babel/plugin-proposal-class-properties", {"loose": true}]
+  ],
+  "env": {
+    "production": {},
+    "development": {
+      "plugins": [["emotion", {"sourceMap": true, "autoLabel": true}]]
+    },
+    "test": {
+      "plugins": [["emotion", {"autoLabel": true}], "dynamic-import-node"]
+    }
+  }
+}

--- a/.storybook/babel.config.js
+++ b/.storybook/babel.config.js
@@ -1,2 +1,0 @@
-/*eslint-env node*/
-module.exports = require('../babel.config');


### PR DESCRIPTION
This is because storybook (at least our version) only seems to support this filename :(