### PR TITLE
feat: Drop project ID param from group absolute URL

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -318,8 +318,6 @@ class Group(Model):
         from sentry import features
         if features.has('organizations:sentry10', self.organization):
             url = reverse('sentry-organization-issue', args=[self.organization.slug, self.id])
-            params = {} if params is None else params
-            params['project'] = self.project.id
         else:
             url = reverse('sentry-group', args=[self.organization.slug, self.project.slug, self.id])
         if params:

--- a/tests/fixtures/emails/assigned.txt
+++ b/tests/fixtures/emails/assigned.txt
@@ -7,7 +7,7 @@ foo@example.com assigned an issue to foo@example.com
 
 ornare elit pulvinar nisl integer cum ad massa
 
-http://testserver/organizations/organization/issues/1/?project=1&amp;referrer=AssignedActivityEmail
+http://testserver/organizations/organization/issues/1/?referrer=AssignedActivityEmail
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/assigned_self.txt
+++ b/tests/fixtures/emails/assigned_self.txt
@@ -7,7 +7,7 @@ foo@example.com assigned an issue to themselves
 
 ornare elit pulvinar nisl integer cum ad massa
 
-http://testserver/organizations/organization/issues/1/?project=1&amp;referrer=AssignedActivityEmail
+http://testserver/organizations/organization/issues/1/?referrer=AssignedActivityEmail
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/note.txt
+++ b/tests/fixtures/emails/note.txt
@@ -9,6 +9,6 @@ metus volutpat
 
 ornare elit pulvinar nisl integer cum ad massa
 
-http://testserver/organizations/organization/issues/1/activity/?project=1&amp;referrer=NoteActivityEmail
+http://testserver/organizations/organization/issues/1/activity/?referrer=NoteActivityEmail
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/regression.txt
+++ b/tests/fixtures/emails/regression.txt
@@ -7,7 +7,7 @@ Sentry marked an issue as a regression
 
 ornare elit pulvinar nisl integer cum ad massa
 
-http://testserver/organizations/organization/issues/1/?project=1&amp;referrer=RegressionActivityEmail
+http://testserver/organizations/organization/issues/1/?referrer=RegressionActivityEmail
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/regression_with_version.txt
+++ b/tests/fixtures/emails/regression_with_version.txt
@@ -7,7 +7,7 @@ Sentry marked an issue as a regression in abcdef
 
 ornare elit pulvinar nisl integer cum ad massa
 
-http://testserver/organizations/organization/issues/1/?project=1&amp;referrer=RegressionActivityEmail
+http://testserver/organizations/organization/issues/1/?referrer=RegressionActivityEmail
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/resolved.txt
+++ b/tests/fixtures/emails/resolved.txt
@@ -7,7 +7,7 @@ Sentry marked an issue as resolved
 
 ornare elit pulvinar nisl integer cum ad massa
 
-http://testserver/organizations/organization/issues/1/?project=1&amp;referrer=ResolvedActivityEmail
+http://testserver/organizations/organization/issues/1/?referrer=ResolvedActivityEmail
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/resolved_in_release.txt
+++ b/tests/fixtures/emails/resolved_in_release.txt
@@ -7,7 +7,7 @@ Sentry marked an issue as resolved in abcdef
 
 ornare elit pulvinar nisl integer cum ad massa
 
-http://testserver/organizations/organization/issues/1/?project=1&amp;referrer=ResolvedInReleaseActivityEmail
+http://testserver/organizations/organization/issues/1/?referrer=ResolvedInReleaseActivityEmail
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/resolved_in_release_upcoming.txt
+++ b/tests/fixtures/emails/resolved_in_release_upcoming.txt
@@ -7,7 +7,7 @@ Sentry marked an issue as resolved in an upcoming release
 
 ornare elit pulvinar nisl integer cum ad massa
 
-http://testserver/organizations/organization/issues/1/?project=1&amp;referrer=ResolvedInReleaseActivityEmail
+http://testserver/organizations/organization/issues/1/?referrer=ResolvedInReleaseActivityEmail
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/fixtures/emails/unassigned.txt
+++ b/tests/fixtures/emails/unassigned.txt
@@ -7,7 +7,7 @@ foo@example.com unassigned an issue
 
 ornare elit pulvinar nisl integer cum ad massa
 
-http://testserver/organizations/organization/issues/1/?project=1&amp;referrer=UnassignedActivityEmail
+http://testserver/organizations/organization/issues/1/?referrer=UnassignedActivityEmail
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -232,10 +232,10 @@ class GroupTest(TestCase):
         assert group.get_email_subject() == '%s - %s' % (group.qualified_short_id, group.title)
 
     def test_get_absolute_url(self):
-        project = self.create_project(name='pumped-quagga')
-        group = self.create_group(project=project)
+        with self.feature('organizations:sentry10'):
+            project = self.create_project(name='pumped-quagga')
+            group = self.create_group(project=project)
 
-        result = group.get_absolute_url({'environment': u'd\u00E9v'})
-        assert result == u'http://testserver/baz/{}/issues/{}/?environment=d%C3%A9v'.format(
-            project.slug,
-            group.id)
+            result = group.get_absolute_url({'environment': u'd\u00E9v'})
+            assert result == u'http://testserver/organizations/baz/issues/{}/?environment=d%C3%A9v'.format(
+                group.id)


### PR DESCRIPTION
Group urls do not need a project ID as part of a URL. We display a locked project
state in the UI so this link should make sense without it. The downside of
this is that navigating away from this page will preserve whatever
project selection a user had previously active.

This came up in SEN-515