### PR TITLE
ref(ui) Use new tooltips in more places

### DIFF
--- a/docs-ui/components/avatar.stories.js
+++ b/docs-ui/components/avatar.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
+import {boolean} from '@storybook/addon-knobs';
 
 import Avatar from 'app/components/avatar';
 
@@ -15,14 +16,16 @@ storiesOf('UI|Avatar', module)
   .add(
     'Letters',
     withInfo('This is the default avatar')(() => {
-      let user = Object.assign({}, USER);
-      return <Avatar user={user} />;
+      const hasTooltip = boolean('Display a tooltip', false);
+      const user = Object.assign({}, USER);
+      return <Avatar user={user} hasTooltip={hasTooltip} />;
     })
   )
   .add(
     'Gravatar',
     withInfo('Avatar source from gravatar')(() => {
-      let user = {
+      const hasTooltip = boolean('Display a tooltip', false);
+      const user = {
         id: 2,
         name: 'Ben Vinegar',
         email: 'ben@benv.ca',
@@ -31,28 +34,30 @@ storiesOf('UI|Avatar', module)
           avatarUuid: '2d641b5d-8c74-44de-9cb6-fbd54701b35e',
         },
       };
-      return <Avatar user={user} />;
+      return <Avatar user={user} hasTooltip={hasTooltip} />;
     })
   )
   .add(
     'Uploaded Image',
     withInfo('Uploaded image')(() => {
-      let user = Object.assign({}, USER, {
+      const hasTooltip = boolean('Display a tooltip', false);
+      const user = Object.assign({}, USER, {
         avatar: {
           avatarType: 'upload',
           avatarUuid: '51e63edabf31412aa2a955e9cf2c1ca0',
         },
       });
-      return <Avatar user={user} />;
+      return <Avatar user={user} hasTooltip={hasTooltip} />;
     })
   )
   .add(
     'Team Avatar',
     withInfo('Avatar for teams')(() => {
-      let team = {
+      const hasTooltip = boolean('Display a tooltip', false);
+      const team = {
         name: 'Captain Planet',
         slug: 'captain-planet',
       };
-      return <Avatar team={team} />;
+      return <Avatar team={team} hasTooltip={hasTooltip} />;
     })
   );

--- a/src/sentry/static/sentry/app/components/avatar/baseAvatar.jsx
+++ b/src/sentry/static/sentry/app/components/avatar/baseAvatar.jsx
@@ -25,7 +25,13 @@ class BaseAvatar extends React.Component {
      * Default gravatar to display
      */
     default: PropTypes.string,
+    /**
+     * Enable to display tooltips.
+     */
     hasTooltip: PropTypes.bool,
+    /**
+     * The type of avatar being rendered.
+     */
     type: PropTypes.string,
     /**
      * Path to uploaded avatar (differs based on model type)
@@ -40,7 +46,13 @@ class BaseAvatar extends React.Component {
     gravatarId: PropTypes.string,
     letterId: PropTypes.string,
     title: PropTypes.string,
+    /**
+     * The content for the tooltip. Requires hasTooltip to display
+     */
     tooltip: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    /**
+     * Additional props for the tooltip
+     */
     tooltipOptions: PropTypes.object,
     /**
      * Should avatar be round instead of a square

--- a/src/sentry/static/sentry/app/components/betaTag.jsx
+++ b/src/sentry/static/sentry/app/components/betaTag.jsx
@@ -1,21 +1,19 @@
 import React from 'react';
 import styled from 'react-emotion';
 import Tag from 'app/views/settings/components/tag';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import space from 'app/styles/space';
 import {t} from 'app/locale';
 
 const BetaTag = () => (
-  <Tooltip
+  <Tooltip2
     title={t('This feature is in beta and may change in the future.')}
-    tooltipOptions={{
-      placement: 'right',
-    }}
+    position="right"
   >
     <StyledTag priority="beta" size="small">
       beta
     </StyledTag>
-  </Tooltip>
+  </Tooltip2>
 );
 
 const StyledTag = styled(Tag)`

--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
@@ -8,7 +8,7 @@ import {capitalize} from 'lodash';
 import ProjectLink from 'app/components/projectLink';
 import {Metadata} from 'app/sentryTypes';
 import EventOrGroupTitle from 'app/components/eventOrGroupTitle';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import {isNativePlatform} from 'app/utils/platform';
 
 /**
@@ -109,9 +109,11 @@ class EventOrGroupHeader extends React.Component {
         style={data.status === 'resolved' ? {textDecoration: 'line-through'} : null}
       >
         {!hideLevel && level && (
-          <Tooltip title={`Error level: ${capitalize(level)}`}>
-            <GroupLevel level={data.level} />
-          </Tooltip>
+          <GroupLevel level={data.level}>
+            <Tooltip2 title={`Error level: ${capitalize(level)}`}>
+              <span />
+            </Tooltip2>
+          </GroupLevel>
         )}
         {!hideIcons && data.status === 'ignored' && <Muted className="icon-soundoff" />}
         {!hideIcons && data.isBookmarked && <Starred className="icon-star-solid" />}
@@ -222,6 +224,12 @@ const GroupLevel = styled('div')`
         return p.theme.gray2;
     }
   }};
+
+  & span {
+    display: block;
+    width: 9px;
+    height: 15px;
+  }
 `;
 
 export default withRouter(EventOrGroupHeader);

--- a/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import {t} from 'app/locale';
 import GuideAnchor from 'app/components/assistant/guideAnchor';
 
@@ -92,13 +92,11 @@ const CrashHeader = createReactClass({
         <h3 className="pull-left">
           {this.props.title}
           <small style={{marginLeft: 5}}>
-            (
-            <Tooltip title={t('Toggle stacktrace order')}>
+            <Tooltip2 title={t('Toggle stacktrace order')}>
               <a onClick={this.toggleOrder} style={{borderBottom: '1px dotted #aaa'}}>
                 {newestFirst ? t('most recent call first') : t('most recent call last')}
               </a>
-            </Tooltip>
-            )
+            </Tooltip2>
           </small>
         </h3>
         <div className="btn-group" style={{marginLeft: 10}}>

--- a/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
@@ -92,11 +92,13 @@ const CrashHeader = createReactClass({
         <h3 className="pull-left">
           {this.props.title}
           <small style={{marginLeft: 5}}>
-            (<Tooltip2 title={t('Toggle stacktrace order')}>
+            (
+            <Tooltip2 title={t('Toggle stacktrace order')}>
               <a onClick={this.toggleOrder} style={{borderBottom: '1px dotted #aaa'}}>
                 {newestFirst ? t('most recent call first') : t('most recent call last')}
               </a>
-            </Tooltip2>)
+            </Tooltip2>
+            )
           </small>
         </h3>
         <div className="btn-group" style={{marginLeft: 10}}>

--- a/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
@@ -92,11 +92,11 @@ const CrashHeader = createReactClass({
         <h3 className="pull-left">
           {this.props.title}
           <small style={{marginLeft: 5}}>
-            <Tooltip2 title={t('Toggle stacktrace order')}>
+            (<Tooltip2 title={t('Toggle stacktrace order')}>
               <a onClick={this.toggleOrder} style={{borderBottom: '1px dotted #aaa'}}>
                 {newestFirst ? t('most recent call first') : t('most recent call last')}
               </a>
-            </Tooltip2>
+            </Tooltip2>)
           </small>
         </h3>
         <div className="btn-group" style={{marginLeft: 10}}>

--- a/src/sentry/static/sentry/app/components/events/interfaces/frameRegisters.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frameRegisters.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import {t} from 'app/locale';
 import {defined, objectToArray} from 'app/utils';
 
@@ -48,9 +48,9 @@ export class RegisterValue extends React.Component {
     return (
       <InlinePre>
         <FixedWidth>{this.formatValue(this.props.value)}</FixedWidth>
-        <Tooltip title={REGISTER_VIEWS[this.state.view]} onClick={this.toggleView}>
-          <Toggle className="icon-filter" />
-        </Tooltip>
+        <Tooltip2 title={REGISTER_VIEWS[this.state.view]}>
+          <Toggle className="icon-filter" onClick={this.toggleView} />
+        </Tooltip2>
       </InlinePre>
     );
   }

--- a/src/sentry/static/sentry/app/components/events/meta/annotatedText.jsx
+++ b/src/sentry/static/sentry/app/components/events/meta/annotatedText.jsx
@@ -4,9 +4,8 @@ import React from 'react';
 import styled from 'react-emotion';
 
 import InlineSvg from 'app/components/inlineSvg';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import {t, tn} from 'app/locale';
-import utils from 'app/utils';
 
 const Chunks = styled('span')`
   span {
@@ -47,9 +46,9 @@ function renderChunk(chunk) {
   if (chunk.type === 'redaction') {
     const title = t('%s due to PII rule "%s"', REMARKS[chunk.remark], chunk.rule_id);
     return (
-      <Tooltip title={title}>
+      <Tooltip2 title={title}>
         <Redaction>{chunk.text}</Redaction>
-      </Tooltip>
+      </Tooltip2>
     );
   }
 
@@ -82,7 +81,7 @@ function renderValue(value, chunks, errors, remarks) {
 
   if (remarks && remarks.length) {
     const title = t('%s due to PII rule "%s"', REMARKS[remarks[0][1]], remarks[0][0]);
-    element = <Tooltip title={title}>{element}</Tooltip>;
+    element = <Tooltip2 title={title}>{element}</Tooltip2>;
   }
 
   return element;
@@ -93,19 +92,21 @@ function renderErrors(errors) {
     return null;
   }
 
-  const tooltip = `
-  <div style="text-align: left">
-    <strong>${tn('Processing Error:', 'Processing Errors:', errors.length)}</strong>
-    <ul>
-      ${errors.map(e => `<li>${utils.escape(e)}</li>`)}
-    </ul>
-  </div>
-  `;
+  const tooltip = (
+    <div style={{'text-align': 'left'}}>
+      <strong>{tn('Processing Error:', 'Processing Errors:', errors.length)}</strong>
+      <ul>
+        {errors.map(e => (
+          <li key={e}>{e}</li>
+        ))}
+      </ul>
+    </div>
+  );
 
   return (
-    <Tooltip title={tooltip} tooltipOptions={{html: true}}>
+    <Tooltip2 title={tooltip}>
       <ErrorIcon src="icon-circle-exclamation" />
-    </Tooltip>
+    </Tooltip2>
   );
 }
 

--- a/src/sentry/static/sentry/app/components/fileChange.jsx
+++ b/src/sentry/static/sentry/app/components/fileChange.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Avatar from 'app/components/avatar';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import InlineSvg from 'app/components/inlineSvg';
 
 class FileChange extends React.PureComponent {
@@ -29,11 +29,11 @@ class FileChange extends React.PureComponent {
           <div className="col-sm-2 avatar-grid align-right">
             {authors.map((author, i) => {
               return (
-                <Tooltip key={i} title={`${author.name} ${author.email}`}>
+                <Tooltip2 key={i} title={`${author.name} ${author.email}`}>
                   <span className="avatar-grid-item m-b-0">
                     <Avatar user={author} />
                   </span>
-                </Tooltip>
+                </Tooltip2>
               );
             })}
           </div>

--- a/src/sentry/static/sentry/app/components/modals/integrationDetailsModal.jsx
+++ b/src/sentry/static/sentry/app/components/modals/integrationDetailsModal.jsx
@@ -15,7 +15,7 @@ import InlineSvg from 'app/components/inlineSvg';
 import PluginIcon from 'app/plugins/components/pluginIcon';
 import SentryTypes from 'app/sentryTypes';
 import Tag from 'app/views/settings/components/tag';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import marked, {singleLineRenderer} from 'app/utils/marked';
 import space from 'app/styles/space';
 
@@ -172,7 +172,7 @@ class IntegrationDetailsModal extends React.Component {
               </Button>
               <Access organization={organization} access={['org:integrations']}>
                 {({hasAccess}) => (
-                  <Tooltip
+                  <Tooltip2
                     title={t('You must be an Owner, Manager or Admin to install this.')}
                     disabled={hasAccess}
                   >
@@ -180,7 +180,7 @@ class IntegrationDetailsModal extends React.Component {
                       data-test-id="add-button"
                       disabled={disabled || !hasAccess}
                     />
-                  </Tooltip>
+                  </Tooltip2>
                 )}
               </Access>
             </div>

--- a/src/sentry/static/sentry/app/components/noProjectMessage.jsx
+++ b/src/sentry/static/sentry/app/components/noProjectMessage.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import {t} from 'app/locale';
 import Button from 'app/components/button';
 import PageHeading from 'app/components/pageHeading';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import ConfigStore from 'app/stores/configStore';
@@ -47,7 +47,7 @@ export default class NoProjectMessage extends React.Component {
             </HelpMessage>
             <Flex align="center">
               <CallToAction>
-                <Tooltip
+                <Tooltip2
                   disabled={canJoinTeam}
                   title={t('You do not have permission to join a team.')}
                 >
@@ -58,11 +58,11 @@ export default class NoProjectMessage extends React.Component {
                   >
                     {t('Join a Team')}
                   </Button>
-                </Tooltip>
+                </Tooltip2>
               </CallToAction>
 
               <CallToAction>
-                <Tooltip
+                <Tooltip2
                   disabled={canCreateProject}
                   title={t('You do not have permission to create a project.')}
                 >
@@ -72,7 +72,7 @@ export default class NoProjectMessage extends React.Component {
                   >
                     {t('Create project')}
                   </Button>
-                </Tooltip>
+                </Tooltip2>
               </CallToAction>
             </Flex>
           </Content>

--- a/src/sentry/static/sentry/app/components/organizations/backToIssues.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/backToIssues.jsx
@@ -13,8 +13,6 @@ const BackToIssues = styled(Link)`
   height: ${space(1.5)};
   border-radius: 50%;
   box-sizing: content-box;
-  margin: 0 -${space(2)} 0 ${space(2)};
-  position: relative;
   z-index: 1;
   transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
@@ -32,8 +32,9 @@ import Tooltip2 from 'app/components/tooltip2';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import ConfigStore from 'app/stores/configStore';
 import withProjects from 'app/utils/withProjects';
-import {getStateFromQuery} from './utils';
 import space from 'app/styles/space';
+
+import {getStateFromQuery} from './utils';
 
 class GlobalSelectionHeader extends React.Component {
   static propTypes = {

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
@@ -28,11 +28,12 @@ import MultipleEnvironmentSelector from 'app/components/organizations/multipleEn
 import MultipleProjectSelector from 'app/components/organizations/multipleProjectSelector';
 import SentryTypes from 'app/sentryTypes';
 import TimeRangeSelector from 'app/components/organizations/timeRangeSelector';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import ConfigStore from 'app/stores/configStore';
 import withProjects from 'app/utils/withProjects';
 import {getStateFromQuery} from './utils';
+import space from 'app/styles/space';
 
 class GlobalSelectionHeader extends React.Component {
   static propTypes = {
@@ -330,16 +331,13 @@ class GlobalSelectionHeader extends React.Component {
     const {organization, location} = this.props;
     return (
       <BackButtonWrapper>
-        <Tooltip
-          title={t('Back to Issues Stream')}
-          tooltipOptions={{placement: 'bottom'}}
-        >
+        <Tooltip2 title={t('Back to Issues Stream')} position="bottom">
           <BackToIssues
             to={`/organizations/${organization.slug}/issues/${location.search}`}
           >
             <InlineSvg src="icon-arrow-left" />
           </BackToIssues>
-        </Tooltip>
+        </Tooltip2>
       </BackButtonWrapper>
     );
   };
@@ -423,4 +421,6 @@ const BackButtonWrapper = styled('div')`
   display: flex;
   align-items: center;
   height: 100%;
+  position: relative;
+  left: ${space(2)};
 `;

--- a/src/sentry/static/sentry/app/components/organizations/headerItem.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/headerItem.jsx
@@ -4,7 +4,7 @@ import styled from 'react-emotion';
 import {Link} from 'react-router';
 
 import InlineSvg from 'app/components/inlineSvg';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import space from 'app/styles/space';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 
@@ -76,14 +76,9 @@ class HeaderItem extends React.Component {
           </StyledChevron>
         )}
         {locked && (
-          <Tooltip
-            title={lockedMessage || 'This selection is locked'}
-            tooltipOptions={{
-              placement: 'bottom',
-            }}
-          >
+          <Tooltip2 title={lockedMessage || 'This selection is locked'} position="bottom">
             <StyledLock src="icon-lock" />
-          </Tooltip>
+          </Tooltip2>
         )}
       </StyledHeaderItem>
     );

--- a/src/sentry/static/sentry/app/components/sidebar/onboardingStatus.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/onboardingStatus.jsx
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import Tooltip2 from 'app/components/tooltip2';
 import {analytics} from 'app/utils/analytics';
-import {t} from '../../locale';
+import {tct} from 'app/locale';
 import SidebarPanel from './sidebarPanel';
 import TodoList, {TASKS} from '../onboardingWizard/todos';
-import Tooltip from '../tooltip';
 
 class OnboardingStatus extends React.Component {
   static propTypes = {
@@ -59,17 +59,18 @@ class OnboardingStatus extends React.Component {
     if (doneTasks.length >= allDisplayedTasks.length) {
       return null;
     }
+    const title = tct(
+      'Getting started with Sentry: [br] [done] / [all] tasks completed',
+      {
+        br: <br />,
+        done: doneTasks.length,
+        all: allDisplayedTasks.length,
+      }
+    );
 
     return (
       <div className={currentPanel === 'todos' ? 'onboarding active' : 'onboarding'}>
-        <Tooltip
-          title={t(
-            `Getting started with Sentry: <br />${doneTasks.length} / ${
-              allDisplayedTasks.length
-            } tasks completed`
-          )}
-          tooltipOptions={{html: true}}
-        >
+        <Tooltip2 title={title}>
           <div
             data-test-id="onboarding-progress-bar"
             className="onboarding-progress-bar"
@@ -77,7 +78,7 @@ class OnboardingStatus extends React.Component {
           >
             <div className="slider" style={style} />
           </div>
-        </Tooltip>
+        </Tooltip2>
         {showPanel && currentPanel === 'todos' && (
           <SidebarPanel
             collapsed={collapsed}

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
@@ -4,10 +4,10 @@ import React from 'react';
 import styled, {css} from 'react-emotion';
 
 import HookOrDefault from 'app/components/hookOrDefault';
+import Tooltip2 from 'app/components/tooltip2';
 
 import Link from '../links/link';
 import TextOverflow from '../textOverflow';
-import Tooltip from '../tooltip';
 
 const LabelHook = HookOrDefault({
   hookName: 'sidebar:item-label',
@@ -82,11 +82,7 @@ class SidebarItem extends React.Component {
     const placement = isTop ? 'bottom' : 'right';
 
     return (
-      <Tooltip
-        disabled={!collapsed}
-        title={label}
-        tooltipOptions={{placement, html: true}}
-      >
+      <Tooltip2 disabled={!collapsed} title={label} placement={placement}>
         <StyledSidebarItem
           data-test-id={this.props['data-test-id']}
           active={active || isActiveRouter}
@@ -109,7 +105,7 @@ class SidebarItem extends React.Component {
             )}
           </SidebarItemWrapper>
         </StyledSidebarItem>
-      </Tooltip>
+      </Tooltip2>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
@@ -17,7 +17,7 @@ import EventOrGroupTitle from 'app/components/eventOrGroupTitle';
 import GuideAnchor from 'app/components/assistant/guideAnchor';
 import OrganizationState from 'app/mixins/organizationState';
 import ProjectBadge from 'app/components/idBadge/projectBadge';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import {t} from 'app/locale';
 import SentryTypes from 'app/sentryTypes';
 
@@ -163,11 +163,11 @@ const GroupHeader = createReactClass({
                 <div className="short-id-box count align-right">
                   <h6 className="nav-header">
                     <GuideAnchor target="issue_number" type="text" />
-                    <Tooltip
+                    <Tooltip2
                       title={t(
                         'This identifier is unique across your organization, and can be used to reference an issue in various places, like commit messages.'
                       )}
-                      tooltipOptions={{placement: 'bottom'}}
+                      position="bottom"
                     >
                       <a
                         className="help-link"
@@ -175,7 +175,7 @@ const GroupHeader = createReactClass({
                       >
                         {t('Issue #')}
                       </a>
-                    </Tooltip>
+                    </Tooltip2>
                   </h6>
                   <ShortId
                     shortId={group.shortId}

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/seenBy.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/seenBy.jsx
@@ -6,7 +6,7 @@ import SentryTypes from 'app/sentryTypes';
 import ConfigStore from 'app/stores/configStore';
 import AvatarList from 'app/components/avatar/avatarList';
 import {userDisplayName} from 'app/utils/formatters';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import {t} from 'app/locale';
 
 export default class GroupSeenBy extends React.Component {
@@ -47,9 +47,9 @@ export default class GroupSeenBy extends React.Component {
           )}
         />
         <IconWrapper>
-          <Tooltip title={t("People who've viewed this issue")}>
+          <Tooltip2 title={t("People who've viewed this issue")}>
             <EyeIcon className="icon-eye" />
-          </Tooltip>
+          </Tooltip2>
         </IconWrapper>
       </SeenByWrapper>
     );

--- a/src/sentry/static/sentry/app/views/organizationDiscover/result/table.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDiscover/result/table.jsx
@@ -5,7 +5,7 @@ import styled from 'react-emotion';
 import {t} from 'app/locale';
 import SentryTypes from 'app/sentryTypes';
 import Link from 'app/components/links/link';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import Panel from 'app/components/panels/panel';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import withOrganization from 'app/utils/withOrganization';
@@ -100,11 +100,11 @@ class ResultTable extends React.Component {
       : `/${slug}/${projectSlug}/`;
 
     return (
-      <Tooltip title={t('Open event')}>
+      <Tooltip2 title={t('Open event')}>
         <Link href={`${basePath}events/${event.id}/`} target="_blank">
           {event.id}
         </Link>
-      </Tooltip>
+      </Tooltip2>
     );
   };
 
@@ -118,11 +118,11 @@ class ResultTable extends React.Component {
       : `/${slug}/${projectSlug}/`;
 
     return (
-      <Tooltip title={t('Open issue')}>
+      <Tooltip2 title={t('Open issue')}>
         <Link to={`${basePath}issues/${event['issue.id']}`} target="_blank">
           {event['issue.id']}
         </Link>
-      </Tooltip>
+      </Tooltip2>
     );
   };
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegrationButton.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegrationButton.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import {t} from 'app/locale';
 import AddIntegration from 'app/views/organizationIntegrations/addIntegration';
 import Button from 'app/components/button';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 
 export default class AddIntegrationButton extends React.Component {
   static propTypes = {
@@ -27,7 +27,7 @@ export default class AddIntegrationButton extends React.Component {
       buttonText || t(reinstall ? 'Enable' : 'Add %s', provider.metadata.noun);
 
     return (
-      <Tooltip
+      <Tooltip2
         disabled={provider.canAdd}
         title={`Integration cannot be added on Sentry. Enable this integration via the ${
           provider.name
@@ -44,7 +44,7 @@ export default class AddIntegrationButton extends React.Component {
             </Button>
           )}
         </AddIntegration>
-      </Tooltip>
+      </Tooltip2>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.jsx
@@ -10,7 +10,7 @@ import Alert from 'app/components/alert';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
 import IntegrationItem from 'app/views/organizationIntegrations/integrationItem';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 
 const CONFIGURABLE_FEATURES = ['commits', 'alert-rule'];
 
@@ -128,9 +128,9 @@ export default class InstalledIntegration extends React.Component {
                 />
               )}
               {integration.status === 'active' && (
-                <Tooltip
+                <Tooltip2
                   disabled={this.hasConfiguration()}
-                  tooltipOptions={{placement: 'left'}}
+                  position="left"
                   title="Integration not configurable"
                 >
                   <StyledButton
@@ -144,7 +144,7 @@ export default class InstalledIntegration extends React.Component {
                   >
                     Configure
                   </StyledButton>
-                </Tooltip>
+                </Tooltip2>
               )}
             </Box>
             <Box>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationItem.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationItem.jsx
@@ -5,7 +5,7 @@ import styled from 'react-emotion';
 
 import {t} from 'app/locale';
 import IntegrationIcon from 'app/views/organizationIntegrations/integrationIcon';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import space from 'app/styles/space';
 
 export default class IntegrationItem extends React.Component {
@@ -26,13 +26,13 @@ export default class IntegrationItem extends React.Component {
           <IntegrationName data-test-id="integration-name">
             {integration.name}
             {integration.status === 'disabled' && (
-              <Tooltip
+              <Tooltip2
                 title={t(
                   'This Integration has been disconnected from the external provider'
                 )}
               >
                 <small> — {t('Disabled')}</small>
-              </Tooltip>
+              </Tooltip2>
             )}
           </IntegrationName>
           <DomainName compact={compact}>{integration.domainName}</DomainName>

--- a/src/sentry/static/sentry/app/views/organizationProjectsDashboard/projectNav.jsx
+++ b/src/sentry/static/sentry/app/views/organizationProjectsDashboard/projectNav.jsx
@@ -13,7 +13,7 @@ import MenuItem from 'app/components/menuItem';
 import {t} from 'app/locale';
 import Button from 'app/components/button';
 import ProjectSelector from 'app/components/projectHeader/projectSelector';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 
 const ProjectNav = createReactClass({
   mixins: [OrganizationState],
@@ -64,9 +64,9 @@ const ProjectNav = createReactClass({
       if (item.disabled) {
         acc.push(
           <li role="presentation" key={item.title} disabled>
-            <Tooltip title={item.tooltip}>
+            <Tooltip2 title={item.tooltip}>
               <span>{item.title}</span>
-            </Tooltip>
+            </Tooltip2>
           </li>
         );
       } else {

--- a/src/sentry/static/sentry/app/views/projectDebugFiles.jsx
+++ b/src/sentry/static/sentry/app/views/projectDebugFiles.jsx
@@ -19,7 +19,7 @@ import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader
 import Tag from 'app/views/settings/components/tag';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import TimeSince from 'app/components/timeSince';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import space from 'app/styles/space';
 
 function getFileType(dsym) {
@@ -184,11 +184,9 @@ class ProjectDebugSymbols extends AsyncComponent {
 
               {features &&
                 features.map(feature => (
-                  <Tooltip key={feature} title={getFeatureTooltip(feature)}>
-                    <span>
-                      <Tag inline>{feature}</Tag>
-                    </span>
-                  </Tooltip>
+                  <Tooltip2 key={feature} title={getFeatureTooltip(feature)}>
+                    <Tag inline>{feature}</Tag>
+                  </Tooltip2>
                 ))}
             </DebugSymbolDetails>
           </Box>
@@ -210,7 +208,7 @@ class ProjectDebugSymbols extends AsyncComponent {
             </Access>
             <Access access={['project:write']}>
               {({hasAccess}) => (
-                <Tooltip
+                <Tooltip2
                   disabled={hasAccess}
                   title={t('You do not have permission to delete debug files.')}
                 >
@@ -227,7 +225,7 @@ class ProjectDebugSymbols extends AsyncComponent {
                       disabled={!hasAccess}
                     />
                   </Confirm>
-                </Tooltip>
+                </Tooltip2>
               )}
             </Access>
           </Box>

--- a/src/sentry/static/sentry/app/views/projectEnvironments.jsx
+++ b/src/sentry/static/sentry/app/views/projectEnvironments.jsx
@@ -31,7 +31,7 @@ import PermissionAlert from 'app/views/settings/project/permissionAlert';
 import SentryTypes from 'app/sentryTypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import Tag from 'app/views/settings/components/tag';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import recreateRoute from 'app/utils/recreateRoute';
 import space from 'app/styles/space';
 
@@ -266,14 +266,11 @@ const ProjectEnvironments = createReactClass({
           id: project.defaultEnvironment,
           displayName: (
             <React.Fragment>
-              <Tooltip
-                title={t('This is not an active environment')}
-                tooltipOptions={{container: 'body'}}
-              >
+              <Tooltip2 title={t('This is not an active environment')}>
                 <span css={{marginRight: 8}}>
                   <InvalidDefaultEnvironmentIcon />
                 </span>
-              </Tooltip>
+              </Tooltip2>
               <code>{project.defaultEnvironment}</code>
             </React.Fragment>
           ),

--- a/src/sentry/static/sentry/app/views/projectTags.jsx
+++ b/src/sentry/static/sentry/app/views/projectTags.jsx
@@ -12,7 +12,7 @@ import LinkWithConfirmation from 'app/components/links/linkWithConfirmation';
 import PermissionAlert from 'app/views/settings/project/permissionAlert';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 
 export default class ProjectTags extends AsyncView {
   getEndpoints() {
@@ -87,7 +87,7 @@ export default class ProjectTags extends AsyncView {
                         <span>{key}</span>
                       </Box>
                       <Flex align="center" p={2}>
-                        <Tooltip
+                        <Tooltip2
                           disabled={enabled}
                           title={
                             hasAccess
@@ -108,7 +108,7 @@ export default class ProjectTags extends AsyncView {
                               disabled={!enabled}
                             />
                           </LinkWithConfirmation>
-                        </Tooltip>
+                        </Tooltip2>
                       </Flex>
                     </PanelItem>
                   );

--- a/src/sentry/static/sentry/app/views/releases/detail/shared/commitAuthorStats.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/shared/commitAuthorStats.jsx
@@ -5,7 +5,6 @@ import {Flex} from 'grid-emotion';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import LoadingError from 'app/components/loadingError';
 import Avatar from 'app/components/avatar';
-import Tooltip from 'app/components/tooltip';
 
 import withApi from 'app/utils/withApi';
 
@@ -118,9 +117,12 @@ class CommitAuthorStats extends React.Component {
               return (
                 <PanelItem key={i} p={1} align="center">
                   <Flex>
-                    <Tooltip title={`${author.name} ${author.email}`}>
-                      <Avatar user={author} size={20} />
-                    </Tooltip>
+                    <Avatar
+                      user={author}
+                      size={20}
+                      hasTooltip
+                      tooltip={`${author.name} ${author.email}`}
+                    />
                   </Flex>
                   <Flex flex="1" px={1}>
                     <CommitBar

--- a/src/sentry/static/sentry/app/views/releases/detail/shared/releaseArtifacts.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/shared/releaseArtifacts.jsx
@@ -14,7 +14,7 @@ import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import Pagination from 'app/components/pagination';
 import SentryTypes from 'app/sentryTypes';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 
@@ -160,7 +160,7 @@ class ReleaseArtifacts extends React.Component {
                           <span className="icon icon-open" />
                         </a>
                       ) : (
-                        <Tooltip
+                        <Tooltip2
                           title={t(
                             'You do not have the required permission to download this artifact.'
                           )}
@@ -168,7 +168,7 @@ class ReleaseArtifacts extends React.Component {
                           <div className="btn btn-sm btn-default disabled">
                             <span className="icon icon-open" />
                           </div>
-                        </Tooltip>
+                        </Tooltip2>
                       )}
                       <div style={{marginLeft: 5}}>
                         <LinkWithConfirmation

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityDetails.jsx
@@ -20,7 +20,7 @@ import RecoveryCodes from 'app/views/settings/account/accountSecurity/components
 import RemoveConfirm from 'app/views/settings/account/accountSecurity/components/removeConfirm';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import U2fEnrolledDetails from 'app/views/settings/account/accountSecurity/components/u2fEnrolledDetails';
 
 const ENDPOINT = '/users/me/authenticators/';
@@ -133,7 +133,7 @@ class AccountSecurityDetails extends AsyncView {
           action={
             authenticator.isEnrolled &&
             authenticator.removeButton && (
-              <Tooltip
+              <Tooltip2
                 title={t(
                   "Two-factor authentication is required for at least one organization you're a member of."
                 )}
@@ -142,7 +142,7 @@ class AccountSecurityDetails extends AsyncView {
                 <RemoveConfirm onConfirm={this.handleRemove} disabled={deleteDisabled}>
                   <Button priority="danger">{authenticator.removeButton}</Button>
                 </RemoveConfirm>
-              </Tooltip>
+              </Tooltip2>
             )
           }
         />

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/u2fEnrolledDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/u2fEnrolledDetails.jsx
@@ -77,12 +77,12 @@ class U2fEnrolledDetails extends React.Component {
                     }
                   >
                     <Button size="small" priority="danger">
-                      <Tooltip
+                      <Tooltip2
                         disabled={!isLastDevice}
                         title={t('Can not remove last U2F device')}
                       >
                         <span className="icon icon-trash" />
-                      </Tooltip>
+                      </Tooltip2>
                     </Button>
                   </Confirm>
                 </Box>

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/u2fEnrolledDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/u2fEnrolledDetails.jsx
@@ -10,7 +10,7 @@ import DateTime from 'app/components/dateTime';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 
 /**
  * List u2f devices w/ ability to remove a single device

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/index.jsx
@@ -17,7 +17,7 @@ import NavTabs from 'app/components/navTabs';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import TwoFactorRequired from 'app/views/settings/account/accountSecurity/components/twoFactorRequired';
 import RemoveConfirm from 'app/views/settings/account/accountSecurity/components/removeConfirm';
 import PasswordForm from 'app/views/settings/account/passwordForm';
@@ -152,7 +152,7 @@ class AccountSecurity extends AsyncView {
                       )}
 
                       {!isBackupInterface && isEnrolled && (
-                        <Tooltip
+                        <Tooltip2
                           title={t(
                             `Two-factor authentication is required for organization(s): ${this.formatOrgSlugs()}.`
                           )}
@@ -166,7 +166,7 @@ class AccountSecurity extends AsyncView {
                               <span className="icon icon-trash" />
                             </Button>
                           </RemoveConfirm>
-                        </Tooltip>
+                        </Tooltip2>
                       )}
 
                       {isBackupInterface && !isEnrolled ? t('requires 2FA') : null}

--- a/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldControl.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldControl.jsx
@@ -5,7 +5,7 @@ import styled from 'react-emotion';
 
 import FieldControlState from 'app/views/settings/components/forms/field/fieldControlState';
 import InlineSvg from 'app/components/inlineSvg';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 
 // This wraps Control + ControlError message
 // * can NOT be a flex box here because of `position: absolute` on "control error message"
@@ -73,9 +73,9 @@ class FieldControl extends React.Component {
 
           {disabled && disabledReason && (
             <Flex align="center" ml={1} className="disabled-indicator">
-              <Tooltip title={disabledReason}>
+              <Tooltip2 title={disabledReason}>
                 <StyledInlineSvg src="icon-circle-question" size="18px" />
-              </Tooltip>
+              </Tooltip2>
             </Flex>
           )}
 

--- a/src/sentry/static/sentry/app/views/settings/components/forms/returnButton.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/returnButton.jsx
@@ -3,7 +3,7 @@ import styled from 'react-emotion';
 
 import {t} from 'app/locale';
 import InlineSvg from 'app/components/inlineSvg';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 
 const SubmitButton = styled('div')`
   background: transparent;
@@ -37,11 +37,11 @@ const ClickTargetStyled = styled('div')`
 const returnButton = props => {
   return (
     <ClickTargetStyled {...props}>
-      <Tooltip title={t('Save')}>
+      <Tooltip2 title={t('Save')}>
         <SubmitButton>
           <InlineSvg size="0.75em" src="icon-return-key" />
         </SubmitButton>
-      </Tooltip>
+      </Tooltip2>
     </ClickTargetStyled>
   );
 };

--- a/src/sentry/static/sentry/app/views/settings/organizationAuditLog/auditLogList.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuditLog/auditLogList.jsx
@@ -11,7 +11,7 @@ import Pagination from 'app/components/pagination';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import SelectField from 'app/components/forms/selectField';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 
 const UserInfo = styled(Box)`
@@ -116,12 +116,12 @@ class AuditLogList extends React.Component {
                     </UserInfo>
                     <Box w={150}>{entry.event}</Box>
                     <Box w={130}>
-                      <Tooltip
+                      <Tooltip2
                         title={entry.ipAddress}
                         disabled={entry.ipAddress && entry.ipAddress.length <= ipv4Length}
                       >
                         <OverflowBox>{entry.ipAddress}</OverflowBox>
-                      </Tooltip>
+                      </Tooltip2>
                     </Box>
                     <Box w={150} p={1}>
                       <DateTime date={entry.dateCreated} />

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow.jsx
@@ -9,7 +9,6 @@ import Confirm from 'app/components/confirm';
 import ConfirmDelete from 'app/components/confirmDelete';
 import PropTypes from 'prop-types';
 import SentryTypes from 'app/sentryTypes';
-import Tooltip from 'app/components/tooltip';
 import {PanelItem} from 'app/components/panels';
 import {t} from 'app/locale';
 import styled from 'react-emotion';
@@ -139,20 +138,24 @@ export default class SentryApplicationRow extends React.PureComponent {
                   {({hasAccess}) => (
                     <React.Fragment>
                       {!hasAccess && (
-                        <Tooltip
+                        <Button
+                          disabled
                           title={t('Owner permissions are required for this action.')}
-                        >
-                          <Button disabled size="small" icon="icon-trash" />
-                        </Tooltip>
+                          size="small"
+                          icon="icon-trash"
+                        />
                       )}
                       {hasAccess && this.renderRemoveApp(app)}
                     </React.Fragment>
                   )}
                 </Access>
               ) : (
-                <Tooltip title={t('Published apps cannot be removed.')}>
-                  <Button disabled size="small" icon="icon-trash" />
-                </Tooltip>
+                <Button
+                  disabled
+                  title={t('Published apps cannot be removed.')}
+                  size="small"
+                  icon="icon-trash"
+                />
               )}
             </Box>
           )}

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/subscriptionBox.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/subscriptionBox.jsx
@@ -5,7 +5,7 @@ import {t} from 'app/locale';
 import {DESCRIPTIONS} from 'app/views/settings/organizationDeveloperSettings/constants';
 import styled from 'react-emotion';
 import Checkbox from 'app/components/checkbox';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import {Flex} from 'grid-emotion';
 
 export default class SubscriptionBox extends React.Component {
@@ -37,7 +37,7 @@ export default class SubscriptionBox extends React.Component {
     return (
       <React.Fragment>
         <SubscriptionGridItemWrapper key={resource}>
-          <Tooltip disabled={!disabled} title={message}>
+          <Tooltip2 disabled={!disabled} title={message}>
             <SubscriptionGridItem disabled={disabled}>
               <SubscriptionInfo>
                 <SubscriptionTitle>{t(`${resource}`)}</SubscriptionTitle>
@@ -54,7 +54,7 @@ export default class SubscriptionBox extends React.Component {
                 onChange={this.onChange}
               />
             </SubscriptionGridItem>
-          </Tooltip>
+          </Tooltip2>
         </SubscriptionGridItemWrapper>
       </React.Fragment>
     );

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberDetail.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberDetail.jsx
@@ -18,7 +18,7 @@ import {removeAuthenticator} from 'app/actionCreators/account';
 import SentryTypes from 'app/sentryTypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TeamSelect from 'app/views/settings/components/teamSelect';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import recreateRoute from 'app/utils/recreateRoute';
 
 import RoleSelect from './inviteMember/roleSelect';
@@ -309,7 +309,7 @@ class OrganizationMemberDetail extends AsyncView {
                   'Resetting two-factor authentication will remove all two-factor authentication methods for this member.'
                 )}
               >
-                <Tooltip
+                <Tooltip2
                   data-test-id="reset-2fa-tooltip"
                   disabled={this.showResetButton()}
                   title={this.getTooltip()}
@@ -327,7 +327,7 @@ class OrganizationMemberDetail extends AsyncView {
                       {t('Reset two-factor authentication')}
                     </Button>
                   </Confirm>
-                </Tooltip>
+                </Tooltip2>
               </Field>
             </PanelBody>
           </Panel>

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberRow.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberRow.jsx
@@ -12,7 +12,7 @@ import InlineSvg from 'app/components/inlineSvg';
 import Link from 'app/components/links/link';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import SentryTypes from 'app/sentryTypes';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import recreateRoute from 'app/utils/recreateRoute';
 import {conditionalGuideAnchor} from 'app/components/assistant/guideAnchor';
 
@@ -160,9 +160,9 @@ export default class OrganizationMemberRow extends React.PureComponent {
             ) : (
               <div>
                 {!has2fa ? (
-                  <Tooltip title={t('Two-factor auth not enabled')}>
+                  <Tooltip2 title={t('Two-factor auth not enabled')}>
                     <NoTwoFactorIcon />
-                  </Tooltip>
+                  </Tooltip2>
                 ) : (
                   <HasTwoFactorIcon />
                 )}

--- a/src/sentry/static/sentry/app/views/settings/organizationTeams/teamProjects.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationTeams/teamProjects.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
 
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import withApi from 'app/utils/withApi';
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import space from 'app/styles/space';
@@ -143,7 +143,7 @@ const TeamProjects = createReactClass({
       sortProjects(projects).map((project, i) => (
         <StyledPanelItem key={project.id}>
           <ProjectListItem project={project} organization={this.context.organization} />
-          <Tooltip
+          <Tooltip2
             disabled={canWrite}
             title={t('You do not have enough permission to change project association.')}
           >
@@ -156,7 +156,7 @@ const TeamProjects = createReactClass({
             >
               <RemoveIcon /> {t('Remove')}
             </Button>
-          </Tooltip>
+          </Tooltip2>
         </StyledPanelItem>
       ))
     ) : (

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/groupTombstones.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/groupTombstones.jsx
@@ -9,7 +9,7 @@ import AsyncComponent from 'app/components/asyncComponent';
 import Avatar from 'app/components/avatar';
 import EventOrGroupHeader from 'app/components/eventOrGroupHeader';
 import LinkWithConfirmation from 'app/components/links/linkWithConfirmation';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import {Panel, PanelItem} from 'app/components/panels';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 
@@ -35,13 +35,15 @@ class GroupTombstoneRow extends React.Component {
         </StyledBox>
         <Box w={20} mx={30}>
           {actor && (
-            <Tooltip title={t('Discarded by %s', actor.name || actor.email)}>
-              <Avatar user={data.actor} />
-            </Tooltip>
+            <Avatar
+              user={data.actor}
+              hasTooltip
+              tooltip={t('Discarded by %s', actor.name || actor.email)}
+            />
           )}
         </Box>
         <Box w={30}>
-          <Tooltip title={t('Undiscard')}>
+          <Tooltip2 title={t('Undiscard')}>
             <LinkWithConfirmation
               className="group-remove btn btn-default btn-sm"
               message={t(
@@ -57,7 +59,7 @@ class GroupTombstoneRow extends React.Component {
             >
               <span className="icon-trash undiscard" />
             </LinkWithConfirmation>
-          </Tooltip>
+          </Tooltip2>
         </Box>
       </PanelItem>
     );

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/selectOwners.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/selectOwners.jsx
@@ -19,7 +19,7 @@ import ActorAvatar from 'app/components/actorAvatar';
 import SentryTypes from 'app/sentryTypes';
 import Button from 'app/components/button';
 import InlineSvg from 'app/components/inlineSvg';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 
 class ValueComponent extends React.Component {
   static propTypes = {
@@ -105,12 +105,12 @@ export default class SelectOwners extends React.Component {
       disabled: true,
       label: (
         <DisabledLabel>
-          <Tooltip
-            tooltipOptions={{container: 'body', placement: 'left'}}
+          <Tooltip2
+            position="left"
             title={t('%s is not a member of project', user.name || user.email)}
           >
             {this.renderUserBadge(user)}
-          </Tooltip>
+          </Tooltip2>
         </DisabledLabel>
       ),
     };
@@ -139,14 +139,14 @@ export default class SelectOwners extends React.Component {
       label: (
         <Flex justify="space-between">
           <DisabledLabel>
-            <Tooltip
-              tooltipOptions={{container: 'body', placement: 'left'}}
+            <Tooltip2
+              position="left"
               title={t('%s is not a member of project', `#${team.slug}`)}
             >
               <IdBadge team={team} />
-            </Tooltip>
+            </Tooltip2>
           </DisabledLabel>
-          <Tooltip
+          <Tooltip2
             title={
               canAddTeam
                 ? t('Add %s to project', `#${team.slug}`)
@@ -161,7 +161,7 @@ export default class SelectOwners extends React.Component {
             >
               <InlineSvg src="icon-circle-add" />
             </AddToProjectButton>
-          </Tooltip>
+          </Tooltip2>
         </Flex>
       ),
     };

--- a/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
@@ -10,7 +10,7 @@ import AsyncView from 'app/views/asyncView';
 import Link from 'app/components/links/link';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TeamSelect from 'app/views/settings/components/teamSelect';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import space from 'app/styles/space';
 
 class ProjectTeams extends AsyncView {
@@ -117,15 +117,15 @@ class ProjectTeams extends AsyncView {
     const menuHeader = (
       <StyledTeamsLabel>
         {t('Teams')}
-        <Tooltip
+        <Tooltip2
           disabled={canCreateTeam}
           title={t('You must be a project admin to create teams')}
-          tooltipOptions={{placement: 'top'}}
+          position="top"
         >
           <StyledCreateTeamLink disabled={!canCreateTeam} onClick={this.handleCreateTeam}>
             {t('Create Team')}
           </StyledCreateTeamLink>
-        </Tooltip>
+        </Tooltip2>
       </StyledTeamsLabel>
     );
 

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertHeader.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertHeader.jsx
@@ -7,7 +7,7 @@ import Button from 'app/components/button';
 import ListLink from 'app/components/links/listLink';
 import NavTabs from 'app/components/navTabs';
 
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 
@@ -31,7 +31,7 @@ export default withOrganization(
         <SettingsPageHeader
           title={t('Alerts')}
           action={
-            <Tooltip
+            <Tooltip2
               disabled={canEditRule}
               title={t('You do not have permission to edit alert rules.')}
             >
@@ -44,7 +44,7 @@ export default withOrganization(
               >
                 {t('New Alert Rule')}
               </Button>
-            </Tooltip>
+            </Tooltip2>
           }
           tabs={
             <NavTabs underlined={true}>

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertRules.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertRules.jsx
@@ -21,7 +21,7 @@ import EmptyStateWarning from 'app/components/emptyStateWarning';
 import EnvironmentStore from 'app/stores/environmentStore';
 import PermissionAlert from 'app/views/settings/project/permissionAlert';
 import SentryTypes from 'app/sentryTypes';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import recreateRoute from 'app/utils/recreateRoute';
 import withApi from 'app/utils/withApi';
 
@@ -104,7 +104,7 @@ const RuleRow = withApi(
             </TextColorLink>
 
             <Flex>
-              <Tooltip
+              <Tooltip2
                 disabled={canEdit}
                 title={t('You do not have permission to edit alert rules.')}
               >
@@ -117,9 +117,9 @@ const RuleRow = withApi(
                 >
                   {t('Edit Rule')}
                 </Button>
-              </Tooltip>
+              </Tooltip2>
 
-              <Tooltip
+              <Tooltip2
                 disabled={canEdit}
                 title={t('You do not have permission to edit alert rules.')}
               >
@@ -130,7 +130,7 @@ const RuleRow = withApi(
                 >
                   <Button size="xsmall" icon="icon-trash" />
                 </Confirm>
-              </Tooltip>
+              </Tooltip2>
             </Flex>
           </PanelHeader>
 

--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -21,7 +21,7 @@ import ResolveActions from 'app/components/actions/resolve';
 import SelectedGroupStore from 'app/stores/selectedGroupStore';
 import SentryTypes from 'app/sentryTypes';
 import ToolbarHeader from 'app/components/toolbarHeader';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import withApi from 'app/utils/withApi';
 
 const BULK_LIMIT = 1000;
@@ -482,12 +482,11 @@ const StreamActions = createReactClass({
               </DropdownLink>
             </div>
             <div className="btn-group">
-              <Tooltip
+              <Tooltip2
                 title={t(
                   '%s real-time updates',
                   realtimeActive ? t('Pause') : t('Enable')
                 )}
-                tooltipOptions={{container: 'body'}}
               >
                 <a
                   className="btn btn-default btn-sm hidden-xs realtime-control"
@@ -499,7 +498,7 @@ const StreamActions = createReactClass({
                     <span className="icon icon-play" />
                   )}
                 </a>
-              </Tooltip>
+              </Tooltip2>
             </div>
           </ActionSet>
           <Box w={160} mx={2} className="hidden-xs hidden-sm">

--- a/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/stream/savedSearchSelector.jsx
@@ -10,7 +10,7 @@ import DropdownLink from 'app/components/dropdownLink';
 import QueryCount from 'app/components/queryCount';
 import MenuItem from 'app/components/menuItem';
 import SentryTypes from 'app/sentryTypes';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import Tag from 'app/views/settings/components/tag';
 import {BooleanField, FormState, TextField} from 'app/components/forms';
 import withApi from 'app/utils/withApi';
@@ -119,7 +119,7 @@ const SaveSearchButton = withApi(
       const access = new Set(organization.access);
       return (
         <React.Fragment>
-          <Tooltip
+          <Tooltip2
             title="You must select issues from a single project to create new saved searches"
             disabled={!disabled}
           >
@@ -133,7 +133,7 @@ const SaveSearchButton = withApi(
             >
               {children}
             </Button>
-          </Tooltip>
+          </Tooltip2>
           <Modal
             show={this.state.isModalOpen}
             animation={false}
@@ -281,7 +281,7 @@ const SavedSearchSelector = withApi(
                 {t('Save Current Search')}
               </SaveSearchButton>
 
-              <Tooltip
+              <Tooltip2
                 title="You must select issues from a single project to manage saved searches"
                 disabled={hasProject}
               >
@@ -293,7 +293,7 @@ const SavedSearchSelector = withApi(
                 >
                   {t('Manage')}
                 </Button>
-              </Tooltip>
+              </Tooltip2>
             </ButtonBar>
           </StyledDropdownLink>
         </Container>

--- a/tests/js/spec/components/__snapshots__/returnButton.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/returnButton.spec.jsx.snap
@@ -2,7 +2,9 @@
 
 exports[`returnButton renders 1`] = `
 <ClickTargetStyled>
-  <Tooltip
+  <Tooltip2
+    containerDisplayMode="inline-block"
+    position="top"
     title="Save"
   >
     <SubmitButton>
@@ -11,6 +13,6 @@ exports[`returnButton renders 1`] = `
         src="icon-return-key"
       />
     </SubmitButton>
-  </Tooltip>
+  </Tooltip2>
 </ClickTargetStyled>
 `;

--- a/tests/js/spec/components/events/__snapshots__/crashContent.spec.jsx.snap
+++ b/tests/js/spec/components/events/__snapshots__/crashContent.spec.jsx.snap
@@ -121,21 +121,46 @@ exports[`CrashContent renders with meta data 1`] = `
                     value="python err A949AE01EBB07300D62AE0178F0944DD21F8C98C err"
                   >
                     <span>
-                      <Tooltip
+                      <Tooltip2
+                        containerDisplayMode="inline-block"
+                        position="top"
                         title="Pseudonymized due to PII rule \\"device_id\\""
                       >
-                        <Redaction
-                          className="tip"
-                          title="Pseudonymized due to PII rule \\"device_id\\""
-                        >
-                          <span
-                            className="tip css-ielfiw-Redaction e1p1th7g1"
-                            title="Pseudonymized due to PII rule \\"device_id\\""
-                          >
-                            python err A949AE01EBB07300D62AE0178F0944DD21F8C98C err
-                          </span>
-                        </Redaction>
-                      </Tooltip>
+                        <Manager>
+                          <Reference>
+                            <InnerReference
+                              setReferenceNode={[Function]}
+                            >
+                              <Container
+                                aria-describedby="tooltip-123456"
+                                containerDisplayMode="inline-block"
+                                innerRef={[Function]}
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                              >
+                                <span
+                                  aria-describedby="tooltip-123456"
+                                  className="css-1m3e0hg-Container e7ebgxc0"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  <Redaction>
+                                    <span
+                                      className="css-ielfiw-Redaction e1p1th7g1"
+                                    >
+                                      python err A949AE01EBB07300D62AE0178F0944DD21F8C98C err
+                                    </span>
+                                  </Redaction>
+                                </span>
+                              </Container>
+                            </InnerReference>
+                          </Reference>
+                        </Manager>
+                      </Tooltip2>
                        
                     </span>
                   </AnnotatedText>

--- a/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
+++ b/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
@@ -628,8 +628,10 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
             renderNoAccessMessage={false}
             requireAll={true}
           >
-            <Tooltip
+            <Tooltip2
+              containerDisplayMode="inline-block"
               disabled={true}
+              position="top"
               title="You must be an Owner, Manager or Admin to install this."
             >
               <AddButton
@@ -683,8 +685,10 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
                     }
                   }
                 >
-                  <Tooltip
+                  <Tooltip2
+                    containerDisplayMode="inline-block"
                     disabled={true}
+                    position="top"
                     title="Integration cannot be added on Sentry. Enable this integration via the GitHub instance."
                   >
                     <AddIntegration
@@ -803,10 +807,10 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
                         </StyledButton>
                       </Button>
                     </AddIntegration>
-                  </Tooltip>
+                  </Tooltip2>
                 </AddIntegrationButton>
               </AddButton>
-            </Tooltip>
+            </Tooltip2>
           </Access>
         </AccessContainer>
       </withConfig(AccessContainer)>

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -67,7 +67,7 @@ describe('Sidebar', function() {
     expect(wrapper.find('OrgOrUserName').text()).toContain(organization.name);
     expect(wrapper.find('UserNameOrEmail').text()).toContain(user.name);
 
-    wrapper.find('SidebarCollapseItem').simulate('click');
+    wrapper.find('SidebarCollapseItem StyledSidebarItem').simulate('click');
     await tick();
     wrapper.update();
 
@@ -75,13 +75,13 @@ describe('Sidebar', function() {
     // Instead check for `SidebarItemLabel` which doesn't exist in collapsed state
     expect(wrapper.find('SidebarItemLabel')).toHaveLength(0);
 
-    wrapper.find('SidebarCollapseItem').simulate('click');
+    wrapper.find('SidebarCollapseItem StyledSidebarItem').simulate('click');
     await tick();
     wrapper.update();
     expect(wrapper.find('SidebarItemLabel').length).toBeGreaterThan(0);
   });
 
-  it('can have onboarding feature', function() {
+  it('can have onboarding feature', async function() {
     wrapper = mount(
       <SidebarContainer
         organization={{...organization, features: ['onboarding']}}
@@ -95,6 +95,7 @@ describe('Sidebar', function() {
 
     wrapper.find('[data-test-id="onboarding-progress-bar"]').simulate('click');
     wrapper.update();
+
     expect(wrapper.find('OnboardingStatus SidebarPanel')).toMatchSnapshot();
   });
 

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -620,8 +620,10 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                         </div>
                       </Container>
                     </ProjectItem>
-                    <Tooltip
+                    <Tooltip2
+                      containerDisplayMode="inline-block"
                       disabled={true}
+                      position="top"
                       title="You do not have enough permission to change project association."
                     >
                       <Button
@@ -699,7 +701,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                           </ForwardRef>
                         </StyledButton>
                       </Button>
-                    </Tooltip>
+                    </Tooltip2>
                   </div>
                 </Base>
               </StyledPanelItem>
@@ -990,8 +992,10 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                         </div>
                       </Container>
                     </ProjectItem>
-                    <Tooltip
+                    <Tooltip2
+                      containerDisplayMode="inline-block"
                       disabled={true}
+                      position="top"
                       title="You do not have enough permission to change project association."
                     >
                       <Button
@@ -1069,7 +1073,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                           </ForwardRef>
                         </StyledButton>
                       </Button>
-                    </Tooltip>
+                    </Tooltip2>
                   </div>
                 </Base>
               </StyledPanelItem>

--- a/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
@@ -446,8 +446,10 @@ exports[`ProjectTags renders 1`] = `
                                   className="css-p3ab1k"
                                   is={null}
                                 >
-                                  <Tooltip
+                                  <Tooltip2
+                                    containerDisplayMode="inline-block"
                                     disabled={true}
+                                    position="top"
                                     title="This tag cannot be deleted."
                                   >
                                     <LinkWithConfirmation
@@ -620,7 +622,7 @@ exports[`ProjectTags renders 1`] = `
                                         </Modal>
                                       </Confirm>
                                     </LinkWithConfirmation>
-                                  </Tooltip>
+                                  </Tooltip2>
                                 </div>
                               </Base>
                             </Flex>
@@ -676,8 +678,10 @@ exports[`ProjectTags renders 1`] = `
                                   className="css-p3ab1k"
                                   is={null}
                                 >
-                                  <Tooltip
+                                  <Tooltip2
+                                    containerDisplayMode="inline-block"
                                     disabled={true}
+                                    position="top"
                                     title="This tag cannot be deleted."
                                   >
                                     <LinkWithConfirmation
@@ -850,7 +854,7 @@ exports[`ProjectTags renders 1`] = `
                                         </Modal>
                                       </Confirm>
                                     </LinkWithConfirmation>
-                                  </Tooltip>
+                                  </Tooltip2>
                                 </div>
                               </Base>
                             </Flex>
@@ -906,8 +910,10 @@ exports[`ProjectTags renders 1`] = `
                                   className="css-p3ab1k"
                                   is={null}
                                 >
-                                  <Tooltip
+                                  <Tooltip2
+                                    containerDisplayMode="inline-block"
                                     disabled={true}
+                                    position="top"
                                     title="This tag cannot be deleted."
                                   >
                                     <LinkWithConfirmation
@@ -1080,7 +1086,7 @@ exports[`ProjectTags renders 1`] = `
                                         </Modal>
                                       </Confirm>
                                     </LinkWithConfirmation>
-                                  </Tooltip>
+                                  </Tooltip2>
                                 </div>
                               </Base>
                             </Flex>
@@ -1136,188 +1142,216 @@ exports[`ProjectTags renders 1`] = `
                                   className="css-p3ab1k"
                                   is={null}
                                 >
-                                  <Tooltip
+                                  <Tooltip2
+                                    containerDisplayMode="inline-block"
                                     disabled={false}
+                                    position="top"
                                     title="This tag cannot be deleted."
                                   >
-                                    <LinkWithConfirmation
-                                      className="tip"
-                                      disabled={true}
-                                      message="Are you sure you want to remove this tag?"
-                                      onConfirm={[Function]}
-                                      title="This tag cannot be deleted."
-                                    >
-                                      <Confirm
-                                        cancelText="Cancel"
-                                        confirmText="Confirm"
-                                        disableConfirmButton={false}
-                                        disabled={true}
-                                        message="Are you sure you want to remove this tag?"
-                                        onConfirm={[Function]}
-                                        priority="primary"
-                                        stopPropagation={false}
-                                      >
-                                        <a
-                                          className="tip disabled"
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          title="This tag cannot be deleted."
+                                    <Manager>
+                                      <Reference>
+                                        <InnerReference
+                                          setReferenceNode={[Function]}
                                         >
-                                          <Button
-                                            data-test-id="delete"
-                                            disabled={true}
-                                            icon="icon-trash"
-                                            size="xsmall"
+                                          <Container
+                                            aria-describedby="tooltip-123456"
+                                            containerDisplayMode="inline-block"
+                                            innerRef={[Function]}
+                                            onBlur={[Function]}
+                                            onFocus={[Function]}
+                                            onMouseEnter={[Function]}
+                                            onMouseLeave={[Function]}
                                           >
-                                            <StyledButton
-                                              aria-disabled={true}
-                                              data-test-id="delete"
-                                              disabled={true}
-                                              href={null}
-                                              onClick={[Function]}
-                                              role="button"
-                                              size="xsmall"
-                                              to={null}
+                                            <span
+                                              aria-describedby="tooltip-123456"
+                                              className="css-1m3e0hg-Container e7ebgxc0"
+                                              onBlur={[Function]}
+                                              onFocus={[Function]}
+                                              onMouseEnter={[Function]}
+                                              onMouseLeave={[Function]}
                                             >
-                                              <ForwardRef
-                                                aria-disabled={true}
-                                                className="css-bzxnfi-StyledButton-getColors e12ma6z0"
-                                                data-test-id="delete"
+                                              <LinkWithConfirmation
                                                 disabled={true}
-                                                href={null}
-                                                onClick={[Function]}
-                                                role="button"
-                                                size="xsmall"
-                                                to={null}
+                                                message="Are you sure you want to remove this tag?"
+                                                onConfirm={[Function]}
+                                                title="Remove tag?"
                                               >
-                                                <button
-                                                  aria-disabled={true}
-                                                  className="css-bzxnfi-StyledButton-getColors e12ma6z0"
-                                                  data-test-id="delete"
-                                                  href={null}
-                                                  onClick={[Function]}
-                                                  role="button"
-                                                  size="xsmall"
-                                                  to={null}
+                                                <Confirm
+                                                  cancelText="Cancel"
+                                                  confirmText="Confirm"
+                                                  disableConfirmButton={false}
+                                                  disabled={true}
+                                                  message="Are you sure you want to remove this tag?"
+                                                  onConfirm={[Function]}
+                                                  priority="primary"
+                                                  stopPropagation={false}
                                                 >
-                                                  <ButtonLabel
-                                                    size="xsmall"
+                                                  <a
+                                                    className="disabled"
+                                                    disabled={true}
+                                                    onClick={[Function]}
+                                                    title="Remove tag?"
                                                   >
-                                                    <Component
-                                                      className="css-uthd1f-ButtonLabel e12ma6z1"
+                                                    <Button
+                                                      data-test-id="delete"
+                                                      disabled={true}
+                                                      icon="icon-trash"
                                                       size="xsmall"
                                                     >
-                                                      <span
-                                                        className="css-uthd1f-ButtonLabel e12ma6z1"
+                                                      <StyledButton
+                                                        aria-disabled={true}
+                                                        data-test-id="delete"
+                                                        disabled={true}
+                                                        href={null}
+                                                        onClick={[Function]}
+                                                        role="button"
+                                                        size="xsmall"
+                                                        to={null}
                                                       >
-                                                        <Icon
-                                                          hasChildren={false}
+                                                        <ForwardRef
+                                                          aria-disabled={true}
+                                                          className="css-bzxnfi-StyledButton-getColors e12ma6z0"
+                                                          data-test-id="delete"
+                                                          disabled={true}
+                                                          href={null}
+                                                          onClick={[Function]}
+                                                          role="button"
                                                           size="xsmall"
+                                                          to={null}
                                                         >
-                                                          <Component
-                                                            className="css-ljhpxy-Icon e12ma6z2"
-                                                            hasChildren={false}
+                                                          <button
+                                                            aria-disabled={true}
+                                                            className="css-bzxnfi-StyledButton-getColors e12ma6z0"
+                                                            data-test-id="delete"
+                                                            href={null}
+                                                            onClick={[Function]}
+                                                            role="button"
                                                             size="xsmall"
+                                                            to={null}
                                                           >
-                                                            <span
-                                                              className="css-ljhpxy-Icon e12ma6z2"
+                                                            <ButtonLabel
                                                               size="xsmall"
                                                             >
-                                                              <StyledInlineSvg
-                                                                size="12px"
-                                                                src="icon-trash"
+                                                              <Component
+                                                                className="css-uthd1f-ButtonLabel e12ma6z1"
+                                                                size="xsmall"
                                                               >
-                                                                <InlineSvg
-                                                                  className="css-1ov3rcq-StyledInlineSvg e12ma6z3"
-                                                                  size="12px"
-                                                                  src="icon-trash"
+                                                                <span
+                                                                  className="css-uthd1f-ButtonLabel e12ma6z1"
                                                                 >
-                                                                  <StyledSvg
-                                                                    className="css-1ov3rcq-StyledInlineSvg e12ma6z3"
-                                                                    height="12px"
-                                                                    viewBox={Object {}}
-                                                                    width="12px"
+                                                                  <Icon
+                                                                    hasChildren={false}
+                                                                    size="xsmall"
                                                                   >
-                                                                    <svg
-                                                                      className="e12ma6z3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                      height="12px"
-                                                                      viewBox={Object {}}
-                                                                      width="12px"
+                                                                    <Component
+                                                                      className="css-ljhpxy-Icon e12ma6z2"
+                                                                      hasChildren={false}
+                                                                      size="xsmall"
                                                                     >
-                                                                      <use
-                                                                        href="#test"
-                                                                        xlinkHref="#test"
-                                                                      />
-                                                                    </svg>
-                                                                  </StyledSvg>
-                                                                </InlineSvg>
-                                                              </StyledInlineSvg>
-                                                            </span>
-                                                          </Component>
-                                                        </Icon>
-                                                      </span>
-                                                    </Component>
-                                                  </ButtonLabel>
-                                                </button>
-                                              </ForwardRef>
-                                            </StyledButton>
-                                          </Button>
-                                        </a>
-                                        <Modal
-                                          animation={false}
-                                          autoFocus={true}
-                                          backdrop={true}
-                                          bsClass="modal"
-                                          dialogComponentClass={[Function]}
-                                          enforceFocus={true}
-                                          keyboard={true}
-                                          manager={
-                                            ModalManager {
-                                              "add": [Function],
-                                              "containers": Array [],
-                                              "data": Array [],
-                                              "handleContainerOverflow": true,
-                                              "hideSiblingNodes": true,
-                                              "isTopModal": [Function],
-                                              "modals": Array [],
-                                              "remove": [Function],
-                                            }
-                                          }
-                                          onHide={[Function]}
-                                          renderBackdrop={[Function]}
-                                          restoreFocus={true}
-                                          show={false}
-                                        >
-                                          <Modal
-                                            autoFocus={true}
-                                            backdrop={true}
-                                            backdropClassName="modal-backdrop"
-                                            containerClassName="modal-open"
-                                            enforceFocus={true}
-                                            keyboard={true}
-                                            manager={
-                                              ModalManager {
-                                                "add": [Function],
-                                                "containers": Array [],
-                                                "data": Array [],
-                                                "handleContainerOverflow": true,
-                                                "hideSiblingNodes": true,
-                                                "isTopModal": [Function],
-                                                "modals": Array [],
-                                                "remove": [Function],
-                                              }
-                                            }
-                                            onEntering={[Function]}
-                                            onExited={[Function]}
-                                            onHide={[Function]}
-                                            renderBackdrop={[Function]}
-                                            restoreFocus={true}
-                                            show={false}
-                                          />
-                                        </Modal>
-                                      </Confirm>
-                                    </LinkWithConfirmation>
-                                  </Tooltip>
+                                                                      <span
+                                                                        className="css-ljhpxy-Icon e12ma6z2"
+                                                                        size="xsmall"
+                                                                      >
+                                                                        <StyledInlineSvg
+                                                                          size="12px"
+                                                                          src="icon-trash"
+                                                                        >
+                                                                          <InlineSvg
+                                                                            className="css-1ov3rcq-StyledInlineSvg e12ma6z3"
+                                                                            size="12px"
+                                                                            src="icon-trash"
+                                                                          >
+                                                                            <StyledSvg
+                                                                              className="css-1ov3rcq-StyledInlineSvg e12ma6z3"
+                                                                              height="12px"
+                                                                              viewBox={Object {}}
+                                                                              width="12px"
+                                                                            >
+                                                                              <svg
+                                                                                className="e12ma6z3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                                                height="12px"
+                                                                                viewBox={Object {}}
+                                                                                width="12px"
+                                                                              >
+                                                                                <use
+                                                                                  href="#test"
+                                                                                  xlinkHref="#test"
+                                                                                />
+                                                                              </svg>
+                                                                            </StyledSvg>
+                                                                          </InlineSvg>
+                                                                        </StyledInlineSvg>
+                                                                      </span>
+                                                                    </Component>
+                                                                  </Icon>
+                                                                </span>
+                                                              </Component>
+                                                            </ButtonLabel>
+                                                          </button>
+                                                        </ForwardRef>
+                                                      </StyledButton>
+                                                    </Button>
+                                                  </a>
+                                                  <Modal
+                                                    animation={false}
+                                                    autoFocus={true}
+                                                    backdrop={true}
+                                                    bsClass="modal"
+                                                    dialogComponentClass={[Function]}
+                                                    enforceFocus={true}
+                                                    keyboard={true}
+                                                    manager={
+                                                      ModalManager {
+                                                        "add": [Function],
+                                                        "containers": Array [],
+                                                        "data": Array [],
+                                                        "handleContainerOverflow": true,
+                                                        "hideSiblingNodes": true,
+                                                        "isTopModal": [Function],
+                                                        "modals": Array [],
+                                                        "remove": [Function],
+                                                      }
+                                                    }
+                                                    onHide={[Function]}
+                                                    renderBackdrop={[Function]}
+                                                    restoreFocus={true}
+                                                    show={false}
+                                                  >
+                                                    <Modal
+                                                      autoFocus={true}
+                                                      backdrop={true}
+                                                      backdropClassName="modal-backdrop"
+                                                      containerClassName="modal-open"
+                                                      enforceFocus={true}
+                                                      keyboard={true}
+                                                      manager={
+                                                        ModalManager {
+                                                          "add": [Function],
+                                                          "containers": Array [],
+                                                          "data": Array [],
+                                                          "handleContainerOverflow": true,
+                                                          "hideSiblingNodes": true,
+                                                          "isTopModal": [Function],
+                                                          "modals": Array [],
+                                                          "remove": [Function],
+                                                        }
+                                                      }
+                                                      onEntering={[Function]}
+                                                      onExited={[Function]}
+                                                      onHide={[Function]}
+                                                      renderBackdrop={[Function]}
+                                                      restoreFocus={true}
+                                                      show={false}
+                                                    />
+                                                  </Modal>
+                                                </Confirm>
+                                              </LinkWithConfirmation>
+                                            </span>
+                                          </Container>
+                                        </InnerReference>
+                                      </Reference>
+                                    </Manager>
+                                  </Tooltip2>
                                 </div>
                               </Base>
                             </Flex>
@@ -1373,187 +1407,215 @@ exports[`ProjectTags renders 1`] = `
                                   className="css-p3ab1k"
                                   is={null}
                                 >
-                                  <Tooltip
+                                  <Tooltip2
+                                    containerDisplayMode="inline-block"
+                                    position="top"
                                     title="This tag cannot be deleted."
                                   >
-                                    <LinkWithConfirmation
-                                      className="tip"
-                                      disabled={true}
-                                      message="Are you sure you want to remove this tag?"
-                                      onConfirm={[Function]}
-                                      title="This tag cannot be deleted."
-                                    >
-                                      <Confirm
-                                        cancelText="Cancel"
-                                        confirmText="Confirm"
-                                        disableConfirmButton={false}
-                                        disabled={true}
-                                        message="Are you sure you want to remove this tag?"
-                                        onConfirm={[Function]}
-                                        priority="primary"
-                                        stopPropagation={false}
-                                      >
-                                        <a
-                                          className="tip disabled"
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          title="This tag cannot be deleted."
+                                    <Manager>
+                                      <Reference>
+                                        <InnerReference
+                                          setReferenceNode={[Function]}
                                         >
-                                          <Button
-                                            data-test-id="delete"
-                                            disabled={true}
-                                            icon="icon-trash"
-                                            size="xsmall"
+                                          <Container
+                                            aria-describedby="tooltip-123456"
+                                            containerDisplayMode="inline-block"
+                                            innerRef={[Function]}
+                                            onBlur={[Function]}
+                                            onFocus={[Function]}
+                                            onMouseEnter={[Function]}
+                                            onMouseLeave={[Function]}
                                           >
-                                            <StyledButton
-                                              aria-disabled={true}
-                                              data-test-id="delete"
-                                              disabled={true}
-                                              href={null}
-                                              onClick={[Function]}
-                                              role="button"
-                                              size="xsmall"
-                                              to={null}
+                                            <span
+                                              aria-describedby="tooltip-123456"
+                                              className="css-1m3e0hg-Container e7ebgxc0"
+                                              onBlur={[Function]}
+                                              onFocus={[Function]}
+                                              onMouseEnter={[Function]}
+                                              onMouseLeave={[Function]}
                                             >
-                                              <ForwardRef
-                                                aria-disabled={true}
-                                                className="css-bzxnfi-StyledButton-getColors e12ma6z0"
-                                                data-test-id="delete"
+                                              <LinkWithConfirmation
                                                 disabled={true}
-                                                href={null}
-                                                onClick={[Function]}
-                                                role="button"
-                                                size="xsmall"
-                                                to={null}
+                                                message="Are you sure you want to remove this tag?"
+                                                onConfirm={[Function]}
+                                                title="Remove tag?"
                                               >
-                                                <button
-                                                  aria-disabled={true}
-                                                  className="css-bzxnfi-StyledButton-getColors e12ma6z0"
-                                                  data-test-id="delete"
-                                                  href={null}
-                                                  onClick={[Function]}
-                                                  role="button"
-                                                  size="xsmall"
-                                                  to={null}
+                                                <Confirm
+                                                  cancelText="Cancel"
+                                                  confirmText="Confirm"
+                                                  disableConfirmButton={false}
+                                                  disabled={true}
+                                                  message="Are you sure you want to remove this tag?"
+                                                  onConfirm={[Function]}
+                                                  priority="primary"
+                                                  stopPropagation={false}
                                                 >
-                                                  <ButtonLabel
-                                                    size="xsmall"
+                                                  <a
+                                                    className="disabled"
+                                                    disabled={true}
+                                                    onClick={[Function]}
+                                                    title="Remove tag?"
                                                   >
-                                                    <Component
-                                                      className="css-uthd1f-ButtonLabel e12ma6z1"
+                                                    <Button
+                                                      data-test-id="delete"
+                                                      disabled={true}
+                                                      icon="icon-trash"
                                                       size="xsmall"
                                                     >
-                                                      <span
-                                                        className="css-uthd1f-ButtonLabel e12ma6z1"
+                                                      <StyledButton
+                                                        aria-disabled={true}
+                                                        data-test-id="delete"
+                                                        disabled={true}
+                                                        href={null}
+                                                        onClick={[Function]}
+                                                        role="button"
+                                                        size="xsmall"
+                                                        to={null}
                                                       >
-                                                        <Icon
-                                                          hasChildren={false}
+                                                        <ForwardRef
+                                                          aria-disabled={true}
+                                                          className="css-bzxnfi-StyledButton-getColors e12ma6z0"
+                                                          data-test-id="delete"
+                                                          disabled={true}
+                                                          href={null}
+                                                          onClick={[Function]}
+                                                          role="button"
                                                           size="xsmall"
+                                                          to={null}
                                                         >
-                                                          <Component
-                                                            className="css-ljhpxy-Icon e12ma6z2"
-                                                            hasChildren={false}
+                                                          <button
+                                                            aria-disabled={true}
+                                                            className="css-bzxnfi-StyledButton-getColors e12ma6z0"
+                                                            data-test-id="delete"
+                                                            href={null}
+                                                            onClick={[Function]}
+                                                            role="button"
                                                             size="xsmall"
+                                                            to={null}
                                                           >
-                                                            <span
-                                                              className="css-ljhpxy-Icon e12ma6z2"
+                                                            <ButtonLabel
                                                               size="xsmall"
                                                             >
-                                                              <StyledInlineSvg
-                                                                size="12px"
-                                                                src="icon-trash"
+                                                              <Component
+                                                                className="css-uthd1f-ButtonLabel e12ma6z1"
+                                                                size="xsmall"
                                                               >
-                                                                <InlineSvg
-                                                                  className="css-1ov3rcq-StyledInlineSvg e12ma6z3"
-                                                                  size="12px"
-                                                                  src="icon-trash"
+                                                                <span
+                                                                  className="css-uthd1f-ButtonLabel e12ma6z1"
                                                                 >
-                                                                  <StyledSvg
-                                                                    className="css-1ov3rcq-StyledInlineSvg e12ma6z3"
-                                                                    height="12px"
-                                                                    viewBox={Object {}}
-                                                                    width="12px"
+                                                                  <Icon
+                                                                    hasChildren={false}
+                                                                    size="xsmall"
                                                                   >
-                                                                    <svg
-                                                                      className="e12ma6z3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
-                                                                      height="12px"
-                                                                      viewBox={Object {}}
-                                                                      width="12px"
+                                                                    <Component
+                                                                      className="css-ljhpxy-Icon e12ma6z2"
+                                                                      hasChildren={false}
+                                                                      size="xsmall"
                                                                     >
-                                                                      <use
-                                                                        href="#test"
-                                                                        xlinkHref="#test"
-                                                                      />
-                                                                    </svg>
-                                                                  </StyledSvg>
-                                                                </InlineSvg>
-                                                              </StyledInlineSvg>
-                                                            </span>
-                                                          </Component>
-                                                        </Icon>
-                                                      </span>
-                                                    </Component>
-                                                  </ButtonLabel>
-                                                </button>
-                                              </ForwardRef>
-                                            </StyledButton>
-                                          </Button>
-                                        </a>
-                                        <Modal
-                                          animation={false}
-                                          autoFocus={true}
-                                          backdrop={true}
-                                          bsClass="modal"
-                                          dialogComponentClass={[Function]}
-                                          enforceFocus={true}
-                                          keyboard={true}
-                                          manager={
-                                            ModalManager {
-                                              "add": [Function],
-                                              "containers": Array [],
-                                              "data": Array [],
-                                              "handleContainerOverflow": true,
-                                              "hideSiblingNodes": true,
-                                              "isTopModal": [Function],
-                                              "modals": Array [],
-                                              "remove": [Function],
-                                            }
-                                          }
-                                          onHide={[Function]}
-                                          renderBackdrop={[Function]}
-                                          restoreFocus={true}
-                                          show={false}
-                                        >
-                                          <Modal
-                                            autoFocus={true}
-                                            backdrop={true}
-                                            backdropClassName="modal-backdrop"
-                                            containerClassName="modal-open"
-                                            enforceFocus={true}
-                                            keyboard={true}
-                                            manager={
-                                              ModalManager {
-                                                "add": [Function],
-                                                "containers": Array [],
-                                                "data": Array [],
-                                                "handleContainerOverflow": true,
-                                                "hideSiblingNodes": true,
-                                                "isTopModal": [Function],
-                                                "modals": Array [],
-                                                "remove": [Function],
-                                              }
-                                            }
-                                            onEntering={[Function]}
-                                            onExited={[Function]}
-                                            onHide={[Function]}
-                                            renderBackdrop={[Function]}
-                                            restoreFocus={true}
-                                            show={false}
-                                          />
-                                        </Modal>
-                                      </Confirm>
-                                    </LinkWithConfirmation>
-                                  </Tooltip>
+                                                                      <span
+                                                                        className="css-ljhpxy-Icon e12ma6z2"
+                                                                        size="xsmall"
+                                                                      >
+                                                                        <StyledInlineSvg
+                                                                          size="12px"
+                                                                          src="icon-trash"
+                                                                        >
+                                                                          <InlineSvg
+                                                                            className="css-1ov3rcq-StyledInlineSvg e12ma6z3"
+                                                                            size="12px"
+                                                                            src="icon-trash"
+                                                                          >
+                                                                            <StyledSvg
+                                                                              className="css-1ov3rcq-StyledInlineSvg e12ma6z3"
+                                                                              height="12px"
+                                                                              viewBox={Object {}}
+                                                                              width="12px"
+                                                                            >
+                                                                              <svg
+                                                                                className="e12ma6z3 css-1jjmnki-StyledSvg-StyledInlineSvg e2idor0"
+                                                                                height="12px"
+                                                                                viewBox={Object {}}
+                                                                                width="12px"
+                                                                              >
+                                                                                <use
+                                                                                  href="#test"
+                                                                                  xlinkHref="#test"
+                                                                                />
+                                                                              </svg>
+                                                                            </StyledSvg>
+                                                                          </InlineSvg>
+                                                                        </StyledInlineSvg>
+                                                                      </span>
+                                                                    </Component>
+                                                                  </Icon>
+                                                                </span>
+                                                              </Component>
+                                                            </ButtonLabel>
+                                                          </button>
+                                                        </ForwardRef>
+                                                      </StyledButton>
+                                                    </Button>
+                                                  </a>
+                                                  <Modal
+                                                    animation={false}
+                                                    autoFocus={true}
+                                                    backdrop={true}
+                                                    bsClass="modal"
+                                                    dialogComponentClass={[Function]}
+                                                    enforceFocus={true}
+                                                    keyboard={true}
+                                                    manager={
+                                                      ModalManager {
+                                                        "add": [Function],
+                                                        "containers": Array [],
+                                                        "data": Array [],
+                                                        "handleContainerOverflow": true,
+                                                        "hideSiblingNodes": true,
+                                                        "isTopModal": [Function],
+                                                        "modals": Array [],
+                                                        "remove": [Function],
+                                                      }
+                                                    }
+                                                    onHide={[Function]}
+                                                    renderBackdrop={[Function]}
+                                                    restoreFocus={true}
+                                                    show={false}
+                                                  >
+                                                    <Modal
+                                                      autoFocus={true}
+                                                      backdrop={true}
+                                                      backdropClassName="modal-backdrop"
+                                                      containerClassName="modal-open"
+                                                      enforceFocus={true}
+                                                      keyboard={true}
+                                                      manager={
+                                                        ModalManager {
+                                                          "add": [Function],
+                                                          "containers": Array [],
+                                                          "data": Array [],
+                                                          "handleContainerOverflow": true,
+                                                          "hideSiblingNodes": true,
+                                                          "isTopModal": [Function],
+                                                          "modals": Array [],
+                                                          "remove": [Function],
+                                                        }
+                                                      }
+                                                      onEntering={[Function]}
+                                                      onExited={[Function]}
+                                                      onHide={[Function]}
+                                                      renderBackdrop={[Function]}
+                                                      restoreFocus={true}
+                                                      show={false}
+                                                    />
+                                                  </Modal>
+                                                </Confirm>
+                                              </LinkWithConfirmation>
+                                            </span>
+                                          </Container>
+                                        </InnerReference>
+                                      </Reference>
+                                    </Manager>
+                                  </Tooltip2>
                                 </div>
                               </Base>
                             </Flex>

--- a/tests/js/spec/views/__snapshots__/projectTeams.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTeams.spec.jsx.snap
@@ -15,14 +15,11 @@ exports[`ProjectTeams renders 1`] = `
       menuHeader={
         <StyledTeamsLabel>
           Teams
-          <Tooltip
+          <Tooltip2
+            containerDisplayMode="inline-block"
             disabled={true}
+            position="top"
             title="You must be a project admin to create teams"
-            tooltipOptions={
-              Object {
-                "placement": "top",
-              }
-            }
           >
             <StyledCreateTeamLink
               disabled={false}
@@ -30,7 +27,7 @@ exports[`ProjectTeams renders 1`] = `
             >
               Create Team
             </StyledCreateTeamLink>
-          </Tooltip>
+          </Tooltip2>
         </StyledTeamsLabel>
       }
       onAddTeam={[Function]}

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -791,14 +791,10 @@ exports[`RuleBuilder renders 1`] = `
                                     justify="space-between"
                                   >
                                     <DisabledLabel>
-                                      <Tooltip
+                                      <Tooltip2
+                                        containerDisplayMode="inline-block"
+                                        position="left"
                                         title="#team-not-in-project is not a member of project"
-                                        tooltipOptions={
-                                          Object {
-                                            "container": "body",
-                                            "placement": "left",
-                                          }
-                                        }
                                       >
                                         <IdBadge
                                           team={
@@ -811,9 +807,11 @@ exports[`RuleBuilder renders 1`] = `
                                             }
                                           }
                                         />
-                                      </Tooltip>
+                                      </Tooltip2>
                                     </DisabledLabel>
-                                    <Tooltip
+                                    <Tooltip2
+                                      containerDisplayMode="inline-block"
+                                      position="top"
                                       title="Add #team-not-in-project to project"
                                     >
                                       <AddToProjectButton
@@ -826,7 +824,7 @@ exports[`RuleBuilder renders 1`] = `
                                           src="icon-circle-add"
                                         />
                                       </AddToProjectButton>
-                                    </Tooltip>
+                                    </Tooltip2>
                                   </Flex>,
                                   "searchKey": "#team-not-in-project",
                                   "value": "team:4",
@@ -839,14 +837,10 @@ exports[`RuleBuilder renders 1`] = `
                                   },
                                   "disabled": true,
                                   "label": <DisabledLabel>
-                                    <Tooltip
+                                    <Tooltip2
+                                      containerDisplayMode="inline-block"
+                                      position="left"
                                       title="John Smith is not a member of project"
-                                      tooltipOptions={
-                                        Object {
-                                          "container": "body",
-                                          "placement": "left",
-                                        }
-                                      }
                                     >
                                       <IdBadge
                                         avatarSize={24}
@@ -860,7 +854,7 @@ exports[`RuleBuilder renders 1`] = `
                                           }
                                         }
                                       />
-                                    </Tooltip>
+                                    </Tooltip2>
                                   </DisabledLabel>,
                                   "searchKey": "johnsmith@example.com john smith",
                                   "value": "user:2",
@@ -2361,14 +2355,10 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                     justify="space-between"
                                   >
                                     <DisabledLabel>
-                                      <Tooltip
+                                      <Tooltip2
+                                        containerDisplayMode="inline-block"
+                                        position="left"
                                         title="#team-not-in-project is not a member of project"
-                                        tooltipOptions={
-                                          Object {
-                                            "container": "body",
-                                            "placement": "left",
-                                          }
-                                        }
                                       >
                                         <IdBadge
                                           team={
@@ -2381,9 +2371,11 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                             }
                                           }
                                         />
-                                      </Tooltip>
+                                      </Tooltip2>
                                     </DisabledLabel>
-                                    <Tooltip
+                                    <Tooltip2
+                                      containerDisplayMode="inline-block"
+                                      position="top"
                                       title="Add #team-not-in-project to project"
                                     >
                                       <AddToProjectButton
@@ -2396,7 +2388,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                           src="icon-circle-add"
                                         />
                                       </AddToProjectButton>
-                                    </Tooltip>
+                                    </Tooltip2>
                                   </Flex>,
                                   "searchKey": "#team-not-in-project",
                                   "value": "team:4",
@@ -2409,14 +2401,10 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                   },
                                   "disabled": true,
                                   "label": <DisabledLabel>
-                                    <Tooltip
+                                    <Tooltip2
+                                      containerDisplayMode="inline-block"
+                                      position="left"
                                       title="John Smith is not a member of project"
-                                      tooltipOptions={
-                                        Object {
-                                          "container": "body",
-                                          "placement": "left",
-                                        }
-                                      }
                                     >
                                       <IdBadge
                                         avatarSize={24}
@@ -2430,7 +2418,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                           }
                                         }
                                       />
-                                    </Tooltip>
+                                    </Tooltip2>
                                   </DisabledLabel>,
                                   "searchKey": "johnsmith@example.com john smith",
                                   "value": "user:2",

--- a/tests/js/spec/views/accountSecurity.spec.jsx
+++ b/tests/js/spec/views/accountSecurity.spec.jsx
@@ -153,7 +153,7 @@ describe('AccountSecurity', function() {
     ).toBe(false);
     expect(
       wrapper
-        .find('Tooltip')
+        .find('Tooltip2')
         .first()
         .prop('disabled')
     ).toBe(true);
@@ -202,8 +202,8 @@ describe('AccountSecurity', function() {
     expect(wrapper.find('CircleIndicator').prop('enabled')).toBe(true);
 
     expect(wrapper.find('RemoveConfirm').prop('disabled')).toBe(true);
-    expect(wrapper.find('Tooltip').prop('disabled')).toBe(false);
-    expect(wrapper.find('Tooltip').prop('title')).toContain('test 1 and test 2');
+    expect(wrapper.find('Tooltip2').prop('disabled')).toBe(false);
+    expect(wrapper.find('Tooltip2').prop('title')).toContain('test 1 and test 2');
 
     // This will open confirm modal
     wrapper.find('Button .icon-trash').simulate('click');

--- a/tests/js/spec/views/groupDetails/__snapshots__/groupSimilar.spec.jsx.snap
+++ b/tests/js/spec/views/groupDetails/__snapshots__/groupSimilar.spec.jsx.snap
@@ -875,20 +875,35 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                             }
                                           }
                                         >
-                                          <Tooltip
-                                            title="Error level: Error"
+                                          <GroupLevel
+                                            level="error"
                                           >
-                                            <GroupLevel
-                                              className="tip"
-                                              level="error"
-                                              title="Error level: Error"
+                                            <div
+                                              className="css-1oawdkn-GroupLevel eex8od5"
                                             >
-                                              <div
-                                                className="tip css-hpn2f3-GroupLevel eex8od5"
+                                              <Tooltip2
+                                                containerDisplayMode="inline-block"
+                                                position="top"
                                                 title="Error level: Error"
-                                              />
-                                            </GroupLevel>
-                                          </Tooltip>
+                                              >
+                                                <Manager>
+                                                  <Reference>
+                                                    <InnerReference
+                                                      setReferenceNode={[Function]}
+                                                    >
+                                                      <span
+                                                        aria-describedby="tooltip-123456"
+                                                        onBlur={[Function]}
+                                                        onFocus={[Function]}
+                                                        onMouseEnter={[Function]}
+                                                        onMouseLeave={[Function]}
+                                                      />
+                                                    </InnerReference>
+                                                  </Reference>
+                                                </Manager>
+                                              </Tooltip2>
+                                            </div>
+                                          </GroupLevel>
                                           <EventOrGroupTitle
                                             data={
                                               Object {

--- a/tests/js/spec/views/organizationIncidents/details/index.spec.jsx
+++ b/tests/js/spec/views/organizationIncidents/details/index.spec.jsx
@@ -22,7 +22,8 @@ describe('IncidentDetails', function() {
 
   it('loads incident', async function() {
     const wrapper = mount(
-      <IncidentDetails params={{orgId: 'org-slug', incidentId: mockIncident.id}} />
+      <IncidentDetails params={{orgId: 'org-slug', incidentId: mockIncident.id}} />,
+      TestStubs.routerContext()
     );
     expect(wrapper.find('LoadingIndicator')).toHaveLength(1);
     await tick();
@@ -32,7 +33,8 @@ describe('IncidentDetails', function() {
 
   it('handles invalid incident', async function() {
     const wrapper = mount(
-      <IncidentDetails params={{orgId: 'org-slug', incidentId: '456'}} />
+      <IncidentDetails params={{orgId: 'org-slug', incidentId: '456'}} />,
+      TestStubs.routerContext()
     );
     await tick();
     wrapper.update();

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/subscriptionBox.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/subscriptionBox.spec.jsx.snap
@@ -13,8 +13,10 @@ exports[`SubscriptionBox renders resource checkbox 1`] = `
     <div
       className="css-8xqq56-SubscriptionGridItemWrapper e139qogw2"
     >
-      <Tooltip
+      <Tooltip2
+        containerDisplayMode="inline-block"
         disabled={true}
+        position="top"
         title="Must have at least 'Read' permissions enabled for issue"
       >
         <SubscriptionGridItem
@@ -69,7 +71,7 @@ exports[`SubscriptionBox renders resource checkbox 1`] = `
             </Checkbox>
           </div>
         </SubscriptionGridItem>
-      </Tooltip>
+      </Tooltip2>
     </div>
   </SubscriptionGridItemWrapper>
 </SubscriptionBox>

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/subscriptionBox.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/subscriptionBox.spec.jsx
@@ -33,6 +33,6 @@ describe('SubscriptionBox', () => {
 
   it('renders tooltip when checkbox is disabled', () => {
     wrapper.setProps({disabled: true});
-    expect(wrapper.find('Tooltip').prop('disabled')).toBe(false);
+    expect(wrapper.find('Tooltip2').prop('disabled')).toBe(false);
   });
 });

--- a/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/sentryAppInstallations.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/sentryAppInstallations.spec.jsx.snap
@@ -156,60 +156,76 @@ exports[`Sentry App Installations when Apps exist displays all Apps owned by the
                         >
                           Sample App
                           <BetaTag>
-                            <Tooltip
+                            <Tooltip2
+                              containerDisplayMode="inline-block"
+                              position="right"
                               title="This feature is in beta and may change in the future."
-                              tooltipOptions={
-                                Object {
-                                  "placement": "right",
-                                }
-                              }
                             >
-                              <StyledTag
-                                className="tip"
-                                priority="beta"
-                                size="small"
-                                title="This feature is in beta and may change in the future."
-                              >
-                                <Tag
-                                  className="tip css-f9iwbc-StyledTag e1xs0x250"
-                                  priority="beta"
-                                  size="small"
-                                  title="This feature is in beta and may change in the future."
-                                >
-                                  <TagTextStyled
-                                    className="tip css-f9iwbc-StyledTag e1xs0x250"
-                                    priority="beta"
-                                    size="small"
-                                    title="This feature is in beta and may change in the future."
+                              <Manager>
+                                <Reference>
+                                  <InnerReference
+                                    setReferenceNode={[Function]}
                                   >
-                                    <Component
-                                      className="tip e1xs0x250 css-4og6iv-TagTextStyled-StyledTag e6q9yfr0"
-                                      priority="beta"
-                                      size="small"
-                                      title="This feature is in beta and may change in the future."
+                                    <Container
+                                      aria-describedby="tooltip-123456"
+                                      containerDisplayMode="inline-block"
+                                      innerRef={[Function]}
+                                      onBlur={[Function]}
+                                      onFocus={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
                                     >
-                                      <Box
-                                        className="tip e1xs0x250 css-4og6iv-TagTextStyled-StyledTag e6q9yfr0"
-                                        title="This feature is in beta and may change in the future."
+                                      <span
+                                        aria-describedby="tooltip-123456"
+                                        className="css-1m3e0hg-Container e7ebgxc0"
+                                        onBlur={[Function]}
+                                        onFocus={[Function]}
+                                        onMouseEnter={[Function]}
+                                        onMouseLeave={[Function]}
                                       >
-                                        <Base
-                                          className="tip e1xs0x250 e6q9yfr0 css-1r8ewb4-TagTextStyled-StyledTag"
-                                          title="This feature is in beta and may change in the future."
+                                        <StyledTag
+                                          priority="beta"
+                                          size="small"
                                         >
-                                          <div
-                                            className="tip e1xs0x250 e6q9yfr0 css-1r8ewb4-TagTextStyled-StyledTag"
-                                            is={null}
-                                            title="This feature is in beta and may change in the future."
+                                          <Tag
+                                            className="css-f9iwbc-StyledTag e1xs0x250"
+                                            priority="beta"
+                                            size="small"
                                           >
-                                            beta
-                                          </div>
-                                        </Base>
-                                      </Box>
-                                    </Component>
-                                  </TagTextStyled>
-                                </Tag>
-                              </StyledTag>
-                            </Tooltip>
+                                            <TagTextStyled
+                                              className="css-f9iwbc-StyledTag e1xs0x250"
+                                              priority="beta"
+                                              size="small"
+                                            >
+                                              <Component
+                                                className="e1xs0x250 css-4og6iv-TagTextStyled-StyledTag e6q9yfr0"
+                                                priority="beta"
+                                                size="small"
+                                              >
+                                                <Box
+                                                  className="e1xs0x250 css-4og6iv-TagTextStyled-StyledTag e6q9yfr0"
+                                                >
+                                                  <Base
+                                                    className="e1xs0x250 e6q9yfr0 css-1r8ewb4-TagTextStyled-StyledTag"
+                                                  >
+                                                    <div
+                                                      className="e1xs0x250 e6q9yfr0 css-1r8ewb4-TagTextStyled-StyledTag"
+                                                      is={null}
+                                                    >
+                                                      beta
+                                                    </div>
+                                                  </Base>
+                                                </Box>
+                                              </Component>
+                                            </TagTextStyled>
+                                          </Tag>
+                                        </StyledTag>
+                                      </span>
+                                    </Container>
+                                  </InnerReference>
+                                </Reference>
+                              </Manager>
+                            </Tooltip2>
                           </BetaTag>
                         </div>
                       </SentryAppName>

--- a/tests/js/spec/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
@@ -324,7 +324,7 @@ describe('OrganizationMemberDetail', function() {
     });
 
     const button = 'Button[data-test-id="reset-2fa"]';
-    const tooltip = 'Tooltip[data-test-id="reset-2fa-tooltip"]';
+    const tooltip = 'Tooltip2[data-test-id="reset-2fa-tooltip"]';
 
     const expectButtonEnabled = () => {
       expect(wrapper.find(button).text()).toEqual('Reset two-factor authentication');


### PR DESCRIPTION
Replace the jquery based tooltip with the popper based one for non-chart call sites in sentry. Updating the charts is going to be done separately as they are complicated.

Refs SEN-611