### PR TITLE
ref(ui): Extract tag distribution meter into a separate component

### DIFF
--- a/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
+++ b/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
@@ -1,21 +1,15 @@
-import {Link} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import styled from 'react-emotion';
-import isPropValid from '@emotion/is-prop-valid';
 
-import {percent} from 'app/utils';
 import {t} from 'app/locale';
-import DeviceName, {
-  deviceNameMapper,
-  loadDeviceListModule,
-} from 'app/components/deviceName';
+import {deviceNameMapper, loadDeviceListModule} from 'app/components/deviceName';
 import SentryTypes from 'app/sentryTypes';
-import Tooltip from 'app/components/tooltip';
 import withEnvironment from 'app/utils/withEnvironment';
 
-const TagDistributionMeter = createReactClass({
+import TagDistributionMeter from 'app/components/tagDistributionMeter';
+
+const GroupTagDistributionMeter = createReactClass({
   displayName: 'TagDistributionMeter',
 
   propTypes: {
@@ -80,194 +74,53 @@ const TagDistributionMeter = createReactClass({
       });
   },
 
-  /**
-   * Render segments of tag distribution
-   *
-   * e.g.
-   *
-   * .--------.-----.----------------.
-   * |  web-1 |web-2|     other      |
-   * `--------'-----'----------------'
-   */
+  render() {
+    const {organization, projectId, group, tag, totalValues, topValues} = this.props;
+    const {loading, error} = this.state;
 
-  renderSegments() {
-    const {organization, projectId, group, totalValues, topValues, tag} = this.props;
     const hasSentry10 = new Set(organization.features).has('sentry10');
 
-    const totalVisible = topValues.reduce((sum, value) => sum + value.count, 0);
-    const hasOther = totalVisible < totalValues;
-    const otherPct = percent(totalValues - totalVisible, totalValues);
-    const otherPctLabel = Math.floor(otherPct);
     const url = hasSentry10
       ? `/organizations/${organization.slug}/issues/${group.id}/tags/${tag}/`
       : `/${organization.slug}/${projectId}/issues/${group.id}/tags/${tag}/`;
 
-    return (
-      <React.Fragment>
-        {topValues.map((value, index) => {
-          const pct = percent(value.count, totalValues);
-          const pctLabel = Math.floor(pct);
+    let segments = [];
 
-          const tooltipHtml = (
-            <React.Fragment>
-              <div className="truncate">
-                {deviceNameMapper(value.name || '', this.state.iOSDeviceList) || ''}
-              </div>
-              {pctLabel}%
-            </React.Fragment>
-          );
+    if (topValues) {
+      const totalVisible = topValues.reduce((sum, value) => sum + value.count, 0);
+      const hasOther = totalVisible < totalValues;
 
-          return (
-            <Tooltip key={value.value} title={tooltipHtml} containerDisplayMode="inline">
-              <Segment
-                style={{width: pct + '%'}}
-                to={url}
-                index={index}
-                first={index == 0}
-                last={!hasOther && index == topValues.length - 1}
-              >
-                <Description first={index == 0}>
-                  <Percentage>{pctLabel}%</Percentage>
-                  <Label>
-                    <DeviceName>{value.name}</DeviceName>
-                  </Label>
-                </Description>
-              </Segment>
-            </Tooltip>
-          );
-        })}
-        {hasOther && (
-          <Tooltip
-            key="other"
-            containerDisplayMode="inline"
-            title={
-              <React.Fragment>
-                Other
-                <br />
-                {otherPctLabel}%
-              </React.Fragment>
-            }
-          >
-            <Segment
-              index={9}
-              first={!topValues.length}
-              last={true}
-              css={{width: otherPct + '%'}}
-              to={url}
-            >
-              <Description first={!topValues.length}>
-                <Percentage>{otherPctLabel}%</Percentage>
-                <Label>{t('Other')}</Label>
-              </Description>
-            </Segment>
-          </Tooltip>
-        )}
-      </React.Fragment>
-    );
-  },
+      if (hasOther) {
+        topValues.push({
+          value: 'other',
+          name: t('Other'),
+          count: totalValues - totalVisible,
+        });
+      }
 
-  renderBody() {
-    if (this.state.loading || this.state.error) {
-      return null;
+      segments = this.state.iOSDeviceList
+        ? topValues.map(value => ({
+            ...value,
+            name: deviceNameMapper(value.name || '', this.state.iOSDeviceList) || '',
+            url,
+          }))
+        : topValues.map(value => ({
+            ...value,
+            url,
+          }));
     }
 
-    if (!this.props.totalValues) {
-      return <p>{t('No recent data.')}</p>;
-    }
-
-    return this.renderSegments();
-  },
-
-  render() {
     return (
-      <DistributionGraph>
-        <Tag>{this.props.tag}</Tag>
-        {this.renderBody()}
-      </DistributionGraph>
+      <TagDistributionMeter
+        title={tag}
+        totalValues={totalValues}
+        isLoading={loading}
+        hasError={error}
+        segments={segments}
+      />
     );
   },
 });
 
-const DistributionGraph = styled('div')`
-  position: relative;
-  font-size: 13px;
-  margin-bottom: 10px;
-`;
-
-const Tag = styled('div')`
-  position: relative;
-  font-size: 13px;
-  margin: 10px 0 8px;
-  font-weight: bold;
-  z-index: 5;
-  line-height: 1;
-`;
-
-const Description = styled('span', {shouldForwardProp: isPropValid})`
-  background-color: #fff;
-  position: absolute;
-  text-align: right;
-  top: -1px;
-  right: 0;
-  line-height: 1;
-  z-index: 1;
-  width: 100%;
-  display: ${p => (p.first ? 'block' : 'none')};
-
-  &:hover {
-    display: block;
-    z-index: 2;
-  }
-`;
-
-const Percentage = styled('span')`
-  margin-right: 6px;
-  color: ${p => p.theme.gray2};
-  display: inline-block;
-  vertical-align: middle;
-`;
-
-const Label = styled('span')`
-  display: inline-block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 45%;
-  vertical-align: middle;
-`;
-
-const getColor = p => {
-  return [
-    '#7c7484',
-    '#867f90',
-    '#918a9b',
-    '#9b96a7',
-    '#a6a1b3',
-    '#b0acbe',
-    '#bbb7ca',
-    '#c5c3d6',
-    '#d0cee1',
-    '#dad9ed',
-  ][p.index];
-};
-
-const Segment = styled(Link, {shouldForwardProp: isPropValid})`
-  height: 16px;
-  display: inline-block;
-  color: inherit;
-
-  &:hover {
-    background: ${p => p.theme.purple};
-  }
-
-  border-top-left-radius: ${p => p.first && p.theme.borderRadius};
-  border-bottom-left-radius: ${p => p.first && p.theme.borderRadius};
-
-  border-top-right-radius: ${p => p.last && p.theme.borderRadius};
-  border-bottom-right-radius: ${p => p.last && p.theme.borderRadius};
-
-  background-color: ${getColor};
-`;
-
-export {TagDistributionMeter};
-export default withEnvironment(TagDistributionMeter);
+export {GroupTagDistributionMeter};
+export default withEnvironment(GroupTagDistributionMeter);

--- a/src/sentry/static/sentry/app/components/tagDistributionMeter/index.jsx
+++ b/src/sentry/static/sentry/app/components/tagDistributionMeter/index.jsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import {Link} from 'react-router';
+import PropTypes from 'prop-types';
+import styled from 'react-emotion';
+import isPropValid from '@emotion/is-prop-valid';
+
+import {t} from 'app/locale';
+import {percent} from 'app/utils';
+import Tooltip from 'app/components/tooltip';
+
+export default class TagDistributionMeter extends React.Component {
+  static propTypes = {
+    title: PropTypes.string.isRequired,
+    totalValues: PropTypes.number,
+    isLoading: PropTypes.bool,
+    hasError: PropTypes.bool,
+    segments: PropTypes.arrayOf(
+      PropTypes.shape({
+        count: PropTypes.number.isRequired,
+        name: PropTypes.string.isRequired,
+        value: PropTypes.string.isRequired,
+        url: PropTypes.string.isRequired,
+      })
+    ).isRequired,
+    renderEmpty: PropTypes.func,
+    renderLoading: PropTypes.func,
+    renderError: PropTypes.func,
+  };
+
+  static defaultProps = {
+    isLoading: false,
+    hasError: false,
+    renderLoading: () => null,
+    renderEmpty: () => <p>{t('No recent data.')}</p>,
+    renderError: () => null,
+  };
+
+  renderSegments() {
+    const {segments, totalValues} = this.props;
+
+    return (
+      <React.Fragment>
+        {segments.map((value, index) => {
+          const pct = percent(value.count, totalValues);
+          const pctLabel = Math.floor(pct);
+
+          const tooltipHtml = (
+            <React.Fragment>
+              <div className="truncate">{value.name}</div>
+              {pctLabel}%
+            </React.Fragment>
+          );
+
+          return (
+            <Tooltip key={value.value} title={tooltipHtml} containerDisplayMode="inline">
+              <Segment
+                style={{width: pct + '%'}}
+                to={value.url}
+                index={index}
+                first={index === 0}
+                last={index === segments.length - 1}
+              >
+                <Description first={index == 0}>
+                  <Percentage>{pctLabel}%</Percentage>
+                  <Label>{value.name}</Label>
+                </Description>
+              </Segment>
+            </Tooltip>
+          );
+        })}
+      </React.Fragment>
+    );
+  }
+
+  renderTag() {
+    const {
+      isLoading,
+      hasError,
+      totalValues,
+      renderLoading,
+      renderError,
+      renderEmpty,
+    } = this.props;
+
+    if (isLoading) {
+      return renderLoading();
+    }
+
+    if (hasError) {
+      return renderError();
+    }
+
+    if (!totalValues) {
+      return renderEmpty();
+    }
+
+    return this.renderSegments();
+  }
+
+  render() {
+    const {title} = this.props;
+
+    return (
+      <DistributionGraph>
+        <Title>{title}</Title>
+        {this.renderTag()}
+      </DistributionGraph>
+    );
+  }
+}
+
+const DistributionGraph = styled('div')`
+  position: relative;
+  font-size: 13px;
+  margin-bottom: 10px;
+`;
+
+const Title = styled('div')`
+  position: relative;
+  font-size: 13px;
+  margin: 10px 0 8px;
+  font-weight: bold;
+  z-index: 5;
+  line-height: 1;
+`;
+
+const getColor = p => {
+  return [
+    '#7c7484',
+    '#867f90',
+    '#918a9b',
+    '#9b96a7',
+    '#a6a1b3',
+    '#b0acbe',
+    '#bbb7ca',
+    '#c5c3d6',
+    '#d0cee1',
+    '#dad9ed',
+  ][p.index];
+};
+
+const Segment = styled(Link, {shouldForwardProp: isPropValid})`
+  height: 16px;
+  display: inline-block;
+  color: inherit;
+
+  &:hover {
+    background: ${p => p.theme.purple};
+  }
+
+  border-top-left-radius: ${p => p.first && p.theme.borderRadius};
+  border-bottom-left-radius: ${p => p.first && p.theme.borderRadius};
+
+  border-top-right-radius: ${p => p.last && p.theme.borderRadius};
+  border-bottom-right-radius: ${p => p.last && p.theme.borderRadius};
+
+  background-color: ${getColor};
+`;
+
+const Description = styled('span', {shouldForwardProp: isPropValid})`
+  background-color: #fff;
+  position: absolute;
+  text-align: right;
+  top: -1px;
+  right: 0;
+  line-height: 1;
+  z-index: 1;
+  width: 100%;
+  display: ${p => (p.first ? 'block' : 'none')};
+
+  &:hover {
+    display: block;
+    z-index: 2;
+  }
+`;
+
+const Percentage = styled('span')`
+  margin-right: 6px;
+  color: ${p => p.theme.gray2};
+  display: inline-block;
+  vertical-align: middle;
+`;
+
+const Label = styled('span')`
+  display: inline-block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 45%;
+  vertical-align: middle;
+`;

--- a/tests/js/spec/components/group/tagDistributionMeter.spec.jsx
+++ b/tests/js/spec/components/group/tagDistributionMeter.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mount} from 'enzyme';
 
-import {TagDistributionMeter} from 'app/components/group/tagDistributionMeter';
+import {GroupTagDistributionMeter} from 'app/components/group/tagDistributionMeter';
 
 describe('TagDistributionMeter', function() {
   let element;
@@ -13,7 +13,7 @@ describe('TagDistributionMeter', function() {
     organization = TestStubs.Organization();
 
     element = mount(
-      <TagDistributionMeter
+      <GroupTagDistributionMeter
         key="element"
         tag="browser"
         group={{id: '1337'}}
@@ -25,7 +25,7 @@ describe('TagDistributionMeter', function() {
     );
 
     emptyElement = mount(
-      <TagDistributionMeter
+      <GroupTagDistributionMeter
         key="emptyElement"
         tag="browser"
         group={{id: '1337'}}


### PR DESCRIPTION
This will make it easier to reuse outside of a single issue context in
future.