### PR TITLE
ref(search): Changed regex for raw search.

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -88,7 +88,7 @@ search_term     = key_val_term / quoted_raw_search / raw_search
 key_val_term    = space? (time_filter / rel_time_filter / specific_time_filter
                   / numeric_filter / has_filter / is_filter / basic_filter)
                   space?
-raw_search      = ~r"\ *([^\ ^\n]+)\ *"
+raw_search      = (!key_val_term ~r"\ *([^\ ^\n]+)\ *" )*
 quoted_raw_search = spaces quoted_value spaces
 
 # standard key:val filter
@@ -228,23 +228,7 @@ class SearchVisitor(NodeVisitor):
         children = [child for group in children for child in _flatten(group)]
         children = filter(None, _flatten(children))
 
-        # Now collapse all adjacent `message` filters together. The assumption
-        # being that any messages next to each other are part of the same term,
-        # but if they're separated by a tag then they're a separate term.
-        def merge_messages(search_filters, item):
-            if not search_filters:
-                search_filters.append(item)
-                return search_filters
-
-            prev_filter = search_filters[-1]
-            if prev_filter.key.name == 'message' and item.key.name == 'message':
-                new_message = u'%s %s' % (prev_filter.value.raw_value, item.value.raw_value)
-                search_filters[-1] = prev_filter._replace(value=SearchValue(new_message))
-            else:
-                search_filters.append(item)
-            return search_filters
-
-        return reduce(merge_messages, children, [])
+        return children
 
     def visit_key_val_term(self, node, children):
         _, key_val_term, _ = children
@@ -252,7 +236,7 @@ class SearchVisitor(NodeVisitor):
         return key_val_term[0]
 
     def visit_raw_search(self, node, children):
-        value = node.match.groups()[0]
+        value = node.text.strip(' ')
 
         if not value:
             return None
@@ -269,7 +253,8 @@ class SearchVisitor(NodeVisitor):
             return None
         return SearchFilter(SearchKey('message'), "=", SearchValue(value))
 
-    def visit_numeric_filter(self, node, (search_key, _, operator, search_value)):
+    def visit_numeric_filter(self, node, children):
+        (search_key, _, operator, search_value) = children
         operator = operator[0] if not isinstance(operator, Node) else '='
 
         if search_key.name in self.numeric_keys:
@@ -284,7 +269,8 @@ class SearchVisitor(NodeVisitor):
             )
             return self._handle_basic_filter(search_key, '=', search_value)
 
-    def visit_time_filter(self, node, (search_key, _, operator, search_value)):
+    def visit_time_filter(self, node, children):
+        (search_key, _, operator, search_value) = children
         if search_key.name in self.date_keys:
             try:
                 search_value = parse_datetime_string(search_value)
@@ -295,7 +281,8 @@ class SearchVisitor(NodeVisitor):
             search_value = operator + search_value if operator != '=' else search_value
             return self._handle_basic_filter(search_key, '=', SearchValue(search_value))
 
-    def visit_rel_time_filter(self, node, (search_key, _, value)):
+    def visit_rel_time_filter(self, node, children):
+        (search_key, _, value) = children
         if search_key.name in self.date_keys:
             try:
                 from_val, to_val = parse_datetime_range(value.text)
@@ -313,10 +300,11 @@ class SearchVisitor(NodeVisitor):
         else:
             return self._handle_basic_filter(search_key, '=', SearchValue(value.text))
 
-    def visit_specific_time_filter(self, node, (search_key, _, date_value)):
+    def visit_specific_time_filter(self, node, children):
         # If we specify a specific date, it means any event on that day, and if
         # we specify a specific datetime then it means a few minutes interval
         # on either side of that datetime
+        (search_key, _, date_value) = children
         if search_key.name not in self.date_keys:
             return self._handle_basic_filter(search_key, '=', SearchValue(date_value))
 
@@ -356,7 +344,8 @@ class SearchVisitor(NodeVisitor):
 
         return node.text == '!'
 
-    def visit_basic_filter(self, node, (negation, search_key, _, search_value)):
+    def visit_basic_filter(self, node, children):
+        (negation, search_key, _, search_value) = children
         operator = '!=' if self.is_negated(negation) else '='
         return self._handle_basic_filter(search_key, operator, search_value)
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -103,7 +103,7 @@ class ParseSearchQueryTest(TestCase):
             SearchFilter(
                 key=SearchKey(name='message'),
                 operator='=',
-                value=SearchValue(raw_value='hello there'),
+                value=SearchValue(raw_value='hello   there'),
             ),
         ]
 


### PR DESCRIPTION
Previously, we had a method called `merge_messages` which merged adjacent `SearchFilters` who both had messages as values. This regex removed the necessity for that method by creating a better match so that any adjacent messages and spaces will be preserved. Note that this is a change in the existing functionality, which removed all but one space between messages 