### PR TITLE
fix(ui): Fix emotion deprecation warnings on PanelBody

### DIFF
--- a/src/sentry/static/sentry/app/components/panels/panelBody.jsx
+++ b/src/sentry/static/sentry/app/components/panels/panelBody.jsx
@@ -14,10 +14,11 @@ const PanelBody = ({className, disablePadding, flex, direction, ...props}) => {
     : '';
   const flexDirection = flex ? direction : undefined;
   const Comp = flex ? Flex : 'div';
+  const textClassName = textStyles(props);
 
   return (
     <Comp
-      className={cx(padding, textStyles(), className)}
+      className={cx(padding, textClassName, className)}
       {...props}
       direction={flexDirection}
     />


### PR DESCRIPTION
emotion is deprecating passing functions into `cx`