### PR TITLE
ref(ui): Remove redundant font-family defs

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/settingsWrapper.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsWrapper.jsx
@@ -47,7 +47,6 @@ export default withLatestContext(SettingsWrapper);
 const StyledSettingsWrapper = styled.div`
   display: flex;
   flex: 1;
-  font-family: 'Rubik', sans-serif;
   font-size: 16px;
   color: ${p => p.theme.gray5};
   margin-bottom: -20px; /* to account for footer margin top */

--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -4,7 +4,6 @@ html {
 
 body {
   margin: 0;
-  font-family: @font-family-base;
   font-size: 16px;
   line-height: 24px;
   color: @gray-darker;
@@ -23,7 +22,6 @@ body {
 
   &.body-sidebar {
     padding-left: @sidebar-expanded-width;
-    font-family: 'Rubik', 'Avenir Next', 'Helvetica Neue', sans-serif;
 
     &.collapsed {
       padding-left: @sidebar-collapsed-width;


### PR DESCRIPTION
We define a less variable for the base font-family which I believe `react-bootstrap` uses when generating its CSS. These are all just redundant defs.