### PR TITLE
ref(native): Do not compute caches in DIF upload

### DIFF
--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 @instrumented_task(name='sentry.tasks.assemble.assemble_dif', queue='assemble')
 def assemble_dif(project_id, name, checksum, chunks, **kwargs):
     from sentry.models import ChunkFileState, debugfile, Project, \
-        ProjectDebugFile, set_assemble_status, BadDif
+        set_assemble_status, BadDif
     from sentry.reprocessing import bump_reprocessing_revision
 
     with configure_scope() as scope:
@@ -61,16 +61,6 @@ def assemble_dif(project_id, name, checksum, chunks, **kwargs):
                 # created, someone else has created it and will bump the
                 # revision instead.
                 bump_reprocessing_revision(project)
-
-                # Try to generate caches from this DIF immediately. If this
-                # fails, we can capture the error and report it to the uploader.
-                # Also, we remove the file to prevent it from erroring again.
-                error = ProjectDebugFile.difcache.generate_caches(project, dif, temp_file.name)
-                if error is not None:
-                    set_assemble_status(project, checksum, ChunkFileState.ERROR,
-                                        detail=error)
-                    indicate_success = False
-                    dif.delete()
 
             if indicate_success:
                 set_assemble_status(project, checksum, ChunkFileState.OK,

--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -53,7 +53,7 @@ class AssembleTest(TestCase):
 
         assert get_assemble_status(self.project, total_checksum)[0] == ChunkFileState.ERROR
 
-    def test_dif_and_caches(self):
+    def test_dif(self):
         sym_file = self.load_fixture('crash.sym')
         blob1 = FileBlob.from_file(ContentFile(sym_file))
         total_checksum = sha1(sym_file).hexdigest()
@@ -71,8 +71,6 @@ class AssembleTest(TestCase):
         ).get()
 
         assert dif.file.headers == {'Content-Type': 'text/x-breakpad'}
-        assert dif.projectsymcachefile.exists()
-        assert dif.projectcficachefile.exists()
 
     def test_assemble_from_files(self):
         files = []


### PR DESCRIPTION
This removes ahead-of-time computation of SymCaches and CFI caches in Sentry during upload. 

Caches will still be computed just-in-time in `process_event` by `get_symcaches` and `get_cficaches`. However, as long as we keep symbolicator enabled, this will be dead code and should be removed in a subsequent refactor.

After fixing the CPU spike issue in symbolicator, we can merge this. Afterwards, we can still disable symbolicator without severe consequences.