### PR TITLE
feat(grouping): Normalize lambda names in stacktraces

### DIFF
--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -213,7 +213,8 @@ def get_function_component(function, platform, legacy_function_logic,
                 hint='ignored unknown function'
             )
         elif legacy_function_logic:
-            new_function = trim_function_name(func, platform)
+            new_function = trim_function_name(func, platform,
+                                              normalize_lambdas=False)
             if new_function != func:
                 function_component.update(
                     values=[new_function],

--- a/tests/sentry/grouping/grouping_inputs/native-complex-function-names.json
+++ b/tests/sentry/grouping/grouping_inputs/native-complex-function-names.json
@@ -19,6 +19,11 @@
               "function": "Scaleform::GFx::AS3::IMEManager::DispatchEvent(char const *,char const *,char const *)",
               "instruction_addr": "0x10918cd81",
               "in_app": false
+            },
+            {
+              "function": "<lambda_5db80dab47756d3e72c2dcd38b80b1dd>::operator()",
+              "instruction_addr": "0x10918dda1",
+              "in_app": false
             }
           ]
         },

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined:2019_04_07/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined:2019_04_07/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-09T18:49:35.092083Z'
+created: '2019-05-11T09:56:03.074860Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -15,11 +15,14 @@ app:
           frame (non app frame)
             function* (isolated function)
               u'Scaleform::GFx::AS3::IMEManager::DispatchEvent'
+          frame (non app frame)
+            function*
+              u'<lambda_5db80dab47756d3e72c2dcd38b80b1dd>::operator()'
         type (ignored because exception is synthetic)
           u'log_demo'
 --------------------------------------------------------------------------
 system:
-  hash: '9b78cced1eefcd0c655a0a3d8ce2cdd2'
+  hash: 'e4dcc3896f798a517fb40f50daace658'
   component:
     system*
       exception*
@@ -30,5 +33,8 @@ system:
           frame*
             function* (isolated function)
               u'Scaleform::GFx::AS3::IMEManager::DispatchEvent'
+          frame*
+            function*
+              u'<lambda_5db80dab47756d3e72c2dcd38b80b1dd>::operator()'
         type (ignored because exception is synthetic)
           u'log_demo'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy:2019_03_12/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy:2019_03_12/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-16T14:31:51.256670Z'
+created: '2019-05-11T09:56:04.447818Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -15,6 +15,9 @@ app:
           frame (frame considered in-app because no frame is in-app)
             function (function name is used only if module or filename are available)
               u'Scaleform::GFx::AS3::IMEManager::DispatchEvent(char const *,char const *,char const *)'
+          frame (frame considered in-app because no frame is in-app)
+            function (function name is used only if module or filename are available)
+              u'<lambda_5db80dab47756d3e72c2dcd38b80b1dd>::operator()'
         type*
           u'log_demo'
         value*
@@ -32,6 +35,9 @@ system:
           frame
             function (function name is used only if module or filename are available)
               u'Scaleform::GFx::AS3::IMEManager::DispatchEvent(char const *,char const *,char const *)'
+          frame
+            function (function name is used only if module or filename are available)
+              u'<lambda_5db80dab47756d3e72c2dcd38b80b1dd>::operator()'
         type*
           u'log_demo'
         value*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_05/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_05/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-09T18:49:36.714864Z'
+created: '2019-05-11T09:56:05.696521Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -15,11 +15,14 @@ app:
           frame (non app frame)
             function* (isolated function)
               u'Scaleform::GFx::AS3::IMEManager::DispatchEvent'
+          frame (non app frame)
+            function*
+              u'<lambda_5db80dab47756d3e72c2dcd38b80b1dd>::operator()'
         type (ignored because exception is synthetic)
           u'log_demo'
 --------------------------------------------------------------------------
 system:
-  hash: '9b78cced1eefcd0c655a0a3d8ce2cdd2'
+  hash: 'e4dcc3896f798a517fb40f50daace658'
   component:
     system*
       exception*
@@ -30,5 +33,8 @@ system:
           frame*
             function* (isolated function)
               u'Scaleform::GFx::AS3::IMEManager::DispatchEvent'
+          frame*
+            function*
+              u'<lambda_5db80dab47756d3e72c2dcd38b80b1dd>::operator()'
         type (ignored because exception is synthetic)
           u'log_demo'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_17/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_17/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-26T19:30:17.911166Z'
+created: '2019-05-11T09:56:06.984699Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -15,13 +15,16 @@ app:
           frame (non app frame)
             function*
               u'Scaleform::GFx::AS3::IMEManager::DispatchEvent'
+          frame (non app frame)
+            function*
+              u'<lambda>::operator()'
         type (ignored because exception is synthetic)
           u'log_demo'
         value*
           u'Holy shit everything is on fire!'
 --------------------------------------------------------------------------
 system:
-  hash: '9b78cced1eefcd0c655a0a3d8ce2cdd2'
+  hash: '61d21e6d53c0837718af047c20e5e7ea'
   component:
     system*
       exception*
@@ -32,6 +35,9 @@ system:
           frame*
             function*
               u'Scaleform::GFx::AS3::IMEManager::DispatchEvent'
+          frame*
+            function*
+              u'<lambda>::operator()'
         type (ignored because exception is synthetic)
           u'log_demo'
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T07:29:42.628861Z'
+created: '2019-05-11T09:56:08.384459Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -15,13 +15,16 @@ app:
           frame (non app frame)
             function*
               u'Scaleform::GFx::AS3::IMEManager::DispatchEvent'
+          frame (non app frame)
+            function*
+              u'<lambda>::operator()'
         type (ignored because exception is synthetic)
           u'log_demo'
         value*
           u'Holy shit everything is on fire!'
 --------------------------------------------------------------------------
 system:
-  hash: '9b78cced1eefcd0c655a0a3d8ce2cdd2'
+  hash: '61d21e6d53c0837718af047c20e5e7ea'
   component:
     system*
       exception*
@@ -32,6 +35,9 @@ system:
           frame*
             function*
               u'Scaleform::GFx::AS3::IMEManager::DispatchEvent'
+          frame*
+            function*
+              u'<lambda>::operator()'
         type (ignored because exception is synthetic)
           u'log_demo'
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/stacktraces/test_functions.py
+++ b/tests/sentry/stacktraces/test_functions.py
@@ -100,6 +100,26 @@ from sentry.stacktraces.functions import replace_enclosed_string, split_func_tok
             'ViewController.causeCrash(Any) -> SomeObject',
             'ViewController.causeCrash',
         ],
+        [
+            'main::$_0',
+            'main::lambda',
+        ],
+        [
+            'main::$_42',
+            'main::lambda',
+        ],
+        [
+            'main::{lambda(int)#1}',
+            'main::lambda',
+        ],
+        [
+            'main::{lambda()#42}',
+            'main::lambda',
+        ],
+        [
+            'lambda_7156c3ceaa11256748687ab67e3ef4cd',
+            'lambda',
+        ],
     ]
 )
 def test_trim_function_name(input, output):


### PR DESCRIPTION
This now normalizes lambda names detected from clang, gcc and msvc to
just `lambda`.  There are still platform differences between them but
they cannot be resolved because not all compilers have all information
in the symbol.

This also has some grouping impact because the newest newstyle grouping
algorithms will use the trimmed function name as input.

Since those are still not stable I decided to regress on the grouping
there instead of having to store the old value away in the frame just to
satisfy these grouping algorithms.