### PR TITLE
fix: Add missing Kafka outcomes topic const

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1580,6 +1580,7 @@ KAFKA_PREPROCESS = 'events-preprocess'
 KAFKA_PROCESS = 'events-process'
 KAFKA_SAVE = 'events-save'
 KAFKA_EVENTS = 'events'
+KAFKA_OUTCOMES = 'outcomes'
 
 KAFKA_TOPICS = {
     KAFKA_PREPROCESS: {


### PR DESCRIPTION
This blocks getsentry deploys. `outcomes` topic appears to exist in datadog.