### PR TITLE
fix(settings): Fix missing borders for Integrations List

### DIFF
--- a/src/sentry/static/sentry/app/utils/withApi.jsx
+++ b/src/sentry/static/sentry/app/utils/withApi.jsx
@@ -16,7 +16,9 @@ const withApi = WrappedComponent => {
       this.api.clear();
     }
     render() {
-      return <WrappedComponent api={this.api} {...this.props} />;
+      const {['data-test-id']: _, ...props} = this.props;
+
+      return <WrappedComponent api={this.api} {...props} />;
     }
   }
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
@@ -134,19 +134,18 @@ class OrganizationIntegrations extends AsyncComponent {
 
   renderProvider(provider) {
     return (
-      <IntegrationRow key={`row-${provider.key}`}>
-        <ProviderRow
-          key={provider.key}
-          provider={provider}
-          orgId={this.props.params.orgId}
-          integrations={provider.integrations}
-          onInstall={this.onInstall}
-          onRemove={this.onRemove}
-          onDisable={this.onDisable}
-          onReinstall={this.onInstall}
-          enabledPlugins={this.enabledPlugins}
-        />
-      </IntegrationRow>
+      <ProviderRow
+        key={`row-${provider.key}`}
+        data-test-id="integration-row"
+        provider={provider}
+        orgId={this.props.params.orgId}
+        integrations={provider.integrations}
+        onInstall={this.onInstall}
+        onRemove={this.onRemove}
+        onDisable={this.onDisable}
+        onReinstall={this.onInstall}
+        enabledPlugins={this.enabledPlugins}
+      />
     );
   }
 
@@ -155,14 +154,13 @@ class OrganizationIntegrations extends AsyncComponent {
     const {appInstalls} = this.state;
 
     return (
-      <IntegrationRow key={`row-${key}`}>
-        <SentryAppInstallations
-          key={key}
-          organization={organization}
-          installs={appInstalls}
-          applications={apps}
-        />
-      </IntegrationRow>
+      <SentryAppInstallations
+        key={`sentry-app-row-${key}`}
+        data-test-id="integration-row"
+        organization={organization}
+        installs={appInstalls}
+        applications={apps}
+      />
     );
   }
 
@@ -231,8 +229,6 @@ class OrganizationIntegrations extends AsyncComponent {
     );
   }
 }
-
-const IntegrationRow = styled('div')``;
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`
   position: absolute;

--- a/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
@@ -157,7 +157,7 @@ describe('OrganizationIntegrations', () => {
     });
 
     it('sorts Sentry App Integrations among Integrations, alphabetically', () => {
-      const rows = wrapper.find('IntegrationRow');
+      const rows = wrapper.find('[data-test-id="integration-row"]');
 
       expect(rows.length).toBe(4);
 
@@ -367,9 +367,7 @@ describe('OrganizationIntegrations', () => {
       it('displays an Update when the Plugin is enabled but a new Integration is not', () => {
         expect(
           wrapper
-            .find('ProviderRow')
-            .filterWhere(n => n.key() === 'vsts')
-            .find('Button')
+            .find('ProviderRow PanelItem[data-test-id="vsts"] Button')
             .first()
             .text()
         ).toBe('Update');
@@ -378,9 +376,7 @@ describe('OrganizationIntegrations', () => {
       it('displays Add Another button when both Integration and Plugin are enabled', () => {
         expect(
           wrapper
-            .find('ProviderRow')
-            .filterWhere(n => n.key() === 'github')
-            .find('Button')
+            .find('ProviderRow PanelItem[data-test-id="github"] Button')
             .first()
             .text()
         ).toBe('Add Another');
@@ -389,9 +385,7 @@ describe('OrganizationIntegrations', () => {
       it('display an Install button when its not an upgradable Integration', () => {
         expect(
           wrapper
-            .find('ProviderRow')
-            .filterWhere(n => n.key() === 'jira')
-            .find('Button')
+            .find('ProviderRow PanelItem[data-test-id="jira"] Button')
             .first()
             .text()
         ).toBe('Install');


### PR DESCRIPTION
This removes the extra `IntegrationRow` styled component that causes issues with our Panel/PanelItem (since it depends on `:last-child`). IntegrationRow was only used for tests. This surfaced a problem with our HoCs in that it passes `data-test-id` to its children and causes issues when using selectors in enzyme (it'll return the component and its HoC when you search for the `data-test-id`).

Closes https://github.com/getsentry/sentry/pull/13180

![image](https://user-images.githubusercontent.com/435981/57647709-8cc8b580-7578-11e9-8252-e8c41b291f6b.png)

![image](https://user-images.githubusercontent.com/435981/57729419-fa451680-764a-11e9-9326-fe13c30e2f01.png)
