### PR TITLE
fix(jsgrouping): Fix js grouping in newstyle to not ignore anonymous functions entirely

### DIFF
--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -366,8 +366,13 @@ def get_frame_component(frame, event, meta, legacy_function_logic=False,
         if func:
             func = func.rsplit('.', 1)[-1]
         if func in (None, '?', '<anonymous function>', '<anonymous>',
-                    'Anonymous function', 'eval') or \
-           func.endswith('/<') or \
+                    'Anonymous function') \
+           or func.endswith('/<'):
+            function_component.update(
+                contributes=False,
+                hint='ignored unknown function name'
+            )
+        if (func == 'eval') or \
            frame.abs_path in ('[native code]', 'native code', 'eval code', '<anonymous>'):
             rv.update(
                 contributes=False,

--- a/tests/sentry/grouping/grouping_inputs/javascript-xbrowser-firefox.json
+++ b/tests/sentry/grouping/grouping_inputs/javascript-xbrowser-firefox.json
@@ -35,6 +35,7 @@
               "in_app": false
             },
             {
+              "function": "eval",
               "abs_path": "file:///private/tmp/test.html",
               "filename": "/private/tmp/test.html",
               "lineno": 1,

--- a/tests/sentry/grouping/grouping_inputs/javascript-xbrowser-http-firefox.json
+++ b/tests/sentry/grouping/grouping_inputs/javascript-xbrowser-http-firefox.json
@@ -38,6 +38,7 @@
               "filename": "/test.html"
             },
             {
+              "function": "eval",
               "abs_path": "http://localhost:4001/test.html",
               "module": "test",
               "filename": "/test.html",

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined:2019_04_07/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined:2019_04_07/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:13:29.297921Z'
+created: '2019-05-10T13:21:29.445249Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -31,6 +31,8 @@ app:
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
+            function (function name is used only if module or filename are available)
+              u'eval'
             lineno (line number is used only if module or filename are available)
               1
           frame (frame considered in-app because no frame is in-app)
@@ -101,6 +103,8 @@ system:
           frame
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
+            function (function name is used only if module or filename are available)
+              u'eval'
             lineno (line number is used only if module or filename are available)
               1
           frame

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined:2019_04_07/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined:2019_04_07/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:44:33.408562Z'
+created: '2019-05-10T13:21:29.479938Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -39,7 +39,9 @@ app:
               u'test'
             filename (module takes precedence)
               u'/test.html'
-            lineno*
+            function*
+              u'eval'
+            lineno (function takes precedence)
               1
           frame* (frame considered in-app because no frame is in-app)
             module*
@@ -92,7 +94,7 @@ app:
           u'bad'
 --------------------------------------------------------------------------
 system:
-  hash: '76257a5880699cfcb33257b10f7808c0'
+  hash: '71036056ea01a28f0931ab8e951206e2'
   component:
     system*
       exception*
@@ -127,7 +129,9 @@ system:
               u'test'
             filename (module takes precedence)
               u'/test.html'
-            lineno*
+            function*
+              u'eval'
+            lineno (function takes precedence)
               1
           frame*
             module*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy:2019_03_12/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy:2019_03_12/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:13:30.311148Z'
+created: '2019-05-10T13:21:30.528503Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -31,6 +31,8 @@ app:
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
+            function (function name is used only if module or filename are available)
+              u'eval'
             lineno (line number is used only if module or filename are available)
               1
           frame (frame considered in-app because no frame is in-app)
@@ -101,6 +103,8 @@ system:
           frame
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
+            function (function name is used only if module or filename are available)
+              u'eval'
             lineno (line number is used only if module or filename are available)
               1
           frame

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy:2019_03_12/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy:2019_03_12/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:44:34.492469Z'
+created: '2019-05-10T13:21:30.564413Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -39,7 +39,9 @@ app:
               u'test'
             filename (module takes precedence)
               u'/test.html'
-            lineno*
+            function*
+              u'eval'
+            lineno (function takes precedence)
               1
           frame* (frame considered in-app because no frame is in-app)
             module*
@@ -92,7 +94,7 @@ app:
           u'bad'
 --------------------------------------------------------------------------
 system:
-  hash: '76257a5880699cfcb33257b10f7808c0'
+  hash: '71036056ea01a28f0931ab8e951206e2'
   component:
     system*
       exception*
@@ -127,7 +129,9 @@ system:
               u'test'
             filename (module takes precedence)
               u'/test.html'
-            lineno*
+            function*
+              u'eval'
+            lineno (function takes precedence)
               1
           frame*
             module*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_05/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_05/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:13:31.268322Z'
+created: '2019-05-10T13:21:31.567127Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -25,6 +25,8 @@ app:
           frame (non app frame)
             filename (ignored because frame points to a URL)
               u'test.html'
+            function*
+              u'eval'
           frame (non app frame)
             filename (ignored because frame points to a URL)
               u'test.html'
@@ -54,7 +56,7 @@ app:
           u'Error'
 --------------------------------------------------------------------------
 system:
-  hash: '10a56c6cae9b8877c1267ece4b9a1dcf'
+  hash: 'fe1acbd354c812ab2969a76083b84e7f'
   component:
     system*
       exception*
@@ -72,9 +74,11 @@ system:
               u'test.html'
             function*
               u'aha'
-          frame
+          frame*
             filename (ignored because frame points to a URL)
               u'test.html'
+            function*
+              u'eval'
           frame*
             filename (ignored because frame points to a URL)
               u'test.html'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_05/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_05/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:44:35.526386Z'
+created: '2019-05-10T13:21:31.600141Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -33,6 +33,8 @@ app:
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
+            function*
+              u'eval'
           frame (non app frame)
             module*
               u'test'
@@ -72,7 +74,7 @@ app:
           u'Error'
 --------------------------------------------------------------------------
 system:
-  hash: '605738cf134b9fca3ff91d6ebb31125b'
+  hash: '7eb6de53ca3380ea437501f940974f21'
   component:
     system*
       exception*
@@ -101,6 +103,8 @@ system:
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
+            function*
+              u'eval'
           frame*
             module*
               u'test'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_17/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_17/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:13:32.244466Z'
+created: '2019-05-10T13:21:32.625659Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -25,6 +25,8 @@ app:
           frame (non app frame)
             filename (ignored because frame points to a URL)
               u'test.html'
+            function*
+              u'eval'
           frame (non app frame)
             filename (ignored because frame points to a URL)
               u'test.html'
@@ -56,7 +58,7 @@ app:
           u'bad'
 --------------------------------------------------------------------------
 system:
-  hash: '10a56c6cae9b8877c1267ece4b9a1dcf'
+  hash: 'fe1acbd354c812ab2969a76083b84e7f'
   component:
     system*
       exception*
@@ -74,9 +76,11 @@ system:
               u'test.html'
             function*
               u'aha'
-          frame
+          frame*
             filename (ignored because frame points to a URL)
               u'test.html'
+            function*
+              u'eval'
           frame*
             filename (ignored because frame points to a URL)
               u'test.html'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_17/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_17/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:44:36.528296Z'
+created: '2019-05-10T13:21:32.663146Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -33,6 +33,8 @@ app:
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
+            function*
+              u'eval'
           frame (non app frame)
             module*
               u'test'
@@ -74,7 +76,7 @@ app:
           u'bad'
 --------------------------------------------------------------------------
 system:
-  hash: '605738cf134b9fca3ff91d6ebb31125b'
+  hash: '7eb6de53ca3380ea437501f940974f21'
   component:
     system*
       exception*
@@ -103,6 +105,8 @@ system:
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
+            function*
+              u'eval'
           frame*
             module*
               u'test'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T22:36:43.422914Z'
+created: '2019-05-10T12:45:55.182908Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,6 +14,7 @@ app:
               u'app/components/modals/createTeamModal'
             filename (module takes precedence)
               u'createteammodal.jsx'
+            function (ignored unknown function name)
             context-line*
               u'onError(err);'
           frame (non app frame)
@@ -31,16 +32,17 @@ app:
           u"Cannot read property 'submitError' of null"
 --------------------------------------------------------------------------
 system:
-  hash: '2f2dc85b9b0cd1e3be91984802c7b1b7'
+  hash: '26552f86ca2368e708afa1df6effc1c5'
   component:
     system*
       exception*
         stacktrace*
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'app/components/modals/createTeamModal'
             filename (module takes precedence)
               u'createteammodal.jsx'
+            function (ignored unknown function name)
             context-line*
               u'onError(err);'
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/frame_ignores_module_if_page_url.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/frame_ignores_module_if_page_url.pysnap
@@ -1,29 +1,28 @@
 ---
-created: '2019-05-08T07:33:31.722343Z'
+created: '2019-05-10T12:45:55.344044Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: None
   component:
-    app
+    app (stacktrace of system takes precedence)
       stacktrace
         frame (non app frame)
           module*
             u'foo/bar/baz'
           filename (ignored because frame points to a URL)
             u'foo.py'
---------------------------------------------------------------------------
-fallback:
-  hash: 'd41d8cd98f00b204e9800998ecf8427e'
+          function (ignored unknown function name)
 --------------------------------------------------------------------------
 system:
-  hash: None
+  hash: 'a7a536723f7289f3ab7cbb444b7058ac'
   component:
-    system
-      stacktrace
-        frame (ignored low quality javascript frame)
+    system*
+      stacktrace*
+        frame*
           module*
             u'foo/bar/baz'
           filename (ignored because frame points to a URL)
             u'foo.py'
+          function (ignored unknown function name)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/javascript_xbrowser_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:13:33.261561Z'
+created: '2019-05-10T12:59:49.524963Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,6 +12,7 @@ app:
           frame (non app frame)
             filename*
               u'test.html'
+            function (ignored unknown function name)
           frame (non app frame)
             filename*
               u'test.html'
@@ -40,6 +41,7 @@ app:
           frame (non app frame)
             filename*
               u'test.html'
+            function (ignored unknown function name)
           frame (non app frame)
             filename*
               u'test.html'
@@ -61,14 +63,15 @@ app:
           u'bad'
 --------------------------------------------------------------------------
 system:
-  hash: '992d9978c56ad65c987156d1a9dd528a'
+  hash: 'c63e8727af1a8fe75872b6a762797113'
   component:
     system*
       exception*
         stacktrace*
-          frame (ignored low quality javascript frame)
+          frame*
             filename*
               u'test.html'
+            function (ignored unknown function name)
           frame*
             filename*
               u'test.html'
@@ -94,9 +97,10 @@ system:
               u'<anonymous>'
             function* (trimmed javascript function)
               u'map'
-          frame (ignored low quality javascript frame)
+          frame*
             filename*
               u'test.html'
+            function (ignored unknown function name)
           frame*
             filename*
               u'test.html'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/javascript_xbrowser_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:13:33.273801Z'
+created: '2019-05-10T12:45:55.643244Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,7 +12,7 @@ app:
           frame (non app frame)
             filename*
               u'test.html'
-            function*
+            function (ignored unknown function name)
               u'Anonymous function'
           frame (non app frame)
             filename*
@@ -42,7 +42,7 @@ app:
           frame (non app frame)
             filename*
               u'test.html'
-            function*
+            function (ignored unknown function name)
               u'Anonymous function'
           frame (non app frame)
             filename*
@@ -65,15 +65,15 @@ app:
           u'bad'
 --------------------------------------------------------------------------
 system:
-  hash: '992d9978c56ad65c987156d1a9dd528a'
+  hash: 'c63e8727af1a8fe75872b6a762797113'
   component:
     system*
       exception*
         stacktrace*
-          frame (ignored low quality javascript frame)
+          frame*
             filename*
               u'test.html'
-            function*
+            function (ignored unknown function name)
               u'Anonymous function'
           frame*
             filename*
@@ -100,10 +100,10 @@ system:
               u'native code'
             function* (trimmed javascript function)
               u'map'
-          frame (ignored low quality javascript frame)
+          frame*
             filename*
               u'test.html'
-            function*
+            function (ignored unknown function name)
               u'Anonymous function'
           frame*
             filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:13:33.285957Z'
+created: '2019-05-10T13:28:59.012503Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,6 +12,7 @@ app:
           frame (non app frame)
             filename*
               u'test.html'
+            function (ignored unknown function name)
           frame (non app frame)
             filename*
               u'test.html'
@@ -25,6 +26,8 @@ app:
           frame (non app frame)
             filename*
               u'test.html'
+            function*
+              u'eval'
           frame (non app frame)
             filename*
               u'test.html'
@@ -33,7 +36,7 @@ app:
           frame (non app frame)
             filename*
               u'test.html'
-            function*
+            function (ignored unknown function name)
               u'test/<'
           frame (non app frame)
             filename*
@@ -56,14 +59,15 @@ app:
           u'bad'
 --------------------------------------------------------------------------
 system:
-  hash: '992d9978c56ad65c987156d1a9dd528a'
+  hash: 'c63e8727af1a8fe75872b6a762797113'
   component:
     system*
       exception*
         stacktrace*
-          frame (ignored low quality javascript frame)
+          frame*
             filename*
               u'test.html'
+            function (ignored unknown function name)
           frame*
             filename*
               u'test.html'
@@ -77,15 +81,17 @@ system:
           frame (ignored low quality javascript frame)
             filename*
               u'test.html'
+            function*
+              u'eval'
           frame*
             filename*
               u'test.html'
             function*
               u'test'
-          frame (ignored low quality javascript frame)
+          frame*
             filename*
               u'test.html'
-            function*
+            function (ignored unknown function name)
               u'test/<'
           frame*
             filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/javascript_xbrowser_http_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:44:37.521495Z'
+created: '2019-05-10T12:59:49.569993Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,6 +14,7 @@ app:
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
+            function (ignored unknown function name)
           frame (non app frame)
             module*
               u'test'
@@ -52,6 +53,7 @@ app:
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
+            function (ignored unknown function name)
           frame (non app frame)
             module*
               u'test'
@@ -79,16 +81,17 @@ app:
           u'bad'
 --------------------------------------------------------------------------
 system:
-  hash: 'a40b332d0f8a51220c57733fe759fd28'
+  hash: 'b2602ad455472dede8e4c340d8a7eaba'
   component:
     system*
       exception*
         stacktrace*
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
+            function (ignored unknown function name)
           frame*
             module*
               u'test'
@@ -122,11 +125,12 @@ system:
               u'<anonymous>'
             function* (trimmed javascript function)
               u'map'
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
+            function (ignored unknown function name)
           frame*
             module*
               u'test'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/javascript_xbrowser_http_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:44:37.533792Z'
+created: '2019-05-10T12:45:55.687880Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,7 +14,7 @@ app:
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
-            function*
+            function (ignored unknown function name)
               u'Anonymous function'
           frame (non app frame)
             module*
@@ -54,7 +54,7 @@ app:
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
-            function*
+            function (ignored unknown function name)
               u'Anonymous function'
           frame (non app frame)
             module*
@@ -83,17 +83,17 @@ app:
           u'bad'
 --------------------------------------------------------------------------
 system:
-  hash: 'a40b332d0f8a51220c57733fe759fd28'
+  hash: 'b2602ad455472dede8e4c340d8a7eaba'
   component:
     system*
       exception*
         stacktrace*
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
-            function*
+            function (ignored unknown function name)
               u'Anonymous function'
           frame*
             module*
@@ -128,12 +128,12 @@ system:
               u'native code'
             function* (trimmed javascript function)
               u'map'
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
-            function*
+            function (ignored unknown function name)
               u'Anonymous function'
           frame*
             module*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:44:37.545007Z'
+created: '2019-05-10T13:28:59.047346Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,6 +14,7 @@ app:
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
+            function (ignored unknown function name)
           frame (non app frame)
             module*
               u'test'
@@ -33,6 +34,8 @@ app:
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
+            function*
+              u'eval'
           frame (non app frame)
             module*
               u'test'
@@ -45,7 +48,7 @@ app:
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
-            function*
+            function (ignored unknown function name)
               u'test/<'
           frame (non app frame)
             module*
@@ -74,16 +77,17 @@ app:
           u'bad'
 --------------------------------------------------------------------------
 system:
-  hash: 'a40b332d0f8a51220c57733fe759fd28'
+  hash: 'b2602ad455472dede8e4c340d8a7eaba'
   component:
     system*
       exception*
         stacktrace*
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
+            function (ignored unknown function name)
           frame*
             module*
               u'test'
@@ -103,6 +107,8 @@ system:
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
+            function*
+              u'eval'
           frame*
             module*
               u'test'
@@ -110,12 +116,12 @@ system:
               u'test.html'
             function*
               u'test'
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
-            function*
+            function (ignored unknown function name)
               u'test/<'
           frame*
             module*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/javascript_xbrowser_http_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:44:37.556286Z'
+created: '2019-05-10T12:58:20.716069Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,6 +14,7 @@ app:
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
+            function (ignored unknown function name)
           frame (non app frame)
             module*
               u'test'
@@ -50,6 +51,7 @@ app:
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
+            function (ignored unknown function name)
           frame (non app frame)
             module*
               u'test'
@@ -82,16 +84,17 @@ app:
           u'bad'
 --------------------------------------------------------------------------
 system:
-  hash: 'a40b332d0f8a51220c57733fe759fd28'
+  hash: 'b2602ad455472dede8e4c340d8a7eaba'
   component:
     system*
       exception*
         stacktrace*
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
+            function (ignored unknown function name)
           frame*
             module*
               u'test'
@@ -123,11 +126,12 @@ system:
               u'[native code]'
             function*
               u'map'
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'test'
             filename (ignored because frame points to a URL)
               u'test.html'
+            function (ignored unknown function name)
           frame*
             module*
               u'test'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/javascript_xbrowser_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:13:33.298272Z'
+created: '2019-05-10T12:58:20.731060Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,6 +12,7 @@ app:
           frame (non app frame)
             filename*
               u'test.html'
+            function (ignored unknown function name)
           frame (non app frame)
             filename*
               u'test.html'
@@ -40,6 +41,7 @@ app:
           frame (non app frame)
             filename*
               u'test.html'
+            function (ignored unknown function name)
           frame (non app frame)
             filename*
               u'test.html'
@@ -66,14 +68,15 @@ app:
           u'bad'
 --------------------------------------------------------------------------
 system:
-  hash: '992d9978c56ad65c987156d1a9dd528a'
+  hash: 'c63e8727af1a8fe75872b6a762797113'
   component:
     system*
       exception*
         stacktrace*
-          frame (ignored low quality javascript frame)
+          frame*
             filename*
               u'test.html'
+            function (ignored unknown function name)
           frame*
             filename*
               u'test.html'
@@ -99,9 +102,10 @@ system:
               u'[native code]'
             function*
               u'map'
-          frame (ignored low quality javascript frame)
+          frame*
             filename*
               u'test.html'
+            function (ignored unknown function name)
           frame*
             filename*
               u'test.html'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/minified_javascript.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T07:33:32.089211Z'
+created: '2019-05-10T13:28:59.194675Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,7 +22,7 @@ app:
               u'sentry/dist/vendor'
             filename (ignored because frame points to a URL)
               u'vendor.js'
-            function*
+            function (ignored unknown function name)
               u'S/<'
             context-line (discarded because line too long)
           frame (non app frame)
@@ -62,7 +62,7 @@ app:
               u'sentry/dist/vendor'
             filename (ignored because frame points to a URL)
               u'vendor.js'
-            function* (trimmed javascript function)
+            function (ignored unknown function name)
               u'_invoke</<'
             context-line (discarded because line too long)
           frame (non app frame)
@@ -78,7 +78,7 @@ app:
               u'sentry/dist/app'
             filename (ignored because frame points to a URL)
               u'app.js'
-            function*
+            function (ignored unknown function name)
               u'e/<'
             context-line (discarded because line too long)
           frame (non app frame)
@@ -86,7 +86,7 @@ app:
               u'sentry/dist/app'
             filename (ignored because frame points to a URL)
               u'app.js'
-            function*
+            function (ignored unknown function name)
               u'e/</a</<'
             context-line (discarded because line too long)
           frame (non app frame)
@@ -94,7 +94,7 @@ app:
               u'sentry/dist/vendor'
             filename (ignored because frame points to a URL)
               u'vendor.js'
-            function* (trimmed javascript function)
+            function (ignored unknown function name)
               u'exports/<'
             context-line (discarded because line too long)
           frame (non app frame)
@@ -110,7 +110,7 @@ app:
               u'sentry/dist/vendor'
             filename (ignored because frame points to a URL)
               u'vendor.js'
-            function* (trimmed javascript function)
+            function (ignored unknown function name)
               u'exports/</<'
             context-line (discarded because line too long)
           frame (non app frame)
@@ -142,7 +142,7 @@ app:
               u'sentry/dist/vendor'
             filename (ignored because frame points to a URL)
               u'vendor.js'
-            function* (trimmed javascript function)
+            function (ignored unknown function name)
               u'_invoke</<'
             context-line (discarded because line too long)
           frame (non app frame)
@@ -158,7 +158,7 @@ app:
               u'sentry/dist/app'
             filename (ignored because frame points to a URL)
               u'app.js'
-            function*
+            function (ignored unknown function name)
               u'e/<'
             context-line (discarded because line too long)
           frame (non app frame)
@@ -182,14 +182,14 @@ app:
               u'sentry/dist/vendor'
             filename (ignored because frame points to a URL)
               u'vendor.js'
-            function* (trimmed javascript function)
+            function (ignored unknown function name)
               u'wrapTimeFunction/<'
             context-line (discarded because line too long)
         type*
           u'NS_ERROR_NOT_INITIALIZED'
 --------------------------------------------------------------------------
 system:
-  hash: '229ba965d8c77f776bcc01d92969615e'
+  hash: 'dcfcd48a02c100bbe4023cbc783054f0'
   component:
     system*
       exception*
@@ -202,12 +202,12 @@ system:
             function*
               u'M'
             context-line (discarded because line too long)
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'sentry/dist/vendor'
             filename (ignored because frame points to a URL)
               u'vendor.js'
-            function*
+            function (ignored unknown function name)
               u'S/<'
             context-line (discarded because line too long)
           frame*
@@ -242,12 +242,12 @@ system:
             function*
               u'g/</t[e]'
             context-line (discarded because line too long)
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'sentry/dist/vendor'
             filename (ignored because frame points to a URL)
               u'vendor.js'
-            function* (trimmed javascript function)
+            function (ignored unknown function name)
               u'_invoke</<'
             context-line (discarded because line too long)
           frame*
@@ -258,28 +258,28 @@ system:
             function*
               u'W'
             context-line (discarded because line too long)
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'sentry/dist/app'
             filename (ignored because frame points to a URL)
               u'app.js'
-            function*
+            function (ignored unknown function name)
               u'e/<'
             context-line (discarded because line too long)
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'sentry/dist/app'
             filename (ignored because frame points to a URL)
               u'app.js'
-            function*
+            function (ignored unknown function name)
               u'e/</a</<'
             context-line (discarded because line too long)
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'sentry/dist/vendor'
             filename (ignored because frame points to a URL)
               u'vendor.js'
-            function* (trimmed javascript function)
+            function (ignored unknown function name)
               u'exports/<'
             context-line (discarded because line too long)
           frame*
@@ -290,12 +290,12 @@ system:
             function*
               u'L'
             context-line (discarded because line too long)
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'sentry/dist/vendor'
             filename (ignored because frame points to a URL)
               u'vendor.js'
-            function* (trimmed javascript function)
+            function (ignored unknown function name)
               u'exports/</<'
             context-line (discarded because line too long)
           frame*
@@ -322,12 +322,12 @@ system:
             function*
               u'g/</t[e]'
             context-line (discarded because line too long)
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'sentry/dist/vendor'
             filename (ignored because frame points to a URL)
               u'vendor.js'
-            function* (trimmed javascript function)
+            function (ignored unknown function name)
               u'_invoke</<'
             context-line (discarded because line too long)
           frame*
@@ -338,12 +338,12 @@ system:
             function*
               u'W'
             context-line (discarded because line too long)
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'sentry/dist/app'
             filename (ignored because frame points to a URL)
               u'app.js'
-            function*
+            function (ignored unknown function name)
               u'e/<'
             context-line (discarded because line too long)
           frame*
@@ -362,12 +362,12 @@ system:
             function* (trimmed javascript function)
               u'e'
             context-line (discarded because line too long)
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'sentry/dist/vendor'
             filename (ignored because frame points to a URL)
               u'vendor.js'
-            function* (trimmed javascript function)
+            function (ignored unknown function name)
               u'wrapTimeFunction/<'
             context-line (discarded because line too long)
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/node_exception_weird.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2019-05-08T07:39:46.454178Z'
+created: '2019-05-10T12:45:55.934160Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: '280318c52af37d73af6668b1b911e01d'
+  hash: 'a20509269752c9a1bea6078851e4d39c'
   component:
     app*
       exception*
@@ -18,12 +18,12 @@ app:
               u'withScope'
             context-line*
               u'*/'
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'onunhandledrejection.ts'
             filename (module takes precedence)
               u'onunhandledrejection.ts'
-            function* (trimmed javascript function)
+            function (ignored unknown function name)
               u'<anonymous>'
           frame (non app frame)
             module*
@@ -39,7 +39,7 @@ app:
               u'jest-mock.build:index'
             filename (module takes precedence)
               u'index.js'
-            function* (trimmed javascript function)
+            function (ignored unknown function name)
               u'<anonymous>'
             context-line*
               u'})();'
@@ -57,7 +57,7 @@ app:
               u'jest-mock.build:index'
             filename (module takes precedence)
               u'index.js'
-            function* (trimmed javascript function)
+            function (ignored unknown function name)
               u'<anonymous>'
             context-line*
               u'return original.apply(this, arguments);'
@@ -101,7 +101,7 @@ app:
           u'bla'
 --------------------------------------------------------------------------
 system:
-  hash: '149f3f2fba7318d20804b50c70fcaa37'
+  hash: '252dc79eb5653bf822e2684d90734cb8'
   component:
     system*
       exception*
@@ -115,12 +115,12 @@ system:
               u'withScope'
             context-line*
               u'*/'
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'onunhandledrejection.ts'
             filename (module takes precedence)
               u'onunhandledrejection.ts'
-            function* (trimmed javascript function)
+            function (ignored unknown function name)
               u'<anonymous>'
           frame*
             module*
@@ -131,12 +131,12 @@ system:
               u'mockConstructor [as captureException]'
             context-line*
               u'return fn.apply(this, arguments);'
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'jest-mock.build:index'
             filename (module takes precedence)
               u'index.js'
-            function* (trimmed javascript function)
+            function (ignored unknown function name)
               u'<anonymous>'
             context-line*
               u'})();'
@@ -149,12 +149,12 @@ system:
               u'finalReturnValue'
             context-line*
               u'return specificMockImpl.apply(this, arguments);'
-          frame (ignored low quality javascript frame)
+          frame*
             module*
               u'jest-mock.build:index'
             filename (module takes precedence)
               u'index.js'
-            function* (trimmed javascript function)
+            function (ignored unknown function name)
               u'<anonymous>'
             context-line*
               u'return original.apply(this, arguments);'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:13:33.547540Z'
+created: '2019-05-10T12:45:56.069725Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,6 +11,7 @@ app:
         frame (non app frame)
           filename (anonymous filename discarded)
             u'<anonymous>'
+          function (ignored unknown function name)
         frame (non app frame)
           filename*
             u'dojo.js'
@@ -30,6 +31,7 @@ system:
         frame (ignored low quality javascript frame)
           filename (anonymous filename discarded)
             u'<anonymous>'
+          function (ignored unknown function name)
         frame*
           filename*
             u'dojo.js'


### PR DESCRIPTION
This fix is necessary because the currently 2019-05 rule for newstyle grouping rejects
all anonymous frames which was unintentional.  It was intentional to just ignore the
function name in these cases.

However this also shows a bug in the JS SDK now.  The fixture for firefox had to be
amended to include the `eval` frame which is currently incorrectly removed by
sentry's tracekit.