### PR TITLE
fix(email) Add shim property for django18 compatibility

### DIFF
--- a/src/sentry/tasks/email.py
+++ b/src/sentry/tasks/email.py
@@ -73,4 +73,8 @@ def process_inbound_email(mailfrom, group_id, payload):
     max_retries=None
 )
 def send_email(message):
+    # Shim for handling emails made in 1.6 and handled in 1.8+
+    if not hasattr(message, 'reply_to'):
+        message.reply_to = []
+
     send_messages([message])

--- a/src/sentry/tasks/email.py
+++ b/src/sentry/tasks/email.py
@@ -73,7 +73,12 @@ def process_inbound_email(mailfrom, group_id, payload):
     max_retries=None
 )
 def send_email(message):
-    # Shim for handling emails made in 1.6 and handled in 1.8+
+    # HACK(django18) Django 1.8 assumes that message objects have a reply_to attribute
+    # When a message is enqueued by django 1.6 we need to patch that property on
+    # so that the message can be converted to a stdlib one.
+    #
+    # See
+    # https://github.com/django/django/blob/c686dd8e6bb3817bcf04b8f13c025b4d3c3dc6dc/django/core/mail/message.py#L273-L274
     if not hasattr(message, 'reply_to'):
         message.reply_to = []
 


### PR DESCRIPTION
Django 1.8 expects that email objects have a `reply_to` attribute. By adding that attribute we can have forwards compatibility. The django 1.6 implementation of EmailMultiAlternatives ignores the `reply_to`
attribute (https://github.com/django/django/blob/1.6.11/django/core/mail/message.py)

Fixes SENTRY-AP6