### PR TITLE
feat(build) Add support for additional ignores in bin/scan

### DIFF
--- a/bin/scan
+++ b/bin/scan
@@ -34,6 +34,14 @@ ignored=(
     36810
 )
 
+# Take additional ignores from argv.
+# This enables script re-use in getsentry
+if [ $# -ge 1 ]; then
+    for i in "$@"; do
+        ignored+=("$i")
+    done
+fi
+
 args="--full-report"
 for i in ${ignored[@]}; do
   args="$args --ignore=${i}"


### PR DESCRIPTION
As per some discussion around adding a bin/scan to getsentry this makes
it possible to additional ignored error codes to bin/scan so that we can
re-use this script in other projects.

Refs SEN-550