### PR TITLE
fix(link): Fix link proptype

### DIFF
--- a/src/sentry/static/sentry/app/components/links/link.jsx
+++ b/src/sentry/static/sentry/app/components/links/link.jsx
@@ -8,7 +8,7 @@ import {Link as RouterLink} from 'react-router';
  */
 class Link extends React.Component {
   static propTypes = {
-    to: PropTypes.string,
+    to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     href: PropTypes.string,
   };
 


### PR DESCRIPTION
Links should accept an object as well as string as a proptype.
Objects with the format {pathname: '/path/', query: {}} are valid `to`
values for links.