### PR TITLE
fix(forms): Merge global submit errors into errors map

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
@@ -649,7 +649,7 @@ class FormModel {
   @action
   submitError(err) {
     this.formState = FormState.ERROR;
-    this.formErrors = err.responseJSON;
+    this.errors.merge(err.responseJSON);
     this.handleErrorResponse(err);
   }
 }


### PR DESCRIPTION
The `formErrors` property was not used anywhere else in the form model.  In general it seems more correct to expect the response JSON to merge field errors.