### PR TITLE
fix(api): Fix broken incident tests caused by bad merge

### DIFF
--- a/src/sentry/api/endpoints/organization_incident_index.py
+++ b/src/sentry/api/endpoints/organization_incident_index.py
@@ -120,7 +120,7 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
                 query=result.get('query', ''),
                 date_started=result['dateStarted'],
                 date_detected=result.get('dateDetected', result['dateStarted']),
-                projects=all_projects,
+                projects=result['projects'],
                 groups=groups,
             )
             return Response(serialize(incident, request.user), status=201)


### PR DESCRIPTION
We handle loading the projects for groups in the `create_incident` function now, so no need to pass all projects in.