### PR TITLE
chore: Bump moment-timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "mobx": "^3.2.2",
     "mobx-react": "^4.2.2",
     "moment": "2.23.0",
-    "moment-timezone": "0.5.23",
+    "moment-timezone": "0.5.25",
     "node-libs-browser": "0.5.3",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "papaparse": "^4.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8869,10 +8869,10 @@ mockdate@2.0.2:
   resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.2.tgz#5ae0c0eaf8fe23e009cd01f9889b42c4f634af12"
   integrity sha1-WuDA6vj+I+AJzQH5iJtCxPY0rxI=
 
-moment-timezone@0.5.23:
-  version "0.5.23"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.23.tgz#7cbb00db2c14c71b19303cb47b0fb0a6d8651463"
-  integrity sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==
+moment-timezone@0.5.25:
+  version "0.5.25"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.25.tgz#a11bfa2f74e088327f2cd4c08b3e7bdf55957810"
+  integrity sha512-DgEaTyN/z0HFaVcVbSyVCUU6HeFdnNC3vE4c9cgu2dgMTvjBUBdBzWfasTBmAW45u5OIMeCJtU8yNjM22DHucw==
   dependencies:
     moment ">= 2.9.0"
 


### PR DESCRIPTION
Get the latest in timezone data.

Fixes #9945