### PR TITLE
fix(symbolicator): Handle missing registers in minidump

### DIFF
--- a/src/sentry/lang/native/minidump.py
+++ b/src/sentry/lang/native/minidump.py
@@ -244,7 +244,8 @@ def merge_symbolicator_minidump_response(data, response):
         else:
             data_thread['stacktrace'] = data_stacktrace = {'frames': []}
 
-        data_stacktrace['registers'] = complete_stacktrace['registers']
+        if complete_stacktrace.get('registers'):
+            data_stacktrace['registers'] = complete_stacktrace['registers']
 
         for complete_frame in reversed(complete_stacktrace['frames']):
             new_frame = {}


### PR DESCRIPTION
We don't understand why the registers are missing at all, but at this stage in the process there's nothing we can do about it.

Fix SENTRY-AQ7