### PR TITLE
fix(jira) Update descriptor for gdpr status

### DIFF
--- a/src/sentry/integrations/jira/descriptor.py
+++ b/src/sentry/integrations/jira/descriptor.py
@@ -52,6 +52,9 @@ class JiraDescriptorEndpoint(Endpoint):
                         'excludeBody': False,
                     }],
                 },
+                'apiMigrations': {
+                    'gdpr': False,
+                },
                 'scopes': [
                     'read',
                     'write',


### PR DESCRIPTION
Atlassian has asked us to update our integration's gdpr migration status. We are not ready *yet* so we'll set the flag to false.

Refs SEN-572