### PR TITLE
feat(incidents): Implement create new incident workflow

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/incident.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/incident.jsx
@@ -1,0 +1,38 @@
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  clearIndicators,
+} from 'app/actionCreators/indicator';
+import {t} from 'app/locale';
+
+/**
+ * Creates a new incident
+ *
+ * @param {Object} api API Client
+ * @param {Object} organization Organization object
+ * @param {String} title Title of the incident
+ * @param {String[]} groups List of group ids
+ */
+export async function createIncident(api, organization, title, groups) {
+  addLoadingMessage(t('Creating new incident...'));
+
+  try {
+    const resp = await api.requestPromise(
+      `/organizations/${organization.slug}/incidents/`,
+      {
+        method: 'POST',
+        data: {
+          title,
+          groups,
+          dateStarted: new Date(),
+          query: '',
+        },
+      }
+    );
+    clearIndicators();
+    return resp;
+  } catch (err) {
+    addErrorMessage(t('Unable to create incident'));
+    throw err;
+  }
+}

--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -397,7 +397,9 @@ const StreamActions = createReactClass({
                   className="btn btn-default btn-sm hidden-sm hidden-xs"
                   title={t('Create new incident')}
                   disabled={!anySelected}
-                  onAction={() => openCreateIncidentModal({organization})}
+                  onAction={() =>
+                    openCreateIncidentModal({organization, issues: Array.from(issues)})
+                  }
                 >
                   <InlineSvg src="icon-circle-add" />
                 </ActionLink>

--- a/tests/js/spec/components/modals/createIncidentModal.spec.jsx
+++ b/tests/js/spec/components/modals/createIncidentModal.spec.jsx
@@ -1,0 +1,67 @@
+import {Modal} from 'react-bootstrap';
+import {browserHistory} from 'react-router';
+import React from 'react';
+
+import {mount} from 'enzyme';
+import CreateIncidentModal from 'app/components/modals/createIncidentModal';
+
+describe('CreateIncidentModal', function() {
+  const org = TestStubs.Organization();
+  const closeModal = jest.fn();
+  const onClose = jest.fn();
+  const onSuccess = jest.fn();
+
+  beforeEach(function() {
+    onClose.mockReset();
+    onSuccess.mockReset();
+  });
+
+  afterEach(function() {
+    browserHistory.push.mockReset();
+  });
+
+  it('creates and redirects to newly created incident', async function() {
+    const mock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/incidents/',
+      method: 'POST',
+      body: {
+        identifier: '11111',
+      },
+    });
+    const wrapper = mount(
+      <CreateIncidentModal
+        Body={Modal.Body}
+        Header={Modal.Header}
+        organization={org}
+        closeModal={closeModal}
+        onClose={onClose}
+        issues={['123', '456']}
+      />,
+      TestStubs.routerContext()
+    );
+
+    wrapper.find('Input[name="title"]').simulate('change', {target: {value: 'Oh no'}});
+
+    wrapper.find('Form').simulate('submit');
+
+    expect(mock).toHaveBeenCalledWith(
+      '/organizations/org-slug/incidents/',
+      expect.objectContaining({
+        data: {
+          dateStarted: new Date(),
+          groups: ['123', '456'],
+          query: '',
+          title: 'Oh no',
+        },
+        method: 'POST',
+      })
+    );
+    await tick();
+    expect(onClose).toHaveBeenCalled();
+    expect(closeModal).toHaveBeenCalled();
+
+    expect(browserHistory.push).toHaveBeenCalledWith(
+      '/organizations/org-slug/incidents/11111/'
+    );
+  });
+});


### PR DESCRIPTION
Connect "Create new Incident" modal to API. Redirect to incident details after successful creation (currently does not work because details endpoint is not implemented)

Fixes SEN-525