### PR TITLE
fix(vsts) Reduce logging volume from Azure devops

### DIFF
--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -108,7 +108,7 @@ class WorkItemWebhook(Endpoint):
                 'vsts.updated-workitem-fields-not-passed',
                 extra={
                     'error': six.text_type(e),
-                    'payload': data,
+                    'workItemId': data['resource']['workItemId'],
                     'integration_id': integration.id
                 }
             )


### PR DESCRIPTION
We generally don't need the entire payload for a workitem when we cannot use it. Instead log the workitem item id so we can track back which work item was sending us events.

cc @JTCunning 