### PR TITLE
feat(ui) Add a popper based tooltip

### DIFF
--- a/docs-ui/components/tooltip.stories.js
+++ b/docs-ui/components/tooltip.stories.js
@@ -1,42 +1,85 @@
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
-import {text, boolean} from '@storybook/addon-knobs';
+import {text, boolean, select} from '@storybook/addon-knobs';
 
 import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import Button from 'app/components/button';
 
-storiesOf('UI|Tooltip', module).add(
-  'Tooltip',
-  withInfo({
-    text: 'Adds a tool to any component',
-    propTablesExclude: [Button],
-  })(() => {
-    let title = text('My tooltip', 'My tooltip');
-    let disabled = boolean('Disabled', false);
+storiesOf('UI|Tooltip', module)
+  .add(
+    'Tooltip',
+    withInfo({
+      text: 'Adds a tool to any component',
+      propTablesExclude: [Button],
+    })(() => {
+      const title = text('My tooltip', 'My tooltip');
+      const disabled = boolean('Disabled', false);
 
-    return (
-      <div>
-        <p>Test</p>
+      return (
         <div>
-          <Tooltip title={title} disabled={disabled}>
-            <Button>Custom React Component</Button>
-          </Tooltip>
-        </div>
-        <p>Test with options</p>
+          <p>Test</p>
+          <div>
+            <Tooltip title={title} disabled={disabled}>
+              <Button>Custom React Component</Button>
+            </Tooltip>
+          </div>
+          <p>Test with options</p>
 
-        <div>
-          <Tooltip
-            title={title}
-            disabled={disabled}
-            tooltipOptions={{
-              placement: 'bottom',
-            }}
-          >
-            <button>Native button</button>
-          </Tooltip>
+          <div>
+            <Tooltip
+              title={title}
+              disabled={disabled}
+              tooltipOptions={{
+                placement: 'bottom',
+              }}
+            >
+              <button>Native button</button>
+            </Tooltip>
+          </div>
         </div>
-      </div>
-    );
-  })
-);
+      );
+    })
+  )
+  .add(
+    'Tooltip v2',
+    withInfo({
+      text: 'Adds a tooltip to any component,',
+      propTablesExclude: [Button, 'Button'],
+    })(() => {
+      const title = text('tooltip', 'Basic tooltip content');
+      const disabled = boolean('Disabled', false);
+      const position = select(
+        'position',
+        {top: 'top', bottom: 'bottom', left: 'left', right: 'right'},
+        'top'
+      );
+
+      return (
+        <React.Fragment>
+          <h3>With styled component trigger</h3>
+          <p>
+            <Tooltip2 isStyled title={title} position={position} disabled={disabled}>
+              <Button>Custom React Component</Button>
+            </Tooltip2>
+          </p>
+
+          <h3>With element title and native html element</h3>
+          <p>
+            <Tooltip2
+              title={
+                <span>
+                  <em>so strong</em>
+                </span>
+              }
+              position={position}
+              disabled={disabled}
+            >
+              <button>Native button</button>
+            </Tooltip2>
+          </p>
+        </React.Fragment>
+      );
+    })
+  );

--- a/docs-ui/components/tooltip.stories.js
+++ b/docs-ui/components/tooltip.stories.js
@@ -7,6 +7,12 @@ import Tooltip from 'app/components/tooltip';
 import Tooltip2 from 'app/components/tooltip2';
 import Button from 'app/components/button';
 
+class CustomThing extends React.Component {
+  render() {
+    return <span>A class component with no ref</span>;
+  }
+}
+
 storiesOf('UI|Tooltip', module)
   .add(
     'Tooltip',
@@ -46,7 +52,7 @@ storiesOf('UI|Tooltip', module)
     'Tooltip v2',
     withInfo({
       text: 'Adds a tooltip to any component,',
-      propTablesExclude: [Button, 'Button'],
+      propTablesExclude: [CustomThing, Button, 'Button'],
     })(() => {
       const title = text('tooltip', 'Basic tooltip content');
       const disabled = boolean('Disabled', false);
@@ -60,9 +66,30 @@ storiesOf('UI|Tooltip', module)
         <React.Fragment>
           <h3>With styled component trigger</h3>
           <p>
-            <Tooltip2 isStyled title={title} position={position} disabled={disabled}>
-              <Button>Custom React Component</Button>
+            <Tooltip2 title={title} position={position} disabled={disabled}>
+              <Button>Styled button</Button>
             </Tooltip2>
+          </p>
+
+          <h3>With class component trigger</h3>
+          <p>
+            <Tooltip2 title={title} position={position} disabled={disabled}>
+              <CustomThing>Custom React Component</CustomThing>
+            </Tooltip2>
+          </p>
+
+          <h3>With an SVG element trigger</h3>
+          <p>
+            <svg
+              viewBox="0 0 100 100"
+              width="100"
+              height="100"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <Tooltip2 title={title} position={position} disabled={disabled}>
+                <circle cx="50" cy="50" r="50" />
+              </Tooltip2>
+            </svg>
           </p>
 
           <h3>With element title and native html element</h3>

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "react-keydown": "^1.9.7",
     "react-lazyload": "^2.3.0",
     "react-mentions": "^1.2.0",
+    "react-popper": "^1.3.3",
     "react-router": "3.2.0",
     "react-select": "^1.2.1",
     "react-sparklines": "1.7.0",

--- a/src/sentry/static/sentry/app/components/avatar/avatarList.jsx
+++ b/src/sentry/static/sentry/app/components/avatar/avatarList.jsx
@@ -37,8 +37,8 @@ export default class AvatarList extends React.Component {
     const visibleUsers = users.slice(0, maxVisibleAvatars);
     const numCollapsedUsers = users.length - visibleUsers.length;
 
-    if (!tooltipOptions.placement) {
-      tooltipOptions.placement = 'top auto';
+    if (!tooltipOptions.position) {
+      tooltipOptions.position = 'top';
     }
 
     return (

--- a/src/sentry/static/sentry/app/components/avatar/baseAvatar.jsx
+++ b/src/sentry/static/sentry/app/components/avatar/baseAvatar.jsx
@@ -5,7 +5,7 @@ import qs from 'query-string';
 import styled from 'react-emotion';
 
 import LetterAvatar from 'app/components/letterAvatar';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 
 import {imageStyle} from './styles';
 import Gravatar from './gravatar';
@@ -151,7 +151,7 @@ class BaseAvatar extends React.Component {
     }
 
     return (
-      <Tooltip title={tooltip} tooltipOptions={tooltipOptions} disabled={!hasTooltip}>
+      <Tooltip2 title={tooltip} disabled={!hasTooltip} isStyled {...tooltipOptions}>
         <StyledBaseAvatar
           loaded={this.state.hasLoaded}
           className={classNames('avatar', className)}
@@ -164,7 +164,7 @@ class BaseAvatar extends React.Component {
           {this.state.showBackupAvatar && this.renderLetterAvatar()}
           {this.renderImg()}
         </StyledBaseAvatar>
-      </Tooltip>
+      </Tooltip2>
     );
   }
 }

--- a/src/sentry/static/sentry/app/components/avatar/baseAvatar.jsx
+++ b/src/sentry/static/sentry/app/components/avatar/baseAvatar.jsx
@@ -40,7 +40,7 @@ class BaseAvatar extends React.Component {
     gravatarId: PropTypes.string,
     letterId: PropTypes.string,
     title: PropTypes.string,
-    tooltip: PropTypes.string,
+    tooltip: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     tooltipOptions: PropTypes.object,
     /**
      * Should avatar be round instead of a square

--- a/src/sentry/static/sentry/app/components/avatar/baseAvatar.jsx
+++ b/src/sentry/static/sentry/app/components/avatar/baseAvatar.jsx
@@ -151,7 +151,7 @@ class BaseAvatar extends React.Component {
     }
 
     return (
-      <Tooltip2 title={tooltip} disabled={!hasTooltip} isStyled {...tooltipOptions}>
+      <Tooltip2 title={tooltip} disabled={!hasTooltip} {...tooltipOptions}>
         <StyledBaseAvatar
           loaded={this.state.hasLoaded}
           className={classNames('avatar', className)}

--- a/src/sentry/static/sentry/app/components/tooltip2.jsx
+++ b/src/sentry/static/sentry/app/components/tooltip2.jsx
@@ -1,0 +1,210 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import styled from 'react-emotion';
+import PropTypes from 'prop-types';
+
+import {Manager, Reference, Popper} from 'react-popper';
+
+class Tooltip2 extends React.Component {
+  static propTypes = {
+    /**
+     * Disable the tooltip display entirely
+     */
+    disabled: PropTypes.bool,
+    /**
+     * The content to show in the tooltip popover
+     */
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    /**
+     * Position for the tooltip.
+     */
+    position: PropTypes.oneOf([
+      'bottom',
+      'top',
+      'left',
+      'right',
+      'bottom-start',
+      'bottom-end',
+      'top-start',
+      'top-end',
+      'left-start',
+      'left-end',
+      'right-start',
+      'right-end',
+      'auto',
+    ]),
+    /**
+     * Set to true if your reference element is a styled component
+     * or needs to receive `innerRef`
+     */
+    isStyled: PropTypes.bool,
+    /**
+     * Additional style rules for the tooltip content.
+     */
+    popperStyle: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  };
+
+  static defaultProps = {
+    position: 'top',
+    isStyled: false,
+  };
+
+  constructor(props) {
+    super(props);
+
+    let portal = document.getElementById('tooltip-portal');
+    if (!portal) {
+      portal = document.createElement('div');
+      portal.setAttribute('id', 'tooltip-portal');
+      document.body.appendChild(portal);
+    }
+    this.portalEl = portal;
+  }
+
+  state = {
+    isOpen: false,
+  };
+
+  componentDidMount() {
+    this.tooltipId =
+      'tooltip_' +
+      Math.random()
+        .toString(36)
+        .substr(2, 10);
+  }
+
+  handleOpen = evt => {
+    this.setState({isOpen: true});
+  };
+
+  handleClose = evt => {
+    this.setState({isOpen: false});
+  };
+
+  render() {
+    const {disabled, children, title, position, popperStyle, isStyled} = this.props;
+    const {isOpen} = this.state;
+    if (disabled) {
+      return children;
+    }
+
+    let tip = null;
+    if (isOpen) {
+      tip = ReactDOM.createPortal(
+        <Popper placement={position}>
+          {({ref, style, placement, arrowProps}) => (
+            <TooltipContent
+              id={this.tooltipId}
+              aria-hidden={!isOpen}
+              isOpen={isOpen}
+              innerRef={ref}
+              style={style}
+              data-placement={placement}
+              popperStyle={popperStyle}
+            >
+              {title}
+              <TooltipArrow
+                innerRef={arrowProps.ref}
+                data-placement={placement}
+                style={arrowProps.style}
+              />
+            </TooltipContent>
+          )}
+        </Popper>,
+        this.portalEl
+      );
+    }
+
+    return (
+      <Manager>
+        <Reference>
+          {({ref}) => {
+            return React.cloneElement(children, {
+              'aria-describedby': this.tooltipId,
+              onFocus: this.handleOpen,
+              onBlur: this.handleOpen,
+              onMouseEnter: this.handleOpen,
+              onMouseLeave: this.handleClose,
+              ...(isStyled ? {innerRef: ref} : {ref}),
+            });
+          }}
+        </Reference>
+        {tip}
+      </Manager>
+    );
+  }
+}
+
+const TooltipContent = styled('span')`
+  color: #fff;
+  background: #000;
+  opacity: 0.9;
+  padding: 5px 10px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
+  border-radius: ${p => p.theme.borderRadius};
+  overflow-wrap: break-word;
+  max-width: 200px;
+
+  font-weight: bold;
+  font-size: ${p => p.theme.fontSizeSmall};
+  line-height: 1.4;
+
+  margin: 6px;
+  text-align: center;
+  ${props => props.popperStyle};
+`;
+
+const TooltipArrow = styled('span')`
+  position: absolute;
+  width: 10px;
+  height: 5px;
+
+  &[data-placement*='bottom'] {
+    top: 0;
+    left: 0;
+    margin-top: -5px;
+    &::before {
+      border-width: 0 5px 5px 5px;
+      border-color: transparent transparent #000 transparent;
+    }
+  }
+
+  &[data-placement*='top'] {
+    bottom: 0;
+    left: 0;
+    margin-bottom: -5px;
+    &::before {
+      border-width: 5px 5px 0 5px;
+      border-color: #000 transparent transparent transparent;
+    }
+  }
+
+  &[data-placement*='right'] {
+    left: 0;
+    margin-left: -5px;
+    &::before {
+      border-width: 5px 5px 5px 0;
+      border-color: transparent #000 transparent transparent;
+    }
+  }
+
+  &[data-placement*='left'] {
+    right: 0;
+    margin-right: -5px;
+    &::before {
+      border-width: 5px 0 5px 5px;
+      border-color: transparent transparent transparent #000;
+    }
+  }
+
+  &::before {
+    content: '';
+    margin: auto;
+    display: block;
+    width: 0;
+    height: 0;
+    border-style: solid;
+  }
+`;
+
+export default Tooltip2;

--- a/src/sentry/static/sentry/app/components/tooltip2.jsx
+++ b/src/sentry/static/sentry/app/components/tooltip2.jsx
@@ -89,9 +89,9 @@ class Tooltip2 extends React.Component {
     };
     if (children.type instanceof Function) {
       return (
-        <span {...propList} ref={ref}>
+        <Container {...propList} innerRef={ref}>
           {children}
-        </span>
+        </Container>
       );
     }
     return React.cloneElement(children, {
@@ -151,6 +151,12 @@ class Tooltip2 extends React.Component {
     );
   }
 }
+
+// Using an inline-block solves the container being smaller
+// than the elements it is wrapping
+const Container = styled('span')`
+  display: inline-block;
+`;
 
 const TooltipContent = styled('span')`
   color: #fff;

--- a/src/sentry/static/sentry/app/components/tooltip2.jsx
+++ b/src/sentry/static/sentry/app/components/tooltip2.jsx
@@ -4,6 +4,7 @@ import styled from 'react-emotion';
 import PropTypes from 'prop-types';
 
 import {Manager, Reference, Popper} from 'react-popper';
+import {domId} from 'app/utils/domId';
 
 class Tooltip2 extends React.Component {
   static propTypes = {
@@ -66,11 +67,7 @@ class Tooltip2 extends React.Component {
   };
 
   componentDidMount() {
-    this.tooltipId =
-      'tooltip_' +
-      Math.random()
-        .toString(36)
-        .substr(2, 10);
+    this.tooltipId = domId('tooltip-');
   }
 
   handleOpen = evt => {

--- a/src/sentry/static/sentry/app/components/tooltip2.jsx
+++ b/src/sentry/static/sentry/app/components/tooltip2.jsx
@@ -144,6 +144,7 @@ const TooltipContent = styled('span')`
   border-radius: ${p => p.theme.borderRadius};
   overflow-wrap: break-word;
   max-width: 200px;
+  z-index: ${p => p.theme.zIndex.tooltip};
 
   font-weight: bold;
   font-size: ${p => p.theme.fontSizeSmall};

--- a/src/sentry/static/sentry/app/components/tooltip2.jsx
+++ b/src/sentry/static/sentry/app/components/tooltip2.jsx
@@ -72,13 +72,6 @@ class Tooltip2 extends React.Component {
     this.setState({isOpen: false});
   };
 
-  /**
-   * Different kinds of children need different wrapping.
-   * For custom components and function components we have
-   * to add a span as we can't trust the component to implement
-   * forward refs. For svg and html elements we can clone
-   * the child and push more props onto it.
-   */
   renderTrigger(children, ref) {
     const propList = {
       'aria-describedby': this.tooltipId,
@@ -87,6 +80,10 @@ class Tooltip2 extends React.Component {
       onMouseEnter: this.handleOpen,
       onMouseLeave: this.handleClose,
     };
+    // Use the `type` property of the react instance to detect whether we
+    // have a basic element (type=string) or a class/function component (type=function)
+    // Because we can't rely on the child element implementing forwardRefs we wrap
+    // it with a span tag so that popper has ref
     if (children.type instanceof Function) {
       return (
         <Container {...propList} innerRef={ref}>
@@ -94,6 +91,7 @@ class Tooltip2 extends React.Component {
         </Container>
       );
     }
+    // Basic DOM nodes can be cloned and have more props applied.
     return React.cloneElement(children, {
       ...propList,
       ref,

--- a/src/sentry/static/sentry/app/components/tooltip2.jsx
+++ b/src/sentry/static/sentry/app/components/tooltip2.jsx
@@ -86,9 +86,18 @@ class Tooltip2 extends React.Component {
     }
 
     let tip = null;
+    const modifiers = {
+      hide: {enabled: false},
+      preventOverflow: {
+        padding: 10,
+        enabled: true,
+        boundariesElement: 'viewport',
+      },
+    };
+
     if (isOpen) {
       tip = ReactDOM.createPortal(
-        <Popper placement={position}>
+        <Popper placement={position} modifiers={modifiers}>
           {({ref, style, placement, arrowProps}) => (
             <TooltipContent
               id={this.tooltipId}

--- a/src/sentry/static/sentry/app/utils/__mocks__/domId.jsx
+++ b/src/sentry/static/sentry/app/utils/__mocks__/domId.jsx
@@ -1,0 +1,5 @@
+function domId(prefix) {
+  return prefix + '123456';
+}
+
+export {domId};

--- a/src/sentry/static/sentry/app/utils/domId.jsx
+++ b/src/sentry/static/sentry/app/utils/domId.jsx
@@ -1,0 +1,10 @@
+function domId(prefix) {
+  return (
+    prefix +
+    Math.random()
+      .toString(36)
+      .substr(2, 10)
+  );
+}
+
+export {domId};

--- a/src/sentry/static/sentry/app/utils/theme.jsx
+++ b/src/sentry/static/sentry/app/utils/theme.jsx
@@ -90,6 +90,8 @@ const theme = {
     sidebar: 1010,
     orgAndUserMenu: 1011,
 
+    tooltip: 1070,
+
     // Sentry user feedback modal
     sentryErrorEmbed: 1090,
 

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/seenBy.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/seenBy.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import moment from 'moment';
-import _ from 'lodash';
 import styled from 'react-emotion';
 
 import SentryTypes from 'app/sentryTypes';
@@ -39,8 +38,13 @@ export default class GroupSeenBy extends React.Component {
           avatarSize={28}
           maxVisibleAvatars={10}
           tooltipOptions={{html: true}}
-          renderTooltip={user => `${_.escape(userDisplayName(user))} <br/>
-            ${moment(user.lastSeen).format('LL')}`}
+          renderTooltip={user => (
+            <React.Fragment>
+              {userDisplayName(user)}
+              <br />
+              {moment(user.lastSeen).format('LL')}
+            </React.Fragment>
+          )}
         />
         <IconWrapper>
           <Tooltip title={t("People who've viewed this issue")}>

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -52,6 +52,7 @@ jest.mock('lodash/debounce', () => jest.fn(fn => fn));
 jest.mock('app/utils/recreateRoute');
 jest.mock('app/translations');
 jest.mock('app/api');
+jest.mock('app/utils/domId');
 jest.mock('app/utils/withOrganization');
 jest.mock('scroll-to-element', () => {});
 jest.mock('react-router', () => {

--- a/tests/js/spec/components/avatar/__snapshots__/avatarList.spec.jsx.snap
+++ b/tests/js/spec/components/avatar/__snapshots__/avatarList.spec.jsx.snap
@@ -231,79 +231,93 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                 type="letter_avatar"
                 uploadPath="avatar"
               >
-                <Tooltip
+                <Tooltip2
                   disabled={false}
+                  isStyled={true}
+                  position="top"
                   title="Foo Bar (foo@example.com)"
-                  tooltipOptions={
-                    Object {
-                      "placement": "top auto",
-                    }
-                  }
                 >
-                  <StyledBaseAvatar
-                    className="tip avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                    loaded={true}
-                    round={true}
-                    style={
-                      Object {
-                        "height": "28px",
-                        "width": "28px",
-                      }
-                    }
-                    title="Foo Bar (foo@example.com)"
-                  >
-                    <span
-                      className="tip avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
-                      style={
-                        Object {
-                          "height": "28px",
-                          "width": "28px",
-                        }
-                      }
-                      title="Foo Bar (foo@example.com)"
-                    >
-                      <LetterAvatar
-                        displayName="Foo Bar"
-                        identifier="foo@example.com"
-                        round={true}
+                  <Manager>
+                    <Reference>
+                      <InnerReference
+                        setReferenceNode={[Function]}
                       >
-                        <Svg
+                        <StyledBaseAvatar
+                          aria-describedby="tooltip_5xnxosaaqo"
+                          className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                          innerRef={[Function]}
+                          loaded={true}
+                          onBlur={[Function]}
+                          onFocus={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           round={true}
-                          viewBox="0 0 120 120"
+                          style={
+                            Object {
+                              "height": "28px",
+                              "width": "28px",
+                            }
+                          }
                         >
-                          <svg
-                            className="css-1r4mnb9-Svg e1knxa8x0"
-                            viewBox="0 0 120 120"
-                          >
-                            <rect
-                              fill="#315cac"
-                              height="120"
-                              rx="15"
-                              ry="15"
-                              width="120"
-                              x="0"
-                              y="0"
-                            />
-                            <text
-                              fill="#FFFFFF"
-                              fontSize="65"
-                              style={
-                                Object {
-                                  "dominantBaseline": "central",
-                                }
+                          <span
+                            aria-describedby="tooltip_5xnxosaaqo"
+                            className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                            onBlur={[Function]}
+                            onFocus={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            style={
+                              Object {
+                                "height": "28px",
+                                "width": "28px",
                               }
-                              textAnchor="middle"
-                              x="50%"
-                              y="50%"
+                            }
+                          >
+                            <LetterAvatar
+                              displayName="Foo Bar"
+                              identifier="foo@example.com"
+                              round={true}
                             >
-                              FB
-                            </text>
-                          </svg>
-                        </Svg>
-                      </LetterAvatar>
-                    </span>
-                  </StyledBaseAvatar>
-                </Tooltip>
+                              <Svg
+                                round={true}
+                                viewBox="0 0 120 120"
+                              >
+                                <svg
+                                  className="css-1r4mnb9-Svg e1knxa8x0"
+                                  viewBox="0 0 120 120"
+                                >
+                                  <rect
+                                    fill="#315cac"
+                                    height="120"
+                                    rx="15"
+                                    ry="15"
+                                    width="120"
+                                    x="0"
+                                    y="0"
+                                  />
+                                  <text
+                                    fill="#FFFFFF"
+                                    fontSize="65"
+                                    style={
+                                      Object {
+                                        "dominantBaseline": "central",
+                                      }
+                                    }
+                                    textAnchor="middle"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    FB
+                                  </text>
+                                </svg>
+                              </Svg>
+                            </LetterAvatar>
+                          </span>
+                        </StyledBaseAvatar>
+                      </InnerReference>
+                    </Reference>
+                  </Manager>
+                </Tooltip2>
               </BaseAvatar>
             </UserAvatar>
           </Avatar>
@@ -405,79 +419,93 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                 type="letter_avatar"
                 uploadPath="avatar"
               >
-                <Tooltip
+                <Tooltip2
                   disabled={false}
+                  isStyled={true}
+                  position="top"
                   title="Foo Bar (foo@example.com)"
-                  tooltipOptions={
-                    Object {
-                      "placement": "top auto",
-                    }
-                  }
                 >
-                  <StyledBaseAvatar
-                    className="tip avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                    loaded={true}
-                    round={true}
-                    style={
-                      Object {
-                        "height": "28px",
-                        "width": "28px",
-                      }
-                    }
-                    title="Foo Bar (foo@example.com)"
-                  >
-                    <span
-                      className="tip avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
-                      style={
-                        Object {
-                          "height": "28px",
-                          "width": "28px",
-                        }
-                      }
-                      title="Foo Bar (foo@example.com)"
-                    >
-                      <LetterAvatar
-                        displayName="Foo Bar"
-                        identifier="foo@example.com"
-                        round={true}
+                  <Manager>
+                    <Reference>
+                      <InnerReference
+                        setReferenceNode={[Function]}
                       >
-                        <Svg
+                        <StyledBaseAvatar
+                          aria-describedby="tooltip_7xsj156yci"
+                          className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                          innerRef={[Function]}
+                          loaded={true}
+                          onBlur={[Function]}
+                          onFocus={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           round={true}
-                          viewBox="0 0 120 120"
+                          style={
+                            Object {
+                              "height": "28px",
+                              "width": "28px",
+                            }
+                          }
                         >
-                          <svg
-                            className="css-1r4mnb9-Svg e1knxa8x0"
-                            viewBox="0 0 120 120"
-                          >
-                            <rect
-                              fill="#315cac"
-                              height="120"
-                              rx="15"
-                              ry="15"
-                              width="120"
-                              x="0"
-                              y="0"
-                            />
-                            <text
-                              fill="#FFFFFF"
-                              fontSize="65"
-                              style={
-                                Object {
-                                  "dominantBaseline": "central",
-                                }
+                          <span
+                            aria-describedby="tooltip_7xsj156yci"
+                            className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                            onBlur={[Function]}
+                            onFocus={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            style={
+                              Object {
+                                "height": "28px",
+                                "width": "28px",
                               }
-                              textAnchor="middle"
-                              x="50%"
-                              y="50%"
+                            }
+                          >
+                            <LetterAvatar
+                              displayName="Foo Bar"
+                              identifier="foo@example.com"
+                              round={true}
                             >
-                              FB
-                            </text>
-                          </svg>
-                        </Svg>
-                      </LetterAvatar>
-                    </span>
-                  </StyledBaseAvatar>
-                </Tooltip>
+                              <Svg
+                                round={true}
+                                viewBox="0 0 120 120"
+                              >
+                                <svg
+                                  className="css-1r4mnb9-Svg e1knxa8x0"
+                                  viewBox="0 0 120 120"
+                                >
+                                  <rect
+                                    fill="#315cac"
+                                    height="120"
+                                    rx="15"
+                                    ry="15"
+                                    width="120"
+                                    x="0"
+                                    y="0"
+                                  />
+                                  <text
+                                    fill="#FFFFFF"
+                                    fontSize="65"
+                                    style={
+                                      Object {
+                                        "dominantBaseline": "central",
+                                      }
+                                    }
+                                    textAnchor="middle"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    FB
+                                  </text>
+                                </svg>
+                              </Svg>
+                            </LetterAvatar>
+                          </span>
+                        </StyledBaseAvatar>
+                      </InnerReference>
+                    </Reference>
+                  </Manager>
+                </Tooltip2>
               </BaseAvatar>
             </UserAvatar>
           </Avatar>
@@ -579,79 +607,93 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                 type="letter_avatar"
                 uploadPath="avatar"
               >
-                <Tooltip
+                <Tooltip2
                   disabled={false}
+                  isStyled={true}
+                  position="top"
                   title="Foo Bar (foo@example.com)"
-                  tooltipOptions={
-                    Object {
-                      "placement": "top auto",
-                    }
-                  }
                 >
-                  <StyledBaseAvatar
-                    className="tip avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                    loaded={true}
-                    round={true}
-                    style={
-                      Object {
-                        "height": "28px",
-                        "width": "28px",
-                      }
-                    }
-                    title="Foo Bar (foo@example.com)"
-                  >
-                    <span
-                      className="tip avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
-                      style={
-                        Object {
-                          "height": "28px",
-                          "width": "28px",
-                        }
-                      }
-                      title="Foo Bar (foo@example.com)"
-                    >
-                      <LetterAvatar
-                        displayName="Foo Bar"
-                        identifier="foo@example.com"
-                        round={true}
+                  <Manager>
+                    <Reference>
+                      <InnerReference
+                        setReferenceNode={[Function]}
                       >
-                        <Svg
+                        <StyledBaseAvatar
+                          aria-describedby="tooltip_pbui7dx3sk"
+                          className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                          innerRef={[Function]}
+                          loaded={true}
+                          onBlur={[Function]}
+                          onFocus={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           round={true}
-                          viewBox="0 0 120 120"
+                          style={
+                            Object {
+                              "height": "28px",
+                              "width": "28px",
+                            }
+                          }
                         >
-                          <svg
-                            className="css-1r4mnb9-Svg e1knxa8x0"
-                            viewBox="0 0 120 120"
-                          >
-                            <rect
-                              fill="#315cac"
-                              height="120"
-                              rx="15"
-                              ry="15"
-                              width="120"
-                              x="0"
-                              y="0"
-                            />
-                            <text
-                              fill="#FFFFFF"
-                              fontSize="65"
-                              style={
-                                Object {
-                                  "dominantBaseline": "central",
-                                }
+                          <span
+                            aria-describedby="tooltip_pbui7dx3sk"
+                            className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                            onBlur={[Function]}
+                            onFocus={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            style={
+                              Object {
+                                "height": "28px",
+                                "width": "28px",
                               }
-                              textAnchor="middle"
-                              x="50%"
-                              y="50%"
+                            }
+                          >
+                            <LetterAvatar
+                              displayName="Foo Bar"
+                              identifier="foo@example.com"
+                              round={true}
                             >
-                              FB
-                            </text>
-                          </svg>
-                        </Svg>
-                      </LetterAvatar>
-                    </span>
-                  </StyledBaseAvatar>
-                </Tooltip>
+                              <Svg
+                                round={true}
+                                viewBox="0 0 120 120"
+                              >
+                                <svg
+                                  className="css-1r4mnb9-Svg e1knxa8x0"
+                                  viewBox="0 0 120 120"
+                                >
+                                  <rect
+                                    fill="#315cac"
+                                    height="120"
+                                    rx="15"
+                                    ry="15"
+                                    width="120"
+                                    x="0"
+                                    y="0"
+                                  />
+                                  <text
+                                    fill="#FFFFFF"
+                                    fontSize="65"
+                                    style={
+                                      Object {
+                                        "dominantBaseline": "central",
+                                      }
+                                    }
+                                    textAnchor="middle"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    FB
+                                  </text>
+                                </svg>
+                              </Svg>
+                            </LetterAvatar>
+                          </span>
+                        </StyledBaseAvatar>
+                      </InnerReference>
+                    </Reference>
+                  </Manager>
+                </Tooltip2>
               </BaseAvatar>
             </UserAvatar>
           </Avatar>
@@ -753,79 +795,93 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                 type="letter_avatar"
                 uploadPath="avatar"
               >
-                <Tooltip
+                <Tooltip2
                   disabled={false}
+                  isStyled={true}
+                  position="top"
                   title="Foo Bar (foo@example.com)"
-                  tooltipOptions={
-                    Object {
-                      "placement": "top auto",
-                    }
-                  }
                 >
-                  <StyledBaseAvatar
-                    className="tip avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                    loaded={true}
-                    round={true}
-                    style={
-                      Object {
-                        "height": "28px",
-                        "width": "28px",
-                      }
-                    }
-                    title="Foo Bar (foo@example.com)"
-                  >
-                    <span
-                      className="tip avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
-                      style={
-                        Object {
-                          "height": "28px",
-                          "width": "28px",
-                        }
-                      }
-                      title="Foo Bar (foo@example.com)"
-                    >
-                      <LetterAvatar
-                        displayName="Foo Bar"
-                        identifier="foo@example.com"
-                        round={true}
+                  <Manager>
+                    <Reference>
+                      <InnerReference
+                        setReferenceNode={[Function]}
                       >
-                        <Svg
+                        <StyledBaseAvatar
+                          aria-describedby="tooltip_odmxpdwl9w"
+                          className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                          innerRef={[Function]}
+                          loaded={true}
+                          onBlur={[Function]}
+                          onFocus={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           round={true}
-                          viewBox="0 0 120 120"
+                          style={
+                            Object {
+                              "height": "28px",
+                              "width": "28px",
+                            }
+                          }
                         >
-                          <svg
-                            className="css-1r4mnb9-Svg e1knxa8x0"
-                            viewBox="0 0 120 120"
-                          >
-                            <rect
-                              fill="#315cac"
-                              height="120"
-                              rx="15"
-                              ry="15"
-                              width="120"
-                              x="0"
-                              y="0"
-                            />
-                            <text
-                              fill="#FFFFFF"
-                              fontSize="65"
-                              style={
-                                Object {
-                                  "dominantBaseline": "central",
-                                }
+                          <span
+                            aria-describedby="tooltip_odmxpdwl9w"
+                            className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                            onBlur={[Function]}
+                            onFocus={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            style={
+                              Object {
+                                "height": "28px",
+                                "width": "28px",
                               }
-                              textAnchor="middle"
-                              x="50%"
-                              y="50%"
+                            }
+                          >
+                            <LetterAvatar
+                              displayName="Foo Bar"
+                              identifier="foo@example.com"
+                              round={true}
                             >
-                              FB
-                            </text>
-                          </svg>
-                        </Svg>
-                      </LetterAvatar>
-                    </span>
-                  </StyledBaseAvatar>
-                </Tooltip>
+                              <Svg
+                                round={true}
+                                viewBox="0 0 120 120"
+                              >
+                                <svg
+                                  className="css-1r4mnb9-Svg e1knxa8x0"
+                                  viewBox="0 0 120 120"
+                                >
+                                  <rect
+                                    fill="#315cac"
+                                    height="120"
+                                    rx="15"
+                                    ry="15"
+                                    width="120"
+                                    x="0"
+                                    y="0"
+                                  />
+                                  <text
+                                    fill="#FFFFFF"
+                                    fontSize="65"
+                                    style={
+                                      Object {
+                                        "dominantBaseline": "central",
+                                      }
+                                    }
+                                    textAnchor="middle"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    FB
+                                  </text>
+                                </svg>
+                              </Svg>
+                            </LetterAvatar>
+                          </span>
+                        </StyledBaseAvatar>
+                      </InnerReference>
+                    </Reference>
+                  </Manager>
+                </Tooltip2>
               </BaseAvatar>
             </UserAvatar>
           </Avatar>
@@ -927,79 +983,93 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                 type="letter_avatar"
                 uploadPath="avatar"
               >
-                <Tooltip
+                <Tooltip2
                   disabled={false}
+                  isStyled={true}
+                  position="top"
                   title="Foo Bar (foo@example.com)"
-                  tooltipOptions={
-                    Object {
-                      "placement": "top auto",
-                    }
-                  }
                 >
-                  <StyledBaseAvatar
-                    className="tip avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                    loaded={true}
-                    round={true}
-                    style={
-                      Object {
-                        "height": "28px",
-                        "width": "28px",
-                      }
-                    }
-                    title="Foo Bar (foo@example.com)"
-                  >
-                    <span
-                      className="tip avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
-                      style={
-                        Object {
-                          "height": "28px",
-                          "width": "28px",
-                        }
-                      }
-                      title="Foo Bar (foo@example.com)"
-                    >
-                      <LetterAvatar
-                        displayName="Foo Bar"
-                        identifier="foo@example.com"
-                        round={true}
+                  <Manager>
+                    <Reference>
+                      <InnerReference
+                        setReferenceNode={[Function]}
                       >
-                        <Svg
+                        <StyledBaseAvatar
+                          aria-describedby="tooltip_thjwyj6gbk"
+                          className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                          innerRef={[Function]}
+                          loaded={true}
+                          onBlur={[Function]}
+                          onFocus={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           round={true}
-                          viewBox="0 0 120 120"
+                          style={
+                            Object {
+                              "height": "28px",
+                              "width": "28px",
+                            }
+                          }
                         >
-                          <svg
-                            className="css-1r4mnb9-Svg e1knxa8x0"
-                            viewBox="0 0 120 120"
-                          >
-                            <rect
-                              fill="#315cac"
-                              height="120"
-                              rx="15"
-                              ry="15"
-                              width="120"
-                              x="0"
-                              y="0"
-                            />
-                            <text
-                              fill="#FFFFFF"
-                              fontSize="65"
-                              style={
-                                Object {
-                                  "dominantBaseline": "central",
-                                }
+                          <span
+                            aria-describedby="tooltip_thjwyj6gbk"
+                            className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                            onBlur={[Function]}
+                            onFocus={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            style={
+                              Object {
+                                "height": "28px",
+                                "width": "28px",
                               }
-                              textAnchor="middle"
-                              x="50%"
-                              y="50%"
+                            }
+                          >
+                            <LetterAvatar
+                              displayName="Foo Bar"
+                              identifier="foo@example.com"
+                              round={true}
                             >
-                              FB
-                            </text>
-                          </svg>
-                        </Svg>
-                      </LetterAvatar>
-                    </span>
-                  </StyledBaseAvatar>
-                </Tooltip>
+                              <Svg
+                                round={true}
+                                viewBox="0 0 120 120"
+                              >
+                                <svg
+                                  className="css-1r4mnb9-Svg e1knxa8x0"
+                                  viewBox="0 0 120 120"
+                                >
+                                  <rect
+                                    fill="#315cac"
+                                    height="120"
+                                    rx="15"
+                                    ry="15"
+                                    width="120"
+                                    x="0"
+                                    y="0"
+                                  />
+                                  <text
+                                    fill="#FFFFFF"
+                                    fontSize="65"
+                                    style={
+                                      Object {
+                                        "dominantBaseline": "central",
+                                      }
+                                    }
+                                    textAnchor="middle"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    FB
+                                  </text>
+                                </svg>
+                              </Svg>
+                            </LetterAvatar>
+                          </span>
+                        </StyledBaseAvatar>
+                      </InnerReference>
+                    </Reference>
+                  </Manager>
+                </Tooltip2>
               </BaseAvatar>
             </UserAvatar>
           </Avatar>
@@ -1161,79 +1231,93 @@ exports[`AvatarList renders with user avatars 1`] = `
                 type="letter_avatar"
                 uploadPath="avatar"
               >
-                <Tooltip
+                <Tooltip2
                   disabled={false}
+                  isStyled={true}
+                  position="top"
                   title="Foo Bar (foo@example.com)"
-                  tooltipOptions={
-                    Object {
-                      "placement": "top auto",
-                    }
-                  }
                 >
-                  <StyledBaseAvatar
-                    className="tip avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                    loaded={true}
-                    round={true}
-                    style={
-                      Object {
-                        "height": "28px",
-                        "width": "28px",
-                      }
-                    }
-                    title="Foo Bar (foo@example.com)"
-                  >
-                    <span
-                      className="tip avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
-                      style={
-                        Object {
-                          "height": "28px",
-                          "width": "28px",
-                        }
-                      }
-                      title="Foo Bar (foo@example.com)"
-                    >
-                      <LetterAvatar
-                        displayName="Foo Bar"
-                        identifier="foo@example.com"
-                        round={true}
+                  <Manager>
+                    <Reference>
+                      <InnerReference
+                        setReferenceNode={[Function]}
                       >
-                        <Svg
+                        <StyledBaseAvatar
+                          aria-describedby="tooltip_jj4rpyzs79"
+                          className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                          innerRef={[Function]}
+                          loaded={true}
+                          onBlur={[Function]}
+                          onFocus={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           round={true}
-                          viewBox="0 0 120 120"
+                          style={
+                            Object {
+                              "height": "28px",
+                              "width": "28px",
+                            }
+                          }
                         >
-                          <svg
-                            className="css-1r4mnb9-Svg e1knxa8x0"
-                            viewBox="0 0 120 120"
-                          >
-                            <rect
-                              fill="#315cac"
-                              height="120"
-                              rx="15"
-                              ry="15"
-                              width="120"
-                              x="0"
-                              y="0"
-                            />
-                            <text
-                              fill="#FFFFFF"
-                              fontSize="65"
-                              style={
-                                Object {
-                                  "dominantBaseline": "central",
-                                }
+                          <span
+                            aria-describedby="tooltip_jj4rpyzs79"
+                            className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                            onBlur={[Function]}
+                            onFocus={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            style={
+                              Object {
+                                "height": "28px",
+                                "width": "28px",
                               }
-                              textAnchor="middle"
-                              x="50%"
-                              y="50%"
+                            }
+                          >
+                            <LetterAvatar
+                              displayName="Foo Bar"
+                              identifier="foo@example.com"
+                              round={true}
                             >
-                              FB
-                            </text>
-                          </svg>
-                        </Svg>
-                      </LetterAvatar>
-                    </span>
-                  </StyledBaseAvatar>
-                </Tooltip>
+                              <Svg
+                                round={true}
+                                viewBox="0 0 120 120"
+                              >
+                                <svg
+                                  className="css-1r4mnb9-Svg e1knxa8x0"
+                                  viewBox="0 0 120 120"
+                                >
+                                  <rect
+                                    fill="#315cac"
+                                    height="120"
+                                    rx="15"
+                                    ry="15"
+                                    width="120"
+                                    x="0"
+                                    y="0"
+                                  />
+                                  <text
+                                    fill="#FFFFFF"
+                                    fontSize="65"
+                                    style={
+                                      Object {
+                                        "dominantBaseline": "central",
+                                      }
+                                    }
+                                    textAnchor="middle"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    FB
+                                  </text>
+                                </svg>
+                              </Svg>
+                            </LetterAvatar>
+                          </span>
+                        </StyledBaseAvatar>
+                      </InnerReference>
+                    </Reference>
+                  </Manager>
+                </Tooltip2>
               </BaseAvatar>
             </UserAvatar>
           </Avatar>
@@ -1335,79 +1419,93 @@ exports[`AvatarList renders with user avatars 1`] = `
                 type="letter_avatar"
                 uploadPath="avatar"
               >
-                <Tooltip
+                <Tooltip2
                   disabled={false}
+                  isStyled={true}
+                  position="top"
                   title="Foo Bar (foo@example.com)"
-                  tooltipOptions={
-                    Object {
-                      "placement": "top auto",
-                    }
-                  }
                 >
-                  <StyledBaseAvatar
-                    className="tip avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                    loaded={true}
-                    round={true}
-                    style={
-                      Object {
-                        "height": "28px",
-                        "width": "28px",
-                      }
-                    }
-                    title="Foo Bar (foo@example.com)"
-                  >
-                    <span
-                      className="tip avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
-                      style={
-                        Object {
-                          "height": "28px",
-                          "width": "28px",
-                        }
-                      }
-                      title="Foo Bar (foo@example.com)"
-                    >
-                      <LetterAvatar
-                        displayName="Foo Bar"
-                        identifier="foo@example.com"
-                        round={true}
+                  <Manager>
+                    <Reference>
+                      <InnerReference
+                        setReferenceNode={[Function]}
                       >
-                        <Svg
+                        <StyledBaseAvatar
+                          aria-describedby="tooltip_uwj895ejkm"
+                          className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                          innerRef={[Function]}
+                          loaded={true}
+                          onBlur={[Function]}
+                          onFocus={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           round={true}
-                          viewBox="0 0 120 120"
+                          style={
+                            Object {
+                              "height": "28px",
+                              "width": "28px",
+                            }
+                          }
                         >
-                          <svg
-                            className="css-1r4mnb9-Svg e1knxa8x0"
-                            viewBox="0 0 120 120"
-                          >
-                            <rect
-                              fill="#315cac"
-                              height="120"
-                              rx="15"
-                              ry="15"
-                              width="120"
-                              x="0"
-                              y="0"
-                            />
-                            <text
-                              fill="#FFFFFF"
-                              fontSize="65"
-                              style={
-                                Object {
-                                  "dominantBaseline": "central",
-                                }
+                          <span
+                            aria-describedby="tooltip_uwj895ejkm"
+                            className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                            onBlur={[Function]}
+                            onFocus={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            style={
+                              Object {
+                                "height": "28px",
+                                "width": "28px",
                               }
-                              textAnchor="middle"
-                              x="50%"
-                              y="50%"
+                            }
+                          >
+                            <LetterAvatar
+                              displayName="Foo Bar"
+                              identifier="foo@example.com"
+                              round={true}
                             >
-                              FB
-                            </text>
-                          </svg>
-                        </Svg>
-                      </LetterAvatar>
-                    </span>
-                  </StyledBaseAvatar>
-                </Tooltip>
+                              <Svg
+                                round={true}
+                                viewBox="0 0 120 120"
+                              >
+                                <svg
+                                  className="css-1r4mnb9-Svg e1knxa8x0"
+                                  viewBox="0 0 120 120"
+                                >
+                                  <rect
+                                    fill="#315cac"
+                                    height="120"
+                                    rx="15"
+                                    ry="15"
+                                    width="120"
+                                    x="0"
+                                    y="0"
+                                  />
+                                  <text
+                                    fill="#FFFFFF"
+                                    fontSize="65"
+                                    style={
+                                      Object {
+                                        "dominantBaseline": "central",
+                                      }
+                                    }
+                                    textAnchor="middle"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    FB
+                                  </text>
+                                </svg>
+                              </Svg>
+                            </LetterAvatar>
+                          </span>
+                        </StyledBaseAvatar>
+                      </InnerReference>
+                    </Reference>
+                  </Manager>
+                </Tooltip2>
               </BaseAvatar>
             </UserAvatar>
           </Avatar>

--- a/tests/js/spec/components/avatar/__snapshots__/avatarList.spec.jsx.snap
+++ b/tests/js/spec/components/avatar/__snapshots__/avatarList.spec.jsx.snap
@@ -241,26 +241,26 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                       <InnerReference
                         setReferenceNode={[Function]}
                       >
-                        <span
+                        <Container
                           aria-describedby="tooltip-123456"
+                          innerRef={[Function]}
                           onBlur={[Function]}
                           onFocus={[Function]}
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                         >
-                          <StyledBaseAvatar
-                            className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                            loaded={true}
-                            round={true}
-                            style={
-                              Object {
-                                "height": "28px",
-                                "width": "28px",
-                              }
-                            }
+                          <span
+                            aria-describedby="tooltip-123456"
+                            className="css-1m3e0hg-Container e7ebgxc0"
+                            onBlur={[Function]}
+                            onFocus={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
                           >
-                            <span
-                              className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                            <StyledBaseAvatar
+                              className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                              loaded={true}
+                              round={true}
                               style={
                                 Object {
                                   "height": "28px",
@@ -268,48 +268,58 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                                 }
                               }
                             >
-                              <LetterAvatar
-                                displayName="Foo Bar"
-                                identifier="foo@example.com"
-                                round={true}
+                              <span
+                                className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                                style={
+                                  Object {
+                                    "height": "28px",
+                                    "width": "28px",
+                                  }
+                                }
                               >
-                                <Svg
+                                <LetterAvatar
+                                  displayName="Foo Bar"
+                                  identifier="foo@example.com"
                                   round={true}
-                                  viewBox="0 0 120 120"
                                 >
-                                  <svg
-                                    className="css-1r4mnb9-Svg e1knxa8x0"
+                                  <Svg
+                                    round={true}
                                     viewBox="0 0 120 120"
                                   >
-                                    <rect
-                                      fill="#315cac"
-                                      height="120"
-                                      rx="15"
-                                      ry="15"
-                                      width="120"
-                                      x="0"
-                                      y="0"
-                                    />
-                                    <text
-                                      fill="#FFFFFF"
-                                      fontSize="65"
-                                      style={
-                                        Object {
-                                          "dominantBaseline": "central",
-                                        }
-                                      }
-                                      textAnchor="middle"
-                                      x="50%"
-                                      y="50%"
+                                    <svg
+                                      className="css-1r4mnb9-Svg e1knxa8x0"
+                                      viewBox="0 0 120 120"
                                     >
-                                      FB
-                                    </text>
-                                  </svg>
-                                </Svg>
-                              </LetterAvatar>
-                            </span>
-                          </StyledBaseAvatar>
-                        </span>
+                                      <rect
+                                        fill="#315cac"
+                                        height="120"
+                                        rx="15"
+                                        ry="15"
+                                        width="120"
+                                        x="0"
+                                        y="0"
+                                      />
+                                      <text
+                                        fill="#FFFFFF"
+                                        fontSize="65"
+                                        style={
+                                          Object {
+                                            "dominantBaseline": "central",
+                                          }
+                                        }
+                                        textAnchor="middle"
+                                        x="50%"
+                                        y="50%"
+                                      >
+                                        FB
+                                      </text>
+                                    </svg>
+                                  </Svg>
+                                </LetterAvatar>
+                              </span>
+                            </StyledBaseAvatar>
+                          </span>
+                        </Container>
                       </InnerReference>
                     </Reference>
                   </Manager>
@@ -425,26 +435,26 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                       <InnerReference
                         setReferenceNode={[Function]}
                       >
-                        <span
+                        <Container
                           aria-describedby="tooltip-123456"
+                          innerRef={[Function]}
                           onBlur={[Function]}
                           onFocus={[Function]}
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                         >
-                          <StyledBaseAvatar
-                            className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                            loaded={true}
-                            round={true}
-                            style={
-                              Object {
-                                "height": "28px",
-                                "width": "28px",
-                              }
-                            }
+                          <span
+                            aria-describedby="tooltip-123456"
+                            className="css-1m3e0hg-Container e7ebgxc0"
+                            onBlur={[Function]}
+                            onFocus={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
                           >
-                            <span
-                              className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                            <StyledBaseAvatar
+                              className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                              loaded={true}
+                              round={true}
                               style={
                                 Object {
                                   "height": "28px",
@@ -452,48 +462,58 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                                 }
                               }
                             >
-                              <LetterAvatar
-                                displayName="Foo Bar"
-                                identifier="foo@example.com"
-                                round={true}
+                              <span
+                                className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                                style={
+                                  Object {
+                                    "height": "28px",
+                                    "width": "28px",
+                                  }
+                                }
                               >
-                                <Svg
+                                <LetterAvatar
+                                  displayName="Foo Bar"
+                                  identifier="foo@example.com"
                                   round={true}
-                                  viewBox="0 0 120 120"
                                 >
-                                  <svg
-                                    className="css-1r4mnb9-Svg e1knxa8x0"
+                                  <Svg
+                                    round={true}
                                     viewBox="0 0 120 120"
                                   >
-                                    <rect
-                                      fill="#315cac"
-                                      height="120"
-                                      rx="15"
-                                      ry="15"
-                                      width="120"
-                                      x="0"
-                                      y="0"
-                                    />
-                                    <text
-                                      fill="#FFFFFF"
-                                      fontSize="65"
-                                      style={
-                                        Object {
-                                          "dominantBaseline": "central",
-                                        }
-                                      }
-                                      textAnchor="middle"
-                                      x="50%"
-                                      y="50%"
+                                    <svg
+                                      className="css-1r4mnb9-Svg e1knxa8x0"
+                                      viewBox="0 0 120 120"
                                     >
-                                      FB
-                                    </text>
-                                  </svg>
-                                </Svg>
-                              </LetterAvatar>
-                            </span>
-                          </StyledBaseAvatar>
-                        </span>
+                                      <rect
+                                        fill="#315cac"
+                                        height="120"
+                                        rx="15"
+                                        ry="15"
+                                        width="120"
+                                        x="0"
+                                        y="0"
+                                      />
+                                      <text
+                                        fill="#FFFFFF"
+                                        fontSize="65"
+                                        style={
+                                          Object {
+                                            "dominantBaseline": "central",
+                                          }
+                                        }
+                                        textAnchor="middle"
+                                        x="50%"
+                                        y="50%"
+                                      >
+                                        FB
+                                      </text>
+                                    </svg>
+                                  </Svg>
+                                </LetterAvatar>
+                              </span>
+                            </StyledBaseAvatar>
+                          </span>
+                        </Container>
                       </InnerReference>
                     </Reference>
                   </Manager>
@@ -609,26 +629,26 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                       <InnerReference
                         setReferenceNode={[Function]}
                       >
-                        <span
+                        <Container
                           aria-describedby="tooltip-123456"
+                          innerRef={[Function]}
                           onBlur={[Function]}
                           onFocus={[Function]}
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                         >
-                          <StyledBaseAvatar
-                            className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                            loaded={true}
-                            round={true}
-                            style={
-                              Object {
-                                "height": "28px",
-                                "width": "28px",
-                              }
-                            }
+                          <span
+                            aria-describedby="tooltip-123456"
+                            className="css-1m3e0hg-Container e7ebgxc0"
+                            onBlur={[Function]}
+                            onFocus={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
                           >
-                            <span
-                              className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                            <StyledBaseAvatar
+                              className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                              loaded={true}
+                              round={true}
                               style={
                                 Object {
                                   "height": "28px",
@@ -636,48 +656,58 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                                 }
                               }
                             >
-                              <LetterAvatar
-                                displayName="Foo Bar"
-                                identifier="foo@example.com"
-                                round={true}
+                              <span
+                                className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                                style={
+                                  Object {
+                                    "height": "28px",
+                                    "width": "28px",
+                                  }
+                                }
                               >
-                                <Svg
+                                <LetterAvatar
+                                  displayName="Foo Bar"
+                                  identifier="foo@example.com"
                                   round={true}
-                                  viewBox="0 0 120 120"
                                 >
-                                  <svg
-                                    className="css-1r4mnb9-Svg e1knxa8x0"
+                                  <Svg
+                                    round={true}
                                     viewBox="0 0 120 120"
                                   >
-                                    <rect
-                                      fill="#315cac"
-                                      height="120"
-                                      rx="15"
-                                      ry="15"
-                                      width="120"
-                                      x="0"
-                                      y="0"
-                                    />
-                                    <text
-                                      fill="#FFFFFF"
-                                      fontSize="65"
-                                      style={
-                                        Object {
-                                          "dominantBaseline": "central",
-                                        }
-                                      }
-                                      textAnchor="middle"
-                                      x="50%"
-                                      y="50%"
+                                    <svg
+                                      className="css-1r4mnb9-Svg e1knxa8x0"
+                                      viewBox="0 0 120 120"
                                     >
-                                      FB
-                                    </text>
-                                  </svg>
-                                </Svg>
-                              </LetterAvatar>
-                            </span>
-                          </StyledBaseAvatar>
-                        </span>
+                                      <rect
+                                        fill="#315cac"
+                                        height="120"
+                                        rx="15"
+                                        ry="15"
+                                        width="120"
+                                        x="0"
+                                        y="0"
+                                      />
+                                      <text
+                                        fill="#FFFFFF"
+                                        fontSize="65"
+                                        style={
+                                          Object {
+                                            "dominantBaseline": "central",
+                                          }
+                                        }
+                                        textAnchor="middle"
+                                        x="50%"
+                                        y="50%"
+                                      >
+                                        FB
+                                      </text>
+                                    </svg>
+                                  </Svg>
+                                </LetterAvatar>
+                              </span>
+                            </StyledBaseAvatar>
+                          </span>
+                        </Container>
                       </InnerReference>
                     </Reference>
                   </Manager>
@@ -793,26 +823,26 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                       <InnerReference
                         setReferenceNode={[Function]}
                       >
-                        <span
+                        <Container
                           aria-describedby="tooltip-123456"
+                          innerRef={[Function]}
                           onBlur={[Function]}
                           onFocus={[Function]}
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                         >
-                          <StyledBaseAvatar
-                            className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                            loaded={true}
-                            round={true}
-                            style={
-                              Object {
-                                "height": "28px",
-                                "width": "28px",
-                              }
-                            }
+                          <span
+                            aria-describedby="tooltip-123456"
+                            className="css-1m3e0hg-Container e7ebgxc0"
+                            onBlur={[Function]}
+                            onFocus={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
                           >
-                            <span
-                              className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                            <StyledBaseAvatar
+                              className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                              loaded={true}
+                              round={true}
                               style={
                                 Object {
                                   "height": "28px",
@@ -820,48 +850,58 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                                 }
                               }
                             >
-                              <LetterAvatar
-                                displayName="Foo Bar"
-                                identifier="foo@example.com"
-                                round={true}
+                              <span
+                                className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                                style={
+                                  Object {
+                                    "height": "28px",
+                                    "width": "28px",
+                                  }
+                                }
                               >
-                                <Svg
+                                <LetterAvatar
+                                  displayName="Foo Bar"
+                                  identifier="foo@example.com"
                                   round={true}
-                                  viewBox="0 0 120 120"
                                 >
-                                  <svg
-                                    className="css-1r4mnb9-Svg e1knxa8x0"
+                                  <Svg
+                                    round={true}
                                     viewBox="0 0 120 120"
                                   >
-                                    <rect
-                                      fill="#315cac"
-                                      height="120"
-                                      rx="15"
-                                      ry="15"
-                                      width="120"
-                                      x="0"
-                                      y="0"
-                                    />
-                                    <text
-                                      fill="#FFFFFF"
-                                      fontSize="65"
-                                      style={
-                                        Object {
-                                          "dominantBaseline": "central",
-                                        }
-                                      }
-                                      textAnchor="middle"
-                                      x="50%"
-                                      y="50%"
+                                    <svg
+                                      className="css-1r4mnb9-Svg e1knxa8x0"
+                                      viewBox="0 0 120 120"
                                     >
-                                      FB
-                                    </text>
-                                  </svg>
-                                </Svg>
-                              </LetterAvatar>
-                            </span>
-                          </StyledBaseAvatar>
-                        </span>
+                                      <rect
+                                        fill="#315cac"
+                                        height="120"
+                                        rx="15"
+                                        ry="15"
+                                        width="120"
+                                        x="0"
+                                        y="0"
+                                      />
+                                      <text
+                                        fill="#FFFFFF"
+                                        fontSize="65"
+                                        style={
+                                          Object {
+                                            "dominantBaseline": "central",
+                                          }
+                                        }
+                                        textAnchor="middle"
+                                        x="50%"
+                                        y="50%"
+                                      >
+                                        FB
+                                      </text>
+                                    </svg>
+                                  </Svg>
+                                </LetterAvatar>
+                              </span>
+                            </StyledBaseAvatar>
+                          </span>
+                        </Container>
                       </InnerReference>
                     </Reference>
                   </Manager>
@@ -977,26 +1017,26 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                       <InnerReference
                         setReferenceNode={[Function]}
                       >
-                        <span
+                        <Container
                           aria-describedby="tooltip-123456"
+                          innerRef={[Function]}
                           onBlur={[Function]}
                           onFocus={[Function]}
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                         >
-                          <StyledBaseAvatar
-                            className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                            loaded={true}
-                            round={true}
-                            style={
-                              Object {
-                                "height": "28px",
-                                "width": "28px",
-                              }
-                            }
+                          <span
+                            aria-describedby="tooltip-123456"
+                            className="css-1m3e0hg-Container e7ebgxc0"
+                            onBlur={[Function]}
+                            onFocus={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
                           >
-                            <span
-                              className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                            <StyledBaseAvatar
+                              className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                              loaded={true}
+                              round={true}
                               style={
                                 Object {
                                   "height": "28px",
@@ -1004,48 +1044,58 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                                 }
                               }
                             >
-                              <LetterAvatar
-                                displayName="Foo Bar"
-                                identifier="foo@example.com"
-                                round={true}
+                              <span
+                                className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                                style={
+                                  Object {
+                                    "height": "28px",
+                                    "width": "28px",
+                                  }
+                                }
                               >
-                                <Svg
+                                <LetterAvatar
+                                  displayName="Foo Bar"
+                                  identifier="foo@example.com"
                                   round={true}
-                                  viewBox="0 0 120 120"
                                 >
-                                  <svg
-                                    className="css-1r4mnb9-Svg e1knxa8x0"
+                                  <Svg
+                                    round={true}
                                     viewBox="0 0 120 120"
                                   >
-                                    <rect
-                                      fill="#315cac"
-                                      height="120"
-                                      rx="15"
-                                      ry="15"
-                                      width="120"
-                                      x="0"
-                                      y="0"
-                                    />
-                                    <text
-                                      fill="#FFFFFF"
-                                      fontSize="65"
-                                      style={
-                                        Object {
-                                          "dominantBaseline": "central",
-                                        }
-                                      }
-                                      textAnchor="middle"
-                                      x="50%"
-                                      y="50%"
+                                    <svg
+                                      className="css-1r4mnb9-Svg e1knxa8x0"
+                                      viewBox="0 0 120 120"
                                     >
-                                      FB
-                                    </text>
-                                  </svg>
-                                </Svg>
-                              </LetterAvatar>
-                            </span>
-                          </StyledBaseAvatar>
-                        </span>
+                                      <rect
+                                        fill="#315cac"
+                                        height="120"
+                                        rx="15"
+                                        ry="15"
+                                        width="120"
+                                        x="0"
+                                        y="0"
+                                      />
+                                      <text
+                                        fill="#FFFFFF"
+                                        fontSize="65"
+                                        style={
+                                          Object {
+                                            "dominantBaseline": "central",
+                                          }
+                                        }
+                                        textAnchor="middle"
+                                        x="50%"
+                                        y="50%"
+                                      >
+                                        FB
+                                      </text>
+                                    </svg>
+                                  </Svg>
+                                </LetterAvatar>
+                              </span>
+                            </StyledBaseAvatar>
+                          </span>
+                        </Container>
                       </InnerReference>
                     </Reference>
                   </Manager>
@@ -1221,26 +1271,26 @@ exports[`AvatarList renders with user avatars 1`] = `
                       <InnerReference
                         setReferenceNode={[Function]}
                       >
-                        <span
+                        <Container
                           aria-describedby="tooltip-123456"
+                          innerRef={[Function]}
                           onBlur={[Function]}
                           onFocus={[Function]}
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                         >
-                          <StyledBaseAvatar
-                            className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                            loaded={true}
-                            round={true}
-                            style={
-                              Object {
-                                "height": "28px",
-                                "width": "28px",
-                              }
-                            }
+                          <span
+                            aria-describedby="tooltip-123456"
+                            className="css-1m3e0hg-Container e7ebgxc0"
+                            onBlur={[Function]}
+                            onFocus={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
                           >
-                            <span
-                              className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                            <StyledBaseAvatar
+                              className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                              loaded={true}
+                              round={true}
                               style={
                                 Object {
                                   "height": "28px",
@@ -1248,48 +1298,58 @@ exports[`AvatarList renders with user avatars 1`] = `
                                 }
                               }
                             >
-                              <LetterAvatar
-                                displayName="Foo Bar"
-                                identifier="foo@example.com"
-                                round={true}
+                              <span
+                                className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                                style={
+                                  Object {
+                                    "height": "28px",
+                                    "width": "28px",
+                                  }
+                                }
                               >
-                                <Svg
+                                <LetterAvatar
+                                  displayName="Foo Bar"
+                                  identifier="foo@example.com"
                                   round={true}
-                                  viewBox="0 0 120 120"
                                 >
-                                  <svg
-                                    className="css-1r4mnb9-Svg e1knxa8x0"
+                                  <Svg
+                                    round={true}
                                     viewBox="0 0 120 120"
                                   >
-                                    <rect
-                                      fill="#315cac"
-                                      height="120"
-                                      rx="15"
-                                      ry="15"
-                                      width="120"
-                                      x="0"
-                                      y="0"
-                                    />
-                                    <text
-                                      fill="#FFFFFF"
-                                      fontSize="65"
-                                      style={
-                                        Object {
-                                          "dominantBaseline": "central",
-                                        }
-                                      }
-                                      textAnchor="middle"
-                                      x="50%"
-                                      y="50%"
+                                    <svg
+                                      className="css-1r4mnb9-Svg e1knxa8x0"
+                                      viewBox="0 0 120 120"
                                     >
-                                      FB
-                                    </text>
-                                  </svg>
-                                </Svg>
-                              </LetterAvatar>
-                            </span>
-                          </StyledBaseAvatar>
-                        </span>
+                                      <rect
+                                        fill="#315cac"
+                                        height="120"
+                                        rx="15"
+                                        ry="15"
+                                        width="120"
+                                        x="0"
+                                        y="0"
+                                      />
+                                      <text
+                                        fill="#FFFFFF"
+                                        fontSize="65"
+                                        style={
+                                          Object {
+                                            "dominantBaseline": "central",
+                                          }
+                                        }
+                                        textAnchor="middle"
+                                        x="50%"
+                                        y="50%"
+                                      >
+                                        FB
+                                      </text>
+                                    </svg>
+                                  </Svg>
+                                </LetterAvatar>
+                              </span>
+                            </StyledBaseAvatar>
+                          </span>
+                        </Container>
                       </InnerReference>
                     </Reference>
                   </Manager>
@@ -1405,26 +1465,26 @@ exports[`AvatarList renders with user avatars 1`] = `
                       <InnerReference
                         setReferenceNode={[Function]}
                       >
-                        <span
+                        <Container
                           aria-describedby="tooltip-123456"
+                          innerRef={[Function]}
                           onBlur={[Function]}
                           onFocus={[Function]}
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                         >
-                          <StyledBaseAvatar
-                            className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                            loaded={true}
-                            round={true}
-                            style={
-                              Object {
-                                "height": "28px",
-                                "width": "28px",
-                              }
-                            }
+                          <span
+                            aria-describedby="tooltip-123456"
+                            className="css-1m3e0hg-Container e7ebgxc0"
+                            onBlur={[Function]}
+                            onFocus={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
                           >
-                            <span
-                              className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                            <StyledBaseAvatar
+                              className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                              loaded={true}
+                              round={true}
                               style={
                                 Object {
                                   "height": "28px",
@@ -1432,48 +1492,58 @@ exports[`AvatarList renders with user avatars 1`] = `
                                 }
                               }
                             >
-                              <LetterAvatar
-                                displayName="Foo Bar"
-                                identifier="foo@example.com"
-                                round={true}
+                              <span
+                                className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                                style={
+                                  Object {
+                                    "height": "28px",
+                                    "width": "28px",
+                                  }
+                                }
                               >
-                                <Svg
+                                <LetterAvatar
+                                  displayName="Foo Bar"
+                                  identifier="foo@example.com"
                                   round={true}
-                                  viewBox="0 0 120 120"
                                 >
-                                  <svg
-                                    className="css-1r4mnb9-Svg e1knxa8x0"
+                                  <Svg
+                                    round={true}
                                     viewBox="0 0 120 120"
                                   >
-                                    <rect
-                                      fill="#315cac"
-                                      height="120"
-                                      rx="15"
-                                      ry="15"
-                                      width="120"
-                                      x="0"
-                                      y="0"
-                                    />
-                                    <text
-                                      fill="#FFFFFF"
-                                      fontSize="65"
-                                      style={
-                                        Object {
-                                          "dominantBaseline": "central",
-                                        }
-                                      }
-                                      textAnchor="middle"
-                                      x="50%"
-                                      y="50%"
+                                    <svg
+                                      className="css-1r4mnb9-Svg e1knxa8x0"
+                                      viewBox="0 0 120 120"
                                     >
-                                      FB
-                                    </text>
-                                  </svg>
-                                </Svg>
-                              </LetterAvatar>
-                            </span>
-                          </StyledBaseAvatar>
-                        </span>
+                                      <rect
+                                        fill="#315cac"
+                                        height="120"
+                                        rx="15"
+                                        ry="15"
+                                        width="120"
+                                        x="0"
+                                        y="0"
+                                      />
+                                      <text
+                                        fill="#FFFFFF"
+                                        fontSize="65"
+                                        style={
+                                          Object {
+                                            "dominantBaseline": "central",
+                                          }
+                                        }
+                                        textAnchor="middle"
+                                        x="50%"
+                                        y="50%"
+                                      >
+                                        FB
+                                      </text>
+                                    </svg>
+                                  </Svg>
+                                </LetterAvatar>
+                              </span>
+                            </StyledBaseAvatar>
+                          </span>
+                        </Container>
                       </InnerReference>
                     </Reference>
                   </Manager>

--- a/tests/js/spec/components/avatar/__snapshots__/avatarList.spec.jsx.snap
+++ b/tests/js/spec/components/avatar/__snapshots__/avatarList.spec.jsx.snap
@@ -233,7 +233,6 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
               >
                 <Tooltip2
                   disabled={false}
-                  isStyled={true}
                   position="top"
                   title="Foo Bar (foo@example.com)"
                 >
@@ -242,30 +241,17 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                       <InnerReference
                         setReferenceNode={[Function]}
                       >
-                        <StyledBaseAvatar
+                        <span
                           aria-describedby="tooltip-123456"
-                          className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                          innerRef={[Function]}
-                          loaded={true}
                           onBlur={[Function]}
                           onFocus={[Function]}
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
-                          round={true}
-                          style={
-                            Object {
-                              "height": "28px",
-                              "width": "28px",
-                            }
-                          }
                         >
-                          <span
-                            aria-describedby="tooltip-123456"
-                            className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
-                            onBlur={[Function]}
-                            onFocus={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
+                          <StyledBaseAvatar
+                            className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                            loaded={true}
+                            round={true}
                             style={
                               Object {
                                 "height": "28px",
@@ -273,47 +259,57 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                               }
                             }
                           >
-                            <LetterAvatar
-                              displayName="Foo Bar"
-                              identifier="foo@example.com"
-                              round={true}
+                            <span
+                              className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                              style={
+                                Object {
+                                  "height": "28px",
+                                  "width": "28px",
+                                }
+                              }
                             >
-                              <Svg
+                              <LetterAvatar
+                                displayName="Foo Bar"
+                                identifier="foo@example.com"
                                 round={true}
-                                viewBox="0 0 120 120"
                               >
-                                <svg
-                                  className="css-1r4mnb9-Svg e1knxa8x0"
+                                <Svg
+                                  round={true}
                                   viewBox="0 0 120 120"
                                 >
-                                  <rect
-                                    fill="#315cac"
-                                    height="120"
-                                    rx="15"
-                                    ry="15"
-                                    width="120"
-                                    x="0"
-                                    y="0"
-                                  />
-                                  <text
-                                    fill="#FFFFFF"
-                                    fontSize="65"
-                                    style={
-                                      Object {
-                                        "dominantBaseline": "central",
-                                      }
-                                    }
-                                    textAnchor="middle"
-                                    x="50%"
-                                    y="50%"
+                                  <svg
+                                    className="css-1r4mnb9-Svg e1knxa8x0"
+                                    viewBox="0 0 120 120"
                                   >
-                                    FB
-                                  </text>
-                                </svg>
-                              </Svg>
-                            </LetterAvatar>
-                          </span>
-                        </StyledBaseAvatar>
+                                    <rect
+                                      fill="#315cac"
+                                      height="120"
+                                      rx="15"
+                                      ry="15"
+                                      width="120"
+                                      x="0"
+                                      y="0"
+                                    />
+                                    <text
+                                      fill="#FFFFFF"
+                                      fontSize="65"
+                                      style={
+                                        Object {
+                                          "dominantBaseline": "central",
+                                        }
+                                      }
+                                      textAnchor="middle"
+                                      x="50%"
+                                      y="50%"
+                                    >
+                                      FB
+                                    </text>
+                                  </svg>
+                                </Svg>
+                              </LetterAvatar>
+                            </span>
+                          </StyledBaseAvatar>
+                        </span>
                       </InnerReference>
                     </Reference>
                   </Manager>
@@ -421,7 +417,6 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
               >
                 <Tooltip2
                   disabled={false}
-                  isStyled={true}
                   position="top"
                   title="Foo Bar (foo@example.com)"
                 >
@@ -430,30 +425,17 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                       <InnerReference
                         setReferenceNode={[Function]}
                       >
-                        <StyledBaseAvatar
+                        <span
                           aria-describedby="tooltip-123456"
-                          className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                          innerRef={[Function]}
-                          loaded={true}
                           onBlur={[Function]}
                           onFocus={[Function]}
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
-                          round={true}
-                          style={
-                            Object {
-                              "height": "28px",
-                              "width": "28px",
-                            }
-                          }
                         >
-                          <span
-                            aria-describedby="tooltip-123456"
-                            className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
-                            onBlur={[Function]}
-                            onFocus={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
+                          <StyledBaseAvatar
+                            className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                            loaded={true}
+                            round={true}
                             style={
                               Object {
                                 "height": "28px",
@@ -461,47 +443,57 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                               }
                             }
                           >
-                            <LetterAvatar
-                              displayName="Foo Bar"
-                              identifier="foo@example.com"
-                              round={true}
+                            <span
+                              className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                              style={
+                                Object {
+                                  "height": "28px",
+                                  "width": "28px",
+                                }
+                              }
                             >
-                              <Svg
+                              <LetterAvatar
+                                displayName="Foo Bar"
+                                identifier="foo@example.com"
                                 round={true}
-                                viewBox="0 0 120 120"
                               >
-                                <svg
-                                  className="css-1r4mnb9-Svg e1knxa8x0"
+                                <Svg
+                                  round={true}
                                   viewBox="0 0 120 120"
                                 >
-                                  <rect
-                                    fill="#315cac"
-                                    height="120"
-                                    rx="15"
-                                    ry="15"
-                                    width="120"
-                                    x="0"
-                                    y="0"
-                                  />
-                                  <text
-                                    fill="#FFFFFF"
-                                    fontSize="65"
-                                    style={
-                                      Object {
-                                        "dominantBaseline": "central",
-                                      }
-                                    }
-                                    textAnchor="middle"
-                                    x="50%"
-                                    y="50%"
+                                  <svg
+                                    className="css-1r4mnb9-Svg e1knxa8x0"
+                                    viewBox="0 0 120 120"
                                   >
-                                    FB
-                                  </text>
-                                </svg>
-                              </Svg>
-                            </LetterAvatar>
-                          </span>
-                        </StyledBaseAvatar>
+                                    <rect
+                                      fill="#315cac"
+                                      height="120"
+                                      rx="15"
+                                      ry="15"
+                                      width="120"
+                                      x="0"
+                                      y="0"
+                                    />
+                                    <text
+                                      fill="#FFFFFF"
+                                      fontSize="65"
+                                      style={
+                                        Object {
+                                          "dominantBaseline": "central",
+                                        }
+                                      }
+                                      textAnchor="middle"
+                                      x="50%"
+                                      y="50%"
+                                    >
+                                      FB
+                                    </text>
+                                  </svg>
+                                </Svg>
+                              </LetterAvatar>
+                            </span>
+                          </StyledBaseAvatar>
+                        </span>
                       </InnerReference>
                     </Reference>
                   </Manager>
@@ -609,7 +601,6 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
               >
                 <Tooltip2
                   disabled={false}
-                  isStyled={true}
                   position="top"
                   title="Foo Bar (foo@example.com)"
                 >
@@ -618,30 +609,17 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                       <InnerReference
                         setReferenceNode={[Function]}
                       >
-                        <StyledBaseAvatar
+                        <span
                           aria-describedby="tooltip-123456"
-                          className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                          innerRef={[Function]}
-                          loaded={true}
                           onBlur={[Function]}
                           onFocus={[Function]}
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
-                          round={true}
-                          style={
-                            Object {
-                              "height": "28px",
-                              "width": "28px",
-                            }
-                          }
                         >
-                          <span
-                            aria-describedby="tooltip-123456"
-                            className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
-                            onBlur={[Function]}
-                            onFocus={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
+                          <StyledBaseAvatar
+                            className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                            loaded={true}
+                            round={true}
                             style={
                               Object {
                                 "height": "28px",
@@ -649,47 +627,57 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                               }
                             }
                           >
-                            <LetterAvatar
-                              displayName="Foo Bar"
-                              identifier="foo@example.com"
-                              round={true}
+                            <span
+                              className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                              style={
+                                Object {
+                                  "height": "28px",
+                                  "width": "28px",
+                                }
+                              }
                             >
-                              <Svg
+                              <LetterAvatar
+                                displayName="Foo Bar"
+                                identifier="foo@example.com"
                                 round={true}
-                                viewBox="0 0 120 120"
                               >
-                                <svg
-                                  className="css-1r4mnb9-Svg e1knxa8x0"
+                                <Svg
+                                  round={true}
                                   viewBox="0 0 120 120"
                                 >
-                                  <rect
-                                    fill="#315cac"
-                                    height="120"
-                                    rx="15"
-                                    ry="15"
-                                    width="120"
-                                    x="0"
-                                    y="0"
-                                  />
-                                  <text
-                                    fill="#FFFFFF"
-                                    fontSize="65"
-                                    style={
-                                      Object {
-                                        "dominantBaseline": "central",
-                                      }
-                                    }
-                                    textAnchor="middle"
-                                    x="50%"
-                                    y="50%"
+                                  <svg
+                                    className="css-1r4mnb9-Svg e1knxa8x0"
+                                    viewBox="0 0 120 120"
                                   >
-                                    FB
-                                  </text>
-                                </svg>
-                              </Svg>
-                            </LetterAvatar>
-                          </span>
-                        </StyledBaseAvatar>
+                                    <rect
+                                      fill="#315cac"
+                                      height="120"
+                                      rx="15"
+                                      ry="15"
+                                      width="120"
+                                      x="0"
+                                      y="0"
+                                    />
+                                    <text
+                                      fill="#FFFFFF"
+                                      fontSize="65"
+                                      style={
+                                        Object {
+                                          "dominantBaseline": "central",
+                                        }
+                                      }
+                                      textAnchor="middle"
+                                      x="50%"
+                                      y="50%"
+                                    >
+                                      FB
+                                    </text>
+                                  </svg>
+                                </Svg>
+                              </LetterAvatar>
+                            </span>
+                          </StyledBaseAvatar>
+                        </span>
                       </InnerReference>
                     </Reference>
                   </Manager>
@@ -797,7 +785,6 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
               >
                 <Tooltip2
                   disabled={false}
-                  isStyled={true}
                   position="top"
                   title="Foo Bar (foo@example.com)"
                 >
@@ -806,30 +793,17 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                       <InnerReference
                         setReferenceNode={[Function]}
                       >
-                        <StyledBaseAvatar
+                        <span
                           aria-describedby="tooltip-123456"
-                          className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                          innerRef={[Function]}
-                          loaded={true}
                           onBlur={[Function]}
                           onFocus={[Function]}
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
-                          round={true}
-                          style={
-                            Object {
-                              "height": "28px",
-                              "width": "28px",
-                            }
-                          }
                         >
-                          <span
-                            aria-describedby="tooltip-123456"
-                            className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
-                            onBlur={[Function]}
-                            onFocus={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
+                          <StyledBaseAvatar
+                            className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                            loaded={true}
+                            round={true}
                             style={
                               Object {
                                 "height": "28px",
@@ -837,47 +811,57 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                               }
                             }
                           >
-                            <LetterAvatar
-                              displayName="Foo Bar"
-                              identifier="foo@example.com"
-                              round={true}
+                            <span
+                              className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                              style={
+                                Object {
+                                  "height": "28px",
+                                  "width": "28px",
+                                }
+                              }
                             >
-                              <Svg
+                              <LetterAvatar
+                                displayName="Foo Bar"
+                                identifier="foo@example.com"
                                 round={true}
-                                viewBox="0 0 120 120"
                               >
-                                <svg
-                                  className="css-1r4mnb9-Svg e1knxa8x0"
+                                <Svg
+                                  round={true}
                                   viewBox="0 0 120 120"
                                 >
-                                  <rect
-                                    fill="#315cac"
-                                    height="120"
-                                    rx="15"
-                                    ry="15"
-                                    width="120"
-                                    x="0"
-                                    y="0"
-                                  />
-                                  <text
-                                    fill="#FFFFFF"
-                                    fontSize="65"
-                                    style={
-                                      Object {
-                                        "dominantBaseline": "central",
-                                      }
-                                    }
-                                    textAnchor="middle"
-                                    x="50%"
-                                    y="50%"
+                                  <svg
+                                    className="css-1r4mnb9-Svg e1knxa8x0"
+                                    viewBox="0 0 120 120"
                                   >
-                                    FB
-                                  </text>
-                                </svg>
-                              </Svg>
-                            </LetterAvatar>
-                          </span>
-                        </StyledBaseAvatar>
+                                    <rect
+                                      fill="#315cac"
+                                      height="120"
+                                      rx="15"
+                                      ry="15"
+                                      width="120"
+                                      x="0"
+                                      y="0"
+                                    />
+                                    <text
+                                      fill="#FFFFFF"
+                                      fontSize="65"
+                                      style={
+                                        Object {
+                                          "dominantBaseline": "central",
+                                        }
+                                      }
+                                      textAnchor="middle"
+                                      x="50%"
+                                      y="50%"
+                                    >
+                                      FB
+                                    </text>
+                                  </svg>
+                                </Svg>
+                              </LetterAvatar>
+                            </span>
+                          </StyledBaseAvatar>
+                        </span>
                       </InnerReference>
                     </Reference>
                   </Manager>
@@ -985,7 +969,6 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
               >
                 <Tooltip2
                   disabled={false}
-                  isStyled={true}
                   position="top"
                   title="Foo Bar (foo@example.com)"
                 >
@@ -994,30 +977,17 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                       <InnerReference
                         setReferenceNode={[Function]}
                       >
-                        <StyledBaseAvatar
+                        <span
                           aria-describedby="tooltip-123456"
-                          className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                          innerRef={[Function]}
-                          loaded={true}
                           onBlur={[Function]}
                           onFocus={[Function]}
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
-                          round={true}
-                          style={
-                            Object {
-                              "height": "28px",
-                              "width": "28px",
-                            }
-                          }
                         >
-                          <span
-                            aria-describedby="tooltip-123456"
-                            className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
-                            onBlur={[Function]}
-                            onFocus={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
+                          <StyledBaseAvatar
+                            className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                            loaded={true}
+                            round={true}
                             style={
                               Object {
                                 "height": "28px",
@@ -1025,47 +995,57 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                               }
                             }
                           >
-                            <LetterAvatar
-                              displayName="Foo Bar"
-                              identifier="foo@example.com"
-                              round={true}
+                            <span
+                              className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                              style={
+                                Object {
+                                  "height": "28px",
+                                  "width": "28px",
+                                }
+                              }
                             >
-                              <Svg
+                              <LetterAvatar
+                                displayName="Foo Bar"
+                                identifier="foo@example.com"
                                 round={true}
-                                viewBox="0 0 120 120"
                               >
-                                <svg
-                                  className="css-1r4mnb9-Svg e1knxa8x0"
+                                <Svg
+                                  round={true}
                                   viewBox="0 0 120 120"
                                 >
-                                  <rect
-                                    fill="#315cac"
-                                    height="120"
-                                    rx="15"
-                                    ry="15"
-                                    width="120"
-                                    x="0"
-                                    y="0"
-                                  />
-                                  <text
-                                    fill="#FFFFFF"
-                                    fontSize="65"
-                                    style={
-                                      Object {
-                                        "dominantBaseline": "central",
-                                      }
-                                    }
-                                    textAnchor="middle"
-                                    x="50%"
-                                    y="50%"
+                                  <svg
+                                    className="css-1r4mnb9-Svg e1knxa8x0"
+                                    viewBox="0 0 120 120"
                                   >
-                                    FB
-                                  </text>
-                                </svg>
-                              </Svg>
-                            </LetterAvatar>
-                          </span>
-                        </StyledBaseAvatar>
+                                    <rect
+                                      fill="#315cac"
+                                      height="120"
+                                      rx="15"
+                                      ry="15"
+                                      width="120"
+                                      x="0"
+                                      y="0"
+                                    />
+                                    <text
+                                      fill="#FFFFFF"
+                                      fontSize="65"
+                                      style={
+                                        Object {
+                                          "dominantBaseline": "central",
+                                        }
+                                      }
+                                      textAnchor="middle"
+                                      x="50%"
+                                      y="50%"
+                                    >
+                                      FB
+                                    </text>
+                                  </svg>
+                                </Svg>
+                              </LetterAvatar>
+                            </span>
+                          </StyledBaseAvatar>
+                        </span>
                       </InnerReference>
                     </Reference>
                   </Manager>
@@ -1233,7 +1213,6 @@ exports[`AvatarList renders with user avatars 1`] = `
               >
                 <Tooltip2
                   disabled={false}
-                  isStyled={true}
                   position="top"
                   title="Foo Bar (foo@example.com)"
                 >
@@ -1242,30 +1221,17 @@ exports[`AvatarList renders with user avatars 1`] = `
                       <InnerReference
                         setReferenceNode={[Function]}
                       >
-                        <StyledBaseAvatar
+                        <span
                           aria-describedby="tooltip-123456"
-                          className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                          innerRef={[Function]}
-                          loaded={true}
                           onBlur={[Function]}
                           onFocus={[Function]}
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
-                          round={true}
-                          style={
-                            Object {
-                              "height": "28px",
-                              "width": "28px",
-                            }
-                          }
                         >
-                          <span
-                            aria-describedby="tooltip-123456"
-                            className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
-                            onBlur={[Function]}
-                            onFocus={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
+                          <StyledBaseAvatar
+                            className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                            loaded={true}
+                            round={true}
                             style={
                               Object {
                                 "height": "28px",
@@ -1273,47 +1239,57 @@ exports[`AvatarList renders with user avatars 1`] = `
                               }
                             }
                           >
-                            <LetterAvatar
-                              displayName="Foo Bar"
-                              identifier="foo@example.com"
-                              round={true}
+                            <span
+                              className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                              style={
+                                Object {
+                                  "height": "28px",
+                                  "width": "28px",
+                                }
+                              }
                             >
-                              <Svg
+                              <LetterAvatar
+                                displayName="Foo Bar"
+                                identifier="foo@example.com"
                                 round={true}
-                                viewBox="0 0 120 120"
                               >
-                                <svg
-                                  className="css-1r4mnb9-Svg e1knxa8x0"
+                                <Svg
+                                  round={true}
                                   viewBox="0 0 120 120"
                                 >
-                                  <rect
-                                    fill="#315cac"
-                                    height="120"
-                                    rx="15"
-                                    ry="15"
-                                    width="120"
-                                    x="0"
-                                    y="0"
-                                  />
-                                  <text
-                                    fill="#FFFFFF"
-                                    fontSize="65"
-                                    style={
-                                      Object {
-                                        "dominantBaseline": "central",
-                                      }
-                                    }
-                                    textAnchor="middle"
-                                    x="50%"
-                                    y="50%"
+                                  <svg
+                                    className="css-1r4mnb9-Svg e1knxa8x0"
+                                    viewBox="0 0 120 120"
                                   >
-                                    FB
-                                  </text>
-                                </svg>
-                              </Svg>
-                            </LetterAvatar>
-                          </span>
-                        </StyledBaseAvatar>
+                                    <rect
+                                      fill="#315cac"
+                                      height="120"
+                                      rx="15"
+                                      ry="15"
+                                      width="120"
+                                      x="0"
+                                      y="0"
+                                    />
+                                    <text
+                                      fill="#FFFFFF"
+                                      fontSize="65"
+                                      style={
+                                        Object {
+                                          "dominantBaseline": "central",
+                                        }
+                                      }
+                                      textAnchor="middle"
+                                      x="50%"
+                                      y="50%"
+                                    >
+                                      FB
+                                    </text>
+                                  </svg>
+                                </Svg>
+                              </LetterAvatar>
+                            </span>
+                          </StyledBaseAvatar>
+                        </span>
                       </InnerReference>
                     </Reference>
                   </Manager>
@@ -1421,7 +1397,6 @@ exports[`AvatarList renders with user avatars 1`] = `
               >
                 <Tooltip2
                   disabled={false}
-                  isStyled={true}
                   position="top"
                   title="Foo Bar (foo@example.com)"
                 >
@@ -1430,30 +1405,17 @@ exports[`AvatarList renders with user avatars 1`] = `
                       <InnerReference
                         setReferenceNode={[Function]}
                       >
-                        <StyledBaseAvatar
+                        <span
                           aria-describedby="tooltip-123456"
-                          className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
-                          innerRef={[Function]}
-                          loaded={true}
                           onBlur={[Function]}
                           onFocus={[Function]}
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
-                          round={true}
-                          style={
-                            Object {
-                              "height": "28px",
-                              "width": "28px",
-                            }
-                          }
                         >
-                          <span
-                            aria-describedby="tooltip-123456"
-                            className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
-                            onBlur={[Function]}
-                            onFocus={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
+                          <StyledBaseAvatar
+                            className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
+                            loaded={true}
+                            round={true}
                             style={
                               Object {
                                 "height": "28px",
@@ -1461,47 +1423,57 @@ exports[`AvatarList renders with user avatars 1`] = `
                               }
                             }
                           >
-                            <LetterAvatar
-                              displayName="Foo Bar"
-                              identifier="foo@example.com"
-                              round={true}
+                            <span
+                              className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
+                              style={
+                                Object {
+                                  "height": "28px",
+                                  "width": "28px",
+                                }
+                              }
                             >
-                              <Svg
+                              <LetterAvatar
+                                displayName="Foo Bar"
+                                identifier="foo@example.com"
                                 round={true}
-                                viewBox="0 0 120 120"
                               >
-                                <svg
-                                  className="css-1r4mnb9-Svg e1knxa8x0"
+                                <Svg
+                                  round={true}
                                   viewBox="0 0 120 120"
                                 >
-                                  <rect
-                                    fill="#315cac"
-                                    height="120"
-                                    rx="15"
-                                    ry="15"
-                                    width="120"
-                                    x="0"
-                                    y="0"
-                                  />
-                                  <text
-                                    fill="#FFFFFF"
-                                    fontSize="65"
-                                    style={
-                                      Object {
-                                        "dominantBaseline": "central",
-                                      }
-                                    }
-                                    textAnchor="middle"
-                                    x="50%"
-                                    y="50%"
+                                  <svg
+                                    className="css-1r4mnb9-Svg e1knxa8x0"
+                                    viewBox="0 0 120 120"
                                   >
-                                    FB
-                                  </text>
-                                </svg>
-                              </Svg>
-                            </LetterAvatar>
-                          </span>
-                        </StyledBaseAvatar>
+                                    <rect
+                                      fill="#315cac"
+                                      height="120"
+                                      rx="15"
+                                      ry="15"
+                                      width="120"
+                                      x="0"
+                                      y="0"
+                                    />
+                                    <text
+                                      fill="#FFFFFF"
+                                      fontSize="65"
+                                      style={
+                                        Object {
+                                          "dominantBaseline": "central",
+                                        }
+                                      }
+                                      textAnchor="middle"
+                                      x="50%"
+                                      y="50%"
+                                    >
+                                      FB
+                                    </text>
+                                  </svg>
+                                </Svg>
+                              </LetterAvatar>
+                            </span>
+                          </StyledBaseAvatar>
+                        </span>
                       </InnerReference>
                     </Reference>
                   </Manager>

--- a/tests/js/spec/components/avatar/__snapshots__/avatarList.spec.jsx.snap
+++ b/tests/js/spec/components/avatar/__snapshots__/avatarList.spec.jsx.snap
@@ -6,7 +6,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
   maxVisibleAvatars={5}
   tooltipOptions={
     Object {
-      "placement": "top auto",
+      "position": "top",
     }
   }
   typeMembers="users"
@@ -140,7 +140,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
           size={28}
           tooltipOptions={
             Object {
-              "placement": "top auto",
+              "position": "top",
             }
           }
           user={
@@ -166,7 +166,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
             size={28}
             tooltipOptions={
               Object {
-                "placement": "top auto",
+                "position": "top",
               }
             }
             user={
@@ -193,7 +193,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
               size={28}
               tooltipOptions={
                 Object {
-                  "placement": "top auto",
+                  "position": "top",
                 }
               }
               user={
@@ -225,7 +225,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                 tooltip="Foo Bar (foo@example.com)"
                 tooltipOptions={
                   Object {
-                    "placement": "top auto",
+                    "position": "top",
                   }
                 }
                 type="letter_avatar"
@@ -243,7 +243,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <StyledBaseAvatar
-                          aria-describedby="tooltip_5xnxosaaqo"
+                          aria-describedby="tooltip-123456"
                           className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
                           innerRef={[Function]}
                           loaded={true}
@@ -260,7 +260,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                           }
                         >
                           <span
-                            aria-describedby="tooltip_5xnxosaaqo"
+                            aria-describedby="tooltip-123456"
                             className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
                             onBlur={[Function]}
                             onFocus={[Function]}
@@ -328,7 +328,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
           size={28}
           tooltipOptions={
             Object {
-              "placement": "top auto",
+              "position": "top",
             }
           }
           user={
@@ -354,7 +354,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
             size={28}
             tooltipOptions={
               Object {
-                "placement": "top auto",
+                "position": "top",
               }
             }
             user={
@@ -381,7 +381,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
               size={28}
               tooltipOptions={
                 Object {
-                  "placement": "top auto",
+                  "position": "top",
                 }
               }
               user={
@@ -413,7 +413,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                 tooltip="Foo Bar (foo@example.com)"
                 tooltipOptions={
                   Object {
-                    "placement": "top auto",
+                    "position": "top",
                   }
                 }
                 type="letter_avatar"
@@ -431,7 +431,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <StyledBaseAvatar
-                          aria-describedby="tooltip_7xsj156yci"
+                          aria-describedby="tooltip-123456"
                           className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
                           innerRef={[Function]}
                           loaded={true}
@@ -448,7 +448,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                           }
                         >
                           <span
-                            aria-describedby="tooltip_7xsj156yci"
+                            aria-describedby="tooltip-123456"
                             className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
                             onBlur={[Function]}
                             onFocus={[Function]}
@@ -516,7 +516,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
           size={28}
           tooltipOptions={
             Object {
-              "placement": "top auto",
+              "position": "top",
             }
           }
           user={
@@ -542,7 +542,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
             size={28}
             tooltipOptions={
               Object {
-                "placement": "top auto",
+                "position": "top",
               }
             }
             user={
@@ -569,7 +569,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
               size={28}
               tooltipOptions={
                 Object {
-                  "placement": "top auto",
+                  "position": "top",
                 }
               }
               user={
@@ -601,7 +601,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                 tooltip="Foo Bar (foo@example.com)"
                 tooltipOptions={
                   Object {
-                    "placement": "top auto",
+                    "position": "top",
                   }
                 }
                 type="letter_avatar"
@@ -619,7 +619,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <StyledBaseAvatar
-                          aria-describedby="tooltip_pbui7dx3sk"
+                          aria-describedby="tooltip-123456"
                           className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
                           innerRef={[Function]}
                           loaded={true}
@@ -636,7 +636,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                           }
                         >
                           <span
-                            aria-describedby="tooltip_pbui7dx3sk"
+                            aria-describedby="tooltip-123456"
                             className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
                             onBlur={[Function]}
                             onFocus={[Function]}
@@ -704,7 +704,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
           size={28}
           tooltipOptions={
             Object {
-              "placement": "top auto",
+              "position": "top",
             }
           }
           user={
@@ -730,7 +730,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
             size={28}
             tooltipOptions={
               Object {
-                "placement": "top auto",
+                "position": "top",
               }
             }
             user={
@@ -757,7 +757,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
               size={28}
               tooltipOptions={
                 Object {
-                  "placement": "top auto",
+                  "position": "top",
                 }
               }
               user={
@@ -789,7 +789,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                 tooltip="Foo Bar (foo@example.com)"
                 tooltipOptions={
                   Object {
-                    "placement": "top auto",
+                    "position": "top",
                   }
                 }
                 type="letter_avatar"
@@ -807,7 +807,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <StyledBaseAvatar
-                          aria-describedby="tooltip_odmxpdwl9w"
+                          aria-describedby="tooltip-123456"
                           className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
                           innerRef={[Function]}
                           loaded={true}
@@ -824,7 +824,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                           }
                         >
                           <span
-                            aria-describedby="tooltip_odmxpdwl9w"
+                            aria-describedby="tooltip-123456"
                             className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
                             onBlur={[Function]}
                             onFocus={[Function]}
@@ -892,7 +892,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
           size={28}
           tooltipOptions={
             Object {
-              "placement": "top auto",
+              "position": "top",
             }
           }
           user={
@@ -918,7 +918,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
             size={28}
             tooltipOptions={
               Object {
-                "placement": "top auto",
+                "position": "top",
               }
             }
             user={
@@ -945,7 +945,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
               size={28}
               tooltipOptions={
                 Object {
-                  "placement": "top auto",
+                  "position": "top",
                 }
               }
               user={
@@ -977,7 +977,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                 tooltip="Foo Bar (foo@example.com)"
                 tooltipOptions={
                   Object {
-                    "placement": "top auto",
+                    "position": "top",
                   }
                 }
                 type="letter_avatar"
@@ -995,7 +995,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <StyledBaseAvatar
-                          aria-describedby="tooltip_thjwyj6gbk"
+                          aria-describedby="tooltip-123456"
                           className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
                           innerRef={[Function]}
                           loaded={true}
@@ -1012,7 +1012,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                           }
                         >
                           <span
-                            aria-describedby="tooltip_thjwyj6gbk"
+                            aria-describedby="tooltip-123456"
                             className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
                             onBlur={[Function]}
                             onFocus={[Function]}
@@ -1086,7 +1086,7 @@ exports[`AvatarList renders with user avatars 1`] = `
   maxVisibleAvatars={5}
   tooltipOptions={
     Object {
-      "placement": "top auto",
+      "position": "top",
     }
   }
   typeMembers="users"
@@ -1140,7 +1140,7 @@ exports[`AvatarList renders with user avatars 1`] = `
           size={28}
           tooltipOptions={
             Object {
-              "placement": "top auto",
+              "position": "top",
             }
           }
           user={
@@ -1166,7 +1166,7 @@ exports[`AvatarList renders with user avatars 1`] = `
             size={28}
             tooltipOptions={
               Object {
-                "placement": "top auto",
+                "position": "top",
               }
             }
             user={
@@ -1193,7 +1193,7 @@ exports[`AvatarList renders with user avatars 1`] = `
               size={28}
               tooltipOptions={
                 Object {
-                  "placement": "top auto",
+                  "position": "top",
                 }
               }
               user={
@@ -1225,7 +1225,7 @@ exports[`AvatarList renders with user avatars 1`] = `
                 tooltip="Foo Bar (foo@example.com)"
                 tooltipOptions={
                   Object {
-                    "placement": "top auto",
+                    "position": "top",
                   }
                 }
                 type="letter_avatar"
@@ -1243,7 +1243,7 @@ exports[`AvatarList renders with user avatars 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <StyledBaseAvatar
-                          aria-describedby="tooltip_jj4rpyzs79"
+                          aria-describedby="tooltip-123456"
                           className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
                           innerRef={[Function]}
                           loaded={true}
@@ -1260,7 +1260,7 @@ exports[`AvatarList renders with user avatars 1`] = `
                           }
                         >
                           <span
-                            aria-describedby="tooltip_jj4rpyzs79"
+                            aria-describedby="tooltip-123456"
                             className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
                             onBlur={[Function]}
                             onFocus={[Function]}
@@ -1328,7 +1328,7 @@ exports[`AvatarList renders with user avatars 1`] = `
           size={28}
           tooltipOptions={
             Object {
-              "placement": "top auto",
+              "position": "top",
             }
           }
           user={
@@ -1354,7 +1354,7 @@ exports[`AvatarList renders with user avatars 1`] = `
             size={28}
             tooltipOptions={
               Object {
-                "placement": "top auto",
+                "position": "top",
               }
             }
             user={
@@ -1381,7 +1381,7 @@ exports[`AvatarList renders with user avatars 1`] = `
               size={28}
               tooltipOptions={
                 Object {
-                  "placement": "top auto",
+                  "position": "top",
                 }
               }
               user={
@@ -1413,7 +1413,7 @@ exports[`AvatarList renders with user avatars 1`] = `
                 tooltip="Foo Bar (foo@example.com)"
                 tooltipOptions={
                   Object {
-                    "placement": "top auto",
+                    "position": "top",
                   }
                 }
                 type="letter_avatar"
@@ -1431,7 +1431,7 @@ exports[`AvatarList renders with user avatars 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <StyledBaseAvatar
-                          aria-describedby="tooltip_uwj895ejkm"
+                          aria-describedby="tooltip-123456"
                           className="avatar css-ptswrs-StyledAvatar-Circle e1axh4r50"
                           innerRef={[Function]}
                           loaded={true}
@@ -1448,7 +1448,7 @@ exports[`AvatarList renders with user avatars 1`] = `
                           }
                         >
                           <span
-                            aria-describedby="tooltip_uwj895ejkm"
+                            aria-describedby="tooltip-123456"
                             className="avatar e1axh4r50 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e1z0ohzl0"
                             onBlur={[Function]}
                             onFocus={[Function]}

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -285,8 +285,10 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                 type="letter_avatar"
                 uploadPath="organization-avatar"
               >
-                <Tooltip
+                <Tooltip2
                   disabled={true}
+                  isStyled={true}
+                  position="top"
                   title="org-slug"
                 >
                   <StyledBaseAvatar
@@ -347,7 +349,7 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                       </LetterAvatar>
                     </span>
                   </StyledBaseAvatar>
-                </Tooltip>
+                </Tooltip2>
               </BaseAvatar>
             </OrganizationAvatar>
           </Avatar>
@@ -753,8 +755,10 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                                     type="letter_avatar"
                                     uploadPath="avatar"
                                   >
-                                    <Tooltip
+                                    <Tooltip2
                                       disabled={true}
+                                      isStyled={true}
+                                      position="top"
                                       title="Foo Bar (foo@example.com)"
                                     >
                                       <StyledBaseAvatar
@@ -818,7 +822,7 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                                           </LetterAvatar>
                                         </span>
                                       </StyledBaseAvatar>
-                                    </Tooltip>
+                                    </Tooltip2>
                                   </BaseAvatar>
                                 </UserAvatar>
                               </Avatar>
@@ -1954,8 +1958,10 @@ exports[`Sidebar renders without org and router 1`] = `
                                     type="letter_avatar"
                                     uploadPath="avatar"
                                   >
-                                    <Tooltip
+                                    <Tooltip2
                                       disabled={true}
+                                      isStyled={true}
+                                      position="top"
                                       title="Foo Bar (foo@example.com)"
                                     >
                                       <StyledBaseAvatar
@@ -2019,7 +2025,7 @@ exports[`Sidebar renders without org and router 1`] = `
                                           </LetterAvatar>
                                         </span>
                                       </StyledBaseAvatar>
-                                    </Tooltip>
+                                    </Tooltip2>
                                   </BaseAvatar>
                                 </UserAvatar>
                               </Avatar>

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -287,7 +287,6 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
               >
                 <Tooltip2
                   disabled={true}
-                  isStyled={true}
                   position="top"
                   title="org-slug"
                 >
@@ -757,7 +756,6 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                                   >
                                     <Tooltip2
                                       disabled={true}
-                                      isStyled={true}
                                       position="top"
                                       title="Foo Bar (foo@example.com)"
                                     >
@@ -1960,7 +1958,6 @@ exports[`Sidebar renders without org and router 1`] = `
                                   >
                                     <Tooltip2
                                       disabled={true}
-                                      isStyled={true}
                                       position="top"
                                       title="Foo Bar (foo@example.com)"
                                     >

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -2627,74 +2627,93 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                               type="letter_avatar"
                                               uploadPath="avatar"
                                             >
-                                              <Tooltip
+                                              <Tooltip2
                                                 disabled={false}
+                                                isStyled={true}
+                                                position="top"
                                                 title="Jane Doe (janedoe@example.com)"
                                               >
-                                                <StyledBaseAvatar
-                                                  className="tip avatar"
-                                                  loaded={true}
-                                                  round={true}
-                                                  style={
-                                                    Object {
-                                                      "height": "28px",
-                                                      "width": "28px",
-                                                    }
-                                                  }
-                                                  title="Jane Doe (janedoe@example.com)"
-                                                >
-                                                  <span
-                                                    className="tip avatar css-3f9bmx-StyledBaseAvatar e1z0ohzl0"
-                                                    style={
-                                                      Object {
-                                                        "height": "28px",
-                                                        "width": "28px",
-                                                      }
-                                                    }
-                                                    title="Jane Doe (janedoe@example.com)"
-                                                  >
-                                                    <LetterAvatar
-                                                      displayName="Jane Doe"
-                                                      identifier="janedoe@example.com"
-                                                      round={true}
+                                                <Manager>
+                                                  <Reference>
+                                                    <InnerReference
+                                                      setReferenceNode={[Function]}
                                                     >
-                                                      <Svg
+                                                      <StyledBaseAvatar
+                                                        aria-describedby="tooltip_9dyzij1zjr"
+                                                        className="avatar"
+                                                        innerRef={[Function]}
+                                                        loaded={true}
+                                                        onBlur={[Function]}
+                                                        onFocus={[Function]}
+                                                        onMouseEnter={[Function]}
+                                                        onMouseLeave={[Function]}
                                                         round={true}
-                                                        viewBox="0 0 120 120"
+                                                        style={
+                                                          Object {
+                                                            "height": "28px",
+                                                            "width": "28px",
+                                                          }
+                                                        }
                                                       >
-                                                        <svg
-                                                          className="css-1r4mnb9-Svg e1knxa8x0"
-                                                          viewBox="0 0 120 120"
-                                                        >
-                                                          <rect
-                                                            fill="#f868bc"
-                                                            height="120"
-                                                            rx="15"
-                                                            ry="15"
-                                                            width="120"
-                                                            x="0"
-                                                            y="0"
-                                                          />
-                                                          <text
-                                                            fill="#FFFFFF"
-                                                            fontSize="65"
-                                                            style={
-                                                              Object {
-                                                                "dominantBaseline": "central",
-                                                              }
+                                                        <span
+                                                          aria-describedby="tooltip_9dyzij1zjr"
+                                                          className="avatar css-3f9bmx-StyledBaseAvatar e1z0ohzl0"
+                                                          onBlur={[Function]}
+                                                          onFocus={[Function]}
+                                                          onMouseEnter={[Function]}
+                                                          onMouseLeave={[Function]}
+                                                          style={
+                                                            Object {
+                                                              "height": "28px",
+                                                              "width": "28px",
                                                             }
-                                                            textAnchor="middle"
-                                                            x="50%"
-                                                            y="50%"
+                                                          }
+                                                        >
+                                                          <LetterAvatar
+                                                            displayName="Jane Doe"
+                                                            identifier="janedoe@example.com"
+                                                            round={true}
                                                           >
-                                                            JD
-                                                          </text>
-                                                        </svg>
-                                                      </Svg>
-                                                    </LetterAvatar>
-                                                  </span>
-                                                </StyledBaseAvatar>
-                                              </Tooltip>
+                                                            <Svg
+                                                              round={true}
+                                                              viewBox="0 0 120 120"
+                                                            >
+                                                              <svg
+                                                                className="css-1r4mnb9-Svg e1knxa8x0"
+                                                                viewBox="0 0 120 120"
+                                                              >
+                                                                <rect
+                                                                  fill="#f868bc"
+                                                                  height="120"
+                                                                  rx="15"
+                                                                  ry="15"
+                                                                  width="120"
+                                                                  x="0"
+                                                                  y="0"
+                                                                />
+                                                                <text
+                                                                  fill="#FFFFFF"
+                                                                  fontSize="65"
+                                                                  style={
+                                                                    Object {
+                                                                      "dominantBaseline": "central",
+                                                                    }
+                                                                  }
+                                                                  textAnchor="middle"
+                                                                  x="50%"
+                                                                  y="50%"
+                                                                >
+                                                                  JD
+                                                                </text>
+                                                              </svg>
+                                                            </Svg>
+                                                          </LetterAvatar>
+                                                        </span>
+                                                      </StyledBaseAvatar>
+                                                    </InnerReference>
+                                                  </Reference>
+                                                </Manager>
+                                              </Tooltip2>
                                             </BaseAvatar>
                                           </UserAvatar>
                                         </Avatar>

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -2639,7 +2639,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                                       setReferenceNode={[Function]}
                                                     >
                                                       <StyledBaseAvatar
-                                                        aria-describedby="tooltip_9dyzij1zjr"
+                                                        aria-describedby="tooltip-123456"
                                                         className="avatar"
                                                         innerRef={[Function]}
                                                         loaded={true}
@@ -2656,7 +2656,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                                         }
                                                       >
                                                         <span
-                                                          aria-describedby="tooltip_9dyzij1zjr"
+                                                          aria-describedby="tooltip-123456"
                                                           className="avatar css-3f9bmx-StyledBaseAvatar e1z0ohzl0"
                                                           onBlur={[Function]}
                                                           onFocus={[Function]}

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -2637,26 +2637,26 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                                     <InnerReference
                                                       setReferenceNode={[Function]}
                                                     >
-                                                      <span
+                                                      <Container
                                                         aria-describedby="tooltip-123456"
+                                                        innerRef={[Function]}
                                                         onBlur={[Function]}
                                                         onFocus={[Function]}
                                                         onMouseEnter={[Function]}
                                                         onMouseLeave={[Function]}
                                                       >
-                                                        <StyledBaseAvatar
-                                                          className="avatar"
-                                                          loaded={true}
-                                                          round={true}
-                                                          style={
-                                                            Object {
-                                                              "height": "28px",
-                                                              "width": "28px",
-                                                            }
-                                                          }
+                                                        <span
+                                                          aria-describedby="tooltip-123456"
+                                                          className="css-1m3e0hg-Container e7ebgxc0"
+                                                          onBlur={[Function]}
+                                                          onFocus={[Function]}
+                                                          onMouseEnter={[Function]}
+                                                          onMouseLeave={[Function]}
                                                         >
-                                                          <span
-                                                            className="avatar css-3f9bmx-StyledBaseAvatar e1z0ohzl0"
+                                                          <StyledBaseAvatar
+                                                            className="avatar"
+                                                            loaded={true}
+                                                            round={true}
                                                             style={
                                                               Object {
                                                                 "height": "28px",
@@ -2664,48 +2664,58 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                                               }
                                                             }
                                                           >
-                                                            <LetterAvatar
-                                                              displayName="Jane Doe"
-                                                              identifier="janedoe@example.com"
-                                                              round={true}
+                                                            <span
+                                                              className="avatar css-3f9bmx-StyledBaseAvatar e1z0ohzl0"
+                                                              style={
+                                                                Object {
+                                                                  "height": "28px",
+                                                                  "width": "28px",
+                                                                }
+                                                              }
                                                             >
-                                                              <Svg
+                                                              <LetterAvatar
+                                                                displayName="Jane Doe"
+                                                                identifier="janedoe@example.com"
                                                                 round={true}
-                                                                viewBox="0 0 120 120"
                                                               >
-                                                                <svg
-                                                                  className="css-1r4mnb9-Svg e1knxa8x0"
+                                                                <Svg
+                                                                  round={true}
                                                                   viewBox="0 0 120 120"
                                                                 >
-                                                                  <rect
-                                                                    fill="#f868bc"
-                                                                    height="120"
-                                                                    rx="15"
-                                                                    ry="15"
-                                                                    width="120"
-                                                                    x="0"
-                                                                    y="0"
-                                                                  />
-                                                                  <text
-                                                                    fill="#FFFFFF"
-                                                                    fontSize="65"
-                                                                    style={
-                                                                      Object {
-                                                                        "dominantBaseline": "central",
-                                                                      }
-                                                                    }
-                                                                    textAnchor="middle"
-                                                                    x="50%"
-                                                                    y="50%"
+                                                                  <svg
+                                                                    className="css-1r4mnb9-Svg e1knxa8x0"
+                                                                    viewBox="0 0 120 120"
                                                                   >
-                                                                    JD
-                                                                  </text>
-                                                                </svg>
-                                                              </Svg>
-                                                            </LetterAvatar>
-                                                          </span>
-                                                        </StyledBaseAvatar>
-                                                      </span>
+                                                                    <rect
+                                                                      fill="#f868bc"
+                                                                      height="120"
+                                                                      rx="15"
+                                                                      ry="15"
+                                                                      width="120"
+                                                                      x="0"
+                                                                      y="0"
+                                                                    />
+                                                                    <text
+                                                                      fill="#FFFFFF"
+                                                                      fontSize="65"
+                                                                      style={
+                                                                        Object {
+                                                                          "dominantBaseline": "central",
+                                                                        }
+                                                                      }
+                                                                      textAnchor="middle"
+                                                                      x="50%"
+                                                                      y="50%"
+                                                                    >
+                                                                      JD
+                                                                    </text>
+                                                                  </svg>
+                                                                </Svg>
+                                                              </LetterAvatar>
+                                                            </span>
+                                                          </StyledBaseAvatar>
+                                                        </span>
+                                                      </Container>
                                                     </InnerReference>
                                                   </Reference>
                                                 </Manager>

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -2629,7 +2629,6 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                             >
                                               <Tooltip2
                                                 disabled={false}
-                                                isStyled={true}
                                                 position="top"
                                                 title="Jane Doe (janedoe@example.com)"
                                               >
@@ -2638,30 +2637,17 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                                     <InnerReference
                                                       setReferenceNode={[Function]}
                                                     >
-                                                      <StyledBaseAvatar
+                                                      <span
                                                         aria-describedby="tooltip-123456"
-                                                        className="avatar"
-                                                        innerRef={[Function]}
-                                                        loaded={true}
                                                         onBlur={[Function]}
                                                         onFocus={[Function]}
                                                         onMouseEnter={[Function]}
                                                         onMouseLeave={[Function]}
-                                                        round={true}
-                                                        style={
-                                                          Object {
-                                                            "height": "28px",
-                                                            "width": "28px",
-                                                          }
-                                                        }
                                                       >
-                                                        <span
-                                                          aria-describedby="tooltip-123456"
-                                                          className="avatar css-3f9bmx-StyledBaseAvatar e1z0ohzl0"
-                                                          onBlur={[Function]}
-                                                          onFocus={[Function]}
-                                                          onMouseEnter={[Function]}
-                                                          onMouseLeave={[Function]}
+                                                        <StyledBaseAvatar
+                                                          className="avatar"
+                                                          loaded={true}
+                                                          round={true}
                                                           style={
                                                             Object {
                                                               "height": "28px",
@@ -2669,47 +2655,57 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                                             }
                                                           }
                                                         >
-                                                          <LetterAvatar
-                                                            displayName="Jane Doe"
-                                                            identifier="janedoe@example.com"
-                                                            round={true}
+                                                          <span
+                                                            className="avatar css-3f9bmx-StyledBaseAvatar e1z0ohzl0"
+                                                            style={
+                                                              Object {
+                                                                "height": "28px",
+                                                                "width": "28px",
+                                                              }
+                                                            }
                                                           >
-                                                            <Svg
+                                                            <LetterAvatar
+                                                              displayName="Jane Doe"
+                                                              identifier="janedoe@example.com"
                                                               round={true}
-                                                              viewBox="0 0 120 120"
                                                             >
-                                                              <svg
-                                                                className="css-1r4mnb9-Svg e1knxa8x0"
+                                                              <Svg
+                                                                round={true}
                                                                 viewBox="0 0 120 120"
                                                               >
-                                                                <rect
-                                                                  fill="#f868bc"
-                                                                  height="120"
-                                                                  rx="15"
-                                                                  ry="15"
-                                                                  width="120"
-                                                                  x="0"
-                                                                  y="0"
-                                                                />
-                                                                <text
-                                                                  fill="#FFFFFF"
-                                                                  fontSize="65"
-                                                                  style={
-                                                                    Object {
-                                                                      "dominantBaseline": "central",
-                                                                    }
-                                                                  }
-                                                                  textAnchor="middle"
-                                                                  x="50%"
-                                                                  y="50%"
+                                                                <svg
+                                                                  className="css-1r4mnb9-Svg e1knxa8x0"
+                                                                  viewBox="0 0 120 120"
                                                                 >
-                                                                  JD
-                                                                </text>
-                                                              </svg>
-                                                            </Svg>
-                                                          </LetterAvatar>
-                                                        </span>
-                                                      </StyledBaseAvatar>
+                                                                  <rect
+                                                                    fill="#f868bc"
+                                                                    height="120"
+                                                                    rx="15"
+                                                                    ry="15"
+                                                                    width="120"
+                                                                    x="0"
+                                                                    y="0"
+                                                                  />
+                                                                  <text
+                                                                    fill="#FFFFFF"
+                                                                    fontSize="65"
+                                                                    style={
+                                                                      Object {
+                                                                        "dominantBaseline": "central",
+                                                                      }
+                                                                    }
+                                                                    textAnchor="middle"
+                                                                    x="50%"
+                                                                    y="50%"
+                                                                  >
+                                                                    JD
+                                                                  </text>
+                                                                </svg>
+                                                              </Svg>
+                                                            </LetterAvatar>
+                                                          </span>
+                                                        </StyledBaseAvatar>
+                                                      </span>
                                                     </InnerReference>
                                                   </Reference>
                                                 </Manager>

--- a/tests/js/spec/views/releases/detail/__snapshots__/releaseCommits.spec.jsx.snap
+++ b/tests/js/spec/views/releases/detail/__snapshots__/releaseCommits.spec.jsx.snap
@@ -218,8 +218,10 @@ Users now have access to useful links from the blogs and docs on Spike-protectio
                                     uploadId={null}
                                     uploadPath="avatar"
                                   >
-                                    <Tooltip
+                                    <Tooltip2
                                       disabled={true}
+                                      isStyled={true}
+                                      position="top"
                                       title="Foo Bar (example@sentry.io)"
                                     >
                                       <StyledBaseAvatar
@@ -283,7 +285,7 @@ Users now have access to useful links from the blogs and docs on Spike-protectio
                                           </LetterAvatar>
                                         </span>
                                       </StyledBaseAvatar>
-                                    </Tooltip>
+                                    </Tooltip2>
                                   </BaseAvatar>
                                 </UserAvatar>
                               </Avatar>
@@ -626,8 +628,10 @@ Users now have access to useful links from the blogs and docs on Spike-protectio
                                     uploadId={null}
                                     uploadPath="avatar"
                                   >
-                                    <Tooltip
+                                    <Tooltip2
                                       disabled={true}
+                                      isStyled={true}
+                                      position="top"
                                       title="Foo Bar (example@sentry.io)"
                                     >
                                       <StyledBaseAvatar
@@ -691,7 +695,7 @@ Users now have access to useful links from the blogs and docs on Spike-protectio
                                           </LetterAvatar>
                                         </span>
                                       </StyledBaseAvatar>
-                                    </Tooltip>
+                                    </Tooltip2>
                                   </BaseAvatar>
                                 </UserAvatar>
                               </Avatar>

--- a/tests/js/spec/views/releases/detail/__snapshots__/releaseCommits.spec.jsx.snap
+++ b/tests/js/spec/views/releases/detail/__snapshots__/releaseCommits.spec.jsx.snap
@@ -220,7 +220,6 @@ Users now have access to useful links from the blogs and docs on Spike-protectio
                                   >
                                     <Tooltip2
                                       disabled={true}
-                                      isStyled={true}
                                       position="top"
                                       title="Foo Bar (example@sentry.io)"
                                     >
@@ -630,7 +629,6 @@ Users now have access to useful links from the blogs and docs on Spike-protectio
                                   >
                                     <Tooltip2
                                       disabled={true}
-                                      isStyled={true}
                                       position="top"
                                       title="Foo Bar (example@sentry.io)"
                                     >

--- a/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/sentryAppInstallations.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/sentryAppInstallations.spec.jsx.snap
@@ -464,6 +464,7 @@ exports[`Sentry App Installations when Apps exist displays all Apps owned by the
                                         "sentryErrorEmbed": 1090,
                                         "sidebar": 1010,
                                         "toast": 10001,
+                                        "tooltip": 1070,
                                       },
                                     }
                                   }
@@ -735,6 +736,7 @@ exports[`Sentry App Installations when Apps exist displays all Apps owned by the
                                                 "sentryErrorEmbed": 1090,
                                                 "sidebar": 1010,
                                                 "toast": 10001,
+                                                "tooltip": 1070,
                                               },
                                             }
                                           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4028,6 +4028,14 @@ create-react-class@^15.5.1, create-react-class@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+create-react-context@<=0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
+  integrity sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
+
 cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -5648,7 +5656,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.16:
+fbjs@^0.8.0, fbjs@^0.8.16:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -6267,6 +6275,11 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
+
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
 
 gzip-size@5.0.0:
   version "5.0.0"
@@ -9806,6 +9819,11 @@ po-catalog-loader@2.0.0:
   dependencies:
     loader-utils "1.1.0"
 
+popper.js@^1.14.4:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.15.0.tgz#5560b99bbad7647e9faa475c6b8056621f5a4ff2"
+  integrity sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA==
+
 portfinder@^1.0.9:
   version "1.0.13"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.13.tgz#bb32ecd87c27104ae6ee44b5a3ccbf0ebb1aede9"
@@ -10980,6 +10998,18 @@ react-overlays@^0.8.0:
     prop-types-extra "^1.0.1"
     react-transition-group "^2.2.0"
     warning "^3.0.0"
+
+react-popper@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.3.tgz#2c6cef7515a991256b4f0536cd4bdcb58a7b6af6"
+  integrity sha512-ynMZBPkXONPc5K4P5yFWgZx5JGAUIP3pGGLNs58cfAPgK67olx7fmLp+AdpZ0+GoQ+ieFDa/z4cdV6u7sioH6w==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    create-react-context "<=0.2.2"
+    popper.js "^1.14.4"
+    prop-types "^15.6.1"
+    typed-styles "^0.0.7"
+    warning "^4.0.2"
 
 react-prop-types@^0.4.0:
   version "0.4.0"
@@ -13221,6 +13251,11 @@ type-is@~1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
+typed-styles@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.7.tgz#93392a008794c4595119ff62dde6809dbc40a3d9"
+  integrity sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -13645,6 +13680,13 @@ warning@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
   integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
+  dependencies:
+    loose-envify "^1.0.0"
+
+warning@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
   dependencies:
     loose-envify "^1.0.0"
 


### PR DESCRIPTION
This tooltip allows us to more easily render react elements as the tooltip comments and removes a dependency on jQuery / bootstrap allowing us to upgrade to a non-vulnerable version of bootstrap.

I've used a portal for the tooltip because the elements it generates cannot exist inside an SVG canvas, and conditionally rendering means we won't spam the DOM with tons of tooltip elements for content that cannot be seen.

The `Tooltip2` name is rubbish and can be replaced with something else.

Refs SEN-595