### PR TITLE
feat(ui): Add prop to align dropdown menu to right for `DropdownControl`

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownControl.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownControl.jsx
@@ -25,6 +25,8 @@ class DropdownControl extends React.Component {
     // Should the menu contents always be rendered?  Defaults to true.
     // Set to false to have menu contents removed from the DOM on close.
     alwaysRenderMenu: PropTypes.bool,
+    // Align the dropdown menu to the right. (Default aligns to left)
+    alignRight: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -46,7 +48,7 @@ class DropdownControl extends React.Component {
   }
 
   render() {
-    const {children, alwaysRenderMenu, menuOffset, menuWidth} = this.props;
+    const {children, alwaysRenderMenu, alignRight, menuOffset, menuWidth} = this.props;
 
     return (
       <Container>
@@ -57,6 +59,7 @@ class DropdownControl extends React.Component {
                 {this.renderButton(isOpen, getActorProps)}
                 <MenuContainer
                   {...getMenuProps({isStyled: true})}
+                  alignRight={alignRight}
                   menuWidth={menuWidth}
                   menuOffset={menuOffset}
                   isOpen={isOpen}
@@ -91,6 +94,7 @@ const MenuContainer = styled('ul')`
 
   position: absolute;
   top: ${p => p.menuOffset};
+  ${p => p.alignRight && 'right: 0'};
   padding: 0;
   margin: 0;
   z-index: ${p => p.theme.zIndex.dropdownAutocomplete.menu};


### PR DESCRIPTION
This allows the dropdown menu in a `<DropdownControl>` to be aligned to the right