### PR TITLE
ref(app-platform): UI for internal app details

### DIFF
--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -21,23 +21,19 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
             queryset = SentryApp.objects.filter(status=SentryAppStatus.PUBLISHED)
 
         elif status == 'unpublished':
-            if is_active_superuser(request):
-                queryset = SentryApp.objects.filter(
-                    status=SentryAppStatus.UNPUBLISHED
-                )
-            else:
-                queryset = SentryApp.objects.filter(
-                    status=SentryAppStatus.UNPUBLISHED,
+            queryset = SentryApp.objects.filter(
+                status=SentryAppStatus.UNPUBLISHED,
+            )
+            if not is_active_superuser(request):
+                queryset = queryset.filter(
                     owner__in=request.user.get_orgs(),
                 )
         elif status == 'internal':
-            if is_active_superuser(request):
-                queryset = SentryApp.objects.filter(
-                    status=SentryAppStatus.INTERNAL,
-                )
-            else:
-                queryset = SentryApp.objects.filter(
-                    status=SentryAppStatus.INTERNAL,
+            queryset = SentryApp.objects.filter(
+                status=SentryAppStatus.INTERNAL,
+            )
+            if not is_active_superuser(request):
+                queryset = queryset.filter(
                     owner__in=request.user.get_orgs(),
                 )
         else:

--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -30,6 +30,16 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
                     status=SentryAppStatus.UNPUBLISHED,
                     owner__in=request.user.get_orgs(),
                 )
+        elif status == 'internal':
+            if is_active_superuser(request):
+                queryset = SentryApp.objects.filter(
+                    status=SentryAppStatus.INTERNAL,
+                )
+            else:
+                queryset = SentryApp.objects.filter(
+                    status=SentryAppStatus.INTERNAL,
+                    owner__in=request.user.get_orgs(),
+                )
         else:
             if is_active_superuser(request):
                 queryset = SentryApp.objects.all()

--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -29,13 +29,22 @@ class SentryAppSerializer(Serializer):
         if is_active_superuser(env.request) or (
             hasattr(user, 'get_orgs') and obj.owner in user.get_orgs()
         ):
-            data.update({
-                'clientId': obj.application.client_id,
-                'clientSecret': obj.application.client_secret,
-                'owner': {
-                    'id': obj.owner.id,
-                    'slug': obj.owner.slug,
-                },
-            })
+            if obj.is_internal:
+                install = obj.installations.first()
+                data.update({
+                    'installation': {
+                        'uuid': install.uuid,
+                    },
+                    'token': install.api_token.token,
+                })
+            else:
+                data.update({
+                    'clientId': obj.application.client_id,
+                    'clientSecret': obj.application.client_secret,
+                    'owner': {
+                        'id': obj.owner.id,
+                        'slug': obj.owner.slug,
+                    },
+                })
 
         return data

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -143,6 +143,14 @@ class SentryApp(ParanoidModel, HasApiScopes):
     def is_published(self):
         return self.status == SentryAppStatus.PUBLISHED
 
+    @property
+    def is_unpublished(self):
+        return self.status == SentryAppStatus.UNPUBLISHED
+
+    @property
+    def is_internal(self):
+        return self.status == SentryAppStatus.INTERNAL
+
     def save(self, *args, **kwargs):
         self._set_slug()
         self.date_updated = timezone.now()

--- a/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
+++ b/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
@@ -7,6 +7,12 @@ const forms = [
     title: 'Integration Details',
     fields: [
       {
+        name: 'internal',
+        label: 'Internal',
+        type: 'boolean',
+        help: 'Choose this to make your integration Internal.',
+      },
+      {
         name: 'name',
         type: 'string',
         required: true,

--- a/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
+++ b/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
@@ -10,7 +10,8 @@ const forms = [
         name: 'internal',
         label: 'Internal',
         type: 'boolean',
-        help: 'Choose this to make your integration Internal.',
+        help:
+          'If enabled, your integration will automatically be installed and for use within your organization only.',
       },
       {
         name: 'name',
@@ -49,7 +50,7 @@ const forms = [
         type: 'boolean',
         label: 'Alert Rule Action',
         help: tct(
-          'If enabled, this application will be an action under alert rules in Sentry. The notification destination is the Webhook URL specified above. More on actions [learn_more:Here].',
+          'If enabled, this integration will be an action under alert rules in Sentry. The notification destination is the Webhook URL specified above. More on actions [learn_more:Here].',
           {
             learn_more: (
               <a href="https://docs.sentry.io/product/notifications/#actions" />

--- a/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
+++ b/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import {tct} from 'app/locale';
+import {t, tct} from 'app/locale';
+
+const INTERNAL_OPTION_DISABLED_REASON = t(
+  "This option can't be changed once selected. Please make a new integration if you no longer want it to be internal."
+);
 
 const forms = [
   {
@@ -7,9 +11,11 @@ const forms = [
     title: 'Integration Details',
     fields: [
       {
-        name: 'internal',
+        name: 'isInternal',
         label: 'Internal',
         type: 'boolean',
+        disabled: ({statusDisabled}) => statusDisabled,
+        disabledReason: INTERNAL_OPTION_DISABLED_REASON,
         help:
           'If enabled, your integration will automatically be installed and for use within your organization only.',
       },

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
@@ -105,6 +105,7 @@ export default class SentryApplicationDetails extends AsyncView {
           initialData={{
             organization: orgId,
             isAlertable: false,
+            internal: app && app.status == 'internal' ? true : false,
             schema: {},
             scopes: [],
             ...app,
@@ -119,28 +120,51 @@ export default class SentryApplicationDetails extends AsyncView {
           {app && (
             <Panel>
               <PanelHeader>{t('Credentials')}</PanelHeader>
-              <PanelBody>
-                <FormField name="clientId" label="Client ID" overflow>
-                  {({value}) => {
-                    return (
-                      <TextCopyInput>
-                        {getDynamicText({value, fixed: 'PERCY_CLIENT_ID'})}
-                      </TextCopyInput>
-                    );
-                  }}
-                </FormField>
-                <FormField overflow name="clientSecret" label="Client Secret">
-                  {({value}) => {
-                    return value ? (
-                      <TextCopyInput>
-                        {getDynamicText({value, fixed: 'PERCY_CLIENT_SECRET'})}
-                      </TextCopyInput>
-                    ) : (
-                      <em>hidden</em>
-                    );
-                  }}
-                </FormField>
-              </PanelBody>
+              {app.status == 'internal' ? (
+                <PanelBody>
+                  <FormField name="token" label="Token" overflow>
+                    {({value}) => {
+                      return (
+                        <TextCopyInput>
+                          {getDynamicText({value, fixed: 'PERCY_CLIENT_ID'})}
+                        </TextCopyInput>
+                      );
+                    }}
+                  </FormField>
+                  <FormField overflow name="installation" label="Installation ID">
+                    {({value}) => {
+                      return (
+                        <TextCopyInput>
+                          {getDynamicText({value: value.uuid, fixed: 'PERCY_CLIENT_ID'})}
+                        </TextCopyInput>
+                      );
+                    }}
+                  </FormField>
+                </PanelBody>
+              ) : (
+                <PanelBody>
+                  <FormField name="clientId" label="Client ID" overflow>
+                    {({value}) => {
+                      return (
+                        <TextCopyInput>
+                          {getDynamicText({value, fixed: 'PERCY_CLIENT_ID'})}
+                        </TextCopyInput>
+                      );
+                    }}
+                  </FormField>
+                  <FormField overflow name="clientSecret" label="Client Secret">
+                    {({value}) => {
+                      return value ? (
+                        <TextCopyInput>
+                          {getDynamicText({value, fixed: 'PERCY_CLIENT_SECRET'})}
+                        </TextCopyInput>
+                      ) : (
+                        <em>hidden</em>
+                      );
+                    }}
+                  </FormField>
+                </PanelBody>
+              )}
             </Panel>
           )}
         </Form>

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
@@ -126,7 +126,7 @@ export default class SentryApplicationDetails extends AsyncView {
                     {({value}) => {
                       return (
                         <TextCopyInput>
-                          {getDynamicText({value, fixed: 'PERCY_CLIENT_ID'})}
+                          {getDynamicText({value, fixed: 'PERCY_ACCESS_TOKEN'})}
                         </TextCopyInput>
                       );
                     }}
@@ -135,7 +135,10 @@ export default class SentryApplicationDetails extends AsyncView {
                     {({value}) => {
                       return (
                         <TextCopyInput>
-                          {getDynamicText({value: value.uuid, fixed: 'PERCY_CLIENT_ID'})}
+                          {getDynamicText({
+                            value: value.uuid,
+                            fixed: 'PERCY_INSTALLATION_ID',
+                          })}
                         </TextCopyInput>
                       );
                     }}

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
@@ -91,7 +91,7 @@ export default class SentryApplicationDetails extends AsyncView {
     const {app} = this.state;
     const scopes = (app && [...app.scopes]) || [];
     const events = (app && this.normalize(app.events)) || [];
-
+    const statusDisabled = app && app.status == 'internal' ? true : false;
     const method = app ? 'PUT' : 'POST';
     const endpoint = app ? `/sentry-apps/${app.slug}/` : '/sentry-apps/';
 
@@ -105,7 +105,7 @@ export default class SentryApplicationDetails extends AsyncView {
           initialData={{
             organization: orgId,
             isAlertable: false,
-            internal: app && app.status == 'internal' ? true : false,
+            isInternal: app && app.status == 'internal' ? true : false,
             schema: {},
             scopes: [],
             ...app,
@@ -113,7 +113,11 @@ export default class SentryApplicationDetails extends AsyncView {
           model={this.form}
           onSubmitSuccess={this.onSubmitSuccess}
         >
-          <JsonForm location={this.props.location} forms={sentryApplicationForm} />
+          <JsonForm
+            additionalFieldProps={{statusDisabled}}
+            location={this.props.location}
+            forms={sentryApplicationForm}
+          />
 
           <PermissionsObserver scopes={scopes} events={events} />
 

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
@@ -75,6 +75,7 @@ describe('Sentry Application Details', function() {
       wrapper.find('form').simulate('submit');
 
       const data = {
+        internal: false,
         name: 'Test App',
         author: 'Sentry',
         organization: org.slug,

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
@@ -97,7 +97,58 @@ describe('Sentry Application Details', function() {
     });
   });
 
-  describe('editing an existing Sentry App', () => {
+  describe('Renders application data and credentials', function() {
+    beforeEach(() => {
+      sentryApp = TestStubs.SentryApp();
+      sentryApp.events = ['issue'];
+
+      Client.addMockResponse({
+        url: `/sentry-apps/${sentryApp.slug}/`,
+        body: sentryApp,
+      });
+
+      wrapper = mount(
+        <SentryApplicationDetails params={{appSlug: sentryApp.slug, orgId}} />,
+        TestStubs.routerContext()
+      );
+    });
+
+    it('it shows application data', function() {
+      // data should be filled out
+      expect(wrapper.find('PermissionsObserver').prop('scopes')).toEqual([
+        'project:read',
+      ]);
+    });
+
+    it('renders clientId and clientSecret for non-internal apps', function() {
+      expect(wrapper.find('#clientId').exists()).toBe(true);
+      expect(wrapper.find('#clientSecret').exists()).toBe(true);
+    });
+
+    it('renders installationId and token for internal apps', function() {
+      sentryApp = TestStubs.SentryApp({
+        status: 'internal',
+        installation: {uuid: 'xxxxxx'},
+        token: 'xxxx',
+      });
+      sentryApp.events = ['issue'];
+
+      Client.addMockResponse({
+        url: `/sentry-apps/${sentryApp.slug}/`,
+        body: sentryApp,
+      });
+
+      wrapper = mount(
+        <SentryApplicationDetails params={{appSlug: sentryApp.slug, orgId}} />,
+        TestStubs.routerContext()
+      );
+
+      expect(wrapper.find('#installation').exists()).toBe(true);
+      expect(wrapper.find('#token').exists()).toBe(true);
+    });
+  });
+
+  describe('Editing an existing Sentry App', () => {
     beforeEach(() => {
       sentryApp = TestStubs.SentryApp();
       sentryApp.events = ['issue'];
@@ -117,21 +168,6 @@ describe('Sentry Application Details', function() {
         <SentryApplicationDetails params={{appSlug: sentryApp.slug, orgId}} />,
         TestStubs.routerContext()
       );
-    });
-
-    it('it shows application data and credentials', function() {
-      // data should be filled out
-      expect(wrapper.find('PermissionsObserver').prop('scopes')).toEqual([
-        'project:read',
-      ]);
-
-      // 'Credentials' should be last PanelHeader when editing an application.
-      expect(
-        wrapper
-          .find('PanelHeader')
-          .last()
-          .text()
-      ).toBe('Credentials');
     });
 
     it('it updates app with correct data', function() {

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
@@ -75,7 +75,6 @@ describe('Sentry Application Details', function() {
       wrapper.find('form').simulate('submit');
 
       const data = {
-        internal: false,
         name: 'Test App',
         author: 'Sentry',
         organization: org.slug,
@@ -83,6 +82,7 @@ describe('Sentry Application Details', function() {
         webhookUrl: 'https://webhook.com',
         scopes: observable(['member:read', 'member:admin', 'event:read', 'event:admin']),
         events: observable(['issue']),
+        isInternal: false,
         isAlertable: true,
         schema: {},
       };
@@ -97,7 +97,7 @@ describe('Sentry Application Details', function() {
     });
   });
 
-  describe('Renders application data and credentials', function() {
+  describe('Renders for non-internal apps', function() {
     beforeEach(() => {
       sentryApp = TestStubs.SentryApp();
       sentryApp.events = ['issue'];
@@ -124,8 +124,10 @@ describe('Sentry Application Details', function() {
       expect(wrapper.find('#clientId').exists()).toBe(true);
       expect(wrapper.find('#clientSecret').exists()).toBe(true);
     });
+  });
 
-    it('renders installationId and token for internal apps', function() {
+  describe('Renders for internal apps', () => {
+    beforeEach(() => {
       sentryApp = TestStubs.SentryApp({
         status: 'internal',
         installation: {uuid: 'xxxxxx'},
@@ -142,7 +144,16 @@ describe('Sentry Application Details', function() {
         <SentryApplicationDetails params={{appSlug: sentryApp.slug, orgId}} />,
         TestStubs.routerContext()
       );
-
+    });
+    it('has internal option disabled', function() {
+      expect(
+        wrapper
+          .find('Field[name="isInternal"]')
+          .find('FieldControl')
+          .prop('disabled')
+      ).toBe(true);
+    });
+    it('shows installationId and token', function() {
       expect(wrapper.find('#installation').exists()).toBe(true);
       expect(wrapper.find('#token').exists()).toBe(true);
     });

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -16,6 +16,7 @@ class SentryAppsTest(APITestCase):
         self.user = self.create_user(email='boop@example.com')
         self.org = self.create_organization(owner=self.user)
         self.super_org = self.create_organization(owner=self.superuser)
+        self.internal_org = self.create_organization(owner=self.user)
 
         self.published_app = self.create_sentry_app(
             name='Test',
@@ -34,6 +35,13 @@ class SentryAppsTest(APITestCase):
             scopes=(),
             webhook_url='https://example.com',
         )
+
+        self.create_project(organization=self.internal_org)
+        self.internal_app = self.create_internal_integration(
+            name='Internal',
+            organization=self.internal_org,
+        )
+        self.install = self.internal_app.installations.first()
 
         self.url = reverse('sentry-api-0-sentry-apps')
 
@@ -75,6 +83,36 @@ class GetSentryAppsTest(SentryAppsTest):
                 'slug': self.org.slug,
             }
         } in json.loads(response.content)
+
+    def test_users_filter_on_internal_apps(self):
+        self.login_as(user=self.user)
+        url = u'{}?status=internal'.format(self.url)
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200
+        assert {
+            'name': self.internal_app.name,
+            'author': self.internal_app.author,
+            'slug': self.internal_app.slug,
+            'scopes': [],
+            'events': [],
+            'status': self.internal_app.get_status_display(),
+            'uuid': self.internal_app.uuid,
+            'webhookUrl': self.internal_app.webhook_url,
+            'redirectUrl': self.internal_app.redirect_url,
+            'isAlertable': self.internal_app.is_alertable,
+            'overview': self.internal_app.overview,
+            'schema': {},
+            'installation': {
+                'uuid': self.install.uuid,
+            },
+            'token': self.install.api_token.token
+        } in json.loads(response.content)
+
+        response_uuids = set(o['uuid'] for o in response.data)
+        assert self.published_app.uuid not in response_uuids
+        assert self.unpublished_app.uuid not in response_uuids
+        assert self.unowned_unpublished_app.uuid not in response_uuids
 
     def test_superuser_filter_on_published(self):
         self.login_as(user=self.superuser, superuser=True)
@@ -149,16 +187,16 @@ class GetSentryAppsTest(SentryAppsTest):
         assert self.published_app.uuid not in response_uuids
         assert self.unowned_unpublished_app.uuid not in response_uuids
 
-        def test_user_filter_on_published(self):
-            self.login_as(user=self.user)
-            url = u'{}?status=published'.format(self.url)
-            response = self.client.get(url, format='json')
+    def test_user_filter_on_published(self):
+        self.login_as(user=self.user)
+        url = u'{}?status=published'.format(self.url)
+        response = self.client.get(url, format='json')
 
-            assert response.status_code == 200
-            response_uuids = set(o['uuid'] for o in response.data)
-            assert self.published_app.uuid in response_uuids
-            assert self.unpublished_app not in response_uuids
-            assert self.unowned_unpublished_app.uuid not in response_uuids
+        assert response.status_code == 200
+        response_uuids = set(o['uuid'] for o in response.data)
+        assert self.published_app.uuid in response_uuids
+        assert self.unpublished_app not in response_uuids
+        assert self.unowned_unpublished_app.uuid not in response_uuids
 
     def test_users_dont_see_unpublished_apps_their_org_owns(self):
         self.login_as(user=self.user)
@@ -177,6 +215,21 @@ class GetSentryAppsTest(SentryAppsTest):
 
         assert response.status_code == 200
         assert self.unowned_unpublished_app.uuid not in [
+            a['uuid'] for a in response.data
+        ]
+
+    def test_users_dont_see_internal_apps_outside_their_orgs(self):
+        new_org = self.create_organization()
+        self.create_project(organization=new_org)
+
+        internal_app = self.create_internal_integration(
+            name='Internal Nosee',
+            organization=new_org,
+        )
+        self.login_as(user=self.user)
+
+        response = self.client.get(self.url, format='json')
+        assert internal_app.uuid not in [
             a['uuid'] for a in response.data
         ]
 

--- a/tests/sentry/models/test_sentryapp.py
+++ b/tests/sentry/models/test_sentryapp.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from sentry.constants import SentryAppStatus
 from sentry.testutils import TestCase
 from sentry.models import ApiApplication, SentryApp
 
@@ -41,3 +42,18 @@ class SentryAppTest(TestCase):
         assert self.sentry_app.application.sentry_app == self.sentry_app
         assert self.sentry_app.proxy_user.sentry_app == self.sentry_app
         assert self.sentry_app in self.sentry_app.owner.owned_sentry_apps.all()
+
+    def test_is_unpublished(self):
+        self.sentry_app.status = SentryAppStatus.UNPUBLISHED
+        self.sentry_app.save()
+        assert self.sentry_app.is_unpublished
+
+    def test_is_published(self):
+        self.sentry_app.status = SentryAppStatus.PUBLISHED
+        self.sentry_app.save()
+        assert self.sentry_app.is_published
+
+    def test_is_internal(self):
+        self.sentry_app.status = SentryAppStatus.INTERNAL
+        self.sentry_app.save()
+        assert self.sentry_app.is_internal


### PR DESCRIPTION
This PR adds the first UI pieces for Internal Apps.

**What are internal apps?**
In short, they are a simplified version of the current applications you can build on the Sentry Integration Platform.
* No OAuth process needed
* Automatically installed and given an access token (which lasts forever unless regenerated)
* Only scoped to the Sentry organization where the application was created

**UI Changes** 
Toggle for making an app internal 
>![Screen Shot 2019-05-20 at 10 54 14 AM](https://user-images.githubusercontent.com/15368179/58041735-ad9b8880-7aed-11e9-9317-7992aaa3dce5.png)

Disable when already internal
![Screen Shot 2019-05-21 at 1 44 29 PM](https://user-images.githubusercontent.com/15368179/58135183-59240600-7bde-11e9-90f6-2b87e9c5d0df.png)

Installation ID and token are the credentials shown


