### PR TITLE
test(js): Remove `withApi` gobbling up `data-test-id`

### DIFF
--- a/src/sentry/static/sentry/app/utils/withApi.jsx
+++ b/src/sentry/static/sentry/app/utils/withApi.jsx
@@ -16,9 +16,7 @@ const withApi = WrappedComponent => {
       this.api.clear();
     }
     render() {
-      const {['data-test-id']: _, ...props} = this.props;
-
-      return <WrappedComponent api={this.api} {...props} />;
+      return <WrappedComponent api={this.api} {...this.props} />;
     }
   }
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
@@ -13,9 +13,9 @@ import LoadingIndicator from 'app/components/loadingIndicator';
 import MigrationWarnings from 'app/views/organizationIntegrations/migrationWarnings';
 import PermissionAlert from 'app/views/settings/organization/permissionAlert';
 import ProviderRow from 'app/views/organizationIntegrations/providerRow';
-import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import SentryAppInstallations from 'app/views/organizationIntegrations/sentryAppInstallations';
 import SentryTypes from 'app/sentryTypes';
+import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import withOrganization from 'app/utils/withOrganization';
 
 class OrganizationIntegrations extends AsyncComponent {
@@ -157,6 +157,7 @@ class OrganizationIntegrations extends AsyncComponent {
       <SentryAppInstallations
         key={`sentry-app-row-${key}`}
         data-test-id="integration-row"
+        api={this.api}
         organization={organization}
         installs={appInstalls}
         applications={apps}

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppInstallations.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppInstallations.jsx
@@ -12,7 +12,6 @@ import {
 } from 'app/actionCreators/sentryAppInstallations';
 import {addQueryParamsToExistingUrl} from 'app/utils/queryString';
 import {openSentryAppPermissionModal} from 'app/actionCreators/modal';
-import withApi from 'app/utils/withApi';
 
 class SentryAppInstallations extends React.Component {
   static propTypes = {
@@ -107,5 +106,4 @@ class SentryAppInstallations extends React.Component {
   }
 }
 
-export default withApi(SentryAppInstallations);
-export {SentryAppInstallations};
+export default SentryAppInstallations;

--- a/tests/js/spec/views/settings/organizationIntegrations/sentryAppInstallations.spec.jsx
+++ b/tests/js/spec/views/settings/organizationIntegrations/sentryAppInstallations.spec.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {Client} from 'app/api';
 import {mount} from 'enzyme';
 import {openSentryAppPermissionModal} from 'app/actionCreators/modal';
-import {SentryAppInstallations} from 'app/views/organizationIntegrations/sentryAppInstallations';
+import SentryAppInstallations from 'app/views/organizationIntegrations/sentryAppInstallations';
 
 jest.mock('app/actionCreators/modal', () => ({
   openSentryAppPermissionModal: jest.fn(),


### PR DESCRIPTION
This will cause very difficult to debug issues if you try to apply a `data-test-id` to a component that is wrapped with `withApi`. (especially in acceptance tests).
  This was originally implemented to solved a jest test, but this was refactored to remove wrapping `SentryAppInstallations` with the HoC. Since its parent component already has an instance of the API client, this method is cleaner anyway.