### PR TITLE
fix(ui): Fix minor issue with attachment downloads

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventAttachments.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventAttachments.jsx
@@ -102,13 +102,11 @@ class EventAttachments extends React.Component {
                           <Button
                             size="xsmall"
                             icon="icon-download"
-                            onClick={
-                              downloadUrl && (() => (window.location = downloadUrl))
-                            }
+                            href={downloadUrl}
                             disabled={!downloadUrl}
                             title={
                               !downloadUrl &&
-                              t('Insufficient permissions to download artifacts')
+                              t('Insufficient permissions to download attachments')
                             }
                           >
                             {t('Download')}

--- a/src/sentry/static/sentry/app/views/projectDebugFiles.jsx
+++ b/src/sentry/static/sentry/app/views/projectDebugFiles.jsx
@@ -196,7 +196,7 @@ class ProjectDebugSymbols extends AsyncComponent {
                 <Button
                   size="xsmall"
                   icon="icon-download"
-                  onClick={() => (window.location = url)}
+                  href={url}
                   disabled={!hasAccess}
                   css={{
                     marginRight: space(0.5),


### PR DESCRIPTION
Fixes the hover text for attachment download and uses a proper `href` to download.
Also applying the same fix to the debug file download, where this download button was copied from.