### PR TITLE
fix(issues-stream): Fix when project slug is "constructor"

### DIFF
--- a/src/sentry/static/sentry/app/components/groupList.jsx
+++ b/src/sentry/static/sentry/app/components/groupList.jsx
@@ -170,10 +170,10 @@ const GroupList = createReactClass({
         <GroupListHeader />
         <PanelBody>
           {this.state.groups.map(({id, project}) => {
-            let members = null;
-            if (this.state.memberList) {
-              members = this.state.memberList[project.slug] || null;
-            }
+            const members =
+              this.state.memberList && this.state.memberList.hasOwnProperty(project.slug)
+                ? this.state.memberList[project.slug]
+                : null;
 
             return (
               <StreamGroup


### PR DESCRIPTION
Issues streak breaks if members list has not yet loaded and we have a project named "constructor"

Fixes JAVASCRIPT-9E3