### PR TITLE
feat: Track other outcomes

### DIFF
--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -455,6 +455,8 @@ def _do_save_event(cache_key=None, data=None, start_time=None, event_id=None,
         project_id = data.pop('project')
 
     key_id = None if data is None else data.get('key_id')
+    if key_id is not None:
+        key_id = int(key_id)
     timestamp = to_datetime(start_time) if start_time is not None else None
 
     delete_raw_event(project_id, event_id, allow_hint_clear=True)

--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -6,10 +6,11 @@ sentry.utils.outcomes.py
 """
 from __future__ import absolute_import
 
-import random
-import time
+from datetime import datetime
 from django.conf import settings
 from enum import IntEnum
+import random
+import time
 
 from sentry import tsdb, options
 from sentry.utils import json, metrics
@@ -49,6 +50,12 @@ def track_outcome(org_id, project_id, key_id, outcome, reason=None, timestamp=No
                 settings.KAFKA_CLUSTERS[outcomes['cluster']]
             )
         )
+
+    assert isinstance(org_id, int)
+    assert isinstance(project_id, int)
+    assert isinstance(key_id, (type(None), int))
+    assert isinstance(outcome, Outcome)
+    assert isinstance(timestamp, (type(None), datetime))
 
     timestamp = timestamp or to_datetime(time.time())
     increment_list = []


### PR DESCRIPTION
These are things that raise APIErrors but that we don't track in
outcomes at the moment. They may be useful for debugging people's
integrations, or generally checking our API health.

Note that these outcomes are all Outcome.INVALID, which is only reported
to legacy TSDB if the `reason` is in the FilterStatsKeys. For all of
these new ones, that will not be the case, and the metrics will only
be reported to Kafka/Snuba Outcomes.