### PR TITLE
Revert "fix: Add event size metric with event_id"

### DIFF
--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -6,7 +6,6 @@ from datetime import datetime
 
 from sentry.models import Event, EventDict
 from sentry.utils import json, metrics
-from sentry.utils.safe import get_path
 
 
 logger = logging.getLogger(__name__)
@@ -104,16 +103,6 @@ def get_task_kwargs_for_message(value):
 
     metrics.timing('evenstream.events.size.data', len(value))
     payload = json.loads(value)
-
-    event_id = get_path(payload, 2, 'event_id')
-    project_id = get_path(payload, 2, 'project_id')
-    metrics.incr(
-        'evenstream.events.size.data.mb_bucket.%s' % (len(value) // (10 ** 6),),
-        tags={
-            'project_id': project_id or 'None',
-            'event': '%s,%s' % (project_id, event_id)
-        }
-    )
 
     try:
         version = payload[0]


### PR DESCRIPTION
This is now how metrics are supposed to be used.