### PR TITLE
feat(api): Use `identifier` instead of db id when fetching Incident details

### DIFF
--- a/src/sentry/api/endpoints/organization_incident_details.py
+++ b/src/sentry/api/endpoints/organization_incident_details.py
@@ -28,7 +28,7 @@ class OrganizationIncidentDetailsEndpoint(OrganizationEndpoint):
         try:
             kwargs['incident'] = Incident.objects.get(
                 organization=organization,
-                id=incident_id,
+                identifier=incident_id,
             )
         except Incident.DoesNotExist:
             raise ResourceDoesNotExist

--- a/tests/sentry/api/endpoints/test_organization_incident_details.py
+++ b/tests/sentry/api/endpoints/test_organization_incident_details.py
@@ -33,7 +33,7 @@ class IncidentDetailsTest(APITestCase):
         incident = self.create_incident(seen_by=[self.user])
         self.login_as(self.user)
         with self.feature('organizations:incidents'):
-            resp = self.get_valid_response(incident.organization.slug, incident.id)
+            resp = self.get_valid_response(incident.organization.slug, incident.identifier)
 
         expected = serialize(incident)
 


### PR DESCRIPTION
Change to use `identifier` which is unique to an organization instead of exposing the database id for an Incident object