### PR TITLE
fix(ui) Rebuild hovercards using popper

### DIFF
--- a/docs-ui/components/hovercard.stories.js
+++ b/docs-ui/components/hovercard.stories.js
@@ -1,9 +1,16 @@
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
-import {text} from '@storybook/addon-knobs';
+import {text, select} from '@storybook/addon-knobs';
 
 import Hovercard from 'app/components/hovercard';
+
+const positionOptions = {
+  top: 'top',
+  bottom: 'bottom',
+  left: 'left',
+  right: 'right',
+};
 
 storiesOf('UI|Hovercard', module).add(
   'Hovercard',
@@ -21,6 +28,7 @@ storiesOf('UI|Hovercard', module).add(
       <Hovercard
         header={text('Header', 'Hovercard Header')}
         body={text('Body', 'Hovercard body (can also be a React node)')}
+        position={select('position', positionOptions, 'top', 'Hovercard positioning')}
       >
         Hover over me
       </Hovercard>

--- a/src/sentry/static/sentry/app/components/hovercard.jsx
+++ b/src/sentry/static/sentry/app/components/hovercard.jsx
@@ -1,162 +1,180 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import ReactDOM from 'react-dom';
 import classNames from 'classnames';
-import styled, {css, keyframes} from 'react-emotion';
+import {Manager, Reference, Popper} from 'react-popper';
+import styled, {keyframes} from 'react-emotion';
 
 import {fadeIn} from 'app/styles/animations';
 import space from 'app/styles/space';
-
-const DEFAULT_POSITION = {x: 'middle', y: 'top', offset: 0};
+import {domId} from 'app/utils/domId';
 
 class Hovercard extends React.Component {
   static propTypes = {
+    /**
+     * Time in ms until hovercard is hidden
+     */
     displayTimeout: PropTypes.number,
+    /**
+     * Classname to apply to the hovercard
+     */
     className: PropTypes.string,
+    /**
+     * Classname to apply to the hovercard container
+     */
     containerClassName: PropTypes.string,
+    /**
+     * Element to display in the header
+     */
     header: PropTypes.node,
+    /**
+     * Element to display in the body
+     */
     body: PropTypes.node,
+    /**
+     * Classname to apply to body container
+     */
     bodyClassName: PropTypes.string,
+    /**
+     * Position tooltip should take relative to the child element
+     */
+    position: PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
   };
 
   static defaultProps = {
     displayTimeout: 100,
+    position: 'top',
   };
 
   constructor(...args) {
     super(...args);
-    this.hoverWait = null;
-    this.cardElement = React.createRef();
-    this.containerElement = React.createRef();
+
+    let portal = document.getElementById('hovercard-portal');
+    if (!portal) {
+      portal = document.createElement('div');
+      portal.setAttribute('id', 'hovercard-portal');
+      document.body.appendChild(portal);
+    }
+    this.portalEl = portal;
+    this.tooltipId = domId('hovercard-');
   }
 
   state = {
     visible: false,
-    rendered: false,
-    position: null,
   };
 
   handleToggleOn = () => this.toggleHovercard(true);
   handleToggleOff = () => this.toggleHovercard(false);
 
   toggleHovercard = visible => {
-    const {header, body} = this.props;
+    const {header, body, displayTimeout} = this.props;
 
     // Don't toggle hovercard if both of these are null
     if (!header && !body) {
       return;
     }
-
-    if (this.hoverWait !== null) {
+    if (this.hoverWait) {
       clearTimeout(this.hoverWait);
     }
 
-    const rendered = visible;
-    const timeout = this.props.displayTimeout;
-
-    // Immediately render the hovercard, but don't mark it as visible until
-    // after the delay period. This allows us to compute the size of the
-    // hovercard to position it before it is made visible.
-    if (visible) {
-      this.setState({rendered}, () => this.positionCard());
-    }
-
-    this.hoverWait = setTimeout(
-      () => this.setState({visible, rendered, ...(!rendered ? {position: null} : {})}),
-      timeout
-    );
+    this.hoverWait = setTimeout(() => this.setState({visible}), displayTimeout);
   };
 
-  positionCard() {
-    if (!this.cardElement.current || this.state.visible) {
-      return;
-    }
-    const rect = this.cardElement.current.getBoundingClientRect();
-
-    // Computes the offset that the hovercard should be from the anchor point
-    // of the container (top or bottom absolute position).
-    const offset = this.containerElement.current.offsetHeight;
-
-    const y = rect.top - offset < 0 ? 'bottom' : 'top';
-    const x =
-      rect.right > window.innerWidth && !(rect.left < 0)
-        ? 'right'
-        : rect.left < 0
-        ? 'left'
-        : 'middle';
-
-    this.setState({position: {x, y, offset}});
-  }
-
   render() {
-    const {bodyClassName, containerClassName, className, header, body} = this.props;
-    const {rendered, visible, position} = this.state;
+    const {
+      bodyClassName,
+      containerClassName,
+      className,
+      header,
+      body,
+      position,
+    } = this.props;
+    const {visible} = this.state;
 
     // Maintain the hovercard class name for BC with less styles
     const cx = classNames('hovercard', className);
+    const modifiers = {
+      hide: {
+        enabled: false,
+      },
+      preventOverflow: {
+        padding: 10,
+        enabled: true,
+        boundariesElement: 'viewport',
+      },
+    };
 
     return (
-      <Container
-        className={containerClassName}
-        innerRef={this.containerElement}
-        onMouseEnter={this.handleToggleOn}
-        onMouseLeave={this.handleToggleOff}
-      >
-        {this.props.children}
-        {rendered && (
-          <StyledHovercard
-            visible={visible}
-            withHeader={!!header}
-            className={cx}
-            position={position || DEFAULT_POSITION}
-            innerRef={this.cardElement}
-          >
-            {header && <Header>{header}</Header>}
-            {body && <Body className={bodyClassName}>{body}</Body>}
-          </StyledHovercard>
-        )}
-      </Container>
+      <Manager>
+        <Reference>
+          {({ref}) => (
+            <Container
+              innerRef={ref}
+              aria-describedby={this.tooltipId}
+              onMouseEnter={this.handleToggleOn}
+              onMouseLeave={this.handleToggleOff}
+              className={containerClassName}
+            >
+              {this.props.children}
+            </Container>
+          )}
+        </Reference>
+        {visible &&
+          ReactDOM.createPortal(
+            <Popper placement={position} modifiers={modifiers}>
+              {({ref, style, placement, arrowProps}) => (
+                <StyledHovercard
+                  innerRef={ref}
+                  visible={visible}
+                  withHeader={!!header}
+                  style={style}
+                  data-placement={placement}
+                  onMouseEnter={this.handleToggleOn}
+                  onMouseLeave={this.handleToggleOff}
+                  className={cx}
+                >
+                  {header && <Header>{header}</Header>}
+                  {body && <Body className={bodyClassName}>{body}</Body>}
+                  <HovercardArrow
+                    innerRef={arrowProps.ref}
+                    style={arrowProps.style}
+                    data-placement={placement}
+                  />
+                </StyledHovercard>
+              )}
+            </Popper>,
+            this.portalEl
+          )}
+      </Manager>
     );
   }
 }
 
-const translateX = x => `translateX(${x === 'middle' ? '-50%' : 0})`;
-const slideTranslateY = y => `translateY(${(y === 'top' ? -1 : 1) * 14}px)`;
-
 const slideIn = p => keyframes`
   from {
-    transform: ${translateX(p.position.x)} ${slideTranslateY(p.position.y)};
+    top: -10px;
   }
   to {
-    transform: ${translateX(p.position.x)} translateY(0);
+    top: 0;
   }
 `;
 
-const positionX = offset => p => css`
-  right: ${p.position.x === 'right' ? offset : 'inherit'};
-  left: ${p.position.x === 'middle'
-    ? '50%'
-    : p.position.x === 'left'
-    ? offset
-    : 'inherit'};
-
-  transform: ${translateX(p.position.x)};
-`;
-
-const positionY = offset => p => css`
-  bottom: ${p.position.y === 'top' ? offset : 'inherit'};
-  top: ${p.position.y === 'bottom' ? offset : 'inherit'};
-`;
-
-const getTipColor = p =>
-  p.position.y === 'bottom' && p.withHeader ? p.theme.offWhite : '#fff';
+const getTipColor = p => (p['data-placement'] === 'bottom' ? p.theme.offWhite : '#fff');
+const TIP_DIRECTIONS = {
+  top: 'top',
+  bottom: 'bottom',
+  left: 'left',
+  right: 'right',
+};
+const getTipDirection = p => TIP_DIRECTIONS[p['data-placement']] || 'top';
 
 const StyledHovercard = styled('div')`
   border-radius: 4px;
   text-align: left;
   padding: 0;
   line-height: 1;
-  /* Some hovercards overlap the toplevel header, so we need the same zindex to appear on top */
-  z-index: ${p => p.theme.zIndex.globalSelectionHeader};
+  /* Some hovercards overlap the toplevel header and sidebar, and we need to appear on top */
+  z-index: ${p => p.theme.zIndex.tooltip};
   white-space: initial;
   color: ${p => p.theme.gray5};
   border: 1px solid ${p => p.theme.borderLight};
@@ -169,30 +187,23 @@ const StyledHovercard = styled('div')`
   font-family: ${p => p.theme.text.family};
 
   position: absolute;
-  ${positionX('-2px')};
-  ${p => positionY(`${p.position.offset + 12}px`)};
+  visibility: ${p => (p.visible ? 'visible' : 'hidden')};
 
   animation: ${fadeIn} 100ms, ${slideIn} 100ms ease-in-out;
   animation-play-state: ${p => (p.visible ? 'running' : 'paused')};
-  visibility: ${p => (p.visible ? 'visible' : 'hidden')};
 
-  &:before,
-  &:after {
-    content: '';
-    display: block;
-    position: absolute;
-    z-index: -1;
-    border: 10px solid transparent;
-    /* stylelint-disable-next-line property-no-unknown */
-    border-${p => p.position.y}-color: ${getTipColor};
-    ${positionX('20px')};
-    ${positionY('-20px')};
+  /* Offset for the arrow */
+  &[data-placement*='top'] {
+    margin-bottom: 15px;
   }
-
-  &:before {
-    /* stylelint-disable-next-line property-no-unknown */
-    border-${p => p.position.y}-color: ${p => p.theme.borderLight};
-    ${positionY('-21px')};
+  &[data-placement*='bottom'] {
+    margin-top: 15px;
+  }
+  &[data-placement*='left'] {
+    margin-left: 15px;
+  }
+  &[data-placement*='right'] {
+    margin-right: 15px;
   }
 `;
 
@@ -216,6 +227,67 @@ const Header = styled('div')`
 const Body = styled('div')`
   padding: ${space(2)};
   min-height: 30px;
+`;
+
+const HovercardArrow = styled('span')`
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  z-index: -1;
+
+  &::before,
+  &::after {
+    content: '';
+    margin: auto;
+    position: absolute;
+    display: block;
+    width: 0;
+    height: 0;
+    top: 0;
+    left: 0;
+  }
+
+  /* before element is the hairline border, it is repositioned for each orientation */
+  &::before {
+    top: 1px;
+    border: 10px solid transparent;
+    /* stylelint-disable-next-line property-no-unknown */
+    border-${getTipDirection}-color: ${p => p.theme.borderLight};
+  }
+  &::after {
+    border: 10px solid transparent;
+    /* stylelint-disable-next-line property-no-unknown */
+    border-${getTipDirection}-color: ${getTipColor};
+  }
+
+  &[data-placement*='bottom'] {
+    top: -20px;
+    left: 0;
+    &:before {
+      top: -1px;
+    }
+  }
+
+  &[data-placement*='top'] {
+    bottom: -20px;
+    left: 0;
+  }
+
+  &[data-placement*='right'] {
+    left: -20px;
+    &:before {
+      top: 0;
+      left: -1px;
+    }
+  }
+
+  &[data-placement*='left'] {
+    right: -20px;
+    &:before {
+      top: 0;
+      left: 1px;
+    }
+  }
 `;
 
 export default Hovercard;

--- a/src/sentry/static/sentry/app/components/hovercard.jsx
+++ b/src/sentry/static/sentry/app/components/hovercard.jsx
@@ -9,6 +9,8 @@ import {fadeIn} from 'app/styles/animations';
 import space from 'app/styles/space';
 import {domId} from 'app/utils/domId';
 
+const VALID_DIRECTIONS = ['top', 'bottom', 'left', 'right'];
+
 class Hovercard extends React.Component {
   static propTypes = {
     /**
@@ -38,7 +40,7 @@ class Hovercard extends React.Component {
     /**
      * Position tooltip should take relative to the child element
      */
-    position: PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
+    position: PropTypes.oneOf(VALID_DIRECTIONS),
   };
 
   static defaultProps = {
@@ -160,13 +162,8 @@ const slideIn = p => keyframes`
 `;
 
 const getTipColor = p => (p['data-placement'] === 'bottom' ? p.theme.offWhite : '#fff');
-const TIP_DIRECTIONS = {
-  top: 'top',
-  bottom: 'bottom',
-  left: 'left',
-  right: 'right',
-};
-const getTipDirection = p => TIP_DIRECTIONS[p['data-placement']] || 'top';
+const getTipDirection = p =>
+  VALID_DIRECTIONS.includes(p['data-placement']) ? p['data-placement'] : 'top';
 
 const StyledHovercard = styled('div')`
   border-radius: 4px;

--- a/src/sentry/static/sentry/app/components/hovercard.jsx
+++ b/src/sentry/static/sentry/app/components/hovercard.jsx
@@ -130,7 +130,7 @@ class Hovercard extends React.Component {
                   visible={visible}
                   withHeader={!!header}
                   style={style}
-                  data-placement={placement}
+                  placement={placement}
                   onMouseEnter={this.handleToggleOn}
                   onMouseLeave={this.handleToggleOff}
                   className={cx}
@@ -140,7 +140,7 @@ class Hovercard extends React.Component {
                   <HovercardArrow
                     innerRef={arrowProps.ref}
                     style={arrowProps.style}
-                    data-placement={placement}
+                    placement={placement}
                   />
                 </StyledHovercard>
               )}
@@ -161,9 +161,9 @@ const slideIn = p => keyframes`
   }
 `;
 
-const getTipColor = p => (p['data-placement'] === 'bottom' ? p.theme.offWhite : '#fff');
+const getTipColor = p => (p.placement === 'bottom' ? p.theme.offWhite : '#fff');
 const getTipDirection = p =>
-  VALID_DIRECTIONS.includes(p['data-placement']) ? p['data-placement'] : 'top';
+  VALID_DIRECTIONS.includes(p.placement) ? p.placement : 'top';
 
 const StyledHovercard = styled('div')`
   border-radius: 4px;
@@ -190,18 +190,10 @@ const StyledHovercard = styled('div')`
   animation-play-state: ${p => (p.visible ? 'running' : 'paused')};
 
   /* Offset for the arrow */
-  &[data-placement*='top'] {
-    margin-bottom: 15px;
-  }
-  &[data-placement*='bottom'] {
-    margin-top: 15px;
-  }
-  &[data-placement*='left'] {
-    margin-left: 15px;
-  }
-  &[data-placement*='right'] {
-    margin-right: 15px;
-  }
+  ${p => (p.placement === 'top' ? 'margin-bottom: 15px' : '')};
+  ${p => (p.placement === 'bottom' ? 'margin-top: 15px' : '')};
+  ${p => (p.placement === 'left' ? 'margin-left: 15px' : '')};
+  ${p => (p.placement === 'right' ? 'margin-right: 15px' : '')};
 `;
 
 const Container = styled('span')`
@@ -232,6 +224,11 @@ const HovercardArrow = styled('span')`
   height: 20px;
   z-index: -1;
 
+  ${p => (p.placement === 'top' ? 'bottom: -20px; left: 0' : '')};
+  ${p => (p.placement === 'bottom' ? 'top: -20px; left: 0' : '')};
+  ${p => (p.placement === 'left' ? 'right: -20px' : '')};
+  ${p => (p.placement === 'right' ? 'left: -20px' : '')};
+
   &::before,
   &::after {
     content: '';
@@ -250,40 +247,15 @@ const HovercardArrow = styled('span')`
     border: 10px solid transparent;
     /* stylelint-disable-next-line property-no-unknown */
     border-${getTipDirection}-color: ${p => p.theme.borderLight};
+
+    ${p => (p.placement === 'bottom' ? 'top: -1px' : '')};
+    ${p => (p.placement === 'left' ? 'top: 0; left: 1px;' : '')};
+    ${p => (p.placement === 'right' ? 'top: 0; left: -1px' : '')};
   }
   &::after {
     border: 10px solid transparent;
     /* stylelint-disable-next-line property-no-unknown */
     border-${getTipDirection}-color: ${getTipColor};
-  }
-
-  &[data-placement*='bottom'] {
-    top: -20px;
-    left: 0;
-    &:before {
-      top: -1px;
-    }
-  }
-
-  &[data-placement*='top'] {
-    bottom: -20px;
-    left: 0;
-  }
-
-  &[data-placement*='right'] {
-    left: -20px;
-    &:before {
-      top: 0;
-      left: -1px;
-    }
-  }
-
-  &[data-placement*='left'] {
-    right: -20px;
-    &:before {
-      top: 0;
-      left: 1px;
-    }
   }
 `;
 

--- a/src/sentry/static/sentry/app/utils/theme.jsx
+++ b/src/sentry/static/sentry/app/utils/theme.jsx
@@ -90,6 +90,7 @@ const theme = {
     sidebar: 1010,
     orgAndUserMenu: 1011,
 
+    // tooltips and hovercards
     tooltip: 1070,
 
     // Sentry user feedback modal

--- a/tests/js/spec/components/__snapshots__/issueSyncListElement.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/issueSyncListElement.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`AlertLink renders 1`] = `
   <Hovercard
     containerClassName="css-2jp7uo-hoverCardContainer"
     displayTimeout={100}
+    position="top"
   >
     <IntegrationIcon
       src="icon-github"

--- a/tests/js/spec/components/events/interfaces/__snapshots__/exceptionMechanism.spec.jsx.snap
+++ b/tests/js/spec/components/events/interfaces/__snapshots__/exceptionMechanism.spec.jsx.snap
@@ -61,6 +61,7 @@ exports[`ExceptionMechanism basic attributes should add the help_link to the des
             </a>
           </span>
         }
+        position="top"
       >
         <InlineSvg
           size="14px"
@@ -92,6 +93,7 @@ exports[`ExceptionMechanism basic attributes should not add the help_link if not
              
           </span>
         }
+        position="top"
       >
         <InlineSvg
           size="14px"
@@ -123,6 +125,7 @@ exports[`ExceptionMechanism basic attributes should render a description hoverca
              
           </span>
         }
+        position="top"
       >
         <InlineSvg
           size="14px"

--- a/tests/js/spec/components/group/__snapshots__/externalIssueActions.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/externalIssueActions.spec.jsx.snap
@@ -155,82 +155,70 @@ exports[`ExternalIssueActions with no external issues linked renders 1`] = `
           containerClassName="css-2jp7uo-hoverCardContainer"
           displayTimeout={100}
           header="Linked GitHub Integration"
+          position="top"
         >
-          <Container
-            className="css-2jp7uo-hoverCardContainer"
-            innerRef={
-              Object {
-                "current": <span
-                  class="css-9q2tea-Container-hoverCardContainer e38w1je1"
-                >
-                  <svg
-                    class="e1vaar1z1 css-ihls3x-StyledSvg-IntegrationIcon e2idor0"
-                    height="1em"
-                    viewBox="[object Object]"
-                    width="1em"
-                  >
-                    <use
-                      href="#test"
-                      xlink:href="#test"
-                    />
-                  </svg>
-                  <a
-                    class="css-1g8yzea-IntegrationLink e1vaar1z2"
-                  >
-                    Link GitHub Issue
-                  </a>
-                </span>,
-              }
-            }
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-          >
-            <span
-              className="css-9q2tea-Container-hoverCardContainer e38w1je1"
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-            >
-              <IntegrationIcon
-                src="icon-github"
+          <Manager>
+            <Reference>
+              <InnerReference
+                setReferenceNode={[Function]}
               >
-                <InlineSvg
-                  className="css-jn9d7y-IntegrationIcon e1vaar1z1"
-                  src="icon-github"
+                <Container
+                  aria-describedby="hovercard-123456"
+                  className="css-2jp7uo-hoverCardContainer"
+                  innerRef={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
-                  <StyledSvg
-                    className="css-jn9d7y-IntegrationIcon e1vaar1z1"
-                    height="1em"
-                    viewBox={Object {}}
-                    width="1em"
+                  <span
+                    aria-describedby="hovercard-123456"
+                    className="css-9q2tea-Container-hoverCardContainer e38w1je1"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
-                    <svg
-                      className="e1vaar1z1 css-ihls3x-StyledSvg-IntegrationIcon e2idor0"
-                      height="1em"
-                      viewBox={Object {}}
-                      width="1em"
+                    <IntegrationIcon
+                      src="icon-github"
                     >
-                      <use
-                        href="#test"
-                        xlinkHref="#test"
-                      />
-                    </svg>
-                  </StyledSvg>
-                </InlineSvg>
-              </IntegrationIcon>
-              <IntegrationLink
-                href={null}
-                onClick={[Function]}
-              >
-                <a
-                  className="css-1g8yzea-IntegrationLink e1vaar1z2"
-                  href={null}
-                  onClick={[Function]}
-                >
-                  Link GitHub Issue
-                </a>
-              </IntegrationLink>
-            </span>
-          </Container>
+                      <InlineSvg
+                        className="css-jn9d7y-IntegrationIcon e1vaar1z1"
+                        src="icon-github"
+                      >
+                        <StyledSvg
+                          className="css-jn9d7y-IntegrationIcon e1vaar1z1"
+                          height="1em"
+                          viewBox={Object {}}
+                          width="1em"
+                        >
+                          <svg
+                            className="e1vaar1z1 css-ihls3x-StyledSvg-IntegrationIcon e2idor0"
+                            height="1em"
+                            viewBox={Object {}}
+                            width="1em"
+                          >
+                            <use
+                              href="#test"
+                              xlinkHref="#test"
+                            />
+                          </svg>
+                        </StyledSvg>
+                      </InlineSvg>
+                    </IntegrationIcon>
+                    <IntegrationLink
+                      href={null}
+                      onClick={[Function]}
+                    >
+                      <a
+                        className="css-1g8yzea-IntegrationLink e1vaar1z2"
+                        href={null}
+                        onClick={[Function]}
+                      >
+                        Link GitHub Issue
+                      </a>
+                    </IntegrationLink>
+                  </span>
+                </Container>
+              </InnerReference>
+            </Reference>
+          </Manager>
         </Hovercard>
         <OpenCloseIcon
           isLinked={null}

--- a/tests/js/spec/views/groupDetails/__snapshots__/groupSimilar.spec.jsx.snap
+++ b/tests/js/spec/views/groupDetails/__snapshots__/groupSimilar.spec.jsx.snap
@@ -780,30 +780,8 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                           },
                                         },
                                       ],
-                                      Array [
-                                        Object {
-                                          "pathname": "/org-slug/project-slug/issues/271/",
-                                          "search": "",
-                                        },
-                                      ],
-                                      Array [
-                                        Object {
-                                          "pathname": "/org-slug/project-slug/issues/",
-                                          "query": Object {
-                                            "query": "logger:javascript",
-                                          },
-                                        },
-                                      ],
                                     ],
                                     "results": Array [
-                                      Object {
-                                        "type": "return",
-                                        "value": undefined,
-                                      },
-                                      Object {
-                                        "type": "return",
-                                        "value": undefined,
-                                      },
                                       Object {
                                         "type": "return",
                                         "value": undefined,
@@ -957,30 +935,8 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                                         },
                                                       },
                                                     ],
-                                                    Array [
-                                                      Object {
-                                                        "pathname": "/org-slug/project-slug/issues/271/",
-                                                        "search": "",
-                                                      },
-                                                    ],
-                                                    Array [
-                                                      Object {
-                                                        "pathname": "/org-slug/project-slug/issues/",
-                                                        "query": Object {
-                                                          "query": "logger:javascript",
-                                                        },
-                                                      },
-                                                    ],
                                                   ],
                                                   "results": Array [
-                                                    Object {
-                                                      "type": "return",
-                                                      "value": undefined,
-                                                    },
-                                                    Object {
-                                                      "type": "return",
-                                                      "value": undefined,
-                                                    },
                                                     Object {
                                                       "type": "return",
                                                       "value": undefined,
@@ -1152,30 +1108,8 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                           },
                                         },
                                       ],
-                                      Array [
-                                        Object {
-                                          "pathname": "/org-slug/project-slug/issues/271/",
-                                          "search": "",
-                                        },
-                                      ],
-                                      Array [
-                                        Object {
-                                          "pathname": "/org-slug/project-slug/issues/",
-                                          "query": Object {
-                                            "query": "logger:javascript",
-                                          },
-                                        },
-                                      ],
                                     ],
                                     "results": Array [
-                                      Object {
-                                        "type": "return",
-                                        "value": undefined,
-                                      },
-                                      Object {
-                                        "type": "return",
-                                        "value": undefined,
-                                      },
                                       Object {
                                         "type": "return",
                                         "value": undefined,
@@ -1583,155 +1517,131 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                         />
                       }
                       displayTimeout={100}
+                      position="top"
                     >
-                      <Container
-                        innerRef={
-                          Object {
-                            "current": <span
-                              class="css-s35yzd-Container e38w1je1"
-                            >
-                              <div
-                                class="css-omtyju-StyledScoreBar eecxaw40"
-                              >
-                                <div
-                                  class="css-1jrlewc-Bar eecxaw41"
-                                  color="#98b480"
-                                  size="40"
-                                />
-                                <div
-                                  class="css-1jrlewc-Bar eecxaw41"
-                                  color="#98b480"
-                                  size="40"
-                                />
-                                <div
-                                  class="css-1jrlewc-Bar eecxaw41"
-                                  color="#98b480"
-                                  size="40"
-                                />
-                                <div
-                                  class="css-1jrlewc-Bar eecxaw41"
-                                  color="#98b480"
-                                  size="40"
-                                />
-                                <div
-                                  class="css-15vxee-Bar eecxaw41"
-                                  size="40"
-                                />
-                              </div>
-                            </span>,
-                          }
-                        }
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                      >
-                        <span
-                          className="css-s35yzd-Container e38w1je1"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                        >
-                          <StyledScoreBar
-                            palette={
-                              Array [
-                                "#ec5e44",
-                                "#f38259",
-                                "#f9a66d",
-                                "#98b480",
-                                "#57be8c",
-                              ]
-                            }
-                            score={4}
-                            size={40}
-                            thickness={4}
-                            vertical={true}
+                      <Manager>
+                        <Reference>
+                          <InnerReference
+                            setReferenceNode={[Function]}
                           >
-                            <ScoreBar
-                              className="css-omtyju-StyledScoreBar eecxaw40"
-                              palette={
-                                Array [
-                                  "#ec5e44",
-                                  "#f38259",
-                                  "#f9a66d",
-                                  "#98b480",
-                                  "#57be8c",
-                                ]
-                              }
-                              score={4}
-                              size={40}
-                              thickness={4}
-                              vertical={true}
+                            <Container
+                              aria-describedby="hovercard-123456"
+                              innerRef={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
                             >
-                              <div
-                                className="css-omtyju-StyledScoreBar eecxaw40"
+                              <span
+                                aria-describedby="hovercard-123456"
+                                className="css-s35yzd-Container e38w1je1"
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
                               >
-                                <Bar
-                                  color="#98b480"
-                                  key="0"
+                                <StyledScoreBar
+                                  palette={
+                                    Array [
+                                      "#ec5e44",
+                                      "#f38259",
+                                      "#f9a66d",
+                                      "#98b480",
+                                      "#57be8c",
+                                    ]
+                                  }
+                                  score={4}
                                   size={40}
                                   thickness={4}
                                   vertical={true}
                                 >
-                                  <div
-                                    className="css-1jrlewc-Bar eecxaw41"
-                                    color="#98b480"
+                                  <ScoreBar
+                                    className="css-omtyju-StyledScoreBar eecxaw40"
+                                    palette={
+                                      Array [
+                                        "#ec5e44",
+                                        "#f38259",
+                                        "#f9a66d",
+                                        "#98b480",
+                                        "#57be8c",
+                                      ]
+                                    }
+                                    score={4}
                                     size={40}
-                                  />
-                                </Bar>
-                                <Bar
-                                  color="#98b480"
-                                  key="1"
-                                  size={40}
-                                  thickness={4}
-                                  vertical={true}
-                                >
-                                  <div
-                                    className="css-1jrlewc-Bar eecxaw41"
-                                    color="#98b480"
-                                    size={40}
-                                  />
-                                </Bar>
-                                <Bar
-                                  color="#98b480"
-                                  key="2"
-                                  size={40}
-                                  thickness={4}
-                                  vertical={true}
-                                >
-                                  <div
-                                    className="css-1jrlewc-Bar eecxaw41"
-                                    color="#98b480"
-                                    size={40}
-                                  />
-                                </Bar>
-                                <Bar
-                                  color="#98b480"
-                                  key="3"
-                                  size={40}
-                                  thickness={4}
-                                  vertical={true}
-                                >
-                                  <div
-                                    className="css-1jrlewc-Bar eecxaw41"
-                                    color="#98b480"
-                                    size={40}
-                                  />
-                                </Bar>
-                                <Bar
-                                  empty={true}
-                                  key="empty-0"
-                                  size={40}
-                                  thickness={4}
-                                  vertical={true}
-                                >
-                                  <div
-                                    className="css-15vxee-Bar eecxaw41"
-                                    size={40}
-                                  />
-                                </Bar>
-                              </div>
-                            </ScoreBar>
-                          </StyledScoreBar>
-                        </span>
-                      </Container>
+                                    thickness={4}
+                                    vertical={true}
+                                  >
+                                    <div
+                                      className="css-omtyju-StyledScoreBar eecxaw40"
+                                    >
+                                      <Bar
+                                        color="#98b480"
+                                        key="0"
+                                        size={40}
+                                        thickness={4}
+                                        vertical={true}
+                                      >
+                                        <div
+                                          className="css-1jrlewc-Bar eecxaw41"
+                                          color="#98b480"
+                                          size={40}
+                                        />
+                                      </Bar>
+                                      <Bar
+                                        color="#98b480"
+                                        key="1"
+                                        size={40}
+                                        thickness={4}
+                                        vertical={true}
+                                      >
+                                        <div
+                                          className="css-1jrlewc-Bar eecxaw41"
+                                          color="#98b480"
+                                          size={40}
+                                        />
+                                      </Bar>
+                                      <Bar
+                                        color="#98b480"
+                                        key="2"
+                                        size={40}
+                                        thickness={4}
+                                        vertical={true}
+                                      >
+                                        <div
+                                          className="css-1jrlewc-Bar eecxaw41"
+                                          color="#98b480"
+                                          size={40}
+                                        />
+                                      </Bar>
+                                      <Bar
+                                        color="#98b480"
+                                        key="3"
+                                        size={40}
+                                        thickness={4}
+                                        vertical={true}
+                                      >
+                                        <div
+                                          className="css-1jrlewc-Bar eecxaw41"
+                                          color="#98b480"
+                                          size={40}
+                                        />
+                                      </Bar>
+                                      <Bar
+                                        empty={true}
+                                        key="empty-0"
+                                        size={40}
+                                        thickness={4}
+                                        vertical={true}
+                                      >
+                                        <div
+                                          className="css-15vxee-Bar eecxaw41"
+                                          size={40}
+                                        />
+                                      </Bar>
+                                    </div>
+                                  </ScoreBar>
+                                </StyledScoreBar>
+                              </span>
+                            </Container>
+                          </InnerReference>
+                        </Reference>
+                      </Manager>
                     </Hovercard>
                   </div>
                   <div
@@ -1741,147 +1651,127 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                     <Hovercard
                       body={0}
                       displayTimeout={100}
+                      position="top"
                     >
-                      <Container
-                        innerRef={
-                          Object {
-                            "current": <span
-                              class="css-s35yzd-Container e38w1je1"
-                            >
-                              <div
-                                class="css-omtyju-StyledScoreBar eecxaw40"
-                              >
-                                <div
-                                  class="css-15vxee-Bar eecxaw41"
-                                  size="40"
-                                />
-                                <div
-                                  class="css-15vxee-Bar eecxaw41"
-                                  size="40"
-                                />
-                                <div
-                                  class="css-15vxee-Bar eecxaw41"
-                                  size="40"
-                                />
-                                <div
-                                  class="css-15vxee-Bar eecxaw41"
-                                  size="40"
-                                />
-                                <div
-                                  class="css-15vxee-Bar eecxaw41"
-                                  size="40"
-                                />
-                              </div>
-                            </span>,
-                          }
-                        }
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                      >
-                        <span
-                          className="css-s35yzd-Container e38w1je1"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                        >
-                          <StyledScoreBar
-                            palette={
-                              Array [
-                                "#ec5e44",
-                                "#f38259",
-                                "#f9a66d",
-                                "#98b480",
-                                "#57be8c",
-                              ]
-                            }
-                            score={0}
-                            size={40}
-                            thickness={4}
-                            vertical={true}
+                      <Manager>
+                        <Reference>
+                          <InnerReference
+                            setReferenceNode={[Function]}
                           >
-                            <ScoreBar
-                              className="css-omtyju-StyledScoreBar eecxaw40"
-                              palette={
-                                Array [
-                                  "#ec5e44",
-                                  "#f38259",
-                                  "#f9a66d",
-                                  "#98b480",
-                                  "#57be8c",
-                                ]
-                              }
-                              score={0}
-                              size={40}
-                              thickness={4}
-                              vertical={true}
+                            <Container
+                              aria-describedby="hovercard-123456"
+                              innerRef={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
                             >
-                              <div
-                                className="css-omtyju-StyledScoreBar eecxaw40"
+                              <span
+                                aria-describedby="hovercard-123456"
+                                className="css-s35yzd-Container e38w1je1"
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
                               >
-                                <Bar
-                                  empty={true}
-                                  key="empty-0"
+                                <StyledScoreBar
+                                  palette={
+                                    Array [
+                                      "#ec5e44",
+                                      "#f38259",
+                                      "#f9a66d",
+                                      "#98b480",
+                                      "#57be8c",
+                                    ]
+                                  }
+                                  score={0}
                                   size={40}
                                   thickness={4}
                                   vertical={true}
                                 >
-                                  <div
-                                    className="css-15vxee-Bar eecxaw41"
+                                  <ScoreBar
+                                    className="css-omtyju-StyledScoreBar eecxaw40"
+                                    palette={
+                                      Array [
+                                        "#ec5e44",
+                                        "#f38259",
+                                        "#f9a66d",
+                                        "#98b480",
+                                        "#57be8c",
+                                      ]
+                                    }
+                                    score={0}
                                     size={40}
-                                  />
-                                </Bar>
-                                <Bar
-                                  empty={true}
-                                  key="empty-1"
-                                  size={40}
-                                  thickness={4}
-                                  vertical={true}
-                                >
-                                  <div
-                                    className="css-15vxee-Bar eecxaw41"
-                                    size={40}
-                                  />
-                                </Bar>
-                                <Bar
-                                  empty={true}
-                                  key="empty-2"
-                                  size={40}
-                                  thickness={4}
-                                  vertical={true}
-                                >
-                                  <div
-                                    className="css-15vxee-Bar eecxaw41"
-                                    size={40}
-                                  />
-                                </Bar>
-                                <Bar
-                                  empty={true}
-                                  key="empty-3"
-                                  size={40}
-                                  thickness={4}
-                                  vertical={true}
-                                >
-                                  <div
-                                    className="css-15vxee-Bar eecxaw41"
-                                    size={40}
-                                  />
-                                </Bar>
-                                <Bar
-                                  empty={true}
-                                  key="empty-4"
-                                  size={40}
-                                  thickness={4}
-                                  vertical={true}
-                                >
-                                  <div
-                                    className="css-15vxee-Bar eecxaw41"
-                                    size={40}
-                                  />
-                                </Bar>
-                              </div>
-                            </ScoreBar>
-                          </StyledScoreBar>
-                        </span>
-                      </Container>
+                                    thickness={4}
+                                    vertical={true}
+                                  >
+                                    <div
+                                      className="css-omtyju-StyledScoreBar eecxaw40"
+                                    >
+                                      <Bar
+                                        empty={true}
+                                        key="empty-0"
+                                        size={40}
+                                        thickness={4}
+                                        vertical={true}
+                                      >
+                                        <div
+                                          className="css-15vxee-Bar eecxaw41"
+                                          size={40}
+                                        />
+                                      </Bar>
+                                      <Bar
+                                        empty={true}
+                                        key="empty-1"
+                                        size={40}
+                                        thickness={4}
+                                        vertical={true}
+                                      >
+                                        <div
+                                          className="css-15vxee-Bar eecxaw41"
+                                          size={40}
+                                        />
+                                      </Bar>
+                                      <Bar
+                                        empty={true}
+                                        key="empty-2"
+                                        size={40}
+                                        thickness={4}
+                                        vertical={true}
+                                      >
+                                        <div
+                                          className="css-15vxee-Bar eecxaw41"
+                                          size={40}
+                                        />
+                                      </Bar>
+                                      <Bar
+                                        empty={true}
+                                        key="empty-3"
+                                        size={40}
+                                        thickness={4}
+                                        vertical={true}
+                                      >
+                                        <div
+                                          className="css-15vxee-Bar eecxaw41"
+                                          size={40}
+                                        />
+                                      </Bar>
+                                      <Bar
+                                        empty={true}
+                                        key="empty-4"
+                                        size={40}
+                                        thickness={4}
+                                        vertical={true}
+                                      >
+                                        <div
+                                          className="css-15vxee-Bar eecxaw41"
+                                          size={40}
+                                        />
+                                      </Bar>
+                                    </div>
+                                  </ScoreBar>
+                                </StyledScoreBar>
+                              </span>
+                            </Container>
+                          </InnerReference>
+                        </Reference>
+                      </Manager>
                     </Hovercard>
                   </div>
                 </div>

--- a/tests/js/spec/views/groupDetails/__snapshots__/groupSimilar.spec.jsx.snap
+++ b/tests/js/spec/views/groupDetails/__snapshots__/groupSimilar.spec.jsx.snap
@@ -780,8 +780,30 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                           },
                                         },
                                       ],
+                                      Array [
+                                        Object {
+                                          "pathname": "/org-slug/project-slug/issues/271/",
+                                          "search": "",
+                                        },
+                                      ],
+                                      Array [
+                                        Object {
+                                          "pathname": "/org-slug/project-slug/issues/",
+                                          "query": Object {
+                                            "query": "logger:javascript",
+                                          },
+                                        },
+                                      ],
                                     ],
                                     "results": Array [
+                                      Object {
+                                        "type": "return",
+                                        "value": undefined,
+                                      },
+                                      Object {
+                                        "type": "return",
+                                        "value": undefined,
+                                      },
                                       Object {
                                         "type": "return",
                                         "value": undefined,
@@ -935,8 +957,30 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                                         },
                                                       },
                                                     ],
+                                                    Array [
+                                                      Object {
+                                                        "pathname": "/org-slug/project-slug/issues/271/",
+                                                        "search": "",
+                                                      },
+                                                    ],
+                                                    Array [
+                                                      Object {
+                                                        "pathname": "/org-slug/project-slug/issues/",
+                                                        "query": Object {
+                                                          "query": "logger:javascript",
+                                                        },
+                                                      },
+                                                    ],
                                                   ],
                                                   "results": Array [
+                                                    Object {
+                                                      "type": "return",
+                                                      "value": undefined,
+                                                    },
+                                                    Object {
+                                                      "type": "return",
+                                                      "value": undefined,
+                                                    },
                                                     Object {
                                                       "type": "return",
                                                       "value": undefined,
@@ -1108,8 +1152,30 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                           },
                                         },
                                       ],
+                                      Array [
+                                        Object {
+                                          "pathname": "/org-slug/project-slug/issues/271/",
+                                          "search": "",
+                                        },
+                                      ],
+                                      Array [
+                                        Object {
+                                          "pathname": "/org-slug/project-slug/issues/",
+                                          "query": Object {
+                                            "query": "logger:javascript",
+                                          },
+                                        },
+                                      ],
                                     ],
                                     "results": Array [
+                                      Object {
+                                        "type": "return",
+                                        "value": undefined,
+                                      },
+                                      Object {
+                                        "type": "return",
+                                        "value": undefined,
+                                      },
                                       Object {
                                         "type": "return",
                                         "value": undefined,


### PR DESCRIPTION
Replace the positioning system for our hovercards with popper.js. I've also opted to put hovercard content into a Portal as it allows us to easily solve several z-index related issues. Specifically on the sidebar power up icons.

![Screen Shot 2019-05-03 at 1 44 24 PM](https://user-images.githubusercontent.com/24086/57155589-e1667680-6da9-11e9-99a4-e1ddc277a4a0.png)
![Screen Shot 2019-05-03 at 1 45 18 PM](https://user-images.githubusercontent.com/24086/57155590-e1667680-6da9-11e9-9253-84c3d08c8f28.png)
![Screen Shot 2019-05-03 at 1 46 07 PM](https://user-images.githubusercontent.com/24086/57155591-e1667680-6da9-11e9-8d90-cfbd6708564c.png)

I've found one small positioning issue for the release hovercard. Because of the length of the release name container the arrow can point in to the blank space to the left of the element, as seen here:

![Screen Shot 2019-05-03 at 1 45 51 PM](https://user-images.githubusercontent.com/24086/57155604-ec210b80-6da9-11e9-9170-80297becaf73.png)

I think this is a solvable problem if I adjust how release names are styled, but I wanted to keep this on the small side to start with.

Refs SEN-595