### PR TITLE
feat(api): Add endpoint to allow incident comments to be created (SEN-580)

### DIFF
--- a/src/sentry/api/bases/incident.py
+++ b/src/sentry/api/bases/incident.py
@@ -1,11 +1,48 @@
 from __future__ import absolute_import
 
-from sentry.api.bases.organization import OrganizationPermission
+from rest_framework.exceptions import PermissionDenied
+
+from sentry import features
+from sentry.api.bases.organization import (
+    OrganizationEndpoint,
+    OrganizationPermission,
+)
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.incidents.models import Incident
 
 
 class IncidentPermission(OrganizationPermission):
     scope_map = {
         'GET': ['org:read', 'org:write', 'org:admin'],
-        'POST': ['org:write', 'org:admin'],
+        'POST': ['org:write', 'org:admin', 'project:read', 'project:write', 'project:admin'],
         'PUT': ['org:write', 'org:admin'],
     }
+
+
+class IncidentEndpoint(OrganizationEndpoint):
+    def convert_args(self, request, incident_identifier, *args, **kwargs):
+        args, kwargs = super(IncidentEndpoint, self).convert_args(
+            request,
+            *args,
+            **kwargs
+        )
+        organization = kwargs['organization']
+
+        if not features.has('organizations:incidents', organization, actor=request.user):
+            raise ResourceDoesNotExist
+
+        try:
+            incident = kwargs['incident'] = Incident.objects.get(
+                organization=organization,
+                identifier=incident_identifier,
+            )
+        except Incident.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        if not any(
+            project for project in incident.projects.all()
+            if request.access.has_project_access(project)
+        ):
+            raise PermissionDenied
+
+        return args, kwargs

--- a/src/sentry/api/endpoints/organization_incident_comment_index.py
+++ b/src/sentry/api/endpoints/organization_incident_comment_index.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import
+
+from rest_framework import serializers
+from rest_framework.response import Response
+
+from sentry.api.bases.incident import IncidentPermission, IncidentEndpoint
+from sentry.api.serializers import serialize
+from sentry.incidents.logic import create_incident_activity
+from sentry.incidents.models import IncidentActivityType
+
+
+class CommentSerializer(serializers.Serializer):
+    comment = serializers.CharField(required=True)
+
+
+class OrganizationIncidentCommentIndexEndpoint(IncidentEndpoint):
+    permission_classes = (IncidentPermission, )
+
+    def post(self, request, organization, incident):
+        serializer = CommentSerializer(data=request.DATA)
+        if serializer.is_valid():
+            activity = create_incident_activity(
+                incident,
+                IncidentActivityType.COMMENT,
+                user=request.user,
+                comment=serializer.object['comment']
+            )
+            return Response(serialize(activity, request.user), status=201)
+        return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/organization_incident_details.py
+++ b/src/sentry/api/endpoints/organization_incident_details.py
@@ -2,38 +2,16 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
-from sentry import features
-from sentry.api.bases.incident import IncidentPermission
-from sentry.api.bases.organization import OrganizationEndpoint
-from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.bases.incident import (
+    IncidentEndpoint,
+    IncidentPermission,
+)
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.incident import DetailedIncidentSerializer
-from sentry.incidents.models import Incident
 
 
-class OrganizationIncidentDetailsEndpoint(OrganizationEndpoint):
+class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
     permission_classes = (IncidentPermission, )
-
-    def convert_args(self, request, incident_id, *args, **kwargs):
-        args, kwargs = super(OrganizationIncidentDetailsEndpoint, self).convert_args(
-            request,
-            *args,
-            **kwargs
-        )
-        organization = kwargs['organization']
-
-        if not features.has('organizations:incidents', organization, actor=request.user):
-            raise ResourceDoesNotExist
-
-        try:
-            kwargs['incident'] = Incident.objects.get(
-                organization=organization,
-                identifier=incident_id,
-            )
-        except Incident.DoesNotExist:
-            raise ResourceDoesNotExist
-
-        return args, kwargs
 
     def get(self, request, organization, incident):
         """

--- a/src/sentry/api/serializers/models/incidentactivity.py
+++ b/src/sentry/api/serializers/models/incidentactivity.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import
+
+import six
+
+from sentry.api.serializers import (
+    Serializer,
+    register,
+)
+from sentry.incidents.models import (
+    Incident,
+    IncidentActivity,
+)
+
+
+@register(IncidentActivity)
+class IncidentActivitySerializer(Serializer):
+    def get_attrs(self, item_list, **kwargs):
+        incidents = Incident.objects.filter(id__in=set(i.incident_id for i in item_list))
+        incident_lookup = {incident.id: incident for incident in incidents}
+
+        results = {}
+        for activity in item_list:
+            results[activity] = {'incident': incident_lookup[activity.incident_id]}
+
+        return results
+
+    def serialize(self, obj, attrs, user):
+        incident = attrs['incident']
+        return {
+            'id': six.text_type(obj.id),
+            'incidentIdentifier': six.text_type(incident.identifier),
+            'userId': six.text_type(obj.user_id),
+            'type': obj.type,
+            'value': obj.value,
+            'previousValue': obj.previous_value,
+            'comment': obj.comment,
+        }

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -80,6 +80,7 @@ from .endpoints.organization_shortid import ShortIdLookupEndpoint
 from .endpoints.organization_environments import OrganizationEnvironmentsEndpoint
 from .endpoints.organization_eventid import EventIdLookupEndpoint
 from .endpoints.organization_slugs import SlugsUpdateEndpoint
+from .endpoints.organization_incident_comment_index import OrganizationIncidentCommentIndexEndpoint
 from .endpoints.organization_incident_index import OrganizationIncidentIndexEndpoint
 from .endpoints.organization_issues_new import OrganizationIssuesNewEndpoint
 from .endpoints.organization_issues_resolved_in_release import OrganizationIssuesResolvedInReleaseEndpoint
@@ -420,9 +421,14 @@ urlpatterns = patterns(
         name='sentry-api-0-organization-incident-index'
     ),
     url(
-        r'^organizations/(?P<organization_slug>[^\/]+)/incidents/(?P<incident_id>[^\/]+)/$',
+        r'^organizations/(?P<organization_slug>[^\/]+)/incidents/(?P<incident_identifier>[^\/]+)/$',
         OrganizationIncidentDetailsEndpoint.as_view(),
         name='sentry-api-0-organization-incident-details'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/incidents/(?P<incident_identifier>[^\/]+)/comments/$',
+        OrganizationIncidentCommentIndexEndpoint.as_view(),
+        name='sentry-api-0-organization-incident-comments'
     ),
 
     # Organizations

--- a/tests/sentry/api/endpoints/test_organization_incident_comment_index.py
+++ b/tests/sentry/api/endpoints/test_organization_incident_comment_index.py
@@ -1,0 +1,70 @@
+from __future__ import absolute_import
+
+from exam import fixture
+
+from sentry.api.serializers import serialize
+from sentry.incidents.models import (
+    IncidentActivity,
+    IncidentActivityType,
+)
+from sentry.testutils import APITestCase
+
+
+class OrganizationIncidentCommentCreateEndpointTest(APITestCase):
+    endpoint = 'sentry-api-0-organization-incident-comments'
+    method = 'post'
+
+    @fixture
+    def organization(self):
+        return self.create_organization()
+
+    @fixture
+    def project(self):
+        return self.create_project(organization=self.organization)
+
+    @fixture
+    def user(self):
+        return self.create_user()
+
+    def test_simple(self):
+        self.create_member(
+            user=self.user,
+            organization=self.organization,
+            role='owner',
+            teams=[self.team],
+        )
+        self.login_as(self.user)
+        comment = 'hello'
+        incident = self.create_incident()
+        with self.feature('organizations:incidents'):
+            resp = self.get_valid_response(
+                self.organization.slug,
+                incident.identifier,
+                comment=comment,
+                status_code=201,
+            )
+        activity = IncidentActivity.objects.get(id=resp.data['id'])
+        assert activity.type == IncidentActivityType.COMMENT.value
+        assert activity.user == self.user
+        assert activity.comment == comment
+        assert resp.data == serialize([activity])[0]
+
+    def test_access(self):
+        other_user = self.create_user()
+        self.login_as(other_user)
+        other_team = self.create_team()
+        self.create_member(
+            user=self.user,
+            organization=self.organization,
+            role='member',
+            teams=[self.team],
+        )
+        other_project = self.create_project(teams=[other_team])
+        incident = self.create_incident(projects=[other_project])
+        with self.feature('organizations:incidents'):
+            resp = self.get_response(
+                self.organization.slug,
+                incident.identifier,
+                comment='hi',
+            )
+            assert resp.status_code == 403

--- a/tests/sentry/api/serializers/test_incident_activity.py
+++ b/tests/sentry/api/serializers/test_incident_activity.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+
+import six
+
+from sentry.api.serializers import serialize
+from sentry.incidents.models import IncidentActivityType
+from sentry.incidents.logic import create_incident_activity
+from sentry.testutils import TestCase
+
+
+class IncidentSerializerTest(TestCase):
+    def test_simple(self):
+        activity = create_incident_activity(
+            incident=self.create_incident(),
+            activity_type=IncidentActivityType.COMMENT,
+            user=self.user,
+            comment='hello',
+        )
+        result = serialize(activity)
+
+        assert result['id'] == six.text_type(activity.id)
+        assert result['incidentIdentifier'] == six.text_type(activity.incident.identifier)
+        assert result['userId'] == six.text_type(activity.user_id)
+        assert result['type'] == activity.type
+        assert result['value'] is None
+        assert result['previousValue'] is None
+        assert result['comment'] == activity.comment


### PR DESCRIPTION
This adds an endpoint to allow users to create comments. Just accepts the `comment` param, and
creates an activity row for that comment.

Also updates permissions so that only users with access to a project that's related to the Incident can post comments