### PR TITLE
chore: Remove usage of SubfieldBase as it is deprecated

### DIFF
--- a/src/sentry/db/models/fields/encrypted.py
+++ b/src/sentry/db/models/fields/encrypted.py
@@ -7,14 +7,22 @@ __all__ = (
 import six
 
 from django.conf import settings
-from django.db import models
 from django.db.models import CharField, TextField
 from jsonfield import JSONField
 from picklefield.fields import PickledObjectField
+from sentry.db.models.utils import Creator
 from sentry.utils.encryption import decrypt, encrypt
 
 
 class EncryptedCharField(CharField):
+    def contribute_to_class(self, cls, name):
+        """
+        Add a descriptor for backwards compatibility
+        with previous Django behavior.
+        """
+        super(EncryptedCharField, self).contribute_to_class(cls, name)
+        setattr(cls, name, Creator(self))
+
     def get_db_prep_value(self, value, *args, **kwargs):
         value = super(EncryptedCharField, self).get_db_prep_value(value, *args, **kwargs)
         return encrypt(value)
@@ -74,6 +82,14 @@ class EncryptedPickledObjectField(PickledObjectField):
 
 
 class EncryptedTextField(TextField):
+    def contribute_to_class(self, cls, name):
+        """
+        Add a descriptor for backwards compatibility
+        with previous Django behavior.
+        """
+        super(EncryptedTextField, self).contribute_to_class(cls, name)
+        setattr(cls, name, Creator(self))
+
     def get_db_prep_value(self, value, *args, **kwargs):
         value = super(EncryptedTextField, self).get_db_prep_value(value, *args, **kwargs)
         return encrypt(value)
@@ -91,10 +107,6 @@ class EncryptedTextField(TextField):
             )
         )
 
-
-if hasattr(models, 'SubfieldBase'):
-    EncryptedCharField = six.add_metaclass(models.SubfieldBase)(EncryptedCharField)
-    EncryptedTextField = six.add_metaclass(models.SubfieldBase)(EncryptedTextField)
 
 if 'south' in settings.INSTALLED_APPS:
     from south.modelsinspector import add_introspection_rules

--- a/src/sentry/db/models/utils.py
+++ b/src/sentry/db/models/utils.py
@@ -109,3 +109,22 @@ def slugify_instance(inst, label, reserved=(), max_length=30, field_name='slug',
 
     # If at this point, we've exhausted all possibilities, we'll just end up hitting
     # an IntegrityError from database, which is ok, and unlikely to happen
+
+
+class Creator(object):
+    """
+    A descriptor that invokes `to_python` when attributes are set.
+    This provides backwards compatibility for fields that used to use
+    SubfieldBase which will be removed in Django1.10
+    """
+
+    def __init__(self, field):
+        self.field = field
+
+    def __get__(self, obj, type=None):
+        if obj is None:
+            return self
+        return obj.__dict__[self.field.name]
+
+    def __set__(self, obj, value):
+        obj.__dict__[self.field.name] = self.field.to_python(value)


### PR DESCRIPTION
We currently get deprecation warnings on each process startup because we're using django.db.models.Subfieldbase.

Django documentation recommends that anyone needing the descriptor behavior that was offered in earlier versions port it manually to their applications. We do depend on the descriptor behavior as a number of tests failed when I attempted to move our code to use `from_db_value()` and `to_python()`.

See https://docs.djangoproject.com/en/1.8/releases/1.8/#subfieldbase and
https://github.com/django/django/blob/stable/1.8.x/django/db/models/fields/subclassing.py#L31-L44 for the origins of the Creator class.

Refs SEN-618