### PR TITLE
feat(api): Support passing group ids to event search endpoint (SEN-584)

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -1,16 +1,30 @@
 from __future__ import absolute_import
 
+from rest_framework.exceptions import PermissionDenied
+
 from sentry import features
 from sentry.api.bases import OrganizationEndpoint, OrganizationEventsError
 from sentry.api.event_search import get_snuba_query_args, InvalidSearchQuery
+from sentry.models.project import Project
 
 
 class OrganizationEventsEndpointBase(OrganizationEndpoint):
 
     def get_snuba_query_args(self, request, organization):
         params = self.get_filter_params(request, organization)
-        query = request.GET.get('query')
 
+        group_ids = set(map(int, request.GET.getlist('group')))
+        if group_ids:
+            projects = Project.objects.filter(
+                organization=organization,
+                group__id__in=group_ids,
+            ).distinct()
+            if any(p for p in projects if not request.access.has_project_access(p)):
+                raise PermissionDenied
+            params['issue.id'] = list(group_ids)
+            params['project_id'] = list(set([p.id for p in projects] + params['project_id']))
+
+        query = request.GET.get('query')
         try:
             snuba_args = get_snuba_query_args(query=query, params=params)
         except InvalidSearchQuery as exc:

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -588,6 +588,76 @@ class OrganizationEventsEndpointTest(OrganizationEventsTestBase):
             assert response.status_code == 400
             assert response.content == '{"detail": "Boolean search operator OR and AND not allowed in this search."}'
 
+    def test_group_filtering(self):
+        user = self.create_user()
+        org = self.create_organization(owner=user)
+        self.login_as(user=user)
+
+        team = self.create_team(organization=org, members=[user])
+
+        self.login_as(user=user)
+
+        project = self.create_project(organization=org, teams=[team])
+        events = []
+        for event_id, fingerprint in [
+            ('a' * 32, 'put-me-in-group1'),
+            ('b' * 32, 'put-me-in-group1'),
+            ('c' * 32, 'put-me-in-group2'),
+            ('d' * 32, 'put-me-in-group3'),
+        ]:
+            events.append(self.store_event(
+                data={
+                    'event_id': event_id,
+                    'timestamp': self.min_ago.isoformat()[:19],
+                    'fingerprint': [fingerprint],
+                },
+                project_id=project.id
+            ))
+
+        event_1, event_2, event_3, event_4 = events
+        group_1, group_2, group_3 = event_1.group, event_3.group, event_4.group
+
+        base_url = reverse(
+            'sentry-api-0-organization-events',
+            kwargs={
+                'organization_slug': org.slug,
+            }
+        )
+
+        response = self.client.get(base_url, format='json', data={'group': [group_1.id]})
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 2
+        self.assert_events_in_response(response, [event_1.event_id, event_2.event_id])
+
+        response = self.client.get(base_url, format='json', data={'group': [group_3.id]})
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        self.assert_events_in_response(response, [event_4.event_id])
+
+        response = self.client.get(
+            base_url,
+            format='json',
+            data={'group': [group_1.id, group_3.id]},
+        )
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 3
+        self.assert_events_in_response(
+            response,
+            [event_1.event_id, event_2.event_id, event_4.event_id],
+        )
+
+        response = self.client.get(
+            base_url,
+            format='json',
+            data={'group': [group_1.id, group_2.id, group_3.id]},
+        )
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 4
+        self.assert_events_in_response(
+            response,
+            [event_1.event_id, event_2.event_id, event_3.event_id, event_4.event_id],
+        )
+
 
 class OrganizationEventsStatsEndpointTest(OrganizationEventsTestBase):
     def test_simple(self):


### PR DESCRIPTION
When we want to view events related to an incident, we'll pass the following data from the incident
to the organization events endpoint:
 - related project slugs
 - related group ids
 - query
 - start
 - end

This way the user can filter the results however they want using the standard event search page.