### PR TITLE
feat(jira) Update Jira integration to comply with GDPR API changes

### DIFF
--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -67,6 +67,12 @@ class JiraCloud(object):
             params=params))
         return request_spec
 
+    def user_id_field(self):
+        """
+        Jira-Cloud requires GDPR compliant API usage so we have to use accountId
+        """
+        return 'accountId'
+
 
 class JiraApiClient(ApiClient):
     COMMENTS_URL = '/rest/api/2/issue/%s/comment'
@@ -98,7 +104,16 @@ class JiraApiClient(ApiClient):
         add authentication data and transform parameters.
         """
         request_spec = self.jira_style.request_hook(method, path, data, params, **kwargs)
+        if 'headers' not in request_spec:
+            request_spec['headers'] = {}
+
+        # Force adherence to the GDPR compliant API conventions.
+        # See https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide
+        request_spec['headers']['x-atlassian-force-account-id'] = 'true'
         return self._request(**request_spec)
+
+    def user_id_field(self):
+        return self.jira_style.user_id_field()
 
     def get_cached(self, url, params=None):
         """
@@ -219,5 +234,6 @@ class JiraApiClient(ApiClient):
             'transition': {'id': transition_id},
         })
 
-    def assign_issue(self, key, username):
-        return self.put(self.ASSIGN_URL % key, data={'name': username})
+    def assign_issue(self, key, name_or_account_id):
+        user_id_field = self.user_id_field()
+        return self.put(self.ASSIGN_URL % key, data={user_id_field: name_or_account_id})

--- a/src/sentry/integrations/jira/descriptor.py
+++ b/src/sentry/integrations/jira/descriptor.py
@@ -53,7 +53,7 @@ class JiraDescriptorEndpoint(Endpoint):
                     }],
                 },
                 'apiMigrations': {
-                    'gdpr': False,
+                    'gdpr': True,
                 },
                 'scopes': [
                     'read',

--- a/src/sentry/integrations/jira/search.py
+++ b/src/sentry/integrations/jira/search.py
@@ -17,15 +17,20 @@ class JiraSearchEndpoint(IntegrationEndpoint):
             provider=self.provider,
         )
 
-    def _get_formatted_user(self, user):
-        display = '%s %s(%s)' % (
-            user.get('displayName', user['name']),
-            '- %s ' % user.get('emailAddress') if user.get('emailAddress') else '',
-            user['name'],
+    def _get_formatted_user(self, id_field, user):
+        # The name field can be blank in jira-cloud, and the id_field varies by
+        # jira-cloud and jira-server
+        name = user.get('name', '')
+        email = user.get('emailAddress')
+
+        display = '%s %s%s' % (
+            user.get('displayName', name),
+            '- %s ' % email if email else '',
+            '(%s)' % name if name else '',
         )
         return {
-            'value': user['name'],
-            'label': display,
+            'value': user[id_field],
+            'label': display.strip(),
         }
 
     def get(self, request, organization, integration_id):
@@ -56,7 +61,6 @@ class JiraSearchEndpoint(IntegrationEndpoint):
 
         if field in ('assignee', 'reporter'):
             jira_client = installation.get_client()
-            users = []
             try:
                 response = jira_client.search_users_for_project(
                     request.GET.get('project', ''),
@@ -65,9 +69,12 @@ class JiraSearchEndpoint(IntegrationEndpoint):
             except (ApiUnauthorized, ApiError):
                 return Response({'detail': 'Unable to fetch users from Jira'}, status=400)
 
-            for user in response:
-                if user.get('name'):
-                    users.append(self._get_formatted_user(user))
+            user_id_field = jira_client.user_id_field()
+            users = [
+                self._get_formatted_user(user_id_field, user)
+                for user in response
+                if user_id_field in user
+            ]
             return Response(users)
 
         # TODO(jess): handle other autocomplete urls

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -135,3 +135,9 @@ class JiraServer(object):
             data=data,
             params=params))
         return request_spec
+
+    def user_id_field(self):
+        """
+        Jira-Server doesn't require GDPR compliant API usage so we can use `name`
+        """
+        return 'name'

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -411,6 +411,9 @@ class MockJiraApiClient(object):
     def transition_issue(self, issue_key, transition_id):
         pass
 
+    def user_id_field(self):
+        return 'accountId'
+
 
 class JiraIntegrationTest(APITestCase):
     @fixture
@@ -739,8 +742,8 @@ class JiraIntegrationTest(APITestCase):
             responses.GET,
             'https://example.atlassian.net/rest/api/2/user/assignable/search',
             json=[{
+                'accountId': 'deadbeef123',
                 'emailAddress': 'Bob@example.com',
-                'name': 'Bob Example'
             }],
             match_querystring=False,
         )
@@ -758,7 +761,7 @@ class JiraIntegrationTest(APITestCase):
         assign_issue_response = responses.calls[1][1]
         assert assign_issue_url in assign_issue_response.url
         assert assign_issue_response.status_code == 200
-        assert assign_issue_response.request.body == '{"name": "Bob Example"}'
+        assert assign_issue_response.request.body == '{"accountId": "deadbeef123"}'
 
     def test_update_organization_config(self):
         org = self.organization

--- a/tests/sentry/integrations/jira/test_search_endpoint.py
+++ b/tests/sentry/integrations/jira/test_search_endpoint.py
@@ -36,7 +36,11 @@ SAMPLE_SEARCH_RESPONSE = """
 
 SAMPLE_USER_SEARCH_RESPONSE = """
 [
-    {"name": "bob", "displayName": "Bobby", "emailAddress": "bob@example.org"}
+    {
+        "accountId": "deadbeef123",
+        "displayName": "Bobby",
+        "emailAddress": "bob@example.org"
+    }
 ]
 """
 
@@ -151,8 +155,9 @@ class JiraSearchEndpointTest(APITestCase):
 
         resp = self.client.get('%s?project=10000&field=assignee&query=bob' % (path,))
         assert resp.status_code == 200
+        print resp.data
         assert resp.data == [
-            {'value': 'bob', 'label': 'Bobby - bob@example.org (bob)'}
+            {'value': 'deadbeef123', 'label': 'Bobby - bob@example.org'}
         ]
 
     @responses.activate

--- a/tests/sentry/integrations/jira/test_search_endpoint.py
+++ b/tests/sentry/integrations/jira/test_search_endpoint.py
@@ -155,7 +155,6 @@ class JiraSearchEndpointTest(APITestCase):
 
         resp = self.client.get('%s?project=10000&field=assignee&query=bob' % (path,))
         assert resp.status_code == 200
-        print resp.data
         assert resp.data == [
             {'value': 'deadbeef123', 'label': 'Bobby - bob@example.org'}
         ]


### PR DESCRIPTION
Update the Jira Integration to comply with the GDPR API changes that disallow using the `name` and `username` keys to search the Jira API, and remove `name` from the Jira API responses. Instead we need to use `accountId` which is an opaque userid when assigning or referencing users by id.

The Jira-Server integration will continue using `name` as jira-server is not connected to atlassian's centralized authentication services.

Fixes SEN-604