### PR TITLE
ref(app-platform): Transaction with statement

### DIFF
--- a/src/sentry/mediators/mediator.py
+++ b/src/sentry/mediators/mediator.py
@@ -153,15 +153,15 @@ class Mediator(object):
             param.setup(cls, name)
 
     @classmethod
-    @transaction.atomic
     def run(cls, *args, **kwargs):
-        obj = cls(*args, **kwargs)
+        with transaction.atomic():
+            obj = cls(*args, **kwargs)
 
-        with obj.log():
-            result = obj.call()
-            obj.audit()
-            obj.record_analytics()
-            return result
+            with obj.log():
+                result = obj.call()
+                obj.audit()
+                obj.record_analytics()
+                return result
 
     def __init__(self, *args, **kwargs):
         self.kwargs = kwargs


### PR DESCRIPTION
Changes Mediators to use the `with transaction.atomic()` syntax, instead of the decorator, in an attempt to include `BEGIN` and `COMMIT` statements in Sentry Breadcrumbs.