### PR TITLE
fix(help): Result may be missing snippets

### DIFF
--- a/src/sentry/static/sentry/app/components/search/sources/helpSource.jsx
+++ b/src/sentry/static/sentry/app/components/search/sources/helpSource.jsx
@@ -130,11 +130,13 @@ function buildHit(hit, options) {
     htmlString: _highlightResult.title.value,
     markTags: HIGHLIGHT_TAGS,
   });
-  const description = parseHtmlMarks({
-    key: 'description',
-    htmlString: _snippetResult[descriptionKey].value,
-    markTags: HIGHLIGHT_TAGS,
-  });
+  const description = _snippetResult
+    ? parseHtmlMarks({
+        key: 'description',
+        htmlString: _snippetResult[descriptionKey].value,
+        markTags: HIGHLIGHT_TAGS,
+      })
+    : {};
 
   const item = {
     sourceType: 'help',


### PR DESCRIPTION
In the case where no attribute could be snippeted (if there is no description), the _snippetResult will be missing. We will just not show a description in that case.

Fixes JAVASCRIPT-521