### PR TITLE
build(travis): Allow "Symbolicator Integration" to fail in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -291,6 +291,8 @@ matrix:
     # XXX(markus): Remove after rust interfaces are done
     - env: TEST_SUITE=postgres DB=postgres SENTRY_TEST_USE_RUST_INTERFACE_RENORMALIZATION=1
 
+    - env: TEST_SUITE=symbolicator
+
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
This suite seems to be failing and breaking CI, temporarily allow failures.