### PR TITLE
ref(ui): Move "sentry embed" css into React

### DIFF
--- a/src/sentry/static/sentry/app/views/app.jsx
+++ b/src/sentry/static/sentry/app/views/app.jsx
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import {injectGlobal} from 'emotion';
 import {ThemeProvider} from 'emotion-theming';
 import Cookies from 'js-cookie';
 import PropTypes from 'prop-types';
@@ -248,3 +249,11 @@ const App = createReactClass({
 });
 
 export default App;
+
+injectGlobal`
+body {
+  .sentry-error-embed-wrapper {
+    z-index: ${theme.zIndex.sentryErrorEmbed};
+  }
+}
+`;

--- a/src/sentry/static/sentry/app/views/settings/components/settingsWrapper.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsWrapper.jsx
@@ -55,7 +55,4 @@ const StyledSettingsWrapper = styled.div`
   .messages-container {
     margin: 0;
   }
-  .sentry-error-embed-wrapper {
-    z-index: ${p => p.theme.zIndex.sentryErrorEmbed};
-  }
 `;

--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -11,7 +11,6 @@ body {
   -webkit-font-smoothing: antialiased;
   overflow-x: hidden;
   min-height: 100vh;
-  }
 
   &.body-sidebar {
     padding-left: @sidebar-expanded-width;

--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -11,9 +11,6 @@ body {
   -webkit-font-smoothing: antialiased;
   overflow-x: hidden;
   min-height: 100vh;
-
-  .sentry-error-embed-wrapper {
-    z-index: 1005;
   }
 
   &.body-sidebar {


### PR DESCRIPTION
Use emotion `injectGlobal` to define z-index of Sentry embedded report dialog (UI for submitting client feedback from SDK). This keeps causing regressions because it is defined in two areas.

This can potentially cause issues with server rendered views, but there arent too many left and if there are they do not have the global header.