### PR TITLE
ref: Make outcome an Enum

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -8,9 +8,7 @@ from __future__ import absolute_import, print_function
 
 import jsonschema
 import logging
-import random
 import six
-import time
 
 from datetime import datetime, timedelta
 from django.conf import settings
@@ -18,7 +16,7 @@ from django.db import connection, IntegrityError, router, transaction
 from django.utils import timezone
 from django.utils.encoding import force_text
 
-from sentry import buffer, eventtypes, eventstream, features, tagstore, tsdb, filters, options
+from sentry import buffer, eventtypes, eventstream, features, tagstore, tsdb, filters
 from sentry.constants import (
     LOG_LEVELS, LOG_LEVELS_MAP, VALID_PLATFORMS, MAX_TAG_VALUE_LENGTH,
 )
@@ -44,7 +42,7 @@ from sentry.models import (
 from sentry.plugins import plugins
 from sentry.signals import event_discarded, event_saved, first_event_received
 from sentry.tasks.integrations import kick_off_status_syncs
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 from sentry.utils.cache import default_cache
 from sentry.utils.canonical import CanonicalKeyDict
 from sentry.utils.contexts_normalization import normalize_user_agent
@@ -53,12 +51,10 @@ from sentry.utils.data_filters import (
     is_valid_release,
     is_valid_error_message,
     FilterStatKeys,
-    FILTER_STAT_KEYS_TO_VALUES
 )
-from sentry.utils.dates import to_timestamp, to_datetime
+from sentry.utils.dates import to_timestamp
 from sentry.utils.db import is_postgres
 from sentry.utils.geo import rust_geoip
-from sentry.utils.pubsub import QueuedPublisherService, KafkaPublisher
 from sentry.utils.safe import safe_execute, trim, get_path, setdefault_path
 from sentry.utils.validators import is_float
 from sentry.stacktraces.processing import normalize_stacktraces_for_grouping
@@ -327,84 +323,6 @@ def _decode_event(data, content_encoding):
         data = safely_load_json_string(data)
 
     return CanonicalKeyDict(data)
-
-
-outcomes = settings.KAFKA_TOPICS[settings.KAFKA_OUTCOMES]
-outcomes_publisher = None
-
-
-def track_outcome(org_id, project_id, key_id, outcome, reason=None, timestamp=None):
-    """
-    This is a central point to track org/project counters per incoming event.
-    NB: This should only ever be called once per incoming event, which means
-    it should only be called at the point we know the final outcome for the
-    event (invalid, rate_limited, accepted, discarded, etc.)
-
-    This increments all the relevant legacy RedisTSDB counters, as well as
-    sending a single metric event to Kafka which can be used to reconstruct the
-    counters with SnubaTSDB.
-    """
-    global outcomes_publisher
-    if outcomes_publisher is None:
-        outcomes_publisher = QueuedPublisherService(
-            KafkaPublisher(
-                settings.KAFKA_CLUSTERS[outcomes['cluster']]
-            )
-        )
-
-    timestamp = timestamp or to_datetime(time.time())
-    increment_list = []
-    if outcome != 'invalid':
-        # This simply preserves old behavior. We never counted invalid events
-        # (too large, duplicate, CORS) toward regular `received` counts.
-        increment_list.extend([
-            (tsdb.models.project_total_received, project_id),
-            (tsdb.models.organization_total_received, org_id),
-            (tsdb.models.key_total_received, key_id),
-        ])
-
-    if outcome == 'filtered':
-        increment_list.extend([
-            (tsdb.models.project_total_blacklisted, project_id),
-            (tsdb.models.organization_total_blacklisted, org_id),
-            (tsdb.models.key_total_blacklisted, key_id),
-        ])
-    elif outcome == 'rate_limited':
-        increment_list.extend([
-            (tsdb.models.project_total_rejected, project_id),
-            (tsdb.models.organization_total_rejected, org_id),
-            (tsdb.models.key_total_rejected, key_id),
-        ])
-
-    if reason in FILTER_STAT_KEYS_TO_VALUES:
-        increment_list.append((FILTER_STAT_KEYS_TO_VALUES[reason], project_id))
-
-    increment_list = [(model, key) for model, key in increment_list if key is not None]
-    if increment_list:
-        tsdb.incr_multi(increment_list, timestamp=timestamp)
-
-    # Send a snuba metrics payload.
-    if random.random() <= options.get('snuba.track-outcomes-sample-rate'):
-        outcomes_publisher.publish(
-            outcomes['topic'],
-            json.dumps({
-                'timestamp': timestamp,
-                'org_id': org_id,
-                'project_id': project_id,
-                'key_id': key_id,
-                'outcome': outcome,
-                'reason': reason,
-            })
-        )
-
-    metrics.incr(
-        'events.outcomes',
-        skip_internal=True,
-        tags={
-            'outcome': outcome,
-            'reason': reason,
-        },
-    )
 
 
 class EventManager(object):

--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -1,0 +1,105 @@
+"""
+sentry.utils.outcomes.py
+~~~~~~~~~~~~~~~~~~~~
+:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+from __future__ import absolute_import
+
+import random
+import time
+from django.conf import settings
+from enum import IntEnum
+
+from sentry import tsdb, options
+from sentry.utils import json, metrics
+from sentry.utils.data_filters import FILTER_STAT_KEYS_TO_VALUES
+from sentry.utils.dates import to_datetime
+from sentry.utils.pubsub import QueuedPublisherService, KafkaPublisher
+
+# valid values for outcome
+
+
+class Outcome(IntEnum):
+    ACCEPTED = 0
+    FILTERED = 1
+    RATE_LIMITED = 2
+    INVALID = 3
+
+
+outcomes = settings.KAFKA_TOPICS[settings.KAFKA_OUTCOMES]
+outcomes_publisher = None
+
+
+def track_outcome(org_id, project_id, key_id, outcome, reason=None, timestamp=None):
+    """
+    This is a central point to track org/project counters per incoming event.
+    NB: This should only ever be called once per incoming event, which means
+    it should only be called at the point we know the final outcome for the
+    event (invalid, rate_limited, accepted, discarded, etc.)
+
+    This increments all the relevant legacy RedisTSDB counters, as well as
+    sending a single metric event to Kafka which can be used to reconstruct the
+    counters with SnubaTSDB.
+    """
+    global outcomes_publisher
+    if outcomes_publisher is None:
+        outcomes_publisher = QueuedPublisherService(
+            KafkaPublisher(
+                settings.KAFKA_CLUSTERS[outcomes['cluster']]
+            )
+        )
+
+    timestamp = timestamp or to_datetime(time.time())
+    increment_list = []
+    if outcome != Outcome.INVALID:
+        # This simply preserves old behavior. We never counted invalid events
+        # (too large, duplicate, CORS) toward regular `received` counts.
+        increment_list.extend([
+            (tsdb.models.project_total_received, project_id),
+            (tsdb.models.organization_total_received, org_id),
+            (tsdb.models.key_total_received, key_id),
+        ])
+
+    if outcome == Outcome.FILTERED:
+        increment_list.extend([
+            (tsdb.models.project_total_blacklisted, project_id),
+            (tsdb.models.organization_total_blacklisted, org_id),
+            (tsdb.models.key_total_blacklisted, key_id),
+        ])
+    elif outcome == Outcome.RATE_LIMITED:
+        increment_list.extend([
+            (tsdb.models.project_total_rejected, project_id),
+            (tsdb.models.organization_total_rejected, org_id),
+            (tsdb.models.key_total_rejected, key_id),
+        ])
+
+    if reason in FILTER_STAT_KEYS_TO_VALUES:
+        increment_list.append((FILTER_STAT_KEYS_TO_VALUES[reason], project_id))
+
+    increment_list = [(model, key) for model, key in increment_list if key is not None]
+    if increment_list:
+        tsdb.incr_multi(increment_list, timestamp=timestamp)
+
+    # Send a snuba metrics payload.
+    if random.random() <= options.get('snuba.track-outcomes-sample-rate'):
+        outcomes_publisher.publish(
+            outcomes['topic'],
+            json.dumps({
+                'timestamp': timestamp,
+                'org_id': org_id,
+                'project_id': project_id,
+                'key_id': key_id,
+                'outcome': outcome.value,
+                'reason': reason,
+            })
+        )
+
+    metrics.incr(
+        'events.outcomes',
+        skip_internal=True,
+        tags={
+            'outcome': outcome.name.lower(),
+            'reason': reason,
+        },
+    )

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -34,7 +34,7 @@ from sentry.coreapi import (
     Auth, APIError, APIForbidden, APIRateLimited, ClientApiHelper, ClientAuthHelper,
     SecurityAuthHelper, MinidumpAuthHelper, safely_load_json_string, logger as api_logger
 )
-from sentry.event_manager import EventManager, track_outcome
+from sentry.event_manager import EventManager
 from sentry.interfaces import schemas
 from sentry.interfaces.base import get_interface
 from sentry.lang.native.unreal import process_unreal_crash, merge_apple_crash_report, \
@@ -53,6 +53,7 @@ from sentry.utils.http import (
     get_origins,
     is_same_domain,
 )
+from sentry.utils.outcomes import Outcome, track_outcome
 from sentry.utils.pubsub import QueuedPublisherService, KafkaPublisher
 from sentry.utils.safe import safe_execute
 from sentry.web.helpers import render_to_response
@@ -99,7 +100,13 @@ def process_event(event_manager, project, key, remote_addr, helper, attachments)
     start_time = time()
     should_filter, filter_reason = event_manager.should_filter()
     if should_filter:
-        track_outcome(project.organization_id, project.id, key.id, 'filtered', filter_reason)
+        track_outcome(
+            project.organization_id,
+            project.id,
+            key.id,
+            Outcome.FILTERED,
+            filter_reason,
+        )
         metrics.incr(
             'events.blacklisted', tags={'reason': filter_reason}, skip_internal=False
         )
@@ -124,7 +131,13 @@ def process_event(event_manager, project, key, remote_addr, helper, attachments)
             api_logger.debug('Dropped event due to error with rate limiter')
 
         reason = rate_limit.reason_code if rate_limit else None
-        track_outcome(project.organization_id, project.id, key.id, 'rate_limited', reason)
+        track_outcome(
+            project.organization_id,
+            project.id,
+            key.id,
+            Outcome.RATE_LIMITED,
+            reason,
+        )
         metrics.incr(
             'events.dropped',
             tags={
@@ -154,7 +167,13 @@ def process_event(event_manager, project, key, remote_addr, helper, attachments)
     cache_key = 'ev:%s:%s' % (project.id, event_id, )
 
     if cache.get(cache_key) is not None:
-        track_outcome(project.organization_id, project.id, key.id, 'invalid', 'duplicate')
+        track_outcome(
+            project.organization_id,
+            project.id,
+            key.id,
+            Outcome.INVALID,
+            'duplicate',
+        )
         raise APIForbidden(
             'An event with the same ID already exists (%s)' % (event_id, ))
 
@@ -369,7 +388,7 @@ class APIView(BaseView):
                     project.organization_id,
                     project.id,
                     None,
-                    'invalid',
+                    Outcome.INVALID,
                     FilterStatKeys.CORS)
                 raise APIForbidden('Invalid origin: %s' % (origin, ))
 
@@ -519,7 +538,13 @@ class StoreView(APIView):
 
         if data_size > 10000000:
             metrics.timing('events.size.rejected', data_size)
-            track_outcome(project.organization_id, project.id, key.id, 'invalid', 'too_large')
+            track_outcome(
+                project.organization_id,
+                project.id,
+                key.id,
+                Outcome.INVALID,
+                'too_large',
+            )
             raise APIForbidden("Event size exceeded 10MB after normalization.")
 
         metrics.timing(
@@ -876,7 +901,7 @@ class SecurityReportView(StoreView):
                     project.organization_id,
                     project.id,
                     key.id,
-                    'invalid',
+                    Outcome.INVALID,
                     FilterStatKeys.CORS)
             raise APIForbidden('Invalid origin')
 


### PR DESCRIPTION
Store outcomes as integers so they will be faster to filter on in Snuba

Reason could also be an enumerated type, but because reasons can come
from so many different places (web/api.py, filters, and rate limits all
have their own reason strings), it would be somewhat of a nightmare to
try and maintain an enum that was the union of all reasons from all
sources.