### PR TITLE
fix: Update snapshots for symbolicator changes

### DIFF
--- a/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_crash_with_attachments.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_crash_with_attachments.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-02T10:52:12.477754Z'
+created: '2019-05-06T20:21:59.640505Z'
 creator: sentry
 source: tests/symbolicator/test_unreal_full.py
 ---
@@ -377,62 +377,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff7548229e6'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75563d233'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff759a2f3f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7589ca88b'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a4831a8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754814eaa'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff759a2f3f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a4831a8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754814eaa'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754814eaa'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7589e69ae'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff759a2f3f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff759a2f3f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755181c71'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -743,74 +687,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d959f5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8d290'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551659f9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754dbe522'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7589c665e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a672d0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a671f8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8f221'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -933,62 +809,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d959f5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8d290'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551659f9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754dbe522'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7589c665e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -1110,62 +930,6 @@ threads:
         rsp: '0x8c4070f778'
     stacktrace:
       frames:
-      - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d959f5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8d290'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551659f9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754dbe522'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7589c665e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
@@ -1309,86 +1073,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d959f5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8d290'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551659f9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e426b5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3b27e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3af02'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3ae3b'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a19ed98'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3409c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7553a0fdf'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -1527,74 +1211,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d959f5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8d290'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551659f9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754dbe522'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7589c665e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a19ed98'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3409c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7553a0fdf'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -1720,66 +1336,6 @@ threads:
         rsp: '0x8c4088f808'
     stacktrace:
       frames:
-      - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d959f5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8d290'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551659f9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754dbe522'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7589c665e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3469f'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
@@ -1919,74 +1475,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d959f5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8d290'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551659f9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754dbe522'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7589c665e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7553923b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8b7c9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75504b92d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -2125,74 +1613,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d959f5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8d290'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551659f9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754dbe522'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7589c665e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7553923b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8b7c9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75504b92d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -2326,70 +1746,6 @@ threads:
         rsp: '0x8c40a0f2f8'
     stacktrace:
       frames:
-      - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d959f5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8d290'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551659f9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754dbe522'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7589c665e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8b7c9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75504b92d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
@@ -2525,70 +1881,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d959f5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8d290'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551659f9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754dbe522'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7589c665e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a672d0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a672d0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -2662,22 +1954,6 @@ threads:
         rsp: '0x8c40b0f5c8'
     stacktrace:
       frames:
-      - in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75504b92d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
@@ -2761,30 +2037,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a19ed98'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3409c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7553a0fdf'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -2862,30 +2114,6 @@ threads:
         rsp: '0x8c40c0fa78'
     stacktrace:
       frames:
-      - in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a19ed98'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3409c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7553a0fdf'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
@@ -2969,30 +2197,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a19ed98'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3409c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7553a0fdf'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -3074,30 +2278,6 @@ threads:
         rsp: '0x8c40d0f8a8'
     stacktrace:
       frames:
-      - in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a19ed98'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3409c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7553a0fdf'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
@@ -3253,94 +2433,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75506e26d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8d176'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3469f'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3419b'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3409c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e349d6'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e01a18'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8ca09'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1e2338'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1e2338'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75504752f'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d7a570'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8f221'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3aed7'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -3459,62 +2551,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758bbfa00'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a671f8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75503ff42'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a67100'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758c25f01'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff759452a10'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75797c3f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -3604,34 +2640,6 @@ threads:
         rsp: '0x8c3ebff458'
     stacktrace:
       frames:
-      - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
@@ -3735,46 +2743,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75482017b'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff759452a10'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75797c3f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -3876,46 +2844,6 @@ threads:
         rsp: '0x8c40dcf698'
     stacktrace:
       frames:
-      - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75482017b'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff759452a10'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75797c3f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
@@ -4019,46 +2947,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75482017b'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff759452a10'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75797c3f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -4152,38 +3040,6 @@ threads:
         rsp: '0x8c40e0f558'
     stacktrace:
       frames:
-      - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3b27e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
@@ -4279,38 +3135,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3b27e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -4389,22 +3213,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754f680be'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75518c971'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100fa584'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -4478,18 +3286,6 @@ threads:
         rsp: '0x8c4131fd08'
     stacktrace:
       frames:
-      - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff756780450'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - in_app: false
         instruction_addr: '0x7ffe100fa584'
         package: C:\Windows\System32\ntdll.dll
@@ -4597,50 +3393,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754b6efc6'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754efc17c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754f0021d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e19759'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758ae6d48'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a671f8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -4734,38 +3486,6 @@ threads:
         rsp: '0x8c4135fb68'
     stacktrace:
       frames:
-      - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75517fbb1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
@@ -4861,38 +3581,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75517fbb1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -4982,34 +3670,6 @@ threads:
         rsp: '0x8c4139fa08'
     stacktrace:
       frames:
-      - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
@@ -5104,38 +3764,6 @@ threads:
         rsp: '0x8c413bf8c8'
     stacktrace:
       frames:
-      - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75517fbb1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
@@ -5285,38 +3913,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7559e6610'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754f70c36'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754f2efca'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7559ccee1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7559e7c57'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -5398,26 +3994,6 @@ threads:
         rsp: '0x8c4270fa18'
     stacktrace:
       frames:
-      - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e4b37f'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff756cba688'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
@@ -5732,34 +4308,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7549e3f3d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3b984'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -5849,34 +4397,6 @@ threads:
         rsp: '0x8c418ff968'
     stacktrace:
       frames:
-      - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7549e3f3d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3b984'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
@@ -5968,34 +4488,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7549e3f3d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3b984'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -6085,34 +4577,6 @@ threads:
         rsp: '0x8c4193f788'
     stacktrace:
       frames:
-      - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7549e3f3d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3b984'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
@@ -6204,34 +4668,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7549e3f3d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3b984'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -6321,34 +4757,6 @@ threads:
         rsp: '0x8c4197f9c8'
     stacktrace:
       frames:
-      - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7549e3f3d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3b984'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
@@ -6440,34 +4848,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7549e3f3d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3b984'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -6558,34 +4938,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7549e3f3d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3b984'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -6663,30 +5015,6 @@ threads:
         rsp: '0x8c419df5f8'
     stacktrace:
       frames:
-      - in_app: false
-        instruction_addr: '0x7ff757fb47f2'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758adc9f8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3b984'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
@@ -6781,38 +5109,6 @@ threads:
         rsp: '0x8c419efb58'
     stacktrace:
       frames:
-      - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e4b37f'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff757aaf081'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551976c3'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3b984'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - in_app: false
         instruction_addr: '0x7ffe100fa584'
         package: C:\Windows\System32\ntdll.dll
@@ -7002,26 +5298,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff754d8ca09'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d7a570'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -7167,86 +5443,6 @@ threads:
     stacktrace:
       frames:
       - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e4b37f'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7566cc3d7'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7566cbf67'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8d176'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75501f8fc'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75504b92d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754dc5267'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e349d6'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8ca09'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1e2338'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff75a1e2338'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8f221'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754e3419b'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
         instruction_addr: '0x7ffe100f9f84'
         package: C:\Windows\System32\ntdll.dll
         trust: context
@@ -7364,62 +5560,6 @@ threads:
         rsp: '0x8c4189fba8'
     stacktrace:
       frames:
-      - in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7566cc508'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a671f8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff759054684'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7566be97c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff759054684'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7566ce2a3'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff758a67a48'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d8f4e0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff7551976c3'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - in_app: false
-        instruction_addr: '0x7ff754d7feb8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - in_app: false
         instruction_addr: '0x7ffe100fa584'
         package: C:\Windows\System32\ntdll.dll


### PR DESCRIPTION
The changed symbolication status makes a difference on scan frames, as expected.