### PR TITLE
fix(ui) Close saved search selector on subsequent clicks

### DIFF
--- a/src/sentry/static/sentry/app/views/stream/organizationSavedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/stream/organizationSavedSearchSelector.jsx
@@ -100,7 +100,9 @@ const Container = styled.div`
   display: block;
 `;
 
-const StyledDropdownButton = styled(DropdownButton)`
+const StyledDropdownButton = styled(
+  React.forwardRef((prop, ref) => <DropdownButton innerRef={ref} {...prop} />)
+)`
   border-right: 0;
   z-index: ${p => p.theme.zIndex.dropdownAutocomplete.actor};
   border-radius: ${p =>


### PR DESCRIPTION
Because we weren't forwarding refs the dropdown menu didn't know what its 'actor' was and was unable to discard clicks coming from inside the trigger button.