### PR TITLE
feat: Restructure interfaces to support after-the-fact function trimming

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -44,6 +44,7 @@ class EventSerializer(Serializer):
     def _get_entries(self, event, user, is_public=False):
         # XXX(dcramer): These are called entries for future-proofing
 
+        platform = event.platform
         meta = event.data.get('_meta') or {}
         interface_list = []
 
@@ -52,7 +53,7 @@ class EventSerializer(Serializer):
             if key in self._reserved_keys:
                 continue
 
-            data = interface.get_api_context(is_public=is_public)
+            data = interface.get_api_context(is_public=is_public, platform=platform)
             # data might not be returned for e.g. a public HTTP repr
             if not data:
                 continue
@@ -64,7 +65,8 @@ class EventSerializer(Serializer):
 
             api_meta = None
             if meta.get(key):
-                api_meta = interface.get_api_meta(meta[key], is_public=is_public)
+                api_meta = interface.get_api_meta(meta[key], is_public=is_public,
+                                                  platform=platform)
                 api_meta = meta_with_chunks(data, api_meta)
 
             interface_list.append((interface, entry, api_meta))
@@ -82,12 +84,14 @@ class EventSerializer(Serializer):
         if not interface:
             return (None, None)
 
-        data = interface.get_api_context(is_public=is_public)
+        platform = event.platform
+        data = interface.get_api_context(is_public=is_public, platform=platform)
         event_meta = event.data.get('_meta') or {}
         if not data or not event_meta.get(name):
             return (data, None)
 
-        api_meta = interface.get_api_meta(event_meta[name], is_public=is_public)
+        api_meta = interface.get_api_meta(event_meta[name], is_public=is_public,
+                                          platform=platform)
         # data might not be returned for e.g. a public HTTP repr
         if not api_meta:
             return (data, None)

--- a/src/sentry/interfaces/base.py
+++ b/src/sentry/interfaces/base.py
@@ -152,10 +152,10 @@ class Interface(object):
         """Returns the underlying raw data."""
         return self._data
 
-    def get_api_context(self, is_public=False):
+    def get_api_context(self, is_public=False, platform=None):
         return self.to_json()
 
-    def get_api_meta(self, meta, is_public=False):
+    def get_api_meta(self, meta, is_public=False, platform=None):
         return meta
 
     def to_json(self):

--- a/src/sentry/interfaces/breadcrumbs.py
+++ b/src/sentry/interfaces/breadcrumbs.py
@@ -134,7 +134,7 @@ class Breadcrumbs(Interface):
             'data': data
         }
 
-    def get_api_context(self, is_public=False):
+    def get_api_context(self, is_public=False, platform=None):
         def _convert(x):
             return {
                 'type': x['type'],
@@ -150,7 +150,7 @@ class Breadcrumbs(Interface):
             'values': [_convert(v) for v in self.values],
         }
 
-    def get_api_meta(self, meta, is_public=False):
+    def get_api_meta(self, meta, is_public=False, platform=None):
         if meta and 'values' not in meta:
             return {'values': meta}
         else:

--- a/src/sentry/interfaces/exception.py
+++ b/src/sentry/interfaces/exception.py
@@ -365,18 +365,19 @@ class SingleException(Interface):
             'raw_stacktrace': raw_stacktrace,
         })
 
-    def get_api_context(self, is_public=False):
+    def get_api_context(self, is_public=False, platform=None):
         mechanism = isinstance(self.mechanism, Mechanism) and \
-            self.mechanism.get_api_context(is_public=is_public) or \
+            self.mechanism.get_api_context(is_public=is_public, platform=platform) or \
             self.mechanism or None
 
         if self.stacktrace:
-            stacktrace = self.stacktrace.get_api_context(is_public=is_public)
+            stacktrace = self.stacktrace.get_api_context(is_public=is_public, platform=platform)
         else:
             stacktrace = None
 
         if self.raw_stacktrace:
-            raw_stacktrace = self.raw_stacktrace.get_api_context(is_public=is_public)
+            raw_stacktrace = self.raw_stacktrace.get_api_context(
+                is_public=is_public, platform=platform)
         else:
             raw_stacktrace = None
 
@@ -390,12 +391,13 @@ class SingleException(Interface):
             'rawStacktrace': raw_stacktrace,
         }
 
-    def get_api_meta(self, meta, is_public=False):
-        mechanism_meta = self.mechanism.get_api_meta(meta['mechanism'], is_public=is_public) \
+    def get_api_meta(self, meta, is_public=False, platform=None):
+        mechanism_meta = self.mechanism.get_api_meta(
+            meta['mechanism'], is_public=is_public, platform=platform) \
             if isinstance(self.mechanism, Mechanism) and meta.get('mechanism') \
             else None
 
-        stacktrace_meta = self.stacktrace.get_api_meta(meta, is_public=is_public) \
+        stacktrace_meta = self.stacktrace.get_api_meta(meta, is_public=is_public, platform=platform) \
             if self.stacktrace and meta.get('stacktrace') \
             else None
 
@@ -505,16 +507,17 @@ class Exception(Interface):
             'exc_omitted': self.exc_omitted,
         })
 
-    def get_api_context(self, is_public=False):
+    def get_api_context(self, is_public=False, platform=None):
         return {
-            'values': [v.get_api_context(is_public=is_public) for v in self.values if v],
+            'values': [v.get_api_context(is_public=is_public, platform=platform)
+                       for v in self.values if v],
             'hasSystemFrames':
             any(v.stacktrace.get_has_system_frames() for v in self.values if v and v.stacktrace),
             'excOmitted':
             self.exc_omitted,
         }
 
-    def get_api_meta(self, meta, is_public=False):
+    def get_api_meta(self, meta, is_public=False, platform=None):
         if not meta:
             return meta
 
@@ -523,7 +526,8 @@ class Exception(Interface):
         for index, value in six.iteritems(values):
             exc = self.values[int(index)]
             if exc is not None:
-                result[index] = exc.get_api_meta(value, is_public=is_public)
+                result[index] = exc.get_api_meta(value, is_public=is_public,
+                                                 platform=platform)
 
         return {'values': result}
 

--- a/src/sentry/interfaces/http.py
+++ b/src/sentry/interfaces/http.py
@@ -284,7 +284,7 @@ class Http(Interface):
     def get_title(self):
         return _('Request')
 
-    def get_api_context(self, is_public=False):
+    def get_api_context(self, is_public=False, platform=None):
         if is_public:
             return {}
 
@@ -309,7 +309,7 @@ class Http(Interface):
         }
         return data
 
-    def get_api_meta(self, meta, is_public=False):
+    def get_api_meta(self, meta, is_public=False, platform=None):
         if is_public:
             return None
 

--- a/src/sentry/interfaces/sdk.py
+++ b/src/sentry/interfaces/sdk.py
@@ -90,7 +90,7 @@ class Sdk(Interface):
             'packages': self.packages or None
         })
 
-    def get_api_context(self, is_public=False):
+    def get_api_context(self, is_public=False, platform=None):
         newest_version = get_with_prefix(settings.SDK_VERSIONS, self.name)
         newest_name = get_with_prefix(settings.DEPRECATED_SDKS, self.name, self.name)
 
@@ -117,7 +117,7 @@ class Sdk(Interface):
             },
         }
 
-    def get_api_meta(self, meta, is_public=False):
+    def get_api_meta(self, meta, is_public=False, platform=None):
         return {
             '': meta.get(''),
             'name': meta.get('name'),

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -356,7 +356,7 @@ class Frame(Interface):
             'colno': self.colno
         })
 
-    def get_api_context(self, is_public=False, pad_addr=None):
+    def get_api_context(self, is_public=False, pad_addr=None, platform=None):
         data = {
             'filename': self.filename,
             'absPath': self.abs_path,
@@ -398,7 +398,7 @@ class Frame(Interface):
 
         return data
 
-    def get_meta_context(self, meta, is_public=False):
+    def get_meta_context(self, meta, is_public=False, platform=None):
         if not meta:
             return
 
@@ -654,11 +654,12 @@ class Stacktrace(Interface):
             rv = max_addr(rv, frame.symbol_addr)
         return rv
 
-    def get_api_context(self, is_public=False):
+    def get_api_context(self, is_public=False, platform=None):
         longest_addr = self.get_longest_address()
 
         frame_list = [
-            f.get_api_context(is_public=is_public, pad_addr=longest_addr) for f in self.frames
+            f.get_api_context(is_public=is_public, pad_addr=longest_addr,
+                              platform=platform) for f in self.frames
         ]
 
         return {
@@ -668,7 +669,7 @@ class Stacktrace(Interface):
             'hasSystemFrames': self.get_has_system_frames(),
         }
 
-    def get_api_meta(self, meta, is_public=False):
+    def get_api_meta(self, meta, is_public=False, platform=None):
         if not meta:
             return meta
 
@@ -677,7 +678,8 @@ class Stacktrace(Interface):
             if index == '':
                 continue
             frame = self.frames[int(index)]
-            frame_meta[index] = frame.get_api_meta(value, is_public=is_public)
+            frame_meta[index] = frame.get_api_meta(value, is_public=is_public,
+                                                   platform=platform)
 
         return {
             '': meta.get(''),

--- a/src/sentry/interfaces/template.py
+++ b/src/sentry/interfaces/template.py
@@ -93,7 +93,7 @@ class Template(Interface):
 
         return '\n'.join(result)
 
-    def get_api_context(self, is_public=False):
+    def get_api_context(self, is_public=False, platform=None):
         return {
             'lineNo': self.lineno,
             'filename': self.filename,
@@ -105,7 +105,7 @@ class Template(Interface):
             ),
         }
 
-    def get_api_meta(self, meta, is_public=False):
+    def get_api_meta(self, meta, is_public=False, platform=None):
         return {
             '': meta.get(''),
             'lineNo': meta.get('lineno'),

--- a/src/sentry/interfaces/threads.py
+++ b/src/sentry/interfaces/threads.py
@@ -63,7 +63,7 @@ class Threads(Interface):
             'values': [export_thread(x) for x in self.values],
         })
 
-    def get_api_context(self, is_public=False):
+    def get_api_context(self, is_public=False, platform=None):
         def export_thread(data):
             rv = {
                 'id': data['id'],
@@ -83,7 +83,7 @@ class Threads(Interface):
             'values': [export_thread(x) for x in self.values],
         }
 
-    def get_meta_context(self, meta, is_public=False):
+    def get_meta_context(self, meta, is_public=False, platform=None):
         if meta and 'values' not in meta:
             return {'values': meta}
         else:

--- a/src/sentry/interfaces/user.py
+++ b/src/sentry/interfaces/user.py
@@ -120,7 +120,7 @@ class User(Interface):
             'data': self.data or None
         })
 
-    def get_api_context(self, is_public=False):
+    def get_api_context(self, is_public=False, platform=None):
         return {
             'id': self.id,
             'email': self.email,
@@ -130,7 +130,7 @@ class User(Interface):
             'data': self.data,
         }
 
-    def get_api_meta(self, meta, is_public=False):
+    def get_api_meta(self, meta, is_public=False, platform=None):
         return {
             '': meta.get(''),
             'id': meta.get('id'),


### PR DESCRIPTION
We want to introduce trimmed function names into the protocol.  To support
returning platform specific fallbacks in the API we need to pass the
platform down to more places now.