### PR TITLE
ref(auth): Assign existing organization members on user creation

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -507,7 +507,17 @@ def handle_new_user(auth_provider, organization, request, identity):
 
     user.send_confirm_emails(is_new_user=True)
 
-    handle_new_membership(auth_provider, organization, request, auth_identity)
+    # If the user has a pending invitation in this organization, we can
+    # immediately assocaite their user.
+    try:
+        member = OrganizationMember.objects.get(
+            organization=organization,
+            email=user.email,
+        )
+        member.set_user(user)
+        member.save()
+    except OrganizationMember.DoesNotExist:
+        handle_new_membership(auth_provider, organization, request, auth_identity)
 
     return auth_identity
 

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import
+
+import mock
+
+from sentry.models import AuthProvider, OrganizationMember
+from sentry.testutils import TestCase
+from sentry.auth.helper import handle_new_user
+
+
+class HandleNewuserTest(TestCase):
+    @mock.patch('sentry.auth.helper.handle_new_membership')
+    def test_simple(self, mock_handle_new_membership):
+        provider = AuthProvider.objects.create(
+            organization=self.organization,
+            provider='dummy',
+        )
+
+        identity = {
+            'id': '1234',
+            'email': 'test@example.com',
+            'name': 'Morty',
+        }
+
+        auth_identity = handle_new_user(provider, self.organization, None, identity)
+
+        assert mock_handle_new_membership.called
+        assert auth_identity.user.email == identity['email']
+
+    @mock.patch('sentry.auth.helper.handle_new_membership')
+    def test_associated_member_invite(self, mock_handle_new_membership):
+        provider = AuthProvider.objects.create(
+            organization=self.organization,
+            provider='dummy',
+        )
+
+        identity = {
+            'id': '1234',
+            'email': 'test@example.com',
+            'name': 'Morty',
+        }
+
+        OrganizationMember.objects.create(
+            organization=self.organization,
+            email=identity['email'],
+        )
+
+        auth_identity = handle_new_user(provider, self.organization, None, identity)
+
+        assert not mock_handle_new_membership.called
+        assert OrganizationMember.objects.filter(
+            organization=self.organization,
+            user=auth_identity.user,
+        ).exists()


### PR DESCRIPTION
In the case where a user has already been given an OrganizationMember slot, does not have an account, and is having an account created via SSO, we should assign the user on account creation.