### PR TITLE
feat(ui): Remove `RelatedIncidents` from details tab

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
@@ -11,11 +11,9 @@ import theme from 'app/utils/theme';
 
 import IncidentsSuspects from './suspects';
 import Activity from './activity';
-import RelatedIncidents from './relatedIncidents';
 
 const TABS = {
   activity: {name: t('Activity'), component: Activity},
-  related: {name: t('Related incidents'), component: RelatedIncidents},
 };
 
 export default class DetailsBody extends React.Component {

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/relatedIncidents.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/relatedIncidents.jsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-export default class RelatedIncidents extends React.Component {
-  render() {
-    return 'TODO - related incidents';
-  }
-}


### PR DESCRIPTION
This feature is no longer in scope.