### PR TITLE
fix(global-selection-header): Fix invalid projects when switching orgs [SEN-574]

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/globalSelection.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/globalSelection.jsx
@@ -22,6 +22,11 @@ const isEqualWithEmptyArrays = (newQuery, current) => {
   );
 };
 
+// Reset values in global selection store
+export function resetGlobalSelection() {
+  GlobalSelectionActions.reset();
+}
+
 /**
  * Updates global project selection URL param if `router` is supplied
  * OTHERWISE fire action to update projects

--- a/src/sentry/static/sentry/app/actionCreators/organizations.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/organizations.jsx
@@ -1,5 +1,6 @@
 import {browserHistory} from 'react-router';
 
+import {resetGlobalSelection} from 'app/actionCreators/globalSelection';
 import {Client} from 'app/api';
 import IndicatorStore from 'app/stores/indicatorStore';
 import OrganizationsActions from 'app/actions/organizationsActions';
@@ -47,6 +48,10 @@ export function remove(api, {successMessage, errorMessage, orgId} = {}) {
         IndicatorStore.add(errorMessage, 'error', {duration: 3000});
       }
     });
+}
+
+export function switchOrganization(prevOrgId, nextOrgId) {
+  resetGlobalSelection();
 }
 
 export function removeAndRedirectToRemainingOrganization(api, params) {

--- a/src/sentry/static/sentry/app/actions/globalSelectionActions.jsx
+++ b/src/sentry/static/sentry/app/actions/globalSelectionActions.jsx
@@ -1,6 +1,7 @@
 import Reflux from 'reflux';
 
 export default Reflux.createActions([
+  'reset',
   'updateProjects',
   'updateDateTime',
   'updateEnvironments',

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
@@ -102,9 +102,11 @@ class GlobalSelectionHeader extends React.Component {
       return;
     }
 
+    const {location, params, organization, selection} = this.props;
+
     const hasMultipleProjectFeature = this.hasMultipleProjectSelection();
 
-    const stateFromRouter = getStateFromQuery(this.props.location.query);
+    const stateFromRouter = getStateFromQuery(location.query);
     // We should update store if there are any relevant URL parameters when component
     // is mounted
     if (Object.values(stateFromRouter).some(i => !!i)) {
@@ -131,12 +133,13 @@ class GlobalSelectionHeader extends React.Component {
         updateProjects(allowedProjects);
         updateParams({project: allowedProjects}, this.getRouter());
       }
-    } else {
-      // Otherwise, we can update URL with values from store
+    } else if (params && params.orgId === organization.slug) {
+      // Otherwise, if organization has NOT changed,
+      // we can update URL with values from store
       //
       // e.g. when switching to a new view that uses this component,
       // update URL parameters to reflect current store
-      const {datetime, environments, projects} = this.props.selection;
+      const {datetime, environments, projects} = selection;
 
       if (hasMultipleProjectFeature || projects.length === 1) {
         updateParamsWithoutHistory(

--- a/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
+++ b/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
@@ -42,6 +42,7 @@ const isValidSelection = (selection, organization) => {
 const GlobalSelectionStore = Reflux.createStore({
   init() {
     this.reset(this.selection);
+    this.listenTo(GlobalSelectionActions.reset, this.onReset);
     this.listenTo(GlobalSelectionActions.updateProjects, this.updateProjects);
     this.listenTo(GlobalSelectionActions.updateDateTime, this.updateDateTime);
     this.listenTo(GlobalSelectionActions.updateEnvironments, this.updateEnvironments);
@@ -98,6 +99,11 @@ const GlobalSelectionStore = Reflux.createStore({
 
   get() {
     return this.selection;
+  },
+
+  onReset() {
+    this.reset();
+    this.trigger(this.selection);
   },
 
   updateProjects(projects = []) {

--- a/src/sentry/static/sentry/app/views/organizationDetails/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDetails/index.jsx
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 
 import {Client} from 'app/api';
+import {switchOrganization} from 'app/actionCreators/organizations';
 import {t, tct} from 'app/locale';
 import AlertActions from 'app/actions/alertActions';
 import Button from 'app/components/button';
@@ -148,6 +149,15 @@ class OrganizationDetailsBody extends Component {
 }
 
 export default class OrganizationDetails extends Component {
+  componentDidUpdate(prevProps) {
+    if (
+      prevProps.params &&
+      this.props.params &&
+      prevProps.params.orgId !== this.props.params.orgId
+    ) {
+      switchOrganization(prevProps.params.orgId, this.props.params.orgId);
+    }
+  }
   render() {
     return (
       <OrganizationContext includeSidebar useLastOrganization {...this.props}>

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -54,6 +54,17 @@ describe('GlobalSelectionHeader', function() {
     expect(router.push).not.toHaveBeenCalled();
   });
 
+  it('does not update router if org in URL params is different than org in context/props', function() {
+    mount(<GlobalSelectionHeader organization={organization} hasCustomRouting />, {
+      ...routerContext,
+      context: {
+        ...routerContext.context,
+        router: {...routerContext.context.router, params: {orgId: 'diff-org'}},
+      },
+    });
+    expect(router.push).not.toHaveBeenCalled();
+  });
+
   it('does not replace URL with values from store when mounted with no query params', function() {
     mount(<GlobalSelectionHeader organization={organization} />, routerContext);
 
@@ -241,6 +252,7 @@ describe('GlobalSelectionHeader', function() {
     it('selects first project if more than one is requested', function() {
       const initializationObj = initializeOrg({
         router: {
+          params: {orgId: 'org-slug'}, // we need this to be set to make sure org in context is same as current org in URL
           location: {query: {project: [1, 2]}},
         },
       });
@@ -261,6 +273,7 @@ describe('GlobalSelectionHeader', function() {
       const initializationObj = initializeOrg({
         organization: org,
         router: {
+          params: {orgId: 'org-slug'},
           location: {query: {}},
         },
       });


### PR DESCRIPTION
Previously, when switching orgs, `<GlobalSelectionHeader>` was attempting to load its state because it would get remounted with the new organization. However the state was for the previous organization. We now do a check to make sure that the org slug in the URL params is the same as the org slug from context/props before loading state from the store.

Also reset store when we detect that organization has changed.

Fixes SEN-574