### PR TITLE
ref(ui) Use avatar list on release files

### DIFF
--- a/src/sentry/static/sentry/app/components/fileChange.jsx
+++ b/src/sentry/static/sentry/app/components/fileChange.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import Avatar from 'app/components/avatar';
-import Tooltip2 from 'app/components/tooltip2';
+import AvatarList from 'app/components/avatar/avatarList';
 import InlineSvg from 'app/components/inlineSvg';
 
 class FileChange extends React.PureComponent {
@@ -26,16 +25,8 @@ class FileChange extends React.PureComponent {
             <InlineSvg src="icon-file" className="icon-file-generic" size="15" />
             {filename}
           </div>
-          <div className="col-sm-2 avatar-grid align-right">
-            {authors.map((author, i) => {
-              return (
-                <Tooltip2 key={i} title={`${author.name} ${author.email}`}>
-                  <span className="avatar-grid-item m-b-0">
-                    <Avatar user={author} />
-                  </span>
-                </Tooltip2>
-              );
-            })}
+          <div className="col-sm-2 align-right">
+            <AvatarList users={authors} avatarSize={25} typeMember="authors" />
           </div>
         </div>
       </li>


### PR DESCRIPTION
Normalize the release file committer list to use the AvatarList component. This lets us keep the release file grid tidy and matching the rest of the app.

### Old

![Screen Shot 2019-05-14 at 1 39 44 PM](https://user-images.githubusercontent.com/24086/57719446-c91a1580-764d-11e9-8bca-73e95146c6a8.png)

### New

![Screen Shot 2019-05-14 at 1 39 17 PM](https://user-images.githubusercontent.com/24086/57719464-d0d9ba00-764d-11e9-8977-25c4b2c45324.png)
