### PR TITLE
feat(ui): Add DatePickerField when creating an Incident [SEN-634]

### DIFF
--- a/docs-ui/components/form.stories.js
+++ b/docs-ui/components/form.stories.js
@@ -12,6 +12,7 @@ import {action} from '@storybook/addon-actions';
 import {boolean} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
+import DatePickerField from 'app/views/settings/components/forms/datePickerField';
 import Form from 'app/views/settings/components/forms/form';
 import FormField from 'app/views/settings/components/forms/formField';
 import NewBooleanField from 'app/views/settings/components/forms/booleanField';
@@ -219,6 +220,17 @@ storiesOf('Forms|Fields', module)
     })(() => (
       <Form>
         <NewBooleanField name="field" label="New Boolean Field" />
+      </Form>
+    ))
+  )
+  .add(
+    'DatePickerField',
+    withInfo({
+      text: 'Date picker field with a popup calendar picker (for a single date)',
+      propTablesExclude: [Form],
+    })(() => (
+      <Form>
+        <DatePickerField name="field" label="Date Picker Field" />
       </Form>
     ))
   )

--- a/src/sentry/static/sentry/app/actionCreators/incident.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/incident.jsx
@@ -13,7 +13,13 @@ import {t} from 'app/locale';
  * @param {String} title Title of the incident
  * @param {String[]} groups List of group ids
  */
-export async function createIncident(api, organization, title, groups) {
+export async function createIncident(
+  api,
+  organization,
+  title,
+  groups,
+  dateStarted = new Date()
+) {
   addLoadingMessage(t('Creating new incident...'));
 
   try {
@@ -24,7 +30,7 @@ export async function createIncident(api, organization, title, groups) {
         data: {
           title,
           groups,
-          dateStarted: new Date(),
+          dateStarted,
           query: '',
         },
       }

--- a/src/sentry/static/sentry/app/components/modals/createIncidentModal.jsx
+++ b/src/sentry/static/sentry/app/components/modals/createIncidentModal.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import {createIncident} from 'app/actionCreators/incident';
 import {t} from 'app/locale';
+import DatePickerField from 'app/views/settings/components/forms/datePickerField';
 import Form from 'app/views/settings/components/forms/form';
 import SentryTypes from 'app/sentryTypes';
 import TextField from 'app/views/settings/components/forms/textField';
@@ -26,7 +27,13 @@ class CreateIncidentModal extends React.Component {
     setFormSavingState();
 
     try {
-      const incident = await createIncident(api, organization, data.title, issues);
+      const incident = await createIncident(
+        api,
+        organization,
+        data.title,
+        issues,
+        data.dateStarted
+      );
       onSuccess(incident);
     } catch (err) {
       onError(err);
@@ -63,12 +70,24 @@ class CreateIncidentModal extends React.Component {
             onSubmit={this.handleSubmit}
             onSubmitSuccess={this.handleSuccess}
             requireChanges
+            initialData={{
+              date: new Date(),
+            }}
           >
             <TextField
               name="title"
               label={t('Incident Name')}
               placeholder={t('Incident Name')}
               help={t('Give a name to help identify the incident')}
+              required
+              stacked
+              inline={false}
+              flexibleControlStateSize
+            />
+            <DatePickerField
+              name="dateStarted"
+              label={t('Date Started')}
+              help={t('This should be around when the incident first began.')}
               required
               stacked
               inline={false}

--- a/src/sentry/static/sentry/app/views/settings/components/forms/datePickerField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/datePickerField.jsx
@@ -1,0 +1,101 @@
+import 'react-date-range/dist/styles.css';
+import 'react-date-range/dist/theme/default.css';
+
+import {Calendar} from 'react-date-range';
+import React from 'react';
+import moment from 'moment';
+import styled from 'react-emotion';
+
+import {inputStyles} from 'app/styles/input';
+import DropdownMenu from 'app/components/dropdownMenu';
+import InlineSvg from 'app/components/inlineSvg';
+import space from 'app/styles/space';
+
+import InputField from './inputField';
+
+export default class DatePickerField extends React.Component {
+  onChange = (onChange, onBlur, date) => {
+    onChange(date, {});
+    onBlur(date, {});
+  };
+
+  render() {
+    return (
+      <InputField
+        {...this.props}
+        field={({onChange, onBlur, value, disabled, name, id, ...props}) => {
+          const inputValue = !value ? new Date() : new Date(value);
+          const dateString = moment(inputValue).format('lll');
+
+          return (
+            <DropdownMenu>
+              {({isOpen, getRootProps, getActorProps, getMenuProps}) => (
+                <DatePickerWrapper {...getRootProps({isStyled: true})}>
+                  <InputWrapper
+                    name={id}
+                    id={id}
+                    {...getActorProps({isStyled: true})}
+                    isOpen={isOpen}
+                  >
+                    <StyledInput readOnly value={dateString} />
+                    <CalendarIcon>
+                      <InlineSvg src="icon-calendar" />
+                    </CalendarIcon>
+                  </InputWrapper>
+
+                  {isOpen && (
+                    <CalendarMenu {...getMenuProps({isStyled: true})}>
+                      <Calendar
+                        disabled={disabled}
+                        date={!value ? new Date() : new Date(value)}
+                        onChange={date => this.onChange(onChange, onBlur, date)}
+                      />
+                    </CalendarMenu>
+                  )}
+                </DatePickerWrapper>
+              )}
+            </DropdownMenu>
+          );
+        }}
+      />
+    );
+  }
+}
+
+const DatePickerWrapper = styled('div')``;
+const InputWrapper = styled('div')`
+  ${inputStyles}
+  cursor: text;
+  display: flex;
+  z-index: ${p => p.theme.zIndex.dropdownAutocomplete.actor};
+  ${p => p.isOpen && 'border-bottom-left-radius: 0'}
+`;
+
+const StyledInput = styled('input')`
+  border: none;
+  outline: none;
+  flex: 1;
+`;
+
+const CalendarMenu = styled('div')`
+  display: flex;
+  background: white;
+  position: absolute;
+  left: 0;
+  border: 1px solid ${p => p.theme.borderDark};
+  border-top: none;
+  z-index: ${p => p.theme.zIndex.dropdownAutocomplete.menu};
+  margin-top: -1px;
+
+  .rdrMonthAndYearWrapper {
+    height: 50px;
+    padding-top: 0;
+  }
+`;
+
+const CalendarIcon = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${space(1)};
+`;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/datePickerField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/datePickerField.jsx
@@ -25,7 +25,7 @@ export default class DatePickerField extends React.Component {
         {...this.props}
         field={({onChange, onBlur, value, disabled, name, id, ...props}) => {
           const inputValue = !value ? new Date() : new Date(value);
-          const dateString = moment(inputValue).format('lll');
+          const dateString = moment(inputValue).format('LL');
 
           return (
             <DropdownMenu>

--- a/src/sentry/static/sentry/app/views/settings/components/forms/datePickerField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/datePickerField.jsx
@@ -24,7 +24,8 @@ export default class DatePickerField extends React.Component {
       <InputField
         {...this.props}
         field={({onChange, onBlur, value, disabled, name, id, ...props}) => {
-          const inputValue = !value ? new Date() : new Date(value);
+          const dateObj = new Date(value);
+          const inputValue = !isNaN(dateObj.getTime()) ? dateObj : new Date();
           const dateString = moment(inputValue).format('LL');
 
           return (
@@ -47,7 +48,7 @@ export default class DatePickerField extends React.Component {
                     <CalendarMenu {...getMenuProps({isStyled: true})}>
                       <Calendar
                         disabled={disabled}
-                        date={!value ? new Date() : new Date(value)}
+                        date={inputValue}
                         onChange={date => this.onChange(onChange, onBlur, date)}
                       />
                     </CalendarMenu>


### PR DESCRIPTION
This allows you to pick a start date when creating a new (manual) Incident

![image](https://user-images.githubusercontent.com/79684/57743993-39d82680-767c-11e9-9e85-ab36a3a534da.png)

Depends on https://github.com/getsentry/sentry/pull/13205

Fixes SEN-634