### PR TITLE
fix(testing): Fix typo

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -660,7 +660,7 @@ class PermissionTestCase(TestCase):
         self.assert_cannot_access(user, path, **kwargs)
 
     def assert_team_admin_can_access(self, path, **kwargs):
-        return self.assert_role_can_access(path, 'owner', **kwargs)
+        return self.assert_role_can_access(path, 'admin', **kwargs)
 
     def assert_teamless_admin_can_access(self, path, **kwargs):
         user = self.create_user(is_superuser=False)


### PR DESCRIPTION
Pretty sure this is supposed to be `admin`, given the function name and how the other functions work. Of course, we don't actually _use_ this function anywhere, but just in case we decide to someday...