### PR TITLE
feat(incidents): Add incident status functionality

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/header.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/header.jsx
@@ -47,16 +47,9 @@ export default class IncidentHeader extends React.Component {
           }
           menuWidth="160px"
         >
-          {isIncidentOpen && (
-            <StyledMenuItem onSelect={onStatusChange}>
-              {t('Close this incident')}
-            </StyledMenuItem>
-          )}
-          {!isIncidentOpen && (
-            <StyledMenuItem onSelect={onStatusChange}>
-              {t('Reopen this incident')}
-            </StyledMenuItem>
-          )}
+          <StyledMenuItem onSelect={onStatusChange}>
+            {isIncidentOpen ? t('Close this incident') : t('Reopen this incident')}
+          </StyledMenuItem>
         </DropdownControl>
       </Access>
     );

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/header.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/header.jsx
@@ -10,13 +10,57 @@ import InlineSvg from 'app/components/inlineSvg';
 import {PageHeader} from 'app/styles/organization';
 import space from 'app/styles/space';
 import SubscribeButton from 'app/components/subscribeButton';
+import DropdownControl from 'app/components/dropdownControl';
+import MenuItem from 'app/components/menuItem';
+import Access from 'app/components/acl/access';
+import DropdownButton from 'app/components/dropdownButton';
+
+import Status from '../status';
+import {isOpen} from '../utils';
 
 export default class IncidentHeader extends React.Component {
   static propTypes = {
     incident: SentryTypes.Incident,
     params: PropTypes.object.isRequired,
     onSubscriptionChange: PropTypes.func.isRequired,
+    onStatusChange: PropTypes.func.isRequired,
   };
+
+  renderStatus() {
+    const {incident, onStatusChange} = this.props;
+
+    const isIncidentOpen = isOpen(incident);
+
+    return (
+      <Access
+        access={['org:write']}
+        renderNoAccessMessage={() => <Status incident={incident} />}
+      >
+        <DropdownControl
+          button={
+            // eslint-disable-next-line no-shadow
+            ({getActorProps, isOpen}) => (
+              <DropdownButton {...getActorProps()} isOpen={isOpen}>
+                <Status incident={incident} />
+              </DropdownButton>
+            )
+          }
+          menuWidth="160px"
+        >
+          {isIncidentOpen && (
+            <StyledMenuItem onSelect={onStatusChange}>
+              {t('Close this incident')}
+            </StyledMenuItem>
+          )}
+          {!isIncidentOpen && (
+            <StyledMenuItem onSelect={onStatusChange}>
+              {t('Reopen this incident')}
+            </StyledMenuItem>
+          )}
+        </DropdownControl>
+      </Access>
+    );
+  }
 
   render() {
     const {incident, params, onSubscriptionChange} = this.props;
@@ -37,6 +81,10 @@ export default class IncidentHeader extends React.Component {
         </HeaderItem>
         {incident && (
           <GroupedHeaderItems>
+            <HeaderItem>
+              <ItemTitle>{t('Status')}</ItemTitle>
+              <ItemValue>{this.renderStatus()}</ItemValue>
+            </HeaderItem>
             <HeaderItem>
               <ItemTitle>{t('Event count')}</ItemTitle>
               <ItemValue>{incident.eventCount}</ItemValue>
@@ -103,4 +151,10 @@ const IncidentsLink = styled(Link)`
 const Chevron = styled(InlineSvg)`
   color: ${p => p.theme.gray1};
   margin: 0 ${space(0.5)};
+`;
+
+const StyledMenuItem = styled(MenuItem)`
+  font-size: ${p => p.theme.fontSizeMedium};
+  text-align: left;
+  padding: ${space(1)};
 `;

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/index.jsx
@@ -54,19 +54,20 @@ class OrganizationIncidentDetails extends React.Component {
       params: {orgId, incidentId},
     } = this.props;
 
-    const isSubscribed = !this.state.incident.isSubscribed;
+    const isSubscribed = this.state.incident.isSubscribed;
 
-    updateSubscription(api, orgId, incidentId, isSubscribed)
-      .then(() => {
-        this.setState(state => ({
-          incident: {...state.incident, isSubscribed},
-        }));
-      })
-      .catch(() => {
-        addErrorMessage(
-          t('An error occurred, your subscription status was not changed.')
-        );
-      });
+    const newIsSubscribed = !isSubscribed;
+
+    this.setState(state => ({
+      incident: {...state.incident, isSubscribed: newIsSubscribed},
+    }));
+
+    updateSubscription(api, orgId, incidentId, isSubscribed).catch(() => {
+      this.setState(state => ({
+        incident: {...state.incident, isSubscribed},
+      }));
+      addErrorMessage(t('An error occurred, your subscription status was not changed.'));
+    });
   };
 
   handleStatusChange = () => {
@@ -75,19 +76,23 @@ class OrganizationIncidentDetails extends React.Component {
       params: {orgId, incidentId},
     } = this.props;
 
-    const status = isOpen(this.state.incident)
+    const {status} = this.state.incident;
+
+    const newStatus = isOpen(this.state.incident)
       ? INCIDENT_STATUS.CLOSED
       : INCIDENT_STATUS.CREATED;
 
-    updateStatus(api, orgId, incidentId, status)
-      .then(() => {
-        this.setState(state => ({
-          incident: {...state.incident, status},
-        }));
-      })
-      .catch(() => {
-        addErrorMessage(t('An error occurred, your incident status was not changed.'));
-      });
+    this.setState(state => ({
+      incident: {...state.incident, newStatus},
+    }));
+
+    updateStatus(api, orgId, incidentId, status).catch(() => {
+      this.setState(state => ({
+        incident: {...state.incident, status},
+      }));
+
+      addErrorMessage(t('An error occurred, your incident status was not changed.'));
+    });
   };
 
   render() {

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/index.jsx
@@ -10,7 +10,13 @@ import {t} from 'app/locale';
 
 import IncidentHeader from './header';
 import Incidents from './incidents';
-import {fetchIncident, updateSubscription} from '../utils';
+import {
+  INCIDENT_STATUS,
+  fetchIncident,
+  updateSubscription,
+  updateStatus,
+  isOpen,
+} from '../utils';
 
 class OrganizationIncidentDetails extends React.Component {
   static propTypes = {
@@ -63,6 +69,27 @@ class OrganizationIncidentDetails extends React.Component {
       });
   };
 
+  handleStatusChange = () => {
+    const {
+      api,
+      params: {orgId, incidentId},
+    } = this.props;
+
+    const status = isOpen(this.state.incident)
+      ? INCIDENT_STATUS.CLOSED
+      : INCIDENT_STATUS.CREATED;
+
+    updateStatus(api, orgId, incidentId, status)
+      .then(() => {
+        this.setState(state => ({
+          incident: {...state.incident, status},
+        }));
+      })
+      .catch(() => {
+        addErrorMessage(t('An error occurred, your incident status was not changed.'));
+      });
+  };
+
   render() {
     const {incident, isLoading, hasError} = this.state;
 
@@ -72,6 +99,7 @@ class OrganizationIncidentDetails extends React.Component {
           params={this.props.params}
           incident={incident}
           onSubscriptionChange={this.handleSubscriptionChange}
+          onStatusChange={this.handleStatusChange}
         />
         {incident && <Incidents incident={incident} />}
         {isLoading && (

--- a/src/sentry/static/sentry/app/views/organizationIncidents/status.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/status.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
@@ -10,17 +11,19 @@ import {isOpen} from './utils';
 
 export default class Status extends React.Component {
   static propTypes = {
+    className: PropTypes.string,
     incident: SentryTypes.Incident.isRequired,
   };
 
   render() {
-    const isIncidentOpen = isOpen(this.props.incident);
+    const {className, incident} = this.props;
+    const isIncidentOpen = isOpen(incident);
 
     const icon = isIncidentOpen ? 'icon-circle-exclamation' : 'icon-circle-check';
     const text = isIncidentOpen ? t('Open') : t('Closed');
 
     return (
-      <Container>
+      <Container className={className}>
         <Icon src={icon} isOpen={isIncidentOpen} />
         {text}
       </Container>

--- a/src/sentry/static/sentry/app/views/organizationIncidents/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/utils.jsx
@@ -1,3 +1,9 @@
+export const INCIDENT_STATUS = {
+  DETECTED: 0,
+  CREATED: 1,
+  CLOSED: 2,
+};
+
 export function fetchIncident(api, orgId, incidentId) {
   return api.requestPromise(`/organizations/${orgId}/incidents/${incidentId}/`);
 }
@@ -11,6 +17,15 @@ export function updateSubscription(api, orgId, incidentId, isSubscribed) {
   });
 }
 
+export function updateStatus(api, orgId, incidentId, status) {
+  return api.requestPromise(`/organizations/${orgId}/incidents/${incidentId}/`, {
+    method: 'PUT',
+    data: {
+      status,
+    },
+  });
+}
+
 /**
  * Is incident open?
  *
@@ -20,10 +35,10 @@ export function updateSubscription(api, orgId, incidentId, isSubscribed) {
 
 export function isOpen(incident) {
   switch (incident.status) {
-    case 2: // closed
+    case INCIDENT_STATUS.CLOSED:
       return false;
-    case 0: // detected
-    case 1: // created
+    case INCIDENT_STATUS.DETECTED:
+    case INCIDENT_STATUS.CREATED:
     default:
       return true;
   }

--- a/tests/js/spec/views/organizationIncidents/details/index.spec.jsx
+++ b/tests/js/spec/views/organizationIncidents/details/index.spec.jsx
@@ -22,7 +22,8 @@ describe('IncidentDetails', function() {
 
   it('loads incident', async function() {
     const wrapper = mount(
-      <IncidentDetails params={{orgId: 'org-slug', incidentId: mockIncident.id}} />
+      <IncidentDetails params={{orgId: 'org-slug', incidentId: mockIncident.id}} />,
+      TestStubs.routerContext()
     );
     expect(wrapper.find('LoadingIndicator')).toHaveLength(1);
     await tick();
@@ -32,7 +33,8 @@ describe('IncidentDetails', function() {
 
   it('handles invalid incident', async function() {
     const wrapper = mount(
-      <IncidentDetails params={{orgId: 'org-slug', incidentId: '456'}} />
+      <IncidentDetails params={{orgId: 'org-slug', incidentId: '456'}} />,
+      TestStubs.routerContext()
     );
     await tick();
     wrapper.update();


### PR DESCRIPTION
A basic implementation of incident status dropdown and toggling functionality.

Looks something like this right now, could possibly use some design polish later.
<img width="777" alt="Screen Shot 2019-05-08 at 4 55 47 pm" src="https://user-images.githubusercontent.com/1779792/57415840-84f0c600-71b2-11e9-9655-94304999d3dc.png">

Closes SEN-559