### PR TITLE
feat(grouping): Added app matchers to fingerprints and grouping enhancers

### DIFF
--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -12,3 +12,12 @@ def hash_from_values(values):
     for value in values:
         result.update(force_bytes(value, errors='replace'))
     return result.hexdigest()
+
+
+def get_rule_bool(value):
+    if value:
+        value = value.lower()
+        if value in ('1', 'yes', 'true'):
+            return True
+        elif value in ('0', 'no', 'false'):
+            return False

--- a/tests/sentry/grouping/fingerprint_inputs/fingerprint-native-app.json
+++ b/tests/sentry/grouping/fingerprint_inputs/fingerprint-native-app.json
@@ -1,0 +1,450 @@
+{
+  "_fingerprinting_rules": [
+    {
+      "matchers": [
+        ["function", "symbolicator::actors::symcaches::*"],
+        ["app", "true"]
+      ],
+      "fingerprint": ["symcache-error"]
+    }
+  ],
+  "platform": "native",
+  "exception": {
+    "values": [
+      {
+        "type": "Custom",
+        "value": "out of range"
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "<unknown> ",
+              "instruction_addr": "0x0",
+              "in_app": true
+            },
+            {
+              "function": "_start ",
+              "instruction_addr": "0x55b95be9f979",
+              "in_app": true
+            },
+            {
+              "function": "__libc_start_main ",
+              "instruction_addr": "0x7f9c5f4242e0",
+              "in_app": true
+            },
+            {
+              "function": "main ",
+              "instruction_addr": "0x55b95be9fab1",
+              "in_app": true
+            },
+            {
+              "function": "std::panicking::try::h72cb0fef6e9c0ab1 ",
+              "abs_path": "src/libstd/panicking.rs",
+              "package": "std",
+              "filename": "panicking.rs",
+              "lineno": 276,
+              "in_app": false,
+              "instruction_addr": "0x55b95c701ac5"
+            },
+            {
+              "function": "__rust_maybe_catch_panic ",
+              "abs_path": "src/libpanic_unwind/lib.rs",
+              "filename": "lib.rs",
+              "lineno": 92,
+              "in_app": false,
+              "instruction_addr": "0x55b95c706549"
+            },
+            {
+              "function": "std::rt::lang_start_internal::{{closure}}::h8ad4264c6b68797c ",
+              "abs_path": "src/libstd/rt.rs",
+              "package": "std",
+              "filename": "rt.rs",
+              "lineno": 49,
+              "in_app": false,
+              "instruction_addr": "0x55b95c700eb2"
+            },
+            {
+              "function": "std::rt::lang_start::{{closure}}::h4e8f5f76222f4872 ",
+              "package": "std",
+              "instruction_addr": "0x55b95be9fac2",
+              "in_app": false
+            },
+            {
+              "function": "symbolicator::main::h6f87bb5c61153edd ",
+              "package": "symbolicator",
+              "instruction_addr": "0x55b95be9fa86",
+              "in_app": true
+            },
+            {
+              "function": "symbolicator::app::main::h81af9cd0e252b957 ",
+              "package": "symbolicator",
+              "instruction_addr": "0x55b95bec77d3",
+              "in_app": true
+            },
+            {
+              "function": "actix::system::SystemRunner::run::hc8b42dd589d5f34d ",
+              "package": "actix",
+              "instruction_addr": "0x55b95c5c57ab",
+              "in_app": true
+            },
+            {
+              "function": "tokio::runtime::current_thread::runtime::Runtime::block_on::h1384999a7df7dbf5 ",
+              "package": "tokio",
+              "instruction_addr": "0x55b95c5907cf",
+              "in_app": true
+            },
+            {
+              "function": "<std::thread::local::LocalKey<T>>::with::h118d351120ec801c ",
+              "instruction_addr": "0x55b95c5b9832",
+              "in_app": false
+            },
+            {
+              "function": "<std::thread::local::LocalKey<T>>::with::h443d9baf3a401142 ",
+              "instruction_addr": "0x55b95c5ba56e",
+              "in_app": false
+            },
+            {
+              "function": "<std::thread::local::LocalKey<T>>::with::h899f4e1afe99ecb6 ",
+              "instruction_addr": "0x55b95c5bb735",
+              "in_app": false
+            },
+            {
+              "function": "<std::thread::local::LocalKey<T>>::with::h2befa73a071a6170 ",
+              "instruction_addr": "0x55b95c5b9f37",
+              "in_app": false
+            },
+            {
+              "function": "<tokio_current_thread::Entered<'a, P>>::block_on::h45ae18bcb1b8db5c ",
+              "instruction_addr": "0x55b95c588e13",
+              "in_app": true
+            },
+            {
+              "function": "<tokio_current_thread::Entered<'a, P>>::tick::hcea2e6d62cc2b7e5 ",
+              "instruction_addr": "0x55b95c588cf4",
+              "in_app": true
+            },
+            {
+              "function": "<tokio_current_thread::scheduler::Scheduler<U>>::tick::he19f21143658e3f0 ",
+              "instruction_addr": "0x55b95c5b3b19",
+              "in_app": true
+            },
+            {
+              "function": "tokio_current_thread::CurrentRunner::set_spawn::h9e70e2daaa86c968 ",
+              "package": "tokio_current_thread",
+              "instruction_addr": "0x55b95c585783",
+              "in_app": true
+            },
+            {
+              "function": "<futures::task_impl::Spawn<T>>::poll_future_notify::h1da2d19e6bf539c6 ",
+              "instruction_addr": "0x55b95c5b7055",
+              "in_app": true
+            },
+            {
+              "function": "futures::task_impl::std::set::h1cc47adb4a176e58 ",
+              "package": "futures",
+              "instruction_addr": "0x55b95c5914e1",
+              "in_app": true
+            },
+            {
+              "function": "<actix::contextimpl::ContextFut<A, C> as futures::future::Future>::poll::h9de5fbebc1652d47 ",
+              "instruction_addr": "0x55b95bebee0d",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::then::Then<A, B, F> as futures::future::Future>::poll::h67e771243743eb30 ",
+              "instruction_addr": "0x55b95bf8999f",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::lazy::Lazy<F, R> as futures::future::Future>::poll::h9b62d88151002ac4 ",
+              "instruction_addr": "0x55b95bef8608",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::then::Then<A, B, F> as futures::future::Future>::poll::h5567ae25991a6daa ",
+              "instruction_addr": "0x55b95bf89129",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::map_err::MapErr<A, F> as futures::future::Future>::poll::he74c1a2a9e15b1b7 ",
+              "instruction_addr": "0x55b95c04c4e3",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::chain::Chain<A, B, C>>::poll::h7a8ce6865477e15d ",
+              "instruction_addr": "0x55b95bf6c656",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::map::Map<A, F> as futures::future::Future>::poll::h8e9ff78b067eab2e ",
+              "instruction_addr": "0x55b95bfefa21",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::join_all::JoinAll<I> as futures::future::Future>::poll::hbb462bf2c5cac86c ",
+              "instruction_addr": "0x55b95c016474",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::chain::Chain<A, B, C>>::poll::hbc46b1836174f434 ",
+              "instruction_addr": "0x55b95bf75b51",
+              "in_app": true
+            },
+            {
+              "function": "symbolicator::actors::symcaches::SymCacheFile::parse::hdccb68bbe02b50a3 ",
+              "package": "symbolicator",
+              "instruction_addr": "0x55b95bec3b73",
+              "in_app": true
+            },
+            {
+              "function": "symbolic_symcache::cache::SymCache::parse::hb8a4e051c56bfdd0 ",
+              "package": "symbolic_symcache",
+              "instruction_addr": "0x55b95c41433f",
+              "in_app": true
+            },
+            {
+              "function": "symbolic_symcache::format::Header::parse::h9e4b9050799f7a0b ",
+              "package": "symbolic_symcache",
+              "instruction_addr": "0x55b95c4159b0",
+              "in_app": true
+            },
+            {
+              "function": "<failure::error::error_impl::ErrorImpl as core::convert::From<F>>::from::he5d6dd47a3a261a9 ",
+              "instruction_addr": "0x55b95c4167b5",
+              "in_app": false
+            },
+            {
+              "function": "<failure::backtrace::Backtrace as core::default::Default>::default::h493a6077db117c42 ",
+              "instruction_addr": "0x55b95c69a1cf",
+              "in_app": false
+            },
+            {
+              "function": "failure::backtrace::internal::InternalBacktrace::new::h5c964837d568bbe5 ",
+              "package": "failure",
+              "instruction_addr": "0x55b95c699f2f",
+              "in_app": false
+            }
+          ]
+        },
+        "type": "SymCacheError",
+        "value": "invalid symcache header"
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "<unknown> ",
+              "instruction_addr": "0x0",
+              "in_app": true
+            },
+            {
+              "function": "_start ",
+              "instruction_addr": "0x55b95be9f979",
+              "in_app": true
+            },
+            {
+              "function": "__libc_start_main ",
+              "instruction_addr": "0x7f9c5f4242e0",
+              "in_app": true
+            },
+            {
+              "function": "main ",
+              "instruction_addr": "0x55b95be9fab1",
+              "in_app": true
+            },
+            {
+              "function": "std::panicking::try::h72cb0fef6e9c0ab1 ",
+              "abs_path": "src/libstd/panicking.rs",
+              "package": "std",
+              "filename": "panicking.rs",
+              "lineno": 276,
+              "in_app": false,
+              "instruction_addr": "0x55b95c701ac5"
+            },
+            {
+              "function": "__rust_maybe_catch_panic ",
+              "abs_path": "src/libpanic_unwind/lib.rs",
+              "filename": "lib.rs",
+              "lineno": 92,
+              "in_app": false,
+              "instruction_addr": "0x55b95c706549"
+            },
+            {
+              "function": "std::rt::lang_start_internal::{{closure}}::h8ad4264c6b68797c ",
+              "abs_path": "src/libstd/rt.rs",
+              "package": "std",
+              "filename": "rt.rs",
+              "lineno": 49,
+              "in_app": false,
+              "instruction_addr": "0x55b95c700eb2"
+            },
+            {
+              "function": "std::rt::lang_start::{{closure}}::h4e8f5f76222f4872 ",
+              "package": "std",
+              "instruction_addr": "0x55b95be9fac2",
+              "in_app": false
+            },
+            {
+              "function": "symbolicator::main::h6f87bb5c61153edd ",
+              "package": "symbolicator",
+              "instruction_addr": "0x55b95be9fa86",
+              "in_app": true
+            },
+            {
+              "function": "symbolicator::app::main::h81af9cd0e252b957 ",
+              "package": "symbolicator",
+              "instruction_addr": "0x55b95bec77d3",
+              "in_app": true
+            },
+            {
+              "function": "actix::system::SystemRunner::run::hc8b42dd589d5f34d ",
+              "package": "actix",
+              "instruction_addr": "0x55b95c5c57ab",
+              "in_app": true
+            },
+            {
+              "function": "tokio::runtime::current_thread::runtime::Runtime::block_on::h1384999a7df7dbf5 ",
+              "package": "tokio",
+              "instruction_addr": "0x55b95c5907cf",
+              "in_app": true
+            },
+            {
+              "function": "<std::thread::local::LocalKey<T>>::with::h118d351120ec801c ",
+              "instruction_addr": "0x55b95c5b9832",
+              "in_app": false
+            },
+            {
+              "function": "<std::thread::local::LocalKey<T>>::with::h443d9baf3a401142 ",
+              "instruction_addr": "0x55b95c5ba56e",
+              "in_app": false
+            },
+            {
+              "function": "<std::thread::local::LocalKey<T>>::with::h899f4e1afe99ecb6 ",
+              "instruction_addr": "0x55b95c5bb735",
+              "in_app": false
+            },
+            {
+              "function": "<std::thread::local::LocalKey<T>>::with::h2befa73a071a6170 ",
+              "instruction_addr": "0x55b95c5b9f37",
+              "in_app": false
+            },
+            {
+              "function": "<tokio_current_thread::Entered<'a, P>>::block_on::h45ae18bcb1b8db5c ",
+              "instruction_addr": "0x55b95c588e13",
+              "in_app": true
+            },
+            {
+              "function": "<tokio_current_thread::Entered<'a, P>>::tick::hcea2e6d62cc2b7e5 ",
+              "instruction_addr": "0x55b95c588cf4",
+              "in_app": true
+            },
+            {
+              "function": "<tokio_current_thread::scheduler::Scheduler<U>>::tick::he19f21143658e3f0 ",
+              "instruction_addr": "0x55b95c5b3b19",
+              "in_app": true
+            },
+            {
+              "function": "tokio_current_thread::CurrentRunner::set_spawn::h9e70e2daaa86c968 ",
+              "package": "tokio_current_thread",
+              "instruction_addr": "0x55b95c585783",
+              "in_app": true
+            },
+            {
+              "function": "<futures::task_impl::Spawn<T>>::poll_future_notify::h1da2d19e6bf539c6 ",
+              "instruction_addr": "0x55b95c5b7055",
+              "in_app": true
+            },
+            {
+              "function": "futures::task_impl::std::set::h1cc47adb4a176e58 ",
+              "package": "futures",
+              "instruction_addr": "0x55b95c5914e1",
+              "in_app": true
+            },
+            {
+              "function": "<actix::contextimpl::ContextFut<A, C> as futures::future::Future>::poll::h9de5fbebc1652d47 ",
+              "instruction_addr": "0x55b95bebee0d",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::then::Then<A, B, F> as futures::future::Future>::poll::h67e771243743eb30 ",
+              "instruction_addr": "0x55b95bf8999f",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::lazy::Lazy<F, R> as futures::future::Future>::poll::h9b62d88151002ac4 ",
+              "instruction_addr": "0x55b95bef8608",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::then::Then<A, B, F> as futures::future::Future>::poll::h5567ae25991a6daa ",
+              "instruction_addr": "0x55b95bf89129",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::map_err::MapErr<A, F> as futures::future::Future>::poll::he74c1a2a9e15b1b7 ",
+              "instruction_addr": "0x55b95c04c4e3",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::chain::Chain<A, B, C>>::poll::h7a8ce6865477e15d ",
+              "instruction_addr": "0x55b95bf6c656",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::map::Map<A, F> as futures::future::Future>::poll::h8e9ff78b067eab2e ",
+              "instruction_addr": "0x55b95bfefa21",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::join_all::JoinAll<I> as futures::future::Future>::poll::hbb462bf2c5cac86c ",
+              "instruction_addr": "0x55b95c016474",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::chain::Chain<A, B, C>>::poll::hbc46b1836174f434 ",
+              "instruction_addr": "0x55b95bf75b51",
+              "in_app": true
+            },
+            {
+              "function": "symbolicator::actors::symcaches::SymCacheFile::parse::hdccb68bbe02b50a3 ",
+              "package": "symbolicator",
+              "instruction_addr": "0x55b95bec3b73",
+              "in_app": true
+            },
+            {
+              "function": "symbolic_symcache::cache::SymCache::parse::hb8a4e051c56bfdd0 ",
+              "package": "symbolic_symcache",
+              "instruction_addr": "0x55b95c41433f",
+              "in_app": true
+            },
+            {
+              "function": "symbolic_symcache::format::Header::parse::h9e4b9050799f7a0b ",
+              "package": "symbolic_symcache",
+              "instruction_addr": "0x55b95c4159b0",
+              "in_app": true
+            },
+            {
+              "function": "<failure::error::error_impl::ErrorImpl as core::convert::From<F>>::from::he5d6dd47a3a261a9 ",
+              "instruction_addr": "0x55b95c4167b5",
+              "in_app": false
+            },
+            {
+              "function": "<failure::backtrace::Backtrace as core::default::Default>::default::h493a6077db117c42 ",
+              "instruction_addr": "0x55b95c69a1cf",
+              "in_app": false
+            },
+            {
+              "function": "failure::backtrace::internal::InternalBacktrace::new::h5c964837d568bbe5 ",
+              "package": "failure",
+              "instruction_addr": "0x55b95c699f2f",
+              "in_app": false
+            }
+          ]
+        },
+        "type": "SymCacheError",
+        "value": "failed to parse symcache"
+      }
+    ]
+  }
+}

--- a/tests/sentry/grouping/fingerprint_inputs/fingerprint-native-non-app.json
+++ b/tests/sentry/grouping/fingerprint_inputs/fingerprint-native-non-app.json
@@ -1,0 +1,450 @@
+{
+  "_fingerprinting_rules": [
+    {
+      "matchers": [
+        ["function", "symbolicator::actors::symcaches::*"],
+        ["app", "false"]
+      ],
+      "fingerprint": ["symcache-error"]
+    }
+  ],
+  "platform": "native",
+  "exception": {
+    "values": [
+      {
+        "type": "Custom",
+        "value": "out of range"
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "<unknown> ",
+              "instruction_addr": "0x0",
+              "in_app": true
+            },
+            {
+              "function": "_start ",
+              "instruction_addr": "0x55b95be9f979",
+              "in_app": true
+            },
+            {
+              "function": "__libc_start_main ",
+              "instruction_addr": "0x7f9c5f4242e0",
+              "in_app": true
+            },
+            {
+              "function": "main ",
+              "instruction_addr": "0x55b95be9fab1",
+              "in_app": true
+            },
+            {
+              "function": "std::panicking::try::h72cb0fef6e9c0ab1 ",
+              "abs_path": "src/libstd/panicking.rs",
+              "package": "std",
+              "filename": "panicking.rs",
+              "lineno": 276,
+              "in_app": false,
+              "instruction_addr": "0x55b95c701ac5"
+            },
+            {
+              "function": "__rust_maybe_catch_panic ",
+              "abs_path": "src/libpanic_unwind/lib.rs",
+              "filename": "lib.rs",
+              "lineno": 92,
+              "in_app": false,
+              "instruction_addr": "0x55b95c706549"
+            },
+            {
+              "function": "std::rt::lang_start_internal::{{closure}}::h8ad4264c6b68797c ",
+              "abs_path": "src/libstd/rt.rs",
+              "package": "std",
+              "filename": "rt.rs",
+              "lineno": 49,
+              "in_app": false,
+              "instruction_addr": "0x55b95c700eb2"
+            },
+            {
+              "function": "std::rt::lang_start::{{closure}}::h4e8f5f76222f4872 ",
+              "package": "std",
+              "instruction_addr": "0x55b95be9fac2",
+              "in_app": false
+            },
+            {
+              "function": "symbolicator::main::h6f87bb5c61153edd ",
+              "package": "symbolicator",
+              "instruction_addr": "0x55b95be9fa86",
+              "in_app": true
+            },
+            {
+              "function": "symbolicator::app::main::h81af9cd0e252b957 ",
+              "package": "symbolicator",
+              "instruction_addr": "0x55b95bec77d3",
+              "in_app": true
+            },
+            {
+              "function": "actix::system::SystemRunner::run::hc8b42dd589d5f34d ",
+              "package": "actix",
+              "instruction_addr": "0x55b95c5c57ab",
+              "in_app": true
+            },
+            {
+              "function": "tokio::runtime::current_thread::runtime::Runtime::block_on::h1384999a7df7dbf5 ",
+              "package": "tokio",
+              "instruction_addr": "0x55b95c5907cf",
+              "in_app": true
+            },
+            {
+              "function": "<std::thread::local::LocalKey<T>>::with::h118d351120ec801c ",
+              "instruction_addr": "0x55b95c5b9832",
+              "in_app": false
+            },
+            {
+              "function": "<std::thread::local::LocalKey<T>>::with::h443d9baf3a401142 ",
+              "instruction_addr": "0x55b95c5ba56e",
+              "in_app": false
+            },
+            {
+              "function": "<std::thread::local::LocalKey<T>>::with::h899f4e1afe99ecb6 ",
+              "instruction_addr": "0x55b95c5bb735",
+              "in_app": false
+            },
+            {
+              "function": "<std::thread::local::LocalKey<T>>::with::h2befa73a071a6170 ",
+              "instruction_addr": "0x55b95c5b9f37",
+              "in_app": false
+            },
+            {
+              "function": "<tokio_current_thread::Entered<'a, P>>::block_on::h45ae18bcb1b8db5c ",
+              "instruction_addr": "0x55b95c588e13",
+              "in_app": true
+            },
+            {
+              "function": "<tokio_current_thread::Entered<'a, P>>::tick::hcea2e6d62cc2b7e5 ",
+              "instruction_addr": "0x55b95c588cf4",
+              "in_app": true
+            },
+            {
+              "function": "<tokio_current_thread::scheduler::Scheduler<U>>::tick::he19f21143658e3f0 ",
+              "instruction_addr": "0x55b95c5b3b19",
+              "in_app": true
+            },
+            {
+              "function": "tokio_current_thread::CurrentRunner::set_spawn::h9e70e2daaa86c968 ",
+              "package": "tokio_current_thread",
+              "instruction_addr": "0x55b95c585783",
+              "in_app": true
+            },
+            {
+              "function": "<futures::task_impl::Spawn<T>>::poll_future_notify::h1da2d19e6bf539c6 ",
+              "instruction_addr": "0x55b95c5b7055",
+              "in_app": true
+            },
+            {
+              "function": "futures::task_impl::std::set::h1cc47adb4a176e58 ",
+              "package": "futures",
+              "instruction_addr": "0x55b95c5914e1",
+              "in_app": true
+            },
+            {
+              "function": "<actix::contextimpl::ContextFut<A, C> as futures::future::Future>::poll::h9de5fbebc1652d47 ",
+              "instruction_addr": "0x55b95bebee0d",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::then::Then<A, B, F> as futures::future::Future>::poll::h67e771243743eb30 ",
+              "instruction_addr": "0x55b95bf8999f",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::lazy::Lazy<F, R> as futures::future::Future>::poll::h9b62d88151002ac4 ",
+              "instruction_addr": "0x55b95bef8608",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::then::Then<A, B, F> as futures::future::Future>::poll::h5567ae25991a6daa ",
+              "instruction_addr": "0x55b95bf89129",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::map_err::MapErr<A, F> as futures::future::Future>::poll::he74c1a2a9e15b1b7 ",
+              "instruction_addr": "0x55b95c04c4e3",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::chain::Chain<A, B, C>>::poll::h7a8ce6865477e15d ",
+              "instruction_addr": "0x55b95bf6c656",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::map::Map<A, F> as futures::future::Future>::poll::h8e9ff78b067eab2e ",
+              "instruction_addr": "0x55b95bfefa21",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::join_all::JoinAll<I> as futures::future::Future>::poll::hbb462bf2c5cac86c ",
+              "instruction_addr": "0x55b95c016474",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::chain::Chain<A, B, C>>::poll::hbc46b1836174f434 ",
+              "instruction_addr": "0x55b95bf75b51",
+              "in_app": true
+            },
+            {
+              "function": "symbolicator::actors::symcaches::SymCacheFile::parse::hdccb68bbe02b50a3 ",
+              "package": "symbolicator",
+              "instruction_addr": "0x55b95bec3b73",
+              "in_app": true
+            },
+            {
+              "function": "symbolic_symcache::cache::SymCache::parse::hb8a4e051c56bfdd0 ",
+              "package": "symbolic_symcache",
+              "instruction_addr": "0x55b95c41433f",
+              "in_app": true
+            },
+            {
+              "function": "symbolic_symcache::format::Header::parse::h9e4b9050799f7a0b ",
+              "package": "symbolic_symcache",
+              "instruction_addr": "0x55b95c4159b0",
+              "in_app": true
+            },
+            {
+              "function": "<failure::error::error_impl::ErrorImpl as core::convert::From<F>>::from::he5d6dd47a3a261a9 ",
+              "instruction_addr": "0x55b95c4167b5",
+              "in_app": false
+            },
+            {
+              "function": "<failure::backtrace::Backtrace as core::default::Default>::default::h493a6077db117c42 ",
+              "instruction_addr": "0x55b95c69a1cf",
+              "in_app": false
+            },
+            {
+              "function": "failure::backtrace::internal::InternalBacktrace::new::h5c964837d568bbe5 ",
+              "package": "failure",
+              "instruction_addr": "0x55b95c699f2f",
+              "in_app": false
+            }
+          ]
+        },
+        "type": "SymCacheError",
+        "value": "invalid symcache header"
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "<unknown> ",
+              "instruction_addr": "0x0",
+              "in_app": true
+            },
+            {
+              "function": "_start ",
+              "instruction_addr": "0x55b95be9f979",
+              "in_app": true
+            },
+            {
+              "function": "__libc_start_main ",
+              "instruction_addr": "0x7f9c5f4242e0",
+              "in_app": true
+            },
+            {
+              "function": "main ",
+              "instruction_addr": "0x55b95be9fab1",
+              "in_app": true
+            },
+            {
+              "function": "std::panicking::try::h72cb0fef6e9c0ab1 ",
+              "abs_path": "src/libstd/panicking.rs",
+              "package": "std",
+              "filename": "panicking.rs",
+              "lineno": 276,
+              "in_app": false,
+              "instruction_addr": "0x55b95c701ac5"
+            },
+            {
+              "function": "__rust_maybe_catch_panic ",
+              "abs_path": "src/libpanic_unwind/lib.rs",
+              "filename": "lib.rs",
+              "lineno": 92,
+              "in_app": false,
+              "instruction_addr": "0x55b95c706549"
+            },
+            {
+              "function": "std::rt::lang_start_internal::{{closure}}::h8ad4264c6b68797c ",
+              "abs_path": "src/libstd/rt.rs",
+              "package": "std",
+              "filename": "rt.rs",
+              "lineno": 49,
+              "in_app": false,
+              "instruction_addr": "0x55b95c700eb2"
+            },
+            {
+              "function": "std::rt::lang_start::{{closure}}::h4e8f5f76222f4872 ",
+              "package": "std",
+              "instruction_addr": "0x55b95be9fac2",
+              "in_app": false
+            },
+            {
+              "function": "symbolicator::main::h6f87bb5c61153edd ",
+              "package": "symbolicator",
+              "instruction_addr": "0x55b95be9fa86",
+              "in_app": true
+            },
+            {
+              "function": "symbolicator::app::main::h81af9cd0e252b957 ",
+              "package": "symbolicator",
+              "instruction_addr": "0x55b95bec77d3",
+              "in_app": true
+            },
+            {
+              "function": "actix::system::SystemRunner::run::hc8b42dd589d5f34d ",
+              "package": "actix",
+              "instruction_addr": "0x55b95c5c57ab",
+              "in_app": true
+            },
+            {
+              "function": "tokio::runtime::current_thread::runtime::Runtime::block_on::h1384999a7df7dbf5 ",
+              "package": "tokio",
+              "instruction_addr": "0x55b95c5907cf",
+              "in_app": true
+            },
+            {
+              "function": "<std::thread::local::LocalKey<T>>::with::h118d351120ec801c ",
+              "instruction_addr": "0x55b95c5b9832",
+              "in_app": false
+            },
+            {
+              "function": "<std::thread::local::LocalKey<T>>::with::h443d9baf3a401142 ",
+              "instruction_addr": "0x55b95c5ba56e",
+              "in_app": false
+            },
+            {
+              "function": "<std::thread::local::LocalKey<T>>::with::h899f4e1afe99ecb6 ",
+              "instruction_addr": "0x55b95c5bb735",
+              "in_app": false
+            },
+            {
+              "function": "<std::thread::local::LocalKey<T>>::with::h2befa73a071a6170 ",
+              "instruction_addr": "0x55b95c5b9f37",
+              "in_app": false
+            },
+            {
+              "function": "<tokio_current_thread::Entered<'a, P>>::block_on::h45ae18bcb1b8db5c ",
+              "instruction_addr": "0x55b95c588e13",
+              "in_app": true
+            },
+            {
+              "function": "<tokio_current_thread::Entered<'a, P>>::tick::hcea2e6d62cc2b7e5 ",
+              "instruction_addr": "0x55b95c588cf4",
+              "in_app": true
+            },
+            {
+              "function": "<tokio_current_thread::scheduler::Scheduler<U>>::tick::he19f21143658e3f0 ",
+              "instruction_addr": "0x55b95c5b3b19",
+              "in_app": true
+            },
+            {
+              "function": "tokio_current_thread::CurrentRunner::set_spawn::h9e70e2daaa86c968 ",
+              "package": "tokio_current_thread",
+              "instruction_addr": "0x55b95c585783",
+              "in_app": true
+            },
+            {
+              "function": "<futures::task_impl::Spawn<T>>::poll_future_notify::h1da2d19e6bf539c6 ",
+              "instruction_addr": "0x55b95c5b7055",
+              "in_app": true
+            },
+            {
+              "function": "futures::task_impl::std::set::h1cc47adb4a176e58 ",
+              "package": "futures",
+              "instruction_addr": "0x55b95c5914e1",
+              "in_app": true
+            },
+            {
+              "function": "<actix::contextimpl::ContextFut<A, C> as futures::future::Future>::poll::h9de5fbebc1652d47 ",
+              "instruction_addr": "0x55b95bebee0d",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::then::Then<A, B, F> as futures::future::Future>::poll::h67e771243743eb30 ",
+              "instruction_addr": "0x55b95bf8999f",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::lazy::Lazy<F, R> as futures::future::Future>::poll::h9b62d88151002ac4 ",
+              "instruction_addr": "0x55b95bef8608",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::then::Then<A, B, F> as futures::future::Future>::poll::h5567ae25991a6daa ",
+              "instruction_addr": "0x55b95bf89129",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::map_err::MapErr<A, F> as futures::future::Future>::poll::he74c1a2a9e15b1b7 ",
+              "instruction_addr": "0x55b95c04c4e3",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::chain::Chain<A, B, C>>::poll::h7a8ce6865477e15d ",
+              "instruction_addr": "0x55b95bf6c656",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::map::Map<A, F> as futures::future::Future>::poll::h8e9ff78b067eab2e ",
+              "instruction_addr": "0x55b95bfefa21",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::join_all::JoinAll<I> as futures::future::Future>::poll::hbb462bf2c5cac86c ",
+              "instruction_addr": "0x55b95c016474",
+              "in_app": true
+            },
+            {
+              "function": "<futures::future::chain::Chain<A, B, C>>::poll::hbc46b1836174f434 ",
+              "instruction_addr": "0x55b95bf75b51",
+              "in_app": true
+            },
+            {
+              "function": "symbolicator::actors::symcaches::SymCacheFile::parse::hdccb68bbe02b50a3 ",
+              "package": "symbolicator",
+              "instruction_addr": "0x55b95bec3b73",
+              "in_app": true
+            },
+            {
+              "function": "symbolic_symcache::cache::SymCache::parse::hb8a4e051c56bfdd0 ",
+              "package": "symbolic_symcache",
+              "instruction_addr": "0x55b95c41433f",
+              "in_app": true
+            },
+            {
+              "function": "symbolic_symcache::format::Header::parse::h9e4b9050799f7a0b ",
+              "package": "symbolic_symcache",
+              "instruction_addr": "0x55b95c4159b0",
+              "in_app": true
+            },
+            {
+              "function": "<failure::error::error_impl::ErrorImpl as core::convert::From<F>>::from::he5d6dd47a3a261a9 ",
+              "instruction_addr": "0x55b95c4167b5",
+              "in_app": false
+            },
+            {
+              "function": "<failure::backtrace::Backtrace as core::default::Default>::default::h493a6077db117c42 ",
+              "instruction_addr": "0x55b95c69a1cf",
+              "in_app": false
+            },
+            {
+              "function": "failure::backtrace::internal::InternalBacktrace::new::h5c964837d568bbe5 ",
+              "package": "failure",
+              "instruction_addr": "0x55b95c699f2f",
+              "in_app": false
+            }
+          ]
+        },
+        "type": "SymCacheError",
+        "value": "failed to parse symcache"
+      }
+    ]
+  }
+}

--- a/tests/sentry/grouping/snapshots/test_enhancer/test_basic_parsing.pysnap
+++ b/tests/sentry/grouping/snapshots/test_enhancer/test_basic_parsing.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-03T18:39:26.343115Z'
+created: '2019-05-10T09:19:47.569014Z'
 creator: sentry
 source: tests/sentry/grouping/test_enhancer.py
 ---
@@ -69,6 +69,17 @@ rules:
   matchers:
   - key: family
     pattern: javascript
+  - key: path
+    pattern: '*/test.js'
+- actions:
+  - flag: false
+    key: app
+    range: null
+  matchers:
+  - key: family
+    pattern: javascript
+  - key: app
+    pattern: '1'
   - key: path
     pattern: '*/test.js'
 version: 1

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_app.pysnap
@@ -1,0 +1,17 @@
+---
+created: '2019-05-10T09:35:38.127307Z'
+creator: sentry
+source: tests/sentry/grouping/test_fingerprinting.py
+---
+config:
+  rules:
+  - fingerprint:
+    - symcache-error
+    matchers:
+    - - function
+      - symbolicator::actors::symcaches::*
+    - - app
+      - 'true'
+  version: 1
+fingerprint:
+- symcache-error

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_non_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_non_app.pysnap
@@ -1,0 +1,17 @@
+---
+created: '2019-05-10T09:35:38.141252Z'
+creator: sentry
+source: tests/sentry/grouping/test_fingerprinting.py
+---
+config:
+  rules:
+  - fingerprint:
+    - symcache-error
+    matchers:
+    - - function
+      - symbolicator::actors::symcaches::*
+    - - app
+      - 'false'
+  version: 1
+fingerprint:
+- '{{ default }}'

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -32,6 +32,7 @@ function:ThreadStartMac                         v-group
 family:native module:std::*                     -app
 module:core::*                                  -app
 family:javascript path:*/test.js                -app
+family:javascript app:1 path:*/test.js          -app
 ''', bases=['common:v1'])
 
     dumped = enhancement.dumps()
@@ -96,6 +97,32 @@ def test_family_matching():
 
     assert bool(native_rule.get_matching_frame_actions({
         'function': 'std::whatever',
+    }, 'native'))
+
+
+def test_app_matching():
+    enhancement = Enhancements.from_config_string('''
+        family:javascript path:**/test.js app:yes       +app
+        family:native path:**/test.c app:no            -group
+    ''')
+    app_yes_rule, app_no_rule = enhancement.rules
+
+    assert bool(app_yes_rule.get_matching_frame_actions({
+        'abs_path': 'http://example.com/foo/TEST.js',
+        'in_app': True
+    }, 'javascript'))
+    assert not bool(app_yes_rule.get_matching_frame_actions({
+        'abs_path': 'http://example.com/foo/TEST.js',
+        'in_app': False
+    }, 'javascript'))
+
+    assert bool(app_no_rule.get_matching_frame_actions({
+        'abs_path': '/test.c',
+        'in_app': False
+    }, 'native'))
+    assert not bool(app_no_rule.get_matching_frame_actions({
+        'abs_path': '/test.c',
+        'in_app': True
     }, 'native'))
 
 

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -16,6 +16,7 @@ def test_basic_parsing(insta_snapshot):
 # This is a config
 type:DatabaseUnavailable                        -> DatabaseUnavailable
 function:assertion_failed module:foo            -> AssertionFailed, foo
+app:true                                        -> aha
 ''')
     assert rules._to_config_structure() == {
         'rules': [
@@ -23,7 +24,9 @@ function:assertion_failed module:foo            -> AssertionFailed, foo
              'fingerprint': ['DatabaseUnavailable']},
             {'matchers': [['function', 'assertion_failed'],
                           ['module', 'foo']],
-             'fingerprint': ['AssertionFailed', 'foo']}
+             'fingerprint': ['AssertionFailed', 'foo']},
+            {'matchers': [['app', 'true']],
+             'fingerprint': ['aha']},
         ],
         'version': 1
     }


### PR DESCRIPTION
This lets one constrain a rule for grouping enhancers or fingerprints on
the current value of `in_app`.  This is particularly useful if the
fingerprinting code should only take functions into account that are marked
as in-app.