### PR TITLE
fix(integrations) Track requests made in metric

### DIFF
--- a/src/sentry/integrations/bitbucket/client.py
+++ b/src/sentry/integrations/bitbucket/client.py
@@ -42,6 +42,7 @@ class BitbucketApiClient(ApiClient):
 
     NOTE: repo is the fully qualified slug containing 'username/repo_slug'
     """
+    integration_name = 'bitbucket'
 
     def __init__(self, base_url, shared_secret, subject, *args, **kwargs):
         # subject is probably the clientKey

--- a/src/sentry/integrations/client.py
+++ b/src/sentry/integrations/client.py
@@ -160,6 +160,8 @@ class ApiClient(object):
         full_url = self.build_url(path)
         host = urlparse(full_url).netloc
         session = build_session()
+
+        metrics.incr('integrations.http_request', tags={'host': host})
         try:
             resp = getattr(session, method.lower())(
                 url=full_url,

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -10,6 +10,7 @@ class GitHubClientMixin(ApiClient):
     allow_redirects = True
 
     base_url = 'https://api.github.com'
+    integration_name = 'github'
 
     def get_jwt(self):
         return get_jwt()

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -45,6 +45,8 @@ class GitLabSetupClient(ApiClient):
     needed to build installation metadata
     """
 
+    integration_name = 'gitlab_setup'
+
     def __init__(self, base_url, access_token, verify_ssl):
         self.base_url = base_url
         self.token = access_token
@@ -74,6 +76,7 @@ class GitLabSetupClient(ApiClient):
 
 
 class GitLabApiClient(ApiClient):
+    integration_name = 'gitlab'
 
     def __init__(self, installation):
         self.installation = installation

--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -90,6 +90,8 @@ class JiraApiClient(ApiClient):
     ASSIGN_URL = '/rest/api/2/issue/%s/assignee'
     TRANSITION_URL = '/rest/api/2/issue/%s/transitions'
 
+    integration_name = 'jira'
+
     def __init__(self, base_url, jira_style, verify_ssl):
         self.base_url = base_url
         # `jira_style` encapsulates differences between jira server & jira cloud.
@@ -108,7 +110,8 @@ class JiraApiClient(ApiClient):
             request_spec['headers'] = {}
 
         # Force adherence to the GDPR compliant API conventions.
-        # See https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide
+        # See
+        # https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide
         request_spec['headers']['x-atlassian-force-account-id'] = 'true'
         return self._request(**request_spec)
 

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -20,6 +20,7 @@ class JiraServerSetupClient(ApiClient):
     request_token_url = u'{}/plugins/servlet/oauth/request-token'
     access_token_url = u'{}/plugins/servlet/oauth/access-token'
     authorize_url = u'{}/plugins/servlet/oauth/authorize?oauth_token={}'
+    integration_name = 'jira_server_setup'
 
     def __init__(self, base_url, consumer_key, private_key, verify_ssl=True):
         self.base_url = base_url

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -39,6 +39,7 @@ class VstsApiPath(object):
 class VstsApiClient(ApiClient, OAuth2RefreshMixin):
     api_version = '4.1'
     api_version_preview = '-preview.1'
+    integration_name = 'vsts'
 
     def __init__(self, identity, oauth_redirect_url, *args, **kwargs):
         super(VstsApiClient, self).__init__(*args, **kwargs)


### PR DESCRIPTION
We already have metrics for each response code/failure mode but we didn't have request started metrics. Having this additional metric will let us more easily build alerts based on the % of failed requests.

Refs SEN-630