### PR TITLE
feat(symbolicator): Show malformed minidumps as processing issues

### DIFF
--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -421,11 +421,8 @@ def reprocess_minidump(data):
         minidump=make_buffered_slice_reader(minidump.data, None)
     )
 
-    if not handle_symbolicator_response_status(data, response):
-        default_cache.set(minidump_is_reprocessed_cache_key, True, 3600)
-        return
-
-    merge_symbolicator_minidump_response(data, response)
+    if handle_symbolicator_response_status(data, response):
+        merge_symbolicator_minidump_response(data, response)
 
     event_cache_key = cache_key_for_event(data)
     default_cache.set(event_cache_key, dict(data), 3600)

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -14,12 +14,11 @@ from sentry.plugins import Plugin2
 from sentry.lang.native.cfi import reprocess_minidump_with_cfi
 from sentry.lang.native.minidump import get_attached_minidump, is_minidump_event, merge_symbolicator_minidump_response
 from sentry.lang.native.symbolizer import Symbolizer, SymbolicationFailed
-from sentry.lang.native.symbolicator import run_symbolicator, merge_symbolicator_image, create_minidump_task
+from sentry.lang.native.symbolicator import run_symbolicator, merge_symbolicator_image, create_minidump_task, handle_symbolicator_response_status
 from sentry.lang.native.utils import get_sdk_from_event, handle_symbolication_failed, cpu_name_from_data, \
     merge_symbolicated_frame, rebase_addr, signal_from_data
 from sentry.lang.native.systemsymbols import lookup_system_symbols
 from sentry.models import Project
-from sentry.models.eventerror import EventError
 from sentry.utils import metrics
 from sentry.utils.in_app import is_known_third_party
 from sentry.utils.safe import get_path
@@ -276,11 +275,7 @@ class NativeStacktraceProcessor(StacktraceProcessor):
             signal=self.signal
         )
 
-        if not rv:
-            handle_symbolication_failed(
-                SymbolicationFailed(type=EventError.NATIVE_SYMBOLICATOR_FAILED),
-                data=self.data,
-            )
+        if not handle_symbolicator_response_status(self.data, rv):
             return
 
         # TODO(markus): Set signal and os context from symbolicator response,
@@ -426,11 +421,7 @@ def reprocess_minidump(data):
         minidump=make_buffered_slice_reader(minidump.data, None)
     )
 
-    if not response:
-        handle_symbolication_failed(
-            SymbolicationFailed(type=EventError.NATIVE_SYMBOLICATOR_FAILED),
-            data=data,
-        )
+    if not handle_symbolicator_response_status(data, response):
         default_cache.set(minidump_is_reprocessed_cache_key, True, 3600)
         return
 

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -345,17 +345,17 @@ def run_symbolicator(project, request_id_cache_key, create_task=create_payload_t
 
 def handle_symbolicator_response_status(event_data, response_json):
     if not response_json:
-        error = SymbolicationFailed(type=EventError.NATIVE_SYMBOLICATOR_FAILED)
+        error = SymbolicationFailed(type=EventError.NATIVE_INTERNAL_FAILURE)
     elif response_json['status'] == 'completed':
         return True
     elif response_json['status'] == 'failed':
         error = SymbolicationFailed(message=response_json.get('message') or None,
-                                    type=EventError.NATIVE_FAILED)
+                                    type=EventError.NATIVE_SYMBOLICATOR_FAILED)
     else:
         logger.error('Unexpected symbolicator status: %s', response_json['status'])
-        error = SymbolicationFailed(type=EventError.NATIVE_SYMBOLICATOR_FAILED)
+        error = SymbolicationFailed(type=EventError.NATIVE_INTERNAL_FAILURE)
 
-    handle_symbolication_failed(error)
+    handle_symbolication_failed(error, data=event_data)
 
 
 def _poll_symbolication_task(sess, base_url, request_id, project_id):

--- a/src/sentry/lang/native/symbolizer.py
+++ b/src/sentry/lang/native/symbolizer.py
@@ -23,9 +23,12 @@ USER_FIXABLE_ERRORS = (
     EventError.NATIVE_BAD_DSYM,
     EventError.NATIVE_MISSING_SYMBOL,
 
-    # XXX: user can't fix this, but they should see it regardless to see it's
-    # not their fault. Also better than silently creating an unsymbolicated event
+    # Emitted for e.g. broken minidumps
     EventError.NATIVE_SYMBOLICATOR_FAILED,
+
+    # We want to let the user know when calling symbolicator failed, even
+    # though it's not user fixable.
+    EventError.NATIVE_INTERNAL_FAILURE,
 )
 
 

--- a/src/sentry/models/eventerror.py
+++ b/src/sentry/models/eventerror.py
@@ -48,6 +48,7 @@ class EventError(object):
     NATIVE_MISSING_SYMBOL = 'native_missing_symbol'
     NATIVE_SIMULATOR_FRAME = 'native_simulator_frame'
     NATIVE_UNKNOWN_IMAGE = 'native_unknown_image'
+    NATIVE_FAILED = 'native_failed'
     NATIVE_SYMBOLICATOR_FAILED = 'native_symbolicator_failed'
 
     # Processing: Proguard
@@ -94,6 +95,7 @@ class EventError(object):
         NATIVE_MISSING_SYMBOL: u'Could not resolve one or more frames in debug information file.',
         NATIVE_SIMULATOR_FRAME: u'Encountered an unprocessable simulator frame.',
         NATIVE_UNKNOWN_IMAGE: u'A binary image is referenced that is unknown.',
+        NATIVE_FAILED: u'Failed to process.',
         NATIVE_SYMBOLICATOR_FAILED: u'Failed to call Sentry-internal service.',
 
         PROGUARD_MISSING_MAPPING: u'A proguard mapping file was missing.',

--- a/src/sentry/models/eventerror.py
+++ b/src/sentry/models/eventerror.py
@@ -48,7 +48,6 @@ class EventError(object):
     NATIVE_MISSING_SYMBOL = 'native_missing_symbol'
     NATIVE_SIMULATOR_FRAME = 'native_simulator_frame'
     NATIVE_UNKNOWN_IMAGE = 'native_unknown_image'
-    NATIVE_FAILED = 'native_failed'
     NATIVE_SYMBOLICATOR_FAILED = 'native_symbolicator_failed'
 
     # Processing: Proguard
@@ -95,8 +94,7 @@ class EventError(object):
         NATIVE_MISSING_SYMBOL: u'Could not resolve one or more frames in debug information file.',
         NATIVE_SIMULATOR_FRAME: u'Encountered an unprocessable simulator frame.',
         NATIVE_UNKNOWN_IMAGE: u'A binary image is referenced that is unknown.',
-        NATIVE_FAILED: u'Failed to process.',
-        NATIVE_SYMBOLICATOR_FAILED: u'Failed to call Sentry-internal service.',
+        NATIVE_SYMBOLICATOR_FAILED: u'Failed to process native stacktraces.',
 
         PROGUARD_MISSING_MAPPING: u'A proguard mapping file was missing.',
         PROGUARD_MISSING_LINENO: u'A proguard mapping file does not contain line info.',


### PR DESCRIPTION
Symbolicator is not started:

![Screenshot 2019-05-14 at 14 15 58](https://user-images.githubusercontent.com/837573/57697992-c969df00-7654-11e9-98aa-4c4236c55760.png)

Symbolicator tries to open empty minidump (faked by purposefully sending empty string in sentry to get past store):
![Screenshot 2019-05-14 at 14 29 51](https://user-images.githubusercontent.com/837573/57697993-c969df00-7654-11e9-8562-026374af4fc0.png)