### PR TITLE
ref(roles): Change "owner" to "org owner"

### DIFF
--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -65,7 +65,8 @@ class OrganizationIndexEndpoint(Endpoint):
 
         :qparam bool member: restrict results to organizations which you have
                              membership
-        :qparam bool owner: restrict results to organizations which are owner
+        :qparam bool owner: restrict results to organizations in which you are
+                            an organization owner
 
         :auth: required
         """

--- a/src/sentry/api/endpoints/project_transfer.py
+++ b/src/sentry/api/endpoints/project_transfer.py
@@ -65,7 +65,7 @@ class ProjectTransferEndpoint(ProjectEndpoint):
                 user__is_active=True,
             )[0]
         except IndexError:
-            return Response({'detail': 'Could not find owner with that email'},
+            return Response({'detail': 'Could not find an organization owner with that email'},
                             status=status.HTTP_404_NOT_FOUND)
 
         transaction_id = uuid4().hex

--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -94,10 +94,10 @@ GUIDES = {
                 'target': 'ignore_delete_discard',
             },
             {
-                'title': _('Owners'),
+                'title': _('Issue Owners'),
                 'message': _(
                     'Define users or teams that are responsible for specific paths or URLS so '
-                    'that notifications can be routed to the correct owner. Learn more '
+                    'that notifications can be routed to the correct people. Learn more '
                     '<a href="https://docs.sentry.io/learn/issue-owners/" target="_blank">here</a>.'),
                 'target': 'owners',
             },
@@ -110,8 +110,8 @@ GUIDES = {
         'steps': [
             {
                 'title': _('Releases'),
-                'message': _('A release is a specific version of your code deployed to an '
-                             'environment. When you tell Sentry about your releases, it can '
+                'message': _('A release is a specific version of your code.'
+                             'When you tell Sentry about your releases, it can '
                              'predict which commits caused an error and who might be a likely '
                              'owner.'),
                 'target': 'releases',

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1282,8 +1282,8 @@ SENTRY_ROLES = (
         ),
     }, {
         'id': 'owner',
-        'name': 'Owner',
-        'desc': 'Gains full permission across the organization. Can manage members as well as perform catastrophic operations such as removing the organization.',
+        'name': 'Organization Owner',
+        'desc': 'Unrestricted access to the organization, its data, and its settings. Can add, modify, and delete projects and members, as well as make billing and plan changes.',
         'is_global': True,
         'scopes': set(
             [

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -396,7 +396,7 @@ class VstsIntegrationProvider(IntegrationProvider):
             if e.code != 400 or 'permission' not in e.message:
                 raise e
             raise IntegrationError(
-                'You do not have sufficent account access to create an integration.\nPlease check with the owner of this account.'
+                'You do not have sufficent account access to create an integration.\nPlease check with the owner of this Azure DevOps account.'
             )
 
         subscription_id = subscription['id']

--- a/src/sentry/static/sentry/app/components/modals/integrationDetailsModal.jsx
+++ b/src/sentry/static/sentry/app/components/modals/integrationDetailsModal.jsx
@@ -173,7 +173,9 @@ class IntegrationDetailsModal extends React.Component {
               <Access organization={organization} access={['org:integrations']}>
                 {({hasAccess}) => (
                   <Tooltip
-                    title={t('You must be an Owner, Manager or Admin to install this.')}
+                    title={t(
+                      'You must be an organization owner, manager or admin to install this.'
+                    )}
                     disabled={hasAccess}
                   >
                     <AddButton

--- a/src/sentry/static/sentry/app/components/onboardingWizard/todos.jsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/todos.jsx
@@ -39,7 +39,7 @@ const TASKS = [
     description: t('Bring your team aboard'),
     detailedDescription: t(
       `Let Sentry help your team triage and assign issues. Improve your workflow
-           by unlocking mentions, assignment, and suggested issue owners.`
+          by unlocking mentions, assignment, and suggested issue owners.`
     ),
     skippable: true,
     prereq: [],

--- a/src/sentry/static/sentry/app/components/onboardingWizard/todos.jsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/todos.jsx
@@ -39,7 +39,7 @@ const TASKS = [
     description: t('Bring your team aboard'),
     detailedDescription: t(
       `Let Sentry help your team triage and assign issues. Improve your workflow
-          by unlocking suggested owners, mentions, and assignment.`
+           by unlocking mentions, assignment, and suggested issue owners.`
     ),
     skippable: true,
     prereq: [],
@@ -80,7 +80,7 @@ const TASKS = [
     description: t('See which releases cause errors'),
     detailedDescription: t(
       `Set up commits for additional context when determining the cause of an issue
-          e.g. suggested owners and resolve issues via commit messages.`
+          (e.g. suggested issue owners) and resolve issues via commit messages.`
     ),
     skippable: true,
     prereq: [1, 2],

--- a/src/sentry/static/sentry/app/components/onboardingWizard/todos.jsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/todos.jsx
@@ -35,7 +35,7 @@ const TASKS = [
   },
   {
     task: 3,
-    title: t('Invite team member'),
+    title: t('Invite team members'),
     description: t('Bring your team aboard'),
     detailedDescription: t(
       `Let Sentry help your team triage and assign issues. Improve your workflow
@@ -51,9 +51,7 @@ const TASKS = [
     task: 4,
     title: t('Add a second platform'),
     description: t('Add Sentry to a second platform'),
-    detailedDescription: t(
-      'Cross platform functionality to support both your frontend and backend.'
-    ),
+    detailedDescription: t('Capture errors from both your front and back ends.'),
     skippable: true,
     prereq: [1, 2],
     featureLocation: 'organization',
@@ -66,7 +64,7 @@ const TASKS = [
     description: t('Know who is being affected by crashes'),
     detailedDescription: t(
       `Unlock features that let you
-          drill down into the number of users affected by an issue as well as get a broader sense about the quality of the application.`
+          drill down into the number of users affected by an issue and get a broader sense about the quality of your application.`
     ),
     skippable: true,
     prereq: [1, 2],
@@ -79,8 +77,8 @@ const TASKS = [
     title: t('Set up release tracking'),
     description: t('See which releases cause errors'),
     detailedDescription: t(
-      `Set up commits for additional context when determining the cause of an issue
-          (e.g. suggested issue owners) and resolve issues via commit messages.`
+      `Set up releases and associate commits to gain additional context when determining the cause of an issue
+          and unlock the ability to resolve issues via commit message.`
     ),
     skippable: true,
     prereq: [1, 2],
@@ -93,7 +91,7 @@ const TASKS = [
     title: t('Upload source maps'),
     description: t('Deminify JavaScript stack traces'),
     detailedDescription: t(
-      `View source code context obtained from stack traces in their
+      `View source code context obtained from stack traces in its
           original untransformed form, which is particularly useful for debugging minified code.`
     ),
     skippable: true,
@@ -125,7 +123,7 @@ const TASKS = [
   {
     task: 10,
     title: t('Set up an alerts service'),
-    description: t('Receive Sentry alerts in Slack'),
+    description: t('Receive Sentry alerts in Slack, PagerDuty, and more.'),
     skippable: true,
     prereq: [1, 2],
     featureLocation: 'project',

--- a/src/sentry/static/sentry/app/views/integrationInstallation.jsx
+++ b/src/sentry/static/sentry/app/views/integrationInstallation.jsx
@@ -116,7 +116,7 @@ export default class IntegrationInstallation extends AsyncView {
             <p>
               {tct(
                 `You do not have permission to install integrations in
-                  [organization]. Ask your organization owner or manager to
+                  [organization]. Ask an organization owner or manager to
                   visit this page to finish installing this integration.`,
                 {organization: <strong>{organization.slug}</strong>}
               )}

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
@@ -200,7 +200,7 @@ export default class IntegrationRepos extends AsyncComponent {
                 icon="icon-commit"
                 title={t('Sentry is better with commit data')}
                 description={t(
-                  'Add a repository to begin tracking its commit data. Then, set up release tracking to unlock features like suspect commits, suggested owners, and deploy emails.'
+                  'Add a repository to begin tracking its commit data. Then, set up release tracking to unlock features like suspect commits, suggested issue owners, and deploy emails.'
                 )}
                 action={
                   <Button href="https://docs.sentry.io/learn/releases/">

--- a/src/sentry/static/sentry/app/views/settings/account/accountClose.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountClose.jsx
@@ -138,11 +138,11 @@ class AccountClose extends AsyncView {
           <PanelBody>
             <PanelAlert type="info">
               {t(
-                'Ownership will remain with other members if an organization is not deleted.'
+                'Ownership will remain with other organization owners if an organization is not deleted.'
               )}
               <br />
               {t(
-                'Disabled boxes mean that there is no other owner within the organization so no one else can take ownership.'
+                'Boxes which can\'t be unchecked mean that you are the only organization owner and the organization <b>will be deleted</b>.'
               )}
             </PanelAlert>
 

--- a/src/sentry/static/sentry/app/views/settings/account/accountClose.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountClose.jsx
@@ -11,7 +11,7 @@ import {
 } from 'app/components/panels';
 import {addMessage, addErrorMessage} from 'app/actionCreators/indicator';
 import {openModal} from 'app/actionCreators/modal';
-import {t} from 'app/locale';
+import {t, tct} from 'app/locale';
 import Alert from 'app/components/alert';
 import AsyncView from 'app/views/asyncView';
 import Button from 'app/components/button';
@@ -141,8 +141,9 @@ class AccountClose extends AsyncView {
                 'Ownership will remain with other organization owners if an organization is not deleted.'
               )}
               <br />
-              {t(
-                "Boxes which can't be unchecked mean that you are the only organization owner and the organization <b>will be deleted</b>."
+              {tct(
+                "Boxes which can't be unchecked mean that you are the only organization owner and the organization [strong:will be deleted].",
+                {strong: <strong />}
               )}
             </PanelAlert>
 

--- a/src/sentry/static/sentry/app/views/settings/account/accountClose.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountClose.jsx
@@ -142,7 +142,7 @@ class AccountClose extends AsyncView {
               )}
               <br />
               {t(
-                'Boxes which can\'t be unchecked mean that you are the only organization owner and the organization <b>will be deleted</b>.'
+                "Boxes which can't be unchecked mean that you are the only organization owner and the organization <b>will be deleted</b>."
               )}
             </PanelAlert>
 

--- a/src/sentry/static/sentry/app/views/settings/organization/permissionAlert.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/permissionAlert.jsx
@@ -11,7 +11,7 @@ const PermissionAlert = ({access, ...props}) => (
       !hasAccess && (
         <Alert type="warning" icon="icon-warning-sm" {...props}>
           {t(
-            'These settings can only be edited by users with the owner or manager role.'
+            'These settings can only be edited by users with the organization owner or manager role.'
           )}
         </Alert>
       )

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow.jsx
@@ -140,7 +140,9 @@ export default class SentryApplicationRow extends React.PureComponent {
                       {!hasAccess && (
                         <Button
                           disabled
-                          title={t('Owner permissions are required for this action.')}
+                          title={t(
+                            'Organization owner permissions are required for this action.'
+                          )}
                           size="small"
                           icon="icon-trash"
                         />

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/index.jsx
@@ -42,9 +42,9 @@ const STATIC_ROLE_LIST = [
   },
   {
     id: 'owner',
-    name: 'Owner',
+    name: 'Organization Owner',
     desc:
-      'Gains full permission across the organization. Can manage members as well as perform catastrophic operations such as removing the organization.',
+      'Unrestricted access to the organization, its data, and its settings. Can add, modify, and delete projects and members, as well as make billing and plan changes.',
   },
 ];
 

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberRow.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberRow.jsx
@@ -234,7 +234,9 @@ export default class OrganizationMemberRow extends React.PureComponent {
                 size="small"
                 icon="icon-exit"
                 disabled
-                title={t('You cannot leave this organization as you are the only organization owner.')}
+                title={t(
+                  'You cannot leave this organization as you are the only organization owner.'
+                )}
               >
                 {t('Leave')}
               </Button>

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberRow.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberRow.jsx
@@ -234,7 +234,7 @@ export default class OrganizationMemberRow extends React.PureComponent {
                 size="small"
                 icon="icon-exit"
                 disabled
-                title={t('You cannot leave the organization as you are the only owner.')}
+                title={t('You cannot leave this organization as you are the only organization owner.')}
               >
                 {t('Leave')}
               </Button>

--- a/src/sentry/static/sentry/app/views/settings/project/permissionAlert.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/permissionAlert.jsx
@@ -11,7 +11,7 @@ const PermissionAlert = ({access, ...props}) => (
       !hasAccess && (
         <Alert type="warning" icon="icon-warning-sm" {...props}>
           {t(
-            'These settings can only be edited by users with the owner, manager, or admin role.'
+            'These settings can only be edited by users with the organization owner, manager, or admin role.'
           )}
         </Alert>
       )

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/ownerInput.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/ownerInput.jsx
@@ -68,7 +68,7 @@ class OwnerInput extends React.Component {
 
     request
       .then(() => {
-        addSuccessMessage(t('Updated ownership rules'));
+        addSuccessMessage(t('Updated issue ownership rules'));
         this.setState({
           initialText: text,
         });
@@ -77,7 +77,7 @@ class OwnerInput extends React.Component {
         this.setState({error: error.responseJSON});
         if (error.status === 403) {
           addErrorMessage(
-            t("You don't have permission to modify ownership rules for this project")
+            t("You don't have permission to modify issue ownership rules for this project")
           );
         } else if (
           error.status === 400 &&
@@ -85,10 +85,10 @@ class OwnerInput extends React.Component {
           error.responseJSON.raw[0].startsWith('Invalid rule owners:')
         ) {
           addErrorMessage(
-            t('Unable to save ownership rules changes: ' + error.responseJSON.raw[0])
+            t('Unable to save issue ownership rule changes: ' + error.responseJSON.raw[0])
           );
         } else {
-          addErrorMessage(t('Unable to save ownership rules changes'));
+          addErrorMessage(t('Unable to save issue ownership rule changes'));
         }
       });
 

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/ownerInput.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/ownerInput.jsx
@@ -77,7 +77,9 @@ class OwnerInput extends React.Component {
         this.setState({error: error.responseJSON});
         if (error.status === 403) {
           addErrorMessage(
-            t("You don't have permission to modify issue ownership rules for this project")
+            t(
+              "You don't have permission to modify issue ownership rules for this project"
+            )
           );
         } else if (
           error.status === 400 &&

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/ruleBuilder.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/ruleBuilder.jsx
@@ -62,7 +62,7 @@ class RuleBuilder extends React.Component {
     const {type, text, owners, isValid} = this.state;
 
     if (!isValid) {
-      addErrorMessage('A Rule needs a type, a value, and one or more owners.');
+      addErrorMessage('A rule needs a type, a value, and one or more issue owners.');
       return;
     }
 

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/selectOwners.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/selectOwners.jsx
@@ -314,7 +314,7 @@ export default class SelectOwners extends React.Component {
         disabled={this.props.disabled}
         cache={false}
         valueComponent={ValueComponent}
-        placeholder={t('Add Owners')}
+        placeholder={t('owners')}
         onInputChange={this.handleInputChange}
         onChange={this.handleChange}
         value={this.props.value}

--- a/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
@@ -108,7 +108,7 @@ class ProjectTeams extends AsyncView {
     const hasAccess = organization.access.includes('project:write');
     const confirmRemove = t(
       'This is the last team with access to this project. Removing it will mean ' +
-        'only owners and managers will be able to access the project pages. Are ' +
+        'only organization owners and managers will be able to access the project pages. Are ' +
         'you sure you want to remove this team from the project %s?',
       params.projectId
     );

--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
@@ -189,7 +189,7 @@ class ProjectGeneralSettings extends AsyncView {
                 </TextBlock>
                 <TextBlock>
                   {t(
-                    'Please enter the email of an organization owner for the org to which you would like to transfer this project.'
+                    'Please enter the email of an organization owner to whom you would like to transfer this project.'
                   )}
                 </TextBlock>
                 <Panel>

--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
@@ -189,7 +189,7 @@ class ProjectGeneralSettings extends AsyncView {
                 </TextBlock>
                 <TextBlock>
                   {t(
-                    'Please enter the organization owner you would like to transfer this project to.'
+                    'Please enter the email of an organization owner for the org to which you would like to transfer this project.'
                   )}
                 </TextBlock>
                 <Panel>
@@ -206,11 +206,8 @@ class ProjectGeneralSettings extends AsyncView {
                       label={t('Organization Owner')}
                       placeholder="admin@example.com"
                       required
-                      help={tct(
-                        'A request will be emailed to the new owner in order to transfer [project] to a new organization.',
-                        {
-                          project: <strong> {project.slug} </strong>,
-                        }
+                      help={t(
+                        'A request will be emailed to this address, asking the organization owner to accept the project transfer.'
                       )}
                     />
                   </Form>

--- a/src/sentry/templates/sentry/emails/transfer_project.html
+++ b/src/sentry/templates/sentry/emails/transfer_project.html
@@ -18,7 +18,7 @@
         <pre>requested at: {{ request_time }}</pre>
     </p>
     <p>Click below to approve the transfer of
-        <strong>{{ project_name }}</strong>. If you are the owner of more than one Sentry organization, you will be asked to choose which one should accept the project.</p>
+        <strong>{{ project_name }}</strong>. If you are an organization owner for more than one Sentry organization, you will be asked to choose which one should accept the project.</p>
     <p>
         <a href="{{ url }}" class="btn">Approve Transfer</a>
     </p>

--- a/src/sentry/templates/sentry/emails/transfer_project.txt
+++ b/src/sentry/templates/sentry/emails/transfer_project.txt
@@ -4,6 +4,6 @@ From Organization: {{ from_org }}
 Project: {{ project_name }}
 Requested by: {{ requester }}
 Requested at: {{ request_time }}>
-Click below to approve the transfer of {{ project_name }}. If you are the owner of more than one Sentry organization, you will be asked to choose which one should accept the project.
+Click below to approve the transfer of {{ project_name }}. If you are an organization owner for more than one Sentry organization, you will be asked to choose which one should accept the project.
 
 Approve transfer: {{url}}

--- a/src/sentry/templates/sentry/integrations/jira-config.html
+++ b/src/sentry/templates/sentry/integrations/jira-config.html
@@ -57,8 +57,8 @@
             </p>
             <p>
               The Sentry Jira integration is now enabled for the selected
-              organizations. Return to your sentry organization to configure the Jira
-              integration for your organization.
+              organizations. Return to your Sentry organization to finish configuring the
+              integration.
             </p>
           </div>
         {% endif %}
@@ -81,7 +81,7 @@
           </form>
         {% elif not completed %}
           <div class="aui-message aui-message-warning">
-            <p>You must have Organization Owner or Manager permissions in Sentry to complete setup.</p>
+            <p>You must be an organization owner or manager in Sentry to complete setup.</p>
           </div>
         {% endif %}
 

--- a/src/sentry/templates/sentry/integrations/jira-config.html
+++ b/src/sentry/templates/sentry/integrations/jira-config.html
@@ -81,7 +81,7 @@
           </form>
         {% elif not completed %}
           <div class="aui-message aui-message-warning">
-            <p>You must have Owner or Manager permissions in Sentry to complete setup.</p>
+            <p>You must have Organization Owner or Manager permissions in Sentry to complete setup.</p>
           </div>
         {% endif %}
 

--- a/src/sentry/templates/sentry/integrations/vsts-config.html
+++ b/src/sentry/templates/sentry/integrations/vsts-config.html
@@ -12,7 +12,7 @@
 <h3>Azure DevOps Configuration</h3>
 {% if no_accounts %}
   <p>
-    {% trans "No accounts found. Please check that you are an account owner." %}
+    {% trans "No accounts found. Please check that you are an Azure DevOps account owner." %}
   </p>
 {% else %}
   <form action="" method="post" class="form-stacked">

--- a/tests/js/fixtures/githubRepositoryProvider.js
+++ b/tests/js/fixtures/githubRepositoryProvider.js
@@ -8,7 +8,7 @@ export function GitHubRepositoryProvider(params = {}) {
         label: 'Repository Name',
         type: 'text',
         placeholder: 'e.g. getsentry/sentry',
-        help: 'Enter your repository name, including the GitHub organization.',
+        help: 'Enter your repository name, in the form <github-org/repo-name>.',
         required: true,
       },
     ],

--- a/tests/js/fixtures/githubRepositoryProvider.js
+++ b/tests/js/fixtures/githubRepositoryProvider.js
@@ -8,7 +8,7 @@ export function GitHubRepositoryProvider(params = {}) {
         label: 'Repository Name',
         type: 'text',
         placeholder: 'e.g. getsentry/sentry',
-        help: 'Enter your repository name, including the owner.',
+        help: 'Enter your repository name, including the GitHub organization.',
         required: true,
       },
     ],

--- a/tests/js/spec/components/group/suggestedOwners.spec.jsx
+++ b/tests/js/spec/components/group/suggestedOwners.spec.jsx
@@ -56,7 +56,7 @@ describe('SuggestedOwners', function() {
 
     expect(wrapper.find('ActorAvatar')).toHaveLength(2);
 
-    // One includes committers the other includes ownership rules
+    // One includes committers, the other includes ownership rules
     expect(
       wrapper
         .find('SuggestedOwnerHovercard')

--- a/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
+++ b/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
@@ -632,7 +632,7 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
               containerDisplayMode="inline-block"
               disabled={true}
               position="top"
-              title="You must be an Owner, Manager or Admin to install this."
+              title="You must be an Organization Owner, Manager or Admin to install this."
             >
               <AddButton
                 data-test-id="add-button"

--- a/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
+++ b/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
@@ -632,7 +632,7 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
               containerDisplayMode="inline-block"
               disabled={true}
               position="top"
-              title="You must be an Organization Owner, Manager or Admin to install this."
+              title="You must be an organization owner, manager or admin to install this."
             >
               <AddButton
                 data-test-id="add-button"

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -1687,8 +1687,8 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             </ForwardRef>
                                           </StyledButton>
                                         </Button>
-
-                                        ·
+                                         
+                                        · 
                                         <a
                                           onClick={[Function]}
                                         >
@@ -1992,8 +1992,8 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             </ForwardRef>
                                           </StyledButton>
                                         </Button>
-
-                                        ·
+                                         
+                                        · 
                                         <a
                                           onClick={[Function]}
                                         >
@@ -2015,14 +2015,14 @@ exports[`Sidebar can have onboarding feature 1`] = `
                           Object {
                             "description": "Bring your team aboard",
                             "detailedDescription": "Let Sentry help your team triage and assign issues. Improve your workflow
-          by unlocking suggested owners, mentions, and assignment.",
+          by unlocking mentions, assignment, and suggested issue owners.",
                             "display": true,
                             "featureLocation": "organization",
                             "location": "members/",
                             "prereq": Array [],
                             "skippable": true,
                             "task": 3,
-                            "title": "Invite team member",
+                            "title": "Invite team members",
                           }
                         }
                       >
@@ -2104,7 +2104,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         <h4
                                           className="css-158to6c-ItemHeader e1a4o5476"
                                         >
-                                          Invite team member
+                                          Invite team members
                                         </h4>
                                       </ItemHeader>
                                     </a>
@@ -2295,8 +2295,8 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             </ForwardRef>
                                           </StyledButton>
                                         </Button>
-
-                                        ·
+                                         
+                                        · 
                                         <a
                                           onClick={[Function]}
                                         >
@@ -2317,7 +2317,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                         task={
                           Object {
                             "description": "Add Sentry to a second platform",
-                            "detailedDescription": "Cross platform functionality to support both your frontend and backend.",
+                            "detailedDescription": "Capture errors from both your front and back ends.",
                             "display": true,
                             "featureLocation": "organization",
                             "location": "projects/new/",
@@ -2602,8 +2602,8 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             </ForwardRef>
                                           </StyledButton>
                                         </Button>
-
-                                        ·
+                                         
+                                        · 
                                         <a
                                           onClick={[Function]}
                                         >
@@ -2625,7 +2625,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                           Object {
                             "description": "Know who is being affected by crashes",
                             "detailedDescription": "Unlock features that let you
-          drill down into the number of users affected by an issue as well as get a broader sense about the quality of the application.",
+          drill down into the number of users affected by an issue and get a broader sense about the quality of your application.",
                             "display": true,
                             "featureLocation": "absolute",
                             "location": "https://docs.sentry.io/enriching-error-data/context/#capturing-the-user",
@@ -2911,8 +2911,8 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             </ForwardRef>
                                           </StyledButton>
                                         </Button>
-
-                                        ·
+                                         
+                                        · 
                                         <a
                                           onClick={[Function]}
                                         >
@@ -2933,8 +2933,8 @@ exports[`Sidebar can have onboarding feature 1`] = `
                         task={
                           Object {
                             "description": "See which releases cause errors",
-                            "detailedDescription": "Set up commits for additional context when determining the cause of an issue
-          e.g. suggested owners and resolve issues via commit messages.",
+                            "detailedDescription": "Set up releases and associate commits to gain additional context when determining the cause of an issue
+          and unlock the ability to resolve issues via commit message.",
                             "display": true,
                             "featureLocation": "project",
                             "location": "settings/release-tracking/",
@@ -2981,8 +2981,8 @@ exports[`Sidebar can have onboarding feature 1`] = `
                           task={
                             Object {
                               "description": "See which releases cause errors",
-                              "detailedDescription": "Set up commits for additional context when determining the cause of an issue
-          (e.g. suggested issue owners) and resolve issues via commit messages.",
+                              "detailedDescription": "Set up releases and associate commits to gain additional context when determining the cause of an issue
+          and unlock the ability to resolve issues via commit message.",
                               "display": true,
                               "featureLocation": "project",
                               "location": "settings/release-tracking/",
@@ -3220,8 +3220,8 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             </ForwardRef>
                                           </StyledButton>
                                         </Button>
-
-                                        ·
+                                         
+                                        · 
                                         <a
                                           onClick={[Function]}
                                         >
@@ -3242,7 +3242,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                         task={
                           Object {
                             "description": "Deminify JavaScript stack traces",
-                            "detailedDescription": "View source code context obtained from stack traces in their
+                            "detailedDescription": "View source code context obtained from stack traces in its
           original untransformed form, which is particularly useful for debugging minified code.",
                             "display": true,
                             "featureLocation": "absolute",
@@ -3529,8 +3529,8 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             </ForwardRef>
                                           </StyledButton>
                                         </Button>
-
-                                        ·
+                                         
+                                        · 
                                         <a
                                           onClick={[Function]}
                                         >

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -2067,7 +2067,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                               "prereq": Array [],
                               "skippable": true,
                               "task": 3,
-                              "title": "Invite team member",
+                              "title": "Invite team members",
                             }
                           }
                         >
@@ -2364,7 +2364,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                           task={
                             Object {
                               "description": "Add Sentry to a second platform",
-                              "detailedDescription": "Cross platform functionality to support both your frontend and backend.",
+                              "detailedDescription": "Capture errors from both your front and back ends.",
                               "display": true,
                               "featureLocation": "organization",
                               "location": "projects/new/",
@@ -2673,7 +2673,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                             Object {
                               "description": "Know who is being affected by crashes",
                               "detailedDescription": "Unlock features that let you
-          drill down into the number of users affected by an issue as well as get a broader sense about the quality of the application.",
+          drill down into the number of users affected by an issue and get a broader sense about the quality of your application.",
                               "display": true,
                               "featureLocation": "absolute",
                               "location": "https://docs.sentry.io/enriching-error-data/context/#capturing-the-user",
@@ -3290,7 +3290,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                           task={
                             Object {
                               "description": "Deminify JavaScript stack traces",
-                              "detailedDescription": "View source code context obtained from stack traces in their
+                              "detailedDescription": "View source code context obtained from stack traces in its
           original untransformed form, which is particularly useful for debugging minified code.",
                               "display": true,
                               "featureLocation": "absolute",

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -1687,8 +1687,8 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             </ForwardRef>
                                           </StyledButton>
                                         </Button>
-                                         
-                                        · 
+
+                                        ·
                                         <a
                                           onClick={[Function]}
                                         >
@@ -1992,8 +1992,8 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             </ForwardRef>
                                           </StyledButton>
                                         </Button>
-                                         
-                                        · 
+
+                                        ·
                                         <a
                                           onClick={[Function]}
                                         >
@@ -2060,7 +2060,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                             Object {
                               "description": "Bring your team aboard",
                               "detailedDescription": "Let Sentry help your team triage and assign issues. Improve your workflow
-          by unlocking suggested owners, mentions, and assignment.",
+          by unlocking mentions, assignment, and suggested issue owners.",
                               "display": true,
                               "featureLocation": "organization",
                               "location": "members/",
@@ -2295,8 +2295,8 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             </ForwardRef>
                                           </StyledButton>
                                         </Button>
-                                         
-                                        · 
+
+                                        ·
                                         <a
                                           onClick={[Function]}
                                         >
@@ -2602,8 +2602,8 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             </ForwardRef>
                                           </StyledButton>
                                         </Button>
-                                         
-                                        · 
+
+                                        ·
                                         <a
                                           onClick={[Function]}
                                         >
@@ -2911,8 +2911,8 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             </ForwardRef>
                                           </StyledButton>
                                         </Button>
-                                         
-                                        · 
+
+                                        ·
                                         <a
                                           onClick={[Function]}
                                         >
@@ -2982,7 +2982,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                             Object {
                               "description": "See which releases cause errors",
                               "detailedDescription": "Set up commits for additional context when determining the cause of an issue
-          e.g. suggested owners and resolve issues via commit messages.",
+          (e.g. suggested issue owners) and resolve issues via commit messages.",
                               "display": true,
                               "featureLocation": "project",
                               "location": "settings/release-tracking/",
@@ -3220,8 +3220,8 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             </ForwardRef>
                                           </StyledButton>
                                         </Button>
-                                         
-                                        · 
+
+                                        ·
                                         <a
                                           onClick={[Function]}
                                         >
@@ -3529,8 +3529,8 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             </ForwardRef>
                                           </StyledButton>
                                         </Button>
-                                         
-                                        · 
+
+                                        ·
                                         <a
                                           onClick={[Function]}
                                         >

--- a/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
@@ -594,7 +594,7 @@ exports[`Project Ownership Input renders 1`] = `
                   loadOptions={[Function]}
                   onChange={[Function]}
                   onInputChange={[Function]}
-                  placeholder="Add Owners"
+                  placeholder="owners"
                   value={Array []}
                   valueComponent={[Function]}
                 >
@@ -610,7 +610,7 @@ exports[`Project Ownership Input renders 1`] = `
                     multiple={true}
                     onChange={[Function]}
                     onInputChange={[Function]}
-                    placeholder="Add Owners"
+                    placeholder="owners"
                     value={Array []}
                     valueComponent={[Function]}
                   >
@@ -630,7 +630,7 @@ exports[`Project Ownership Input renders 1`] = `
                       multiple={true}
                       onChange={[Function]}
                       onInputChange={[Function]}
-                      placeholder="Add Owners"
+                      placeholder="owners"
                       value={Array []}
                       valueComponent={[Function]}
                     >
@@ -650,7 +650,7 @@ exports[`Project Ownership Input renders 1`] = `
                         multiple={true}
                         onChange={[Function]}
                         onInputChange={[Function]}
-                        placeholder="Add Owners"
+                        placeholder="owners"
                         value={Array []}
                         valueComponent={[Function]}
                       >
@@ -671,7 +671,7 @@ exports[`Project Ownership Input renders 1`] = `
                           multiple={true}
                           onChange={[Function]}
                           onInputChange={[Function]}
-                          placeholder="Add Owners"
+                          placeholder="owners"
                           value={Array []}
                           valueComponent={[Function]}
                         >
@@ -695,7 +695,7 @@ exports[`Project Ownership Input renders 1`] = `
                             onChange={[Function]}
                             onInputChange={[Function]}
                             options={Array []}
-                            placeholder="Add Owners"
+                            placeholder="owners"
                             searchPromptText="Type to search"
                             value={Array []}
                             valueComponent={[Function]}

--- a/tests/js/spec/views/__snapshots__/projectTeams.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTeams.spec.jsx.snap
@@ -10,7 +10,7 @@ exports[`ProjectTeams renders 1`] = `
       title="project-slug Teams"
     />
     <withApi(TeamSelect)
-      confirmLastTeamRemoveMessage="This is the last team with access to this project. Removing it will mean only owners and managers will be able to access the project pages. Are you sure you want to remove this team from the project project-slug?"
+      confirmLastTeamRemoveMessage="This is the last team with access to this project. Removing it will mean only organization owners and managers will be able to access the project pages. Are you sure you want to remove this team from the project project-slug?"
       disabled={false}
       menuHeader={
         <StyledTeamsLabel>

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -575,7 +575,7 @@ exports[`RuleBuilder renders 1`] = `
                 loadOptions={[Function]}
                 onChange={[Function]}
                 onInputChange={[Function]}
-                placeholder="Add Owners"
+                placeholder="owners"
                 value={Array []}
                 valueComponent={[Function]}
               >
@@ -591,7 +591,7 @@ exports[`RuleBuilder renders 1`] = `
                   multiple={true}
                   onChange={[Function]}
                   onInputChange={[Function]}
-                  placeholder="Add Owners"
+                  placeholder="owners"
                   value={Array []}
                   valueComponent={[Function]}
                 >
@@ -611,7 +611,7 @@ exports[`RuleBuilder renders 1`] = `
                     multiple={true}
                     onChange={[Function]}
                     onInputChange={[Function]}
-                    placeholder="Add Owners"
+                    placeholder="owners"
                     value={Array []}
                     valueComponent={[Function]}
                   >
@@ -631,7 +631,7 @@ exports[`RuleBuilder renders 1`] = `
                       multiple={true}
                       onChange={[Function]}
                       onInputChange={[Function]}
-                      placeholder="Add Owners"
+                      placeholder="owners"
                       value={Array []}
                       valueComponent={[Function]}
                     >
@@ -652,7 +652,7 @@ exports[`RuleBuilder renders 1`] = `
                         multiple={true}
                         onChange={[Function]}
                         onInputChange={[Function]}
-                        placeholder="Add Owners"
+                        placeholder="owners"
                         value={Array []}
                         valueComponent={[Function]}
                       >
@@ -676,7 +676,7 @@ exports[`RuleBuilder renders 1`] = `
                           onChange={[Function]}
                           onInputChange={[Function]}
                           options={Array []}
-                          placeholder="Add Owners"
+                          placeholder="owners"
                           searchPromptText="Type to search"
                           value={Array []}
                           valueComponent={[Function]}
@@ -862,7 +862,7 @@ exports[`RuleBuilder renders 1`] = `
                               ]
                             }
                             pageSize={5}
-                            placeholder="Add Owners"
+                            placeholder="owners"
                             removeSelected={true}
                             required={false}
                             rtl={false}
@@ -894,7 +894,7 @@ exports[`RuleBuilder renders 1`] = `
                                   <div
                                     className="Select-placeholder"
                                   >
-                                    Add Owners
+                                    owners
                                   </div>
                                   <AutosizeInput
                                     aria-activedescendant="react-select-3--value"
@@ -1911,7 +1911,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                 loadOptions={[Function]}
                 onChange={[Function]}
                 onInputChange={[Function]}
-                placeholder="Add Owners"
+                placeholder="owners"
                 value={
                   Array [
                     Object {
@@ -1965,7 +1965,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                   multiple={true}
                   onChange={[Function]}
                   onInputChange={[Function]}
-                  placeholder="Add Owners"
+                  placeholder="owners"
                   value={
                     Array [
                       Object {
@@ -2023,7 +2023,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                     multiple={true}
                     onChange={[Function]}
                     onInputChange={[Function]}
-                    placeholder="Add Owners"
+                    placeholder="owners"
                     value={
                       Array [
                         Object {
@@ -2081,7 +2081,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                       multiple={true}
                       onChange={[Function]}
                       onInputChange={[Function]}
-                      placeholder="Add Owners"
+                      placeholder="owners"
                       value={
                         Array [
                           Object {
@@ -2140,7 +2140,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                         multiple={true}
                         onChange={[Function]}
                         onInputChange={[Function]}
-                        placeholder="Add Owners"
+                        placeholder="owners"
                         value={
                           Array [
                             Object {
@@ -2202,7 +2202,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                           onChange={[Function]}
                           onInputChange={[Function]}
                           options={Array []}
-                          placeholder="Add Owners"
+                          placeholder="owners"
                           searchPromptText="Type to search"
                           value={
                             Array [
@@ -2426,7 +2426,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                               ]
                             }
                             pageSize={5}
-                            placeholder="Add Owners"
+                            placeholder="owners"
                             removeSelected={true}
                             required={false}
                             rtl={false}
@@ -2500,7 +2500,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                     key="value-0-user:1"
                                     onClick={null}
                                     onRemove={[Function]}
-                                    placeholder="Add Owners"
+                                    placeholder="owners"
                                     value={
                                       Object {
                                         "actor": Object {

--- a/tests/js/spec/views/projectGeneralSettings.spec.jsx
+++ b/tests/js/spec/views/projectGeneralSettings.spec.jsx
@@ -212,7 +212,7 @@ describe('projectGeneralSettings', function() {
         .first()
         .text()
     ).toBe(
-      'These settings can only be edited by users with the owner, manager, or admin role.'
+      'These settings can only be edited by users with the organization owner, manager, or admin role.'
     );
   });
 

--- a/tests/js/spec/views/settings/organizationGeneralSettings.spec.jsx
+++ b/tests/js/spec/views/settings/organizationGeneralSettings.spec.jsx
@@ -124,7 +124,7 @@ describe('OrganizationGeneralSettings', function() {
         .first()
         .text()
     ).toEqual(
-      'These settings can only be edited by users with the owner or manager role.'
+      'These settings can only be edited by users with the organization owner or manager role.'
     );
   });
 

--- a/tests/sentry/integrations/jira/test_configure.py
+++ b/tests/sentry/integrations/jira/test_configure.py
@@ -11,7 +11,7 @@ from sentry.testutils import APITestCase
 from sentry.utils.http import absolute_uri
 
 
-PERMISSIONS_WARNING = 'You must have Organization Owner or Manager permissions in Sentry to complete setup.'
+PERMISSIONS_WARNING = 'You must be an organization owner or manager in Sentry to complete setup.'
 REFRESH_REQUIRED = 'This page has expired, please refresh to configure your Sentry integration'
 LOGIN_REQUIRED = 'Please login to your Sentry account to access the Sentry Add-on configuration'
 ORGANIZATIONS_FORM = 'Enabled Sentry Organizations'

--- a/tests/sentry/integrations/jira/test_configure.py
+++ b/tests/sentry/integrations/jira/test_configure.py
@@ -11,7 +11,7 @@ from sentry.testutils import APITestCase
 from sentry.utils.http import absolute_uri
 
 
-PERMISSIONS_WARNING = 'You must have Owner or Manager permissions in Sentry to complete setup.'
+PERMISSIONS_WARNING = 'You must have Organization Owner or Manager permissions in Sentry to complete setup.'
 REFRESH_REQUIRED = 'This page has expired, please refresh to configure your Sentry integration'
 LOGIN_REQUIRED = 'Please login to your Sentry account to access the Sentry Add-on configuration'
 ORGANIZATIONS_FORM = 'Enabled Sentry Organizations'


### PR DESCRIPTION
Per SEN-598, rename "owner" role to "org owner." Also clarify places where "owner" actually means "issue owner," and do other language clean-up.

To be merged at the same time as ~https://github.com/getsentry/getsentry/pull/2895~, ~https://github.com/getsentry/sentry.io/pull/583~, https://github.com/getsentry/sentry-docs/pull/983, and ~https://github.com/getsentry/static-sites/pull/1~, and just before ~https://github.com/getsentry/sentry/pull/13239~.