### PR TITLE
fix: Always display checkbox in project selector

### DIFF
--- a/src/sentry/static/sentry/app/components/globalSelectionHeaderRow.jsx
+++ b/src/sentry/static/sentry/app/components/globalSelectionHeaderRow.jsx
@@ -23,11 +23,9 @@ class GlobalSelectionHeaderRow extends React.Component {
     return (
       <Container {...props}>
         <Content multi={multi}>{children}</Content>
-        {multi && (
-          <CheckboxWrapper onClick={onCheckClick} checked={checked}>
-            <Checkbox checked={checked} />
-          </CheckboxWrapper>
-        )}
+        <CheckboxWrapper onClick={multi ? onCheckClick : null} checked={checked}>
+          <Checkbox checked={checked} />
+        </CheckboxWrapper>
       </Container>
     );
   }


### PR DESCRIPTION
Always display the checkbox indicating selected projects even if the
multi-project mode feature is switched off. This fixes an issue making
it difficult to figure out which project was active when there are
multiple long project names with the same starting sequence of letters
as the full names would be truncated.

Closes #12693