### PR TITLE
fix(ui): Typo 'Substitued' -> 'Substituted'

### DIFF
--- a/src/sentry/static/sentry/app/components/events/meta/annotatedText.jsx
+++ b/src/sentry/static/sentry/app/components/events/meta/annotatedText.jsx
@@ -37,7 +37,7 @@ const ErrorIcon = styled(InlineSvg)`
 const REMARKS = {
   a: 'Annotated',
   x: 'Removed',
-  s: 'Substitued',
+  s: 'Substituted',
   m: 'Masked',
   p: 'Pseudonymized',
   e: 'Encrypted',


### PR DESCRIPTION
Redaction tooltips had a misspelling. Thought I would submit a quick fix.