### PR TITLE
ref(lint): Remove unused global declarations in eslint

### DIFF
--- a/src/sentry/static/sentry/app/components/dynamicWrapper.jsx
+++ b/src/sentry/static/sentry/app/components/dynamicWrapper.jsx
@@ -1,4 +1,3 @@
-/* global process */
 // eslint-disable-next-line no-unused-vars
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -1,4 +1,3 @@
-/* global module */
 import '@babel/polyfill';
 import 'bootstrap/js/alert';
 import 'bootstrap/js/tab';

--- a/src/sentry/static/sentry/app/utils/statics-setup.js
+++ b/src/sentry/static/sentry/app/utils/statics-setup.js
@@ -1,4 +1,7 @@
 /* eslint no-native-reassign:0 */
+
+// This (global) errors for some reason :|
+/* eslint-disable-next-line no-unused-vars */
 /* global __webpack_public_path__ */
 
 /**

--- a/tests/js/spec/components/repositoryRow.spec.jsx
+++ b/tests/js/spec/components/repositoryRow.spec.jsx
@@ -1,4 +1,3 @@
-/*global global*/
 import React from 'react';
 
 import {Client} from 'app/api';

--- a/tests/js/spec/utils/consolidatedScopes.spec.jsx
+++ b/tests/js/spec/utils/consolidatedScopes.spec.jsx
@@ -1,4 +1,3 @@
-/*global global*/
 import ConsolidatedScopes from 'app/utils/consolidatedScopes';
 
 describe('ConsolidatedScopes', () => {

--- a/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
@@ -1,4 +1,3 @@
-/*global global*/
 import React from 'react';
 
 import {Client} from 'app/api';

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
@@ -1,4 +1,3 @@
-/*global global*/
 import React from 'react';
 
 import {Client} from 'app/api';

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/permissionSelection.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/permissionSelection.spec.jsx
@@ -1,4 +1,3 @@
-/*global global*/
 import React from 'react';
 
 import {mount} from 'enzyme';

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/permissionsObserver.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/permissionsObserver.spec.jsx
@@ -1,4 +1,3 @@
-/*global global*/
 import React from 'react';
 
 import {mount} from 'enzyme';

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.jsx
@@ -1,4 +1,3 @@
-/*global global*/
 import React from 'react';
 
 import {mount} from 'enzyme';

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
@@ -1,4 +1,3 @@
-/*global global*/
 import {observable} from 'mobx';
 import React from 'react';
 

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/subscriptionBox.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/subscriptionBox.spec.jsx
@@ -1,4 +1,3 @@
-/*global global*/
 import React from 'react';
 
 import {mount} from 'enzyme';

--- a/tests/js/spec/views/settings/organizationIntegrations/sentryAppInstallations.spec.jsx
+++ b/tests/js/spec/views/settings/organizationIntegrations/sentryAppInstallations.spec.jsx
@@ -1,4 +1,3 @@
-/*global global*/
 import React from 'react';
 
 import {Client} from 'app/api';


### PR DESCRIPTION
This is so we can get the eslint rule: `no-unused-vars: { vars: "all"}`  to pass