### PR TITLE
fix(API): Remove deprecated parameter from org index endpoint docstring

### DIFF
--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -63,8 +63,6 @@ class OrganizationIndexEndpoint(Endpoint):
         user bound context.  For API key based requests this will
         only return the organization that belongs to the key.
 
-        :qparam bool member: restrict results to organizations which you have
-                             membership
         :qparam bool owner: restrict results to organizations in which you are
                             an organization owner
 


### PR DESCRIPTION
Seems like a legacy parameter, possibly? In any case, we don't use it anywhere in the endpoint, so let's not tell people they can send it.

~Once https://github.com/getsentry/sentry/pull/13077 gets merged, this should be rebased, then merged.~ DONE 

Then the API docs need to be regenerated, and those changes added to https://github.com/getsentry/sentry-docs/pull/983 before it's merged.