### PR TITLE
build: Increase default selenium browser size to 1600x1200

### DIFF
--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -247,11 +247,14 @@ def pytest_addoption(parser):
         '--window-size',
         dest='window_size',
         help='window size (WIDTHxHEIGHT)',
-        default='1280x800')
+        default='1680x1050')
     group._addoption('--phantomjs-path', dest='phantomjs_path', help='path to phantomjs driver')
     group._addoption('--chrome-path', dest='chrome_path', help='path to google-chrome')
     group._addoption('--chromedriver-path', dest='chromedriver_path', help='path to chromedriver')
-    group._addoption('--no-headless', dest='no_headless', help='show a browser while running the tests (chrome)')
+    group._addoption(
+        '--no-headless',
+        dest='no_headless',
+        help='show a browser while running the tests (chrome)')
 
 
 def pytest_configure(config):


### PR DESCRIPTION
This improves debugability since most window sizes we test against are closer to this. Tools like Percy already give us the ability to dynamically augment multiple sizes, so this is only for local testing and pytest fixture output.