### PR TITLE
fix(ui) Revert bootstrap upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-loader": "^8.0.0",
     "babel-plugin-emotion": "9.2.11",
     "babel-plugin-lodash": "^3.3.4",
-    "bootstrap": "3.4.0",
+    "bootstrap": "3.3.5",
     "classnames": "2.2.0",
     "clipboard": "^1.7.1",
     "color": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2980,10 +2980,10 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bootstrap@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.0.tgz#f8d77540dd3062283d2ae7687e21c1e691961640"
-  integrity sha512-F1yTDO9OHKH0xjl03DsOe8Nu1OWBIeAugGMhy3UTIYDdbbIPesQIhCEbj+HEr6wqlwweGAlP8F3OBC6kEuhFuw==
+bootstrap@3.3.5:
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.5.tgz#1777ab79299b128d87dce7cbd86fdc46ac69c0b1"
+  integrity sha1-F3ereSmbEo2H3OfL2G/cRqxpwLE=
 
 boxen@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
As of 3.3.7 bootstrap no longer positions tooltips over SVG elements properly. They introduced a change that skips position calculation on SVG elements as it was implemented inconsistently in jQuery 3. See https://github.com/twbs/bootstrap/issues/20381#issuecomment-379777182

Because tooltip positioning is broken we can't upgrade until we remove the dependency on bootstrap's tooltips.

See getsentry/getsentry#2877 as well

Refs SEN-577