### PR TITLE
ref(ui): Forward ref to ExternalLink

### DIFF
--- a/src/sentry/static/sentry/app/components/links/externalLink.jsx
+++ b/src/sentry/static/sentry/app/components/links/externalLink.jsx
@@ -7,9 +7,9 @@ import PropTypes from 'prop-types';
  * By default will open in a new tab with `rel="noreferrer noopener"` to guard against
  * `target="_blank"` vulnerabilities
  */
-export default function ExternalLink({href, ...otherProps}) {
-  return <a {...otherProps} href={href} />;
-}
+const ExternalLink = React.forwardRef(({href, ...otherProps}, ref) => {
+  return <a ref={ref} {...otherProps} href={href} />;
+});
 
 ExternalLink.propTypes = {
   href: PropTypes.string.isRequired,
@@ -22,3 +22,5 @@ ExternalLink.defaultProps = {
   target: '_blank',
   rel: 'noreferrer noopener',
 };
+
+export default ExternalLink;

--- a/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
+++ b/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
@@ -298,7 +298,7 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
               className="css-roynbj"
               is={null}
             >
-              <ExternalLink
+              <ForwardRef
                 href="http://example.com/integration_source_url"
                 rel="noreferrer noopener"
                 target="_blank"
@@ -310,8 +310,8 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
                 >
                   View Source
                 </a>
-              </ExternalLink>
-              <ExternalLink
+              </ForwardRef>
+              <ForwardRef
                 href="http://example.com/integration_issue_url"
                 rel="noreferrer noopener"
                 target="_blank"
@@ -323,7 +323,7 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
                 >
                   Report Issue
                 </a>
-              </ExternalLink>
+              </ForwardRef>
             </div>
           </Base>
         </Box>

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -1165,7 +1165,7 @@ exports[`Sidebar SidebarPanel can display Broadcasts panel and mark as seen 1`] 
         <div
           className="css-7bhqyd-Text er110872"
         >
-          <ExternalLink
+          <ForwardRef
             href="https://docs.sentry.io/hosted/clients/javascript/sourcemaps/#uploading-source-maps-to-sentry"
             rel="noreferrer noopener"
             target="_blank"
@@ -1177,7 +1177,7 @@ exports[`Sidebar SidebarPanel can display Broadcasts panel and mark as seen 1`] 
             >
               Read More
             </a>
-          </ExternalLink>
+          </ForwardRef>
         </div>
       </Text>
     </div>
@@ -1266,7 +1266,7 @@ exports[`Sidebar SidebarPanel can show Incidents in Sidebar Panel 1`] = `
                 role="button"
                 size="small"
               >
-                <ExternalLink
+                <ForwardRef
                   aria-disabled={false}
                   aria-label="Learn more"
                   className="css-o6814l-StyledButton-getColors e12ma6z0"
@@ -1303,7 +1303,7 @@ exports[`Sidebar SidebarPanel can show Incidents in Sidebar Panel 1`] = `
                       </Component>
                     </ButtonLabel>
                   </a>
-                </ExternalLink>
+                </ForwardRef>
               </ForwardRef>
             </StyledButton>
           </Button>

--- a/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
@@ -666,7 +666,7 @@ exports[`ProjectPluginDetails renders 1`] = `
                       URL
                     </dt>
                     <dd>
-                      <ExternalLink
+                      <ForwardRef
                         href="https://github.com/getsentry/sentry"
                         rel="noreferrer noopener"
                         target="_blank"
@@ -678,7 +678,7 @@ exports[`ProjectPluginDetails renders 1`] = `
                         >
                           github.com/getsentry/sentry
                         </a>
-                      </ExternalLink>
+                      </ForwardRef>
                     </dd>
                   </div>
                   <dt>

--- a/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
@@ -196,7 +196,7 @@ exports[`ProjectTags renders 1`] = `
                 Each event in Sentry may be annotated with various tags (key and value pairs).
                  Learn how to 
               </span>
-              <ExternalLink
+              <ForwardRef
                 href="https://docs.sentry.io/hosted/learn/context/"
                 key="2"
                 rel="noreferrer noopener"
@@ -213,7 +213,7 @@ exports[`ProjectTags renders 1`] = `
                     add custom tags
                   </span>
                 </a>
-              </ExternalLink>
+              </ForwardRef>
               <span
                 key="3"
               >

--- a/tests/js/spec/views/onboarding/__snapshots__/configure.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/__snapshots__/configure.spec.jsx.snap
@@ -476,7 +476,7 @@ exports[`Configure should render correctly render() should render platform docs 
                                                             role="button"
                                                             size="small"
                                                           >
-                                                            <ExternalLink
+                                                            <ForwardRef
                                                               aria-disabled={false}
                                                               aria-label="Full Documentation"
                                                               className="css-o6814l-StyledButton-getColors e12ma6z0"
@@ -513,7 +513,7 @@ exports[`Configure should render correctly render() should render platform docs 
                                                                   </Component>
                                                                 </ButtonLabel>
                                                               </a>
-                                                            </ExternalLink>
+                                                            </ForwardRef>
                                                           </ForwardRef>
                                                         </StyledButton>
                                                       </Button>

--- a/tests/js/spec/views/organizationProjectsDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationProjectsDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -914,7 +914,7 @@ exports[`ProjectCard renders 1`] = `
                                   role="button"
                                   size="xsmall"
                                 >
-                                  <ExternalLink
+                                  <ForwardRef
                                     aria-disabled={false}
                                     aria-label="Track deploys"
                                     className="css-o6814l-StyledButton-getColors e12ma6z0"
@@ -951,7 +951,7 @@ exports[`ProjectCard renders 1`] = `
                                         </Component>
                                       </ButtonLabel>
                                     </a>
-                                  </ExternalLink>
+                                  </ForwardRef>
                                 </ForwardRef>
                               </StyledButton>
                             </Button>

--- a/tests/js/spec/views/projectPlugins/__snapshots__/projectPluginsRow.spec.jsx.snap
+++ b/tests/js/spec/views/projectPlugins/__snapshots__/projectPluginsRow.spec.jsx.snap
@@ -204,7 +204,7 @@ exports[`ProjectPluginRow renders 1`] = `
                           </div>
                         </PluginName>
                         <div>
-                          <ExternalLink
+                          <ForwardRef
                             className="css-8vm1xp-grayText"
                             href="https://github.com/getsentry/sentry"
                             rel="noreferrer noopener"
@@ -218,7 +218,7 @@ exports[`ProjectPluginRow renders 1`] = `
                             >
                               Sentry Team
                             </a>
-                          </ExternalLink>
+                          </ForwardRef>
                           <span>
                              
                             ·

--- a/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectCspReports.spec.jsx.snap
+++ b/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectCspReports.spec.jsx.snap
@@ -59,7 +59,7 @@ exports[`ProjectCspReports renders 1`] = `
           <span
             key="4"
           >
-            <ExternalLink
+            <ForwardRef
               href="https://en.wikipedia.org/wiki/Content_Security_Policy"
               key="1"
               rel="noreferrer noopener"
@@ -70,7 +70,7 @@ exports[`ProjectCspReports renders 1`] = `
               >
                 Content Security Policy
               </span>
-            </ExternalLink>
+            </ForwardRef>
             <span
               key="2"
             >

--- a/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectExpectCtReports.spec.jsx.snap
+++ b/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectExpectCtReports.spec.jsx.snap
@@ -34,7 +34,7 @@ exports[`ProjectExpectCtReports renders 1`] = `
           <span
             key="4"
           >
-            <ExternalLink
+            <ForwardRef
               href="https://en.wikipedia.org/wiki/Certificate_Transparency"
               key="1"
               rel="noreferrer noopener"
@@ -45,7 +45,7 @@ exports[`ProjectExpectCtReports renders 1`] = `
               >
                 Certificate Transparency
               </span>
-            </ExternalLink>
+            </ForwardRef>
             <span
               key="2"
             >

--- a/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectHpkpReports.spec.jsx.snap
+++ b/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectHpkpReports.spec.jsx.snap
@@ -34,7 +34,7 @@ exports[`ProjectHpkpReports renders 1`] = `
           <span
             key="4"
           >
-            <ExternalLink
+            <ForwardRef
               href="https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning"
               key="1"
               rel="noreferrer noopener"
@@ -45,7 +45,7 @@ exports[`ProjectHpkpReports renders 1`] = `
               >
                 HTTP Public Key Pinning
               </span>
-            </ExternalLink>
+            </ForwardRef>
             <span
               key="2"
             >

--- a/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -217,7 +217,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
             >
               API keys grant access to the 
             </span>
-            <ExternalLink
+            <ForwardRef
               href="https://docs.sentry.io/hosted/api/"
               key="2"
               rel="noreferrer noopener"
@@ -234,7 +234,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
                   developer web API
                 </span>
               </a>
-            </ExternalLink>
+            </ForwardRef>
             <span
               key="3"
             >

--- a/tests/js/spec/views/settings/__snapshots__/organizationAuthList.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationAuthList.spec.jsx.snap
@@ -35,7 +35,7 @@ exports[`OrganizationAuthList renders 1`] = `
           >
             Get started with Single Sign-on for your organization by selecting a provider. Read more in our 
           </span>
-          <ExternalLink
+          <ForwardRef
             href="https://docs.sentry.io/learn/sso/"
             key="2"
             rel="noreferrer noopener"
@@ -46,7 +46,7 @@ exports[`OrganizationAuthList renders 1`] = `
             >
               SSO documentation
             </span>
-          </ExternalLink>
+          </ForwardRef>
           <span
             key="3"
           >
@@ -131,7 +131,7 @@ exports[`OrganizationAuthList renders with no providers 1`] = `
           >
             Get started with Single Sign-on for your organization by selecting a provider. Read more in our 
           </span>
-          <ExternalLink
+          <ForwardRef
             href="https://docs.sentry.io/learn/sso/"
             key="2"
             rel="noreferrer noopener"
@@ -142,7 +142,7 @@ exports[`OrganizationAuthList renders with no providers 1`] = `
             >
               SSO documentation
             </span>
-          </ExternalLink>
+          </ForwardRef>
           <span
             key="3"
           >


### PR DESCRIPTION
Makes this easier to use when using libraries that need refs to the dom
