### PR TITLE
feat(incidents): Refactor incident details and suspects

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
@@ -18,7 +18,7 @@ const TABS = {
   related: {name: t('Related incidents'), component: RelatedIncidents},
 };
 
-export default class Incidents extends React.Component {
+export default class DetailsBody extends React.Component {
   static propTypes = {
     incident: SentryTypes.Incident,
   };
@@ -33,7 +33,7 @@ export default class Incidents extends React.Component {
   }
 
   render() {
-    const {incident} = this.props;
+    const {params, incident} = this.props;
     const {activeTab} = this.state;
     const ActiveComponent = TABS[activeTab].component;
 
@@ -48,12 +48,12 @@ export default class Incidents extends React.Component {
                 </li>
               ))}
             </NavTabs>
-            <ActiveComponent />
+            <ActiveComponent params={params} incident={incident} />
           </PageContent>
         </Main>
         <Sidebar>
           <PageContent>
-            <IncidentsSuspects incident={incident} />
+            <IncidentsSuspects suspects={[]} />
           </PageContent>
         </Sidebar>
       </StyledPageContent>

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/header.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/header.jsx
@@ -18,7 +18,7 @@ import DropdownButton from 'app/components/dropdownButton';
 import Status from '../status';
 import {isOpen} from '../utils';
 
-export default class IncidentHeader extends React.Component {
+export default class DetailsHeader extends React.Component {
   static propTypes = {
     incident: SentryTypes.Incident,
     params: PropTypes.object.isRequired,

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/index.jsx
@@ -8,8 +8,8 @@ import {PageContent} from 'app/styles/organization';
 import withApi from 'app/utils/withApi';
 import {t} from 'app/locale';
 
-import IncidentHeader from './header';
-import Incidents from './incidents';
+import DetailsHeader from './header';
+import DetailsBody from './body';
 import {
   INCIDENT_STATUS,
   fetchIncident,
@@ -97,16 +97,17 @@ class OrganizationIncidentDetails extends React.Component {
 
   render() {
     const {incident, isLoading, hasError} = this.state;
+    const {params} = this.props;
 
     return (
       <React.Fragment>
-        <IncidentHeader
-          params={this.props.params}
+        <DetailsHeader
+          params={params}
           incident={incident}
           onSubscriptionChange={this.handleSubscriptionChange}
           onStatusChange={this.handleStatusChange}
         />
-        {incident && <Incidents incident={incident} />}
+        <DetailsBody params={params} incident={incident} />
         {isLoading && (
           <PageContent>
             <LoadingIndicator />

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/suspects.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/suspects.jsx
@@ -1,14 +1,15 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
-import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {Panel, PanelBody, PanelItem} from 'app/components/panels';
+import {t} from 'app/locale';
 import space from 'app/styles/space';
 
 export default class Suspects extends React.Component {
   static propTypes = {
-    incident: SentryTypes.Incident.isRequired,
+    // TODO: Make this a shape once we figure out data model
+    suspects: PropTypes.array,
   };
 
   renderEmpty() {
@@ -16,12 +17,12 @@ export default class Suspects extends React.Component {
   }
 
   render() {
-    const {suspects} = this.props.incident;
+    const {suspects} = this.props;
 
     return (
       <Container>
         <h6>{t('Suspects')}</h6>
-        {suspects.length > 0 && (
+        {suspects && suspects.length > 0 && (
           <Panel>
             <PanelBody>
               {suspects.map(suspect => (
@@ -32,7 +33,7 @@ export default class Suspects extends React.Component {
             </PanelBody>
           </Panel>
         )}
-        {suspects.length === 0 && this.renderEmpty()}
+        {(!suspects || suspects.length === 0) && this.renderEmpty()}
       </Container>
     );
   }


### PR DESCRIPTION
Rename "details/incidents" to "details/body" to "match" `IncidentHeader`. `Incidents` implies we are looking at multiple incidents, but the component is just giving more details about the incident (activity + suspects).

Also refactor `IncidentSuspects` a bit to not depend on an incident object. It is likely that we have a separate endpoint for it instead of returning it with incident details. This also allows us to render suspects component without waiting for incident details request to finish.