### PR TITLE
chore: Remove unused re-export for tooltips

### DIFF
--- a/src/sentry/static/sentry/app/components/tooltip2.jsx
+++ b/src/sentry/static/sentry/app/components/tooltip2.jsx
@@ -1,4 +1,0 @@
-import Tooltip from 'app/components/tooltip';
-
-// Re-export for backwards compatibility and getsentry.
-export default Tooltip;


### PR DESCRIPTION
This module has no references in either sentry or getsentry.

Refs SEN-633