### PR TITLE
dx(yarn): Run `yarn install --check-files` when verify tree fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "test-staged": "yarn test --findRelatedTests $(git diff --name-only --cached)",
     "lint": "node_modules/.bin/eslint tests/js src/sentry/static/sentry/app --ext .js,.jsx",
     "lint:css": "stylelint 'src/sentry/static/sentry/app/**/*.jsx'",
-    "dev": "(yarn check --verify-tree || yarn) && sentry devserver --browser-reload",
+    "dev": "(yarn check --verify-tree || yarn install --check-files) && sentry devserver --browser-reload",
     "dev-server": "webpack-dev-server",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "storybook-build": "build-storybook -c .storybook -o .storybook-out && sed -i -e 's/\\/sb_dll/sb_dll/g' .storybook-out/index.html",


### PR DESCRIPTION
A common problem is with node packages not existing in `node_modules`, even though `yarn install`
says everything is up to date.  This adds an additional step to check packages against what exists
in `node_modules` and run `yarn install --check-files` if check fails.
This should install the packages missing from `node_modules`.