### PR TITLE
tests: Add tags to python sample data

### DIFF
--- a/src/sentry/data/samples/python.json
+++ b/src/sentry/data/samples/python.json
@@ -2,7 +2,7 @@
   "tags": [
     ["level", "error"],
     ["server_name", "web01.example.org"],
-    ["os.name", "Linux"]
+    ["environment", "prod"],
   ],
   "sentry.interfaces.Stacktrace": {
     "frames": [

--- a/src/sentry/data/samples/python.json
+++ b/src/sentry/data/samples/python.json
@@ -1,268 +1,279 @@
 {
-    "sentry.interfaces.Stacktrace": {
-        "frames": [
-            {
-                "function": "build_msg",
-                "abs_path": "/home/ubuntu/.virtualenvs/getsentry/src/raven/raven/base.py",
-                "pre_context": [
-                    "                frames = stack",
-                    "",
-                    "            data.update({",
-                    "                'sentry.interfaces.Stacktrace': {",
-                    "                    'frames': get_stack_info(frames,"
-                ],
-                "vars": {
-                    "'event_id'": "'54a322436e1b47b88e239b78998ae742'",
-                    "'culprit'": null,
-                    "'event_type'": "'raven.events.Message'",
-                    "'date'": "datetime.datetime(2013, 8, 13, 3, 8, 24, 880386)",
-                    "'extra'": {
-                        "'loadavg'": [
-                            0.37255859375,
-                            0.5341796875,
-                            0.62939453125
-                        ],
-                        "'user'": "'dcramer'",
-                        "'go_deeper'": [
-                            [
-                                {
-                                    "'foo'": "'bar'",
-                                    "'bar'": ["'baz'"]
-                                }
-                            ]
-                        ]
-                    },
-                    "'v'": {
-                        "'message'": "u'This is a test message generated using ``raven test``'",
-                        "'params'": []
-                    },
-                    "'kwargs'": {
-                        "'message'": "'This is a test message generated using ``raven test``'",
-                        "'level'": 20
-                    },
-                    "'stack'": true,
-                    "'frames'": "<generator object iter_stack_frames at 0x107bcc3c0>",
-                    "'tags'": null,
-                    "'time_spent'": null,
-                    "'self'": "<raven.base.Client object at 0x107bb8210>",
-                    "'data'": {
-                        "'sentry.interfaces.Message'": {
-                            "'message'": "u'This is a test message generated using ``raven test``'",
-                            "'params'": []
-                        },
-                        "'message'": "u'This is a test message generated using ``raven test``'"
-                    },
-                    "'result'": {
-                        "'sentry.interfaces.Message'": {
-                            "'message'": "u'This is a test message generated using ``raven test``'",
-                            "'params'": []
-                        },
-                        "'message'": "u'This is a test message generated using ``raven test``'"
-                    },
-                    "'handler'": "<raven.events.Message object at 0x107bd0890>",
-                    "'k'": "'sentry.interfaces.Message'",
-                    "'public_key'": null
-                },
-                "module": "raven.base",
-                "filename": "raven/base.py",
-                "post_context": [
-                    "                },",
-                    "            })",
-                    "",
-                    "        if 'sentry.interfaces.Stacktrace' in data:",
-                    "            if self.include_paths:"
-                ],
-                "colno": null,
-                "in_app": false,
-                "data": {},
-                "context_line": "                        transformer=self.transform)",
-                "lineno": 303
-            },
-            {
-                "function": "capture",
-                "abs_path": "/home/ubuntu/.virtualenvs/getsentry/src/raven/raven/base.py",
-                "pre_context": [
-                    "        if not self.is_enabled():",
-                    "            return",
-                    "",
-                    "        data = self.build_msg(",
-                    "            event_type, data, date, time_spent, extra, stack, tags=tags,"
-                ],
-                "vars": {
-                    "'event_type'": "'raven.events.Message'",
-                    "'date'": null,
-                    "'extra'": {
-                        "'loadavg'": [
-                            0.37255859375,
-                            0.5341796875,
-                            0.62939453125
-                        ],
-                        "'user'": "'dcramer'",
-                        "'go_deeper'": [
-                            [
-                                {
-                                    "'foo'": "'bar'",
-                                    "'bar'": ["'baz'"]
-                                }
-                            ]
-                        ]
-                    },
-                    "'stack'": true,
-                    "'tags'": null,
-                    "'time_spent'": null,
-                    "'self'": "<raven.base.Client object at 0x107bb8210>",
-                    "'data'": null,
-                    "'kwargs'": {
-                        "'message'": "'This is a test message generated using ``raven test``'",
-                        "'level'": 20
-                    }
-                },
-                "module": "raven.base",
-                "filename": "raven/base.py",
-                "post_context": [
-                    "",
-                    "        self.send(**data)",
-                    "",
-                    "        return (data.get('event_id'),)",
-                    ""
-                ],
-                "colno": null,
-                "in_app": false,
-                "data": {},
-                "context_line": "            **kwargs)",
-                "lineno": 459
-            },
-            {
-                "function": "captureMessage",
-                "abs_path": "/home/ubuntu/.virtualenvs/getsentry/src/raven/raven/base.py",
-                "pre_context": [
-                    "        \"\"\"",
-                    "        Creates an event from ``message``.",
-                    "",
-                    "        >>> client.captureMessage('My event just happened!')",
-                    "        \"\"\""
-                ],
-                "vars": {
-                    "'message'": "'This is a test message generated using ``raven test``'",
-                    "'kwargs'": {
-                        "'extra'": {
-                            "'loadavg'": [
-                                0.37255859375,
-                                0.5341796875,
-                                0.62939453125
-                            ],
-                            "'user'": "'dcramer'",
-                            "'go_deeper'": [
-                                [
-                                    {
-                                        "'foo'": "'bar'",
-                                        "'bar'": ["'baz'"]
-                                    }
-                                ]
-                            ]
-                        },
-                        "'stack'": true,
-                        "'data'": null,
-                        "'level'": 20,
-                        "'tags'": null
-                    },
-                    "'self'": "<raven.base.Client object at 0x107bb8210>"
-                },
-                "module": "raven.base",
-                "filename": "raven/base.py",
-                "post_context": [
-                    "",
-                    "    def captureException(self, exc_info=None, **kwargs):",
-                    "        \"\"\"",
-                    "        Creates an event from an exception.",
-                    ""
-                ],
-                "colno": null,
-                "in_app": false,
-                "data": {},
-                "context_line": "        return self.capture('raven.events.Message', message=message, **kwargs)",
-                "lineno": 577
-            },
-            {
-                "function": "send_test_message",
-                "abs_path": "/home/ubuntu/.virtualenvs/getsentry/src/raven/raven/scripts/runner.py",
-                "pre_context": [
-                    "        level=logging.INFO,",
-                    "        stack=True,",
-                    "        tags=options.get('tags', {}),",
-                    "        extra={",
-                    "            'user': get_uid(),"
-                ],
-                "vars": {
-                    "'client'": "<raven.base.Client object at 0x107bb8210>",
-                    "'options'": {
-                        "'tags'": null,
-                        "'data'": null
-                    },
-                    "'data'": null,
-                    "'k'": "'secret_key'"
-                },
-                "module": "raven.scripts.runner",
-                "filename": "raven/scripts/runner.py",
-                "post_context": [
-                    "        },",
-                    "    ))",
-                    "",
-                    "    if client.state.did_fail():",
-                    "        print('error!')"
-                ],
-                "colno": null,
-                "in_app": false,
-                "data": {},
-                "context_line": "            'loadavg': get_loadavg(),",
-                "lineno": 77
-            },
-            {
-                "function": "main",
-                "abs_path": "/home/ubuntu/.virtualenvs/getsentry/src/raven/raven/scripts/runner.py",
-                "pre_context": [
-                    "    print(\"Using DSN configuration:\")",
-                    "    print(\" \", dsn)",
-                    "    print()",
-                    "",
-                    "    client = Client(dsn, include_paths=['raven'])"
-                ],
-                "vars": {
-                    "'root'": "<logging.Logger object at 0x107ba5b10>",
-                    "'parser'": "<optparse.OptionParser instance at 0x107ba3368>",
-                    "'dsn'": "'https://ebc35f33e151401f9deac549978bda11:f3403f81e12e4c24942d505f086b2cad@sentry.io/1'",
-                    "'opts'": "<Values at 0x107ba3b00: {'data': None, 'tags': None}>",
-                    "'client'": "<raven.base.Client object at 0x107bb8210>",
-                    "'args'": [
-                        "'test'",
-                        "'https://ebc35f33e151401f9deac549978bda11:f3403f81e12e4c24942d505f086b2cad@sentry.io/1'"
-                    ]
-                },
-                "module": "raven.scripts.runner",
-                "filename": "raven/scripts/runner.py",
-                "post_context": [],
-                "colno": null,
-                "in_app": false,
-                "data": {},
-                "context_line": "    send_test_message(client, opts.__dict__)",
-                "lineno": 112
-            }
-        ]
-    },
-    "sentry.interfaces.Template":{
-        "abs_path": "/srv/example/templates/debug_toolbar/base.html",
+  "tags": [
+    ["level", "error"],
+    ["server_name", "web01.example.org"],
+    ["os.name", "Linux"]
+  ],
+  "sentry.interfaces.Stacktrace": {
+    "frames": [
+      {
+        "function": "build_msg",
+        "abs_path": "/home/ubuntu/.virtualenvs/getsentry/src/raven/raven/base.py",
         "pre_context": [
-            "{% endif %}\n",
-            "<script src=\"{% static 'debug_toolbar/js/toolbar.js' %}\"></script>\n",
-            "<div id=\"djDebug\" hidden=\"hidden\" dir=\"ltr\"\n"
+          "                frames = stack",
+          "",
+          "            data.update({",
+          "                'sentry.interfaces.Stacktrace': {",
+          "                    'frames': get_stack_info(frames,"
         ],
+        "vars": {
+          "'event_id'": "'54a322436e1b47b88e239b78998ae742'",
+          "'culprit'": null,
+          "'event_type'": "'raven.events.Message'",
+          "'date'": "datetime.datetime(2013, 8, 13, 3, 8, 24, 880386)",
+          "'extra'": {
+            "'loadavg'": [
+              0.37255859375,
+              0.5341796875,
+              0.62939453125
+            ],
+            "'user'": "'dcramer'",
+            "'go_deeper'": [
+              [
+                {
+                  "'foo'": "'bar'",
+                  "'bar'": [
+                    "'baz'"
+                  ]
+                }
+              ]
+            ]
+          },
+          "'v'": {
+            "'message'": "u'This is a test message generated using ``raven test``'",
+            "'params'": []
+          },
+          "'kwargs'": {
+            "'message'": "'This is a test message generated using ``raven test``'",
+            "'level'": 20
+          },
+          "'stack'": true,
+          "'frames'": "<generator object iter_stack_frames at 0x107bcc3c0>",
+          "'tags'": null,
+          "'time_spent'": null,
+          "'self'": "<raven.base.Client object at 0x107bb8210>",
+          "'data'": {
+            "'sentry.interfaces.Message'": {
+              "'message'": "u'This is a test message generated using ``raven test``'",
+              "'params'": []
+            },
+            "'message'": "u'This is a test message generated using ``raven test``'"
+          },
+          "'result'": {
+            "'sentry.interfaces.Message'": {
+              "'message'": "u'This is a test message generated using ``raven test``'",
+              "'params'": []
+            },
+            "'message'": "u'This is a test message generated using ``raven test``'"
+          },
+          "'handler'": "<raven.events.Message object at 0x107bd0890>",
+          "'k'": "'sentry.interfaces.Message'",
+          "'public_key'": null
+        },
+        "module": "raven.base",
+        "filename": "raven/base.py",
         "post_context": [
-            "     {{ toolbar.config.ROOT_TAG_EXTRA_ATTRS|safe }}>\n",
-            "\t<div hidden=\"hidden\" id=\"djDebugToolbar\">\n",
-            "\t\t<ul id=\"djDebugPanelList\">\n"
+          "                },",
+          "            })",
+          "",
+          "        if 'sentry.interfaces.Stacktrace' in data:",
+          "            if self.include_paths:"
         ],
-        "filename": "debug_toolbar/base.html",
-        "lineno": 14,
-        "context_line": "     data-store-id=\"{{ toolbar.store_id }}\" data-render-panel-url=\"{% url 'djdt:render_panel' %}\"\n"
-    }
+        "colno": null,
+        "in_app": false,
+        "data": {},
+        "context_line": "                        transformer=self.transform)",
+        "lineno": 303
+      },
+      {
+        "function": "capture",
+        "abs_path": "/home/ubuntu/.virtualenvs/getsentry/src/raven/raven/base.py",
+        "pre_context": [
+          "        if not self.is_enabled():",
+          "            return",
+          "",
+          "        data = self.build_msg(",
+          "            event_type, data, date, time_spent, extra, stack, tags=tags,"
+        ],
+        "vars": {
+          "'event_type'": "'raven.events.Message'",
+          "'date'": null,
+          "'extra'": {
+            "'loadavg'": [
+              0.37255859375,
+              0.5341796875,
+              0.62939453125
+            ],
+            "'user'": "'dcramer'",
+            "'go_deeper'": [
+              [
+                {
+                  "'foo'": "'bar'",
+                  "'bar'": [
+                    "'baz'"
+                  ]
+                }
+              ]
+            ]
+          },
+          "'stack'": true,
+          "'tags'": null,
+          "'time_spent'": null,
+          "'self'": "<raven.base.Client object at 0x107bb8210>",
+          "'data'": null,
+          "'kwargs'": {
+            "'message'": "'This is a test message generated using ``raven test``'",
+            "'level'": 20
+          }
+        },
+        "module": "raven.base",
+        "filename": "raven/base.py",
+        "post_context": [
+          "",
+          "        self.send(**data)",
+          "",
+          "        return (data.get('event_id'),)",
+          ""
+        ],
+        "colno": null,
+        "in_app": false,
+        "data": {},
+        "context_line": "            **kwargs)",
+        "lineno": 459
+      },
+      {
+        "function": "captureMessage",
+        "abs_path": "/home/ubuntu/.virtualenvs/getsentry/src/raven/raven/base.py",
+        "pre_context": [
+          "        \"\"\"",
+          "        Creates an event from ``message``.",
+          "",
+          "        >>> client.captureMessage('My event just happened!')",
+          "        \"\"\""
+        ],
+        "vars": {
+          "'message'": "'This is a test message generated using ``raven test``'",
+          "'kwargs'": {
+            "'extra'": {
+              "'loadavg'": [
+                0.37255859375,
+                0.5341796875,
+                0.62939453125
+              ],
+              "'user'": "'dcramer'",
+              "'go_deeper'": [
+                [
+                  {
+                    "'foo'": "'bar'",
+                    "'bar'": [
+                      "'baz'"
+                    ]
+                  }
+                ]
+              ]
+            },
+            "'stack'": true,
+            "'data'": null,
+            "'level'": 20,
+            "'tags'": null
+          },
+          "'self'": "<raven.base.Client object at 0x107bb8210>"
+        },
+        "module": "raven.base",
+        "filename": "raven/base.py",
+        "post_context": [
+          "",
+          "    def captureException(self, exc_info=None, **kwargs):",
+          "        \"\"\"",
+          "        Creates an event from an exception.",
+          ""
+        ],
+        "colno": null,
+        "in_app": false,
+        "data": {},
+        "context_line": "        return self.capture('raven.events.Message', message=message, **kwargs)",
+        "lineno": 577
+      },
+      {
+        "function": "send_test_message",
+        "abs_path": "/home/ubuntu/.virtualenvs/getsentry/src/raven/raven/scripts/runner.py",
+        "pre_context": [
+          "        level=logging.INFO,",
+          "        stack=True,",
+          "        tags=options.get('tags', {}),",
+          "        extra={",
+          "            'user': get_uid(),"
+        ],
+        "vars": {
+          "'client'": "<raven.base.Client object at 0x107bb8210>",
+          "'options'": {
+            "'tags'": null,
+            "'data'": null
+          },
+          "'data'": null,
+          "'k'": "'secret_key'"
+        },
+        "module": "raven.scripts.runner",
+        "filename": "raven/scripts/runner.py",
+        "post_context": [
+          "        },",
+          "    ))",
+          "",
+          "    if client.state.did_fail():",
+          "        print('error!')"
+        ],
+        "colno": null,
+        "in_app": false,
+        "data": {},
+        "context_line": "            'loadavg': get_loadavg(),",
+        "lineno": 77
+      },
+      {
+        "function": "main",
+        "abs_path": "/home/ubuntu/.virtualenvs/getsentry/src/raven/raven/scripts/runner.py",
+        "pre_context": [
+          "    print(\"Using DSN configuration:\")",
+          "    print(\" \", dsn)",
+          "    print()",
+          "",
+          "    client = Client(dsn, include_paths=['raven'])"
+        ],
+        "vars": {
+          "'root'": "<logging.Logger object at 0x107ba5b10>",
+          "'parser'": "<optparse.OptionParser instance at 0x107ba3368>",
+          "'dsn'": "'https://ebc35f33e151401f9deac549978bda11:f3403f81e12e4c24942d505f086b2cad@sentry.io/1'",
+          "'opts'": "<Values at 0x107ba3b00: {'data': None, 'tags': None}>",
+          "'client'": "<raven.base.Client object at 0x107bb8210>",
+          "'args'": [
+            "'test'",
+            "'https://ebc35f33e151401f9deac549978bda11:f3403f81e12e4c24942d505f086b2cad@sentry.io/1'"
+          ]
+        },
+        "module": "raven.scripts.runner",
+        "filename": "raven/scripts/runner.py",
+        "post_context": [],
+        "colno": null,
+        "in_app": false,
+        "data": {},
+        "context_line": "    send_test_message(client, opts.__dict__)",
+        "lineno": 112
+      }
+    ]
+  },
+  "sentry.interfaces.Template": {
+    "abs_path": "/srv/example/templates/debug_toolbar/base.html",
+    "pre_context": [
+      "{% endif %}\n",
+      "<script src=\"{% static 'debug_toolbar/js/toolbar.js' %}\"></script>\n",
+      "<div id=\"djDebug\" hidden=\"hidden\" dir=\"ltr\"\n"
+    ],
+    "post_context": [
+      "     {{ toolbar.config.ROOT_TAG_EXTRA_ATTRS|safe }}>\n",
+      "\t<div hidden=\"hidden\" id=\"djDebugToolbar\">\n",
+      "\t\t<ul id=\"djDebugPanelList\">\n"
+    ],
+    "filename": "debug_toolbar/base.html",
+    "lineno": 14,
+    "context_line": "     data-store-id=\"{{ toolbar.store_id }}\" data-render-panel-url=\"{% url 'djdt:render_panel' %}\"\n"
+  }
 }

--- a/src/sentry/data/samples/python.json
+++ b/src/sentry/data/samples/python.json
@@ -2,7 +2,7 @@
   "tags": [
     ["level", "error"],
     ["server_name", "web01.example.org"],
-    ["environment", "prod"],
+    ["environment", "prod"]
   ],
   "sentry.interfaces.Stacktrace": {
     "frames": [

--- a/src/sentry/static/sentry/app/components/group/releaseStats.jsx
+++ b/src/sentry/static/sentry/app/components/group/releaseStats.jsx
@@ -5,6 +5,7 @@ import SentryTypes from 'app/sentryTypes';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import GroupReleaseChart from 'app/components/group/releaseChart';
 import SeenInfo from 'app/components/group/seenInfo';
+import getDynamicText from 'app/utils/getDynamicText';
 import {t} from 'app/locale';
 
 const GroupReleaseStats = createReactClass({
@@ -79,7 +80,10 @@ const GroupReleaseStats = createReactClass({
               <SeenInfo
                 orgId={orgId}
                 projectId={projectId}
-                date={group.firstSeen}
+                date={getDynamicText({
+                  value: group.firstSeen,
+                  fixed: '2015-08-13T03:08:25Z',
+                })}
                 dateGlobal={allEnvironments.firstSeen}
                 hasRelease={hasRelease}
                 environment={shortEnvironmentLabel}
@@ -94,7 +98,10 @@ const GroupReleaseStats = createReactClass({
               <SeenInfo
                 orgId={orgId}
                 projectId={projectId}
-                date={group.lastSeen}
+                date={getDynamicText({
+                  value: group.lastSeen,
+                  fixed: '2016-01-13T03:08:25Z',
+                })}
                 dateGlobal={allEnvironments.lastSeen}
                 hasRelease={hasRelease}
                 environment={shortEnvironmentLabel}

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -1,10 +1,12 @@
 from __future__ import absolute_import
 
 import json
+import pytz
 
 from datetime import datetime
 from django.conf import settings
 from django.utils import timezone
+from mock import patch
 
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.utils.samples import load_data
@@ -24,7 +26,7 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         self.login_as(self.user)
         self.dismiss_assistant()
 
-    def create_sample_event(self, platform, default=None, sample_name=None):
+    def create_sample_event(self, platform, default=None, sample_name=None, time=None):
         event_data = load_data(platform, default=default, sample_name=sample_name)
         event_data['event_id'] = 'd964fdbd649a4cf8bfc35d18082b6b0e'
         event = self.store_event(
@@ -32,7 +34,9 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
             project_id=self.project.id,
             assert_no_errors=False,
         )
-        event.datetime = datetime(2017, 9, 6, 0, 0)
+        if time is None:
+            time = datetime(2017, 9, 6, 0, 0)
+        event.datetime = time
         event.save()
         event.group.update(
             first_seen=datetime(2015, 8, 13, 3, 8, 25, tzinfo=timezone.utc),
@@ -47,9 +51,13 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         )
         self.wait_until_loaded()
 
-    def test_python_event(self):
+    @patch('django.utils.timezone.now')
+    def test_python_event(self, mock_now):
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
+        mock_now.return_value = now
         event = self.create_sample_event(
             platform='python',
+            time=now,
         )
         self.visit_issue(event.group.id)
         self.browser.snapshot('issue details python')

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -30,12 +30,18 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         self.dismiss_assistant()
 
     def create_sample_event(self, platform, default=None, sample_name=None, time=None):
-        if time is None:
-            time = datetime(2017, 9, 6, 0, 0)
         event_data = load_data(platform, default=default, sample_name=sample_name)
         event_data['event_id'] = 'd964fdbd649a4cf8bfc35d18082b6b0e'
-        event_data['timestamp'] = time.isoformat()
-        event_data['received'] = time.isoformat()
+
+        # Only set these properties if we were given a time.
+        # event processing will mark old time values as processing errors.
+        if time:
+            event_data['timestamp'] = time.isoformat()
+            event_data['received'] = time.isoformat()
+
+        # We need a fallback datetime for the event
+        if time is None:
+            time = datetime(2017, 9, 6, 0, 0)
         event = self.store_event(
             data=event_data,
             project_id=self.project.id,


### PR DESCRIPTION
Add a few tags to the sample python data. This will populate the tag meters in percy and allow us catch issues similar to the tag bar problems yesterday.