### PR TITLE
feat(forms): Allow custom submit handler to update model saving state

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/form.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/form.jsx
@@ -109,7 +109,8 @@ export default class Form extends React.Component {
         this.model.getData(),
         this.onSubmitSuccess,
         this.onSubmitError,
-        e
+        e,
+        this.model.setFormSaving.bind(this.model)
       );
     } else {
       this.model.saveForm();

--- a/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/model.jsx
@@ -359,7 +359,7 @@ class FormModel {
       data: this.getTransformedData(),
     });
 
-    this.formState = FormState.SAVING;
+    this.setFormSaving();
     request
       .then(resp => {
         // save snapshot
@@ -547,6 +547,11 @@ class FormModel {
     }
 
     return this.saveField(id, currentValue);
+  }
+
+  @action
+  setFormSaving() {
+    this.formState = FormState.SAVING;
   }
 
   /**


### PR DESCRIPTION
When using `<Form>`, you can specify a custom submit handler. However you will not be able to update
model saving state (which generally disables the submit button). Pass a model action that updates saving state to the submit callback handler.