### PR TITLE
(fix) do not fully destroy SOUTH_DATABASE_ADAPTERS setting while init

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -380,7 +380,7 @@ def validate_options(settings):
 
 
 def fix_south(settings):
-    settings.SOUTH_DATABASE_ADAPTERS = {}
+    settings.SOUTH_DATABASE_ADAPTERS = getattr(settings, 'SOUTH_DATABASE_ADAPTERS', {})
 
     # South needs an adapter defined conditionally
     for key, value in six.iteritems(settings.DATABASES):


### PR DESCRIPTION
Hi! Founded problem with `settings.SOUTH_DATABASE_ADAPTERS`
When engine is not sentry.db.postgres there is no possibility to SET SOUTH_DATABASE_ADAPTERS['default'] (which is mandatory for south), cause sentry initializer resets its value to empty dict

This PR fixes problem, SOUTH_DATABASE_ADAPTERS resets to empty dict only if it does not already exists


e.g.: we have
`DATABASES['default']['ENGINE']: 'my_super_postgre_driver'`
and
`SOUTH_DATABASE_ADAPTERS = {'default': 'south.db.postgresql_psycopg2'}`

now correct SOUTH_DATABASE_ADAPTERS would be passed to south module