### PR TITLE
fix(ui) Don't drop project selection when paginating saved searches

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -482,20 +482,15 @@ const OrganizationStream = createReactClass({
 
     if (savedSearch && savedSearch.id) {
       path = `/organizations/${organization.slug}/issues/searches/${savedSearch.id}/`;
-      // Drop query and project, adding the search project if available.
+
+      // Remove the query as saved searches bring their own query string.
       delete query.query;
-      delete query.project;
 
-      if (savedSearch.projectId) {
+      // If we aren't going to another page in the same search
+      // drop the query and replace the current project, with the saved search search project
+      // if available.
+      if (!query.cursor && savedSearch.projectId) {
         query.project = [savedSearch.projectId];
-      }
-
-      // If the saved search is project-less and the user doesn't have
-      // global-views we retain their current project filter
-      // so that the backend doesn't reject their request.
-      const hasMultipleProjectSelection = this.getFeatures().has('global-views');
-      if (!savedSearch.projectId && !hasMultipleProjectSelection) {
-        query.project = this.props.selection.projects;
       }
     } else {
       path = `/organizations/${organization.slug}/issues/`;

--- a/tests/js/spec/views/organizationStream/overview.spec.jsx
+++ b/tests/js/spec/views/organizationStream/overview.spec.jsx
@@ -474,6 +474,7 @@ describe('OrganizationStream', function() {
           pathname: '/organizations/org-slug/issues/searches/789/',
           query: {
             environment: [],
+            project: [],
             sort: 'freq',
           },
         })
@@ -683,6 +684,7 @@ describe('OrganizationStream', function() {
         expect.objectContaining({
           pathname: '/organizations/org-slug/issues/searches/234/',
           query: {
+            project: [],
             environment: [],
           },
         })
@@ -762,6 +764,46 @@ describe('OrganizationStream', function() {
       });
     });
 
+    it('transitions to cursor with project-less saved search', function() {
+      savedSearch = {
+        id: 123,
+        projectId: null,
+        query: 'foo:bar',
+      };
+      instance.transitionTo({cursor: '1554756114000:0:0'}, savedSearch);
+
+      // should keep the current project selection as we're going to the next page.
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        pathname: '/organizations/org-slug/issues/searches/123/',
+        query: {
+          environment: [],
+          project: [parseInt(project.id, 10)],
+          cursor: '1554756114000:0:0',
+          statsPeriod: '14d',
+        },
+      });
+    });
+
+    it('transitions to cursor with project saved search', function() {
+      savedSearch = {
+        id: 123,
+        projectId: 999,
+        query: 'foo:bar',
+      };
+      instance.transitionTo({cursor: '1554756114000:0:0'}, savedSearch);
+
+      // should keep the current project selection as we're going to the next page.
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        pathname: '/organizations/org-slug/issues/searches/123/',
+        query: {
+          environment: [],
+          project: [parseInt(project.id, 10)],
+          cursor: '1554756114000:0:0',
+          statsPeriod: '14d',
+        },
+      });
+    });
+
     it('transitions to saved search that has a projectId', function() {
       savedSearch = {
         id: 123,
@@ -780,7 +822,7 @@ describe('OrganizationStream', function() {
       });
     });
 
-    it('goes to all projects when using a basic saved searches and global-views feature', function() {
+    it('goes to all projects when using a basic saved search and global-views feature', function() {
       organization.features = ['global-views'];
       savedSearch = {
         id: 1,
@@ -792,6 +834,7 @@ describe('OrganizationStream', function() {
       expect(browserHistory.push).toHaveBeenCalledWith({
         pathname: '/organizations/org-slug/issues/searches/1/',
         query: {
+          project: [parseInt(project.id, 10)],
           environment: [],
           statsPeriod: '14d',
         },


### PR DESCRIPTION
When the issue stream is paginated we should not drop the currently
selected project when going to subsequent pages. The previous logic did
not check for the presence of a cursor parameter and assumed that having
a saved-search meant we were switching to a new saved search.

I've also chosen to not clear the project selection when navigating to
the a project-less saved search as the user likely wants to keep the
filtering conditions they've already setup.

Fixes SEN-225
Fixes ISSUE-351