### PR TITLE
fix(app-platform): Prevent ApiGrant IntegrityError

### DIFF
--- a/src/sentry/mediators/token_exchange/grant_exchanger.py
+++ b/src/sentry/mediators/token_exchange/grant_exchanger.py
@@ -25,11 +25,12 @@ class GrantExchanger(Mediator):
 
     def call(self):
         self._validate()
+        self._create_token()
 
         # Once it's exchanged it's no longer valid and should not be
         # exchangable, so we delete it.
         self._delete_grant()
-        self._create_token()
+
         return self.token
 
     def record_analytics(self):


### PR DESCRIPTION
For some reason, the previous order of queries was causing an
IntegrityError relating to `sentry_sentryappinstallations.api_grant_id`
referencing a row that no longer existed. This didn't make sense because
we were NULL'ing out the reference BEFORE deleting the row. I suspect
something to do with the transaction or possibly memoizing these objects
(seems ridiculous, but who knows) was causing this.

Creating the new token first THEN deleting the ApiGrant seems to fix the
issue. I'm not entirely sure how, though, tbh. Love computers.