### PR TITLE
feat(savedsearches) Merge saved-searches into sentry10

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/savedSearches.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/savedSearches.jsx
@@ -8,13 +8,9 @@ export function resetSavedSearches() {
   SavedSearchesActions.resetSavedSearches();
 }
 
-export function fetchSavedSearches(api, orgId, projectMap, useOrgSavedSearches = false) {
+export function fetchSavedSearches(api, orgId) {
   const url = `/organizations/${orgId}/searches/`;
-
-  const data = {};
-  if (useOrgSavedSearches) {
-    data.use_org_level = '1';
-  }
+  const data = {use_org_level: 1};
 
   SavedSearchesActions.startFetchSavedSearches();
 
@@ -25,14 +21,7 @@ export function fetchSavedSearches(api, orgId, projectMap, useOrgSavedSearches =
 
   promise
     .then(resp => {
-      // Add in project slugs so that we can display them in the picker bars.
-      // TODO(billyvg): #org-saved-searches -- cleanup when removing project saved searches
-      const savedSearchList = resp.map(search => ({
-        ...search,
-        projectSlug: projectMap[search.projectId],
-      }));
-
-      SavedSearchesActions.fetchSavedSearchesSuccess(savedSearchList);
+      SavedSearchesActions.fetchSavedSearchesSuccess(resp);
     })
     .catch(err => {
       SavedSearchesActions.fetchSavedSearchesError(err);

--- a/src/sentry/static/sentry/app/utils/withSavedSearches.jsx
+++ b/src/sentry/static/sentry/app/utils/withSavedSearches.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 
-import Feature from 'app/components/acl/feature';
 import SavedSearchesStore from 'app/stores/savedSearchesStore';
 import getDisplayName from 'app/utils/getDisplayName';
 
@@ -22,46 +21,35 @@ const withSavedSearches = WrappedComponent =>
     },
 
     render() {
+      const {params, location} = this.props;
+      const {searchId} = params;
+      const {savedSearches, isLoading} = this.state;
+      let savedSearch = null;
+
+      // Switch to the current saved search or pinned result if available
+      if (!isLoading && savedSearches) {
+        if (searchId) {
+          const match = savedSearches.find(search => search.id === searchId);
+          savedSearch = match ? match : null;
+        }
+
+        // If there's no direct saved search being requested (via URL route)
+        // *AND* there's no query in URL, then check if there is pinned search
+        //
+        // Note: Don't use pinned searches when there is an empty query (query == empty string)
+        if (!savedSearch && typeof location.query.query === 'undefined') {
+          const pin = savedSearches.find(search => search.isPinned);
+          savedSearch = pin ? pin : null;
+        }
+      }
+
       return (
-        <Feature features={['org-saved-searches']}>
-          {({hasFeature}) => {
-            const {params, location} = this.props;
-            const {searchId} = params;
-            const {savedSearches, isLoading} = this.state;
-            let savedSearch = null;
-
-            // Switch to the current saved search or pinned result if available
-            if (!isLoading && savedSearches) {
-              if (searchId) {
-                const match = savedSearches.find(search => search.id === searchId);
-                savedSearch = match ? match : null;
-              }
-
-              // If there's no direct saved search being requested (via URL route)
-              // *AND* there's no query in URL, then check if there is pinned search
-              //
-              // Note: Don't use pinned searches when there is an empty query (query == empty string)
-              if (
-                hasFeature &&
-                !savedSearch &&
-                typeof location.query.query === 'undefined'
-              ) {
-                const pin = savedSearches.find(search => search.isPinned);
-                savedSearch = pin ? pin : null;
-              }
-            }
-
-            return (
-              <WrappedComponent
-                savedSearches={savedSearches}
-                savedSearchLoading={isLoading}
-                savedSearch={savedSearch}
-                useOrgSavedSearches={hasFeature}
-                {...this.props}
-              />
-            );
-          }}
-        </Feature>
+        <WrappedComponent
+          savedSearches={savedSearches}
+          savedSearchLoading={isLoading}
+          savedSearch={savedSearch}
+          {...this.props}
+        />
       );
     },
   });

--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -58,7 +58,6 @@ const OrganizationStream = createReactClass({
     savedSearch: SentryTypes.SavedSearch,
     savedSearches: PropTypes.arrayOf(SentryTypes.SavedSearch),
     savedSearchLoading: PropTypes.bool.isRequired,
-    useOrgSavedSearches: PropTypes.bool.isRequired,
   },
 
   mixins: [
@@ -583,17 +582,8 @@ const OrganizationStream = createReactClass({
   },
 
   fetchSavedSearches() {
-    const {orgId} = this.props.params;
-    const {organization, useOrgSavedSearches} = this.props;
-    const projectMap = organization.projects.reduce((acc, project) => {
-      acc[project.id] = project.slug;
-      return acc;
-    }, {});
-
-    fetchSavedSearches(this.api, orgId, projectMap, useOrgSavedSearches).then(
-      data => {},
-      error => {}
-    );
+    const {organization} = this.props;
+    fetchSavedSearches(this.api, organization.slug).then(data => {}, error => {});
   },
 
   onSavedSearchCreate(newSavedSearch) {

--- a/src/sentry/static/sentry/app/views/projectSavedSearches.jsx
+++ b/src/sentry/static/sentry/app/views/projectSavedSearches.jsx
@@ -241,8 +241,8 @@ class ProjectSavedSearches extends AsyncView {
 }
 
 const ProjectSavedSearchContainer = function(props, context) {
-  const hasSavedSearch = context.organization.features.includes('org-saved-searches');
-  if (hasSavedSearch) {
+  const isSentry10 = context.organization.features.includes('sentry10');
+  if (isSentry10) {
     return <NotFound />;
   }
   return <ProjectSavedSearches {...props} />;

--- a/src/sentry/static/sentry/app/views/projectSettings/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectSettings/index.jsx
@@ -128,7 +128,7 @@ const ProjectSettings = createReactClass({
             <ListLink to={`${pathPrefix}/data-forwarding/`}>
               {t('Data Forwarding')}
             </ListLink>
-            {organization.features.includes('org-saved-searches') === false && (
+            {organization.features.includes('sentry10') === false && (
               <ListLink to={`${pathPrefix}/saved-searches/`}>
                 {t('Saved Searches')}
               </ListLink>

--- a/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.jsx
@@ -51,7 +51,7 @@ export default function getConfiguration({project}) {
             if (!organization || !organization.features) {
               return true;
             }
-            return !organization.features.includes('org-saved-searches');
+            return !organization.features.includes('sentry10');
           },
         },
         {

--- a/src/sentry/static/sentry/app/views/stream/createSavedSearchButton.jsx
+++ b/src/sentry/static/sentry/app/views/stream/createSavedSearchButton.jsx
@@ -92,7 +92,7 @@ class CreateSavedSearchButton extends React.Component {
     const {organization, query} = this.props;
 
     return (
-      <Feature organization={organization} features={['org-saved-searches']}>
+      <Feature organization={organization} features={['sentry10']}>
         <Access organization={organization} access={['org:write']}>
           <Tooltip title={t('Add to organization filter list')}>
             <StyledButton

--- a/src/sentry/static/sentry/app/views/stream/filters.jsx
+++ b/src/sentry/static/sentry/app/views/stream/filters.jsx
@@ -88,12 +88,12 @@ class StreamFilters extends React.Component {
       tagValueLoader,
       tags,
     } = this.props;
-    const hasOrgSavedSearches = organization.features.includes('org-saved-searches');
+    const hasSentry10 = organization.features.includes('sentry10');
 
     return (
       <PageHeader>
         <Feature
-          features={['org-saved-searches']}
+          features={['sentry10']}
           renderDisabled={() => (
             <SavedSearchSelector
               organization={organization}
@@ -113,10 +113,10 @@ class StreamFilters extends React.Component {
             <QueryCount count={queryCount} max={queryMaxCount} />
           </PageHeading>
         </Feature>
-        <SearchContainer isWide={hasOrgSavedSearches}>
+        <SearchContainer isWide={hasSentry10}>
           <SortOptions sort={sort} onSelect={onSortChange} />
 
-          <Feature features={['org-saved-searches']}>
+          <Feature features={['sentry10']}>
             <OrganizationSavedSearchSelector
               key={query}
               organization={organization}

--- a/src/sentry/static/sentry/app/views/stream/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/stream/searchBar.jsx
@@ -63,13 +63,13 @@ class SearchBar extends React.Component {
     this.fetchData();
   }
 
-  hasOrgSavedSearches = () => {
+  hasSentry10 = () => {
     const {organization} = this.props;
-    return organization && organization.features.includes('org-saved-searches');
+    return organization && organization.features.includes('sentry10');
   };
 
   fetchData = async () => {
-    if (!this.hasOrgSavedSearches()) {
+    if (!this.hasSentry10()) {
       this.setState({
         defaultSearchItems: [SEARCH_ITEMS, []],
       });
@@ -118,7 +118,7 @@ class SearchBar extends React.Component {
 
   handleSavedRecentSearch = () => {
     // No need to refetch if recent searches feature is not enabled
-    if (!this.hasOrgSavedSearches()) {
+    if (!this.hasSentry10()) {
       return;
     }
 
@@ -133,7 +133,7 @@ class SearchBar extends React.Component {
       onSidebarToggle,
       ...props
     } = this.props;
-    const hasPinnedSearch = this.hasOrgSavedSearches();
+    const hasPinnedSearch = this.hasSentry10();
 
     return (
       <React.Fragment>
@@ -143,7 +143,7 @@ class SearchBar extends React.Component {
           maxSearchItems={5}
           hasPinnedSearch={hasPinnedSearch}
           savedSearchType={SEARCH_TYPES.ISSUE}
-          displayRecentSearches={this.hasOrgSavedSearches()}
+          displayRecentSearches={this.hasSentry10()}
           onSavedRecentSearch={this.handleSavedRecentSearch}
           onSidebarToggle={onSidebarToggle}
           pinnedSearch={savedSearch && savedSearch.isPinned ? savedSearch : null}

--- a/tests/js/spec/views/organizationStream/overview.spec.jsx
+++ b/tests/js/spec/views/organizationStream/overview.spec.jsx
@@ -123,7 +123,7 @@ describe('OrganizationStream', function() {
   describe('withStores and feature flags', function() {
     const {router, routerContext} = initializeOrg({
       organization: {
-        features: ['org-saved-searches', 'recent-searches', 'global-views'],
+        features: ['sentry10', 'global-views'],
         slug: 'org-slug',
       },
       router: {

--- a/tests/js/spec/views/stream/createSavedSearchButton.spec.jsx
+++ b/tests/js/spec/views/stream/createSavedSearchButton.spec.jsx
@@ -8,7 +8,7 @@ describe('CreateSavedSearchButton', function() {
 
   beforeEach(function() {
     organization = TestStubs.Organization({
-      features: ['org-saved-searches'],
+      features: ['sentry10'],
       access: ['org:write'],
     });
     wrapper = mount(
@@ -93,7 +93,7 @@ describe('CreateSavedSearchButton', function() {
 
     it('hides button if no access', function() {
       const orgWithoutAccess = TestStubs.Organization({
-        features: ['org-saved-searches'],
+        features: ['sentry10'],
         access: ['org:read'],
       });
       wrapper.setProps({organization: orgWithoutAccess});

--- a/tests/js/spec/views/stream/searchBar.spec.jsx
+++ b/tests/js/spec/views/stream/searchBar.spec.jsx
@@ -238,7 +238,7 @@ describe('SearchBar', function() {
     let pinSearch;
     let unpinSearch;
     const {organization, routerContext} = initializeOrg({
-      organization: {features: ['org-saved-searches']},
+      organization: {features: ['sentry10']},
     });
 
     beforeEach(function() {
@@ -260,7 +260,7 @@ describe('SearchBar', function() {
       });
     });
 
-    it('does not have pin icon without org-saved-searches featureflag', function() {
+    it('does not have pin icon without sentry10 featureflag', function() {
       const props = {
         orgId: organization.slug,
         query: 'url:"fu"',


### PR DESCRIPTION
This will mainline organization saved searches for all organizations using sentry10. Enabling organization saved searches for sentry9 users is more complicated and requires a bunch more work.

Refs SEN-469