### PR TITLE
fix(db): Fix behavior with ScoreClause since Django 1.8

### DIFF
--- a/src/bitfield/compat.py
+++ b/src/bitfield/compat.py
@@ -9,19 +9,3 @@ def bitand(a, b):
 
 def bitor(a, b):
     return a.bitor(b)
-
-
-try:
-    from django.db.models.expressions import ExpressionNode
-    ExpressionNode.BITAND  # noqa
-    del ExpressionNode
-except ImportError:
-    # Django >= 1.8
-    pass
-except AttributeError:
-    # Django < 1.5
-    def bitand(a, b):  # NOQA
-        return a & b
-
-    def bitor(a, b):  # NOQA
-        return a | b

--- a/src/sentry/db/models/query.py
+++ b/src/sentry/db/models/query.py
@@ -13,10 +13,11 @@ import six
 
 from django.db import IntegrityError, router, transaction
 from django.db.models import Model, Q
+from django.db.models.expressions import CombinedExpression
 from django.db.models.signals import post_save
 from six.moves import reduce
 
-from .utils import ExpressionNode, resolve_expression_node
+from .utils import resolve_combined_expression
 
 __all__ = ('update', 'create_or_update')
 
@@ -35,8 +36,8 @@ def update(self, using=None, **kwargs):
 
     affected = self.__class__._base_manager.using(using).filter(pk=self.pk).update(**kwargs)
     for k, v in six.iteritems(kwargs):
-        if isinstance(v, ExpressionNode):
-            v = resolve_expression_node(self, v)
+        if isinstance(v, CombinedExpression):
+            v = resolve_combined_expression(self, v)
         setattr(self, k, v)
     if affected == 1:
         post_save.send(sender=self.__class__, instance=self, created=False)
@@ -86,8 +87,8 @@ def create_or_update(model, using=None, **kwargs):
         # we can do create_or_update(..., {'project': 1})
         if not isinstance(v, Model):
             k = model._meta.get_field(k).attname
-        if isinstance(v, ExpressionNode):
-            create_kwargs[k] = resolve_expression_node(inst, v)
+        if isinstance(v, CombinedExpression):
+            create_kwargs[k] = resolve_combined_expression(inst, v)
         else:
             create_kwargs[k] = v
 

--- a/src/sentry/db/models/utils.py
+++ b/src/sentry/db/models/utils.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 import operator
 
 from django.db.models import F
+from django.db.models.expressions import CombinedExpression, Value
 from django.utils.crypto import get_random_string
 from django.template.defaultfilters import slugify
 from uuid import uuid4
@@ -18,49 +19,32 @@ from uuid import uuid4
 from sentry.db.exceptions import CannotResolveExpression
 
 
-class _UnknownType(object):
-    pass
-
-
-try:
-    from django.db.models.expressions import ExpressionNode
-    Value = _UnknownType
-except ImportError:
-    from django.db.models.expressions import Combinable as ExpressionNode, Value
-
-
-EXPRESSION_NODE_CALLBACKS = {
-    ExpressionNode.ADD: operator.add,
-    ExpressionNode.SUB: operator.sub,
-    ExpressionNode.MUL: operator.mul,
-    ExpressionNode.DIV: getattr(operator, 'floordiv', None) or operator.div,
-    ExpressionNode.MOD: operator.mod,
+COMBINED_EXPRESSION_CALLBACKS = {
+    CombinedExpression.ADD: operator.add,
+    CombinedExpression.SUB: operator.sub,
+    CombinedExpression.MUL: operator.mul,
+    CombinedExpression.DIV: operator.floordiv,
+    CombinedExpression.MOD: operator.mod,
+    CombinedExpression.BITAND: operator.and_,
+    CombinedExpression.BITOR: operator.or_,
 }
-try:
-    EXPRESSION_NODE_CALLBACKS[ExpressionNode.AND] = operator.and_
-except AttributeError:
-    EXPRESSION_NODE_CALLBACKS[ExpressionNode.BITAND] = operator.and_
-try:
-    EXPRESSION_NODE_CALLBACKS[ExpressionNode.OR] = operator.or_
-except AttributeError:
-    EXPRESSION_NODE_CALLBACKS[ExpressionNode.BITOR] = operator.or_
 
 
-def resolve_expression_node(instance, node):
+def resolve_combined_expression(instance, node):
     def _resolve(instance, node):
         if isinstance(node, Value):
             return node.value
         if isinstance(node, F):
             return getattr(instance, node.name)
-        if isinstance(node, ExpressionNode):
-            return resolve_expression_node(instance, node)
+        if isinstance(node, CombinedExpression):
+            return resolve_combined_expression(instance, node)
         return node
 
     if isinstance(node, Value):
         return node.value
     if not hasattr(node, 'connector'):
         raise CannotResolveExpression
-    op = EXPRESSION_NODE_CALLBACKS.get(node.connector, None)
+    op = COMBINED_EXPRESSION_CALLBACKS.get(node.connector, None)
     if not op:
         raise CannotResolveExpression
     if hasattr(node, 'children'):

--- a/src/sentry/db/models/utils.py
+++ b/src/sentry/db/models/utils.py
@@ -16,8 +16,6 @@ from django.utils.crypto import get_random_string
 from django.template.defaultfilters import slugify
 from uuid import uuid4
 
-# TODO(mark) remove once getsentry is no longer relying on this
-from django.db.models.expressions import Combinable as ExpressionNode  # noqa
 from sentry.db.exceptions import CannotResolveExpression
 
 
@@ -30,45 +28,6 @@ COMBINED_EXPRESSION_CALLBACKS = {
     CombinedExpression.BITAND: operator.and_,
     CombinedExpression.BITOR: operator.or_,
 }
-
-# TODO(mark) Remove this once getsentry no longer relies on it
-EXPRESSION_NODE_CALLBACKS = {
-    ExpressionNode.ADD: operator.add,
-    ExpressionNode.SUB: operator.sub,
-    ExpressionNode.MUL: operator.mul,
-    ExpressionNode.DIV: getattr(operator, 'floordiv', None) or operator.div,
-    ExpressionNode.MOD: operator.mod,
-    ExpressionNode.BITAND: operator.and_,
-    ExpressionNode.BITOR: operator.or_,
-}
-
-
-def resolve_expression_node(instance, node):
-    # TODO(mark) Remove this once getsentry no longer relies on it
-    def _resolve(instance, node):
-        if isinstance(node, Value):
-            return node.value
-        if isinstance(node, F):
-            return getattr(instance, node.name)
-        if isinstance(node, ExpressionNode):
-            return resolve_expression_node(instance, node)
-        return node
-
-    if isinstance(node, Value):
-        return node.value
-    if not hasattr(node, 'connector'):
-        raise CannotResolveExpression
-    op = EXPRESSION_NODE_CALLBACKS.get(node.connector, None)
-    if not op:
-        raise CannotResolveExpression
-    if hasattr(node, 'children'):
-        children = node.children
-    else:
-        children = [node.lhs, node.rhs]
-    runner = _resolve(instance, children[0])
-    for n in children[1:]:
-        runner = op(runner, _resolve(instance, n))
-    return runner
 
 
 def resolve_combined_expression(instance, node):
@@ -96,6 +55,11 @@ def resolve_combined_expression(instance, node):
     for n in children[1:]:
         runner = op(runner, _resolve(instance, n))
     return runner
+
+
+# TODO(mark) Remove these compatibility aliases once getsentry doesn't use them.
+ExpressionNode = CombinedExpression
+resolve_expression_node = resolve_combined_expression
 
 
 def slugify_instance(inst, label, reserved=(), max_length=30, field_name='slug', *args, **kwargs):

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -252,7 +252,8 @@ class ScoreClause(Func):
         has_values = self.last_seen is not None and self.times_seen is not None
         if is_postgres(db):
             if has_values:
-                sql = 'log(times_seen + %d) * 600 + %d' % (self.times_seen, to_timestamp(sc.last_seen))
+                sql = 'log(times_seen + %d) * 600 + %d' % (self.times_seen,
+                                                           to_timestamp(self.last_seen))
             else:
                 sql = 'log(times_seen) * 600 + last_seen::abstime::int'
         else:

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -13,6 +13,7 @@ import six
 from datetime import datetime, timedelta
 from django.conf import settings
 from django.db import connection, IntegrityError, router, transaction
+from django.db.models import Func
 from django.utils import timezone
 from django.utils.encoding import force_text
 
@@ -231,68 +232,34 @@ class HashDiscarded(Exception):
     pass
 
 
-def scoreclause_sql(sc, connection):
-    db = getattr(connection, 'alias', 'default')
-    has_values = sc.last_seen is not None and sc.times_seen is not None
-    if is_postgres(db):
-        if has_values:
-            sql = 'log(times_seen + %d) * 600 + %d' % (sc.times_seen, to_timestamp(sc.last_seen))
+class ScoreClause(Func):
+    def __init__(self, group=None, last_seen=None, times_seen=None, *args, **kwargs):
+        self.group = group
+        self.last_seen = last_seen
+        self.times_seen = times_seen
+        # times_seen is likely an F-object that needs the value extracted
+        if hasattr(self.times_seen, 'rhs'):
+            self.times_seen = self.times_seen.rhs.value
+        super(ScoreClause, self).__init__(*args, **kwargs)
+
+    def __int__(self):
+        # Calculate the score manually when coercing to an int.
+        # This is used within create_or_update and friends
+        return self.group.get_score() if self.group else 0
+
+    def as_sql(self, compiler, connection, function=None, template=None):
+        db = getattr(connection, 'alias', 'default')
+        has_values = self.last_seen is not None and self.times_seen is not None
+        if is_postgres(db):
+            if has_values:
+                sql = 'log(times_seen + %d) * 600 + %d' % (self.times_seen, to_timestamp(sc.last_seen))
+            else:
+                sql = 'log(times_seen) * 600 + last_seen::abstime::int'
         else:
-            sql = 'log(times_seen) * 600 + last_seen::abstime::int'
-    else:
-        # XXX: if we cant do it atomically let's do it the best we can
-        sql = int(sc)
+            # XXX: if we cant do it atomically let's do it the best we can
+            sql = int(self)
 
-    return (sql, [])
-
-
-try:
-    from django.db.models import Func
-except ImportError:
-    # XXX(dramer): compatibility hack for Django 1.6
-    class ScoreClause(object):
-        def __init__(self, group=None, last_seen=None, times_seen=None, *args, **kwargs):
-            self.group = group
-            self.last_seen = last_seen
-            self.times_seen = times_seen
-            # times_seen is likely an F-object that needs the value extracted
-            if hasattr(self.times_seen, 'children'):
-                self.times_seen = self.times_seen.children[1]
-            super(ScoreClause, self).__init__(*args, **kwargs)
-
-        def __int__(self):
-            # Calculate the score manually when coercing to an int.
-            # This is used within create_or_update and friends
-            return self.group.get_score() if self.group else 0
-
-        def prepare_database_save(self, unused):
-            return self
-
-        def prepare(self, evaluator, query, allow_joins):
-            return
-
-        def evaluate(self, node, qn, connection):
-            return scoreclause_sql(self, connection)
-
-else:
-    # XXX(dramer): compatibility hack for Django 1.8+
-    class ScoreClause(Func):
-        def __init__(self, group=None, last_seen=None, times_seen=None, *args, **kwargs):
-            self.group = group
-            self.last_seen = last_seen
-            self.times_seen = times_seen
-            # times_seen is likely an F-object that needs the value extracted
-            if hasattr(self.times_seen, 'rhs'):
-                self.times_seen = self.times_seen.rhs.value
-            super(ScoreClause, self).__init__(*args, **kwargs)
-
-        def __int__(self):
-            # Calculate the score manually when coercing to an int.
-            # This is used within create_or_update and friends
-            return self.group.get_score() if self.group else 0
-
-        def as_sql(self, compiler, connection, function=None, template=None):
-            return scoreclause_sql(self, connection)
+        return (sql, [])
 
 
 def add_meta_errors(errors, meta):


### PR DESCRIPTION
This was incorrectly assuming that Combinable replaced ExpressionNode,
when CombinedExpression is more accurate. Combinable ends up being too
generic of an "interface" that doesn't represent two nodes being
combined, but any function.

Fixes SENTRY-AS2