### PR TITLE
feat(incidents): Update incidents UI to match API implementation

### DIFF
--- a/src/sentry/static/sentry/app/sentryTypes.jsx
+++ b/src/sentry/static/sentry/app/sentryTypes.jsx
@@ -397,8 +397,9 @@ export const SavedSearch = PropTypes.shape({
 
 export const Incident = PropTypes.shape({
   id: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
-  status: PropTypes.string.isRequired,
+  identifier: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  status: PropTypes.number.isRequired,
   query: PropTypes.string,
   projects: PropTypes.array.isRequired,
   eventCount: PropTypes.number.isRequired,

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/header.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/header.jsx
@@ -30,7 +30,7 @@ export default class IncidentHeader extends React.Component {
               <Chevron src="icon-chevron-right" size={space(2)} />
               {params.incidentId}
             </Title>
-            <div>{incident && incident.name}</div>
+            <div>{incident && incident.title}</div>
           </PageHeading>
         </HeaderItem>
         {incident && (

--- a/src/sentry/static/sentry/app/views/organizationIncidents/list/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/list/index.jsx
@@ -14,6 +14,7 @@ import {PageContent, PageHeader} from 'app/styles/organization';
 import PageHeading from 'app/components/pageHeading';
 import BetaTag from 'app/components/betaTag';
 import space from 'app/styles/space';
+import {getStatus} from '../utils';
 
 const DEFAULT_QUERY_STATUS = 'unresolved';
 
@@ -37,10 +38,10 @@ class OrganizationIncidentsBody extends AsyncComponent {
     return (
       <PanelItem key={incident.id}>
         <TableLayout>
-          <Link to={`/organizations/${orgId}/incidents/${incident.id}/`}>
-            {incident.name}
+          <Link to={`/organizations/${orgId}/incidents/${incident.identifier}/`}>
+            {incident.title}
           </Link>
-          <div>{incident.status}</div>
+          <div>{getStatus(incident.status)}</div>
           <div>{incident.duration}</div>
           <div>{incident.usersAffected}</div>
           <div>{incident.eventCount}</div>

--- a/src/sentry/static/sentry/app/views/organizationIncidents/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/utils.jsx
@@ -1,3 +1,15 @@
 export function fetchIncident(api, orgId, incidentId) {
   return api.requestPromise(`/organizations/${orgId}/incidents/${incidentId}/`);
 }
+
+export function getStatus(status) {
+  switch (status) {
+    case 1:
+      return 'created';
+    case 2:
+      return 'closed';
+    case 0:
+    default:
+      return 'detected';
+  }
+}

--- a/tests/js/fixtures/incident.js
+++ b/tests/js/fixtures/incident.js
@@ -1,0 +1,13 @@
+export function Incident(params) {
+  return {
+    id: '123',
+    identifier: '123',
+    title: 'Too many Chrome errors',
+    status: 0,
+    projects: [],
+    suspects: [],
+    eventCount: 100,
+    usersAffected: 20,
+    ...params,
+  };
+}

--- a/tests/js/spec/views/organizationIncidents/details/index.spec.jsx
+++ b/tests/js/spec/views/organizationIncidents/details/index.spec.jsx
@@ -4,16 +4,7 @@ import {mount} from 'enzyme';
 import IncidentDetails from 'app/views/organizationIncidents/details';
 
 describe('IncidentDetails', function() {
-  const mockIncident = {
-    id: '123',
-    name: 'Too many Chrome errors',
-    status: 'resolved',
-    projects: [],
-    suspects: [],
-    eventCount: 100,
-    usersAffected: 20,
-  };
-
+  const mockIncident = TestStubs.Incident();
   beforeAll(function() {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/incidents/123/',

--- a/tests/js/spec/views/organizationIncidents/list/index.spec.jsx
+++ b/tests/js/spec/views/organizationIncidents/list/index.spec.jsx
@@ -12,7 +12,10 @@ describe('OrganizationIncidentsList', function() {
   beforeEach(function() {
     mock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/incidents/',
-      body: [{id: '1', name: 'First incident'}, {id: '2', name: 'Second incident'}],
+      body: [
+        TestStubs.Incident({id: '1', identifier: '1', title: 'First incident'}),
+        TestStubs.Incident({id: '2', identifier: '1', title: 'Second incident'}),
+      ],
     });
   });
 
@@ -29,8 +32,8 @@ describe('OrganizationIncidentsList', function() {
     const items = wrapper.find('PanelItem');
 
     expect(items).toHaveLength(2);
-    expect(items.at(0).text()).toBe('First incident');
-    expect(items.at(1).text()).toBe('Second incident');
+    expect(items.at(0).text()).toContain('First incident');
+    expect(items.at(1).text()).toContain('Second incident');
   });
 
   it('displays empty state', function() {


### PR DESCRIPTION
The API implementation does `title` instead of `name`, status as integers
and `identifier` instead of `id`