### PR TITLE
fix: Render correct download link for event attachments

### DIFF
--- a/src/sentry/static/sentry/app/utils/attachmentUrl.jsx
+++ b/src/sentry/static/sentry/app/utils/attachmentUrl.jsx
@@ -41,7 +41,7 @@ class AttachmentUrl extends React.PureComponent {
 
   getDownloadUrl(attachment) {
     const {organization, event, projectId} = this.props;
-    return `/api/0/projects/${organization.id}/${projectId}/events/${
+    return `/api/0/projects/${organization.slug}/${projectId}/events/${
       event.id
     }/attachments/${attachment.id}/?download=1`;
   }


### PR DESCRIPTION
Regression in the last refactor. Turns out that `orgId == organization.slug`.