### PR TITLE
fix(issues-stream): Fix pagination [SEN-138]

### DIFF
--- a/src/sentry/static/sentry/app/components/pagination.jsx
+++ b/src/sentry/static/sentry/app/components/pagination.jsx
@@ -7,6 +7,11 @@ import {t} from 'app/locale';
 
 export default class Pagination extends React.Component {
   static propTypes = {
+    // If this is set, reset `cursor` when clicking "previous" if the target cursor is
+    // equal to this prop. This is used as kind of a hack for the situation where you browse "next",
+    // then "previous" so you are back to the "initial" result set, but due to snuba reasons we can't
+    // be certain if there are new "previous" events on the initial page
+    resetPreviousCursor: PropTypes.string,
     pageLinks: PropTypes.string,
     to: PropTypes.string,
     onCursor: PropTypes.func,
@@ -29,7 +34,7 @@ export default class Pagination extends React.Component {
   };
 
   render() {
-    const {className, onCursor, pageLinks} = this.props;
+    const {className, onCursor, pageLinks, resetPreviousCursor} = this.props;
     if (!pageLinks) {
       return null;
     }
@@ -55,7 +60,20 @@ export default class Pagination extends React.Component {
         <div className="btn-group pull-right">
           <a
             onClick={() => {
-              onCursor(links.previous.cursor, path, query);
+              let cursor = links.previous.cursor;
+
+              // Chop off `cursor` if we are trying to click "previous" back to the initial result set,
+              // instead of maintaining a cursor to guarantee consistency, if we navigate back to the "first" page,
+              // reset the cursor so that we have the newest items.
+              if (resetPreviousCursor) {
+                const [initialTs] = resetPreviousCursor.split(':');
+                const [previousTs] = links.previous.cursor.split(':');
+
+                if (previousTs === initialTs) {
+                  cursor = undefined;
+                }
+              }
+              onCursor(cursor, path, query);
             }}
             className={previousPageClassName}
             disabled={links.previous.results === false}

--- a/src/sentry/static/sentry/app/components/pagination.jsx
+++ b/src/sentry/static/sentry/app/components/pagination.jsx
@@ -7,11 +7,6 @@ import {t} from 'app/locale';
 
 export default class Pagination extends React.Component {
   static propTypes = {
-    // If this is set, reset `cursor` when clicking "previous" if the target cursor is
-    // equal to this prop. This is used as kind of a hack for the situation where you browse "next",
-    // then "previous" so you are back to the "initial" result set, but due to snuba reasons we can't
-    // be certain if there are new "previous" events on the initial page
-    resetPreviousCursor: PropTypes.string,
     pageLinks: PropTypes.string,
     to: PropTypes.string,
     onCursor: PropTypes.func,
@@ -34,7 +29,7 @@ export default class Pagination extends React.Component {
   };
 
   render() {
-    const {className, onCursor, pageLinks, resetPreviousCursor} = this.props;
+    const {className, onCursor, pageLinks} = this.props;
     if (!pageLinks) {
       return null;
     }
@@ -60,20 +55,7 @@ export default class Pagination extends React.Component {
         <div className="btn-group pull-right">
           <a
             onClick={() => {
-              let cursor = links.previous.cursor;
-
-              // Chop off `cursor` if we are trying to click "previous" back to the initial result set,
-              // instead of maintaining a cursor to guarantee consistency, if we navigate back to the "first" page,
-              // reset the cursor so that we have the newest items.
-              if (resetPreviousCursor) {
-                const [initialTs] = resetPreviousCursor.split(':');
-                const [previousTs] = links.previous.cursor.split(':');
-
-                if (previousTs === initialTs) {
-                  cursor = undefined;
-                }
-              }
-              onCursor(cursor, path, query);
+              onCursor(links.previous.cursor, path, query, -1);
             }}
             className={previousPageClassName}
             disabled={links.previous.results === false}
@@ -82,7 +64,7 @@ export default class Pagination extends React.Component {
           </a>
           <a
             onClick={() => {
-              onCursor(links.next.cursor, path, query);
+              onCursor(links.next.cursor, path, query, 1);
             }}
             className={nextPageClassName}
             disabled={links.next.results === false}

--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -418,7 +418,9 @@ const OrganizationStream = createReactClass({
     let nextPage = isNaN(queryPageInt) ? pageDiff : queryPageInt + pageDiff;
 
     // unset cursor and page when we navigate back to the first page
-    if (nextPage === 0) {
+    // also reset cursor if somehow the previous button is enabled on
+    // first page and user attempts to go backwards
+    if (nextPage <= 0) {
       cursor = undefined;
       nextPage = undefined;
     }


### PR DESCRIPTION
This fixes pagination on organization issues stream (sentry 10 only). Cursors were incorrectly being updated when auto updates were on. Also removes cursor when you return to first page so we fetch the latest results.

Fixes SEN-138