### PR TITLE
fix(ui) Upgrade to bootstrap 3.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-loader": "^8.0.0",
     "babel-plugin-emotion": "9.2.11",
     "babel-plugin-lodash": "^3.3.4",
-    "bootstrap": "3.4.0",
+    "bootstrap": "3.4.1",
     "classnames": "2.2.0",
     "clipboard": "^1.7.1",
     "color": "^3.1.0",

--- a/src/sentry/static/sentry/app/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/tooltip.jsx
@@ -56,6 +56,12 @@ class Tooltip extends React.Component {
         ? tooltipOptions.call(this)
         : tooltipOptions || {};
 
+    // XXX: If we are sending HTML into the tooltip
+    // we want to turn off sanitization as it breaks
+    // our rich tooltips.
+    if (options.html) {
+      options.sanitize = false;
+    }
     this.$ref.tooltip({
       title,
       delay: 100,

--- a/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
@@ -398,6 +398,7 @@ exports[`GroupReleaseStats renders 1`] = `
                                 "container": "body",
                                 "html": true,
                                 "placement": "bottom",
+                                "sanitize": false,
                               }
                             }
                           >
@@ -454,6 +455,7 @@ exports[`GroupReleaseStats renders 1`] = `
                                 "container": "body",
                                 "html": true,
                                 "placement": "bottom",
+                                "sanitize": false,
                               }
                             }
                           >
@@ -512,6 +514,7 @@ exports[`GroupReleaseStats renders 1`] = `
                             "container": "body",
                             "html": true,
                             "placement": "bottom",
+                            "sanitize": false,
                           }
                         }
                       >
@@ -552,6 +555,7 @@ exports[`GroupReleaseStats renders 1`] = `
                             "container": "body",
                             "html": true,
                             "placement": "bottom",
+                            "sanitize": false,
                           }
                         }
                       >
@@ -819,6 +823,7 @@ exports[`GroupReleaseStats renders 1`] = `
                                 "container": "body",
                                 "html": true,
                                 "placement": "bottom",
+                                "sanitize": false,
                               }
                             }
                           >
@@ -875,6 +880,7 @@ exports[`GroupReleaseStats renders 1`] = `
                                 "container": "body",
                                 "html": true,
                                 "placement": "bottom",
+                                "sanitize": false,
                               }
                             }
                           >
@@ -933,6 +939,7 @@ exports[`GroupReleaseStats renders 1`] = `
                             "container": "body",
                             "html": true,
                             "placement": "bottom",
+                            "sanitize": false,
                           }
                         }
                       >
@@ -973,6 +980,7 @@ exports[`GroupReleaseStats renders 1`] = `
                             "container": "body",
                             "html": true,
                             "placement": "bottom",
+                            "sanitize": false,
                           }
                         }
                       >
@@ -1044,6 +1052,7 @@ exports[`GroupReleaseStats renders 1`] = `
                 tooltipOptions={
                   Object {
                     "html": true,
+                    "sanitize": false,
                   }
                 }
               >
@@ -1132,6 +1141,7 @@ exports[`GroupReleaseStats renders 1`] = `
                 tooltipOptions={
                   Object {
                     "html": true,
+                    "sanitize": false,
                   }
                 }
               >

--- a/tests/js/spec/views/organizationProjectsDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationProjectsDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -711,6 +711,7 @@ exports[`ProjectCard renders 1`] = `
                                             "container": "body",
                                             "html": true,
                                             "placement": "bottom",
+                                            "sanitize": false,
                                           }
                                         }
                                       >
@@ -745,6 +746,7 @@ exports[`ProjectCard renders 1`] = `
                                             "container": "body",
                                             "html": true,
                                             "placement": "bottom",
+                                            "sanitize": false,
                                           }
                                         }
                                       >

--- a/yarn.lock
+++ b/yarn.lock
@@ -2980,10 +2980,10 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bootstrap@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.0.tgz#f8d77540dd3062283d2ae7687e21c1e691961640"
-  integrity sha512-F1yTDO9OHKH0xjl03DsOe8Nu1OWBIeAugGMhy3UTIYDdbbIPesQIhCEbj+HEr6wqlwweGAlP8F3OBC6kEuhFuw==
+bootstrap@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
+  integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
 
 boxen@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
Bootstrap 3.4.1 fixes an XSS issue in tooltips, it does that by sanitizing HTML that is destined for the tooltip. Our tooltips rely on HTML that gets caught by this sanitization process so if we're turning `html` on, we also need to turn `sanitize` off.