### PR TITLE
feat(app-platform): Introduce "internal" status

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -372,12 +372,14 @@ class ObjectStatus(object):
 class SentryAppStatus(object):
     UNPUBLISHED = 0
     PUBLISHED = 1
+    INTERNAL = 2
 
     @classmethod
     def as_choices(cls):
         return (
             (cls.UNPUBLISHED, 'unpublished'),
             (cls.PUBLISHED, 'published'),
+            (cls.INTERNAL, 'internal'),
         )
 
 


### PR DESCRIPTION
Integrations intended to be used as Internal Tools will be denoted as such using this `status` field.