### PR TITLE
fix(plugins) Include organization/project id in failed notifcation logs

### DIFF
--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -75,9 +75,11 @@ class NotificationPlugin(Plugin):
             return self.notify_users(event.group, event, triggering_rules=[
                                      r.label for r in notification.rules])
         except (SSLError, HTTPError, ApiError, PluginError, urllib2.HTTPError) as err:
-            self.logger.info('notification-plugin.notify-failed.', extra={
+            self.logger.info('notification-plugin.notify-failed', extra={
                 'error': six.text_type(err),
-                'plugin': self.slug
+                'plugin': self.slug,
+                'project_id': event.group.project_id,
+                'organization_id': event.group.project.organization_id,
             })
             return False
 


### PR DESCRIPTION
When a notifier fails (like pagerduty) it is helpful to know which organizations and projects had failures.

Fixes SEN-629