### PR TITLE
fix(ui): Only apply pygment highlighting to pre tags

### DIFF
--- a/src/sentry/static/sentry/less/includes/pygments.less
+++ b/src/sentry/static/sentry/less/includes/pygments.less
@@ -1,4 +1,4 @@
-.highlight {
+pre.highlight {
   background: #f5fafe;
   border: 1px solid #c8cbd1;
   box-shadow: 0 2px 0 rgba(37, 11, 54, 0.04);


### PR DESCRIPTION
The highlight class is used for a few other things