### PR TITLE
fix(middleware.proxy): Accept IPv4-mapped IPv6 addresses (#12832)

### DIFF
--- a/src/sentry/middleware/proxy.py
+++ b/src/sentry/middleware/proxy.py
@@ -111,6 +111,16 @@ class SetRemoteAddrFromForwardedFor(object):
             from django.core.exceptions import MiddlewareNotUsed
             raise MiddlewareNotUsed
 
+    def _remove_port_number(self, ip_address):
+        if '[' in ip_address and ']' in ip_address:
+            # IPv6 address with brackets, possibly with a port number
+            return ip_address[ip_address.find('[') + 1:ip_address.find(']')]
+        if '.' in ip_address and ip_address.rfind(':') > ip_address.rfind('.'):
+            # IPv4 address with port number
+            # the last condition excludes IPv4-mapped IPv6 addresses
+            return ip_address.rsplit(':', 1)[0]
+        return ip_address
+
     def process_request(self, request):
         try:
             real_ip = request.META['HTTP_X_FORWARDED_FOR']
@@ -120,9 +130,7 @@ class SetRemoteAddrFromForwardedFor(object):
             # HTTP_X_FORWARDED_FOR can be a comma-separated list of IPs.
             # Take just the first one.
             real_ip = real_ip.split(",")[0].strip()
-            if ':' in real_ip and '.' in real_ip:
-                # Strip the port number off of an IPv4 FORWARDED_FOR entry.
-                real_ip = real_ip.split(':', 1)[0]
+            real_ip = self._remove_port_number(real_ip)
             request.META['REMOTE_ADDR'] = real_ip
 
 


### PR DESCRIPTION
`SetRemoteAddrFromForwardedFor.process_request` fails when being given a IPv4-mapped IPv6 address (eg. `::ffff:10.7.0.1`). This is a small fix which solves this exact case.

Still, I'm not sure about this method. It will still fail if given eg. `[::1]:1234` or `[::ffff:10.7.0.1]:1234`.
(Also, I wonder why it even tries to split the port off. Is it valid for `X-Forwarded-For` to contain a port?)

Edit: Also, this might trigger [a Django bug](https://code.djangoproject.com/ticket/26378), if the embedded IPv4 address starts with `0.`.