### PR TITLE
fix(jira) Use the query parameter instead of username

### DIFF
--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -189,18 +189,17 @@ class JiraApiClient(ApiClient):
 
     def search_users_for_project(self, project, username):
         # Jira Server wants a project key, while cloud is indifferent.
+        # Use the query parameter as our implemention follows jira's gdpr practices
         project_key = self.get_project_key_for_id(project)
         return self.get_cached(
             self.USERS_URL,
-            params={'project': project_key, 'username': username})
+            params={'project': project_key, 'query': username})
 
     def search_users_for_issue(self, issue_key, email):
-        # not actully in the official documentation, but apparently
-        # you can pass email as the username param see:
-        # https://community.atlassian.com/t5/Answers-Developer-Questions/JIRA-Rest-API-find-JIRA-user-based-on-user-s-email-address/qaq-p/532715
+        # Use the query parameter as our implemention follows jira's gdpr practices
         return self.get_cached(
             self.USERS_URL,
-            params={'issueKey': issue_key, 'username': email})
+            params={'issueKey': issue_key, 'query': email})
 
     def create_issue(self, raw_form_data):
         data = {'fields': raw_form_data}

--- a/tests/sentry/integrations/jira/test_search_endpoint.py
+++ b/tests/sentry/integrations/jira/test_search_endpoint.py
@@ -134,6 +134,7 @@ class JiraSearchEndpointTest(APITestCase):
         def responder(request):
             query = parse_qs(urlparse(request.url).query)
             assert 'HSP' == query['project'][0]
+            assert 'bob' == query['query'][0]
             return (200, {}, SAMPLE_USER_SEARCH_RESPONSE)
 
         responses.add_callback(

--- a/tests/sentry/integrations/jira_server/test_search.py
+++ b/tests/sentry/integrations/jira_server/test_search.py
@@ -132,6 +132,7 @@ class JiraSearchEndpointTest(APITestCase):
         def responder(request):
             query = parse_qs(urlparse(request.url).query)
             assert 'HSP' == query['project'][0]
+            assert 'bob' == query['query'][0]
             return (200, {}, EXAMPLE_USER_SEARCH_RESPONSE)
 
         responses.add_callback(


### PR DESCRIPTION
In order to be ready for GDPR we have to use the `query` parameter as the `username` parameter is not available to integrations that are GDPR safe. I checked that this parameter works when creating issues for both jira cloud and jira server.

Fixes SEN-573