### PR TITLE
fix(ui) Constrain release markers to filtered projects

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
+++ b/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
@@ -2,6 +2,7 @@ import {withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
+import {isEqual} from 'lodash';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import {getUserTimezone} from 'app/utils/dates';
@@ -14,8 +15,15 @@ import withOrganization from 'app/utils/withOrganization';
 
 // This is not an exported action/function because releases list uses AsyncComponent
 // and this is not re-used anywhere else afaict
-function getOrganizationReleases(api, organization) {
-  return api.requestPromise(`/organizations/${organization.slug}/releases/`);
+function getOrganizationReleases(api, organization, projects = null) {
+  const query = {};
+  if (projects) {
+    query.project = projects;
+  }
+  return api.requestPromise(`/organizations/${organization.slug}/releases/`, {
+    method: 'GET',
+    query,
+  });
 }
 
 class ReleaseSeries extends React.Component {
@@ -23,6 +31,7 @@ class ReleaseSeries extends React.Component {
     api: PropTypes.object,
     router: PropTypes.object,
     organization: SentryTypes.Organization,
+    projects: PropTypes.arrayOf(PropTypes.number),
 
     utc: PropTypes.bool,
     // Array of releases, if empty, component will fetch releases itself
@@ -40,9 +49,19 @@ class ReleaseSeries extends React.Component {
       return;
     }
 
-    const {api, organization} = this.props;
+    this.fetchData();
+  }
 
-    getOrganizationReleases(api, organization)
+  componentDidUpdate(prevProps) {
+    if (!isEqual(prevProps.projects, this.props.projects)) {
+      this.fetchData();
+    }
+  }
+
+  fetchData() {
+    const {api, organization, projects} = this.props;
+
+    getOrganizationReleases(api, organization, projects)
       .then(releases => {
         this.setState({
           releases,

--- a/src/sentry/static/sentry/app/views/organizationEvents/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/eventsChart.jsx
@@ -74,6 +74,8 @@ class EventsLineChart extends React.Component {
 class EventsChart extends React.Component {
   static propTypes = {
     api: PropTypes.object,
+    projects: PropTypes.arrayOf(PropTypes.number),
+    environments: PropTypes.arrayOf(PropTypes.string),
     period: PropTypes.string,
     query: PropTypes.string,
     start: PropTypes.instanceOf(Date),
@@ -83,17 +85,37 @@ class EventsChart extends React.Component {
   };
 
   render() {
-    const {api, period, utc, query, router, start, end, ...props} = this.props;
+    const {
+      api,
+      period,
+      utc,
+      query,
+      router,
+      start,
+      end,
+      projects,
+      environments,
+      ...props
+    } = this.props;
     // Include previous only on relative dates (defaults to relative if no start and end)
     const includePrevious = !start && !end;
 
     return (
-      <ChartZoom router={router} period={period} utc={utc} {...props}>
+      <ChartZoom
+        router={router}
+        period={period}
+        utc={utc}
+        projects={projects}
+        environments={environments}
+        {...props}
+      >
         {({interval, ...zoomRenderProps}) => (
           <EventsRequest
             {...props}
             api={api}
             period={period}
+            project={projects}
+            environment={environments}
             start={start}
             end={end}
             interval={getInterval(this.props, true)}
@@ -104,7 +126,7 @@ class EventsChart extends React.Component {
           >
             {({loading, reloading, timeseriesData, previousTimeseriesData}) => {
               return (
-                <ReleaseSeries utc={utc} api={api}>
+                <ReleaseSeries utc={utc} api={api} projects={projects}>
                   {({releaseSeries}) => {
                     if (loading && !reloading) {
                       return <LoadingPanel data-test-id="events-request-loading" />;
@@ -149,8 +171,8 @@ const EventsChartContainer = withGlobalSelection(
         return (
           <EventsChart
             {...datetime}
-            project={projects || []}
-            environment={environments || []}
+            projects={projects || []}
+            environments={environments || []}
             {...props}
           />
         );

--- a/tests/js/spec/components/charts/releaseSeries.spec.jsx
+++ b/tests/js/spec/components/charts/releaseSeries.spec.jsx
@@ -44,6 +44,23 @@ describe('ReleaseSeries', function() {
     );
   });
 
+  it('fetches releases with project conditions', async function() {
+    const wrapper = mount(
+      <ReleaseSeries projects={[1, 2]}>{renderFunc}</ReleaseSeries>,
+      routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    expect(releasesMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: {project: [1, 2]},
+      })
+    );
+  });
+
   it('generates an eCharts `markLine` series from releases', async function() {
     const wrapper = mount(<ReleaseSeries>{renderFunc}</ReleaseSeries>, routerContext);
 


### PR DESCRIPTION
Don't display release information for projects not currently selected. This prevents displaying releases from projects that the current user cannot currently see.

Fixes SEN-602