### PR TITLE
fix: Revert integer field changes from #13227

### DIFF
--- a/src/sentry/models/commitfilechange.py
+++ b/src/sentry/models/commitfilechange.py
@@ -12,7 +12,7 @@ class CommitFileChange(Model):
 
     organization_id = BoundedPositiveIntegerField(db_index=True)
     commit = FlexibleForeignKey('sentry.Commit')
-    filename = models.TextField()
+    filename = models.CharField(max_length=255)
     type = models.CharField(
         max_length=1, choices=(('A', 'Added'), ('D', 'Deleted'), ('M', 'Modified'), )
     )

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -20,7 +20,7 @@ from time import time
 
 from sentry.app import locks
 from sentry.db.models import (
-    ArrayField, BoundedBigIntegerField, BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr
+    ArrayField, BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr
 )
 
 from sentry.models import CommitFileChange
@@ -65,7 +65,7 @@ class Release(Model):
         'sentry.Project', related_name='releases', through=ReleaseProject
     )
     # DEPRECATED
-    project_id = BoundedBigIntegerField(null=True)
+    project_id = BoundedPositiveIntegerField(null=True)
     version = models.CharField(max_length=DB_VERSION_LENGTH)
     # ref might be the branch name being released
     ref = models.CharField(max_length=DB_VERSION_LENGTH, null=True, blank=True)

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 from django.db import models
 from six.moves.urllib.parse import urlsplit, urlunsplit
 
-from sentry.db.models import BoundedBigIntegerField, FlexibleForeignKey, Model, sane_repr
+from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr
 from sentry.utils.hashlib import sha1_text
 
 
@@ -26,7 +26,7 @@ class ReleaseFile(Model):
 
     organization = FlexibleForeignKey('sentry.Organization')
     # DEPRECATED
-    project_id = BoundedBigIntegerField(null=True)
+    project_id = BoundedPositiveIntegerField(null=True)
     release = FlexibleForeignKey('sentry.Release')
     file = FlexibleForeignKey('sentry.File')
     ident = models.CharField(max_length=40)

--- a/src/sentry/tagstore/legacy/models/grouptagkey.py
+++ b/src/sentry/tagstore/legacy/models/grouptagkey.py
@@ -11,7 +11,7 @@ from django.db import models, router, transaction, DataError
 
 from sentry.constants import MAX_TAG_KEY_LENGTH
 from sentry.db.models import (
-    Model, BoundedBigIntegerField, BoundedPositiveIntegerField, BaseManager, sane_repr
+    Model, BoundedPositiveIntegerField, BaseManager, sane_repr
 )
 
 
@@ -23,8 +23,8 @@ class GroupTagKey(Model):
     """
     __core__ = False
 
-    project_id = BoundedBigIntegerField(db_index=True, null=True)
-    group_id = BoundedBigIntegerField(db_index=True)
+    project_id = BoundedPositiveIntegerField(db_index=True, null=True)
+    group_id = BoundedPositiveIntegerField(db_index=True)
     key = models.CharField(max_length=MAX_TAG_KEY_LENGTH)
     values_seen = BoundedPositiveIntegerField(default=0)
 

--- a/src/sentry/tagstore/legacy/models/grouptagvalue.py
+++ b/src/sentry/tagstore/legacy/models/grouptagvalue.py
@@ -12,7 +12,7 @@ from django.utils import timezone
 
 from sentry.constants import MAX_TAG_KEY_LENGTH, MAX_TAG_VALUE_LENGTH
 from sentry.db.models import (
-    Model, BoundedBigIntegerField, BoundedPositiveIntegerField, BaseManager, sane_repr)
+    Model, BoundedPositiveIntegerField, BaseManager, sane_repr)
 
 
 class GroupTagValue(Model):
@@ -22,8 +22,8 @@ class GroupTagValue(Model):
     """
     __core__ = False
 
-    project_id = BoundedBigIntegerField(db_index=True, null=True)
-    group_id = BoundedBigIntegerField(db_index=True)
+    project_id = BoundedPositiveIntegerField(db_index=True, null=True)
+    group_id = BoundedPositiveIntegerField(db_index=True)
     times_seen = BoundedPositiveIntegerField(default=0)
     key = models.CharField(max_length=MAX_TAG_KEY_LENGTH)
     value = models.CharField(max_length=MAX_TAG_VALUE_LENGTH)

--- a/src/sentry/tagstore/legacy/models/tagkey.py
+++ b/src/sentry/tagstore/legacy/models/tagkey.py
@@ -13,7 +13,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from sentry.tagstore import TagKeyStatus
 from sentry.constants import MAX_TAG_KEY_LENGTH
-from sentry.db.models import (Model, BoundedBigIntegerField, BoundedPositiveIntegerField, sane_repr)
+from sentry.db.models import (Model, BoundedPositiveIntegerField, sane_repr)
 
 
 class TagKey(Model):
@@ -22,7 +22,7 @@ class TagKey(Model):
     """
     __core__ = False
 
-    project_id = BoundedBigIntegerField(db_index=True)
+    project_id = BoundedPositiveIntegerField(db_index=True)
     key = models.CharField(max_length=MAX_TAG_KEY_LENGTH)
     values_seen = BoundedPositiveIntegerField(default=0)
     label = models.CharField(max_length=64, null=True)

--- a/src/sentry/tagstore/legacy/models/tagvalue.py
+++ b/src/sentry/tagstore/legacy/models/tagvalue.py
@@ -12,7 +12,7 @@ from django.utils import timezone
 
 from sentry.constants import MAX_TAG_KEY_LENGTH, MAX_TAG_VALUE_LENGTH
 from sentry.db.models import (
-    Model, BoundedBigIntegerField, BoundedPositiveIntegerField, GzippedDictField, BaseManager, sane_repr
+    Model, BoundedPositiveIntegerField, GzippedDictField, BaseManager, sane_repr
 )
 
 
@@ -22,7 +22,7 @@ class TagValue(Model):
     """
     __core__ = False
 
-    project_id = BoundedBigIntegerField(db_index=True, null=True)
+    project_id = BoundedPositiveIntegerField(db_index=True, null=True)
     key = models.CharField(max_length=MAX_TAG_KEY_LENGTH)
     value = models.CharField(max_length=MAX_TAG_VALUE_LENGTH)
     data = GzippedDictField(blank=True, null=True)


### PR DESCRIPTION
The integer field changes from #13277 were not no-ops and in some environments south generated migrations for these changes which we don't want restore their definition so that south doesn't create migrations.