### PR TITLE
ref(ui) Update barcharts to use new tooltips

### DIFF
--- a/src/sentry/static/sentry/app/components/group/releaseChart.jsx
+++ b/src/sentry/static/sentry/app/components/group/releaseChart.jsx
@@ -5,7 +5,7 @@ import createReactClass from 'create-react-class';
 import StackedBarChart from 'app/components/stackedBarChart';
 import SentryTypes from 'app/sentryTypes';
 import {t} from 'app/locale';
-import {escape, intcomma} from 'app/utils';
+import {intcomma} from 'app/utils';
 import theme from 'app/utils/theme';
 
 const GroupReleaseChart = createReactClass({

--- a/src/sentry/static/sentry/app/components/group/releaseChart.jsx
+++ b/src/sentry/static/sentry/app/components/group/releaseChart.jsx
@@ -65,27 +65,41 @@ const GroupReleaseChart = createReactClass({
     const {releasePoints, envPoints} = this.state;
 
     return (
-      '<div style="width:150px">' +
-      `<div class="time-label">${timeLabel}</div>` +
-      '<dl class="legend">' +
-      '<dt class="inactive"><span></span></dt>' +
-      `<dd>${intcomma(totalY)} event${totalY !== 1 ? 's' : ''}</dd>` +
-      (environment
-        ? '<dt class="environment"><span></span></dt>' +
-          `<dd>${intcomma(envPoints[point.x] || 0)} event${
-            envPoints[point.x] !== 1 ? 's' : ''
-          }` +
-          `<small>in ${escape(environment)}</small></dd>`
-        : '') +
-      (release
-        ? '<dt class="active"><span></span></dt>' +
-          `<dd>${intcomma(releasePoints[point.x] || 0)} event${
-            releasePoints[point.x] !== 1 ? 's' : ''
-          }` +
-          `<small>in ${escape(release.version.substr(0, 12))}</small></dd>`
-        : '') +
-      '</dl>' +
-      '</div>'
+      <div style={{width: '150px'}}>
+        <div className="time-label">{timeLabel}</div>
+        <dl className="legend">
+          <dt className="inactive">
+            <span />
+          </dt>
+          <dd>
+            {intcomma(totalY)} event{totalY !== 1 ? 's' : ''}
+          </dd>
+          {environment && (
+            <React.Fragment>
+              <dt className="environment">
+                <span />
+              </dt>
+              <dd>
+                {intcomma(envPoints[point.x] || 0)} event
+                {envPoints[point.x] !== 1 ? 's' : ''}
+                <small>in {environment}</small>
+              </dd>
+            </React.Fragment>
+          )}
+          {release && (
+            <React.Fragment>
+              <dt className="active">
+                <span />
+              </dt>
+              <dd>
+                {intcomma(releasePoints[point.x] || 0)} event
+                {releasePoints[point.x] !== 1 ? 's' : ''}
+                <small>in {release.version.substr(0, 12)}</small>
+              </dd>
+            </React.Fragment>
+          )}
+        </dl>
+      </div>
     );
   },
 

--- a/src/sentry/static/sentry/app/components/group/seenInfo.jsx
+++ b/src/sentry/static/sentry/app/components/group/seenInfo.jsx
@@ -46,7 +46,7 @@ const SeenInfo = createReactClass({
     const {date, dateGlobal, title, environment} = this.props;
 
     return (
-      <div style={{width: 170}}>
+      <div style={{width: '170px'}}>
         <div className="time-label">{title}</div>
         <dl className="flat">
           {environment && [

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -4,7 +4,7 @@ import moment from 'moment-timezone';
 import _ from 'lodash';
 import styled, {cx} from 'react-emotion';
 
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import Count from 'app/components/count';
 import ConfigStore from 'app/stores/configStore';
 import theme from 'app/utils/theme';
@@ -154,20 +154,20 @@ class StackedBarChart extends React.Component {
     const format = this.use24Hours() ? 'HH:mm' : 'LT';
 
     return (
-      '<span>' +
-      timeMoment.format('LL') +
-      '<br />' +
-      timeMoment.format(format) +
-      '  &#8594; ' +
-      nextMoment.format(format) +
-      '</span>'
+      <span>
+        {timeMoment.format('LL')}
+        <br />
+        {timeMoment.format(format)}
+        &#8594;
+        {nextMoment.format(format)}
+      </span>
     );
   }
 
   timeLabelAsDay(point) {
     const timeMoment = moment(point.x * 1000);
 
-    return `<span>${timeMoment.format('LL')}</span>`;
+    return <span>{timeMoment.format('LL')}</span>;
   }
 
   timeLabelAsRange(interval, point) {
@@ -175,13 +175,13 @@ class StackedBarChart extends React.Component {
     const nextMoment = timeMoment.clone().add(interval - 1, 'second');
     const format = this.use24Hours() ? 'MMM Do, HH:mm' : 'MMM Do, h:mm a';
 
+    // e.g. Aug 23rd, 12:50 pm
     return (
-      '<span>' +
-      // e.g. Aug 23rd, 12:50 pm
-      timeMoment.format(format) +
-      ' &#8594 ' +
-      nextMoment.format(format) +
-      '</span>'
+      <span>
+        {timeMoment.format(format)}
+        &#8594
+        {nextMoment.format(format)}
+      </span>
     );
   }
 
@@ -214,25 +214,27 @@ class StackedBarChart extends React.Component {
 
   renderMarker(marker, index, pointWidth) {
     const timeLabel = moment(marker.x * 1000).format('lll');
-    const title =
-      '<div style="width:130px">' + marker.label + '<br/>' + timeLabel + '</div>';
+    const title = (
+      <div style={{width: '130px'}}>
+        {marker.label}
+        <br />
+        {timeLabel}
+      </div>
+    );
 
     // example key: m-last-seen-22811123, m-first-seen-228191
     const key = ['m', marker.className, marker.x].join('-');
     const markerOffset = marker.offset || 0;
 
     return (
-      <Tooltip
-        title={title}
+      <CircleSvg
         key={key}
-        tooltipOptions={{html: true, placement: 'bottom', container: 'body'}}
+        left={index * pointWidth}
+        offset={markerOffset || 0}
+        viewBox="0 0 10 10"
+        size={10}
       >
-        <CircleSvg
-          left={index * pointWidth}
-          offset={markerOffset || 0}
-          viewBox="0 0 10 10"
-          size={10}
-        >
+        <Tooltip2 title={title} position="bottom">
           <circle
             data-test-id="chart-column"
             r="4"
@@ -244,32 +246,38 @@ class StackedBarChart extends React.Component {
           >
             {marker.label}
           </circle>
-        </CircleSvg>
-      </Tooltip>
+        </Tooltip2>
+      </CircleSvg>
     );
   }
 
   renderTooltip = (point, pointIdx) => {
     const timeLabel = this.getTimeLabel(point);
     const totalY = point.y.reduce((a, b) => a + b);
-    let title =
-      '<div style="width:130px">' +
-      `<div class="time-label">${timeLabel}</div>` +
-      '</div>';
-    if (this.props.label) {
-      title += `<div class="value-label">${totalY.toLocaleString()} ${
-        this.props.label
-      }</div>`;
-    }
-    point.y.forEach((y, i) => {
-      const s = this.state.series[i];
-      if (s.label) {
-        title += `<div><span style="color:${s.color}">${s.label}:</span> ${(
-          y || 0
-        ).toLocaleString()}</div>`;
-      }
-    });
-    return title;
+    return (
+      <React.Fragment>
+        <div style={{width: '130px'}}>
+          <div className="time-label">{timeLabel}</div>
+        </div>
+        {this.props.label && (
+          <div className="value-label">
+            {totalY.toLocaleString()} {this.props.label}
+          </div>
+        )}
+        {point.y.map((y, i) => {
+          const s = this.state.series[i];
+          if (s.label) {
+            return (
+              <div>
+                <span style={{color: s.color}}>{s.label}:</span>{' '}
+                {(y || 0).toLocaleString()}
+              </div>
+            );
+          }
+          return null;
+        })}
+      </React.Fragment>
+    );
   };
 
   getMinHeight(index, pointLength) {
@@ -314,9 +322,9 @@ class StackedBarChart extends React.Component {
     const tooltipFunc = this.props.tooltip || this.renderTooltip;
 
     return (
-      <Tooltip
+      <Tooltip2
         title={tooltipFunc(this.state.pointIndex[pointIdx], pointIdx, this)}
-        tooltipOptions={{html: true, placement: 'bottom', container: 'body'}}
+        position="bottom"
         key={point.x}
       >
         <g>
@@ -328,7 +336,7 @@ class StackedBarChart extends React.Component {
           />
           {pts}
         </g>
-      </Tooltip>
+      </Tooltip2>
     );
   }
 

--- a/src/sentry/static/sentry/app/components/tooltip2.jsx
+++ b/src/sentry/static/sentry/app/components/tooltip2.jsx
@@ -129,6 +129,7 @@ class Tooltip2 extends React.Component {
           {({ref, style, placement, arrowProps}) => (
             <TooltipContent
               id={this.tooltipId}
+              className="tooltip-content"
               aria-hidden={!isOpen}
               isOpen={isOpen}
               innerRef={ref}
@@ -164,7 +165,7 @@ const Container = styled('span')`
   display: ${p => p.containerDisplayMode};
 `;
 
-const TooltipContent = styled('span')`
+const TooltipContent = styled('div')`
   color: #fff;
   background: #000;
   opacity: 0.9;
@@ -172,7 +173,7 @@ const TooltipContent = styled('span')`
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
   border-radius: ${p => p.theme.borderRadius};
   overflow-wrap: break-word;
-  max-width: 200px;
+  max-width: 225px;
   z-index: ${p => p.theme.zIndex.tooltip};
 
   font-weight: bold;

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/eventToolbar.jsx
@@ -10,7 +10,7 @@ import DateTime from 'app/components/dateTime';
 import ExternalLink from 'app/components/links/externalLink';
 import FileSize from 'app/components/fileSize';
 import SentryTypes from 'app/sentryTypes';
-import Tooltip from 'app/components/tooltip';
+import Tooltip2 from 'app/components/tooltip2';
 import getDynamicText from 'app/utils/getDynamicText';
 
 const formatDateDelta = (reference, observed) => {
@@ -56,29 +56,30 @@ const GroupEventToolbar = createReactClass({
     const options = user ? user.options : {};
     const format = options.clock24Hours ? 'HH:mm:ss z' : 'LTS z';
     const dateCreated = moment(evt.dateCreated);
-    let resp =
-      '<dl class="flat" style="text-align:left;margin:0;min-width:200px">' +
-      '<dt>Occurred</dt>' +
-      '<dd>' +
-      dateCreated.format('ll') +
-      '<br />' +
-      dateCreated.format(format) +
-      '</dd>';
-    if (evt.dateReceived) {
-      const dateReceived = moment(evt.dateReceived);
-      resp +=
-        '<dt>Received</dt>' +
-        '<dd>' +
-        dateReceived.format('ll') +
-        '<br />' +
-        dateReceived.format(format) +
-        '</dd>' +
-        '<dt>Latency</dt>' +
-        '<dd>' +
-        formatDateDelta(dateCreated, dateReceived) +
-        '</dd>';
-    }
-    return resp + '</dl>';
+    const dateReceived = evt.dateReceived ? moment(evt.dateReceived) : null;
+
+    return (
+      <dl className="flat" style={{textAlign: 'left', margin: 0, minWidth: '200px'}}>
+        <dt>Occurred</dt>
+        <dd>
+          {dateCreated.format('ll')}
+          <br />
+          {dateCreated.format(format)}
+        </dd>
+        {dateReceived && (
+          <React.Fragment>
+            <dt>Received</dt>
+            <dd>
+              {dateReceived.format('ll')}
+              <br />
+              {dateReceived.format(format)}
+            </dd>
+            <dt>Latency</dt>
+            <dd>{formatDateDelta(dateCreated, dateReceived)}</dd>
+          </React.Fragment>
+        )}
+      </dl>
+    );
   },
 
   render() {
@@ -176,10 +177,7 @@ const GroupEventToolbar = createReactClass({
           </Link>
         </h4>
         <span>
-          <Tooltip
-            title={this.getDateTooltip()}
-            tooltipOptions={{html: true, container: false}}
-          >
+          <Tooltip2 title={this.getDateTooltip()}>
             <span>
               <DateTime
                 date={getDynamicText({value: evt.dateCreated, fixed: 'Dummy timestamp'})}
@@ -187,7 +185,7 @@ const GroupEventToolbar = createReactClass({
               />
               {isOverLatencyThreshold && <span className="icon-alert" />}
             </span>
-          </Tooltip>
+          </Tooltip2>
           <ExternalLink href={jsonUrl} className="json-link">
             {'JSON'} (<FileSize bytes={evt.size} />)
           </ExternalLink>

--- a/src/sentry/static/sentry/app/views/organizationMonitors/monitorStats.jsx
+++ b/src/sentry/static/sentry/app/views/organizationMonitors/monitorStats.jsx
@@ -47,10 +47,10 @@ export default class MonitorStats extends AsyncComponent {
     const value = `${ok.toLocaleString()} successful<br>${error.toLocaleString()} failed`;
 
     return (
-      '<div style="width:150px">' +
-      `<div class="time-label">${timeLabel}</div>` +
-      `<div class="value-label">${value}</div>` +
-      '</div>'
+      <div style={{width: '150px'}}>
+        <div className="time-label">{timeLabel}</div>
+        <div className="value-label">{value}</div>
+      </div>
     );
   }
 

--- a/src/sentry/static/sentry/app/views/organizationMonitors/monitorStats.jsx
+++ b/src/sentry/static/sentry/app/views/organizationMonitors/monitorStats.jsx
@@ -44,12 +44,14 @@ export default class MonitorStats extends AsyncComponent {
     const timeLabel = chart.getTimeLabel(point);
     const [error, ok] = point.y;
 
-    const value = `${ok.toLocaleString()} successful<br>${error.toLocaleString()} failed`;
-
     return (
       <div style={{width: '150px'}}>
         <div className="time-label">{timeLabel}</div>
-        <div className="value-label">{value}</div>
+        <div className="value-label">
+          {t('%s successful', ok.toLocaleString())}
+          <br />
+          {t('%s failed', error.toLocaleString())}
+        </div>
       </div>
     );
   }

--- a/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
@@ -36,19 +36,25 @@ class OrganizationStats extends React.Component {
     const timeLabel = chart.getTimeLabel(point);
     const [accepted, rejected, blacklisted] = point.y;
 
-    let value = `${intcomma(accepted)} accepted`;
-    if (rejected) {
-      value += `<br>${intcomma(rejected)} rate limited`;
-    }
-    if (blacklisted) {
-      value += `<br>${intcomma(blacklisted)} filtered`;
-    }
-
     return (
-      '<div style="width:150px">' +
-      `<div class="time-label">${timeLabel}</div>` +
-      `<div class="value-label">${value}</div>` +
-      '</div>'
+      <div style={{width: '150px'}}>
+        <div className="time-label">{timeLabel}</div>
+        <div className="value-label">
+          {intcomma(accepted)} accepted
+          {rejected > 0 && (
+            <React.Fragment>
+              <br />
+              {intcomma(rejected)} rate limited
+            </React.Fragment>
+          )}
+          {blacklisted > 0 && (
+            <React.Fragment>
+              <br />
+              {intcomma(blacklisted)} filtered
+            </React.Fragment>
+          )}
+        </div>
+      </div>
     );
   }
 

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.jsx
@@ -1,7 +1,6 @@
 import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactDOMServer from 'react-dom/server';
 import createReactClass from 'create-react-class';
 import moment from 'moment';
 
@@ -142,7 +141,7 @@ const ProjectFiltersChart = createReactClass({
     }
     const {formattedData} = this.state;
 
-    return ReactDOMServer.renderToStaticMarkup(
+    return (
       <div style={{width: '175px'}}>
         <div className="time-label">
           <span>{timeLabel}</span>

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
@@ -113,19 +113,25 @@ const KeyStats = createReactClass({
     const timeLabel = chart.getTimeLabel(point);
     const [accepted, dropped, filtered] = point.y;
 
-    let value = `${accepted.toLocaleString()} accepted`;
-    if (dropped) {
-      value += `<br>${dropped.toLocaleString()} rate limited`;
-    }
-    if (filtered) {
-      value += `<br>${filtered.toLocaleString()} filtered`;
-    }
-
     return (
-      '<div style="width:150px">' +
-      `<div class="time-label">${timeLabel}</div>` +
-      `<div class="value-label">${value}</div>` +
-      '</div>'
+      <div style={{width: '150px'}}>
+        <div className="time-label">{timeLabel}</div>
+        <div className="value-label">
+          {accepted.toLocaleString()} accepted
+          {dropped > 0 && (
+            <React.Fragment>
+              <br />
+              {dropped.toLocaleString()} rate limited
+            </React.Fragment>
+          )}
+          {filtered > 0 && (
+            <React.Fragment>
+              <br />
+              {filtered.toLocaleString()} filtered
+            </React.Fragment>
+          )}
+        </div>
+      </div>
     );
   },
 

--- a/src/sentry/static/sentry/app/views/settings/project/projectServiceHookDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectServiceHookDetails.jsx
@@ -44,10 +44,10 @@ class HookStats extends AsyncComponent {
     const value = `${total.toLocaleString()} events`;
 
     return (
-      '<div style="width:150px">' +
-      `<div class="time-label">${timeLabel}</div>` +
-      `<div class="value-label">${value}</div>` +
-      '</div>'
+      <div style={{width: '150px'}}>
+        <div className="time-label">{timeLabel}</div>
+        <div className="value-label">{value}</div>
+      </div>
     );
   }
 

--- a/src/sentry/static/sentry/less/includes/tooltips.less
+++ b/src/sentry/static/sentry/less/includes/tooltips.less
@@ -2,6 +2,7 @@
 @tooltip-color: @white;
 @tooltip-max-width: 200px;
 
+.tooltip-content,
 .tooltip-inner {
   font-weight: bold;
   padding: 5px 10px;

--- a/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
@@ -1330,7 +1330,7 @@ exports[`GroupReleaseStats renders 1`] = `
                   <div
                     style={
                       Object {
-                        "width": 170,
+                        "width": "170px",
                       }
                     }
                   >
@@ -1469,7 +1469,7 @@ exports[`GroupReleaseStats renders 1`] = `
                   <div
                     style={
                       Object {
-                        "width": 170,
+                        "width": "170px",
                       }
                     }
                   >

--- a/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
@@ -390,200 +390,342 @@ exports[`GroupReleaseStats renders 1`] = `
                           preserveAspectRatio="none"
                           viewBox="0 0 100 400"
                         >
-                          <Tooltip
+                          <Tooltip2
+                            containerDisplayMode="inline-block"
                             key="1517281200"
-                            title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 29th, 7:00 pm &#8594 Jan 30th, 2:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>2 events</dd><dt class=\\"environment\\"><span></span></dt><dd>2 events<small>in All Environments</small></dd></dl></div>"
-                            tooltipOptions={
-                              Object {
-                                "container": "body",
-                                "html": true,
-                                "placement": "bottom",
-                              }
+                            position="bottom"
+                            title={
+                              <div
+                                style={
+                                  Object {
+                                    "width": "150px",
+                                  }
+                                }
+                              >
+                                <div
+                                  className="time-label"
+                                >
+                                  <span>
+                                    Jan 29th, 7:00 pm
+                                    &#8594
+                                    Jan 30th, 2:59 am
+                                  </span>
+                                </div>
+                                <dl
+                                  className="legend"
+                                >
+                                  <dt
+                                    className="inactive"
+                                  >
+                                    <span />
+                                  </dt>
+                                  <dd>
+                                    2
+                                     event
+                                    s
+                                  </dd>
+                                  <React.Fragment>
+                                    <dt
+                                      className="environment"
+                                    >
+                                      <span />
+                                    </dt>
+                                    <dd>
+                                      2
+                                       event
+                                      s
+                                      <small>
+                                        in 
+                                        All Environments
+                                      </small>
+                                    </dd>
+                                  </React.Fragment>
+                                </dl>
+                              </div>
                             }
                           >
-                            <g
-                              className="tip"
-                              title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 29th, 7:00 pm &#8594 Jan 30th, 2:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>2 events</dd><dt class=\\"environment\\"><span></span></dt><dd>2 events<small>in All Environments</small></dd></dl></div>"
-                            >
-                              <rect
-                                height="100%"
-                                opacity="0"
-                                width="51.17%"
-                                x="-0.75%"
-                              />
-                              <rect
-                                className="release barchart-rect"
-                                data-test-id="chart-column"
-                                height="0%"
-                                key="0"
-                                width="49.67%"
-                                x="0%"
-                                y="100%"
-                              >
-                                0
-                              </rect>
-                              <rect
-                                className="environment barchart-rect"
-                                data-test-id="chart-column"
-                                height="19.8%"
-                                key="1"
-                                width="49.67%"
-                                x="0%"
-                                y="80.2%"
-                              >
-                                2
-                              </rect>
-                              <rect
-                                className="inactive barchart-rect"
-                                data-test-id="chart-column"
-                                height="5%"
-                                key="2"
-                                width="49.67%"
-                                x="0%"
-                                y="75.2%"
-                              >
-                                0
-                              </rect>
-                            </g>
-                          </Tooltip>
-                          <Tooltip
+                            <Manager>
+                              <Reference>
+                                <InnerReference
+                                  setReferenceNode={[Function]}
+                                >
+                                  <g
+                                    aria-describedby="tooltip-123456"
+                                    onBlur={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    <rect
+                                      height="100%"
+                                      opacity="0"
+                                      width="51.17%"
+                                      x="-0.75%"
+                                    />
+                                    <rect
+                                      className="release barchart-rect"
+                                      data-test-id="chart-column"
+                                      height="0%"
+                                      key="0"
+                                      width="49.67%"
+                                      x="0%"
+                                      y="100%"
+                                    >
+                                      0
+                                    </rect>
+                                    <rect
+                                      className="environment barchart-rect"
+                                      data-test-id="chart-column"
+                                      height="19.8%"
+                                      key="1"
+                                      width="49.67%"
+                                      x="0%"
+                                      y="80.2%"
+                                    >
+                                      2
+                                    </rect>
+                                    <rect
+                                      className="inactive barchart-rect"
+                                      data-test-id="chart-column"
+                                      height="5%"
+                                      key="2"
+                                      width="49.67%"
+                                      x="0%"
+                                      y="75.2%"
+                                    >
+                                      0
+                                    </rect>
+                                  </g>
+                                </InnerReference>
+                              </Reference>
+                            </Manager>
+                          </Tooltip2>
+                          <Tooltip2
+                            containerDisplayMode="inline-block"
                             key="1517310000"
-                            title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 30th, 3:00 am &#8594 Jan 30th, 10:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
-                            tooltipOptions={
-                              Object {
-                                "container": "body",
-                                "html": true,
-                                "placement": "bottom",
-                              }
+                            position="bottom"
+                            title={
+                              <div
+                                style={
+                                  Object {
+                                    "width": "150px",
+                                  }
+                                }
+                              >
+                                <div
+                                  className="time-label"
+                                >
+                                  <span>
+                                    Jan 30th, 3:00 am
+                                    &#8594
+                                    Jan 30th, 10:59 am
+                                  </span>
+                                </div>
+                                <dl
+                                  className="legend"
+                                >
+                                  <dt
+                                    className="inactive"
+                                  >
+                                    <span />
+                                  </dt>
+                                  <dd>
+                                    1
+                                     event
+                                    
+                                  </dd>
+                                  <React.Fragment>
+                                    <dt
+                                      className="environment"
+                                    >
+                                      <span />
+                                    </dt>
+                                    <dd>
+                                      1
+                                       event
+                                      
+                                      <small>
+                                        in 
+                                        All Environments
+                                      </small>
+                                    </dd>
+                                  </React.Fragment>
+                                </dl>
+                              </div>
                             }
                           >
-                            <g
-                              className="tip"
-                              title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 30th, 3:00 am &#8594 Jan 30th, 10:59 am</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
-                            >
-                              <rect
-                                height="100%"
-                                opacity="0"
-                                width="51.17%"
-                                x="49.67%"
-                              />
-                              <rect
-                                className="release barchart-rect"
-                                data-test-id="chart-column"
-                                height="0%"
-                                key="0"
-                                width="49.67%"
-                                x="50.42%"
-                                y="100%"
-                              >
-                                0
-                              </rect>
-                              <rect
-                                className="environment barchart-rect"
-                                data-test-id="chart-column"
-                                height="9.9%"
-                                key="1"
-                                width="49.67%"
-                                x="50.42%"
-                                y="90.1%"
-                              >
-                                1
-                              </rect>
-                              <rect
-                                className="inactive barchart-rect"
-                                data-test-id="chart-column"
-                                height="5%"
-                                key="2"
-                                width="49.67%"
-                                x="50.42%"
-                                y="85.1%"
-                              >
-                                0
-                              </rect>
-                            </g>
-                          </Tooltip>
+                            <Manager>
+                              <Reference>
+                                <InnerReference
+                                  setReferenceNode={[Function]}
+                                >
+                                  <g
+                                    aria-describedby="tooltip-123456"
+                                    onBlur={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    <rect
+                                      height="100%"
+                                      opacity="0"
+                                      width="51.17%"
+                                      x="49.67%"
+                                    />
+                                    <rect
+                                      className="release barchart-rect"
+                                      data-test-id="chart-column"
+                                      height="0%"
+                                      key="0"
+                                      width="49.67%"
+                                      x="50.42%"
+                                      y="100%"
+                                    >
+                                      0
+                                    </rect>
+                                    <rect
+                                      className="environment barchart-rect"
+                                      data-test-id="chart-column"
+                                      height="9.9%"
+                                      key="1"
+                                      width="49.67%"
+                                      x="50.42%"
+                                      y="90.1%"
+                                    >
+                                      1
+                                    </rect>
+                                    <rect
+                                      className="inactive barchart-rect"
+                                      data-test-id="chart-column"
+                                      height="5%"
+                                      key="2"
+                                      width="49.67%"
+                                      x="50.42%"
+                                      y="85.1%"
+                                    >
+                                      0
+                                    </rect>
+                                  </g>
+                                </InnerReference>
+                              </Reference>
+                            </Manager>
+                          </Tooltip2>
                         </svg>
                       </StyledSvg>
-                      <Tooltip
+                      <CircleSvg
                         key="m-first-seen-1554493445.963"
-                        title="<div style=\\"width:130px\\">First seen<br/>Apr 5, 2019 12:44 PM</div>"
-                        tooltipOptions={
-                          Object {
-                            "container": "body",
-                            "html": true,
-                            "placement": "bottom",
-                          }
-                        }
+                        left={100.84}
+                        offset={-7.5}
+                        size={10}
+                        viewBox="0 0 10 10"
                       >
-                        <CircleSvg
-                          className="tip"
-                          left={100.84}
+                        <svg
+                          className="css-m7l75b-CircleSvg e5t71583"
                           offset={-7.5}
                           size={10}
-                          title="<div style=\\"width:130px\\">First seen<br/>Apr 5, 2019 12:44 PM</div>"
                           viewBox="0 0 10 10"
                         >
-                          <svg
-                            className="tip css-m7l75b-CircleSvg e5t71583"
-                            offset={-7.5}
-                            size={10}
-                            title="<div style=\\"width:130px\\">First seen<br/>Apr 5, 2019 12:44 PM</div>"
-                            viewBox="0 0 10 10"
+                          <Tooltip2
+                            containerDisplayMode="inline-block"
+                            position="bottom"
+                            title={
+                              <div
+                                style={
+                                  Object {
+                                    "width": "130px",
+                                  }
+                                }
+                              >
+                                First seen
+                                <br />
+                                Apr 5, 2019 12:44 PM
+                              </div>
+                            }
                           >
-                            <circle
-                              cx="50%"
-                              cy="50%"
-                              data-test-id="chart-column"
-                              fill="#F868BC"
-                              r="4"
-                              stroke="#fff"
-                              strokeWidth="2"
-                            >
-                              First seen
-                            </circle>
-                          </svg>
-                        </CircleSvg>
-                      </Tooltip>
-                      <Tooltip
+                            <Manager>
+                              <Reference>
+                                <InnerReference
+                                  setReferenceNode={[Function]}
+                                >
+                                  <circle
+                                    aria-describedby="tooltip-123456"
+                                    cx="50%"
+                                    cy="50%"
+                                    data-test-id="chart-column"
+                                    fill="#F868BC"
+                                    onBlur={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                    r="4"
+                                    stroke="#fff"
+                                    strokeWidth="2"
+                                  >
+                                    First seen
+                                  </circle>
+                                </InnerReference>
+                              </Reference>
+                            </Manager>
+                          </Tooltip2>
+                        </svg>
+                      </CircleSvg>
+                      <CircleSvg
                         key="m-last-seen-1554944939"
-                        title="<div style=\\"width:130px\\">Last seen<br/>Apr 10, 2019 6:08 PM</div>"
-                        tooltipOptions={
-                          Object {
-                            "container": "body",
-                            "html": true,
-                            "placement": "bottom",
-                          }
-                        }
+                        left={100.84}
+                        offset={0}
+                        size={10}
+                        viewBox="0 0 10 10"
                       >
-                        <CircleSvg
-                          className="tip"
-                          left={100.84}
+                        <svg
+                          className="css-1yt4gr0-CircleSvg e5t71583"
                           offset={0}
                           size={10}
-                          title="<div style=\\"width:130px\\">Last seen<br/>Apr 10, 2019 6:08 PM</div>"
                           viewBox="0 0 10 10"
                         >
-                          <svg
-                            className="tip css-1yt4gr0-CircleSvg e5t71583"
-                            offset={0}
-                            size={10}
-                            title="<div style=\\"width:130px\\">Last seen<br/>Apr 10, 2019 6:08 PM</div>"
-                            viewBox="0 0 10 10"
+                          <Tooltip2
+                            containerDisplayMode="inline-block"
+                            position="bottom"
+                            title={
+                              <div
+                                style={
+                                  Object {
+                                    "width": "130px",
+                                  }
+                                }
+                              >
+                                Last seen
+                                <br />
+                                Apr 10, 2019 6:08 PM
+                              </div>
+                            }
                           >
-                            <circle
-                              cx="50%"
-                              cy="50%"
-                              data-test-id="chart-column"
-                              fill="#57be8c"
-                              r="4"
-                              stroke="#fff"
-                              strokeWidth="2"
-                            >
-                              Last seen
-                            </circle>
-                          </svg>
-                        </CircleSvg>
-                      </Tooltip>
+                            <Manager>
+                              <Reference>
+                                <InnerReference
+                                  setReferenceNode={[Function]}
+                                >
+                                  <circle
+                                    aria-describedby="tooltip-123456"
+                                    cx="50%"
+                                    cy="50%"
+                                    data-test-id="chart-column"
+                                    fill="#57be8c"
+                                    onBlur={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                    r="4"
+                                    stroke="#fff"
+                                    strokeWidth="2"
+                                  >
+                                    Last seen
+                                  </circle>
+                                </InnerReference>
+                              </Reference>
+                            </Manager>
+                          </Tooltip2>
+                        </svg>
+                      </CircleSvg>
                     </div>
                   </SvgContainer>
                 </figure>
@@ -811,200 +953,342 @@ exports[`GroupReleaseStats renders 1`] = `
                           preserveAspectRatio="none"
                           viewBox="0 0 100 400"
                         >
-                          <Tooltip
+                          <Tooltip2
+                            containerDisplayMode="inline-block"
                             key="1514764800"
-                            title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Dec 31st, 4:00 pm &#8594 Jan 3rd, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
-                            tooltipOptions={
-                              Object {
-                                "container": "body",
-                                "html": true,
-                                "placement": "bottom",
-                              }
+                            position="bottom"
+                            title={
+                              <div
+                                style={
+                                  Object {
+                                    "width": "150px",
+                                  }
+                                }
+                              >
+                                <div
+                                  className="time-label"
+                                >
+                                  <span>
+                                    Dec 31st, 4:00 pm
+                                    &#8594
+                                    Jan 3rd, 3:59 pm
+                                  </span>
+                                </div>
+                                <dl
+                                  className="legend"
+                                >
+                                  <dt
+                                    className="inactive"
+                                  >
+                                    <span />
+                                  </dt>
+                                  <dd>
+                                    1
+                                     event
+                                    
+                                  </dd>
+                                  <React.Fragment>
+                                    <dt
+                                      className="environment"
+                                    >
+                                      <span />
+                                    </dt>
+                                    <dd>
+                                      1
+                                       event
+                                      
+                                      <small>
+                                        in 
+                                        All Environments
+                                      </small>
+                                    </dd>
+                                  </React.Fragment>
+                                </dl>
+                              </div>
                             }
                           >
-                            <g
-                              className="tip"
-                              title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Dec 31st, 4:00 pm &#8594 Jan 3rd, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>1 event</dd><dt class=\\"environment\\"><span></span></dt><dd>1 event<small>in All Environments</small></dd></dl></div>"
-                            >
-                              <rect
-                                height="100%"
-                                opacity="0"
-                                width="51.17%"
-                                x="-0.75%"
-                              />
-                              <rect
-                                className="release barchart-rect"
-                                data-test-id="chart-column"
-                                height="0%"
-                                key="0"
-                                width="49.67%"
-                                x="0%"
-                                y="100%"
-                              >
-                                0
-                              </rect>
-                              <rect
-                                className="environment barchart-rect"
-                                data-test-id="chart-column"
-                                height="0.81%"
-                                key="1"
-                                width="49.67%"
-                                x="0%"
-                                y="99.19%"
-                              >
-                                1
-                              </rect>
-                              <rect
-                                className="inactive barchart-rect"
-                                data-test-id="chart-column"
-                                height="5%"
-                                key="2"
-                                width="49.67%"
-                                x="0%"
-                                y="94.19%"
-                              >
-                                0
-                              </rect>
-                            </g>
-                          </Tooltip>
-                          <Tooltip
+                            <Manager>
+                              <Reference>
+                                <InnerReference
+                                  setReferenceNode={[Function]}
+                                >
+                                  <g
+                                    aria-describedby="tooltip-123456"
+                                    onBlur={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    <rect
+                                      height="100%"
+                                      opacity="0"
+                                      width="51.17%"
+                                      x="-0.75%"
+                                    />
+                                    <rect
+                                      className="release barchart-rect"
+                                      data-test-id="chart-column"
+                                      height="0%"
+                                      key="0"
+                                      width="49.67%"
+                                      x="0%"
+                                      y="100%"
+                                    >
+                                      0
+                                    </rect>
+                                    <rect
+                                      className="environment barchart-rect"
+                                      data-test-id="chart-column"
+                                      height="0.81%"
+                                      key="1"
+                                      width="49.67%"
+                                      x="0%"
+                                      y="99.19%"
+                                    >
+                                      1
+                                    </rect>
+                                    <rect
+                                      className="inactive barchart-rect"
+                                      data-test-id="chart-column"
+                                      height="5%"
+                                      key="2"
+                                      width="49.67%"
+                                      x="0%"
+                                      y="94.19%"
+                                    >
+                                      0
+                                    </rect>
+                                  </g>
+                                </InnerReference>
+                              </Reference>
+                            </Manager>
+                          </Tooltip2>
+                          <Tooltip2
+                            containerDisplayMode="inline-block"
                             key="1515024000"
-                            title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 3rd, 4:00 pm &#8594 Jan 6th, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>122 events</dd><dt class=\\"environment\\"><span></span></dt><dd>122 events<small>in All Environments</small></dd></dl></div>"
-                            tooltipOptions={
-                              Object {
-                                "container": "body",
-                                "html": true,
-                                "placement": "bottom",
-                              }
+                            position="bottom"
+                            title={
+                              <div
+                                style={
+                                  Object {
+                                    "width": "150px",
+                                  }
+                                }
+                              >
+                                <div
+                                  className="time-label"
+                                >
+                                  <span>
+                                    Jan 3rd, 4:00 pm
+                                    &#8594
+                                    Jan 6th, 3:59 pm
+                                  </span>
+                                </div>
+                                <dl
+                                  className="legend"
+                                >
+                                  <dt
+                                    className="inactive"
+                                  >
+                                    <span />
+                                  </dt>
+                                  <dd>
+                                    122
+                                     event
+                                    s
+                                  </dd>
+                                  <React.Fragment>
+                                    <dt
+                                      className="environment"
+                                    >
+                                      <span />
+                                    </dt>
+                                    <dd>
+                                      122
+                                       event
+                                      s
+                                      <small>
+                                        in 
+                                        All Environments
+                                      </small>
+                                    </dd>
+                                  </React.Fragment>
+                                </dl>
+                              </div>
                             }
                           >
-                            <g
-                              className="tip"
-                              title="<div style=\\"width:150px\\"><div class=\\"time-label\\"><span>Jan 3rd, 4:00 pm &#8594 Jan 6th, 3:59 pm</span></div><dl class=\\"legend\\"><dt class=\\"inactive\\"><span></span></dt><dd>122 events</dd><dt class=\\"environment\\"><span></span></dt><dd>122 events<small>in All Environments</small></dd></dl></div>"
-                            >
-                              <rect
-                                height="100%"
-                                opacity="0"
-                                width="51.17%"
-                                x="49.67%"
-                              />
-                              <rect
-                                className="release barchart-rect"
-                                data-test-id="chart-column"
-                                height="0%"
-                                key="0"
-                                width="49.67%"
-                                x="50.42%"
-                                y="100%"
-                              >
-                                0
-                              </rect>
-                              <rect
-                                className="environment barchart-rect"
-                                data-test-id="chart-column"
-                                height="99%"
-                                key="1"
-                                width="49.67%"
-                                x="50.42%"
-                                y="1%"
-                              >
-                                122
-                              </rect>
-                              <rect
-                                className="inactive barchart-rect"
-                                data-test-id="chart-column"
-                                height="5%"
-                                key="2"
-                                width="49.67%"
-                                x="50.42%"
-                                y="-4%"
-                              >
-                                0
-                              </rect>
-                            </g>
-                          </Tooltip>
+                            <Manager>
+                              <Reference>
+                                <InnerReference
+                                  setReferenceNode={[Function]}
+                                >
+                                  <g
+                                    aria-describedby="tooltip-123456"
+                                    onBlur={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    <rect
+                                      height="100%"
+                                      opacity="0"
+                                      width="51.17%"
+                                      x="49.67%"
+                                    />
+                                    <rect
+                                      className="release barchart-rect"
+                                      data-test-id="chart-column"
+                                      height="0%"
+                                      key="0"
+                                      width="49.67%"
+                                      x="50.42%"
+                                      y="100%"
+                                    >
+                                      0
+                                    </rect>
+                                    <rect
+                                      className="environment barchart-rect"
+                                      data-test-id="chart-column"
+                                      height="99%"
+                                      key="1"
+                                      width="49.67%"
+                                      x="50.42%"
+                                      y="1%"
+                                    >
+                                      122
+                                    </rect>
+                                    <rect
+                                      className="inactive barchart-rect"
+                                      data-test-id="chart-column"
+                                      height="5%"
+                                      key="2"
+                                      width="49.67%"
+                                      x="50.42%"
+                                      y="-4%"
+                                    >
+                                      0
+                                    </rect>
+                                  </g>
+                                </InnerReference>
+                              </Reference>
+                            </Manager>
+                          </Tooltip2>
                         </svg>
                       </StyledSvg>
-                      <Tooltip
+                      <CircleSvg
                         key="m-first-seen-1554493445.963"
-                        title="<div style=\\"width:130px\\">First seen<br/>Apr 5, 2019 12:44 PM</div>"
-                        tooltipOptions={
-                          Object {
-                            "container": "body",
-                            "html": true,
-                            "placement": "bottom",
-                          }
-                        }
+                        left={100.84}
+                        offset={-7.5}
+                        size={10}
+                        viewBox="0 0 10 10"
                       >
-                        <CircleSvg
-                          className="tip"
-                          left={100.84}
+                        <svg
+                          className="css-m7l75b-CircleSvg e5t71583"
                           offset={-7.5}
                           size={10}
-                          title="<div style=\\"width:130px\\">First seen<br/>Apr 5, 2019 12:44 PM</div>"
                           viewBox="0 0 10 10"
                         >
-                          <svg
-                            className="tip css-m7l75b-CircleSvg e5t71583"
-                            offset={-7.5}
-                            size={10}
-                            title="<div style=\\"width:130px\\">First seen<br/>Apr 5, 2019 12:44 PM</div>"
-                            viewBox="0 0 10 10"
+                          <Tooltip2
+                            containerDisplayMode="inline-block"
+                            position="bottom"
+                            title={
+                              <div
+                                style={
+                                  Object {
+                                    "width": "130px",
+                                  }
+                                }
+                              >
+                                First seen
+                                <br />
+                                Apr 5, 2019 12:44 PM
+                              </div>
+                            }
                           >
-                            <circle
-                              cx="50%"
-                              cy="50%"
-                              data-test-id="chart-column"
-                              fill="#F868BC"
-                              r="4"
-                              stroke="#fff"
-                              strokeWidth="2"
-                            >
-                              First seen
-                            </circle>
-                          </svg>
-                        </CircleSvg>
-                      </Tooltip>
-                      <Tooltip
+                            <Manager>
+                              <Reference>
+                                <InnerReference
+                                  setReferenceNode={[Function]}
+                                >
+                                  <circle
+                                    aria-describedby="tooltip-123456"
+                                    cx="50%"
+                                    cy="50%"
+                                    data-test-id="chart-column"
+                                    fill="#F868BC"
+                                    onBlur={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                    r="4"
+                                    stroke="#fff"
+                                    strokeWidth="2"
+                                  >
+                                    First seen
+                                  </circle>
+                                </InnerReference>
+                              </Reference>
+                            </Manager>
+                          </Tooltip2>
+                        </svg>
+                      </CircleSvg>
+                      <CircleSvg
                         key="m-last-seen-1554944939"
-                        title="<div style=\\"width:130px\\">Last seen<br/>Apr 10, 2019 6:08 PM</div>"
-                        tooltipOptions={
-                          Object {
-                            "container": "body",
-                            "html": true,
-                            "placement": "bottom",
-                          }
-                        }
+                        left={100.84}
+                        offset={0}
+                        size={10}
+                        viewBox="0 0 10 10"
                       >
-                        <CircleSvg
-                          className="tip"
-                          left={100.84}
+                        <svg
+                          className="css-1yt4gr0-CircleSvg e5t71583"
                           offset={0}
                           size={10}
-                          title="<div style=\\"width:130px\\">Last seen<br/>Apr 10, 2019 6:08 PM</div>"
                           viewBox="0 0 10 10"
                         >
-                          <svg
-                            className="tip css-1yt4gr0-CircleSvg e5t71583"
-                            offset={0}
-                            size={10}
-                            title="<div style=\\"width:130px\\">Last seen<br/>Apr 10, 2019 6:08 PM</div>"
-                            viewBox="0 0 10 10"
+                          <Tooltip2
+                            containerDisplayMode="inline-block"
+                            position="bottom"
+                            title={
+                              <div
+                                style={
+                                  Object {
+                                    "width": "130px",
+                                  }
+                                }
+                              >
+                                Last seen
+                                <br />
+                                Apr 10, 2019 6:08 PM
+                              </div>
+                            }
                           >
-                            <circle
-                              cx="50%"
-                              cy="50%"
-                              data-test-id="chart-column"
-                              fill="#57be8c"
-                              r="4"
-                              stroke="#fff"
-                              strokeWidth="2"
-                            >
-                              Last seen
-                            </circle>
-                          </svg>
-                        </CircleSvg>
-                      </Tooltip>
+                            <Manager>
+                              <Reference>
+                                <InnerReference
+                                  setReferenceNode={[Function]}
+                                >
+                                  <circle
+                                    aria-describedby="tooltip-123456"
+                                    cx="50%"
+                                    cy="50%"
+                                    data-test-id="chart-column"
+                                    fill="#57be8c"
+                                    onBlur={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                    r="4"
+                                    stroke="#fff"
+                                    strokeWidth="2"
+                                  >
+                                    Last seen
+                                  </circle>
+                                </InnerReference>
+                              </Reference>
+                            </Manager>
+                          </Tooltip2>
+                        </svg>
+                      </CircleSvg>
                     </div>
                   </SvgContainer>
                 </figure>

--- a/tests/js/spec/views/organizationProjectsDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationProjectsDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -703,74 +703,144 @@ exports[`ProjectCard renders 1`] = `
                                       preserveAspectRatio="none"
                                       viewBox="0 0 100 400"
                                     >
-                                      <Tooltip
+                                      <Tooltip2
+                                        containerDisplayMode="inline-block"
                                         key="1525042800"
-                                        title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 29, 2018<br />11:00 PM  &#8594; 11:59 PM</span></div></div><div class=\\"value-label\\">1 events</div>"
-                                        tooltipOptions={
-                                          Object {
-                                            "container": "body",
-                                            "html": true,
-                                            "placement": "bottom",
-                                          }
+                                        position="bottom"
+                                        title={
+                                          <React.Fragment>
+                                            <div
+                                              style={
+                                                Object {
+                                                  "width": "130px",
+                                                }
+                                              }
+                                            >
+                                              <div
+                                                className="time-label"
+                                              >
+                                                <span>
+                                                  April 29, 2018
+                                                  <br />
+                                                  11:00 PM
+                                                  →
+                                                  11:59 PM
+                                                </span>
+                                              </div>
+                                            </div>
+                                            <div
+                                              className="value-label"
+                                            >
+                                              1
+                                               
+                                              events
+                                            </div>
+                                          </React.Fragment>
                                         }
                                       >
-                                        <g
-                                          className="tip"
-                                          title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 29, 2018<br />11:00 PM  &#8594; 11:59 PM</span></div></div><div class=\\"value-label\\">1 events</div>"
-                                        >
-                                          <rect
-                                            height="100%"
-                                            opacity="0"
-                                            width="52.3%"
-                                            x="-1.5%"
-                                          />
-                                          <rect
-                                            className="chart-bar barchart-rect"
-                                            data-test-id="chart-column"
-                                            height="9.9%"
-                                            key="0"
-                                            width="49.3%"
-                                            x="0%"
-                                            y="90.1%"
-                                          >
-                                            1
-                                          </rect>
-                                        </g>
-                                      </Tooltip>
-                                      <Tooltip
+                                        <Manager>
+                                          <Reference>
+                                            <InnerReference
+                                              setReferenceNode={[Function]}
+                                            >
+                                              <g
+                                                aria-describedby="tooltip-123456"
+                                                onBlur={[Function]}
+                                                onFocus={[Function]}
+                                                onMouseEnter={[Function]}
+                                                onMouseLeave={[Function]}
+                                              >
+                                                <rect
+                                                  height="100%"
+                                                  opacity="0"
+                                                  width="52.3%"
+                                                  x="-1.5%"
+                                                />
+                                                <rect
+                                                  className="chart-bar barchart-rect"
+                                                  data-test-id="chart-column"
+                                                  height="9.9%"
+                                                  key="0"
+                                                  width="49.3%"
+                                                  x="0%"
+                                                  y="90.1%"
+                                                >
+                                                  1
+                                                </rect>
+                                              </g>
+                                            </InnerReference>
+                                          </Reference>
+                                        </Manager>
+                                      </Tooltip2>
+                                      <Tooltip2
+                                        containerDisplayMode="inline-block"
                                         key="1525046400"
-                                        title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 30, 2018<br />12:00 AM  &#8594; 12:59 AM</span></div></div><div class=\\"value-label\\">2 events</div>"
-                                        tooltipOptions={
-                                          Object {
-                                            "container": "body",
-                                            "html": true,
-                                            "placement": "bottom",
-                                          }
+                                        position="bottom"
+                                        title={
+                                          <React.Fragment>
+                                            <div
+                                              style={
+                                                Object {
+                                                  "width": "130px",
+                                                }
+                                              }
+                                            >
+                                              <div
+                                                className="time-label"
+                                              >
+                                                <span>
+                                                  April 30, 2018
+                                                  <br />
+                                                  12:00 AM
+                                                  →
+                                                  12:59 AM
+                                                </span>
+                                              </div>
+                                            </div>
+                                            <div
+                                              className="value-label"
+                                            >
+                                              2
+                                               
+                                              events
+                                            </div>
+                                          </React.Fragment>
                                         }
                                       >
-                                        <g
-                                          className="tip"
-                                          title="<div style=\\"width:130px\\"><div class=\\"time-label\\"><span>April 30, 2018<br />12:00 AM  &#8594; 12:59 AM</span></div></div><div class=\\"value-label\\">2 events</div>"
-                                        >
-                                          <rect
-                                            height="100%"
-                                            opacity="0"
-                                            width="52.3%"
-                                            x="49.3%"
-                                          />
-                                          <rect
-                                            className="chart-bar barchart-rect"
-                                            data-test-id="chart-column"
-                                            height="19.8%"
-                                            key="0"
-                                            width="49.3%"
-                                            x="50.8%"
-                                            y="80.2%"
-                                          >
-                                            2
-                                          </rect>
-                                        </g>
-                                      </Tooltip>
+                                        <Manager>
+                                          <Reference>
+                                            <InnerReference
+                                              setReferenceNode={[Function]}
+                                            >
+                                              <g
+                                                aria-describedby="tooltip-123456"
+                                                onBlur={[Function]}
+                                                onFocus={[Function]}
+                                                onMouseEnter={[Function]}
+                                                onMouseLeave={[Function]}
+                                              >
+                                                <rect
+                                                  height="100%"
+                                                  opacity="0"
+                                                  width="52.3%"
+                                                  x="49.3%"
+                                                />
+                                                <rect
+                                                  className="chart-bar barchart-rect"
+                                                  data-test-id="chart-column"
+                                                  height="19.8%"
+                                                  key="0"
+                                                  width="49.3%"
+                                                  x="50.8%"
+                                                  y="80.2%"
+                                                >
+                                                  2
+                                                </rect>
+                                              </g>
+                                            </InnerReference>
+                                          </Reference>
+                                        </Manager>
+                                      </Tooltip2>
                                     </svg>
                                   </StyledSvg>
                                 </div>


### PR DESCRIPTION
Update the various barcharts across the application to use the new popper based tooltips. This will need to go out at the same time as the chart-tooltip changes in getsentry.

I've retained the LESS styling of tooltip contents for now. I'll revisit that in a future change when I can add and expose styled components for each of the tooltip bits.

Related to getsentry/getsentry#2901