### PR TITLE
fix: Fix bug where project key ratelimits fail when a project has multiple keys (SEN-650)

### DIFF
--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -76,7 +76,10 @@ class Quota(Service):
         # XXX(epurkhiser): Avoid excessive feature manager checks (which can be
         # expensive depending on feature handlers) for project rate limits.
         # This happens on /store.
-        cache_key = u'project:{}:rate-limits'.format(key.project.id)
+        cache_key = u'project:{}:key:{}:rate-limits'.format(
+            key.project.id,
+            key.id,
+        )
 
         rate_limit = default_cache.get(cache_key)
         if rate_limit is None:

--- a/tests/sentry/quotas/test_base.py
+++ b/tests/sentry/quotas/test_base.py
@@ -43,6 +43,18 @@ class QuotaTest(TestCase):
         )
         assert self.backend.get_key_quota(key) == (0, 0)
 
+    def test_get_key_quota_multiple_keys(self):
+        # This checks for a regression where we'd cache key quotas per project
+        # rather than per key.
+        key = ProjectKey.objects.create(
+            project=self.project, rate_limit_window=None, rate_limit_count=None
+        )
+        rate_limited_key = ProjectKey.objects.create(
+            project=self.project, rate_limit_window=200, rate_limit_count=86400
+        )
+        assert self.backend.get_key_quota(key) == (0, 0)
+        assert self.backend.get_key_quota(rate_limited_key) == (86400, 200)
+
     def test_get_organization_quota_with_account_limit_and_higher_system_limit(self):
         org = self.create_organization()
         OrganizationOption.objects.set_value(org, 'sentry:account-rate-limit', 3600)
@@ -66,7 +78,9 @@ class QuotaTest(TestCase):
         with self.settings(SENTRY_DEFAULT_MAX_EVENTS_PER_MINUTE='50%', SENTRY_SINGLE_ORGANIZATION=False), self.options({'system.rate-limit': 10}):
             assert self.backend.get_organization_quota(org) == (5, 60)
 
-    def test_get_organization_quota_with_no_account_limit_and_relative_system_limit_single_org(self):
+    def test_get_organization_quota_with_no_account_limit_and_relative_system_limit_single_org(
+        self,
+    ):
         org = self.create_organization()
         with self.settings(SENTRY_DEFAULT_MAX_EVENTS_PER_MINUTE='50%', SENTRY_SINGLE_ORGANIZATION=True), self.options({'system.rate-limit': 10}):
             assert self.backend.get_organization_quota(org) == (10, 60)


### PR DESCRIPTION
We have a problem where a customer is complaining that their per key rate limits aren't being
respected.

This happens because `Quota.get_key_quota` caches on the project level, where it should be caching
on the specific key. Since we cache for 10 minutes, this means that whichever key gets called first
caches its rate limit settings, meaning that we randomly have incorrect settings for a given key.

Just need to switch this to cache per key rather than just project.