### PR TITLE
feat(events-v2): Add data for pre-defined events views

### DIFF
--- a/src/sentry/static/sentry/app/components/links/listLink.jsx
+++ b/src/sentry/static/sentry/app/components/links/listLink.jsx
@@ -9,7 +9,7 @@ class ListLink extends React.Component {
 
   static propTypes = {
     activeClassName: PropTypes.string.isRequired,
-    to: PropTypes.string.isRequired,
+    to: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
     query: PropTypes.object,
     onClick: PropTypes.func,
     index: PropTypes.bool,

--- a/src/sentry/static/sentry/app/sentryTypes.jsx
+++ b/src/sentry/static/sentry/app/sentryTypes.jsx
@@ -111,6 +111,19 @@ const DiscoverResultsShape = {
 
 export const DiscoverResults = PropTypes.arrayOf(PropTypes.shape(DiscoverResultsShape));
 
+export const EventView = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  data: PropTypes.shape({
+    query: PropTypes.string.isRequired,
+    fields: PropTypes.arrayOf(PropTypes.string).isRequired,
+    groupBy: PropTypes.arrayOf(PropTypes.string).isRequired,
+    aggregations: PropTypes.arrayOf(PropTypes.array).isRequired,
+    sort: PropTypes.string.isRequired,
+  }).isRequired,
+  tags: PropTypes.arrayOf(PropTypes.string).isRequired,
+});
+
 /**
  * A Member is someone that was invited to Sentry but may
  * not have registered for an account yet
@@ -955,6 +968,7 @@ const SentryTypes = {
   Environment,
   Event,
   EventAttachment,
+  EventView,
   Organization: PropTypes.shape({
     id: PropTypes.string.isRequired,
   }),

--- a/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/index.jsx
@@ -41,7 +41,7 @@ class OrganizationEventsContainer extends React.Component {
   };
 
   render() {
-    const {organization, location, children} = this.props;
+    const {organization, location, children, ...props} = this.props;
 
     const hasEventsV2 = new Set(organization.features).has('events-v2');
 
@@ -54,6 +54,8 @@ class OrganizationEventsContainer extends React.Component {
             )
           }
           organization={organization}
+          location={location}
+          {...props}
         />
       );
     }

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/events.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import SentryTypes from 'app/sentryTypes';
+
+export default class Events extends React.Component {
+  static propTypes = {
+    view: SentryTypes.EventView.isRequired,
+  };
+  render() {
+    return this.props.view.name;
+  }
+}

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/index.jsx
@@ -26,18 +26,18 @@ export default class OrganizationEventsV2 extends React.Component {
 
     return (
       <NavTabs underlined={true}>
-        {ALL_VIEWS.map(view => {
-          const query = view.id === 'all' ? '' : `?view=${view.id}`;
-          return (
-            <ListLink
-              key={view.id}
-              to={`/organizations/${organization.slug}/events/${query}`}
-              isActive={() => view.id === currentView.id}
-            >
-              {view.name}
-            </ListLink>
-          );
-        })}
+        {ALL_VIEWS.map(view => (
+          <ListLink
+            key={view.id}
+            to={{
+              pathname: `/organizations/${organization.slug}/events/`,
+              query: {...this.props.location.query, view: view.id},
+            }}
+            isActive={() => view.id === currentView.id}
+          >
+            {view.name}
+          </ListLink>
+        ))}
       </NavTabs>
     );
   }

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import DocumentTitle from 'react-document-title';
+import PropTypes from 'prop-types';
 
 import {t} from 'app/locale';
 import SentryTypes from 'app/sentryTypes';
@@ -7,14 +8,42 @@ import GlobalSelectionHeader from 'app/components/organizations/globalSelectionH
 import {PageContent, PageHeader} from 'app/styles/organization';
 import PageHeading from 'app/components/pageHeading';
 import BetaTag from 'app/components/betaTag';
+import NavTabs from 'app/components/navTabs';
+import ListLink from 'app/components/links/listLink';
+
+import Events from './events';
+import {ALL_VIEWS, getCurrentView} from './utils';
 
 export default class OrganizationEventsV2 extends React.Component {
   static propTypes = {
-    organization: SentryTypes.Organization,
+    organization: SentryTypes.Organization.isRequired,
+    location: PropTypes.object,
   };
 
-  render() {
+  renderTabs() {
     const {organization} = this.props;
+    const currentView = getCurrentView(this.props.location.query.view);
+
+    return (
+      <NavTabs underlined={true}>
+        {ALL_VIEWS.map(view => {
+          const query = view.id === 'all' ? '' : `?view=${view.id}`;
+          return (
+            <ListLink
+              key={view.id}
+              to={`/organizations/${organization.slug}/events/${query}`}
+              isActive={() => view.id === currentView.id}
+            >
+              {view.name}
+            </ListLink>
+          );
+        })}
+      </NavTabs>
+    );
+  }
+
+  render() {
+    const {organization, location} = this.props;
 
     return (
       <DocumentTitle title={`Events - ${organization.slug} - Sentry`}>
@@ -26,6 +55,8 @@ export default class OrganizationEventsV2 extends React.Component {
                 {t('Events')} <BetaTag />
               </PageHeading>
             </PageHeader>
+            {this.renderTabs()}
+            <Events view={getCurrentView(location.query.view)} />
           </PageContent>
         </React.Fragment>
       </DocumentTitle>

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/utils.jsx
@@ -1,3 +1,66 @@
 export function fetchOrganizationEvents(api, orgSlug, data) {
   return api.requestPromise(`/organizations/${orgSlug}/events/`, data);
 }
+
+export const ALL_VIEWS = [
+  {
+    id: 'all',
+    name: 'All Events',
+    data: {
+      query: '',
+      fields: ['title', 'event.type', 'project.name', 'user.email', 'time'],
+      groupBy: [],
+      aggregations: [],
+      sort: '',
+    },
+    tags: [
+      'event.type',
+      'release',
+      'project.name',
+      'user.email',
+      'user.ip',
+      'environment',
+    ],
+  },
+  {
+    id: 'errors',
+    name: 'Errors',
+    data: {
+      query: '',
+      fields: ['project.name', 'fingerprint', 'count', 'user_count'],
+      groupBy: ['count', 'user_count', 'project.name'],
+      aggregations: [['count', null, 'count'], ['count', 'user', 'user_count']],
+      sort: '',
+    },
+    tags: ['error.type', 'project.name'],
+  },
+  {
+    id: 'csp',
+    name: 'CSP',
+    data: {
+      query: '',
+      fields: ['project.name', 'count', 'user_count'],
+      groupBy: ['count', 'user_count', 'project.name'],
+      aggregations: [['count', null, 'count'], ['count', 'user', 'user_count']],
+      sort: '',
+    },
+    tags: [
+      'project.name',
+      'blocked-uri',
+      'browser.name',
+      'os.name',
+      'effective-directive',
+    ],
+  },
+];
+
+/**
+ * Given a view id, return the corresponding view object
+ *
+ * @param {String} requestedView
+ * @returns {Object}
+ *
+ */
+export function getCurrentView(requestedView) {
+  return ALL_VIEWS.find(view => view.id === requestedView) || ALL_VIEWS[0];
+}

--- a/tests/js/spec/views/organizationEventsV2/index.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/index.spec.jsx
@@ -6,7 +6,10 @@ import OrganizationEventsV2 from 'app/views/organizationEventsV2';
 describe('OrganizationEventsV2', function() {
   it('renders', function() {
     const wrapper = mount(
-      <OrganizationEventsV2 organization={TestStubs.Organization()} />,
+      <OrganizationEventsV2
+        organization={TestStubs.Organization()}
+        location={{query: {}}}
+      />,
       TestStubs.routerContext()
     );
     const content = wrapper.find('PageContent');

--- a/tests/js/spec/views/organizationEventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/utils.spec.jsx
@@ -1,0 +1,14 @@
+import {ALL_VIEWS, getCurrentView} from 'app/views/organizationEventsV2/utils';
+
+describe('getCurrentView()', function() {
+  it('returns current view', function() {
+    expect(getCurrentView('all')).toBe(ALL_VIEWS[0]);
+    expect(getCurrentView('errors')).toBe(ALL_VIEWS[1]);
+    expect(getCurrentView('csp')).toBe(ALL_VIEWS[2]);
+  });
+
+  it('returns default if invalid', function() {
+    expect(getCurrentView(undefined)).toBe(ALL_VIEWS[0]);
+    expect(getCurrentView('blah')).toBe(ALL_VIEWS[0]);
+  });
+});


### PR DESCRIPTION
Add data model to specify the 3 pre-defined events views. Add tabs UI
allowing toggling between the the 3 views.