### PR TITLE
fix(config): Fix default configuration

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1062,7 +1062,9 @@ _SENTRY_TAGSTORE_DEFAULT_MULTI_OPTIONS = {
     ],
     'runner': 'ImmediateRunner',
 }
-SENTRY_TAGSTORE = os.environ.get('SENTRY_TAGSTORE', 'sentry.tagstore.legacy.LegacyTagStorage')
+
+SENTRY_TAGSTORE = os.environ.get('SENTRY_TAGSTORE', 'sentry.tagstore.snuba.SnubaCompatibilityTagStorage')
+
 SENTRY_TAGSTORE_OPTIONS = (
     _SENTRY_TAGSTORE_DEFAULT_MULTI_OPTIONS if 'SENTRY_TAGSTORE_DEFAULT_MULTI_OPTIONS' in os.environ
     else {}
@@ -1077,7 +1079,7 @@ SENTRY_SEARCH_OPTIONS = {}
 # }
 
 # Time-series storage backend
-SENTRY_TSDB = 'sentry.tsdb.dummy.DummyTSDB'
+SENTRY_TSDB = 'sentry.tsdb.redissnuba.RedisSnubaTSDB'
 SENTRY_TSDB_OPTIONS = {}
 
 SENTRY_NEWSLETTER = 'sentry.newsletter.base.Newsletter'

--- a/src/sentry/data/config/sentry.conf.py.default
+++ b/src/sentry/data/config/sentry.conf.py.default
@@ -102,8 +102,7 @@ SENTRY_QUOTAS = 'sentry.quotas.redis.RedisQuota'
 
 # The TSDB is used for building charts as well as making things like per-rate
 # alerts possible.
-
-SENTRY_TSDB = 'sentry.tsdb.redis.RedisTSDB'
+SENTRY_TSDB = 'sentry.tsdb.redissnuba.RedisSnubaTSDB'
 
 ###########
 # Digests #

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -112,6 +112,10 @@ def pytest_configure(config):
         }
     }
 
+    # raduw (10 May 2019) the default snuba tag storage does not implement create_tag_key and get_or_create_tag_key
+    # which are used by some unit tests (remove offending tests ? )
+    settings.SENTRY_TAGSTORE = os.environ.get('SENTRY_TAGSTORE', 'sentry.tagstore.legacy.LegacyTagStorage')
+
     if os.environ.get('USE_SNUBA', False):
         settings.SENTRY_SEARCH = 'sentry.search.snuba.SnubaSearchBackend'
         settings.SENTRY_TAGSTORE = 'sentry.tagstore.snuba.SnubaCompatibilityTagStorage'


### PR DESCRIPTION
Set reasonable defaults for SENTRY_TAGSTORE and SENTRY_TSDB so that
a fresh installation can run out of the box without fiddling with the
configuration.