### PR TITLE
feat(ui) Improve tooltips on breadcrumbs

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs.jsx
@@ -19,6 +19,11 @@ function Collapsed(props) {
   );
 }
 
+Collapsed.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  count: PropTypes.number.isRequired,
+};
+
 function moduleToCategory(module) {
   if (!module) {
     return null;
@@ -29,11 +34,6 @@ function moduleToCategory(module) {
   }
   return module.split(/./)[0];
 }
-
-Collapsed.propTypes = {
-  onClick: PropTypes.func.isRequired,
-  count: PropTypes.number.isRequired,
-};
 
 class BreadcrumbsInterface extends React.Component {
   static propTypes = {

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumb.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumb.jsx
@@ -7,6 +7,7 @@ import HttpRenderer from 'app/components/events/interfaces/breadcrumbs/httpRende
 import ErrorRenderer from 'app/components/events/interfaces/breadcrumbs/errorRenderer';
 import DefaultRenderer from 'app/components/events/interfaces/breadcrumbs/defaultRenderer';
 import ErrorBoundary from 'app/components/errorBoundary';
+import Tooltip from 'app/components/tooltip';
 
 const CUSTOM_RENDERERS = {
   http: HttpRenderer,
@@ -56,9 +57,9 @@ class Breadcrumb extends React.Component {
             <span className="icon" />
           </span>
           {defined(crumb.timestamp) ? (
-            <span className="dt" title={moment(crumb.timestamp).format()}>
-              {moment(crumb.timestamp).format('HH:mm:ss')}
-            </span>
+            <Tooltip title={moment(crumb.timestamp).format()}>
+              <span className="dt">{moment(crumb.timestamp).format('HH:mm:ss')}</span>
+            </Tooltip>
           ) : (
             <span className="dt" />
           )}

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumb.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumb.jsx
@@ -57,7 +57,7 @@ class Breadcrumb extends React.Component {
             <span className="icon" />
           </span>
           {defined(crumb.timestamp) ? (
-            <Tooltip title={moment(crumb.timestamp).format()}>
+            <Tooltip title={moment(crumb.timestamp).format('lll')}>
               <span className="dt">{moment(crumb.timestamp).format('HH:mm:ss')}</span>
             </Tooltip>
           ) : (

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/category.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/category.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
+import Tooltip from 'app/components/tooltip';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 
 class Category extends React.Component {
@@ -24,6 +25,16 @@ class Category extends React.Component {
       title = title.replace('%s', value);
     } else {
       title = value;
+    }
+    // Display has room for approximately 10 wide chars before
+    // overflowing to an ellipsis. We also don't want tooltips on 'exception'
+    // which is 9 characters.
+    if (title.length > 10) {
+      return (
+        <Tooltip title={title} containerDisplayMode="block">
+          <CrumbCategory>{title}</CrumbCategory>
+        </Tooltip>
+      );
     }
     return <CrumbCategory title={title}>{title}</CrumbCategory>;
   }


### PR DESCRIPTION
Add HTML tooltips to breadcrumb timestamps and long category names. Previously only a native tooltip would be shown. This improves that  experience using our tooltip component.

![Screen Shot 2019-05-17 at 1 56 57 PM](https://user-images.githubusercontent.com/24086/57947250-66728500-78ac-11e9-9967-cc76863a5453.png)
![Screen Shot 2019-05-17 at 2 01 22 PM](https://user-images.githubusercontent.com/24086/57947251-670b1b80-78ac-11e9-8389-5269961388a9.png)
