### PR TITLE
fix(ui) Encode environment names when hiding environments

### DIFF
--- a/src/sentry/static/sentry/app/stores/environmentStore.jsx
+++ b/src/sentry/static/sentry/app/stores/environmentStore.jsx
@@ -50,7 +50,7 @@ const EnvironmentStore = Reflux.createStore({
         return toTitleCase(item.name) || DEFAULT_EMPTY_ENV_NAME;
       },
       get urlRoutingName() {
-        return item.name || DEFAULT_EMPTY_ROUTING_NAME;
+        return encodeURIComponent(item.name) || DEFAULT_EMPTY_ROUTING_NAME;
       },
     }));
     this.trigger(this.items);

--- a/src/sentry/static/sentry/app/stores/organizationEnvironmentsStore.jsx
+++ b/src/sentry/static/sentry/app/stores/organizationEnvironmentsStore.jsx
@@ -17,7 +17,7 @@ const OrganizationEnvironmentsStore = Reflux.createStore({
         return toTitleCase(item.name) || DEFAULT_EMPTY_ENV_NAME;
       },
       get urlRoutingName() {
-        return item.name || DEFAULT_EMPTY_ROUTING_NAME;
+        return encodeURIComponent(item.name) || DEFAULT_EMPTY_ROUTING_NAME;
       },
     };
   },

--- a/tests/js/spec/views/projectEnvironments.spec.jsx
+++ b/tests/js/spec/views/projectEnvironments.spec.jsx
@@ -247,6 +247,27 @@ describe('ProjectEnvironments', function() {
       );
     });
 
+    it('hides names requiring encoding', function() {
+      hideMock = MockApiClient.addMockResponse({
+        url: `${baseUrl}%25app_env%25/`,
+        method: 'PUT',
+      });
+
+      const environments = [{id: '1', name: '%app_env%', isHidden: false}];
+      EnvironmentStore.loadInitialData(environments);
+
+      const wrapper = mountComponent(false);
+      wrapper
+        .find('EnvironmentRow[name="%app_env%"] button[aria-label="Hide"]')
+        .simulate('click');
+      expect(hideMock).toHaveBeenCalledWith(
+        `${baseUrl}%25app_env%25/`,
+        expect.objectContaining({
+          data: expect.objectContaining({isHidden: true}),
+        })
+      );
+    });
+
     it('shows', function() {
       EnvironmentStore.loadHiddenData(TestStubs.Environments(true));
       const wrapper = mountComponent(true);


### PR DESCRIPTION
Environment names can contain URL unsafe bytes. Encode those so that URLs stay valid.

Fixes #12956