### PR TITLE
fix(api): Fix reverse url not working with alphanumeric event ids (ISSUE-460)

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -590,7 +590,7 @@ urlpatterns += patterns(
         name='sentry-group'
     ),
     url(
-        r'^(?P<organization_slug>[\w_-]+)/(?P<project_slug>[\w_-]+)/issues/(?P<group_id>\d+)/events/(?P<event_id>\d+)/$',
+        r'^(?P<organization_slug>[\w_-]+)/(?P<project_slug>[\w_-]+)/issues/(?P<group_id>\d+)/events/(?P<event_id>[\w-]+)/$',
         react_page_view,
         name='sentry-group-event'
     ),


### PR DESCRIPTION
This url only expects numeric event ids, but we now need to support alphanumeric ids since we rely
on snuba.