### PR TITLE
fix(ui) Rollback to bootstrap 3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-loader": "^8.0.0",
     "babel-plugin-emotion": "9.2.11",
     "babel-plugin-lodash": "^3.3.4",
-    "bootstrap": "3.4.1",
+    "bootstrap": "3.4.0",
     "classnames": "2.2.0",
     "clipboard": "^1.7.1",
     "color": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2980,10 +2980,10 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bootstrap@3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
-  integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
+bootstrap@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.0.tgz#f8d77540dd3062283d2ae7687e21c1e691961640"
+  integrity sha512-F1yTDO9OHKH0xjl03DsOe8Nu1OWBIeAugGMhy3UTIYDdbbIPesQIhCEbj+HEr6wqlwweGAlP8F3OBC6kEuhFuw==
 
 boxen@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
The changes in 3.4.1 break how we use tooltips. Fixing those compatibility issues could be a longer task so rollback to fix broken tooltips.

Refs ISSUE-450