### PR TITLE
feat(api): Change Incident.identifier to a string

### DIFF
--- a/src/sentry/api/serializers/models/incident.py
+++ b/src/sentry/api/serializers/models/incident.py
@@ -44,7 +44,7 @@ class IncidentSerializer(Serializer):
         aggregates = attrs['aggregates']
         return {
             'id': six.text_type(obj.id),
-            'identifier': obj.identifier,
+            'identifier': six.text_type(obj.identifier),
             'organizationId': six.text_type(obj.organization_id),
             'projects': attrs['projects'],
             'status': obj.status,

--- a/src/sentry/static/sentry/app/sentryTypes.jsx
+++ b/src/sentry/static/sentry/app/sentryTypes.jsx
@@ -397,7 +397,7 @@ export const SavedSearch = PropTypes.shape({
 
 export const Incident = PropTypes.shape({
   id: PropTypes.string.isRequired,
-  identifier: PropTypes.number.isRequired,
+  identifier: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   status: PropTypes.number.isRequired,
   query: PropTypes.string,

--- a/tests/js/fixtures/incident.js
+++ b/tests/js/fixtures/incident.js
@@ -1,7 +1,7 @@
 export function Incident(params) {
   return {
     id: '321',
-    identifier: 123,
+    identifier: '123',
     title: 'Too many Chrome errors',
     status: 0,
     projects: [],

--- a/tests/js/spec/views/organizationIncidents/list/index.spec.jsx
+++ b/tests/js/spec/views/organizationIncidents/list/index.spec.jsx
@@ -13,8 +13,8 @@ describe('OrganizationIncidentsList', function() {
     mock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/incidents/',
       body: [
-        TestStubs.Incident({id: '123', identifier: 1, title: 'First incident'}),
-        TestStubs.Incident({id: '342', identifier: 2, title: 'Second incident'}),
+        TestStubs.Incident({id: '123', identifier: '1', title: 'First incident'}),
+        TestStubs.Incident({id: '342', identifier: '2', title: 'Second incident'}),
       ],
     });
   });

--- a/tests/sentry/api/serializers/test_incident.py
+++ b/tests/sentry/api/serializers/test_incident.py
@@ -19,7 +19,7 @@ class IncidentSerializerTest(TestCase):
         result = serialize(incident)
 
         assert result['id'] == six.text_type(incident.id)
-        assert result['identifier'] == incident.identifier
+        assert result['identifier'] == six.text_type(incident.identifier)
         assert result['organizationId'] == six.text_type(incident.organization_id)
         assert result['projects'] == [p.slug for p in incident.projects.all()]
         assert result['status'] == incident.status


### PR DESCRIPTION
... to be consistent with how our API handles IDs