### PR TITLE
feat(ui): Change error and loading states for Incident Details

### DIFF
--- a/src/sentry/static/sentry/app/components/subscribeButton.jsx
+++ b/src/sentry/static/sentry/app/components/subscribeButton.jsx
@@ -8,15 +8,16 @@ import {t} from 'app/locale';
 
 export default class SubscribeButton extends React.Component {
   static propTypes = {
-    isSubscribed: PropTypes.bool.isRequired,
+    isSubscribed: PropTypes.bool,
     onClick: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
   };
 
   render() {
-    const {isSubscribed, onClick} = this.props;
+    const {isSubscribed, onClick, disabled} = this.props;
 
     return (
-      <Button size="small" onClick={onClick}>
+      <Button size="small" onClick={onClick} disabled={disabled}>
         <Content>
           <SignalIcon className="icon-signal" isSubscribed={isSubscribed} />
           {isSubscribed ? t('Unsubscribe') : t('Subscribe')}

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/header.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/header.jsx
@@ -1,3 +1,4 @@
+import {Link} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
@@ -8,7 +9,7 @@ import Access from 'app/components/acl/access';
 import Count from 'app/components/count';
 import DropdownControl from 'app/components/dropdownControl';
 import InlineSvg from 'app/components/inlineSvg';
-import Link from 'app/components/links/link';
+import LoadingError from 'app/components/loadingError';
 import MenuItem from 'app/components/menuItem';
 import PageHeading from 'app/components/pageHeading';
 import SentryTypes from 'app/sentryTypes';
@@ -22,6 +23,7 @@ export default class DetailsHeader extends React.Component {
   static propTypes = {
     incident: SentryTypes.Incident,
     params: PropTypes.object.isRequired,
+    hasIncidentDetailsError: PropTypes.bool.isRequired,
     onSubscriptionChange: PropTypes.func.isRequired,
     onStatusChange: PropTypes.func.isRequired,
   };
@@ -29,14 +31,19 @@ export default class DetailsHeader extends React.Component {
   renderStatus() {
     const {incident, onStatusChange} = this.props;
 
-    const isIncidentOpen = isOpen(incident);
+    const isIncidentOpen = incident && isOpen(incident);
 
     return (
       <Access
         access={['org:write']}
-        renderNoAccessMessage={() => <Status incident={incident} />}
+        renderNoAccessMessage={() => incident && <Status incident={incident} />}
       >
-        <DropdownControl label={<Status incident={incident} />} menuWidth="160px">
+        <DropdownControl
+          label={incident && <Status incident={incident} />}
+          menuWidth="160px"
+          alignRight
+          buttonProps={!incident ? {disabled: true} : null}
+        >
           <StyledMenuItem onSelect={onStatusChange}>
             {isIncidentOpen ? t('Close this incident') : t('Reopen this incident')}
           </StyledMenuItem>
@@ -46,27 +53,32 @@ export default class DetailsHeader extends React.Component {
   }
 
   render() {
-    const {incident, params, onSubscriptionChange} = this.props;
+    const {hasIncidentDetailsError, incident, params, onSubscriptionChange} = this.props;
     const incidentIdAsInt = parseInt(params.incidentId, 10);
     const formattedIncidentId = !isNaN(incidentIdAsInt)
       ? incidentIdAsInt.toLocaleString()
       : t('Invalid Incident');
+    const isIncidentReady = !!incident && !hasIncidentDetailsError;
 
     return (
       <Header>
         <HeaderItem>
           <PageHeading>
-            <Title>
+            <Breadcrumb>
               <IncidentsLink to={`/organizations/${params.orgId}/incidents/`}>
                 {t('Incidents')}
               </IncidentsLink>
               <Chevron src="icon-chevron-right" size={space(2)} />
               {formattedIncidentId}
-            </Title>
-            <div>{incident && incident.title}</div>
+            </Breadcrumb>
+            <IncidentTitle loading={!isIncidentReady}>
+              {isIncidentReady ? incident.title : 'Loading'}
+            </IncidentTitle>
           </PageHeading>
         </HeaderItem>
-        {incident && (
+        {hasIncidentDetailsError ? (
+          <StyledLoadingError />
+        ) : (
           <GroupedHeaderItems>
             <HeaderItem>
               <ItemTitle>{t('Status')}</ItemTitle>
@@ -74,21 +86,26 @@ export default class DetailsHeader extends React.Component {
             </HeaderItem>
             <HeaderItem>
               <ItemTitle>{t('Event count')}</ItemTitle>
-              <ItemValue>
-                <Count value={incident.totalEvents} />
-              </ItemValue>
+              {isIncidentReady && (
+                <ItemValue>
+                  <Count value={incident.totalEvents} />
+                </ItemValue>
+              )}
             </HeaderItem>
             <HeaderItem>
               <ItemTitle>{t('Users affected')}</ItemTitle>
-              <ItemValue>
-                <Count value={incident.uniqueUsers} />
-              </ItemValue>
+              {isIncidentReady && (
+                <ItemValue>
+                  <Count value={incident.uniqueUsers} />
+                </ItemValue>
+              )}
             </HeaderItem>
             <HeaderItem>
               <ItemTitle>{t('Notifications')}</ItemTitle>
               <ItemValue>
                 <SubscribeButton
-                  isSubscribed={!!incident.isSubscribed}
+                  disabled={!isIncidentReady}
+                  isSubscribed={incident && !!incident.isSubscribed}
                   onClick={onSubscriptionChange}
                 />
               </ItemValue>
@@ -104,6 +121,15 @@ const Header = styled(PageHeader)`
   background-color: ${p => p.theme.white};
   border-bottom: 1px solid ${p => p.theme.borderDark};
   margin-bottom: 0;
+  padding: ${space(3)} 0;
+`;
+
+const StyledLoadingError = styled(LoadingError)`
+  flex: 1;
+
+  &.alert.alert-block {
+    margin: 0 20px;
+  }
 `;
 
 const GroupedHeaderItems = styled('div')`
@@ -112,7 +138,7 @@ const GroupedHeaderItems = styled('div')`
 `;
 
 const HeaderItem = styled('div')`
-  padding: ${space(3)};
+  padding: 0 ${space(3)};
 `;
 
 const ItemTitle = styled('h6')`
@@ -128,11 +154,15 @@ const ItemValue = styled('div')`
   justify-content: flex-end;
   align-items: center;
   font-size: ${p => p.theme.headerFontSize};
-  height: 34px;
+  height: 40px; /* This is the height of the Status dropdown */
 `;
 
-const Title = styled('div')`
+const Breadcrumb = styled('div')`
   margin-bottom: ${space(2)};
+`;
+
+const IncidentTitle = styled('div')`
+  ${p => p.loading && 'opacity: 0'};
 `;
 
 const IncidentsLink = styled(Link)`

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/index.jsx
@@ -96,7 +96,6 @@ class OrganizationIncidentDetails extends React.Component {
     const {incident, hasError} = this.state;
     const {params} = this.props;
 
-    console.log(incident);
     return (
       <React.Fragment>
         <DetailsHeader

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/index.jsx
@@ -2,9 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
-import LoadingIndicator from 'app/components/loadingIndicator';
-import LoadingError from 'app/components/loadingError';
-import {PageContent} from 'app/styles/organization';
 import withApi from 'app/utils/withApi';
 import {t} from 'app/locale';
 
@@ -96,28 +93,25 @@ class OrganizationIncidentDetails extends React.Component {
   };
 
   render() {
-    const {incident, isLoading, hasError} = this.state;
+    const {incident, hasError} = this.state;
     const {params} = this.props;
 
+    console.log(incident);
     return (
       <React.Fragment>
         <DetailsHeader
+          hasIncidentDetailsError={hasError}
           params={params}
           incident={incident}
           onSubscriptionChange={this.handleSubscriptionChange}
           onStatusChange={this.handleStatusChange}
         />
-        <DetailsBody params={params} incident={incident} />
-        {isLoading && (
-          <PageContent>
-            <LoadingIndicator />
-          </PageContent>
-        )}
-        {hasError && (
-          <PageContent>
-            <LoadingError />
-          </PageContent>
-        )}
+
+        <DetailsBody
+          hasIncidentDetailsError={hasError}
+          params={params}
+          incident={incident}
+        />
       </React.Fragment>
     );
   }

--- a/tests/js/fixtures/incident.js
+++ b/tests/js/fixtures/incident.js
@@ -8,6 +8,9 @@ export function Incident(params) {
     totalEvents: 100,
     uniqueUsers: 20,
     isSubscribed: true,
+    eventStats: {
+      data: [],
+    },
     ...params,
   };
 }

--- a/tests/js/spec/views/organizationIncidents/details/index.spec.jsx
+++ b/tests/js/spec/views/organizationIncidents/details/index.spec.jsx
@@ -24,13 +24,31 @@ describe('IncidentDetails', function() {
 
   it('loads incident', async function() {
     const wrapper = mount(
-      <IncidentDetails params={{orgId: 'org-slug', incidentId: mockIncident.id}} />,
+      <IncidentDetails
+        params={{orgId: 'org-slug', incidentId: mockIncident.identifier}}
+      />,
       routerContext
     );
-    expect(wrapper.find('LoadingIndicator')).toHaveLength(1);
+
+    expect(wrapper.find('IncidentTitle').text()).toBe('Loading');
+    expect(wrapper.find('SubscribeButton').prop('disabled')).toBe(true);
+
     await tick();
     wrapper.update();
-    expect(wrapper.find('LoadingIndicator')).toHaveLength(0);
+
+    expect(wrapper.find('IncidentTitle').text()).toBe('Too many Chrome errors');
+    expect(
+      wrapper
+        .find('ItemValue')
+        .at(1)
+        .text()
+    ).toBe('100');
+    expect(
+      wrapper
+        .find('ItemValue')
+        .at(2)
+        .text()
+    ).toBe('20');
   });
 
   it('handles invalid incident', async function() {


### PR DESCRIPTION
This moves error state into the header when details fails to load (since
Activity and Suspects will have their own endpoints).

Remove loading indicator. Makes sure IncidentsHeader loads titles and
maintains heights so that when loading is completed, layout does not
change.

Requires https://github.com/getsentry/sentry/pull/13203

See https://cl.ly/2fb6c53326f2/download/Screen%20Recording%202019-05-14%20at%2006.55%20PM.gif