### PR TITLE
feat(ui): Add action to mark incident as seen [SEN-593]

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/incident.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/incident.jsx
@@ -104,9 +104,9 @@ export async function markIncidentAsSeen(api, orgId, incident) {
 
   try {
     await api.requestPromise(
-      `/organizations/${orgId}/incidents/${incident.identifier}/`,
+      `/organizations/${orgId}/incidents/${incident.identifier}/seen/`,
       {
-        method: 'PUT',
+        method: 'POST',
         data: {
           hasSeen: true,
         },

--- a/src/sentry/static/sentry/app/actionCreators/incident.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/incident.jsx
@@ -94,3 +94,25 @@ export async function updateIncidentNote(api, incidentId, item, note) {
     throw err;
   }
 }
+
+// This doesn't return anything because you shouldn't need to do anything with
+// the result success or fail
+export async function markIncidentAsSeen(api, orgId, incident) {
+  if (!incident || incident.hasSeen) {
+    return;
+  }
+
+  try {
+    await api.requestPromise(
+      `/organizations/${orgId}/incidents/${incident.identifier}/`,
+      {
+        method: 'PUT',
+        data: {
+          hasSeen: true,
+        },
+      }
+    );
+  } catch (err) {
+    // do nothing
+  }
+}

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/index.jsx
@@ -1,12 +1,11 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
-import withApi from 'app/utils/withApi';
+import {markIncidentAsSeen} from 'app/actionCreators/incident';
 import {t} from 'app/locale';
+import withApi from 'app/utils/withApi';
 
-import DetailsHeader from './header';
-import DetailsBody from './body';
 import {
   INCIDENT_STATUS,
   fetchIncident,
@@ -14,6 +13,8 @@ import {
   updateStatus,
   isOpen,
 } from '../utils';
+import DetailsBody from './body';
+import DetailsHeader from './header';
 
 class OrganizationIncidentDetails extends React.Component {
   static propTypes = {
@@ -39,6 +40,7 @@ class OrganizationIncidentDetails extends React.Component {
     fetchIncident(api, orgId, incidentId)
       .then(incident => {
         this.setState({incident, isLoading: false, hasError: false});
+        markIncidentAsSeen(api, orgId, incident);
       })
       .catch(() => {
         this.setState({isLoading: false, hasError: true});


### PR DESCRIPTION
If user visits Incident Details and they have not already seen the Incident, mark the it as seen by user

Depends on https://github.com/getsentry/sentry/pull/13271
Fixes SEN-593