### PR TITLE
feat(incidents): Implement new incident list styles

### DIFF
--- a/src/sentry/static/sentry/app/components/button.jsx
+++ b/src/sentry/static/sentry/app/components/button.jsx
@@ -18,7 +18,7 @@ class Button extends React.Component {
     /**
      * Use this prop if button is a react-router link
      */
-    to: PropTypes.string,
+    to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     /**
      * Use this prop if button should use a normal (non-react-router) link
      */

--- a/src/sentry/static/sentry/app/views/organizationIncidents/list/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/list/index.jsx
@@ -1,15 +1,21 @@
 import React from 'react';
 import DocumentTitle from 'react-document-title';
+import styled from 'react-emotion';
+import {omit} from 'lodash';
 
 import {t} from 'app/locale';
 import AsyncComponent from 'app/components/asyncComponent';
-import {Panel, PanelBody, PanelItem} from 'app/components/panels';
+import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import Link from 'app/components/links/link';
+import Button from 'app/components/button';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import Pagination from 'app/components/pagination';
 import {PageContent, PageHeader} from 'app/styles/organization';
 import PageHeading from 'app/components/pageHeading';
 import BetaTag from 'app/components/betaTag';
+import space from 'app/styles/space';
+
+const DEFAULT_QUERY_STATUS = 'unresolved';
 
 class OrganizationIncidentsBody extends AsyncComponent {
   getEndpoints() {
@@ -30,17 +36,23 @@ class OrganizationIncidentsBody extends AsyncComponent {
 
     return (
       <PanelItem key={incident.id}>
-        <Link to={`/organizations/${orgId}/incidents/${incident.id}/`}>
-          {incident.name}
-        </Link>
+        <TableLayout>
+          <Link to={`/organizations/${orgId}/incidents/${incident.id}/`}>
+            {incident.name}
+          </Link>
+          <div>{incident.status}</div>
+          <div>{incident.duration}</div>
+          <div>{incident.usersAffected}</div>
+          <div>{incident.eventCount}</div>
+        </TableLayout>
       </PanelItem>
     );
   }
 
   renderEmpty() {
     return (
-      <EmptyStateWarning small={true}>
-        <p>{t("You don't have any incidents yet!")}</p>
+      <EmptyStateWarning>
+        <p>{t("You don't have any incidents yet")}</p>
       </EmptyStateWarning>
     );
   }
@@ -51,6 +63,15 @@ class OrganizationIncidentsBody extends AsyncComponent {
     return (
       <React.Fragment>
         <Panel>
+          <PanelHeader>
+            <TableLayout>
+              <div>{t('Incident')}</div>
+              <div>{t('Status')}</div>
+              <div>{t('Duration')}</div>
+              <div>{t('Users affected')}</div>
+              <div>{t('Total events')}</div>
+            </TableLayout>
+          </PanelHeader>
           <PanelBody>
             {incidentList.length === 0 && this.renderEmpty()}
             {incidentList.map(incident => this.renderListItem(incident))}
@@ -64,6 +85,13 @@ class OrganizationIncidentsBody extends AsyncComponent {
 
 class OrganizationIncidents extends React.Component {
   render() {
+    const {pathname, query} = this.props.location;
+
+    const unresolvedQuery = omit(query, 'status');
+    const allIncidentsQuery = {...query, status: ''};
+
+    const status = query.status === undefined ? DEFAULT_QUERY_STATUS : query.status;
+
     return (
       <DocumentTitle title={`Incidents - ${this.props.params.orgId} - Sentry`}>
         <PageContent>
@@ -71,6 +99,23 @@ class OrganizationIncidents extends React.Component {
             <PageHeading withMargins>
               {t('Incidents')} <BetaTag />
             </PageHeading>
+
+            <div className="btn-group">
+              <Button
+                to={{pathname, query: unresolvedQuery}}
+                size="small"
+                className={'btn' + (status === 'unresolved' ? ' active' : '')}
+              >
+                {t('Unresolved')}
+              </Button>
+              <Button
+                to={{pathname, query: allIncidentsQuery}}
+                size="small"
+                className={'btn' + (status === '' ? ' active' : '')}
+              >
+                {t('All Issues')}
+              </Button>
+            </div>
           </PageHeader>
           <OrganizationIncidentsBody {...this.props} />
         </PageContent>
@@ -78,5 +123,12 @@ class OrganizationIncidents extends React.Component {
     );
   }
 }
+
+const TableLayout = styled('div')`
+  display: grid;
+  grid-template-columns: 4fr 1fr 1fr 1fr 1fr;
+  grid-column-gap: ${space(1.5)};
+  width: 100%;
+`;
 
 export default OrganizationIncidents;

--- a/tests/js/spec/views/organizationIncidents/list/index.spec.jsx
+++ b/tests/js/spec/views/organizationIncidents/list/index.spec.jsx
@@ -7,19 +7,22 @@ import OrganizationIncidentsList from 'app/views/organizationIncidents/list';
 
 describe('OrganizationIncidentsList', function() {
   const {routerContext} = initializeOrg();
+  let mock;
+
+  beforeEach(function() {
+    mock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/incidents/',
+      body: [{id: '1', name: 'First incident'}, {id: '2', name: 'Second incident'}],
+    });
+  });
 
   afterEach(function() {
     MockApiClient.clearMockResponses();
   });
 
   it('displays list', function() {
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/incidents/',
-      body: [{id: '1', name: 'First incident'}, {id: '2', name: 'Second incident'}],
-    });
-
     const wrapper = mount(
-      <OrganizationIncidentsList params={{orgId: 'org-slug'}} location={{}} />,
+      <OrganizationIncidentsList params={{orgId: 'org-slug'}} location={{query: {}}} />,
       TestStubs.routerContext()
     );
 
@@ -36,10 +39,52 @@ describe('OrganizationIncidentsList', function() {
       body: [],
     });
     const wrapper = mount(
-      <OrganizationIncidentsList params={{orgId: 'org-slug'}} location={{}} />,
+      <OrganizationIncidentsList params={{orgId: 'org-slug'}} location={{query: {}}} />,
       routerContext
     );
     expect(wrapper.find('PanelItem')).toHaveLength(0);
-    expect(wrapper.text()).toContain("You don't have any incidents yet!");
+    expect(wrapper.text()).toContain("You don't have any incidents yet");
+  });
+
+  it('toggles all/unresolved', function() {
+    const wrapper = mount(
+      <OrganizationIncidentsList
+        params={{orgId: 'org-slug'}}
+        location={{query: {}, search: ''}}
+      />,
+      routerContext
+    );
+
+    expect(
+      wrapper
+        .find('.btn-group')
+        .find('a')
+        .at(0)
+        .hasClass('active')
+    ).toBe(true);
+
+    expect(mock).toHaveBeenCalledTimes(1);
+
+    expect(mock).toHaveBeenCalledWith(
+      '/organizations/org-slug/incidents/',
+      expect.objectContaining({query: {}})
+    );
+
+    wrapper.setProps({location: {query: {status: ''}, search: '?status='}});
+
+    expect(
+      wrapper
+        .find('.btn-group')
+        .find('Button')
+        .at(1)
+        .hasClass('active')
+    ).toBe(true);
+
+    expect(mock).toHaveBeenCalledTimes(2);
+
+    expect(mock).toHaveBeenCalledWith(
+      '/organizations/org-slug/incidents/',
+      expect.objectContaining({query: expect.objectContaining({status: ''})})
+    );
   });
 });


### PR DESCRIPTION
Implement table layout for the incident listing view. Supports pagination and toggling
between all/unresolved incidents.

![Screen Shot 2019-05-01 at 11 15 05 am](https://user-images.githubusercontent.com/1779792/57033739-89d9d680-6c02-11e9-8d55-f3c91bc0ff83.png)

