### PR TITLE
fix(jira) Fix multi-select values

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -319,9 +319,11 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             if 'name' in item:
                 value = item['name']
             elif 'value' in item:
+                # Value based options prefer the value on submit.
+                key = item['value']
                 value = item['value']
             elif 'label' in item:
-                # Label based options are appear to prefer the value on submit.
+                # Label based options prefer the value on submit.
                 key = item['label']
                 value = item['label']
             else:

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -73,6 +73,22 @@ SAMPLE_CREATE_META_RESPONSE = """
                 {"id": 10100, "label": "sad"},
                 {"id": 10101, "label": "happy"}
               ]
+            },
+            "customfield_10300": {
+              "required": false,
+              "schema": {
+                "type": "array",
+                "items": "option",
+                "custom": "com.atlassian.jira.plugin.system.customfieldtypes:multiselect",
+                "customId": 10202
+              },
+              "name": "Feature",
+              "hasDefaultValue": false,
+              "operations": ["add", "set", "remove"],
+              "allowedValues": [
+                {"value": "Feature 1", "id": "10105"},
+                {"value": "Feature 2", "id": "10106"}
+              ]
             }
           }
         }
@@ -476,6 +492,14 @@ class JiraIntegrationTest(APITestCase):
                 'label': 'Mood',
                 'default': '',
                 'choices': [('sad', 'sad'), ('happy', 'happy')],
+            }, {
+                'multiple': True,
+                'required': False,
+                'type': 'select',
+                'name': 'customfield_10300',
+                'label': 'Feature',
+                'default': '',
+                'choices': [('Feature 1', 'Feature 1'), ('Feature 2', 'Feature 2')],
             }]
 
     def test_get_create_issue_config_with_default_and_param(self):
@@ -636,6 +660,8 @@ class JiraIntegrationTest(APITestCase):
             body = json.loads(request.body)
             assert body['fields']['labels'] == ['fuzzy', 'bunnies']
             assert body['fields']['customfield_10200'] == {'value': 'sad'}
+            assert body['fields']['customfield_10300'] == [
+                {'value': 'Feature 1'}, {'value': 'Feature 2'}]
             return (200, {'content-type': 'application/json'}, '{"key":"APP-123"}')
 
         responses.add_callback(
@@ -651,6 +677,7 @@ class JiraIntegrationTest(APITestCase):
             'issuetype': '1',
             'project': '10000',
             'customfield_10200': 'sad',
+            'customfield_10300': ['Feature 1', 'Feature 2'],
             'labels': 'fuzzy , ,  bunnies'
         })
         assert result['key'] == 'APP-123'


### PR DESCRIPTION
Fix multi-select dropdowns and allow them to save their values. Jira rejects the values when provided by id.

Fixes #13001