### PR TITLE
perf(ui): Skip `/committers/` API request if no `firstRelease`

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -156,7 +156,9 @@ class EventEntries extends React.Component {
         {!utils.objectIsEmpty(event.errors) && (
           <EventErrors group={group} event={event} />
         )}{' '}
-        {!isShare && <EventCause event={event} orgId={orgId} projectId={project.slug} />}
+        {!isShare && !!group.firstRelease && (
+          <EventCause event={event} orgId={orgId} projectId={project.slug} />
+        )}
         {event.userReport && (
           <StyledEventUserFeedback
             report={event.userReport}

--- a/tests/js/spec/components/group/suggestedOwners.spec.jsx
+++ b/tests/js/spec/components/group/suggestedOwners.spec.jsx
@@ -10,7 +10,7 @@ describe('SuggestedOwners', function() {
 
   const organization = TestStubs.Organization();
   const project = TestStubs.Project();
-  const group = TestStubs.Group();
+  const group = TestStubs.Group({firstRelease: {}});
 
   const routerContext = TestStubs.routerContext([
     {
@@ -69,6 +69,36 @@ describe('SuggestedOwners', function() {
         .map(node => node.props())
         .some(p => p.commits !== undefined && p.rules === undefined)
     ).toBe(true);
+  });
+
+  it('does not call committers endpoint if `group.firstRelease` does not exist', function() {
+    const committers = Client.addMockResponse({
+      url: `${endpoint}/committers/`,
+      body: {
+        committers: [
+          {
+            author: TestStubs.CommitAuthor(),
+            commits: [TestStubs.Commit()],
+          },
+        ],
+      },
+    });
+
+    Client.addMockResponse({
+      url: `${endpoint}/owners/`,
+      body: {
+        owners: [{type: 'user', ...user}],
+        rules: [[['path', 'sentry/tagstore/*'], [['user', user.email]]]],
+      },
+    });
+
+    const wrapper = mount(
+      <SuggestedOwners project={project} group={TestStubs.Group()} event={event} />,
+      routerContext
+    );
+
+    expect(committers).not.toHaveBeenCalled();
+    expect(wrapper.find('ActorAvatar')).toHaveLength(1);
   });
 
   it('Merges owner matching rules and having suspect commits', function() {


### PR DESCRIPTION
On Issue Details page, we make duplicate requests to a committers endpoint for suspect commits. There will be no suspect commits if you do not have releases setup.