### PR TITLE
fix(issues-search): Fix and log keyboard navigation for search dropdown

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
@@ -624,10 +624,13 @@ class SmartSearchBar extends React.Component {
         const [nextGroupIndex, nextChildrenIndex] =
           findSearchItemByIndex(searchItems, nextActiveSearchItem) || [];
 
-        searchItems[nextGroupIndex].children[nextChildrenIndex] = {
-          ...searchItems[nextGroupIndex].children[nextChildrenIndex],
-          active: true,
-        };
+        // Make sure search items exist (e.g. both groups could be empty)
+        if (searchItems[nextGroupIndex] && searchItems[nextGroupIndex].children) {
+          searchItems[nextGroupIndex].children[nextChildrenIndex] = {
+            ...searchItems[nextGroupIndex].children[nextChildrenIndex],
+            active: true,
+          };
+        }
 
         return {
           activeSearchItem: nextActiveSearchItem,


### PR DESCRIPTION
This protects against an undefined object when trying to set next item as active. This can happen when there are no search results.

Fixes JAVASCRIPT-M6K