### PR TITLE
feat(projects): s10 header

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationProjectsDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationProjectsDashboard/index.jsx
@@ -8,14 +8,17 @@ import styled from 'react-emotion';
 
 import {sortProjects} from 'app/utils';
 import {t} from 'app/locale';
+import Button from 'app/components/button';
 import ConfigStore from 'app/stores/configStore';
 import Feature from 'app/components/acl/feature';
 import IdBadge from 'app/components/idBadge';
 import NoProjectMessage from 'app/components/noProjectMessage';
+import PageHeading from 'app/components/pageHeading';
 import ProjectsStatsStore from 'app/stores/projectsStatsStore';
 import SentryTypes from 'app/sentryTypes';
 import getProjectsByTeams from 'app/utils/getProjectsByTeams';
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
+import space from 'app/styles/space';
 import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
 import withTeams from 'app/utils/withTeams';
@@ -55,6 +58,7 @@ class Dashboard extends React.Component {
     const teamSlugs = Object.keys(projectsByTeam).sort();
     const favorites = projects.filter(project => project.isBookmarked);
     const access = new Set(organization.access);
+    const canCreateProjects = access.has('project:admin');
     const teamsMap = new Map(teams.map(teamObj => [teamObj.slug, teamObj]));
 
     const hasTeamAdminAccess = access.has('team:admin');
@@ -65,6 +69,24 @@ class Dashboard extends React.Component {
 
     return (
       <React.Fragment>
+        {hasSentry10 && projects.length > 0 && (
+          <ProjectsHeader>
+            <PageHeading>Projects</PageHeading>
+            <Button
+              size="small"
+              disabled={!canCreateProjects}
+              title={
+                !canCreateProjects
+                  ? t('You do not have permission to create projects')
+                  : undefined
+              }
+              to={`/organizations/${organization.slug}/projects/new/`}
+              icon="icon-circle-add"
+            >
+              {t('Create Project')}
+            </Button>
+          </ProjectsHeader>
+        )}
         {!hasSentry10 && favorites.length > 0 && (
           <TeamSection
             data-test-id="favorites"
@@ -89,10 +111,10 @@ class Dashboard extends React.Component {
                 title={
                   hasTeamAdminAccess ? (
                     <TeamLink to={`/settings/${organization.slug}/teams/${team.slug}/`}>
-                      <IdBadge team={team} />
+                      <IdBadge team={team} avatarSize={22} />
                     </TeamLink>
                   ) : (
-                    <IdBadge team={team} />
+                    <IdBadge team={team} avatarSize={22} />
                   )
                 }
                 projects={projectsByTeam[slug]}
@@ -127,6 +149,13 @@ const OrganizationDashboard = createReactClass({
 const TeamLink = styled(Link)`
   display: flex;
   align-items: center;
+`;
+
+const ProjectsHeader = styled('div')`
+  padding: ${space(3)} ${space(4)} 0 ${space(4)};
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 `;
 
 export {Dashboard};

--- a/src/sentry/static/sentry/app/views/organizationProjectsDashboard/projectCard.jsx
+++ b/src/sentry/static/sentry/app/views/organizationProjectsDashboard/projectCard.jsx
@@ -52,7 +52,7 @@ class ProjectCard extends React.Component {
             <StyledProjectCardHeader>
               <StyledIdBadge
                 project={project}
-                avatarSize={24}
+                avatarSize={18}
                 displayName={
                   hasProjectAccess ? (
                     <Link

--- a/src/sentry/static/sentry/app/views/organizationProjectsDashboard/teamSection.jsx
+++ b/src/sentry/static/sentry/app/views/organizationProjectsDashboard/teamSection.jsx
@@ -70,6 +70,7 @@ const TeamTitleBar = styled(Flex)`
 
 const TeamName = styled(PageHeading)`
   margin: 4px;
+  font-size: 20px;
   line-height: 24px; /* We need this so that header doesn't flicker when lazy loading because avatarList height > this */
 `;
 

--- a/src/sentry/static/sentry/app/views/organizationProjectsDashboard/teamSection.jsx
+++ b/src/sentry/static/sentry/app/views/organizationProjectsDashboard/teamSection.jsx
@@ -69,7 +69,6 @@ const TeamTitleBar = styled(Flex)`
 `;
 
 const TeamName = styled(PageHeading)`
-  margin: 4px;
   font-size: 20px;
   line-height: 24px; /* We need this so that header doesn't flicker when lazy loading because avatarList height > this */
 `;

--- a/tests/js/spec/views/organizationProjectsDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationProjectsDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -96,7 +96,7 @@ exports[`ProjectCard renders 1`] = `
                 className="css-v59cbs-StyledProjectCardHeader ei886av1"
               >
                 <StyledIdBadge
-                  avatarSize={24}
+                  avatarSize={18}
                   displayName={
                     <span>
                       project-slug
@@ -127,7 +127,7 @@ exports[`ProjectCard renders 1`] = `
                   }
                 >
                   <IdBadge
-                    avatarSize={24}
+                    avatarSize={18}
                     className="css-1gy4gs4-StyledIdBadge ei886av5"
                     displayName={
                       <span>
@@ -166,7 +166,7 @@ exports[`ProjectCard renders 1`] = `
                         mini={true}
                       >
                         <ProjectBadge
-                          avatarSize={24}
+                          avatarSize={18}
                           className="css-1gy4gs4-StyledIdBadge ei886av5"
                           displayName={
                             <span>
@@ -201,7 +201,7 @@ exports[`ProjectCard renders 1`] = `
                         >
                           <BaseBadge
                             avatarProps={Object {}}
-                            avatarSize={24}
+                            avatarSize={18}
                             className="css-1gy4gs4-StyledIdBadge ei886av5"
                             displayName={
                               <span>
@@ -271,7 +271,7 @@ exports[`ProjectCard renders 1`] = `
                                         "teams": Array [],
                                       }
                                     }
-                                    size={24}
+                                    size={18}
                                   >
                                     <Avatar
                                       className="css-robds0-StyledAvatar e165dl3i0"
@@ -299,7 +299,7 @@ exports[`ProjectCard renders 1`] = `
                                           "teams": Array [],
                                         }
                                       }
-                                      size={24}
+                                      size={18}
                                     >
                                       <ProjectAvatar
                                         className="css-robds0-StyledAvatar e165dl3i0"
@@ -327,7 +327,7 @@ exports[`ProjectCard renders 1`] = `
                                             "teams": Array [],
                                           }
                                         }
-                                        size={24}
+                                        size={18}
                                       >
                                         <PlatformList
                                           className="css-robds0-StyledAvatar e165dl3i0"
@@ -340,39 +340,39 @@ exports[`ProjectCard renders 1`] = `
                                               "javascript",
                                             ]
                                           }
-                                          size={24}
+                                          size={18}
                                         >
                                           <PlatformIcons
                                             className="css-robds0-StyledAvatar e165dl3i0"
                                             consistentWidth={false}
                                             direction="right"
                                             max={1}
-                                            size={24}
+                                            size={18}
                                           >
                                             <div
                                               className="e165dl3i0 css-1cou1l3-PlatformIcons-StyledAvatar ezvce7z0"
                                               direction="right"
                                               max={1}
-                                              size={24}
+                                              size={18}
                                             >
                                               <StyledPlatformIcon
                                                 key="javascript"
                                                 platform="javascript"
-                                                size={24}
+                                                size={18}
                                               >
                                                 <Component
-                                                  className="css-1rk01z5-StyledPlatformIcon ezvce7z1"
+                                                  className="css-13qi1e0-StyledPlatformIcon ezvce7z1"
                                                   platform="javascript"
-                                                  size={24}
+                                                  size={18}
                                                 >
                                                   <Platformicon
-                                                    className="css-1rk01z5-StyledPlatformIcon ezvce7z1"
+                                                    className="css-13qi1e0-StyledPlatformIcon ezvce7z1"
                                                     platform="javascript"
-                                                    size="24px"
+                                                    size="18px"
                                                   >
                                                     <img
-                                                      className="css-1rk01z5-StyledPlatformIcon ezvce7z1"
-                                                      height="24px"
+                                                      className="css-13qi1e0-StyledPlatformIcon ezvce7z1"
+                                                      height="18px"
                                                       src={
                                                         Object {
                                                           "default": Object {
@@ -381,7 +381,7 @@ exports[`ProjectCard renders 1`] = `
                                                           },
                                                         }
                                                       }
-                                                      width="24px"
+                                                      width="18px"
                                                     />
                                                   </Platformicon>
                                                 </Component>


### PR DESCRIPTION
When we released Sentry 10, we removed the header from the project page because it had the project dropdown and that was weird. But then we wound up with this kinda strange headerless page:

![image](https://user-images.githubusercontent.com/435981/57661565-4d15c400-75a0-11e9-8dec-67eb7815117e.png)

But the header also had a create project button and people found that button pretty useful. So I added a header back:

![image](https://user-images.githubusercontent.com/435981/57661591-6cacec80-75a0-11e9-9d6b-e233e05c356b.png)

This also adds a proper title to the page, so that it stays consistent with all other pages. Additionally, I fixed some weird avatar size issues on this page and subtly improved the type hierarchy.


