### PR TITLE
chore: Update jsonfield to fix warnings

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -8,7 +8,7 @@ click>=5.0,<7.0
 croniter>=0.3.26,<0.4.0
 cssutils>=0.9.9,<0.10.0
 django-crispy-forms>=1.4.0,<1.5.0
-django-jsonfield>=0.9.13,<0.9.14
+django-jsonfield>0.9.13,<1.0.0
 django-picklefield>=0.3.0,<0.4.0
 django-sudo>=2.1.0,<3.0.0
 django-templatetag-sugar>=0.1.0


### PR DESCRIPTION
Update jsonfield package to resolve warnings related to SubfieldBase metaclass usage.

Fixes several of the following startup warnings
```
RemovedInDjango110Warning: SubfieldBase has been deprecated. Use Field.from_db_value instead.
```

Refs SEN-618