### PR TITLE
ref(ui): Move formatting function out of `<Count>`

### DIFF
--- a/src/sentry/static/sentry/app/components/count.jsx
+++ b/src/sentry/static/sentry/app/components/count.jsx
@@ -1,50 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import createReactClass from 'create-react-class';
+import formatAbbreviatedNumber from 'app/utils/formatAbbreviatedNumber';
 
-export default createReactClass({
-  displayName: 'count',
-
-  propTypes: {
-    value: PropTypes.any.isRequired,
-  },
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return this.props.value !== nextProps.value;
-  },
-
-  numberFormats: [[1000000000, 'b'], [1000000, 'm'], [1000, 'k']],
-
-  floatFormat(number, places) {
-    const multi = Math.pow(10, places);
-    return parseInt(number * multi, 10) / multi;
-  },
-
-  formatNumber(number) {
-    let b, x, y, o, p;
-
-    number = parseInt(number, 10);
-
-    /*eslint no-cond-assign:0*/
-    for (let i = 0; (b = this.numberFormats[i]); i++) {
-      x = b[0];
-      y = b[1];
-      o = Math.floor(number / x);
-      p = number % x;
-      if (o > 0) {
-        if (o / 10 > 1 || !p) {
-          return '' + o + y;
-        }
-        return '' + this.floatFormat(number / x, 1) + y;
-      }
-    }
-    return '' + number.toLocaleString();
-  },
-
+export default class Count extends React.PureComponent {
+  static propTypes = {
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  };
   render() {
     const {value, className} = this.props;
 
-    return <span className={className}>{this.formatNumber(value)}</span>;
-  },
-});
+    return <span className={className}>{formatAbbreviatedNumber(value)}</span>;
+  }
+}

--- a/src/sentry/static/sentry/app/utils/formatAbbreviatedNumber.jsx
+++ b/src/sentry/static/sentry/app/utils/formatAbbreviatedNumber.jsx
@@ -1,0 +1,27 @@
+const numberFormats = [[1000000000, 'b'], [1000000, 'm'], [1000, 'k']];
+
+function floatFormat(number, places) {
+  const multi = Math.pow(10, places);
+  return parseInt(number * multi, 10) / multi;
+}
+
+export default function formatNumber(number) {
+  let b, x, y, o, p;
+
+  number = parseInt(number, 10);
+
+  // eslint-disable-next-line no-cond-assign
+  for (let i = 0; (b = numberFormats[i]); i++) {
+    x = b[0];
+    y = b[1];
+    o = Math.floor(number / x);
+    p = number % x;
+    if (o > 0) {
+      if (o / 10 > 1 || !p) {
+        return '' + o + y;
+      }
+      return '' + floatFormat(number / x, 1) + y;
+    }
+  }
+  return '' + number.toLocaleString();
+}

--- a/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/releaseStats.spec.jsx.snap
@@ -362,13 +362,13 @@ exports[`GroupReleaseStats renders 1`] = `
                   <span
                     className="max-y"
                   >
-                    <count
+                    <Count
                       value={10}
                     >
                       <span>
                         10
                       </span>
-                    </count>
+                    </Count>
                   </span>
                   <span
                     className="min-y"
@@ -925,13 +925,13 @@ exports[`GroupReleaseStats renders 1`] = `
                   <span
                     className="max-y"
                   >
-                    <count
+                    <Count
                       value={122}
                     >
                       <span>
                         122
                       </span>
-                    </count>
+                    </Count>
                   </span>
                   <span
                     className="min-y"

--- a/tests/js/spec/utils/formatAbbreviatedNumber.spec.jsx
+++ b/tests/js/spec/utils/formatAbbreviatedNumber.spec.jsx
@@ -1,0 +1,21 @@
+import formatAbbreviatedNumber from 'app/utils/formatAbbreviatedNumber';
+
+describe('formatAbbreviatedNumber()', function() {
+  it('should abbreviate numbers', function() {
+    expect(formatAbbreviatedNumber(0)).toBe('0');
+    expect(formatAbbreviatedNumber(100)).toBe('100');
+    expect(formatAbbreviatedNumber(1000)).toBe('1k');
+    expect(formatAbbreviatedNumber(10000000)).toBe('10m');
+    expect(formatAbbreviatedNumber(100000000000)).toBe('100b');
+    expect(formatAbbreviatedNumber(1000000000000)).toBe('1000b');
+  });
+
+  it('should abbreviate numbers that are strings', function() {
+    expect(formatAbbreviatedNumber('00')).toBe('0');
+    expect(formatAbbreviatedNumber('100')).toBe('100');
+    expect(formatAbbreviatedNumber('1000')).toBe('1k');
+    expect(formatAbbreviatedNumber('10000000')).toBe('10m');
+    expect(formatAbbreviatedNumber('100000000000')).toBe('100b');
+    expect(formatAbbreviatedNumber('1000000000000')).toBe('1000b');
+  });
+});

--- a/tests/js/spec/views/groupDetails/__snapshots__/groupSimilar.spec.jsx.snap
+++ b/tests/js/spec/views/groupDetails/__snapshots__/groupSimilar.spec.jsx.snap
@@ -1570,7 +1570,7 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                 <div
                   className="similar-score-columns"
                 >
-                  <count
+                  <Count
                     className="similar-score-column"
                     value="90"
                   >
@@ -1579,7 +1579,7 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                     >
                       90
                     </span>
-                  </count>
+                  </Count>
                   <div
                     className="similar-score-column"
                     key="exception"

--- a/tests/js/spec/views/organizationProjectsDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/organizationProjectsDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -675,13 +675,13 @@ exports[`ProjectCard renders 1`] = `
                               <span
                                 className="max-y"
                               >
-                                <count
+                                <Count
                                   value={10}
                                 >
                                   <span>
                                     10
                                   </span>
-                                </count>
+                                </Count>
                               </span>
                               <span
                                 className="min-y"


### PR DESCRIPTION
Move it into `app/utils` so it can be re-used, and refactor `<Count>` to use es6 class + PureComponent