### PR TITLE
fix(sidebar): scrolling sidebar, now with portals

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -235,7 +235,7 @@ class Sidebar extends React.Component {
 
     return (
       <StyledSidebar innerRef={this.sidebarRef} collapsed={collapsed}>
-        <SidebarSectionGroup>
+        <SidebarSectionGroupPrimary>
           <SidebarSection>
             <SidebarDropdown
               onClick={this.hidePanel}
@@ -247,107 +247,140 @@ class Sidebar extends React.Component {
             />
           </SidebarSection>
 
-          {hasOrganization && (
-            <React.Fragment>
-              <SidebarSection>
-                <SidebarItem
-                  {...sidebarItemProps}
-                  index
-                  onClick={this.hidePanel}
-                  icon={<InlineSvg src="icon-projects" />}
-                  label={t('Projects')}
-                  to={
-                    hasSentry10
-                      ? `/organizations/${organization.slug}/projects/`
-                      : `/${organization.slug}/`
-                  }
-                />
-                <Feature features={['sentry10']} organization={organization}>
+          <PrimaryItems>
+            {hasOrganization && (
+              <React.Fragment>
+                <SidebarSection>
                   <SidebarItem
                     {...sidebarItemProps}
-                    onClick={(_id, evt) =>
-                      this.navigateWithGlobalSelection(
-                        `/organizations/${organization.slug}/issues/`,
-                        evt
-                      )
+                    index
+                    onClick={this.hidePanel}
+                    icon={<InlineSvg src="icon-projects" />}
+                    label={t('Projects')}
+                    to={
+                      hasSentry10
+                        ? `/organizations/${organization.slug}/projects/`
+                        : `/${organization.slug}/`
                     }
-                    icon={<InlineSvg src="icon-issues" />}
-                    label={t('Issues')}
-                    to={`/organizations/${organization.slug}/issues/`}
-                    id="issues"
                   />
-                </Feature>
-
-                <Feature
-                  features={['events', 'events-v2']}
-                  requireAll={false}
-                  hookName="events-sidebar-item"
-                  organization={organization}
-                >
-                  <SidebarItem
-                    {...sidebarItemProps}
-                    onClick={(_id, evt) =>
-                      this.navigateWithGlobalSelection(
-                        `/organizations/${organization.slug}/events/`,
-                        evt
-                      )
-                    }
-                    icon={<InlineSvg src="icon-stack" />}
-                    label={t('Events')}
-                    to={`/organizations/${organization.slug}/events/`}
-                    id="events"
-                  />
-                </Feature>
-
-                <Feature features={['incidents']} organization={organization}>
-                  <SidebarItem
-                    {...sidebarItemProps}
-                    onClick={(_id, evt) =>
-                      this.navigateWithGlobalSelection(
-                        `/organizations/${organization.slug}/incidents/`,
-                        evt
-                      )
-                    }
-                    icon={<InlineSvg src="icon-incidents" />}
-                    label={t('Incidents')}
-                    to={`/organizations/${organization.slug}/incidents/`}
-                    id="incidents"
-                  />
-                </Feature>
-
-                {hasSentry10 && (
-                  <React.Fragment>
+                  <Feature features={['sentry10']} organization={organization}>
                     <SidebarItem
                       {...sidebarItemProps}
                       onClick={(_id, evt) =>
                         this.navigateWithGlobalSelection(
-                          `/organizations/${organization.slug}/releases/`,
+                          `/organizations/${organization.slug}/issues/`,
                           evt
                         )
                       }
-                      icon={<InlineSvg src="icon-releases" />}
-                      label={t('Releases')}
-                      to={`/organizations/${organization.slug}/releases/`}
-                      id="releases"
+                      icon={<InlineSvg src="icon-issues" />}
+                      label={t('Issues')}
+                      to={`/organizations/${organization.slug}/issues/`}
+                      id="issues"
                     />
+                  </Feature>
+
+                  <Feature
+                    features={['events', 'events-v2']}
+                    requireAll={false}
+                    hookName="events-sidebar-item"
+                    organization={organization}
+                  >
                     <SidebarItem
                       {...sidebarItemProps}
                       onClick={(_id, evt) =>
                         this.navigateWithGlobalSelection(
-                          `/organizations/${organization.slug}/user-feedback/`,
+                          `/organizations/${organization.slug}/events/`,
                           evt
                         )
                       }
-                      icon={<InlineSvg src="icon-support" />}
-                      label={t('User Feedback')}
-                      to={`/organizations/${organization.slug}/user-feedback/`}
-                      id="user-feedback"
+                      icon={<InlineSvg src="icon-stack" />}
+                      label={t('Events')}
+                      to={`/organizations/${organization.slug}/events/`}
+                      id="events"
                     />
-                  </React.Fragment>
-                )}
+                  </Feature>
 
-                {!hasSentry10 && (
-                  <Feature features={['discover']} organization={organization}>
+                  <Feature features={['incidents']} organization={organization}>
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      onClick={(_id, evt) =>
+                        this.navigateWithGlobalSelection(
+                          `/organizations/${organization.slug}/incidents/`,
+                          evt
+                        )
+                      }
+                      icon={<InlineSvg src="icon-incidents" />}
+                      label={t('Incidents')}
+                      to={`/organizations/${organization.slug}/incidents/`}
+                      id="incidents"
+                    />
+                  </Feature>
+
+                  {hasSentry10 && (
+                    <React.Fragment>
+                      <SidebarItem
+                        {...sidebarItemProps}
+                        onClick={(_id, evt) =>
+                          this.navigateWithGlobalSelection(
+                            `/organizations/${organization.slug}/releases/`,
+                            evt
+                          )
+                        }
+                        icon={<InlineSvg src="icon-releases" />}
+                        label={t('Releases')}
+                        to={`/organizations/${organization.slug}/releases/`}
+                        id="releases"
+                      />
+                      <SidebarItem
+                        {...sidebarItemProps}
+                        onClick={(_id, evt) =>
+                          this.navigateWithGlobalSelection(
+                            `/organizations/${organization.slug}/user-feedback/`,
+                            evt
+                          )
+                        }
+                        icon={<InlineSvg src="icon-support" />}
+                        label={t('User Feedback')}
+                        to={`/organizations/${organization.slug}/user-feedback/`}
+                        id="user-feedback"
+                      />
+                    </React.Fragment>
+                  )}
+
+                  {!hasSentry10 && (
+                    <Feature features={['discover']} organization={organization}>
+                      <SidebarItem
+                        {...sidebarItemProps}
+                        onClick={this.hidePanel}
+                        icon={<InlineSvg src="icon-discover" />}
+                        label={t('Discover')}
+                        to={`/organizations/${organization.slug}/discover/`}
+                        id="discover"
+                      />
+                    </Feature>
+                  )}
+                </SidebarSection>
+
+                <SidebarSection>
+                  <Feature
+                    features={['sentry10', 'discover']}
+                    organization={organization}
+                  >
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      index
+                      onClick={this.hidePanel}
+                      icon={<InlineSvg src="icon-health" />}
+                      label={t('Dashboards')}
+                      to={`/organizations/${organization.slug}/dashboards/`}
+                      id="customizable-dashboards"
+                    />
+                  </Feature>
+                  <Feature
+                    features={['sentry10', 'discover']}
+                    hookName="discover-sidebar-item"
+                    organization={organization}
+                  >
                     <SidebarItem
                       {...sidebarItemProps}
                       onClick={this.hidePanel}
@@ -357,113 +390,85 @@ class Sidebar extends React.Component {
                       id="discover"
                     />
                   </Feature>
+                  <Feature features={['monitors']} organization={organization}>
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      onClick={(_id, evt) =>
+                        this.navigateWithGlobalSelection(
+                          `/organizations/${organization.slug}/monitors/`,
+                          evt
+                        )
+                      }
+                      icon={<InlineSvg src="icon-labs" />}
+                      label={t('Monitors')}
+                      to={`/organizations/${organization.slug}/monitors/`}
+                      id="monitors"
+                    />
+                  </Feature>
+                </SidebarSection>
+
+                {!hasSentry10 && (
+                  <SidebarSection>
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      onClick={this.hidePanel}
+                      icon={<InlineSvg src="icon-user" />}
+                      label={t('Assigned to me')}
+                      to={`/organizations/${organization.slug}/issues/assigned/`}
+                      id="assigned"
+                    />
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      onClick={this.hidePanel}
+                      icon={<InlineSvg src="icon-star" />}
+                      label={t('Bookmarked issues')}
+                      to={`/organizations/${organization.slug}/issues/bookmarks/`}
+                      id="bookmarks"
+                    />
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      onClick={this.hidePanel}
+                      icon={<InlineSvg src="icon-history" />}
+                      label={t('Recently viewed')}
+                      to={`/organizations/${organization.slug}/issues/history/`}
+                      id="history"
+                    />
+                  </SidebarSection>
                 )}
-              </SidebarSection>
 
-              <SidebarSection>
-                <Feature features={['sentry10', 'discover']} organization={organization}>
-                  <SidebarItem
-                    {...sidebarItemProps}
-                    index
-                    onClick={this.hidePanel}
-                    icon={<InlineSvg src="icon-health" />}
-                    label={t('Dashboards')}
-                    to={`/organizations/${organization.slug}/dashboards/`}
-                    id="customizable-dashboards"
-                  />
-                </Feature>
-                <Feature
-                  features={['sentry10', 'discover']}
-                  hookName="discover-sidebar-item"
-                  organization={organization}
-                >
-                  <SidebarItem
-                    {...sidebarItemProps}
-                    onClick={this.hidePanel}
-                    icon={<InlineSvg src="icon-discover" />}
-                    label={t('Discover')}
-                    to={`/organizations/${organization.slug}/discover/`}
-                    id="discover"
-                  />
-                </Feature>
-                <Feature features={['monitors']} organization={organization}>
-                  <SidebarItem
-                    {...sidebarItemProps}
-                    onClick={(_id, evt) =>
-                      this.navigateWithGlobalSelection(
-                        `/organizations/${organization.slug}/monitors/`,
-                        evt
-                      )
-                    }
-                    icon={<InlineSvg src="icon-labs" />}
-                    label={t('Monitors')}
-                    to={`/organizations/${organization.slug}/monitors/`}
-                    id="monitors"
-                  />
-                </Feature>
-              </SidebarSection>
-
-              {!hasSentry10 && (
                 <SidebarSection>
                   <SidebarItem
                     {...sidebarItemProps}
                     onClick={this.hidePanel}
-                    icon={<InlineSvg src="icon-user" />}
-                    label={t('Assigned to me')}
-                    to={`/organizations/${organization.slug}/issues/assigned/`}
-                    id="assigned"
+                    icon={<InlineSvg src="icon-activity" size="22px" />}
+                    label={t('Activity')}
+                    to={`/organizations/${organization.slug}/activity/`}
+                    id="activity"
                   />
                   <SidebarItem
                     {...sidebarItemProps}
                     onClick={this.hidePanel}
-                    icon={<InlineSvg src="icon-star" />}
-                    label={t('Bookmarked issues')}
-                    to={`/organizations/${organization.slug}/issues/bookmarks/`}
-                    id="bookmarks"
-                  />
-                  <SidebarItem
-                    {...sidebarItemProps}
-                    onClick={this.hidePanel}
-                    icon={<InlineSvg src="icon-history" />}
-                    label={t('Recently viewed')}
-                    to={`/organizations/${organization.slug}/issues/history/`}
-                    id="history"
+                    icon={<InlineSvg src="icon-stats" />}
+                    label={t('Stats')}
+                    to={`/organizations/${organization.slug}/stats/`}
+                    id="stats"
                   />
                 </SidebarSection>
-              )}
 
-              <SidebarSection>
-                <SidebarItem
-                  {...sidebarItemProps}
-                  onClick={this.hidePanel}
-                  icon={<InlineSvg src="icon-activity" size="22px" />}
-                  label={t('Activity')}
-                  to={`/organizations/${organization.slug}/activity/`}
-                  id="activity"
-                />
-                <SidebarItem
-                  {...sidebarItemProps}
-                  onClick={this.hidePanel}
-                  icon={<InlineSvg src="icon-stats" />}
-                  label={t('Stats')}
-                  to={`/organizations/${organization.slug}/stats/`}
-                  id="stats"
-                />
-              </SidebarSection>
-
-              <SidebarSection>
-                <SidebarItem
-                  {...sidebarItemProps}
-                  onClick={this.hidePanel}
-                  icon={<InlineSvg src="icon-settings" />}
-                  label={t('Settings')}
-                  to={`/settings/${organization.slug}/`}
-                  id="settings"
-                />
-              </SidebarSection>
-            </React.Fragment>
-          )}
-        </SidebarSectionGroup>
+                <SidebarSection>
+                  <SidebarItem
+                    {...sidebarItemProps}
+                    onClick={this.hidePanel}
+                    icon={<InlineSvg src="icon-settings" />}
+                    label={t('Settings')}
+                    to={`/settings/${organization.slug}/`}
+                    id="settings"
+                  />
+                </SidebarSection>
+              </React.Fragment>
+            )}
+          </PrimaryItems>
+        </SidebarSectionGroupPrimary>
 
         {hasOrganization && (
           <SidebarSectionGroup>
@@ -576,7 +581,7 @@ const StyledSidebar = styled('div')`
   background: linear-gradient(${p => p.theme.gray4}, ${p => p.theme.gray5});
   color: ${p => p.theme.sidebar.color};
   line-height: 1;
-  padding: 12px 19px 2px; /* Allows for 32px avatars  */
+  padding: 12px 0 2px; /* Allows for 32px avatars  */
   width: ${p => p.theme.sidebar.expandedWidth};
   position: fixed;
   top: 0;
@@ -594,20 +599,68 @@ const StyledSidebar = styled('div')`
     height: ${p => p.theme.sidebar.mobileHeight};
     bottom: auto;
     width: auto;
-    padding: 0;
+    padding: 0 ${space(1)};
     align-items: center;
   }
 `;
 
 const SidebarSectionGroup = styled('div')`
   ${responsiveFlex};
-  flex-shrink: 0;
+`;
+
+const SidebarSectionGroupPrimary = styled(SidebarSectionGroup)`
+  /* necessary for child flexing on msedge and ff */
+  min-height: 0;
+  min-width: 0;
+  flex: 1;
+  /* expand to fill the entire height on mobile */
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    height: 100%;
+    align-items: center;
+  }
+`;
+
+const PrimaryItems = styled('div')`
+  overflow: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+  @media (max-height: 600px) and (min-width: ${p => p.theme.breakpoints[0]}) {
+    border-bottom: 1px solid ${p => p.theme.gray3};
+    padding-bottom: ${p => space(1)};
+    box-shadow: rgba(0, 0, 0, 0.15) 0px -10px 10px inset;
+    &::-webkit-scrollbar {
+      background-color: transparent;
+      width: 8px;
+    }
+    &::-webkit-scrollbar-thumb {
+      background: ${p => p.theme.gray3};
+      border-radius: 8px;
+    }
+  }
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    overflow-y: visible;
+    flex-direction: row;
+    height: 100%;
+    align-items: center;
+    border-right: 1px solid ${p => p.theme.gray3};
+    padding-right: ${p => space(1)};
+    margin-right: ${p => space(0.5)};
+    box-shadow: rgba(0, 0, 0, 0.15) -10px 0px 10px inset;
+    ::-webkit-scrollbar {
+      display: none;
+    }
+  }
 `;
 
 const SidebarSection = styled(SidebarSectionGroup)`
   ${p => !p.noMargin && `margin: ${space(1)} 0`};
+  padding: 0 19px;
+
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
-    margin: 0 ${space(1)};
+    margin: 0;
+    padding: 0;
   }
 
   &:empty {


### PR DESCRIPTION
![scroller-2](https://user-images.githubusercontent.com/435981/57898448-f3b2cc80-780d-11e9-8948-1a6ee0576beb.gif)

this is mostly https://github.com/getsentry/sentry/pull/12664, but updated to master and with working tooltips that don't get cropped, courtesy of @markstory.

Eventually, it would be cool to have this entire thing scroll, but we will need to do a similar refactor to `dropdownMenu`, which is pretty old and has some annoying edge cases (like nesting).