### PR TITLE
fix(docs) Fix build error in storybooks

### DIFF
--- a/docs-ui/components/externalLink.stories.js
+++ b/docs-ui/components/externalLink.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import ExternalLink from 'app/components/externalLink';
+import ExternalLink from 'app/components/links/externalLink';
 
 storiesOf('UI|Links/ExternalLink', module).add(
   'default',


### PR DESCRIPTION
The externalLinks component was moved, the stories were referencing the old location.