### PR TITLE
fix(api) Don't 500 on invalid data

### DIFF
--- a/src/sentry/api/endpoints/user_notification_fine_tuning.py
+++ b/src/sentry/api/endpoints/user_notification_fine_tuning.py
@@ -121,7 +121,12 @@ class UserNotificationFineTuningEndpoint(UserEndpoint):
             update_key = 'organization'
             parent_ids = set(self.get_org_ids(user))
 
-        ids_to_update = set([int(i) for i in request.DATA.keys()])
+        try:
+            ids_to_update = set([int(i) for i in request.DATA.keys()])
+        except ValueError:
+            return Response({
+                'detail': 'Invalid id value provided. Id values should be integers.'
+            }, status=status.HTTP_400_BAD_REQUEST)
 
         # make sure that the ids we are going to update are a subset of the user's
         # list of orgs or projects

--- a/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
+++ b/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
@@ -93,6 +93,16 @@ class UserNotificationFineTuningTest(APITestCase):
         resp = self.client.put(url, data=update)
         assert resp.status_code == 403
 
+    def test_invalid_id_value(self):
+        url = reverse(
+            'sentry-api-0-user-notifications-fine-tuning', kwargs={
+                'user_id': 'me',
+                'notification_type': 'alerts',
+            }
+        )
+        resp = self.client.put(url, data={'nope': 1})
+        assert resp.status_code == 400
+
     def test_saves_and_returns_alerts(self):
         url = reverse(
             'sentry-api-0-user-notifications-fine-tuning', kwargs={


### PR DESCRIPTION
When a non-integer id is provided we should not 500. This is a user-input error scenario.

Fixes SENTRY-ANZ