### PR TITLE
feat(search): Allow grouping of boolean search terms in the parser

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -85,7 +85,7 @@ def translate(pat):
 event_search_grammar = Grammar(r"""
 search               = (boolean_term / paren_term / search_term)*
 boolean_term         = (paren_term / search_term) space? (boolean_operator space? (paren_term / search_term) space?)+
-paren_term           = space? paren space? (paren_term / boolean_term)+ space? paren space?
+paren_term           = space? open_paren space? (paren_term / boolean_term)+ space? closed_paren space?
 search_term          = key_val_term / quoted_raw_search / raw_search
 key_val_term         = space? (time_filter / rel_time_filter / specific_time_filter
                        / numeric_filter / has_filter / is_filter / basic_filter)
@@ -124,7 +124,8 @@ rel_date_format      = ~r"[\+\-][0-9]+[wdhm](?=\s|$)"
 # even if the operator is <=
 boolean_operator     = "OR" / "AND"
 operator             = ">=" / "<=" / ">" / "<" / "=" / "!="
-paren                = ")" / "("
+open_paren           = "("
+closed_paren         = ")"
 sep                  = ":"
 space                = " "
 negation             = "!"
@@ -458,7 +459,10 @@ class SearchVisitor(NodeVisitor):
     def visit_search_value(self, node, children):
         return SearchValue(children[0])
 
-    def visit_paren(self, node, children):
+    def visit_closed_paren(self, node, children):
+        return node.text
+
+    def visit_open_paren(self, node, children):
         return node.text
 
     def visit_boolean_operator(self, node, children):

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -82,10 +82,9 @@ def translate(pat):
 # ?              // allow to be empty (allow empty quotes)
 # "              // quote literal
 
-
 event_search_grammar = Grammar(r"""
-search               = (boolean_term / search_term)*
-boolean_term         = (paren_term / search_term) space? (boolean_operator space? (paren_term / search_term))+
+search               = (boolean_term / paren_term / search_term)*
+boolean_term         = (paren_term / search_term) space? (boolean_operator space? (paren_term / search_term) space?)+
 paren_term           = space? paren space? (paren_term / boolean_term)+ space? paren space?
 search_term          = key_val_term / quoted_raw_search / raw_search
 key_val_term         = space? (time_filter / rel_time_filter / specific_time_filter
@@ -159,10 +158,6 @@ def has_boolean_search_terms(search_terms):
 class SearchBoolean(namedtuple('SearchBoolean', 'left_term operator right_term')):
     BOOLEAN_AND = "AND"
     BOOLEAN_OR = "OR"
-
-
-class SearchGroup(namedtuple('SearchGroup', 'values')):
-    pass
 
 
 class SearchFilter(namedtuple('SearchFilter', 'key operator value')):
@@ -327,7 +322,7 @@ class SearchVisitor(NodeVisitor):
         children = self.remove_optional_nodes(children)
         children = self.remove_space(children)
 
-        return SearchGroup(self.flatten(children[1]))
+        return self.flatten(children[1])
 
     def visit_numeric_filter(self, node, children):
         (search_key, _, operator, search_value) = children

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -858,6 +858,16 @@ class ParseBooleanSearchQueryTest(TestCase):
             )
         )]
 
+    def test_grouping_simple(self):
+        result = parse_search_query(
+            '(user.email:foo@example.com OR user.email:bar@example.com) AND user.email:foobar@example.com'
+        )
+        assert result == [SearchBoolean(left_term=self.term1, operator="OR", right_term=self.term2)]
+
+        assert parse_search_query(
+            '(user.email:foo@example.com AND user.email:bar@example.com)'
+        ) == [SearchBoolean(left_term=self.term1, operator="AND", right_term=self.term2)]
+
 
 class GetSnubaQueryArgsTest(TestCase):
     def test_simple(self):

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -916,6 +916,10 @@ class ParseBooleanSearchQueryTest(TestCase):
             )
         )]
 
+    def test_malformed_groups(self):
+        # TODO(lb): what do we do here?
+        pass
+
 
 class GetSnubaQueryArgsTest(TestCase):
     def test_simple(self):

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import datetime
+import pytest
 from datetime import timedelta
 
 from django.utils import timezone
@@ -917,8 +918,14 @@ class ParseBooleanSearchQueryTest(TestCase):
         )]
 
     def test_malformed_groups(self):
-        # TODO(lb): what do we do here?
-        pass
+        with pytest.raises(IncompleteParseError):
+            parse_search_query(
+                '(user.email:foo@example.com OR user.email:bar@example.com'
+            )
+        with pytest.raises(IncompleteParseError):
+            parse_search_query(
+                '((user.email:foo@example.com OR user.email:bar@example.com AND  user.email:bar@example.com)'
+            )
 
 
 class GetSnubaQueryArgsTest(TestCase):
@@ -1025,6 +1032,10 @@ class GetSnubaQueryArgsTest(TestCase):
                 0,
             ]]
         }
+
+    def test_malformed_groups(self):
+        with pytest.raises(InvalidSearchQuery):
+            get_snuba_query_args('(user.email:foo@example.com OR user.email:bar@example.com')
 
 
 class ConvertEndpointParamsTests(TestCase):

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -860,13 +860,30 @@ class ParseBooleanSearchQueryTest(TestCase):
 
     def test_grouping_simple(self):
         result = parse_search_query(
-            '(user.email:foo@example.com OR user.email:bar@example.com) AND user.email:foobar@example.com'
+            '(user.email:foo@example.com OR user.email:bar@example.com)'
         )
         assert result == [SearchBoolean(left_term=self.term1, operator="OR", right_term=self.term2)]
+        result = parse_search_query(
+            '(user.email:foo@example.com OR user.email:bar@example.com) AND user.email:foobar@example.com'
+        )
+        assert result == [SearchBoolean(
+            left_term=SearchBoolean(
+                left_term=self.term1,
+                operator='OR',
+                right_term=self.term2),
+            operator='AND',
+            right_term=self.term3)]
 
-        assert parse_search_query(
-            '(user.email:foo@example.com AND user.email:bar@example.com)'
-        ) == [SearchBoolean(left_term=self.term1, operator="AND", right_term=self.term2)]
+        result = parse_search_query(
+            'user.email:foo@example.com AND (user.email:bar@example.com OR user.email:foobar@example.com)'
+        )
+        assert result == [SearchBoolean(
+            left_term=self.term1,
+            operator='AND',
+            right_term=SearchBoolean(
+                left_term=self.term2,
+                operator='OR',
+                right_term=self.term3))]
 
 
 class GetSnubaQueryArgsTest(TestCase):


### PR DESCRIPTION
This allows statements such as:
`(A OR B) AND C`
as well as nested grouping such as:
`(A OR ( B OR C) AND D)`

Where if a boolean expression is in parenthesis, it is evaluated first. This should allow usage of both boolean `OR` and `AND` in the same search by allowing the user to avoid the implicit-AND.