### PR TITLE
feat: display applied grouping enhancers

### DIFF
--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined:2019_04_07/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined:2019_04_07/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-07T12:50:18.036682Z'
+created: '2019-05-02T18:53:29.310654Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,7 +24,7 @@ app:
           frame (non app frame)
             function*
               u'std::rt::lang_start::{{closure}}'
-          frame* (marked in-app by grouping enhancement rule)
+          frame* (marked in-app by grouping enhancement rule (family:native function:log_demo::*))
             function*
               u'log_demo::main'
           frame (non app frame)
@@ -54,7 +54,7 @@ system:
           frame*
             function*
               u'std::rt::lang_start::{{closure}}'
-          frame* (marked in-app by grouping enhancement rule)
+          frame* (marked in-app by grouping enhancement rule (family:native function:log_demo::*))
             function*
               u'log_demo::main'
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined:2019_04_07/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined:2019_04_07/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-07T13:12:37.272426Z'
+created: '2019-05-02T18:53:29.352014Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,7 +24,7 @@ app:
           frame (non app frame)
             function*
               u'std::rt::lang_start::{{closure}}'
-          frame* (marked in-app by grouping enhancement rule)
+          frame* (marked in-app by grouping enhancement rule (family:native function:log_demo::*))
             function*
               u'log_demo::main'
           frame (non app frame)
@@ -45,7 +45,7 @@ system:
           frame*
             function*
               u'std::rt::lang_start_internal'
-          frame (ignored by grouping enhancement rule)
+          frame (ignored by grouping enhancement rule (family:native function:__*))
             function*
               u'___rust_maybe_catch_panic'
           frame*
@@ -54,10 +54,10 @@ system:
           frame*
             function*
               u'std::rt::lang_start::{{closure}}'
-          frame* (marked in-app by grouping enhancement rule)
+          frame* (marked in-app by grouping enhancement rule (family:native function:log_demo::*))
             function*
               u'log_demo::main'
-          frame (ignored by grouping enhancement rule)
+          frame (ignored by grouping enhancement rule (family:native function:*::__*))
             function*
               u'log::__private_api_log'
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy:2019_03_12/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy:2019_03_12/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-09T07:38:26.537674Z'
+created: '2019-05-02T18:53:30.277588Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -44,16 +44,16 @@ system:
           frame
             function (function name is used only if module or filename are available)
               u'_main'
-          frame (marked out of app by grouping enhancement rule)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::*))
             function (function name is used only if module or filename are available)
               u'std::rt::lang_start_internal'
           frame
             function (function name is used only if module or filename are available)
               u'___rust_maybe_catch_panic'
-          frame (marked out of app by grouping enhancement rule)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::*))
             function (function name is used only if module or filename are available)
               u'std::panicking::try::do_call'
-          frame (marked out of app by grouping enhancement rule)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::*))
             function (function name is used only if module or filename are available)
               u'std::rt::lang_start::{{closure}}'
           frame

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy:2019_03_12/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy:2019_03_12/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-09T07:38:26.571613Z'
+created: '2019-05-02T18:53:30.317409Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -44,16 +44,16 @@ system:
           frame
             function (function name is used only if module or filename are available)
               u'_main'
-          frame (marked out of app by grouping enhancement rule)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::*))
             function (function name is used only if module or filename are available)
               u'std::rt::lang_start_internal'
           frame
             function (function name is used only if module or filename are available)
               u'___rust_maybe_catch_panic'
-          frame (marked out of app by grouping enhancement rule)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::*))
             function (function name is used only if module or filename are available)
               u'std::panicking::try::do_call'
-          frame (marked out of app by grouping enhancement rule)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::*))
             function (function name is used only if module or filename are available)
               u'std::rt::lang_start::{{closure}}'
           frame

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_05/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_05/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-07T12:50:19.615853Z'
+created: '2019-05-02T18:53:31.212549Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,7 +24,7 @@ app:
           frame (non app frame)
             function*
               u'std::rt::lang_start::{{closure}}'
-          frame* (marked in-app by grouping enhancement rule)
+          frame* (marked in-app by grouping enhancement rule (family:native function:log_demo::*))
             function*
               u'log_demo::main'
           frame (non app frame)
@@ -54,7 +54,7 @@ system:
           frame*
             function*
               u'std::rt::lang_start::{{closure}}'
-          frame* (marked in-app by grouping enhancement rule)
+          frame* (marked in-app by grouping enhancement rule (family:native function:log_demo::*))
             function*
               u'log_demo::main'
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_05/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_05/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-07T13:12:38.958947Z'
+created: '2019-05-02T18:53:31.253290Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,7 +24,7 @@ app:
           frame (non app frame)
             function*
               u'std::rt::lang_start::{{closure}}'
-          frame* (marked in-app by grouping enhancement rule)
+          frame* (marked in-app by grouping enhancement rule (family:native function:log_demo::*))
             function*
               u'log_demo::main'
           frame (non app frame)
@@ -45,7 +45,7 @@ system:
           frame*
             function*
               u'std::rt::lang_start_internal'
-          frame (ignored by grouping enhancement rule)
+          frame (ignored by grouping enhancement rule (family:native function:__*))
             function*
               u'___rust_maybe_catch_panic'
           frame*
@@ -54,10 +54,10 @@ system:
           frame*
             function*
               u'std::rt::lang_start::{{closure}}'
-          frame* (marked in-app by grouping enhancement rule)
+          frame* (marked in-app by grouping enhancement rule (family:native function:log_demo::*))
             function*
               u'log_demo::main'
-          frame (ignored by grouping enhancement rule)
+          frame (ignored by grouping enhancement rule (family:native function:*::__*))
             function*
               u'log::__private_api_log'
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_17/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_17/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-17T20:02:29.034332Z'
+created: '2019-05-02T18:53:32.162383Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,7 +24,7 @@ app:
           frame (non app frame)
             function*
               u'std::rt::lang_start::{{closure}}'
-          frame* (marked in-app by grouping enhancement rule)
+          frame* (marked in-app by grouping enhancement rule (family:native function:log_demo::*))
             function*
               u'log_demo::main'
           frame (non app frame)
@@ -56,7 +56,7 @@ system:
           frame*
             function*
               u'std::rt::lang_start::{{closure}}'
-          frame* (marked in-app by grouping enhancement rule)
+          frame* (marked in-app by grouping enhancement rule (family:native function:log_demo::*))
             function*
               u'log_demo::main'
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_17/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_17/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-17T20:02:29.084952Z'
+created: '2019-05-02T18:53:32.201919Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,7 +24,7 @@ app:
           frame (non app frame)
             function*
               u'std::rt::lang_start::{{closure}}'
-          frame* (marked in-app by grouping enhancement rule)
+          frame* (marked in-app by grouping enhancement rule (family:native function:log_demo::*))
             function*
               u'log_demo::main'
           frame (non app frame)
@@ -47,7 +47,7 @@ system:
           frame*
             function*
               u'std::rt::lang_start_internal'
-          frame (ignored by grouping enhancement rule)
+          frame (ignored by grouping enhancement rule (family:native function:__*))
             function*
               u'___rust_maybe_catch_panic'
           frame*
@@ -56,10 +56,10 @@ system:
           frame*
             function*
               u'std::rt::lang_start::{{closure}}'
-          frame* (marked in-app by grouping enhancement rule)
+          frame* (marked in-app by grouping enhancement rule (family:native function:log_demo::*))
             function*
               u'log_demo::main'
-          frame (ignored by grouping enhancement rule)
+          frame (ignored by grouping enhancement rule (family:native function:*::__*))
             function*
               u'log::__private_api_log'
         type*


### PR DESCRIPTION
This now shows which matchers matched in the grouping debug output.  This is useful
when enhancers are applied that might be overly lenient.  Have a look at the snapshot
changes for how this looks like.